### PR TITLE
Fix prepared metadata handoff

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -1569,6 +1569,437 @@ func (c *Core) getGUICachedMeta(path string, signature string, overrides api.Ext
 	return c.getDupeCache(path, "")
 }
 
+// ExportGUICachedPreparedMeta exposes the resolved GUI prepared metadata cache entry
+// so callers can hand off metadata to isolated per-run cores.
+func (c *Core) ExportGUICachedPreparedMeta(ctx context.Context, req api.Request) (api.PreparedMetadata, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return api.PreparedMetadata{}, false, err
+	}
+	path, err := c.resolveSinglePreparedMetaPath(ctx, req.Paths)
+	if err != nil {
+		return api.PreparedMetadata{}, false, err
+	}
+	overrides := mergeExternalIDOverrides(req.ExternalIDOverrides, resolveExternalIDSelection(req.ExternalIDSelections, path))
+	signature := overrideSignature(overrides, req.ReleaseNameOverrides, req.MetadataOverrides, req.TrackerConfigOverrides, req.TrackerSiteOverrides, req.ClientOverrides, req.TorrentOverrides, req.ImageHostOverrides, req.ScreenshotOverrides)
+	meta, ok := c.getGUICachedMeta(path, signature, overrides)
+	if !ok {
+		return api.PreparedMetadata{}, false, nil
+	}
+	return deepCopyPreparedMetadata(meta), true, nil
+}
+
+// ImportPreparedMetadataForGUI stores prepared metadata on a per-run core so GUI dry-run
+// and upload-only flows can reuse metadata prepared on the long-lived GUI core.
+func (c *Core) ImportPreparedMetadataForGUI(ctx context.Context, req api.Request, meta api.PreparedMetadata) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	path, err := c.resolveSinglePreparedMetaPath(ctx, req.Paths)
+	if err != nil {
+		return err
+	}
+	overrides := mergeExternalIDOverrides(req.ExternalIDOverrides, resolveExternalIDSelection(req.ExternalIDSelections, path))
+	signature := overrideSignature(overrides, req.ReleaseNameOverrides, req.MetadataOverrides, req.TrackerConfigOverrides, req.TrackerSiteOverrides, req.ClientOverrides, req.TorrentOverrides, req.ImageHostOverrides, req.ScreenshotOverrides)
+	c.storeDupeCache(path, signature, deepCopyPreparedMetadata(meta))
+	return nil
+}
+
+func (c *Core) resolveSinglePreparedMetaPath(ctx context.Context, paths []string) (string, error) {
+	if len(paths) == 0 {
+		return "", internalerrors.ErrInvalidInput
+	}
+	if c.services.Filesystem == nil {
+		return "", errors.New("core: filesystem service not configured")
+	}
+
+	normalizedPaths, err := c.services.Filesystem.ValidatePaths(ctx, paths)
+	if err != nil {
+		return "", err
+	}
+	if len(normalizedPaths) == 0 {
+		return "", internalerrors.ErrInvalidInput
+	}
+
+	first := normalizedPaths[0]
+	for _, path := range normalizedPaths[1:] {
+		if path != first {
+			return "", internalerrors.ErrInvalidInput
+		}
+	}
+	return first, nil
+}
+
+func deepCopyPreparedMetadata(meta api.PreparedMetadata) api.PreparedMetadata {
+	copyMeta := meta
+	copyMeta.LookupWarnings = append([]string(nil), meta.LookupWarnings...)
+	copyMeta.Paths = append([]string(nil), meta.Paths...)
+	copyMeta.FileList = append([]string(nil), meta.FileList...)
+	copyMeta.Trackers = append([]string(nil), meta.Trackers...)
+	copyMeta.TrackersRemove = append([]string(nil), meta.TrackersRemove...)
+	copyMeta.MatchedTrackers = append([]string(nil), meta.MatchedTrackers...)
+	copyMeta.Release = deepCopyReleaseInfo(meta.Release)
+	copyMeta.TagOverride = deepCopyTagOverride(meta.TagOverride)
+	copyMeta.MetadataOverrides = deepCopyMetadataOverrides(meta.MetadataOverrides)
+	copyMeta.TrackerConfigOverrides = deepCopyTrackerConfigOverrides(meta.TrackerConfigOverrides)
+	copyMeta.TrackerSiteOverrides = deepCopyTrackerSiteOverrides(meta.TrackerSiteOverrides)
+	copyMeta.ClientOverrides = deepCopyClientOverrides(meta.ClientOverrides)
+	copyMeta.ImageHostOverrides = deepCopyImageHostOverrides(meta.ImageHostOverrides)
+	copyMeta.ScreenshotOverrides = deepCopyScreenshotOverrides(meta.ScreenshotOverrides)
+	copyMeta.TorrentOverrides = deepCopyTorrentOverrides(meta.TorrentOverrides)
+	copyMeta.TrackerIDs = cloneStringMap(meta.TrackerIDs)
+	copyMeta.TorrentComments = deepCopyTorrentMatches(meta.TorrentComments)
+	copyMeta.TrackerData = deepCopyTrackerMetadata(meta.TrackerData)
+	copyMeta.ArrGenres = append([]string(nil), meta.ArrGenres...)
+	copyMeta.ExternalIDOverrides = deepCopyExternalIDOverrides(meta.ExternalIDOverrides)
+	copyMeta.ReleaseNameOverrides = deepCopyReleaseNameOverrides(meta.ReleaseNameOverrides)
+	copyMeta.TrackerQuestionnaireAnswers = deepCopyQuestionnaireAnswers(meta.TrackerQuestionnaireAnswers)
+	copyMeta.TVDBAirsDays = append([]string(nil), meta.TVDBAirsDays...)
+	copyMeta.SelectedBDMVPlaylists = deepCopyPlaylistInfos(meta.SelectedBDMVPlaylists)
+	copyMeta.ExternalIDCandidates = deepCopyExternalIDCandidates(meta.ExternalIDCandidates)
+	copyMeta.ExternalMetadata = deepCopyExternalMetadata(meta.ExternalMetadata)
+	copyMeta.AudioLanguages = append([]string(nil), meta.AudioLanguages...)
+	copyMeta.SubtitleLanguages = append([]string(nil), meta.SubtitleLanguages...)
+	copyMeta.ReleaseNameMissing = append([]string(nil), meta.ReleaseNameMissing...)
+	copyMeta.BlockedTrackers = deepCopyBlockedTrackers(meta.BlockedTrackers)
+	copyMeta.TrackerRuleFailures = deepCopyTrackerRuleFailures(meta.TrackerRuleFailures)
+	copyMeta.BDInfo = deepCopyStringInterfaceMap(meta.BDInfo)
+	return copyMeta
+}
+
+func deepCopyReleaseInfo(info api.ReleaseInfo) api.ReleaseInfo {
+	copyInfo := info
+	copyInfo.Codec = append([]string(nil), info.Codec...)
+	copyInfo.Audio = append([]string(nil), info.Audio...)
+	copyInfo.HDR = append([]string(nil), info.HDR...)
+	copyInfo.Language = append([]string(nil), info.Language...)
+	copyInfo.Edition = append([]string(nil), info.Edition...)
+	copyInfo.Other = append([]string(nil), info.Other...)
+	return copyInfo
+}
+
+func deepCopyTagOverride(tag *api.TagOverride) *api.TagOverride {
+	if tag == nil {
+		return nil
+	}
+	copyTag := *tag
+	return &copyTag
+}
+
+func deepCopyMetadataOverrides(overrides api.MetadataOverrides) api.MetadataOverrides {
+	return api.MetadataOverrides{
+		Distributor:      clonePtr(overrides.Distributor),
+		OriginalLanguage: clonePtr(overrides.OriginalLanguage),
+		PersonalRelease:  clonePtr(overrides.PersonalRelease),
+		Commentary:       clonePtr(overrides.Commentary),
+		WebDV:            clonePtr(overrides.WebDV),
+		StreamOptimized:  clonePtr(overrides.StreamOptimized),
+		Anime:            clonePtr(overrides.Anime),
+	}
+}
+
+func deepCopyTrackerConfigOverrides(overrides api.TrackerConfigOverrides) api.TrackerConfigOverrides {
+	return api.TrackerConfigOverrides{
+		Anon:    clonePtr(overrides.Anon),
+		Draft:   clonePtr(overrides.Draft),
+		ModQ:    clonePtr(overrides.ModQ),
+		Channel: clonePtr(overrides.Channel),
+	}
+}
+
+func deepCopyTrackerSiteOverrides(overrides api.TrackerSiteOverrides) api.TrackerSiteOverrides {
+	return api.TrackerSiteOverrides{
+		TIK: api.TIKOverrides{
+			Foreign:  clonePtr(overrides.TIK.Foreign),
+			Opera:    clonePtr(overrides.TIK.Opera),
+			Asian:    clonePtr(overrides.TIK.Asian),
+			DiscType: clonePtr(overrides.TIK.DiscType),
+		},
+	}
+}
+
+func deepCopyClientOverrides(overrides api.ClientOverrides) api.ClientOverrides {
+	return api.ClientOverrides{
+		Client:       clonePtr(overrides.Client),
+		QbitCategory: clonePtr(overrides.QbitCategory),
+		QbitTag:      clonePtr(overrides.QbitTag),
+		ForceRecheck: clonePtr(overrides.ForceRecheck),
+	}
+}
+
+func deepCopyImageHostOverrides(overrides api.ImageHostOverrides) api.ImageHostOverrides {
+	return api.ImageHostOverrides{
+		PreferredHost: clonePtr(overrides.PreferredHost),
+		SkipUpload:    clonePtr(overrides.SkipUpload),
+	}
+}
+
+func deepCopyScreenshotOverrides(overrides api.ScreenshotOverrides) api.ScreenshotOverrides {
+	return api.ScreenshotOverrides{
+		ManualFrames:           append([]int(nil), overrides.ManualFrames...),
+		ComparisonPaths:        append([]string(nil), overrides.ComparisonPaths...),
+		ComparisonPrimaryIndex: clonePtr(overrides.ComparisonPrimaryIndex),
+	}
+}
+
+func deepCopyTorrentOverrides(overrides api.TorrentOverrides) api.TorrentOverrides {
+	return api.TorrentOverrides{
+		InfoHash:        clonePtr(overrides.InfoHash),
+		MaxPieceSizeMiB: clonePtr(overrides.MaxPieceSizeMiB),
+		NoHash:          clonePtr(overrides.NoHash),
+		Rehash:          clonePtr(overrides.Rehash),
+	}
+}
+
+func deepCopyExternalIDOverrides(overrides api.ExternalIDOverrides) api.ExternalIDOverrides {
+	return api.ExternalIDOverrides{
+		TMDBID:   clonePtr(overrides.TMDBID),
+		IMDBID:   clonePtr(overrides.IMDBID),
+		TVDBID:   clonePtr(overrides.TVDBID),
+		TVmazeID: clonePtr(overrides.TVmazeID),
+		MALID:    clonePtr(overrides.MALID),
+	}
+}
+
+func deepCopyReleaseNameOverrides(overrides api.ReleaseNameOverrides) api.ReleaseNameOverrides {
+	return api.ReleaseNameOverrides{
+		Category:         clonePtr(overrides.Category),
+		Type:             clonePtr(overrides.Type),
+		Source:           clonePtr(overrides.Source),
+		Resolution:       clonePtr(overrides.Resolution),
+		Tag:              clonePtr(overrides.Tag),
+		Service:          clonePtr(overrides.Service),
+		Edition:          clonePtr(overrides.Edition),
+		Season:           clonePtr(overrides.Season),
+		Episode:          clonePtr(overrides.Episode),
+		EpisodeTitle:     clonePtr(overrides.EpisodeTitle),
+		ManualYear:       clonePtr(overrides.ManualYear),
+		ManualDate:       clonePtr(overrides.ManualDate),
+		UseSeasonEpisode: clonePtr(overrides.UseSeasonEpisode),
+		NoSeason:         clonePtr(overrides.NoSeason),
+		NoYear:           clonePtr(overrides.NoYear),
+		NoAKA:            clonePtr(overrides.NoAKA),
+		NoTag:            clonePtr(overrides.NoTag),
+		NoEdition:        clonePtr(overrides.NoEdition),
+		NoDub:            clonePtr(overrides.NoDub),
+		NoDual:           clonePtr(overrides.NoDual),
+		DualAudio:        clonePtr(overrides.DualAudio),
+		Region:           clonePtr(overrides.Region),
+	}
+}
+
+func deepCopyQuestionnaireAnswers(input map[string]map[string]string) map[string]map[string]string {
+	if len(input) == 0 {
+		return nil
+	}
+	cloned := make(map[string]map[string]string, len(input))
+	for tracker, values := range input {
+		inner := make(map[string]string, len(values))
+		for key, value := range values {
+			inner[key] = value
+		}
+		cloned[tracker] = inner
+	}
+	return cloned
+}
+
+func deepCopyPlaylistInfos(playlists []api.PlaylistInfo) []api.PlaylistInfo {
+	if len(playlists) == 0 {
+		return nil
+	}
+	cloned := make([]api.PlaylistInfo, len(playlists))
+	for idx, playlist := range playlists {
+		cloned[idx] = playlist
+		cloned[idx].Items = append([]api.PlaylistItem(nil), playlist.Items...)
+	}
+	return cloned
+}
+
+func deepCopyExternalIDCandidates(candidates api.ExternalIDCandidates) api.ExternalIDCandidates {
+	return api.ExternalIDCandidates{
+		TMDB:             append([]api.ExternalIDCandidate(nil), candidates.TMDB...),
+		IMDB:             append([]api.ExternalIDCandidate(nil), candidates.IMDB...),
+		TMDBAutoSelected: candidates.TMDBAutoSelected,
+		IMDBAutoSelected: candidates.IMDBAutoSelected,
+	}
+}
+
+func deepCopyExternalMetadata(metadata api.ExternalMetadata) api.ExternalMetadata {
+	return api.ExternalMetadata{
+		SourcePath: metadata.SourcePath,
+		TMDB:       deepCopyTMDBMetadata(metadata.TMDB),
+		IMDB:       deepCopyIMDBMetadata(metadata.IMDB),
+		TVDB:       deepCopyTVDBMetadata(metadata.TVDB),
+		TVmaze:     deepCopyTVmazeMetadata(metadata.TVmaze),
+		UpdatedAt:  metadata.UpdatedAt,
+	}
+}
+
+func deepCopyTMDBMetadata(metadata *api.TMDBMetadata) *api.TMDBMetadata {
+	if metadata == nil {
+		return nil
+	}
+	cloned := *metadata
+	cloned.OriginCountry = append([]string(nil), metadata.OriginCountry...)
+	cloned.Creators = append([]string(nil), metadata.Creators...)
+	cloned.Directors = append([]string(nil), metadata.Directors...)
+	cloned.Cast = append([]string(nil), metadata.Cast...)
+	cloned.ProductionCompanies = append([]api.TMDBCompany(nil), metadata.ProductionCompanies...)
+	cloned.ProductionCountries = append([]api.TMDBCountry(nil), metadata.ProductionCountries...)
+	cloned.Networks = append([]api.TMDBNetwork(nil), metadata.Networks...)
+	return &cloned
+}
+
+func deepCopyIMDBMetadata(metadata *api.IMDBMetadata) *api.IMDBMetadata {
+	if metadata == nil {
+		return nil
+	}
+	cloned := *metadata
+	cloned.Directors = append([]api.IMDBPerson(nil), metadata.Directors...)
+	cloned.Creators = append([]api.IMDBPerson(nil), metadata.Creators...)
+	cloned.Writers = append([]api.IMDBPerson(nil), metadata.Writers...)
+	cloned.Stars = append([]api.IMDBPerson(nil), metadata.Stars...)
+	cloned.Editions = append([]string(nil), metadata.Editions...)
+	cloned.EditionDetails = deepCopyIMDBEditionDetails(metadata.EditionDetails)
+	cloned.Akas = deepCopyIMDBAKAs(metadata.Akas)
+	cloned.Episodes = append([]api.IMDBEpisode(nil), metadata.Episodes...)
+	cloned.SeasonsSummary = append([]api.IMDBSeasonSummary(nil), metadata.SeasonsSummary...)
+	cloned.SoundMixes = append([]string(nil), metadata.SoundMixes...)
+	return &cloned
+}
+
+func deepCopyTVDBMetadata(metadata *api.TVDBMetadata) *api.TVDBMetadata {
+	if metadata == nil {
+		return nil
+	}
+	cloned := *metadata
+	cloned.Aliases = append([]string(nil), metadata.Aliases...)
+	return &cloned
+}
+
+func deepCopyTVmazeMetadata(metadata *api.TVmazeMetadata) *api.TVmazeMetadata {
+	if metadata == nil {
+		return nil
+	}
+	cloned := *metadata
+	return &cloned
+}
+
+func deepCopyTorrentMatches(matches []api.TorrentMatch) []api.TorrentMatch {
+	if len(matches) == 0 {
+		return nil
+	}
+	cloned := make([]api.TorrentMatch, len(matches))
+	for idx, match := range matches {
+		cloned[idx] = match
+		cloned[idx].TrackerURLsRaw = append([]string(nil), match.TrackerURLsRaw...)
+		cloned[idx].TrackerURLs = append([]api.TrackerMatch(nil), match.TrackerURLs...)
+	}
+	return cloned
+}
+
+func deepCopyTrackerMetadata(metadata []api.TrackerMetadata) []api.TrackerMetadata {
+	if len(metadata) == 0 {
+		return nil
+	}
+	cloned := make([]api.TrackerMetadata, len(metadata))
+	for idx, item := range metadata {
+		cloned[idx] = item
+		cloned[idx].ImageURLs = append([]string(nil), item.ImageURLs...)
+	}
+	return cloned
+}
+
+func deepCopyBlockedTrackers(blocked map[string][]api.TrackerBlockReason) map[string][]api.TrackerBlockReason {
+	if len(blocked) == 0 {
+		return nil
+	}
+	cloned := make(map[string][]api.TrackerBlockReason, len(blocked))
+	for tracker, reasons := range blocked {
+		cloned[tracker] = append([]api.TrackerBlockReason(nil), reasons...)
+	}
+	return cloned
+}
+
+func deepCopyTrackerRuleFailures(failures map[string][]api.RuleFailure) map[string][]api.RuleFailure {
+	if len(failures) == 0 {
+		return nil
+	}
+	cloned := make(map[string][]api.RuleFailure, len(failures))
+	for tracker, items := range failures {
+		cloned[tracker] = append([]api.RuleFailure(nil), items...)
+	}
+	return cloned
+}
+
+func deepCopyIMDBEditionDetails(details map[string]api.IMDBEditionDetail) map[string]api.IMDBEditionDetail {
+	if len(details) == 0 {
+		return nil
+	}
+	cloned := make(map[string]api.IMDBEditionDetail, len(details))
+	for key, detail := range details {
+		copied := detail
+		copied.Attributes = append([]string(nil), detail.Attributes...)
+		cloned[key] = copied
+	}
+	return cloned
+}
+
+func deepCopyIMDBAKAs(items []api.IMDBAKA) []api.IMDBAKA {
+	if len(items) == 0 {
+		return nil
+	}
+	cloned := make([]api.IMDBAKA, len(items))
+	for idx, item := range items {
+		cloned[idx] = item
+		cloned[idx].Attributes = append([]string(nil), item.Attributes...)
+	}
+	return cloned
+}
+
+func deepCopyStringInterfaceMap(input map[string]interface{}) map[string]interface{} {
+	if len(input) == 0 {
+		return nil
+	}
+	cloned := make(map[string]interface{}, len(input))
+	for key, value := range input {
+		cloned[key] = deepCopyInterfaceValue(value)
+	}
+	return cloned
+}
+
+func deepCopyInterfaceValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return deepCopyStringInterfaceMap(typed)
+	case []interface{}:
+		cloned := make([]interface{}, len(typed))
+		for idx, item := range typed {
+			cloned[idx] = deepCopyInterfaceValue(item)
+		}
+		return cloned
+	case []string:
+		return append([]string(nil), typed...)
+	case []int:
+		return append([]int(nil), typed...)
+	case []int64:
+		return append([]int64(nil), typed...)
+	case []float64:
+		return append([]float64(nil), typed...)
+	case []bool:
+		return append([]bool(nil), typed...)
+	default:
+		return typed
+	}
+}
+
+func clonePtr[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
 func (c *Core) DiscoverPlaylists(ctx context.Context, sourcePath string) ([]api.PlaylistInfo, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -5,7 +5,10 @@ package core
 
 import (
 	"context"
+	"errors"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +17,10 @@ import (
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
+
+func ptr[T any](v T) *T {
+	return &v
+}
 
 func TestRunUploadMultiplePaths(t *testing.T) {
 	t.Parallel()
@@ -750,6 +757,473 @@ func TestRunUploadPersistsInfoHash(t *testing.T) {
 	}
 	if repo.saved[0].InfoHash != "hash123" {
 		t.Fatalf("expected info hash saved, got %q", repo.saved[0].InfoHash)
+	}
+}
+
+func TestExportGUICachedPreparedMetaExactSignature(t *testing.T) {
+	t.Parallel()
+
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   &stubTrackers{},
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	prepared := api.PreparedMetadata{
+		SourcePath:           "/tmp/a",
+		ReleaseNameOverrides: api.ReleaseNameOverrides{Edition: ptr("Exact Match")},
+	}
+	req := api.Request{
+		Paths:                []string{"/tmp/a"},
+		Mode:                 api.ModeGUI,
+		ReleaseNameOverrides: api.ReleaseNameOverrides{Edition: ptr("Exact Match")},
+	}
+	if err := core.ImportPreparedMetadataForGUI(context.Background(), req, prepared); err != nil {
+		t.Fatalf("import prepared metadata for gui: %v", err)
+	}
+
+	exported, ok, err := core.ExportGUICachedPreparedMeta(context.Background(), req)
+	if err != nil {
+		t.Fatalf("export gui cached prepared meta: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected cached metadata export to succeed")
+	}
+	if exported.ReleaseNameOverrides.Edition == nil || *exported.ReleaseNameOverrides.Edition != "Exact Match" {
+		t.Fatalf("expected exact-signature metadata, got %#v", exported.ReleaseNameOverrides)
+	}
+}
+
+func TestExportGUICachedPreparedMetaFallsBackForGUIWithoutExternalOverrides(t *testing.T) {
+	t.Parallel()
+
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   &stubTrackers{},
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	prepared := api.PreparedMetadata{SourcePath: "/tmp/a"}
+	if err := core.ImportPreparedMetadataForGUI(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	}, prepared); err != nil {
+		t.Fatalf("import prepared metadata for gui: %v", err)
+	}
+
+	exported, ok, err := core.ExportGUICachedPreparedMeta(context.Background(), api.Request{
+		Paths:                []string{"/tmp/a"},
+		Mode:                 api.ModeGUI,
+		ReleaseNameOverrides: api.ReleaseNameOverrides{Edition: ptr("Later UI edit")},
+	})
+	if err != nil {
+		t.Fatalf("export gui cached prepared meta: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected GUI fallback cache hit")
+	}
+	if exported.SourcePath != "/tmp/a" {
+		t.Fatalf("expected cached source path /tmp/a, got %q", exported.SourcePath)
+	}
+}
+
+func TestExportGUICachedPreparedMetaRequiresExactMatchForExternalOverrides(t *testing.T) {
+	t.Parallel()
+
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   &stubTrackers{},
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	if err := core.ImportPreparedMetadataForGUI(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	}, api.PreparedMetadata{SourcePath: "/tmp/a"}); err != nil {
+		t.Fatalf("import prepared metadata for gui: %v", err)
+	}
+
+	tmdbID := 1234
+
+	_, ok, err := core.ExportGUICachedPreparedMeta(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			TMDBID: &tmdbID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("export gui cached prepared meta: %v", err)
+	}
+	if ok {
+		t.Fatal("expected external ID override to require exact cache signature")
+	}
+}
+
+func TestExportGUICachedPreparedMetaReturnsIsolatedCopy(t *testing.T) {
+	t.Parallel()
+
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   &stubTrackers{},
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	prepared := api.PreparedMetadata{
+		SourcePath: "/tmp/a",
+		Trackers:   []string{"AITHER", "BLU"},
+		TrackerIDs: map[string]string{"AITHER": "111"},
+		TrackerQuestionnaireAnswers: map[string]map[string]string{
+			"AITHER": {"season": "1"},
+		},
+		TrackerRuleFailures: map[string][]api.RuleFailure{
+			"AITHER": {{Rule: "rule_a", Reason: "bad"}},
+		},
+		Release: api.ReleaseInfo{
+			Codec: []string{"x264"},
+		},
+		BDInfo: map[string]interface{}{
+			"playlists": []interface{}{"00001", "00002"},
+		},
+	}
+	if err := core.ImportPreparedMetadataForGUI(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	}, prepared); err != nil {
+		t.Fatalf("import prepared metadata for gui: %v", err)
+	}
+
+	exported, ok, err := core.ExportGUICachedPreparedMeta(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	})
+	if err != nil {
+		t.Fatalf("export gui cached prepared meta: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected cached metadata export to succeed")
+	}
+
+	exported.Trackers[0] = "HDB"
+	exported.TrackerIDs["AITHER"] = "222"
+	exported.TrackerQuestionnaireAnswers["AITHER"]["season"] = "2"
+	exported.TrackerRuleFailures["AITHER"][0].Rule = "rule_b"
+	exported.Release.Codec[0] = "x265"
+	exported.BDInfo["playlists"].([]interface{})[0] = "99999"
+
+	cached, ok := core.getDupeCache("/tmp/a", "")
+	if !ok {
+		t.Fatal("expected cached metadata to remain available")
+	}
+	if cached.Trackers[0] != "AITHER" {
+		t.Fatalf("expected cached trackers to remain isolated, got %#v", cached.Trackers)
+	}
+	if cached.TrackerIDs["AITHER"] != "111" {
+		t.Fatalf("expected cached tracker ids to remain isolated, got %#v", cached.TrackerIDs)
+	}
+	if cached.TrackerQuestionnaireAnswers["AITHER"]["season"] != "1" {
+		t.Fatalf("expected cached questionnaire answers to remain isolated, got %#v", cached.TrackerQuestionnaireAnswers)
+	}
+	if cached.TrackerRuleFailures["AITHER"][0].Rule != "rule_a" {
+		t.Fatalf("expected cached rule failures to remain isolated, got %#v", cached.TrackerRuleFailures)
+	}
+	if cached.Release.Codec[0] != "x264" {
+		t.Fatalf("expected cached release info to remain isolated, got %#v", cached.Release)
+	}
+	if cached.BDInfo["playlists"].([]interface{})[0] != "00001" {
+		t.Fatalf("expected cached BDInfo to remain isolated, got %#v", cached.BDInfo)
+	}
+}
+
+func TestExportGUICachedPreparedMetaConcurrentCopiesStayIsolated(t *testing.T) {
+	t.Parallel()
+
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   &stubTrackers{},
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	if err := core.ImportPreparedMetadataForGUI(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	}, api.PreparedMetadata{
+		SourcePath: "/tmp/a",
+		Trackers:   []string{"AITHER"},
+		TrackerIDs: map[string]string{"AITHER": "111"},
+		TrackerQuestionnaireAnswers: map[string]map[string]string{
+			"AITHER": {"season": "1"},
+		},
+	}); err != nil {
+		t.Fatalf("import prepared metadata for gui: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for idx := 0; idx < 16; idx++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			exported, ok, exportErr := core.ExportGUICachedPreparedMeta(context.Background(), api.Request{
+				Paths: []string{"/tmp/a"},
+				Mode:  api.ModeGUI,
+			})
+			if exportErr != nil || !ok {
+				t.Errorf("export gui cached prepared meta: ok=%t err=%v", ok, exportErr)
+				return
+			}
+			exported.Trackers[0] = "TRACKER"
+			exported.TrackerIDs["AITHER"] = "mutated"
+			exported.TrackerQuestionnaireAnswers["AITHER"]["season"] = strconv.Itoa(i)
+		}(idx)
+	}
+	wg.Wait()
+
+	cached, ok := core.getDupeCache("/tmp/a", "")
+	if !ok {
+		t.Fatal("expected cached metadata to remain available")
+	}
+	if cached.Trackers[0] != "AITHER" {
+		t.Fatalf("expected cached trackers unchanged, got %#v", cached.Trackers)
+	}
+	if cached.TrackerIDs["AITHER"] != "111" {
+		t.Fatalf("expected cached tracker ids unchanged, got %#v", cached.TrackerIDs)
+	}
+	if cached.TrackerQuestionnaireAnswers["AITHER"]["season"] != "1" {
+		t.Fatalf("expected cached questionnaire answers unchanged, got %#v", cached.TrackerQuestionnaireAnswers)
+	}
+}
+
+func TestExportGUICachedPreparedMetaHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   &stubTrackers{},
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, ok, err := core.ExportGUICachedPreparedMeta(ctx, api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	})
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+	if ok {
+		t.Fatal("expected canceled export to report no cached metadata")
+	}
+}
+
+func TestImportPreparedMetadataForGUIHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   &stubTrackers{},
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = core.ImportPreparedMetadataForGUI(ctx, api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	}, api.PreparedMetadata{SourcePath: "/tmp/a"})
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+	if _, ok := core.getDupeCache("/tmp/a", ""); ok {
+		t.Fatal("expected canceled import not to populate cache")
+	}
+}
+
+func TestExportGUICachedPreparedMetaReturnsFilesystemValidationError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("validate boom")
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: stubFS{err: wantErr},
+			Metadata:   &stubMeta{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   &stubTrackers{},
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	_, _, err = core.ExportGUICachedPreparedMeta(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected filesystem validation error, got %v", err)
+	}
+}
+
+func TestImportPreparedMetadataForGUIReturnsFilesystemValidationError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("validate boom")
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: stubFS{err: wantErr},
+			Metadata:   &stubMeta{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   &stubTrackers{},
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	err = core.ImportPreparedMetadataForGUI(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	}, api.PreparedMetadata{SourcePath: "/tmp/a"})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected filesystem validation error, got %v", err)
+	}
+}
+
+func TestExportGUICachedPreparedMetaAllowsDuplicatePathsResolvingToOne(t *testing.T) {
+	t.Parallel()
+
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: stubFS{normalized: []string{"/tmp/a", "/tmp/a"}},
+			Metadata:   &stubMeta{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   &stubTrackers{},
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	if err := core.ImportPreparedMetadataForGUI(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	}, api.PreparedMetadata{SourcePath: "/tmp/a"}); err != nil {
+		t.Fatalf("import prepared metadata for gui: %v", err)
+	}
+
+	_, ok, err := core.ExportGUICachedPreparedMeta(context.Background(), api.Request{
+		Paths: []string{"/tmp/a", "/tmp/a"},
+		Mode:  api.ModeGUI,
+	})
+	if err != nil {
+		t.Fatalf("export gui cached prepared meta: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected duplicate normalized paths to resolve to one cache hit")
+	}
+}
+
+func TestImportPreparedMetadataForGUIAllowsDuplicatePathsResolvingToOne(t *testing.T) {
+	t.Parallel()
+
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: stubFS{normalized: []string{"/tmp/a", "/tmp/a"}},
+			Metadata:   &stubMeta{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   &stubTrackers{},
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	err = core.ImportPreparedMetadataForGUI(context.Background(), api.Request{
+		Paths: []string{"/tmp/a", "/tmp/a"},
+		Mode:  api.ModeGUI,
+	}, api.PreparedMetadata{SourcePath: "/tmp/a"})
+	if err != nil {
+		t.Fatalf("import prepared metadata for gui: %v", err)
+	}
+	if _, ok := core.getDupeCache("/tmp/a", ""); !ok {
+		t.Fatal("expected duplicate normalized paths to import one cache entry")
 	}
 }
 
@@ -1538,9 +2012,18 @@ func (r *recordingRepo) PurgeContentData(_ context.Context, path string) error {
 	return nil
 }
 
-type stubFS struct{}
+type stubFS struct {
+	normalized []string
+	err        error
+}
 
-func (stubFS) ValidatePaths(_ context.Context, paths []string) ([]string, error) {
+func (s stubFS) ValidatePaths(_ context.Context, paths []string) ([]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.normalized != nil {
+		return append([]string(nil), s.normalized...), nil
+	}
 	return paths, nil
 }
 

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -21,6 +21,7 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/core"
 	"github.com/autobrr/upbrr/internal/filesystem"
+	"github.com/autobrr/upbrr/internal/guishared"
 	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/paths"
 	"github.com/autobrr/upbrr/internal/services/bdinfo"
@@ -617,6 +618,9 @@ func (a *App) FetchTrackerDryRun(path string, overrides api.ExternalIDOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(questionnaireAnswers),
 	}
 	req.Options.DryRun = true
+	if err := guishared.SeedRunCorePreparedMeta(ctx, a.core, runCore, req); err != nil {
+		return api.TrackerDryRunPreview{}, err
+	}
 
 	progressCtx := bdinfo.WithProgressReporter(ctx, func(line string) {
 		if strings.TrimSpace(line) == "" {

--- a/internal/guiapp/run_options.go
+++ b/internal/guiapp/run_options.go
@@ -78,7 +78,6 @@ func (a *App) buildRunCore(opts runOptions) (api.Core, *logging.Logger, error) {
 
 	return coreSvc, logger, nil
 }
-
 func buildRunUploadOptions(cfg api.Config, opts runOptions) api.UploadOptions {
 	return api.UploadOptions{
 		Debug:       opts.Debug,

--- a/internal/guiapp/run_options_test.go
+++ b/internal/guiapp/run_options_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/core"
 	"github.com/autobrr/upbrr/internal/filesystem"
+	"github.com/autobrr/upbrr/internal/guishared"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -27,6 +28,11 @@ func (c *closeCounter) Close() error {
 
 type closeCounterCore struct {
 	closeCounter
+	exportedMeta api.PreparedMetadata
+	exportFound  bool
+	exportErr    error
+	importedMeta api.PreparedMetadata
+	importedReq  api.Request
 }
 
 func (c *closeCounterCore) RunUpload(context.Context, api.Request) (api.Result, error) {
@@ -137,6 +143,16 @@ func (c *closeCounterCore) SaveDescriptionOverride(context.Context, api.Request,
 	return nil
 }
 
+func (c *closeCounterCore) ExportGUICachedPreparedMeta(context.Context, api.Request) (api.PreparedMetadata, bool, error) {
+	return c.exportedMeta, c.exportFound, c.exportErr
+}
+
+func (c *closeCounterCore) ImportPreparedMetadataForGUI(_ context.Context, req api.Request, meta api.PreparedMetadata) error {
+	c.importedReq = req
+	c.importedMeta = meta
+	return nil
+}
+
 func TestBuildRunOptionsDefaults(t *testing.T) {
 	t.Parallel()
 
@@ -233,5 +249,46 @@ func TestTrackerUploadJobCloseResourcesIsIdempotent(t *testing.T) {
 	}
 	if got := loggerCloser.count.Load(); got != 1 {
 		t.Fatalf("expected logger close once, got %d", got)
+	}
+}
+
+func TestSeedRunCorePreparedMetaCopiesPreparedMetadata(t *testing.T) {
+	t.Parallel()
+
+	source := &closeCounterCore{
+		exportFound:  true,
+		exportedMeta: api.PreparedMetadata{SourcePath: "C:\\releases\\movie.mkv"},
+	}
+	target := &closeCounterCore{}
+	req := api.Request{
+		Paths: []string{"C:\\releases\\movie.mkv"},
+		Mode:  api.ModeGUI,
+	}
+
+	if err := guishared.SeedRunCorePreparedMeta(context.Background(), source, target, req); err != nil {
+		t.Fatalf("seed run core prepared meta: %v", err)
+	}
+	if target.importedMeta.SourcePath != "C:\\releases\\movie.mkv" {
+		t.Fatalf("expected imported source path, got %q", target.importedMeta.SourcePath)
+	}
+	if len(target.importedReq.Paths) != 1 || target.importedReq.Paths[0] != "C:\\releases\\movie.mkv" {
+		t.Fatalf("expected import request paths to be preserved, got %#v", target.importedReq.Paths)
+	}
+}
+
+func TestSeedRunCorePreparedMetaSkipsWhenNoCacheFound(t *testing.T) {
+	t.Parallel()
+
+	source := &closeCounterCore{}
+	target := &closeCounterCore{}
+
+	if err := guishared.SeedRunCorePreparedMeta(context.Background(), source, target, api.Request{
+		Paths: []string{"C:\\releases\\movie.mkv"},
+		Mode:  api.ModeGUI,
+	}); err != nil {
+		t.Fatalf("seed run core prepared meta: %v", err)
+	}
+	if target.importedMeta.SourcePath != "" {
+		t.Fatalf("expected no metadata import when cache missing, got %#v", target.importedMeta)
 	}
 }

--- a/internal/guiapp/upload_jobs.go
+++ b/internal/guiapp/upload_jobs.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 
+	"github.com/autobrr/upbrr/internal/guishared"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -104,8 +105,27 @@ func (a *App) StartTrackerUpload(path string, overrides api.ExternalIDOverrides,
 	if err != nil {
 		return "", err
 	}
+	baseCtx := a.ctx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+
 	runCore, runLogger, err := a.buildRunCore(runOpts)
 	if err != nil {
+		return "", err
+	}
+
+	seedReq := api.Request{
+		Paths:                []string{trimmedPath},
+		Mode:                 api.ModeGUI,
+		Trackers:             resolvedTrackers,
+		IgnoreDupesFor:       normalizeTrackerList(ignoreDupesFor),
+		ExternalIDOverrides:  overrides,
+		ReleaseNameOverrides: nameOverrides,
+	}
+	if err := guishared.SeedRunCorePreparedMeta(baseCtx, a.core, runCore, seedReq); err != nil {
+		_ = runCore.Close()
+		_ = runLogger.Close()
 		return "", err
 	}
 
@@ -130,10 +150,6 @@ func (a *App) StartTrackerUpload(path string, overrides api.ExternalIDOverrides,
 		job.states[tracker] = TrackerUploadTrackerState{Tracker: tracker, Status: "queued", Message: "queued"}
 	}
 
-	baseCtx := a.ctx
-	if baseCtx == nil {
-		baseCtx = context.Background()
-	}
 	//nolint:gosec // The cancel func is stored on the job and invoked on completion/cancel paths.
 	jobCtx, cancel := context.WithCancel(baseCtx)
 	job.cancel = cancel

--- a/internal/guishared/prepared_meta.go
+++ b/internal/guishared/prepared_meta.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package guishared
+
+import (
+	"context"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+type PreparedMetaExporter interface {
+	ExportGUICachedPreparedMeta(ctx context.Context, req api.Request) (api.PreparedMetadata, bool, error)
+}
+
+type PreparedMetaImporter interface {
+	ImportPreparedMetadataForGUI(ctx context.Context, req api.Request, meta api.PreparedMetadata) error
+}
+
+func SeedRunCorePreparedMeta(ctx context.Context, source api.Core, target api.Core, req api.Request) error {
+	exporter, ok := source.(PreparedMetaExporter)
+	if !ok {
+		return nil
+	}
+	importer, ok := target.(PreparedMetaImporter)
+	if !ok {
+		return nil
+	}
+
+	meta, found, err := exporter.ExportGUICachedPreparedMeta(ctx, req)
+	if err != nil || !found {
+		return err
+	}
+	return importer.ImportPreparedMetadataForGUI(ctx, req, meta)
+}

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -20,6 +20,7 @@ import (
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/filesystem"
 	"github.com/autobrr/upbrr/internal/guiapp"
+	"github.com/autobrr/upbrr/internal/guishared"
 	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/paths"
 	"github.com/autobrr/upbrr/internal/services/bdinfo"
@@ -390,6 +391,9 @@ func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides ap
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(questionnaireAnswers),
 	}
 	req.Options.DryRun = true
+	if err := guishared.SeedRunCorePreparedMeta(ctx, b.core, runCore, req); err != nil {
+		return api.TrackerDryRunPreview{}, err
+	}
 	progressCtx := bdinfo.WithProgressReporter(ctx, func(line string) {
 		if strings.TrimSpace(line) == "" {
 			return

--- a/internal/webserver/jobs.go
+++ b/internal/webserver/jobs.go
@@ -15,13 +15,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/autobrr/upbrr/internal/guishared"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
 const (
-	completedJobRetention  = 24 * time.Hour
-	maxCompletedDupeJobs   = 200
-	maxCompletedUploadJobs = 200
+	completedJobRetention   = 24 * time.Hour
+	maxCompletedDupeJobs    = 200
+	maxCompletedUploadJobs  = 200
+	seedPreparedMetaTimeout = 30 * time.Second
 )
 
 type DupeCheckTrackerState struct {
@@ -384,6 +386,21 @@ func (b *Backend) StartTrackerUpload(sessionID string, path string, overrides ap
 	}
 	runCore, runLogger, err := b.buildRunCore(runOpts)
 	if err != nil {
+		return "", err
+	}
+	seedReq := api.Request{
+		Paths:                []string{trimmedPath},
+		Mode:                 api.ModeGUI,
+		Trackers:             resolvedTrackers,
+		IgnoreDupesFor:       normalizeTrackerList(ignoreDupesFor),
+		ExternalIDOverrides:  overrides,
+		ReleaseNameOverrides: nameOverrides,
+	}
+	seedCtx, cancel := context.WithTimeout(context.Background(), seedPreparedMetaTimeout)
+	defer cancel()
+	if err := guishared.SeedRunCorePreparedMeta(seedCtx, b.core, runCore, seedReq); err != nil {
+		_ = runCore.Close()
+		_ = runLogger.Close()
 		return "", err
 	}
 

--- a/internal/webserver/jobs_test.go
+++ b/internal/webserver/jobs_test.go
@@ -4,10 +4,144 @@
 package webserver
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/autobrr/upbrr/internal/guishared"
+	"github.com/autobrr/upbrr/pkg/api"
 )
+
+type preparedMetaTestCore struct {
+	exportedMeta api.PreparedMetadata
+	exportFound  bool
+	exportErr    error
+	importedMeta api.PreparedMetadata
+	importedReq  api.Request
+}
+
+func (c *preparedMetaTestCore) RunUpload(context.Context, api.Request) (api.Result, error) {
+	return api.Result{}, nil
+}
+
+func (c *preparedMetaTestCore) RunUploadPrepared(context.Context, api.Request) (api.Result, error) {
+	return api.Result{}, nil
+}
+
+func (c *preparedMetaTestCore) FetchMetadataPreview(context.Context, api.Request) (api.MetadataPreview, error) {
+	return api.MetadataPreview{}, nil
+}
+
+func (c *preparedMetaTestCore) FetchDescriptionBuilderPreview(context.Context, api.Request) (api.DescriptionBuilderPreview, error) {
+	return api.DescriptionBuilderPreview{}, nil
+}
+
+func (c *preparedMetaTestCore) FetchPreparationPreview(context.Context, api.Request) (api.PreparationPreview, error) {
+	return api.PreparationPreview{}, nil
+}
+
+func (c *preparedMetaTestCore) FetchTrackerDryRunPreview(context.Context, api.Request) (api.TrackerDryRunPreview, error) {
+	return api.TrackerDryRunPreview{}, nil
+}
+
+func (c *preparedMetaTestCore) CheckDupes(context.Context, api.Request) (api.DupeCheckSummary, error) {
+	return api.DupeCheckSummary{}, nil
+}
+
+func (c *preparedMetaTestCore) BuildUploadReview(context.Context, api.Request) (api.UploadReview, error) {
+	return api.UploadReview{}, nil
+}
+
+func (c *preparedMetaTestCore) FetchScreenshotPlan(context.Context, api.Request) (api.ScreenshotPlan, error) {
+	return api.ScreenshotPlan{}, nil
+}
+
+func (c *preparedMetaTestCore) GenerateScreenshots(context.Context, api.Request, []api.ScreenshotSelection, api.ScreenshotPurpose) (api.ScreenshotResult, error) {
+	return api.ScreenshotResult{}, nil
+}
+
+func (c *preparedMetaTestCore) PreviewScreenshotFrame(context.Context, api.Request, float64) (api.ScreenshotPreview, error) {
+	return api.ScreenshotPreview{}, nil
+}
+
+func (c *preparedMetaTestCore) DeleteScreenshot(context.Context, api.Request, string) error {
+	return nil
+}
+
+func (c *preparedMetaTestCore) DeleteTrackerImageURL(context.Context, api.Request, string) error {
+	return nil
+}
+
+func (c *preparedMetaTestCore) SaveFinalScreenshotSelections(context.Context, api.Request, []api.ScreenshotImage) error {
+	return nil
+}
+
+func (c *preparedMetaTestCore) ListUploadCandidates(context.Context, api.Request) ([]api.ScreenshotImage, error) {
+	return nil, nil
+}
+
+func (c *preparedMetaTestCore) ListUploadedImages(context.Context, api.Request) ([]api.UploadedImageLink, error) {
+	return nil, nil
+}
+
+func (c *preparedMetaTestCore) UploadImages(context.Context, api.Request, string, []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+	return nil, nil
+}
+
+func (c *preparedMetaTestCore) DeleteUploadedImage(context.Context, api.Request, string, string) error {
+	return nil
+}
+
+func (c *preparedMetaTestCore) DiscoverPlaylists(context.Context, string) ([]api.PlaylistInfo, error) {
+	return nil, nil
+}
+
+func (c *preparedMetaTestCore) SavePlaylistSelection(context.Context, string, []string, bool) error {
+	return nil
+}
+
+func (c *preparedMetaTestCore) LoadPlaylistSelection(context.Context, string) (api.PlaylistSelection, error) {
+	return api.PlaylistSelection{}, nil
+}
+
+func (c *preparedMetaTestCore) ListHistory(context.Context) ([]api.HistoryEntry, error) {
+	return nil, nil
+}
+
+func (c *preparedMetaTestCore) GetHistoryOverview(context.Context, string) (api.HistoryOverview, error) {
+	return api.HistoryOverview{}, nil
+}
+
+func (c *preparedMetaTestCore) DeleteHistoryRelease(context.Context, string) error {
+	return nil
+}
+
+func (c *preparedMetaTestCore) DeleteAllHistoryReleases(context.Context) (int, error) {
+	return 0, nil
+}
+
+func (c *preparedMetaTestCore) RenderDescription(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (c *preparedMetaTestCore) SaveDescriptionOverride(context.Context, api.Request, string) error {
+	return nil
+}
+
+func (c *preparedMetaTestCore) Close() error {
+	return nil
+}
+
+func (c *preparedMetaTestCore) ExportGUICachedPreparedMeta(context.Context, api.Request) (api.PreparedMetadata, bool, error) {
+	return c.exportedMeta, c.exportFound, c.exportErr
+}
+
+func (c *preparedMetaTestCore) ImportPreparedMetadataForGUI(_ context.Context, req api.Request, meta api.PreparedMetadata) error {
+	c.importedReq = req
+	c.importedMeta = meta
+	return nil
+}
 
 func TestPruneCompletedDupeJobsLockedKeepsNewestCompleted(t *testing.T) {
 	backend := &Backend{
@@ -74,5 +208,42 @@ func TestPruneCompletedUploadJobsLockedKeepsNewestCompleted(t *testing.T) {
 	}
 	if _, ok := backend.uploads[active.id]; !ok {
 		t.Fatal("expected active upload job to remain")
+	}
+}
+
+func TestSeedRunCorePreparedMetaCopiesPreparedMetadata(t *testing.T) {
+	source := &preparedMetaTestCore{
+		exportFound:  true,
+		exportedMeta: api.PreparedMetadata{SourcePath: "C:\\releases\\movie.mkv"},
+	}
+	target := &preparedMetaTestCore{}
+	req := api.Request{
+		Paths: []string{"C:\\releases\\movie.mkv"},
+		Mode:  api.ModeGUI,
+	}
+
+	if err := guishared.SeedRunCorePreparedMeta(context.Background(), source, target, req); err != nil {
+		t.Fatalf("seed run core prepared meta: %v", err)
+	}
+	if target.importedMeta.SourcePath != "C:\\releases\\movie.mkv" {
+		t.Fatalf("expected imported source path, got %q", target.importedMeta.SourcePath)
+	}
+	if len(target.importedReq.Paths) != 1 || target.importedReq.Paths[0] != "C:\\releases\\movie.mkv" {
+		t.Fatalf("expected import request paths to be preserved, got %#v", target.importedReq.Paths)
+	}
+}
+
+func TestSeedRunCorePreparedMetaSkipsWhenNoCacheFound(t *testing.T) {
+	source := &preparedMetaTestCore{}
+	target := &preparedMetaTestCore{}
+
+	if err := guishared.SeedRunCorePreparedMeta(context.Background(), source, target, api.Request{
+		Paths: []string{"C:\\releases\\movie.mkv"},
+		Mode:  api.ModeGUI,
+	}); err != nil {
+		t.Fatalf("seed run core prepared meta: %v", err)
+	}
+	if target.importedMeta.SourcePath != "" {
+		t.Fatalf("expected no metadata import when cache missing, got %#v", target.importedMeta)
 	}
 }


### PR DESCRIPTION
## Summary
Fix the prepared-metadata cache handoff used by GUI/web dry-run and upload flows.

## What Changed
- added a shared prepared-metadata bridge for handing cached metadata from the long-lived GUI core to isolated per-run cores
- seeded per-run dry-run and upload cores in both Wails and web flows before tracker dry-run or upload-only execution
- deep-copied prepared metadata during export/import to avoid shared mutable slices and maps between cores
- added cancellation checks and a shared single-path resolver for the GUI cache handoff helpers
- added a timeout-bound context for the web upload seed step
- moved the bridge logic into `internal/guishared` so GUI and web use one implementation
- expanded regression coverage for exact-signature lookup, GUI fallback behavior, cancellation, validation errors, duplicate-path handling, and concurrent copy isolation

## Why
Metadata preview, dupe, and preparation screens cached `PreparedMetadata` on the long-lived GUI core, but Upload Targets dry-run and upload execution used fresh per-run cores for debug/log-level isolation. Those run cores could not see the in-memory cache, causing `requires prepared metadata` failures once the workflow reached tracker dry-run or upload execution.

## Impact
- fixes the upload-targets dry-run regression
- keeps GUI and web upload flows aligned
- avoids races from sharing mutable prepared-metadata internals across cores

## Validation
- `go test ./internal/core ./internal/guiapp ./internal/webserver ./internal/guishared`
- `golangci-lint run --timeout=5m`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented prepared metadata caching to reuse cached metadata between operations, improving performance for tracker dry-run and upload operations.

* **Tests**
  * Added comprehensive test coverage for prepared metadata export/import, including cache validation, context cancellation handling, concurrency safety, and metadata isolation verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->