### PR TITLE
Refactor BDMV playlist summary caching

### DIFF
--- a/cmd/upbrr/cli_options.go
+++ b/cmd/upbrr/cli_options.go
@@ -75,6 +75,7 @@ type cliOptions struct {
 	PersonalRelease   bool
 	StreamOptimized   bool
 	WebDV             bool
+	ConfirmBDMVRescan bool
 	NotAnime          bool
 	Anon              bool
 	Draft             bool
@@ -501,6 +502,7 @@ func buildCLIRequest(opts cliOptions, visited map[string]bool, paths []string, s
 		ImageHostOverrides:     buildImageHostOverrides(opts, visited),
 		ScreenshotOverrides:    buildScreenshotOverrides(opts, visited),
 		TorrentOverrides:       buildTorrentOverrides(opts, visited),
+		ConfirmBDMVRescan:      opts.ConfirmBDMVRescan,
 	}
 	if req.Execution.SiteUploadTracker != "" {
 		req.Trackers = []string{req.Execution.SiteUploadTracker}

--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -26,6 +27,18 @@ func runInteractiveCLIPath(ctx context.Context, coreSvc api.Core, baseArgs []str
 		}
 		preview, err := coreSvc.FetchMetadataPreview(ctx, req)
 		if err != nil {
+			var rescanErr *api.BDMVRescanRequiredError
+			if errors.As(err, &rescanErr) && currentOpts.interactionMode() != api.InteractionModeUnattended {
+				confirm, promptErr := promptYesNo(reader, fmt.Sprintf("Cached BDMV summaries exist, but selected playlist(s) %s require a rescan. Rescan now? [Y/n]: ", strings.Join(rescanErr.MissingPlaylists, ", ")), true)
+				if promptErr != nil {
+					return promptErr
+				}
+				if !confirm {
+					return err
+				}
+				currentOpts.ConfirmBDMVRescan = true
+				continue
+			}
 			return err
 		}
 

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -1018,6 +1018,11 @@ export default function App() {
     screenshotsSettingsSaving,
     setScreenshotsSettingsSaving,
     setScreenshotsError,
+    loadScreenshotPlan,
+    readScreenshotImage,
+    setExistingImages,
+    resetScreenshotState: resetScreenshots,
+    handleDeleteTrackerImageURL,
   } = screenshots;
 
   // Upload images workflow hook
@@ -1028,6 +1033,13 @@ export default function App() {
     uploadCandidates: screenshots.uploadCandidates,
     configuredImageHosts,
   });
+  const {
+    refreshUploadedImages,
+    resetUploadState,
+    setUploadSelections,
+    setUploadHost,
+    uploadHost,
+  } = uploadImages;
 
   // Tracker image URL handling
   const trackerImageURLs = useMemo(() => {
@@ -1054,9 +1066,9 @@ export default function App() {
       return;
     }
     for (const url of trackerImageURLs) {
-      await screenshots.handleDeleteTrackerImageURL(url);
+      await handleDeleteTrackerImageURL(url);
     }
-  }, [trackerImageURLs, screenshots.handleDeleteTrackerImageURL]);
+  }, [trackerImageURLs, handleDeleteTrackerImageURL]);
 
   const uploadCandidatePaths = useMemo(() => {
     return new Set(
@@ -1064,14 +1076,14 @@ export default function App() {
     );
   }, [screenshots.uploadCandidates]);
 
-  const resetScreenshotState = () => {
-    screenshots.resetScreenshotState();
-    uploadImages.resetUploadState();
+  const resetScreenshotState = useCallback(() => {
+    resetScreenshots();
+    resetUploadState();
     setUploadToggles({});
     setOverrideRuleBlocks(false);
     setFinalDragIndex(null);
     setLiveCaptureLoading(false);
-  };
+  }, [resetScreenshots, resetUploadState]);
 
 
 
@@ -1593,7 +1605,9 @@ export default function App() {
         path.trim(),
         normalizeOverrides(overrides),
         normalizeReleaseOverrides(nameOverrides),
-        getSelectedTrackers(),
+        Object.entries(releasePageTrackerSelection)
+          .filter(([, selected]) => selected)
+          .map(([name]) => name),
         ignoredDupeTrackers
       );
       const filteredDescriptions = filterPrepDescriptions(result.Descriptions || []);
@@ -1610,7 +1624,7 @@ export default function App() {
     }
   };
 
-  const runDescriptionBuilder = async (overrides: ExternalIDOverrides, nameOverrides: ReleaseNameOverrides) => {
+  const runDescriptionBuilder = useCallback(async (overrides: ExternalIDOverrides, nameOverrides: ReleaseNameOverrides) => {
     setBuilderError("");
     setBuilderSaved("");
     const fetcher = globalThis.go?.guiapp?.App?.FetchDescriptionBuilder;
@@ -1628,7 +1642,9 @@ export default function App() {
         path.trim(),
         normalizeOverrides(overrides),
         normalizeReleaseOverrides(nameOverrides),
-        getSelectedTrackers(),
+        Object.entries(releasePageTrackerSelection)
+          .filter(([, selected]) => selected)
+          .map(([name]) => name),
         ignoredDupeTrackers
       );
       setBuilderPreview(result);
@@ -1640,7 +1656,7 @@ export default function App() {
     } finally {
       setBuilderLoading(false);
     }
-  };
+  }, [path, releasePageTrackerSelection, ignoredDupeTrackers]);
 
   const resetBuilderDescription = async (overrides: ExternalIDOverrides, nameOverrides: ReleaseNameOverrides) => {
     setBuilderError("");
@@ -1765,24 +1781,24 @@ export default function App() {
   const previewFrameRate = useMemo(() => {
     const rate = screenshots.screenshotPlan?.FrameRate || 0;
     return rate > 0 ? rate : 24;
-  }, [screenshots.screenshotPlan, screenshots]);
+  }, [screenshots.screenshotPlan]);
 
-  const previewDuration = useMemo(() => screenshots.screenshotPlan?.DurationSeconds || 0, [screenshots.screenshotPlan, screenshots]);
+  const previewDuration = useMemo(() => screenshots.screenshotPlan?.DurationSeconds || 0, [screenshots.screenshotPlan]);
 
-  const clampPreviewSeconds = (value: number) => {
+  const clampPreviewSeconds = useCallback((value: number) => {
     if (!Number.isFinite(value)) return 0;
     if (previewDuration > 0) {
       return Math.min(Math.max(value, 0), previewDuration);
     }
     return Math.max(value, 0);
-  };
+  }, [previewDuration]);
 
   const livePreviewFrame = useMemo(() => {
     if (previewFrameRate <= 0) return 0;
     const seconds = clampPreviewSeconds(livePreviewSeconds);
     const frame = Math.round(seconds * previewFrameRate);
     return Number.isFinite(frame) ? frame : 0;
-  }, [livePreviewSeconds, previewFrameRate, previewDuration]);
+  }, [livePreviewSeconds, previewFrameRate, clampPreviewSeconds]);
 
   const runLivePreviewAt = async (timestampSeconds: number) => {
     setLivePreviewError("");
@@ -2169,7 +2185,7 @@ export default function App() {
     setMetadataProgressActive(false);
     setMetadataProgressUpdates([]);
     resetScreenshotState();
-  }, [path]);
+  }, [path, resetScreenshotState]);
 
   useEffect(() => {
     if (activeTab !== "description_builder") return;
@@ -2186,21 +2202,21 @@ export default function App() {
     if (builderAutoRequestKey === requestKey) return;
     setBuilderAutoRequestKey(requestKey);
     runDescriptionBuilder(idOverrideState?.overrides || {}, releaseOverrideState?.overrides || {});
-  }, [activeTab, dupeChecked, builderLoading, builderSaving, builderDirty, path, idOverrideState, releaseOverrideState, builderAutoRequestKey]);
+  }, [activeTab, dupeChecked, builderLoading, builderSaving, builderDirty, path, idOverrideState, releaseOverrideState, builderAutoRequestKey, runDescriptionBuilder]);
 
   useEffect(() => {
     if (activeTab !== "screenshots") return;
     if (!dupeChecked) return;
     if (screenshots.screenshotPlan || screenshots.screenshotsLoading) return;
-    screenshots.loadScreenshotPlan();
-  }, [activeTab, dupeChecked, screenshots.screenshotPlan, screenshots.screenshotsLoading, screenshots.loadScreenshotPlan]);
+    loadScreenshotPlan();
+  }, [activeTab, dupeChecked, screenshots.screenshotPlan, screenshots.screenshotsLoading, loadScreenshotPlan]);
 
   useEffect(() => {
     if (activeTab !== "upload_images") return;
     if (!dupeChecked) return;
     if (screenshots.screenshotPlan || screenshots.screenshotsLoading) return;
-    screenshots.loadScreenshotPlan();
-  }, [activeTab, dupeChecked, screenshots.screenshotPlan, screenshots.screenshotsLoading, screenshots.loadScreenshotPlan]);
+    loadScreenshotPlan();
+  }, [activeTab, dupeChecked, screenshots.screenshotPlan, screenshots.screenshotsLoading, loadScreenshotPlan]);
 
   useEffect(() => {
     if (activeTab !== "upload_images") return;
@@ -2213,27 +2229,27 @@ export default function App() {
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {})
         );
         if (!candidates || candidates.length === 0) {
-          screenshots.setExistingImages([]);
-          await uploadImages.refreshUploadedImages();
+          setExistingImages([]);
+          await refreshUploadedImages();
           return;
         }
         const previews = await Promise.all(
           candidates.map(async (image: ScreenshotImage) => {
             try {
-              return await screenshots.readScreenshotImage(image);
+              return await readScreenshotImage(image);
             } catch {
               return null;
             }
           })
         );
-        screenshots.setExistingImages(previews.filter((entry): entry is ScreenshotPreviewImage => Boolean(entry)));
-        await uploadImages.refreshUploadedImages();
+        setExistingImages(previews.filter((entry): entry is ScreenshotPreviewImage => Boolean(entry)));
+        await refreshUploadedImages();
       } catch (err) {
         console.error("Failed to load upload candidates:", err);
       }
     };
     loadUploadCandidates();
-  }, [activeTab, path, idOverrideState, releaseOverrideState, screenshots.setExistingImages, screenshots.readScreenshotImage, uploadImages.refreshUploadedImages]);
+  }, [activeTab, path, idOverrideState, releaseOverrideState, setExistingImages, readScreenshotImage, refreshUploadedImages]);
 
   useEffect(() => {
     if (trackerUploadItems.length === 0) return;
@@ -2264,10 +2280,10 @@ export default function App() {
 
   useEffect(() => {
     if (screenshots.uploadCandidates.length === 0) {
-      uploadImages.setUploadSelections({});
+      setUploadSelections({});
       return;
     }
-    uploadImages.setUploadSelections((prev) => {
+    setUploadSelections((prev) => {
       const next: Record<string, boolean> = { ...prev };
       screenshots.uploadCandidates.forEach((item) => {
         const pathValue = item.image.Path;
@@ -2283,12 +2299,12 @@ export default function App() {
       });
       return next;
     });
-  }, [screenshots.uploadCandidates, uploadCandidatePaths, uploadImages.setUploadSelections]);
+  }, [screenshots.uploadCandidates, uploadCandidatePaths, setUploadSelections]);
 
   useEffect(() => {
-    if (uploadImages.uploadHost || configuredImageHosts.length === 0) return;
-    uploadImages.setUploadHost(configuredImageHosts[0]);
-  }, [configuredImageHosts, uploadImages.uploadHost, uploadImages.setUploadHost]);
+    if (uploadHost || configuredImageHosts.length === 0) return;
+    setUploadHost(configuredImageHosts[0]);
+  }, [configuredImageHosts, uploadHost, setUploadHost]);
 
   // Initialize release page tracker selection when preview loads or trackers change
   useEffect(() => {

--- a/gui/frontend/src/components/LogSettingsPanel.tsx
+++ b/gui/frontend/src/components/LogSettingsPanel.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026, Audionut and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { EventsOn } from "../utils/runtime";
 
 type LogEntry = {
@@ -98,7 +98,7 @@ export default function LogSettingsPanel({
     }
   };
 
-  const appendEntries = (incoming: LogEntry[]) => {
+  const appendEntries = useCallback((incoming: LogEntry[]) => {
     if (incoming.length === 0) return;
     setEntries((prev) => {
       let next = [...prev, ...incoming];
@@ -110,7 +110,7 @@ export default function LogSettingsPanel({
       }
       return next;
     });
-  };
+  }, [autoScroll]);
 
   useEffect(() => {
     const fetchLogPath = async () => {
@@ -141,7 +141,7 @@ export default function LogSettingsPanel({
       }
     };
     fetchRecent();
-  }, []);
+  }, [appendEntries]);
 
   useEffect(() => {
     const fetchMuted = async () => {
@@ -157,7 +157,7 @@ export default function LogSettingsPanel({
       }
     };
     fetchMuted();
-  }, []);
+  }, [appendEntries]);
 
   useEffect(() => {
     let active = true;
@@ -200,7 +200,7 @@ export default function LogSettingsPanel({
         streamStopRef.current = null;
       }
     };
-  }, []);
+  }, [appendEntries]);
 
   useEffect(() => {
     if (!autoScroll) return;

--- a/gui/frontend/src/hooks/useScreenshots.ts
+++ b/gui/frontend/src/hooks/useScreenshots.ts
@@ -375,37 +375,40 @@ export const useScreenshots = ({
   };
 
   // Delete a set of images
-  const deleteImageSet = async (images: ScreenshotImage[], label: string): Promise<ScreenshotImage[]> => {
-    if (images.length === 0) return [];
-    const deleter = globalThis.go?.guiapp?.App?.DeleteScreenshot;
-    if (!deleter || !path.trim()) {
-      return [] as ScreenshotImage[];
-    }
-    if (!globalThis.confirm(`Delete all ${label} images from the temp folder?`)) {
-      return [] as ScreenshotImage[];
-    }
-
-    const deleted: ScreenshotImage[] = [];
-    const failures: string[] = [];
-    for (const image of images) {
-      try {
-        await deleter(
-          path.trim(),
-          normalizeOverrides(idOverrideState?.overrides || {}),
-          normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-          image.Path
-        );
-        deleted.push(image);
-      } catch (err) {
-        failures.push(String(err));
+  const deleteImageSet = useCallback(
+    async (images: ScreenshotImage[], label: string): Promise<ScreenshotImage[]> => {
+      if (images.length === 0) return [];
+      const deleter = globalThis.go?.guiapp?.App?.DeleteScreenshot;
+      if (!deleter || !path.trim()) {
+        return [] as ScreenshotImage[];
       }
-    }
+      if (!globalThis.confirm(`Delete all ${label} images from the temp folder?`)) {
+        return [] as ScreenshotImage[];
+      }
 
-    if (failures.length > 0) {
-      setScreenshotsError(failures[0]);
-    }
-    return deleted;
-  };
+      const deleted: ScreenshotImage[] = [];
+      const failures: string[] = [];
+      for (const image of images) {
+        try {
+          await deleter(
+            path.trim(),
+            normalizeOverrides(idOverrideState?.overrides || {}),
+            normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+            image.Path
+          );
+          deleted.push(image);
+        } catch (err) {
+          failures.push(String(err));
+        }
+      }
+
+      if (failures.length > 0) {
+        setScreenshotsError(failures[0]);
+      }
+      return deleted;
+    },
+    [path, idOverrideState, releaseOverrideState]
+  );
 
   const deleteTrackerImageURL = useCallback(
     async (url: string) => {
@@ -639,7 +642,7 @@ export const useScreenshots = ({
     if (removedFinal) {
       await saveFinalSelections(finalImagesRef.current);
     }
-  }, [trackerImageURLs, handleDeleteTrackerImageURL]);
+  }, [trackerImageURLs, handleDeleteTrackerImageURL, saveFinalSelections]);
 
   // Reset all screenshot state
   const resetScreenshotState = useCallback(() => {

--- a/gui/frontend/src/hooks/useSettingsState.tsx
+++ b/gui/frontend/src/hooks/useSettingsState.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026, Audionut and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import type { ConfigMap, ConfigValue, FieldMeta } from "../types";
 import { formatLabel, normalizeDefaultTrackerList } from "../utils/settings";
@@ -460,10 +460,10 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
     setSettingsError(message);
   };
 
-  const clearSettingsStatus = () => {
+  const clearSettingsStatus = useCallback(() => {
     setSettingsError("");
     setSettingsSaved("");
-  };
+  }, []);
 
   const markSettingsSaved = (message: string) => {
     setSettingsSaved(message);
@@ -568,7 +568,7 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
     });
   };
 
-  const loadSettings = async () => {
+  const loadSettings = useCallback(async () => {
     clearSettingsStatus();
     const getConfig = globalThis.go?.guiapp?.App?.GetConfig;
     if (!getConfig) {
@@ -589,9 +589,9 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
     } finally {
       setSettingsLoading(false);
     }
-  };
+  }, [clearSettingsStatus]);
 
-  const loadDefaultConfig = async () => {
+  const loadDefaultConfig = useCallback(async () => {
     const getDefaultConfig = globalThis.go?.guiapp?.App?.GetDefaultConfig;
     if (!getDefaultConfig) {
       return;
@@ -603,9 +603,9 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
     } catch (err) {
       // Silently fail if we can't load default config; it's optional for tracker comparison
     }
-  };
+  }, []);
 
-  const loadKnownTrackers = async () => {
+  const loadKnownTrackers = useCallback(async () => {
     if (knownTrackersLoading) return;
     const listKnown = globalThis.go?.guiapp?.App?.ListKnownTrackers;
     if (!listKnown) return;
@@ -620,7 +620,7 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
     } finally {
       setKnownTrackersLoading(false);
     }
-  };
+  }, [knownTrackersLoading]);
 
   const handleSaveSettings = async () => {
     clearSettingsStatus();
@@ -649,25 +649,25 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
     if ((activeTab === "input" || activeTab === "settings" || activeTab === "logging" || activeTab === "upload" || activeTab === "upload_images") && !configData) {
       loadSettings();
     }
-  }, [activeTab, configData]);
+  }, [activeTab, configData, loadSettings]);
 
   useEffect(() => {
     if ((activeTab === "settings" || activeTab === "input" || activeTab === "upload") && !defaultConfig) {
       loadDefaultConfig();
     }
-  }, [activeTab, defaultConfig]);
+  }, [activeTab, defaultConfig, loadDefaultConfig]);
 
   useEffect(() => {
     if (activeTab === "settings" && knownTrackers.length === 0 && !knownTrackersLoading) {
       loadKnownTrackers();
     }
-  }, [activeTab, knownTrackers.length, knownTrackersLoading]);
+  }, [activeTab, knownTrackers.length, knownTrackersLoading, loadKnownTrackers]);
 
   useEffect(() => {
     if ((activeTab === "screenshots" || activeTab === "upload_images") && !configData) {
       loadSettings();
     }
-  }, [activeTab, configData]);
+  }, [activeTab, configData, loadSettings]);
 
   const advancedOpen = settingsAdvanced[settingsSection] ?? false;
   const showAdvancedToggle = (() => {
@@ -873,7 +873,7 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
    * - The baseline doesn't have the tracker
    * - It has Unknown keys (custom fields not in the schema)
    */
-  const isTrackerConfigured = (trackerName: string, trackerValue: ConfigMap): boolean => {
+  const isTrackerConfigured = useCallback((trackerName: string, trackerValue: ConfigMap): boolean => {
     if (!defaultConfig || typeof defaultConfig !== "object" || Array.isArray(defaultConfig)) {
       return true; // If we can't load defaults, assume it's configured
     }
@@ -933,7 +933,7 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
 
     // All fields match baseline exactly
     return false;
-  };
+  }, [defaultConfig]);
 
   const trackerSelectionNames = useMemo(() => {
     if (!configData || !configData.Trackers || typeof configData.Trackers !== "object" || Array.isArray(configData.Trackers)) {
@@ -962,7 +962,7 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
       )
       .map(([trackerName]) => trackerName)
       .sort((left, right) => left.localeCompare(right));
-  }, [configData, manualTrackerEntries, defaultConfig, isTrackerConfigured]);
+  }, [configData, manualTrackerEntries, isTrackerConfigured]);
 
   const renderTrackerSection = (advancedOpen: boolean) => {
     try {

--- a/gui/frontend/src/pages/input/index.tsx
+++ b/gui/frontend/src/pages/input/index.tsx
@@ -626,8 +626,8 @@ export default function InputPage(props: Props) {
     [preview.ExternalIDInfo]
   );
 
-  const tmdbCandidates = preview.ExternalIDCandidates?.TMDB || [];
-  const imdbCandidates = preview.ExternalIDCandidates?.IMDB || [];
+  const tmdbCandidates = useMemo(() => preview.ExternalIDCandidates?.TMDB || [], [preview.ExternalIDCandidates?.TMDB]);
+  const imdbCandidates = useMemo(() => preview.ExternalIDCandidates?.IMDB || [], [preview.ExternalIDCandidates?.IMDB]);
   const [candidatePreview, setCandidatePreview] = useState<{
     provider: "tmdb" | "imdb";
     candidate: ExternalIDCandidate;

--- a/gui/frontend/src/pages/playlist_selection/index.tsx
+++ b/gui/frontend/src/pages/playlist_selection/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026, Audionut and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { PlaylistInfo } from "../../types";
 import "./styles.css";
 
@@ -29,11 +29,7 @@ const PlaylistSelectionPage = ({
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
 
-  useEffect(() => {
-    discoverPlaylists();
-  }, [path]);
-
-  const discoverPlaylists = async () => {
+  const discoverPlaylists = useCallback(async () => {
     try {
       setLoading(true);
       setError("");
@@ -57,7 +53,11 @@ const PlaylistSelectionPage = ({
     } finally {
       setLoading(false);
     }
-  };
+  }, [path]);
+
+  useEffect(() => {
+    discoverPlaylists();
+  }, [discoverPlaylists]);
 
   const handleTogglePlaylist = (index: number) => {
     setUseAll(false);

--- a/internal/metadata/discparse/bdinfo.go
+++ b/internal/metadata/discparse/bdinfo.go
@@ -4,6 +4,7 @@
 package discparse
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -109,7 +110,7 @@ func ExtractPlaylistReports(text string, selected []string) ([]PlaylistReport, e
 		return nil, err
 	}
 	if len(blocks) == 0 {
-		return nil, fmt.Errorf("no playlist blocks found in BDInfo report")
+		return nil, errors.New("no playlist blocks found in BDInfo report")
 	}
 
 	reports := make([]PlaylistReport, 0, len(selected))

--- a/internal/metadata/discparse/bdinfo.go
+++ b/internal/metadata/discparse/bdinfo.go
@@ -5,9 +5,37 @@ package discparse
 
 import (
 	"fmt"
+	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 )
+
+var playlistReportHeaderPattern = regexp.MustCompile(`(?m)^\*{20}\r?\nPLAYLIST:\s+([^\r\n]+)\r?\n\*{20}`)
+
+type PlaylistReport struct {
+	Playlist   string
+	Raw        string
+	Summary    string
+	Files      string
+	ExtSummary string
+}
+
+func NormalizePlaylistName(name string) string {
+	trimmed := strings.TrimSpace(name)
+	trimmed = strings.ReplaceAll(trimmed, "\\", "/")
+	if idx := strings.LastIndex(trimmed, "/"); idx >= 0 {
+		trimmed = trimmed[idx+1:]
+	}
+	trimmed = strings.TrimSpace(trimmed)
+	if trimmed == "" {
+		return ""
+	}
+	if !strings.HasSuffix(strings.ToUpper(trimmed), ".MPLS") {
+		trimmed += ".MPLS"
+	}
+	return strings.ToUpper(filepath.Base(trimmed))
+}
 
 // SplitBDInfoReport extracts summary and files sections from a BDInfo report.
 func SplitBDInfoReport(text string) (summary string, files string, extSummary string) {
@@ -38,6 +66,75 @@ func SplitBDInfoReport(text string) (summary string, files string, extSummary st
 	}
 
 	return summary, files, extSummary
+}
+
+// SplitBDInfoPlaylistReports extracts each playlist section from a full BDInfo report.
+func SplitBDInfoPlaylistReports(text string) (map[string]string, error) {
+	matches := playlistReportHeaderPattern.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
+		return nil, nil
+	}
+
+	reports := make(map[string]string, len(matches))
+	for idx, match := range matches {
+		start := match[0]
+		end := len(text)
+		if idx+1 < len(matches) {
+			end = matches[idx+1][0]
+		}
+		name := NormalizePlaylistName(text[match[2]:match[3]])
+		if name == "" {
+			continue
+		}
+		if _, exists := reports[name]; exists {
+			return nil, fmt.Errorf("duplicate playlist block %s found in BDInfo report", name)
+		}
+		reports[name] = strings.TrimSpace(text[start:end])
+	}
+
+	if len(reports) == 0 {
+		return nil, nil
+	}
+	return reports, nil
+}
+
+// ExtractPlaylistReports returns selected playlist reports in selection order.
+func ExtractPlaylistReports(text string, selected []string) ([]PlaylistReport, error) {
+	if len(selected) == 0 {
+		return nil, nil
+	}
+
+	blocks, err := SplitBDInfoPlaylistReports(text)
+	if err != nil {
+		return nil, err
+	}
+	if len(blocks) == 0 {
+		return nil, fmt.Errorf("no playlist blocks found in BDInfo report")
+	}
+
+	reports := make([]PlaylistReport, 0, len(selected))
+	for _, selectedName := range selected {
+		normalized := NormalizePlaylistName(selectedName)
+		block, ok := blocks[normalized]
+		if !ok {
+			return nil, fmt.Errorf("playlist block %s not found in BDInfo report", normalized)
+		}
+
+		summary, files, extSummary := SplitBDInfoReport(block)
+		if strings.TrimSpace(summary) == "" {
+			return nil, fmt.Errorf("playlist block %s did not contain a quick summary", normalized)
+		}
+
+		reports = append(reports, PlaylistReport{
+			Playlist:   normalized,
+			Raw:        block,
+			Summary:    summary,
+			Files:      files,
+			ExtSummary: extSummary,
+		})
+	}
+
+	return reports, nil
 }
 
 // ParseBDInfoFiles parses the FILES section of a BDInfo report.

--- a/internal/metadata/discparse/bdinfo_test.go
+++ b/internal/metadata/discparse/bdinfo_test.go
@@ -3,7 +3,10 @@
 
 package discparse
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseBDInfoFiles(t *testing.T) {
 	input := "00001.m2ts        00:10:00     1,000,000,000  25.00 Mbps"
@@ -104,5 +107,102 @@ func TestSplitBDInfoReportExtSummaryUsesSecondCodeMarker(t *testing.T) {
 				t.Fatalf("expected %q, got %q", tt.want, got)
 			}
 		})
+	}
+}
+
+func TestNormalizePlaylistName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "00001", want: "00001.MPLS"},
+		{input: "00002.mpls", want: "00002.MPLS"},
+		{input: `BDMV\PLAYLIST\00003.mpls`, want: "00003.MPLS"},
+	}
+
+	for _, tt := range tests {
+		if got := NormalizePlaylistName(tt.input); got != tt.want {
+			t.Fatalf("normalize %q: expected %q, got %q", tt.input, tt.want, got)
+		}
+	}
+}
+
+func TestExtractPlaylistReports(t *testing.T) {
+	report := strings.Join([]string{
+		"header",
+		"********************",
+		"PLAYLIST: 00001.MPLS",
+		"********************",
+		"[code]",
+		"table one",
+		"[/code]",
+		"[code]",
+		"DISC INFO:",
+		"extended summary one",
+		"FILES:",
+		"-------------",
+		"00001.m2ts        00:10:00     1,000,000,000",
+		"CHAPTERS:",
+		"QUICK SUMMARY:",
+		"Playlist: 00001.MPLS",
+		"Disc Label: DISCONE",
+		"********************",
+		"FILES:",
+		"[/code]",
+		"********************",
+		"PLAYLIST: 00002.MPLS",
+		"********************",
+		"[code]",
+		"table two",
+		"[/code]",
+		"[code]",
+		"DISC INFO:",
+		"extended summary two",
+		"FILES:",
+		"-------------",
+		"00002.m2ts        00:20:00     2,000,000,000",
+		"CHAPTERS:",
+		"QUICK SUMMARY:",
+		"Playlist: 00002.MPLS",
+		"Disc Label: DISCTWO",
+		"********************",
+		"FILES:",
+		"[/code]",
+	}, "\n")
+
+	reports, err := ExtractPlaylistReports(report, []string{"00002.mpls", "00001"})
+	if err != nil {
+		t.Fatalf("extract reports: %v", err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("expected 2 reports, got %d", len(reports))
+	}
+	if reports[0].Playlist != "00002.MPLS" || !strings.Contains(reports[0].Summary, "DISCTWO") {
+		t.Fatalf("unexpected first report: %#v", reports[0])
+	}
+	if reports[1].Playlist != "00001.MPLS" || !strings.Contains(reports[1].ExtSummary, "extended summary one") {
+		t.Fatalf("unexpected second report: %#v", reports[1])
+	}
+}
+
+func TestSplitBDInfoPlaylistReportsErrorsOnDuplicateNormalizedPlaylist(t *testing.T) {
+	report := strings.Join([]string{
+		"********************",
+		"PLAYLIST: 00001.MPLS",
+		"********************",
+		"[code]",
+		"one",
+		"[/code]",
+		"********************",
+		"PLAYLIST: BDMV/PLAYLIST/00001",
+		"********************",
+		"[code]",
+		"two",
+		"[/code]",
+	}, "\n")
+
+	_, err := SplitBDInfoPlaylistReports(report)
+	if err == nil || !strings.Contains(err.Error(), "duplicate playlist block 00001.MPLS") {
+		t.Fatalf("expected duplicate playlist error, got %v", err)
 	}
 }

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -239,7 +240,10 @@ func loadBDInfo(meta api.PreparedMetadata, dbPath string) *discparse.BDInfo {
 	if err != nil {
 		return nil
 	}
-	path := filepath.Join(tmpDir, "BD_SUMMARY_00.txt")
+	path := paths.BDMVSummaryPath(tmpDir, paths.PrimaryBDMVPlaylist(meta))
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
 	payload, err := os.ReadFile(path)
 	if err != nil {
 		return nil
@@ -944,7 +948,10 @@ func videoEncodeFromMedia(doc mediaInfoDoc, typeValue string) (string, string, b
 }
 
 func editionFromMeta(meta api.PreparedMetadata) (string, string, bool) {
-	edition := strings.TrimSpace(meta.Edition)
+	edition := strings.TrimSpace(resolveMultiPlaylistEdition(meta))
+	if edition == "" {
+		edition = strings.TrimSpace(meta.Edition)
+	}
 	if edition == "" && len(meta.Release.Edition) > 0 {
 		edition = strings.TrimSpace(strings.Join(meta.Release.Edition, " "))
 	}
@@ -958,6 +965,77 @@ func editionFromMeta(meta api.PreparedMetadata) (string, string, bool) {
 		edition = strings.ReplaceAll(edition, "  ", " ")
 	}
 	return edition, repack, false
+}
+
+func resolveMultiPlaylistEdition(meta api.PreparedMetadata) string {
+	if !strings.EqualFold(strings.TrimSpace(meta.DiscType), "BDMV") {
+		return ""
+	}
+	if len(meta.SelectedBDMVPlaylists) < 2 || meta.ExternalMetadata.IMDB == nil || len(meta.ExternalMetadata.IMDB.EditionDetails) == 0 {
+		return ""
+	}
+
+	const leewaySeconds = 50.0
+	withAttributes := make(map[string]struct{})
+	withoutAttributes := false
+
+	for _, playlist := range meta.SelectedBDMVPlaylists {
+		if playlist.Duration <= 0 {
+			continue
+		}
+
+		var best *api.IMDBEditionDetail
+		bestDiff := leewaySeconds + 1
+		for _, detail := range meta.ExternalMetadata.IMDB.EditionDetails {
+			diff := absFloat(playlist.Duration - float64(detail.Seconds))
+			if diff > leewaySeconds {
+				continue
+			}
+			if best == nil || diff < bestDiff {
+				copy := detail
+				best = &copy
+				bestDiff = diff
+			}
+		}
+		if best == nil {
+			continue
+		}
+		if len(best.Attributes) > 0 {
+			name := strings.TrimSpace(strings.Join(best.Attributes, " "))
+			if name != "" {
+				withAttributes[name] = struct{}{}
+			}
+			continue
+		}
+		withoutAttributes = true
+	}
+
+	if len(withAttributes) == 0 {
+		return ""
+	}
+
+	editions := make([]string, 0, len(withAttributes)+1)
+	if withoutAttributes {
+		editions = append(editions, "Theatrical")
+	}
+	attributeNames := make([]string, 0, len(withAttributes))
+	for name := range withAttributes {
+		attributeNames = append(attributeNames, name)
+	}
+	sort.Strings(attributeNames)
+	editions = append(editions, attributeNames...)
+
+	if len(editions) == 1 {
+		return editions[0]
+	}
+	return fmt.Sprintf("%din1 %s", len(editions), strings.Join(editions, " / "))
+}
+
+func absFloat(value float64) float64 {
+	if value < 0 {
+		return -value
+	}
+	return value
 }
 
 func validateMediaInfoSettings(doc mediaInfoDoc) bool {

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -4,363 +4,80 @@
 package metadata
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-func TestContainerFromMetaDisc(t *testing.T) {
-	meta := api.PreparedMetadata{DiscType: "BDMV"}
-	if got := containerFromMeta(meta); got != "m2ts" {
-		t.Fatalf("expected m2ts, got %q", got)
-	}
-	meta.DiscType = "DVD"
-	if got := containerFromMeta(meta); got != "vob" {
-		t.Fatalf("expected vob, got %q", got)
-	}
-}
-
-func TestContainerFromMetaFileList(t *testing.T) {
-	dir := t.TempDir()
-	small := filepath.Join(dir, "small.mkv")
-	large := filepath.Join(dir, "large.mp4")
-	if err := os.WriteFile(small, []byte("small"), 0o600); err != nil {
-		t.Fatalf("write small: %v", err)
-	}
-	if err := os.WriteFile(large, []byte("this is larger"), 0o600); err != nil {
-		t.Fatalf("write large: %v", err)
-	}
-	meta := api.PreparedMetadata{FileList: []string{small, large}}
-	if got := containerFromMeta(meta); got != "mp4" {
-		t.Fatalf("expected mp4, got %q", got)
-	}
-}
-
-func TestVideoEncodeFromMedia(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Video", "Format": "AVC", "Format_Profile": "High 10", "Encoded_Library_Settings": "ref=4", "BitDepth": "10"},
-	}
-	encode, codec, hasSettings, bitDepth := videoEncodeFromMedia(doc, "ENCODE")
-	if encode != "Hi10P x264" {
-		t.Fatalf("expected Hi10P x264, got %q", encode)
-	}
-	if codec != "AVC" {
-		t.Fatalf("expected AVC, got %q", codec)
-	}
-	if !hasSettings {
-		t.Fatalf("expected encode settings true")
-	}
-	if bitDepth != "10" {
-		t.Fatalf("expected bit depth 10, got %q", bitDepth)
-	}
-}
-
-func TestVideoEncodeFromMediaMissingBitDepthDefaultsZero(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Video", "Format": "AVC", "Encoded_Library_Settings": "ref=4"},
-	}
-	_, _, _, bitDepth := videoEncodeFromMedia(doc, "ENCODE")
-	if bitDepth != "0" {
-		t.Fatalf("expected bit depth 0 when missing, got %q", bitDepth)
-	}
-}
-
-func TestVideoEncodeFromMediaMPEG4VisualTypeGating(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Video", "Format": "MPEG-4 Visual", "Encoded_Library_Name": "Xvid 1.3.7"},
-	}
-
-	encode, _, _, _ := videoEncodeFromMedia(doc, "ENCODE")
-	if encode != "XviD" {
-		t.Fatalf("expected XviD for ENCODE, got %q", encode)
-	}
-
-	encode, _, _, _ = videoEncodeFromMedia(doc, "WEBDL")
-	if encode != "" {
-		t.Fatalf("expected empty encode for WEBDL MPEG-4 Visual, got %q", encode)
-	}
-}
-
-func TestVideoEncodeFromMediaHDTVSettingsUseX264(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Video", "Format": "AVC", "Encoded_Library_Settings": "ref=4"},
-	}
-	encode, _, hasSettings, _ := videoEncodeFromMedia(doc, "HDTV")
-	if encode != "x264" {
-		t.Fatalf("expected x264 for HDTV with encode settings, got %q", encode)
-	}
-	if !hasSettings {
-		t.Fatalf("expected encode settings true")
-	}
-}
-
-func TestVideoEncodeFromMediaMPEGVideoCodecVersion(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Video", "Format": "MPEG Video", "Format_Version": "2"},
-	}
-	_, codec, _, _ := videoEncodeFromMedia(doc, "ENCODE")
-	if codec != "MPEG-2" {
-		t.Fatalf("expected MPEG-2 codec, got %q", codec)
-	}
-}
-
-func TestVideoEncodeFromMediaPassthroughCodecs(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Video", "Format": "AV1"},
-	}
-	encode, codec, _, _ := videoEncodeFromMedia(doc, "ENCODE")
-	if encode != "AV1" {
-		t.Fatalf("expected AV1 encode passthrough, got %q", encode)
-	}
-	if codec != "AV1" {
-		t.Fatalf("expected AV1 codec passthrough, got %q", codec)
-	}
-}
-
-func TestHDRFromMedia(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Video", "colour_primaries": "BT.2020", "HDR_Format": "HDR10+"},
-	}
-	if got := hdrFromMedia(doc, nil); got != "HDR10+" {
-		t.Fatalf("expected HDR10+, got %q", got)
-	}
-}
-
-func TestValidateMediaInfoSettings(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Audio", "Format": "AAC"},
-		{"@type": "Video", "Encoded_Library_Settings": "cabac=1"},
-	}
-	if !validateMediaInfoSettings(doc) {
-		t.Fatalf("expected mediainfo settings validation true")
-	}
-}
-
-func TestAudioFromMedia(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Audio", "Format_Commercial": "Dolby Digital Plus", "Channels": "6", "ChannelLayout": "L R C LFE Ls Rs"},
-	}
-	audio, channels, commentary := audioFromMedia(api.PreparedMetadata{}, doc, nil)
-	if audio != "DD+ 5.1" {
-		t.Fatalf("expected DD+ 5.1, got %q", audio)
-	}
-	if channels != "5.1" {
-		t.Fatalf("expected channels 5.1, got %q", channels)
-	}
-	if commentary {
-		t.Fatalf("expected commentary false")
-	}
-}
-
-func TestAudioFromMediaStreamOrderAndCompatibility(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Audio", "StreamOrder": "0", "Format": "DTS", "Format_AdditionalFeatures": "XLL", "Channels": "6", "ChannelLayout": "L R C LFE Ls Rs", "Title": "Compatibility Track"},
-		{"@type": "Audio", "StreamOrder": "1", "Format": "E-AC-3", "Channels": "6", "ChannelLayout": "L R C LFE Ls Rs"},
-		{"@type": "Audio", "StreamOrder": "2", "Format": "AAC", "Channels": "2", "ChannelLayout": "L R", "Title": "Director Commentary"},
-	}
-	audio, channels, commentary := audioFromMedia(api.PreparedMetadata{}, doc, nil)
-	if audio != "DD+ 5.1" {
-		t.Fatalf("expected DD+ 5.1, got %q", audio)
-	}
-	if channels != "5.1" {
-		t.Fatalf("expected channels 5.1, got %q", channels)
-	}
-	if !commentary {
-		t.Fatalf("expected commentary true when any commentary track exists")
-	}
-}
-
-func TestNormalizeAudioFormatMappings(t *testing.T) {
-	tests := []struct {
-		name     string
-		track    map[string]any
-		expected string
-	}{
-		{name: "ac3", track: map[string]any{"Format": "AC-3"}, expected: "DD"},
-		{name: "eac3", track: map[string]any{"Format": "E-AC-3"}, expected: "DD+"},
-		{name: "mlp-fba", track: map[string]any{"Format": "MLP FBA"}, expected: "TrueHD"},
-		{name: "flac", track: map[string]any{"Format": "FLAC"}, expected: "FLAC"},
-		{name: "opus", track: map[string]any{"Format": "Opus"}, expected: "Opus"},
-		{name: "vorbis", track: map[string]any{"Format": "Vorbis"}, expected: "VORBIS"},
-		{name: "pcm", track: map[string]any{"Format": "PCM"}, expected: "LPCM"},
-		{name: "dolby-plus-audio", track: map[string]any{"Format": "Dolby Digital Plus Audio"}, expected: "DD+"},
-		{name: "commercial-priority", track: map[string]any{"Format": "DTS", "Format_Commercial": "DTS-HD Master Audio"}, expected: "DTS-HD MA"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := normalizeAudioFormat(tt.track); got != tt.expected {
-				t.Fatalf("expected %q, got %q", tt.expected, got)
-			}
-		})
-	}
-}
-
-func TestAudioFromMediaDTSAudioExtraSuffixes(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Audio", "Format": "DTS", "Format_AdditionalFeatures": "XLL", "Channels": "6", "ChannelLayout": "L R C LFE Ls Rs"},
-	}
-	audio, _, _ := audioFromMedia(api.PreparedMetadata{}, doc, nil)
-	if audio != "DTS-HD MA 5.1" {
-		t.Fatalf("expected DTS-HD MA 5.1, got %q", audio)
-	}
-
-	doc.Media.Track = []map[string]any{
-		{"@type": "Audio", "Format": "DTS", "Format_AdditionalFeatures": "XLL X", "Channels": "6", "ChannelLayout": "L R C LFE Ls Rs"},
-	}
-	audio, _, _ = audioFromMedia(api.PreparedMetadata{}, doc, nil)
-	if audio != "DTS:X 5.1" {
-		t.Fatalf("expected DTS:X 5.1, got %q", audio)
-	}
-}
-
-func TestApplyDTSAudioAdditionalESRequiresExactMatch(t *testing.T) {
-	if got := applyDTSAudioAdditional("DTS", "ES"); got != "DTS-ES" {
-		t.Fatalf("expected DTS-ES, got %q", got)
-	}
-	if got := applyDTSAudioAdditional("DTS", "ES Matrix"); got != "DTS" {
-		t.Fatalf("expected DTS for non-exact ES additional feature, got %q", got)
-	}
-}
-
-func TestAudioFromMediaMPEGLayerDetection(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Audio", "Format": "MPEG Audio", "Format_Profile": "Layer 2", "Channels": "2", "ChannelLayout": "L R"},
-	}
-	audio, _, _ := audioFromMedia(api.PreparedMetadata{}, doc, nil)
-	if audio != "MP2 2.0" {
-		t.Fatalf("expected MP2 2.0, got %q", audio)
-	}
-
-	doc.Media.Track = []map[string]any{
-		{"@type": "Audio", "Format": "MPEG Audio", "Format_Profile": "Layer 3", "Channels": "2", "ChannelLayout": "L R"},
-	}
-	audio, _, _ = audioFromMedia(api.PreparedMetadata{}, doc, nil)
-	if audio != "MP3 2.0" {
-		t.Fatalf("expected MP3 2.0, got %q", audio)
-	}
-}
-
-func TestAudioFromMediaDDSevenPointOneCorrectsToDDPlus(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Audio", "Format": "AC-3", "Channels": "8", "ChannelLayout": "L R C LFE Ls Rs Lb Rb"},
-	}
-	audio, channels, _ := audioFromMedia(api.PreparedMetadata{}, doc, nil)
-	if channels != "7.1" {
-		t.Fatalf("expected channels 7.1, got %q", channels)
-	}
-	if audio != "DD+ 7.1" {
-		t.Fatalf("expected DD+ 7.1, got %q", audio)
-	}
-}
-
-func TestAudioFromMediaImmersiveIndicators(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Audio", "Format": "E-AC-3", "Format_AdditionalFeatures": "16-ch", "Channels": "8", "ChannelLayout": "L R C LFE Ls Rs Lb Rb"},
-	}
-	audio, _, _ := audioFromMedia(api.PreparedMetadata{}, doc, nil)
-	if audio != "DD+ Atmos 7.1" {
-		t.Fatalf("expected DD+ Atmos 7.1, got %q", audio)
-	}
-
-	doc.Media.Track = []map[string]any{
-		{"@type": "Audio", "Format": "DTS", "Channels": "6", "ChannelLayout": "L R C LFE Ls Rs", "Title": "Auro3D Presentation"},
-	}
-	audio, _, _ = audioFromMedia(api.PreparedMetadata{}, doc, nil)
-	if audio != "DTS Auro3D 5.1" {
-		t.Fatalf("expected DTS Auro3D 5.1, got %q", audio)
-	}
-
-	doc.Media.Track = []map[string]any{
-		{"@type": "Audio", "StreamOrder": "0", "Format": "DTS", "Channels": "6", "ChannelLayout": "L R C LFE Ls Rs", "Title": "Compatibility Track Auro3D"},
-		{"@type": "Audio", "StreamOrder": "1", "Format": "E-AC-3", "Channels": "6", "ChannelLayout": "L R C LFE Ls Rs"},
-	}
-	audio, _, _ = audioFromMedia(api.PreparedMetadata{}, doc, nil)
-	if audio != "DD+ Auro3D 5.1" {
-		t.Fatalf("expected DD+ Auro3D 5.1, got %q", audio)
-	}
-}
-
-func TestAudioFromMediaObjectBasedLayoutAssumesLFE(t *testing.T) {
-	doc := mediaInfoDoc{}
-	doc.Media.Track = []map[string]any{
-		{"@type": "Audio", "Format": "TrueHD", "Channels": "8", "ChannelLayout": "L R C Ls Rs Lb Rb Object Based"},
-	}
-
-	audio, channels, _ := audioFromMedia(api.PreparedMetadata{}, doc, nil)
-	if channels != "7.1" {
-		t.Fatalf("expected object-based layout to map to 7.1, got %q", channels)
-	}
-	if audio != "TrueHD 7.1" {
-		t.Fatalf("expected TrueHD 7.1, got %q", audio)
-	}
-}
-
-func TestResolveService(t *testing.T) {
-	meta := api.PreparedMetadata{SourcePath: "/data/Show.Name.2024.NF.WEB-DL.mkv"}
-	service, longName, filename := resolveService(meta)
-	if service != "NF" {
-		t.Fatalf("expected NF, got %q", service)
-	}
-	if longName != "Netflix" {
-		t.Fatalf("expected Netflix, got %q", longName)
-	}
-	if filename == "" {
-		t.Fatalf("expected filename to be populated")
-	}
-}
-
-func TestApplyMetadataOverrides(t *testing.T) {
-	distributor := "Criterion"
-	trueValue := true
-	falseValue := false
-
+func TestEditionFromMetaMultiPlaylistAggregatesIMDbMatches(t *testing.T) {
 	meta := api.PreparedMetadata{
-		Anime:           true,
-		StreamOptimized: 0,
-		MetadataOverrides: api.MetadataOverrides{
-			Distributor:     &distributor,
-			PersonalRelease: &trueValue,
-			Commentary:      &trueValue,
-			WebDV:           &trueValue,
-			StreamOptimized: &trueValue,
-			Anime:           &falseValue,
+		DiscType: "BDMV",
+		SelectedBDMVPlaylists: []api.PlaylistInfo{
+			{File: "00001.MPLS", Duration: 7200},
+			{File: "00002.MPLS", Duration: 7500},
+		},
+		ExternalMetadata: api.ExternalMetadata{
+			IMDB: &api.IMDBMetadata{
+				EditionDetails: map[string]api.IMDBEditionDetail{
+					"120": {DisplayName: "2h", Seconds: 7200, Minutes: 120},
+					"125": {DisplayName: "2h 5m", Seconds: 7500, Minutes: 125, Attributes: []string{"Extended"}},
+				},
+			},
 		},
 	}
 
-	applyMetadataOverrides(&meta)
+	edition, repack, hybrid := editionFromMeta(meta)
+	if edition != "2in1 Theatrical / Extended" {
+		t.Fatalf("expected aggregated edition, got %q", edition)
+	}
+	if repack != "" || hybrid {
+		t.Fatalf("expected no repack/hybrid, got %q %t", repack, hybrid)
+	}
+}
 
-	if meta.Distributor != "Criterion" {
-		t.Fatalf("expected distributor override, got %q", meta.Distributor)
+func TestEditionFromMetaMultiPlaylistDeduplicatesMatches(t *testing.T) {
+	meta := api.PreparedMetadata{
+		DiscType: "BDMV",
+		SelectedBDMVPlaylists: []api.PlaylistInfo{
+			{File: "00001.MPLS", Duration: 7200},
+			{File: "00002.MPLS", Duration: 7205},
+		},
+		ExternalMetadata: api.ExternalMetadata{
+			IMDB: &api.IMDBMetadata{
+				EditionDetails: map[string]api.IMDBEditionDetail{
+					"120": {DisplayName: "2h", Seconds: 7200, Minutes: 120, Attributes: []string{"Director's Cut"}},
+				},
+			},
+		},
 	}
-	if !meta.PersonalRelease {
-		t.Fatalf("expected personal release override")
+
+	edition, _, _ := editionFromMeta(meta)
+	if edition != "Director's Cut" {
+		t.Fatalf("expected deduped edition, got %q", edition)
 	}
-	if !meta.HasCommentary {
-		t.Fatalf("expected commentary override")
+}
+
+func TestEditionFromMetaMultiPlaylistFallsBackWhenNoIMDbMatch(t *testing.T) {
+	meta := api.PreparedMetadata{
+		DiscType: "BDMV",
+		SelectedBDMVPlaylists: []api.PlaylistInfo{
+			{File: "00001.MPLS", Duration: 7200},
+			{File: "00002.MPLS", Duration: 7500},
+		},
+		Release: api.ReleaseInfo{
+			Edition: []string{"Collector's", "Edition"},
+		},
+		ExternalMetadata: api.ExternalMetadata{
+			IMDB: &api.IMDBMetadata{
+				EditionDetails: map[string]api.IMDBEditionDetail{
+					"90": {DisplayName: "1h 30m", Seconds: 5400, Minutes: 90, Attributes: []string{"Extended"}},
+				},
+			},
+		},
 	}
-	if !meta.WebDV {
-		t.Fatalf("expected webdv override")
-	}
-	if meta.StreamOptimized != 1 {
-		t.Fatalf("expected stream override to set 1, got %d", meta.StreamOptimized)
-	}
-	if meta.Anime {
-		t.Fatalf("expected anime override to set false")
+
+	edition, _, _ := editionFromMeta(meta)
+	if edition != "Collector's Edition" {
+		t.Fatalf("expected fallback edition, got %q", edition)
 	}
 }

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/filesystem"
+	"github.com/autobrr/upbrr/internal/metadata/discparse"
 	"github.com/autobrr/upbrr/internal/metadata/mediainfo"
 	"github.com/autobrr/upbrr/internal/metadata/seasonep"
 	"github.com/autobrr/upbrr/internal/paths"
@@ -44,6 +46,34 @@ type Service struct {
 	radarr   ArrLookupClient
 	tracker  TrackerDataLookup
 }
+
+type cachedBDMVSummary struct {
+	Playlist    string
+	Summary     string
+	ExtSummary  string
+	SummaryPath string
+	ExtPath     string
+}
+
+type bdmvSummaryCache struct {
+	Entries map[string]cachedBDMVSummary
+}
+
+var bdmvSummaryPlaylistPattern = regexp.MustCompile(`(?mi)^Playlist:\s*(.+?)\s*$`)
+
+var (
+	discoverBDMVPlaylists = filesystem.DiscoverPlaylists
+	parseBDMVPlaylist     = filesystem.ParseMPLS
+	executePlaylistBDInfo = func(svc *bdinfo.Service, ctx context.Context, bdmvPath string, playlistFile string, outputPath string) (string, error) {
+		return svc.ExecuteForPlaylist(ctx, bdmvPath, playlistFile, outputPath)
+	}
+	executeFullBDInfoScan = func(svc *bdinfo.Service, ctx context.Context, bdmvPath string, outputDir string) (bdinfo.ScanResult, error) {
+		return svc.ExecuteFullScan(ctx, bdmvPath, outputDir)
+	}
+	parseBDInfoOutput = func(svc *bdinfo.Service, filePath string) (map[string]interface{}, error) {
+		return svc.ParseOutput(filePath)
+	}
+)
 
 type TrackerDataLookup interface {
 	Lookup(
@@ -359,6 +389,12 @@ func (s *Service) Prepare(ctx context.Context, req api.Request) (api.PreparedMet
 
 		if found && len(sel.SelectedPlaylists) > 0 {
 			s.logger.Debugf("metadata: found playlist selection with %d playlists at %s", len(sel.SelectedPlaylists), playlistPath)
+			selectedPlaylists, derr := loadSelectedBDMVPlaylists(ctx, playlistPath, sel.SelectedPlaylists)
+			if derr != nil {
+				return api.PreparedMetadata{}, fmt.Errorf("metadata: discover selected playlists: %w", derr)
+			}
+			meta.SelectedBDMVPlaylists = selectedPlaylists
+			selectedPlaylistNames := playlistNames(meta.SelectedBDMVPlaylists)
 
 			// Execute BDInfo on selected playlists
 			if s.bdinfo != nil {
@@ -374,30 +410,29 @@ func (s *Service) Prepare(ctx context.Context, req api.Request) (api.PreparedMet
 				if err := os.MkdirAll(tmpDir, 0755); err != nil {
 					return api.PreparedMetadata{}, fmt.Errorf("metadata: create bdinfo temp dir: %w", err)
 				}
-				// Execute bdinfo on first selected playlist
-				if len(sel.SelectedPlaylists) > 0 {
-					playlistName := sel.SelectedPlaylists[0]
-					s.logger.Debugf("metadata: executing bdinfo for playlist %s in path %s", playlistName, playlistPath)
 
-					outputPath, berr := s.bdinfo.ExecuteForPlaylist(ctx, playlistPath, playlistName, tmpDir)
-					if berr != nil {
-						return api.PreparedMetadata{}, fmt.Errorf("metadata: bdinfo execution failed: %w", berr)
-					}
-					// Parse bdinfo output
-					s.logger.Debugf("metadata: parsing bdinfo output from %s", outputPath)
-					bdinfoParsed, perr := s.bdinfo.ParseOutput(outputPath)
+				outputPath, needScan, berr := s.resolveOrCreateBDMVSummaries(ctx, req, tmpDir, playlistPath, selectedPlaylistNames)
+				if berr != nil {
+					return api.PreparedMetadata{}, berr
+				}
+				if strings.TrimSpace(outputPath) != "" {
+					s.logger.Debugf("metadata: parsing canonical bdinfo output from %s", outputPath)
+					bdinfoParsed, perr := parseBDInfoOutput(s.bdinfo, outputPath)
 					if perr != nil {
 						return api.PreparedMetadata{}, fmt.Errorf("metadata: bdinfo parse failed: %w", perr)
 					}
 					meta.BDInfo = bdinfoParsed
 					s.logger.Debugf("metadata: bdinfo data collected with %d fields", len(bdinfoParsed))
 				}
+				if needScan {
+					s.logger.Debugf("metadata: bdinfo scan completed for %d selected playlists", len(selectedPlaylistNames))
+				}
 			} else {
 				s.logger.Debugf("metadata: bdinfo service is nil, skipping disc analysis")
 			}
 
 			// Extract m2ts files from selected playlist(s)
-			m2tsFiles, mainFile, err := s.extractM2TSFromPlaylist(ctx, playlistPath, sel.SelectedPlaylists)
+			m2tsFiles, mainFile, err := s.extractM2TSFromPlaylist(ctx, playlistPath, selectedPlaylistNames)
 			if err != nil {
 				s.logger.Debugf("metadata: failed to extract m2ts from playlist: %v", err)
 				// Fall back to regular disc handling
@@ -657,7 +692,7 @@ func (s *Service) extractM2TSFromPlaylist(ctx context.Context, bdmvPath string, 
 		}
 
 		// Parse the playlist file
-		duration, items, err := filesystem.ParseMPLS(playlistPath)
+		duration, items, err := parseBDMVPlaylist(playlistPath)
 		if err != nil {
 			s.logger.Debugf("metadata: failed to parse playlist %s: %v", playlistFile, err)
 			continue
@@ -691,6 +726,231 @@ func (s *Service) extractM2TSFromPlaylist(ctx context.Context, bdmvPath string, 
 
 	s.logger.Debugf("metadata: extracted %d m2ts files from playlists, largest is %s (%d bytes)", len(m2tsFiles), filepath.Base(largestFile), largestSize)
 	return m2tsFiles, largestFile, nil
+}
+
+func loadSelectedBDMVPlaylists(ctx context.Context, bdmvPath string, selected []string) ([]api.PlaylistInfo, error) {
+	discovered, err := discoverBDMVPlaylists(ctx, bdmvPath)
+	if err != nil {
+		return nil, err
+	}
+
+	byName := make(map[string]filesystem.PlaylistInfo, len(discovered))
+	for _, playlist := range discovered {
+		byName[discparse.NormalizePlaylistName(playlist.File)] = playlist
+	}
+
+	result := make([]api.PlaylistInfo, 0, len(selected))
+	for _, name := range selected {
+		normalized := discparse.NormalizePlaylistName(name)
+		playlist, ok := byName[normalized]
+		if !ok {
+			return nil, fmt.Errorf("selected playlist %s was not found during discovery", normalized)
+		}
+		items := make([]api.PlaylistItem, 0, len(playlist.Items))
+		for _, item := range playlist.Items {
+			items = append(items, api.PlaylistItem{
+				File: item.File,
+				Size: item.Size,
+			})
+		}
+		result = append(result, api.PlaylistInfo{
+			File:     playlist.File,
+			Duration: playlist.Duration,
+			Items:    items,
+			Score:    playlist.Score,
+			Edition:  playlist.Edition,
+		})
+	}
+
+	return result, nil
+}
+
+func playlistNames(playlists []api.PlaylistInfo) []string {
+	names := make([]string, 0, len(playlists))
+	for _, playlist := range playlists {
+		normalized := discparse.NormalizePlaylistName(playlist.File)
+		if normalized == "" {
+			continue
+		}
+		names = append(names, normalized)
+	}
+	return names
+}
+
+func writeSelectedPlaylistSummaries(tmpDir string, fullReport string, selected []string) (string, error) {
+	reports, err := discparse.ExtractPlaylistReports(fullReport, selected)
+	if err != nil {
+		return "", err
+	}
+	if len(reports) == 0 {
+		return "", errors.New("no selected playlist reports extracted")
+	}
+
+	rawPath := filepath.Join(tmpDir, "BD_FULL.txt")
+	if err := os.WriteFile(rawPath, []byte(fullReport), 0o600); err != nil {
+		return "", fmt.Errorf("write full report: %w", err)
+	}
+
+	for _, report := range reports {
+		summaryPath := paths.BDMVSummaryPath(tmpDir, report.Playlist)
+		if err := os.WriteFile(summaryPath, []byte(strings.TrimSpace(report.Summary)+"\n"), 0o600); err != nil {
+			return "", fmt.Errorf("write summary %s: %w", report.Playlist, err)
+		}
+
+		extSidecarPath := paths.BDMVExtSummaryPath(tmpDir, report.Playlist)
+		if err := os.WriteFile(extSidecarPath, []byte(strings.TrimSpace(report.ExtSummary)+"\n"), 0o600); err != nil {
+			return "", fmt.Errorf("write extended summary %s: %w", report.Playlist, err)
+		}
+	}
+
+	return paths.BDMVSummaryPath(tmpDir, reports[0].Playlist), nil
+}
+
+func writeCachedSelectedPlaylistSummaries(tmpDir string, cache bdmvSummaryCache, selected []string) (string, error) {
+	if len(selected) == 0 {
+		return "", errors.New("no selected playlists")
+	}
+	entry, ok := cache.Entries[discparse.NormalizePlaylistName(selected[0])]
+	if !ok {
+		return "", fmt.Errorf("cached summary for %s not found", selected[0])
+	}
+	return entry.SummaryPath, nil
+}
+
+func discoverBDMVSummaryCache(tmpDir string) (bdmvSummaryCache, error) {
+	cache := bdmvSummaryCache{Entries: map[string]cachedBDMVSummary{}}
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cache, nil
+		}
+		return cache, fmt.Errorf("read tmp dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, "BD_SUMMARY_") || strings.HasPrefix(name, "BD_SUMMARY_EXT_") || !strings.HasSuffix(name, ".txt") {
+			continue
+		}
+		playlistFromName := paths.BDMVPlaylistKey(strings.TrimSuffix(strings.TrimPrefix(name, "BD_SUMMARY_"), ".txt"))
+		if playlistFromName == "" {
+			continue
+		}
+		summaryPath := filepath.Join(tmpDir, name)
+		summaryPayload, err := os.ReadFile(summaryPath)
+		if err != nil {
+			return bdmvSummaryCache{}, fmt.Errorf("read cached summary %s: %w", name, err)
+		}
+		playlist := parsePlaylistFromSummaryText(string(summaryPayload))
+		if playlist == "" {
+			continue
+		}
+		if playlist != playlistFromName {
+			return bdmvSummaryCache{}, fmt.Errorf("cached summary filename %s does not match playlist %s", name, playlist)
+		}
+		if _, exists := cache.Entries[playlist]; exists {
+			return bdmvSummaryCache{}, fmt.Errorf("duplicate cached playlist summary for %s", playlist)
+		}
+		extPath := paths.BDMVExtSummaryPath(tmpDir, playlist)
+		extPayload := ""
+		if rawExt, err := os.ReadFile(extPath); err == nil {
+			extPayload = string(rawExt)
+		}
+		cache.Entries[playlist] = cachedBDMVSummary{
+			Playlist:    playlist,
+			Summary:     string(summaryPayload),
+			ExtSummary:  extPayload,
+			SummaryPath: summaryPath,
+			ExtPath:     extPath,
+		}
+	}
+
+	return cache, nil
+}
+
+func parsePlaylistFromSummaryText(summary string) string {
+	matches := bdmvSummaryPlaylistPattern.FindStringSubmatch(summary)
+	if len(matches) != 2 {
+		return ""
+	}
+	return discparse.NormalizePlaylistName(matches[1])
+}
+
+func missingCachedPlaylists(cache bdmvSummaryCache, selected []string) []string {
+	var missing []string
+	for _, playlist := range selected {
+		normalized := discparse.NormalizePlaylistName(playlist)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := cache.Entries[normalized]; !ok {
+			missing = append(missing, normalized)
+		}
+	}
+	return missing
+}
+
+func cachedPlaylistNames(cache bdmvSummaryCache) []string {
+	names := make([]string, 0, len(cache.Entries))
+	for name := range cache.Entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (s *Service) resolveOrCreateBDMVSummaries(ctx context.Context, req api.Request, tmpDir string, playlistPath string, selected []string) (string, bool, error) {
+	cache, err := discoverBDMVSummaryCache(tmpDir)
+	if err != nil {
+		return "", false, fmt.Errorf("metadata: discover bdmv tmp cache: %w", err)
+	}
+
+	missing := missingCachedPlaylists(cache, selected)
+	switch {
+	case len(selected) > 0 && len(missing) == 0:
+		outputPath, err := writeCachedSelectedPlaylistSummaries(tmpDir, cache, selected)
+		if err != nil {
+			return "", false, fmt.Errorf("metadata: refresh cached bdmv summaries: %w", err)
+		}
+		return outputPath, false, nil
+	case len(missing) > 0 && len(missing) < len(selected):
+		if req.Options.InteractionMode == api.InteractionModeUnattended || req.ConfirmBDMVRescan {
+			// proceed to rescan
+		} else {
+			return "", false, &api.BDMVRescanRequiredError{
+				SourcePath:        req.Paths[0],
+				SelectedPlaylists: append([]string(nil), selected...),
+				CachedPlaylists:   cachedPlaylistNames(cache),
+				MissingPlaylists:  missing,
+			}
+		}
+	case len(selected) > 0 && len(missing) == len(selected):
+		// No selected playlists are cached, so we need a fresh scan.
+	}
+
+	if len(selected) > 1 {
+		s.logger.Debugf("metadata: executing full-disc bdinfo for %d selected playlists", len(selected))
+		scanResult, berr := executeFullBDInfoScan(s.bdinfo, ctx, playlistPath, tmpDir)
+		if berr != nil {
+			return "", false, fmt.Errorf("metadata: bdinfo full scan failed: %w", berr)
+		}
+		outputPath, werr := writeSelectedPlaylistSummaries(tmpDir, scanResult.ReportText, selected)
+		if werr != nil {
+			return "", false, fmt.Errorf("metadata: derive playlist summaries: %w", werr)
+		}
+		return outputPath, true, nil
+	}
+
+	playlistName := selected[0]
+	s.logger.Debugf("metadata: executing bdinfo for playlist %s in path %s", playlistName, playlistPath)
+	outputPath, berr := executePlaylistBDInfo(s.bdinfo, ctx, playlistPath, playlistName, paths.BDMVSummaryPath(tmpDir, playlistName))
+	if berr != nil {
+		return "", false, fmt.Errorf("metadata: bdinfo execution failed: %w", berr)
+	}
+	return outputPath, true, nil
 }
 
 func metadataFingerprintMatches(primary string, current api.PreparedMetadata, stored db.FileMetadata) bool {

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -856,8 +856,14 @@ func discoverBDMVSummaryCache(tmpDir string) (bdmvSummaryCache, error) {
 		}
 		extPath := paths.BDMVExtSummaryPath(tmpDir, playlist)
 		extPayload := ""
-		if rawExt, err := os.ReadFile(extPath); err == nil {
-			extPayload = string(rawExt)
+		if extPath != "" {
+			cleanTmpDir := filepath.Clean(tmpDir)
+			cleanExtPath := filepath.Clean(extPath)
+			if relPath, err := filepath.Rel(cleanTmpDir, cleanExtPath); err == nil && relPath != ".." && !strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+				if rawExt, err := os.ReadFile(cleanExtPath); err == nil {
+					extPayload = string(rawExt)
+				}
+			}
 		}
 		cache.Entries[playlist] = cachedBDMVSummary{
 			Playlist:    playlist,

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -8,12 +8,18 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	"github.com/autobrr/upbrr/internal/filesystem"
 	"github.com/autobrr/upbrr/internal/metadata/mediainfo"
+	"github.com/autobrr/upbrr/internal/paths"
+	"github.com/autobrr/upbrr/internal/services/bdinfo"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -135,9 +141,538 @@ func TestResolveServiceDarkroom(t *testing.T) {
 	}
 }
 
+func TestPrepareBDMVMultiPlaylistUsesFullScanAndDerivesSummaries(t *testing.T) {
+	base := t.TempDir()
+	sourcePath := filepath.Join(base, "disc")
+	bdmvPath := filepath.Join(sourcePath, "BDMV")
+	if err := os.MkdirAll(filepath.Join(bdmvPath, "PLAYLIST"), 0o755); err != nil {
+		t.Fatalf("mkdir playlist failed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(bdmvPath, "STREAM"), 0o755); err != nil {
+		t.Fatalf("mkdir stream failed: %v", err)
+	}
+
+	repo := &stubRepo{
+		playlistSelection: db.PlaylistSelection{
+			SelectedPlaylists: []string{"00002.MPLS", "00001.MPLS"},
+		},
+		playlistSelectionPath: filepath.ToSlash(filepath.Clean(filepath.Join(sourcePath, "BDMV"))),
+	}
+	cfg := config.Config{MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(base, "db.sqlite")}}
+	service := NewService(repo, WithMediaInfoExporter(&stubMediaInfo{}), WithSceneDetector(stubSceneDetector{}), WithConfig(cfg), WithBDInfoService(bdinfo.New(api.NopLogger{})))
+
+	originalDiscover := discoverBDMVPlaylists
+	originalParse := parseBDMVPlaylist
+	originalFullScan := executeFullBDInfoScan
+	originalPlaylistScan := executePlaylistBDInfo
+	originalParseOutput := parseBDInfoOutput
+	t.Cleanup(func() {
+		discoverBDMVPlaylists = originalDiscover
+		parseBDMVPlaylist = originalParse
+		executeFullBDInfoScan = originalFullScan
+		executePlaylistBDInfo = originalPlaylistScan
+		parseBDInfoOutput = originalParseOutput
+	})
+
+	discoverBDMVPlaylists = func(ctx context.Context, root string) ([]filesystem.PlaylistInfo, error) {
+		return []filesystem.PlaylistInfo{
+			{File: "00001.MPLS", Duration: 5400},
+			{File: "00002.MPLS", Duration: 6000},
+		}, nil
+	}
+	parseBDMVPlaylist = func(mplsPath string) (float64, []filesystem.PlaylistItem, error) {
+		switch filepath.Base(strings.ToUpper(mplsPath)) {
+		case "00001.MPLS":
+			return 5400, []filesystem.PlaylistItem{
+				{File: "00001.m2ts", Size: 100},
+				{File: "00002.m2ts", Size: 150},
+			}, nil
+		case "00002.MPLS":
+			return 6000, []filesystem.PlaylistItem{
+				{File: "00002.m2ts", Size: 150},
+				{File: "00003.m2ts", Size: 200},
+			}, nil
+		default:
+			return 0, nil, errors.New("unexpected playlist")
+		}
+	}
+
+	fullReport := strings.Join([]string{
+		"header",
+		"********************",
+		"PLAYLIST: 00002.MPLS",
+		"********************",
+		"[code]",
+		"table two",
+		"[/code]",
+		"[code]",
+		"DISC INFO:",
+		"extended summary two",
+		"FILES:",
+		"-------------",
+		"00003.m2ts        01:40:00     2,000,000,000",
+		"CHAPTERS:",
+		"QUICK SUMMARY:",
+		"Playlist: 00002.MPLS",
+		"Disc Label: DISC-TWO",
+		"Length: 01:40:00.000",
+		"********************",
+		"FILES:",
+		"[/code]",
+		"********************",
+		"PLAYLIST: 00001.MPLS",
+		"********************",
+		"[code]",
+		"table one",
+		"[/code]",
+		"[code]",
+		"DISC INFO:",
+		"extended summary one",
+		"FILES:",
+		"-------------",
+		"00001.m2ts        01:30:00     1,000,000,000",
+		"CHAPTERS:",
+		"QUICK SUMMARY:",
+		"Playlist: 00001.MPLS",
+		"Disc Label: DISC-ONE",
+		"Length: 01:30:00.000",
+		"********************",
+		"FILES:",
+		"[/code]",
+	}, "\n")
+
+	fullScans := 0
+	playlistScans := 0
+	executeFullBDInfoScan = func(svc *bdinfo.Service, ctx context.Context, bdmvPath string, outputDir string) (bdinfo.ScanResult, error) {
+		fullScans++
+		return bdinfo.ScanResult{
+			ReportPath: filepath.Join(outputDir, "BD_FULL.txt"),
+			ReportText: fullReport,
+		}, nil
+	}
+	executePlaylistBDInfo = func(svc *bdinfo.Service, ctx context.Context, bdmvPath string, playlistFile string, outputDir string) (string, error) {
+		playlistScans++
+		return "", errors.New("unexpected playlist scan")
+	}
+	parseBDInfoOutput = func(svc *bdinfo.Service, filePath string) (map[string]interface{}, error) {
+		payload, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"summary": string(payload)}, nil
+	}
+
+	meta, err := service.Prepare(context.Background(), api.Request{
+		Paths: []string{sourcePath},
+		Mode:  api.ModeCLI,
+	})
+	if err != nil {
+		t.Fatalf("prepare failed: %v", err)
+	}
+
+	if fullScans != 1 {
+		t.Fatalf("expected 1 full scan, got %d", fullScans)
+	}
+	if playlistScans != 0 {
+		t.Fatalf("expected 0 playlist scans, got %d", playlistScans)
+	}
+	if got, want := meta.VideoPath, filepath.Join(bdmvPath, "STREAM", "00003.m2ts"); got != want {
+		t.Fatalf("expected main file %q, got %q", want, got)
+	}
+	wantFiles := []string{
+		filepath.Join(bdmvPath, "STREAM", "00001.m2ts"),
+		filepath.Join(bdmvPath, "STREAM", "00002.m2ts"),
+		filepath.Join(bdmvPath, "STREAM", "00003.m2ts"),
+	}
+	if !reflect.DeepEqual(sortedStrings(meta.FileList), sortedStrings(wantFiles)) {
+		t.Fatalf("unexpected file list: %#v", meta.FileList)
+	}
+	if len(meta.SelectedBDMVPlaylists) != 2 || meta.SelectedBDMVPlaylists[0].File != "00002.MPLS" || meta.SelectedBDMVPlaylists[1].File != "00001.MPLS" {
+		t.Fatalf("unexpected selected playlists: %#v", meta.SelectedBDMVPlaylists)
+	}
+
+	tmpRoot, err := db.Subdir(cfg.MainSettings.DBPath, "tmp")
+	if err != nil {
+		t.Fatalf("tmp root: %v", err)
+	}
+	tmpDir, _, err := paths.ReleaseTempDir(tmpRoot, meta, sourcePath)
+	if err != nil {
+		t.Fatalf("tmp dir: %v", err)
+	}
+
+	assertFileContains(t, paths.BDMVSummaryPath(tmpDir, "00002.MPLS"), "Playlist: 00002.MPLS")
+	assertFileContains(t, paths.BDMVSummaryPath(tmpDir, "00001.MPLS"), "Playlist: 00001.MPLS")
+	assertFileContains(t, paths.BDMVExtSummaryPath(tmpDir, "00002.MPLS"), "extended summary two")
+	assertFileContains(t, paths.BDMVExtSummaryPath(tmpDir, "00001.MPLS"), "extended summary one")
+	assertFileContains(t, filepath.Join(tmpDir, "BD_FULL.txt"), "PLAYLIST: 00002.MPLS")
+}
+
+func TestLoadSelectedBDMVPlaylistsErrorsWhenRequestedPlaylistMissing(t *testing.T) {
+	originalDiscover := discoverBDMVPlaylists
+	t.Cleanup(func() {
+		discoverBDMVPlaylists = originalDiscover
+	})
+
+	discoverBDMVPlaylists = func(ctx context.Context, root string) ([]filesystem.PlaylistInfo, error) {
+		return []filesystem.PlaylistInfo{
+			{File: "00001.MPLS", Duration: 5400},
+		}, nil
+	}
+
+	_, err := loadSelectedBDMVPlaylists(context.Background(), `D:\Disc\BDMV`, []string{"00001.MPLS", "00002.MPLS"})
+	if err == nil || !strings.Contains(err.Error(), "00002.MPLS") {
+		t.Fatalf("expected missing playlist error for 00002.MPLS, got %v", err)
+	}
+}
+
+func TestDiscoverBDMVSummaryCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeBDMVSummaryFixture(t, tmpDir, "00002.MPLS", "extended summary two")
+	writeBDMVSummaryFixture(t, tmpDir, "00001.MPLS", "extended summary one")
+
+	cache, err := discoverBDMVSummaryCache(tmpDir)
+	if err != nil {
+		t.Fatalf("discover cache: %v", err)
+	}
+	if len(cache.Entries) != 2 {
+		t.Fatalf("expected 2 cache entries, got %d", len(cache.Entries))
+	}
+	if got := cache.Entries["00002.MPLS"].ExtPath; got != paths.BDMVExtSummaryPath(tmpDir, "00002.MPLS") {
+		t.Fatalf("expected playlist ext path, got %q", got)
+	}
+	if got := strings.TrimSpace(cache.Entries["00001.MPLS"].ExtSummary); got != "extended summary one" {
+		t.Fatalf("unexpected ext summary: %q", got)
+	}
+}
+
+func TestDiscoverBDMVSummaryCacheIgnoresMalformedSummary(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(paths.BDMVSummaryPath(tmpDir, "00001.MPLS"), []byte("Disc Label: BROKEN\n"), 0o600); err != nil {
+		t.Fatalf("write malformed summary: %v", err)
+	}
+
+	cache, err := discoverBDMVSummaryCache(tmpDir)
+	if err != nil {
+		t.Fatalf("discover cache: %v", err)
+	}
+	if len(cache.Entries) != 0 {
+		t.Fatalf("expected malformed summary to be ignored, got %#v", cache.Entries)
+	}
+}
+
+func TestDiscoverBDMVSummaryCacheErrorsOnDuplicatePlaylist(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeBDMVSummaryFixture(t, tmpDir, "00002.MPLS", "extended summary two")
+	if err := os.WriteFile(filepath.Join(tmpDir, "BD_SUMMARY_00002.txt"), []byte(strings.Join([]string{
+		"Disc Title: Example",
+		"Disc Label: BDMV",
+		"Playlist: 00002.MPLS",
+		"Length: 01:30:00.000",
+	}, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write duplicate summary fixture: %v", err)
+	}
+
+	_, err := discoverBDMVSummaryCache(tmpDir)
+	if err == nil || !strings.Contains(err.Error(), "duplicate cached playlist summary for 00002.MPLS") {
+		t.Fatalf("expected duplicate cache error, got %v", err)
+	}
+}
+
+func TestPrepareBDMVUsesCachedSummariesWithoutRescan(t *testing.T) {
+	base := t.TempDir()
+	sourcePath := filepath.Join(base, "disc")
+	bdmvPath := filepath.Join(sourcePath, "BDMV")
+	if err := os.MkdirAll(filepath.Join(bdmvPath, "PLAYLIST"), 0o755); err != nil {
+		t.Fatalf("mkdir playlist failed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(bdmvPath, "STREAM"), 0o755); err != nil {
+		t.Fatalf("mkdir stream failed: %v", err)
+	}
+
+	repo := &stubRepo{
+		playlistSelection: db.PlaylistSelection{
+			SelectedPlaylists: []string{"00002.MPLS", "00001.MPLS"},
+		},
+		playlistSelectionPath: filepath.ToSlash(filepath.Clean(filepath.Join(sourcePath, "BDMV"))),
+	}
+	cfg := config.Config{MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(base, "db.sqlite")}}
+	service := NewService(repo, WithMediaInfoExporter(&stubMediaInfo{}), WithSceneDetector(stubSceneDetector{}), WithConfig(cfg), WithBDInfoService(bdinfo.New(api.NopLogger{})))
+
+	originalDiscover := discoverBDMVPlaylists
+	originalParse := parseBDMVPlaylist
+	originalFullScan := executeFullBDInfoScan
+	originalPlaylistScan := executePlaylistBDInfo
+	originalParseOutput := parseBDInfoOutput
+	t.Cleanup(func() {
+		discoverBDMVPlaylists = originalDiscover
+		parseBDMVPlaylist = originalParse
+		executeFullBDInfoScan = originalFullScan
+		executePlaylistBDInfo = originalPlaylistScan
+		parseBDInfoOutput = originalParseOutput
+	})
+
+	discoverBDMVPlaylists = func(ctx context.Context, root string) ([]filesystem.PlaylistInfo, error) {
+		return []filesystem.PlaylistInfo{
+			{File: "00001.MPLS", Duration: 5400},
+			{File: "00002.MPLS", Duration: 6000},
+		}, nil
+	}
+	parseBDMVPlaylist = func(mplsPath string) (float64, []filesystem.PlaylistItem, error) {
+		switch filepath.Base(strings.ToUpper(mplsPath)) {
+		case "00001.MPLS":
+			return 5400, []filesystem.PlaylistItem{
+				{File: "00001.m2ts", Size: 100},
+				{File: "00002.m2ts", Size: 150},
+			}, nil
+		case "00002.MPLS":
+			return 6000, []filesystem.PlaylistItem{
+				{File: "00002.m2ts", Size: 150},
+				{File: "00003.m2ts", Size: 200},
+			}, nil
+		default:
+			return 0, nil, errors.New("unexpected playlist")
+		}
+	}
+	fullScans := 0
+	playlistScans := 0
+	executeFullBDInfoScan = func(svc *bdinfo.Service, ctx context.Context, bdmvPath string, outputDir string) (bdinfo.ScanResult, error) {
+		fullScans++
+		return bdinfo.ScanResult{}, errors.New("unexpected full scan")
+	}
+	executePlaylistBDInfo = func(svc *bdinfo.Service, ctx context.Context, bdmvPath string, playlistFile string, outputDir string) (string, error) {
+		playlistScans++
+		return "", errors.New("unexpected playlist scan")
+	}
+	parseBDInfoOutput = func(svc *bdinfo.Service, filePath string) (map[string]interface{}, error) {
+		payload, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"summary": string(payload)}, nil
+	}
+
+	tmpRoot, err := db.Subdir(cfg.MainSettings.DBPath, "tmp")
+	if err != nil {
+		t.Fatalf("tmp root: %v", err)
+	}
+	tmpDir, _, err := paths.ReleaseTempDir(tmpRoot, api.PreparedMetadata{}, sourcePath)
+	if err != nil {
+		t.Fatalf("tmp dir: %v", err)
+	}
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		t.Fatalf("mkdir tmp dir: %v", err)
+	}
+	writeBDMVSummaryFixture(t, tmpDir, "00001.MPLS", "extended summary one")
+	writeBDMVSummaryFixture(t, tmpDir, "00002.MPLS", "extended summary two")
+
+	meta, err := service.Prepare(context.Background(), api.Request{
+		Paths: []string{sourcePath},
+		Mode:  api.ModeCLI,
+	})
+	if err != nil {
+		t.Fatalf("prepare failed: %v", err)
+	}
+
+	if fullScans != 0 {
+		t.Fatalf("expected no full scan, got %d", fullScans)
+	}
+	if playlistScans != 0 {
+		t.Fatalf("expected no playlist scan, got %d", playlistScans)
+	}
+	assertFileContains(t, paths.BDMVSummaryPath(tmpDir, "00002.MPLS"), "Playlist: 00002.MPLS")
+	assertFileContains(t, paths.BDMVSummaryPath(tmpDir, "00001.MPLS"), "Playlist: 00001.MPLS")
+	assertFileContains(t, paths.BDMVExtSummaryPath(tmpDir, "00002.MPLS"), "extended summary two")
+	if got := meta.BDInfo["summary"]; !strings.Contains(got.(string), "Playlist: 00002.MPLS") {
+		t.Fatalf("expected cached canonical summary for first selected playlist, got %#v", meta.BDInfo)
+	}
+}
+
+func TestPrepareBDMVPartialCacheRequiresConfirmation(t *testing.T) {
+	base := t.TempDir()
+	sourcePath := filepath.Join(base, "disc")
+	bdmvPath := filepath.Join(sourcePath, "BDMV")
+	if err := os.MkdirAll(filepath.Join(bdmvPath, "PLAYLIST"), 0o755); err != nil {
+		t.Fatalf("mkdir playlist failed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(bdmvPath, "STREAM"), 0o755); err != nil {
+		t.Fatalf("mkdir stream failed: %v", err)
+	}
+
+	repo := &stubRepo{
+		playlistSelection: db.PlaylistSelection{
+			SelectedPlaylists: []string{"00002.MPLS", "00001.MPLS"},
+		},
+		playlistSelectionPath: filepath.ToSlash(filepath.Clean(filepath.Join(sourcePath, "BDMV"))),
+	}
+	cfg := config.Config{MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(base, "db.sqlite")}}
+	service := NewService(repo, WithMediaInfoExporter(&stubMediaInfo{}), WithSceneDetector(stubSceneDetector{}), WithConfig(cfg), WithBDInfoService(bdinfo.New(api.NopLogger{})))
+
+	originalDiscover := discoverBDMVPlaylists
+	t.Cleanup(func() {
+		discoverBDMVPlaylists = originalDiscover
+	})
+	discoverBDMVPlaylists = func(ctx context.Context, root string) ([]filesystem.PlaylistInfo, error) {
+		return []filesystem.PlaylistInfo{
+			{File: "00001.MPLS", Duration: 5400},
+			{File: "00002.MPLS", Duration: 6000},
+		}, nil
+	}
+
+	tmpRoot, err := db.Subdir(cfg.MainSettings.DBPath, "tmp")
+	if err != nil {
+		t.Fatalf("tmp root: %v", err)
+	}
+	tmpDir, _, err := paths.ReleaseTempDir(tmpRoot, api.PreparedMetadata{}, sourcePath)
+	if err != nil {
+		t.Fatalf("tmp dir: %v", err)
+	}
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		t.Fatalf("mkdir tmp dir: %v", err)
+	}
+	writeBDMVSummaryFixture(t, tmpDir, "00001.MPLS", "extended summary one")
+
+	_, err = service.Prepare(context.Background(), api.Request{
+		Paths:   []string{sourcePath},
+		Mode:    api.ModeCLI,
+		Options: api.UploadOptions{InteractionMode: api.InteractionModeInteractive},
+	})
+	var rescanErr *api.BDMVRescanRequiredError
+	if !errors.As(err, &rescanErr) {
+		t.Fatalf("expected rescan confirmation error, got %v", err)
+	}
+	if !reflect.DeepEqual(rescanErr.MissingPlaylists, []string{"00002.MPLS"}) {
+		t.Fatalf("unexpected missing playlists: %#v", rescanErr.MissingPlaylists)
+	}
+}
+
+func TestPrepareBDMVPartialCacheRescansWhenConfirmed(t *testing.T) {
+	base := t.TempDir()
+	sourcePath := filepath.Join(base, "disc")
+	bdmvPath := filepath.Join(sourcePath, "BDMV")
+	if err := os.MkdirAll(filepath.Join(bdmvPath, "PLAYLIST"), 0o755); err != nil {
+		t.Fatalf("mkdir playlist failed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(bdmvPath, "STREAM"), 0o755); err != nil {
+		t.Fatalf("mkdir stream failed: %v", err)
+	}
+
+	repo := &stubRepo{
+		playlistSelection: db.PlaylistSelection{
+			SelectedPlaylists: []string{"00002.MPLS", "00001.MPLS"},
+		},
+		playlistSelectionPath: filepath.ToSlash(filepath.Clean(filepath.Join(sourcePath, "BDMV"))),
+	}
+	cfg := config.Config{MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(base, "db.sqlite")}}
+	service := NewService(repo, WithMediaInfoExporter(&stubMediaInfo{}), WithSceneDetector(stubSceneDetector{}), WithConfig(cfg), WithBDInfoService(bdinfo.New(api.NopLogger{})))
+
+	originalDiscover := discoverBDMVPlaylists
+	originalParse := parseBDMVPlaylist
+	originalFullScan := executeFullBDInfoScan
+	originalParseOutput := parseBDInfoOutput
+	t.Cleanup(func() {
+		discoverBDMVPlaylists = originalDiscover
+		parseBDMVPlaylist = originalParse
+		executeFullBDInfoScan = originalFullScan
+		parseBDInfoOutput = originalParseOutput
+	})
+	discoverBDMVPlaylists = func(ctx context.Context, root string) ([]filesystem.PlaylistInfo, error) {
+		return []filesystem.PlaylistInfo{
+			{File: "00001.MPLS", Duration: 5400},
+			{File: "00002.MPLS", Duration: 6000},
+		}, nil
+	}
+	parseBDMVPlaylist = func(mplsPath string) (float64, []filesystem.PlaylistItem, error) {
+		return 6000, []filesystem.PlaylistItem{{File: "00003.m2ts", Size: 200}}, nil
+	}
+	fullReport := strings.Join([]string{
+		"********************",
+		"PLAYLIST: 00002.MPLS",
+		"********************",
+		"[code]",
+		"table two",
+		"[/code]",
+		"[code]",
+		"DISC INFO:",
+		"extended summary two",
+		"FILES:",
+		"-------------",
+		"00003.m2ts        01:40:00     2,000,000,000",
+		"CHAPTERS:",
+		"QUICK SUMMARY:",
+		"Playlist: 00002.MPLS",
+		"Disc Label: DISC-TWO",
+		"********************",
+		"FILES:",
+		"[/code]",
+		"********************",
+		"PLAYLIST: 00001.MPLS",
+		"********************",
+		"[code]",
+		"table one",
+		"[/code]",
+		"[code]",
+		"DISC INFO:",
+		"extended summary one",
+		"FILES:",
+		"-------------",
+		"00001.m2ts        01:30:00     1,000,000,000",
+		"CHAPTERS:",
+		"QUICK SUMMARY:",
+		"Playlist: 00001.MPLS",
+		"Disc Label: DISC-ONE",
+		"********************",
+		"FILES:",
+		"[/code]",
+	}, "\n")
+	fullScans := 0
+	executeFullBDInfoScan = func(svc *bdinfo.Service, ctx context.Context, bdmvPath string, outputDir string) (bdinfo.ScanResult, error) {
+		fullScans++
+		return bdinfo.ScanResult{
+			ReportPath: filepath.Join(outputDir, "BD_FULL.txt"),
+			ReportText: fullReport,
+		}, nil
+	}
+	parseBDInfoOutput = func(svc *bdinfo.Service, filePath string) (map[string]interface{}, error) {
+		payload, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]interface{}{"summary": string(payload)}, nil
+	}
+
+	tmpRoot, err := db.Subdir(cfg.MainSettings.DBPath, "tmp")
+	if err != nil {
+		t.Fatalf("tmp root: %v", err)
+	}
+	tmpDir, _, err := paths.ReleaseTempDir(tmpRoot, api.PreparedMetadata{}, sourcePath)
+	if err != nil {
+		t.Fatalf("tmp dir: %v", err)
+	}
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		t.Fatalf("mkdir tmp dir: %v", err)
+	}
+	writeBDMVSummaryFixture(t, tmpDir, "00001.MPLS", "extended summary one")
+
+	_, err = service.Prepare(context.Background(), api.Request{
+		Paths:             []string{sourcePath},
+		Mode:              api.ModeCLI,
+		ConfirmBDMVRescan: true,
+		Options:           api.UploadOptions{InteractionMode: api.InteractionModeInteractive},
+	})
+	if err != nil {
+		t.Fatalf("prepare failed: %v", err)
+	}
+	if fullScans != 1 {
+		t.Fatalf("expected 1 full scan after confirmation, got %d", fullScans)
+	}
+	assertFileContains(t, paths.BDMVSummaryPath(tmpDir, "00002.MPLS"), "Playlist: 00002.MPLS")
+}
+
 type stubRepo struct {
-	saved    db.FileMetadata
-	existing db.FileMetadata
+	saved                 db.FileMetadata
+	existing              db.FileMetadata
+	playlistSelection     db.PlaylistSelection
+	playlistSelectionPath string
 }
 
 type stubMediaInfo struct{}
@@ -302,7 +837,10 @@ func (s *stubRepo) DeleteUploadedImage(context.Context, string, string, string) 
 	return internalerrors.ErrNotImplemented
 }
 
-func (s *stubRepo) GetPlaylistSelection(context.Context, string) (db.PlaylistSelection, error) {
+func (s *stubRepo) GetPlaylistSelection(_ context.Context, path string) (db.PlaylistSelection, error) {
+	if len(s.playlistSelection.SelectedPlaylists) > 0 && (s.playlistSelectionPath == "" || s.playlistSelectionPath == path) {
+		return s.playlistSelection, nil
+	}
 	return db.PlaylistSelection{}, internalerrors.ErrNotImplemented
 }
 
@@ -320,4 +858,39 @@ func (s *stubRepo) ListStoredReleasePaths(context.Context) ([]string, error) {
 
 func (s *stubRepo) PurgeContentData(context.Context, string) error {
 	return internalerrors.ErrNotImplemented
+}
+
+func sortedStrings(values []string) []string {
+	cloned := append([]string(nil), values...)
+	slices.Sort(cloned)
+	return cloned
+}
+
+func assertFileContains(t *testing.T, path string, want string) {
+	t.Helper()
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(payload), want) {
+		t.Fatalf("expected %s to contain %q, got %q", path, want, string(payload))
+	}
+}
+
+func writeBDMVSummaryFixture(t *testing.T, tmpDir string, playlist string, extSummary string) {
+	t.Helper()
+	summaryPath := paths.BDMVSummaryPath(tmpDir, playlist)
+	summary := strings.Join([]string{
+		"Disc Title: Example",
+		"Disc Label: BDMV",
+		"Playlist: " + playlist,
+		"Length: 01:30:00.000",
+	}, "\n") + "\n"
+	if err := os.WriteFile(summaryPath, []byte(summary), 0o600); err != nil {
+		t.Fatalf("write summary fixture: %v", err)
+	}
+	extPath := paths.BDMVExtSummaryPath(tmpDir, playlist)
+	if err := os.WriteFile(extPath, []byte(extSummary+"\n"), 0o600); err != nil {
+		t.Fatalf("write ext fixture: %v", err)
+	}
 }

--- a/internal/paths/bdinfo.go
+++ b/internal/paths/bdinfo.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package paths
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+
+	"github.com/autobrr/upbrr/internal/metadata/discparse"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func BDMVPlaylistKey(playlist string) string {
+	return discparse.NormalizePlaylistName(playlist)
+}
+
+func BDMVSummaryFilename(playlist string) string {
+	key := BDMVPlaylistKey(playlist)
+	if key == "" {
+		return ""
+	}
+	return "BD_SUMMARY_" + key + ".txt"
+}
+
+func BDMVExtSummaryFilename(playlist string) string {
+	key := BDMVPlaylistKey(playlist)
+	if key == "" {
+		return ""
+	}
+	return "BD_SUMMARY_EXT_" + key + ".txt"
+}
+
+func BDMVSummaryPath(tmpDir string, playlist string) string {
+	filename := BDMVSummaryFilename(playlist)
+	if filename == "" {
+		return ""
+	}
+	return filepath.Join(strings.TrimSpace(tmpDir), filename)
+}
+
+func BDMVExtSummaryPath(tmpDir string, playlist string) string {
+	filename := BDMVExtSummaryFilename(playlist)
+	if filename == "" {
+		return ""
+	}
+	return filepath.Join(strings.TrimSpace(tmpDir), filename)
+}
+
+func PrimaryBDMVPlaylist(meta api.PreparedMetadata) string {
+	if len(meta.SelectedBDMVPlaylists) == 0 {
+		return ""
+	}
+	return BDMVPlaylistKey(meta.SelectedBDMVPlaylists[0].File)
+}
+
+func PrimaryBDMVSummaryPath(tmpRoot string, meta api.PreparedMetadata) (string, error) {
+	playlist := PrimaryBDMVPlaylist(meta)
+	if playlist == "" {
+		return "", nil
+	}
+	tmpDir, _, err := ReleaseTempDir(tmpRoot, meta, meta.SourcePath)
+	if err != nil {
+		return "", err
+	}
+	path := BDMVSummaryPath(tmpDir, playlist)
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("paths: missing primary bdmv playlist summary path")
+	}
+	return path, nil
+}
+
+func PrimaryBDMVExtSummaryPath(tmpRoot string, meta api.PreparedMetadata) (string, error) {
+	playlist := PrimaryBDMVPlaylist(meta)
+	if playlist == "" {
+		return "", nil
+	}
+	tmpDir, _, err := ReleaseTempDir(tmpRoot, meta, meta.SourcePath)
+	if err != nil {
+		return "", err
+	}
+	path := BDMVExtSummaryPath(tmpDir, playlist)
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("paths: missing primary bdmv ext summary path")
+	}
+	return path, nil
+}

--- a/internal/services/bdinfo/service.go
+++ b/internal/services/bdinfo/service.go
@@ -21,6 +21,7 @@ type runRequest struct {
 	PlaylistName string
 	ReportPath   string
 	Reporter     ProgressReporter
+	SummaryOnly  bool
 }
 
 var runBDInfo = func(ctx context.Context, req runRequest) (bdrunner.Result, error) {
@@ -30,6 +31,7 @@ var runBDInfo = func(ctx context.Context, req runRequest) (bdrunner.Result, erro
 	settings.SummaryOnly = true
 	settings.GenerateTextSummary = true
 	settings.PlaylistOnly = req.PlaylistName
+	settings.SummaryOnly = req.SummaryOnly
 
 	var reporter func(bdrunner.ProgressEvent)
 	if req.Reporter != nil {
@@ -97,6 +99,12 @@ type Service struct {
 	logger api.Logger
 }
 
+// ScanResult contains the rendered report payload and its persisted location.
+type ScanResult struct {
+	ReportPath string
+	ReportText string
+}
+
 type progressReporterKey struct{}
 
 // ProgressReporter receives raw BDInfo progress lines.
@@ -139,33 +147,48 @@ func New(logger api.Logger) *Service {
 	return &Service{logger: logger}
 }
 
-// ExecuteForPlaylist runs the embedded Go BDInfo scanner for a specific playlist and returns the output path.
-func (s *Service) ExecuteForPlaylist(ctx context.Context, bdmvPath string, playlistFile string, outputDir string) (string, error) {
-	if err := ctx.Err(); err != nil {
+// ExecuteForPlaylist runs the embedded Go BDInfo scanner for a specific playlist and writes to the caller-provided path.
+func (s *Service) ExecuteForPlaylist(ctx context.Context, bdmvPath string, playlistFile string, outputPath string) (string, error) {
+	result, err := s.execute(ctx, bdmvPath, normalizePlaylistSelector(playlistFile), outputPath, true)
+	if err != nil {
 		return "", err
 	}
+	return result.ReportPath, nil
+}
+
+// ExecuteFullScan runs the embedded Go BDInfo scanner for the full disc and returns the raw report.
+func (s *Service) ExecuteFullScan(ctx context.Context, bdmvPath string, outputDir string) (ScanResult, error) {
+	return s.execute(ctx, bdmvPath, "", filepath.Join(outputDir, "BD_FULL.txt"), false)
+}
+
+func (s *Service) execute(ctx context.Context, bdmvPath string, playlistName string, outputPath string, summaryOnly bool) (ScanResult, error) {
+	if err := ctx.Err(); err != nil {
+		return ScanResult{}, err
+	}
 	reporter := progressReporterFromContext(ctx)
+	outputDir := filepath.Dir(outputPath)
 
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		return "", fmt.Errorf("bdinfo: create output dir: %w", err)
+		return ScanResult{}, fmt.Errorf("bdinfo: create output dir: %w", err)
 	}
 
-	s.logger.Debugf("bdinfo: bdmvPath=%s, playlistFile=%s, outputDir=%s", bdmvPath, playlistFile, outputDir)
-
-	playlistName := normalizePlaylistSelector(playlistFile)
-	s.logger.Debugf("bdinfo: normalized playlist name: %s", playlistName)
-
-	outputPath := filepath.Join(outputDir, "BD_SUMMARY_00.txt")
-	s.logger.Debugf("bdinfo: running in-process for playlist %s", playlistName)
+	s.logger.Debugf("bdinfo: bdmvPath=%s, playlistFile=%s, outputDir=%s", bdmvPath, playlistName, filepath.Dir(outputPath))
+	if playlistName != "" {
+		s.logger.Debugf("bdinfo: normalized playlist name: %s", playlistName)
+		s.logger.Debugf("bdinfo: running in-process for playlist %s", playlistName)
+	} else {
+		s.logger.Debugf("bdinfo: running in-process full-disc scan")
+	}
 	result, err := runBDInfo(ctx, runRequest{
 		BDMVPath:     bdmvPath,
 		PlaylistName: playlistName,
 		ReportPath:   outputPath,
 		Reporter:     reporter,
+		SummaryOnly:  summaryOnly,
 	})
 	if err != nil {
 		s.logger.Debugf("bdinfo: in-process execution failed: %v", err)
-		return "", fmt.Errorf("bdinfo: execution failed: %w", err)
+		return ScanResult{}, fmt.Errorf("bdinfo: execution failed: %w", err)
 	}
 	if strings.TrimSpace(result.ReportPath) != "" {
 		outputPath = result.ReportPath
@@ -173,21 +196,28 @@ func (s *Service) ExecuteForPlaylist(ctx context.Context, bdmvPath string, playl
 
 	reportText := result.Report
 	if strings.TrimSpace(reportText) == "" {
-		return "", errors.New("bdinfo: empty report content")
+		return ScanResult{}, errors.New("bdinfo: empty report content")
 	}
 
 	if err := os.WriteFile(outputPath, []byte(reportText), 0o600); err != nil {
-		return "", fmt.Errorf("bdinfo: write output: %w", err)
+		return ScanResult{}, fmt.Errorf("bdinfo: write output: %w", err)
 	}
 
-	s.logger.Debugf("bdinfo: successfully completed for playlist %s", playlistFile)
+	if playlistName != "" {
+		s.logger.Debugf("bdinfo: successfully completed for playlist %s", playlistName)
+	} else {
+		s.logger.Debugf("bdinfo: successfully completed full-disc scan")
+	}
 
 	if _, err := os.Stat(outputPath); err != nil {
-		return "", fmt.Errorf("bdinfo: output not found: %w", err)
+		return ScanResult{}, fmt.Errorf("bdinfo: output not found: %w", err)
 	}
 
 	s.logger.Debugf("bdinfo: output file found at %s", outputPath)
-	return outputPath, nil
+	return ScanResult{
+		ReportPath: outputPath,
+		ReportText: reportText,
+	}, nil
 }
 
 // ParseOutput parses BDInfo output and returns structured data

--- a/internal/services/bdinfo/service_test.go
+++ b/internal/services/bdinfo/service_test.go
@@ -96,7 +96,7 @@ func TestContextCancellation(t *testing.T) {
 	cancel() // Cancel immediately
 
 	// ExecuteForPlaylist should respect context cancellation
-	_, err := svc.ExecuteForPlaylist(ctx, "/nonexistent", "00001.mpls", "/nonexistent")
+	_, err := svc.ExecuteForPlaylist(ctx, "/nonexistent", "00001.mpls", "/nonexistent/BD_SUMMARY_00001.MPLS.txt")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context canceled, got %v", err)
 	}
@@ -104,8 +104,7 @@ func TestContextCancellation(t *testing.T) {
 
 func TestExecuteForPlaylistUsesInProcessRunner(t *testing.T) {
 	tmpDir := t.TempDir()
-	outputDir := filepath.Join(tmpDir, "out")
-	expectedOutput := filepath.Join(outputDir, "BD_SUMMARY_00.txt")
+	expectedOutput := filepath.Join(tmpDir, "out", "BD_SUMMARY_00001.MPLS.txt")
 
 	var captured runRequest
 	originalRunner := runBDInfo
@@ -125,7 +124,7 @@ func TestExecuteForPlaylistUsesInProcessRunner(t *testing.T) {
 	ctx := WithProgressReporter(context.Background(), func(_ string) {
 		reported = true
 	})
-	outputPath, err := svc.ExecuteForPlaylist(ctx, `D:\Media\Movie\BDMV`, "00001", outputDir)
+	outputPath, err := svc.ExecuteForPlaylist(ctx, `D:\Media\Movie\BDMV`, "00001", expectedOutput)
 	if err != nil {
 		t.Fatalf("execute failed: %v", err)
 	}
@@ -143,6 +142,9 @@ func TestExecuteForPlaylistUsesInProcessRunner(t *testing.T) {
 	if captured.ReportPath != expectedOutput {
 		t.Fatalf("expected output path in runner request, got: %s", captured.ReportPath)
 	}
+	if !captured.SummaryOnly {
+		t.Fatalf("expected summary-only mode for playlist scans")
+	}
 	if captured.Reporter == nil {
 		t.Fatalf("expected reporter to be passed to runner")
 	}
@@ -151,9 +153,46 @@ func TestExecuteForPlaylistUsesInProcessRunner(t *testing.T) {
 	}
 }
 
-func TestExecuteForPlaylistNormalizesLowercaseAndPathPlaylist(t *testing.T) {
+func TestExecuteFullScanUsesFullReportMode(t *testing.T) {
 	tmpDir := t.TempDir()
 	outputDir := filepath.Join(tmpDir, "out")
+	expectedOutput := filepath.Join(outputDir, "BD_FULL.txt")
+
+	var captured runRequest
+	originalRunner := runBDInfo
+	runBDInfo = func(ctx context.Context, req runRequest) (bdrunner.Result, error) {
+		captured = req
+		return bdrunner.Result{
+			Report:     "full report content",
+			ReportPath: req.ReportPath,
+		}, nil
+	}
+	t.Cleanup(func() {
+		runBDInfo = originalRunner
+	})
+
+	svc := New(api.NopLogger{})
+	result, err := svc.ExecuteFullScan(context.Background(), `D:\Media\Movie\BDMV`, outputDir)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+
+	if result.ReportPath != expectedOutput {
+		t.Fatalf("expected output %s, got %s", expectedOutput, result.ReportPath)
+	}
+	if result.ReportText != "full report content" {
+		t.Fatalf("unexpected report text: %q", result.ReportText)
+	}
+	if captured.PlaylistName != "" {
+		t.Fatalf("expected no playlist filter for full scan, got %q", captured.PlaylistName)
+	}
+	if captured.SummaryOnly {
+		t.Fatalf("expected full report mode for multi-playlist scans")
+	}
+}
+
+func TestExecuteForPlaylistNormalizesLowercaseAndPathPlaylist(t *testing.T) {
+	tmpDir := t.TempDir()
 
 	tests := []struct {
 		name         string
@@ -181,7 +220,8 @@ func TestExecuteForPlaylistNormalizesLowercaseAndPathPlaylist(t *testing.T) {
 			})
 
 			svc := New(api.NopLogger{})
-			if _, err := svc.ExecuteForPlaylist(context.Background(), `D:\Media\Movie\BDMV`, tc.playlistFile, outputDir); err != nil {
+			outputPath := filepath.Join(tmpDir, tc.want+".txt")
+			if _, err := svc.ExecuteForPlaylist(context.Background(), `D:\Media\Movie\BDMV`, tc.playlistFile, outputPath); err != nil {
 				t.Fatalf("execute failed: %v", err)
 			}
 

--- a/internal/services/description/hdb/builder.go
+++ b/internal/services/description/hdb/builder.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -86,7 +85,10 @@ func buildDiscSection(meta api.PreparedMetadata, dbPath string) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	path := filepath.Join(tmpDir, "BD_SUMMARY_00.txt")
+	path := paths.BDMVSummaryPath(tmpDir, paths.PrimaryBDMVPlaylist(meta))
+	if strings.TrimSpace(path) == "" {
+		return "", nil
+	}
 	content, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/services/description/mtv/builder.go
+++ b/internal/services/description/mtv/builder.go
@@ -6,7 +6,6 @@ package mtv
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -114,7 +113,10 @@ func resolveBDInfoPath(meta api.PreparedMetadata, dbPath string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	path := filepath.Join(tmpDir, "BD_SUMMARY_00.txt")
+	path := paths.BDMVSummaryPath(tmpDir, paths.PrimaryBDMVPlaylist(meta))
+	if strings.TrimSpace(path) == "" {
+		return "", nil
+	}
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
 			return "", nil

--- a/internal/services/screenshots/helpers.go
+++ b/internal/services/screenshots/helpers.go
@@ -250,7 +250,10 @@ func loadBDInfo(tmpRoot string, meta api.PreparedMetadata) (*discparse.BDInfo, e
 	if err != nil {
 		return nil, err
 	}
-	path := filepath.Join(tmpDir, "BD_SUMMARY_00.txt")
+	path := paths.BDMVSummaryPath(tmpDir, paths.PrimaryBDMVPlaylist(meta))
+	if strings.TrimSpace(path) == "" {
+		return nil, nil
+	}
 	payload, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err

--- a/internal/trackers/impl/ar/upload.go
+++ b/internal/trackers/impl/ar/upload.go
@@ -647,7 +647,7 @@ func readBDSummary(meta api.PreparedMetadata, dbPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return readTextFile(filepath.Join(tmpDir, "BD_SUMMARY_00.txt"))
+	return readTextFile(paths.BDMVSummaryPath(tmpDir, paths.PrimaryBDMVPlaylist(meta)))
 }
 
 func resolveFailurePath(meta api.PreparedMetadata, dbPath string) (string, error) {

--- a/internal/trackers/impl/asc/description.go
+++ b/internal/trackers/impl/asc/description.go
@@ -229,7 +229,7 @@ func readBDSummary(meta api.PreparedMetadata, dbPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return readTextFile(filepath.Join(tmpDir, "BD_SUMMARY_00.txt"))
+	return readTextFile(paths.BDMVSummaryPath(tmpDir, paths.PrimaryBDMVPlaylist(meta)))
 }
 
 func sanitizeDescriptionNotes(value string) string {

--- a/internal/trackers/impl/bhd/description.go
+++ b/internal/trackers/impl/bhd/description.go
@@ -6,7 +6,6 @@ package bhd
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/autobrr/upbrr/internal/config"
@@ -162,7 +161,7 @@ func readBDInfoNoErr(dbPath string, meta api.PreparedMetadata) string {
 	if err != nil {
 		return ""
 	}
-	return readTextFileNoErr(filepath.Join(tmpDir, "BD_SUMMARY_00.txt"))
+	return readTextFileNoErr(paths.BDMVSummaryPath(tmpDir, paths.PrimaryBDMVPlaylist(meta)))
 }
 
 func hasGroup(tag string, name string) bool {

--- a/internal/trackers/impl/bhd/upload.go
+++ b/internal/trackers/impl/bhd/upload.go
@@ -310,7 +310,7 @@ func resolveMediaPath(meta api.PreparedMetadata, dbPath string) string {
 		if err != nil {
 			return ""
 		}
-		return filepath.Join(tmpDir, "BD_SUMMARY_00.txt")
+		return paths.BDMVSummaryPath(tmpDir, paths.PrimaryBDMVPlaylist(meta))
 	default:
 		return strings.TrimSpace(meta.MediaInfoTextPath)
 	}

--- a/internal/trackers/impl/bhdtv/upload.go
+++ b/internal/trackers/impl/bhdtv/upload.go
@@ -453,23 +453,24 @@ func readBDInfoNoErr(_ string, meta api.PreparedMetadata) string {
 	if summary, ok := meta.BDInfo["summary"].(string); ok {
 		return strings.TrimSpace(summary)
 	}
-	for _, key := range []string{"BD_SUMMARY_00.txt", "BD_SUMMARY_EXT.txt"} {
-		if infoPath := guessBDInfoPath(meta, key); infoPath != "" {
-			payload, err := os.ReadFile(infoPath)
-			if err == nil {
-				return strings.TrimSpace(string(payload))
-			}
+	if infoPath := guessBDInfoPath(meta); infoPath != "" {
+		payload, err := os.ReadFile(infoPath)
+		if err == nil {
+			return strings.TrimSpace(string(payload))
 		}
 	}
 	return ""
 }
 
-func guessBDInfoPath(meta api.PreparedMetadata, name string) string {
-	base := strings.TrimSpace(meta.MediaInfoTextPath)
-	if base == "" {
+func guessBDInfoPath(meta api.PreparedMetadata) string {
+	if len(meta.SelectedBDMVPlaylists) == 0 {
 		return ""
 	}
-	return filepath.Join(filepath.Dir(base), name)
+	base := strings.TrimSpace(meta.MediaInfoTextPath)
+	if base != "" {
+		return filepath.Join(filepath.Dir(base), paths.BDMVSummaryFilename(paths.PrimaryBDMVPlaylist(meta)))
+	}
+	return ""
 }
 
 func normalizeResolution(value string) string {

--- a/internal/trackers/impl/ptp/upload.go
+++ b/internal/trackers/impl/ptp/upload.go
@@ -1197,7 +1197,7 @@ func readBDSummary(meta api.PreparedMetadata, dbPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return readTextFile(filepath.Join(tmpDir, "BD_SUMMARY_00.txt"))
+	return readTextFile(paths.BDMVSummaryPath(tmpDir, paths.PrimaryBDMVPlaylist(meta)))
 }
 
 func readTextFile(path string) (string, error) {

--- a/internal/trackers/impl/unit3d/description_test.go
+++ b/internal/trackers/impl/unit3d/description_test.go
@@ -110,6 +110,9 @@ func TestBuildUnit3DDescriptionSkipsBDInfo(t *testing.T) {
 	meta := api.PreparedMetadata{
 		SourcePath: filepath.Join(root, "Movie.mkv"),
 		DiscType:   "BDMV",
+		SelectedBDMVPlaylists: []api.PlaylistInfo{
+			{File: "00001.MPLS"},
+		},
 	}
 
 	tmpRoot, err := db.Subdir(dbPath, "tmp")
@@ -120,7 +123,7 @@ func TestBuildUnit3DDescriptionSkipsBDInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("release temp dir: %v", err)
 	}
-	bdinfoPath := filepath.Join(tmpDir, "BD_SUMMARY_00.txt")
+	bdinfoPath := paths.BDMVSummaryPath(tmpDir, "00001.MPLS")
 	if err := os.WriteFile(bdinfoPath, []byte("BDINFO_CONTENT"), 0o600); err != nil {
 		t.Fatalf("write bdinfo: %v", err)
 	}

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -535,7 +535,10 @@ func readBDInfo(dbPath string, meta api.PreparedMetadata) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	path := filepath.Join(tmpDir, "BD_SUMMARY_00.txt")
+	path := paths.BDMVSummaryPath(tmpDir, paths.PrimaryBDMVPlaylist(meta))
+	if strings.TrimSpace(path) == "" {
+		return "", nil
+	}
 	if !existsFile(path) {
 		return "", nil
 	}

--- a/internal/webserver/app_routes.go
+++ b/internal/webserver/app_routes.go
@@ -4,6 +4,7 @@
 package webserver
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/autobrr/upbrr/pkg/api"
@@ -60,19 +61,20 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/FetchMetadata", s.requireSession(func(w http.ResponseWriter, r *http.Request, current session) {
 		var req struct {
-			Path            string
-			SourceLookupURL string
-			Overrides       api.ExternalIDOverrides
-			NameOverrides   api.ReleaseNameOverrides
-			Trackers        []string
+			Path              string
+			SourceLookupURL   string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			Trackers          []string
+			ConfirmBDMVRescan bool
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.FetchMetadata(current.ID, req.Path, req.SourceLookupURL, req.Overrides, req.NameOverrides, req.Trackers)
+		value, err := s.backend.FetchMetadata(current.ID, req.Path, req.SourceLookupURL, req.Overrides, req.NameOverrides, req.Trackers, req.ConfirmBDMVRescan)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeAppError(w, err)
 			return
 		}
 		writeJSON(w, http.StatusOK, value)
@@ -80,19 +82,20 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/ResetMetadata", s.requireSession(func(w http.ResponseWriter, r *http.Request, current session) {
 		var req struct {
-			Path            string
-			SourceLookupURL string
-			Overrides       api.ExternalIDOverrides
-			NameOverrides   api.ReleaseNameOverrides
-			Trackers        []string
+			Path              string
+			SourceLookupURL   string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			Trackers          []string
+			ConfirmBDMVRescan bool
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.ResetMetadata(current.ID, req.Path, req.SourceLookupURL, req.Overrides, req.NameOverrides, req.Trackers)
+		value, err := s.backend.ResetMetadata(current.ID, req.Path, req.SourceLookupURL, req.Overrides, req.NameOverrides, req.Trackers, req.ConfirmBDMVRescan)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeAppError(w, err)
 			return
 		}
 		writeJSON(w, http.StatusOK, value)
@@ -704,4 +707,20 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 		}
 		writeJSON(w, http.StatusOK, value)
 	}))
+}
+
+func writeAppError(w http.ResponseWriter, err error) {
+	var rescanErr *api.BDMVRescanRequiredError
+	if errors.As(err, &rescanErr) {
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"error":              err.Error(),
+			"code":               api.ErrCodeBDMVRescanRequired,
+			"source_path":        rescanErr.SourcePath,
+			"selected_playlists": rescanErr.SelectedPlaylists,
+			"cached_playlists":   rescanErr.CachedPlaylists,
+			"missing_playlists":  rescanErr.MissingPlaylists,
+		})
+		return
+	}
+	writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 }

--- a/internal/webserver/app_routes_errors_test.go
+++ b/internal/webserver/app_routes_errors_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package webserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestWriteAppErrorBDMVRescanRequired(t *testing.T) {
+	recorder := httptest.NewRecorder()
+
+	writeAppError(recorder, &api.BDMVRescanRequiredError{
+		SourcePath:        `/disc`,
+		SelectedPlaylists: []string{"00002.MPLS", "00001.MPLS"},
+		CachedPlaylists:   []string{"00001.MPLS"},
+		MissingPlaylists:  []string{"00002.MPLS"},
+	})
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("expected status 409, got %d", recorder.Code)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if got := payload["code"]; got != api.ErrCodeBDMVRescanRequired {
+		t.Fatalf("expected code %q, got %#v", api.ErrCodeBDMVRescanRequired, got)
+	}
+	if got := payload["source_path"]; got != "/disc" {
+		t.Fatalf("unexpected source path %#v", got)
+	}
+}

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -166,7 +166,7 @@ func (b *Backend) DetectDiscType(path string) (string, error) {
 	return filesystem.DetectDiscType(ctx, path)
 }
 
-func (b *Backend) FetchMetadata(sessionID string, path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string) (api.MetadataPreview, error) {
+func (b *Backend) FetchMetadata(sessionID string, path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, confirmBDMVRescan bool) (api.MetadataPreview, error) {
 	if err := b.requireCore(); err != nil {
 		return api.MetadataPreview{}, err
 	}
@@ -199,12 +199,13 @@ func (b *Backend) FetchMetadata(sessionID string, path string, sourceLookupURL s
 		},
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		ConfirmBDMVRescan:    confirmBDMVRescan,
 	}
 
 	return b.core.FetchMetadataPreview(progressCtx, req)
 }
 
-func (b *Backend) ResetMetadata(sessionID string, path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string) (api.MetadataPreview, error) {
+func (b *Backend) ResetMetadata(sessionID string, path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, confirmBDMVRescan bool) (api.MetadataPreview, error) {
 	if err := b.requireCore(); err != nil {
 		return api.MetadataPreview{}, err
 	}
@@ -302,6 +303,7 @@ func (b *Backend) ResetMetadata(sessionID string, path string, sourceLookupURL s
 		},
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		ConfirmBDMVRescan:    confirmBDMVRescan,
 	}
 	return b.core.FetchMetadataPreview(progressCtx, req)
 }

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -42,6 +42,7 @@ type Request struct {
 	TrackerQuestionnaireAnswers  map[string]map[string]string // keyed by tracker, then questionnaire field key
 	PlaylistSelections           map[string][]string          // keyed by source path, value is selected playlist files
 	PlaylistSelectionsUseAll     map[string]bool              // keyed by source path, value is use-all flag
+	ConfirmBDMVRescan            bool
 }
 
 type ExecutionOptions struct {

--- a/pkg/api/metadata_errors.go
+++ b/pkg/api/metadata_errors.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package api
+
+import (
+	"fmt"
+	"strings"
+)
+
+const ErrCodeBDMVRescanRequired = "bdmv_rescan_required"
+
+type BDMVRescanRequiredError struct {
+	SourcePath        string
+	SelectedPlaylists []string
+	CachedPlaylists   []string
+	MissingPlaylists  []string
+}
+
+func (e *BDMVRescanRequiredError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if len(e.MissingPlaylists) == 0 {
+		return "BDMV rescan confirmation required"
+	}
+	return fmt.Sprintf("BDMV rescan confirmation required for playlist(s): %s", strings.Join(e.MissingPlaylists, ", "))
+}

--- a/pkg/api/metadata_errors.go
+++ b/pkg/api/metadata_errors.go
@@ -3,10 +3,7 @@
 
 package api
 
-import (
-	"fmt"
-	"strings"
-)
+import "strings"
 
 const ErrCodeBDMVRescanRequired = "bdmv_rescan_required"
 
@@ -24,5 +21,5 @@ func (e *BDMVRescanRequiredError) Error() string {
 	if len(e.MissingPlaylists) == 0 {
 		return "BDMV rescan confirmation required"
 	}
-	return fmt.Sprintf("BDMV rescan confirmation required for playlist(s): %s", strings.Join(e.MissingPlaylists, ", "))
+	return "BDMV rescan confirmation required for playlist(s): " + strings.Join(e.MissingPlaylists, ", ")
 }

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -162,6 +162,7 @@ type PreparedMetadata struct {
 	EpisodeTitle                string
 	EpisodeOverview             string
 	EpisodeYear                 int
+	SelectedBDMVPlaylists       []PlaylistInfo
 	ExternalIDs                 ExternalIDs
 	ExternalIDCandidates        ExternalIDCandidates
 	ExternalMetadata            ExternalMetadata


### PR DESCRIPTION
## Summary
- switch BDMV summary caching from selection-order files to playlist-keyed cache files
- reuse keyed cache entries across runs and require explicit confirmation before rescanning partially cached playlist selections
- update BDInfo consumers to resolve the selected playlist summary via shared path helpers instead of canonical `BD_SUMMARY_00.txt`

## What changed
- added playlist-keyed BDMV summary path helpers and moved metadata/cache discovery to keyed filenames
- changed single-playlist and multi-playlist BDInfo handling to write keyed summaries directly while keeping full-disc scans for multi-select
- added `ConfirmBDMVRescan` request support plus a structured `bdmv_rescan_required` response for GUI/web callers and an interactive CLI rescan prompt
- updated media-details, screenshots, description builders, and tracker upload paths to read the first selected playlist's keyed summary
- simplified cache validation by extracting the `Playlist:` line with a lightweight regex instead of full BDInfo parsing during discovery

## Validation
- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-playlist Blu-ray processing with caching and optional rescan confirmation (interactive and API flows).
  * CLI flag to confirm BDMV rescan.

* **Improvements**
  * Better edition detection for multi-playlist Blu-ray content.
  * More robust BD summary file resolution per selected playlist.
  * API/HTTP responses now surface rescan-required information more clearly (conflict response).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->