### PR TITLE
fix(btn): config and claims handling

### DIFF
--- a/gui/frontend/src/hooks/useSettingsState.tsx
+++ b/gui/frontend/src/hooks/useSettingsState.tsx
@@ -176,6 +176,7 @@ const trackerSchemas: Record<string, FieldMeta[]> = {
   BJS: [trackerFieldMeta.LinkDirName, trackerFieldMeta.AnnounceURL, trackerFieldMeta.Anon, trackerFieldMeta.ShowGroupIfAnon],
   BLU: [trackerFieldMeta.LinkDirName, trackerFieldMeta.APIKey, trackerFieldMeta.Anon],
   BT: [trackerFieldMeta.LinkDirName, trackerFieldMeta.AnnounceURL, trackerFieldMeta.Anon],
+  BTN: [trackerFieldMeta.LinkDirName, trackerFieldMeta.APIKey, trackerFieldMeta.Username, trackerFieldMeta.Password, trackerFieldMeta.URL, trackerFieldMeta.OTPURI],
   CBR: [trackerFieldMeta.LinkDirName, trackerFieldMeta.APIKey, trackerFieldMeta.Anon, trackerFieldMeta.ModQ, trackerFieldMeta.TagForCustomRelease],
   CZ: [trackerFieldMeta.LinkDirName, trackerFieldMeta.AnnounceURL, trackerFieldMeta.Anon, trackerFieldMeta.CheckForRules],
   DC: [trackerFieldMeta.LinkDirName, trackerFieldMeta.APIKey, trackerFieldMeta.Anon],

--- a/internal/clients/search.go
+++ b/internal/clients/search.go
@@ -61,7 +61,7 @@ var trackerURLPatterns = map[string][]string{
 	"bjs":    {"tracker.bj-share.info"},
 	"blu":    {"https://blutopia.cc"},
 	"bt":     {"t.brasiltracker.org"},
-	"btn":    {"https://broadcasthe.net"},
+	"btn":    {"https://broadcasthe.net", "https://backup.landof.tv", "https://landof.tv", "landof.tv/"},
 	"cbr":    {"capybarabr.com"},
 	"cz":     {"tracker.cinemaz.to"},
 	"dc":     {"tracker.digitalcore.club", "trackerprxy.digitalcore.club"},
@@ -106,6 +106,27 @@ var trackerURLPatterns = map[string][]string{
 	"tvc":    {"https://tvchaosuk.com"},
 	"ulcx":   {"https://upload.cx"},
 	"yus":    {"https://yu-scene.net"},
+}
+
+var lowerTrackerURLPatterns = buildLowerTrackerURLPatterns(trackerURLPatterns)
+
+func buildLowerTrackerURLPatterns(source map[string][]string) map[string][]string {
+	if len(source) == 0 {
+		return nil
+	}
+	lowered := make(map[string][]string, len(source))
+	for id, patterns := range source {
+		normalized := make([]string, 0, len(patterns))
+		for _, pattern := range patterns {
+			trimmed := strings.ToLower(strings.TrimSpace(pattern))
+			if trimmed == "" {
+				continue
+			}
+			normalized = append(normalized, trimmed)
+		}
+		lowered[id] = normalized
+	}
+	return lowered
 }
 
 func buildTrackerIDPatterns() map[string]trackerPattern {
@@ -467,6 +488,7 @@ func (s *Service) searchQbitClient(ctx context.Context, name string, clientCfg c
 	s.logger.Debugf("clients: %s selected hash %s (preferred=%q)", name, bestMatch.Hash, foundPreferred)
 
 	trackerIDs := collectTrackerIDs(matches, priorityOrder)
+	matchedTrackers = ensureMatchedTrackersForKnownIDs(matchedTrackers, trackerIDs)
 
 	result := api.ClientSearchResult{
 		InfoHash:            "",
@@ -699,9 +721,13 @@ func extractTrackerMatches(comment string, trackerURLs []string, hasWorkingTrack
 func matchTrackerURLs(trackerURLs []string) []string {
 	found := make(map[string]struct{})
 	for _, trackerURL := range trackerURLs {
-		for id, patterns := range trackerURLPatterns {
+		lowerURL := strings.ToLower(strings.TrimSpace(trackerURL))
+		if lowerURL == "" {
+			continue
+		}
+		for id, patterns := range lowerTrackerURLPatterns {
 			for _, pattern := range patterns {
-				if strings.Contains(trackerURL, pattern) {
+				if strings.Contains(lowerURL, pattern) {
 					found[strings.ToUpper(id)] = struct{}{}
 				}
 			}
@@ -789,6 +815,31 @@ func collectTrackerIDs(matches []api.TorrentMatch, priority []string) map[string
 	}
 
 	return trackerIDs
+}
+
+func ensureMatchedTrackersForKnownIDs(matchedTrackers []string, trackerIDs map[string]string) []string {
+	if len(trackerIDs) == 0 {
+		return matchedTrackers
+	}
+	resolved := append([]string{}, matchedTrackers...)
+	for tracker, id := range trackerIDs {
+		if strings.TrimSpace(id) == "" {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(tracker), "btn") && !hasMatchedTracker(resolved, "BTN") {
+			resolved = append(resolved, "BTN")
+		}
+	}
+	return resolved
+}
+
+func hasMatchedTracker(trackers []string, target string) bool {
+	for _, tracker := range trackers {
+		if strings.EqualFold(strings.TrimSpace(tracker), strings.TrimSpace(target)) {
+			return true
+		}
+	}
+	return false
 }
 
 func effectiveTrackerPriority(cfg config.Config) []string {

--- a/internal/clients/search_test.go
+++ b/internal/clients/search_test.go
@@ -146,6 +146,24 @@ func TestSearchPathedTorrentsProxyPrefersPieceSize(t *testing.T) {
 	}
 }
 
+func TestMatchTrackerURLsMatchesBTNLandOfTVAnnounce(t *testing.T) {
+	t.Parallel()
+
+	matched := matchTrackerURLs([]string{"https://landof.tv/redacted/announce"})
+	if !containsString(matched, "BTN") {
+		t.Fatalf("expected BTN in matched trackers, got %v", matched)
+	}
+}
+
+func TestEnsureMatchedTrackersForKnownIDsAddsBTN(t *testing.T) {
+	t.Parallel()
+
+	matched := ensureMatchedTrackersForKnownIDs(nil, map[string]string{"btn": "2202392"})
+	if !containsString(matched, "BTN") {
+		t.Fatalf("expected BTN in matched trackers, got %v", matched)
+	}
+}
+
 func TestResolveSearchClientsUsesClientOverride(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -742,6 +742,52 @@ func DisableUnsupportedTrackerImageRehosts(cfg *Config) []string {
 	return disabled
 }
 
+func ResolveBTNAPIToken(cfg Config) string {
+	if trackerCfg, ok := cfg.Trackers.Trackers["BTN"]; ok {
+		token := strings.TrimSpace(trackerCfg.APIKey)
+		if token != "" {
+			return token
+		}
+	}
+	token := strings.TrimSpace(cfg.Metadata.BTNAPI)
+	return token
+}
+
+// MergeMissingTrackerDefaults backfills tracker stubs from the embedded example
+// config so older saved configs can discover newly added trackers in the GUI.
+func MergeMissingTrackerDefaults(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.Trackers.Trackers == nil {
+		cfg.Trackers.Trackers = map[string]TrackerConfig{}
+	}
+	if cfg.Trackers.DefaultTrackers == nil {
+		cfg.Trackers.DefaultTrackers = CSVList{}
+	}
+	defaults, err := loadEmbeddedDefaultConfigRaw()
+	if err != nil || defaults == nil || len(defaults.Trackers.Trackers) == 0 {
+		if err != nil {
+			return fmt.Errorf("load embedded tracker defaults: %w", err)
+		}
+		return errors.New("load embedded tracker defaults: embedded default trackers missing")
+	}
+	for trackerName, trackerCfg := range defaults.Trackers.Trackers {
+		if _, ok := cfg.Trackers.Trackers[trackerName]; ok {
+			continue
+		}
+		cfg.Trackers.Trackers[trackerName] = trackerCfg
+	}
+	if token := strings.TrimSpace(cfg.Metadata.BTNAPI); token != "" {
+		btnCfg := cfg.Trackers.Trackers["BTN"]
+		if strings.TrimSpace(btnCfg.APIKey) == "" {
+			btnCfg.APIKey = token
+			cfg.Trackers.Trackers["BTN"] = btnCfg
+		}
+	}
+	return nil
+}
+
 func (c TorrentClientConfig) QbitHost() string {
 	if strings.TrimSpace(c.QuiProxyURL) != "" {
 		host := strings.TrimSpace(c.QuiProxyURL)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -368,6 +368,68 @@ func TestLoadEmbeddedDefaultConfig(t *testing.T) {
 	if _, ok := cfg.Trackers.Trackers["AITHER"]; !ok {
 		t.Fatalf("embedded default trackers should include AITHER")
 	}
+	if _, ok := cfg.Trackers.Trackers["BTN"]; !ok {
+		t.Fatalf("embedded default trackers should include BTN")
+	}
+}
+
+func TestMergeMissingTrackerDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Trackers: TrackersConfig{
+			Trackers: map[string]TrackerConfig{
+				"AITHER": {APIKey: "existing"},
+			},
+		},
+	}
+
+	if err := MergeMissingTrackerDefaults(cfg); err != nil {
+		t.Fatalf("merge missing tracker defaults: %v", err)
+	}
+
+	if _, ok := cfg.Trackers.Trackers["BTN"]; !ok {
+		t.Fatalf("expected BTN to be backfilled from embedded defaults")
+	}
+	if got := cfg.Trackers.Trackers["AITHER"].APIKey; got != "existing" {
+		t.Fatalf("expected existing tracker config to be preserved, got %q", got)
+	}
+}
+
+func TestResolveBTNAPITokenPrefersTrackerConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Metadata: MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: TrackersConfig{
+			Trackers: map[string]TrackerConfig{
+				"BTN": {APIKey: "tracker-token"},
+			},
+		},
+	}
+
+	if got := ResolveBTNAPIToken(cfg); got != "tracker-token" {
+		t.Fatalf("expected tracker token, got %q", got)
+	}
+}
+
+func TestMergeMissingTrackerDefaultsBackfillsLegacyBTNAPIIntoTrackerConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Metadata: MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: TrackersConfig{
+			Trackers: map[string]TrackerConfig{},
+		},
+	}
+
+	if err := MergeMissingTrackerDefaults(cfg); err != nil {
+		t.Fatalf("merge missing tracker defaults: %v", err)
+	}
+
+	if got := cfg.Trackers.Trackers["BTN"].APIKey; got != "legacy-token" {
+		t.Fatalf("expected legacy BTN api token to backfill tracker config, got %q", got)
+	}
 }
 
 func TestDisableUnsupportedTrackerImageRehosts(t *testing.T) {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -24,7 +24,7 @@ func EmbeddedExampleYAML() []byte {
 	return copied
 }
 
-func LoadEmbeddedDefaultConfig() (*Config, error) {
+func loadEmbeddedDefaultConfigRaw() (*Config, error) {
 	if len(embeddedExampleYAML) == 0 {
 		return nil, errors.New("embedded default config is empty")
 	}
@@ -33,4 +33,15 @@ func LoadEmbeddedDefaultConfig() (*Config, error) {
 		return nil, fmt.Errorf("parse embedded default config: %w", err)
 	}
 	return &cfg, nil
+}
+
+func LoadEmbeddedDefaultConfig() (*Config, error) {
+	cfg, err := loadEmbeddedDefaultConfigRaw()
+	if err != nil {
+		return nil, err
+	}
+	if err := MergeMissingTrackerDefaults(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
 }

--- a/internal/config/defaults/example.yaml
+++ b/internal/config/defaults/example.yaml
@@ -187,6 +187,13 @@ trackers:
     link_dir_name: ""
     announce_url: ""
     anon: false
+  BTN:
+    link_dir_name: ""
+    api_key: ""
+    username: ""
+    password: ""
+    url: "https://backup.landof.tv"
+    otp_uri: ""
   CBR:
     link_dir_name: ""
     api_key: ""

--- a/internal/dupechecking/btn.go
+++ b/internal/dupechecking/btn.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package dupechecking
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+const btnRPCURL = "https://api.broadcasthe.net/"
+
+type btnHandler struct {
+	cfg  config.Config
+	http *http.Client
+}
+
+func (h btnHandler) Search(ctx context.Context, meta api.PreparedMetadata, _ string) ([]api.DupeEntry, []string, error) {
+	apiToken := strings.TrimSpace(config.ResolveBTNAPIToken(h.cfg))
+	if apiToken == "" {
+		return nil, []string{noteSkip("missing api_key for tracker")}, nil
+	}
+	if !isBTNTVMeta(meta) {
+		return nil, []string{noteSkip("BTN only supports TV dupe search")}, nil
+	}
+
+	filter := make(map[string]any)
+	switch {
+	case btnTrackerID(meta) != "":
+		filter["id"] = btnTrackerID(meta)
+	case meta.ExternalIDs.IMDBID != 0:
+		filter["imdb"] = formatBTNIMDbID(meta.ExternalIDs.IMDBID)
+	case meta.ExternalIDs.TVDBID != 0:
+		filter["tvdb"] = meta.ExternalIDs.TVDBID
+	case btnSearchTitle(meta) != "":
+		filter["searchstr"] = btnSearchTitle(meta)
+	default:
+		return nil, []string{noteSkip("missing btn/imdb/tvdb id and title for BTN dupe search")}, nil
+	}
+
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "upbrr-btn-search",
+		"method":  "getTorrentsSearch",
+		"params":  []any{apiToken, filter, 50},
+	}
+	status, body, err := doJSONPostAny(ctx, h.http, btnRPCURL, payload, nil)
+	if err != nil {
+		return nil, []string{noteSkip("BTN request failed")}, nil
+	}
+	if status < 200 || status >= 300 || body == nil {
+		return nil, []string{noteSkip("BTN search failed")}, nil
+	}
+
+	response, ok := body.(map[string]any)
+	if !ok {
+		return nil, []string{noteSkip("BTN search failed")}, nil
+	}
+	if errPayload, ok := response["error"].(map[string]any); ok && len(errPayload) > 0 {
+		return nil, nil, nil
+	}
+
+	result, _ := response["result"].(map[string]any)
+	if len(result) == 0 {
+		return nil, nil, nil
+	}
+	torrents, _ := result["torrents"].(map[string]any)
+	entries := make([]api.DupeEntry, 0, len(torrents))
+	for torrentID, raw := range torrents {
+		torrentData, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		entry := api.DupeEntry{
+			Name: btnReleaseName(torrentID, torrentData),
+			ID:   strings.TrimSpace(torrentID),
+			Link: btnTorrentLink(torrentID, torrentData),
+			Res:  btnResolution(torrentData),
+			Type: btnType(torrentData),
+		}
+		size := intFromAny(firstValue(torrentData, "Size", "size"))
+		if size > 0 {
+			entry.SizeKnown = true
+			entry.SizeBytes = size
+		}
+		entry.Flags = btnFlags(torrentData)
+		entries = append(entries, entry)
+	}
+	return entries, nil, nil
+}
+
+func isBTNTVMeta(meta api.PreparedMetadata) bool {
+	category := strings.ToUpper(strings.TrimSpace(meta.ExternalIDs.Category))
+	if category == "" {
+		category = strings.ToUpper(strings.TrimSpace(meta.MediaInfoCategory))
+	}
+	return category == "TV"
+}
+
+func btnTrackerID(meta api.PreparedMetadata) string {
+	if len(meta.TrackerIDs) == 0 {
+		return ""
+	}
+	for key, value := range meta.TrackerIDs {
+		if strings.EqualFold(strings.TrimSpace(key), "BTN") {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func formatBTNIMDbID(imdbID int) string {
+	if imdbID <= 0 {
+		return ""
+	}
+	return "tt" + leftPad(imdbID, 7)
+}
+
+func btnSearchTitle(meta api.PreparedMetadata) string {
+	candidates := []string{strings.TrimSpace(meta.Release.Title)}
+	if meta.ExternalMetadata.TVDB != nil {
+		candidates = append(candidates,
+			strings.TrimSpace(meta.ExternalMetadata.TVDB.Name),
+			strings.TrimSpace(meta.ExternalMetadata.TVDB.NameEnglish),
+		)
+	}
+	if meta.ExternalMetadata.TVmaze != nil {
+		candidates = append(candidates, strings.TrimSpace(meta.ExternalMetadata.TVmaze.Name))
+	}
+	candidates = append(candidates,
+		strings.TrimSpace(meta.Filename),
+		strings.TrimSpace(meta.ReleaseName),
+	)
+	for _, candidate := range candidates {
+		if candidate != "" {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func btnReleaseName(torrentID string, torrentData map[string]any) string {
+	candidates := []string{
+		stringFromAny(firstValue(torrentData, "ReleaseName", "releaseName")),
+		stringFromAny(firstValue(torrentData, "SceneName", "Name", "name")),
+		stringFromAny(firstValue(torrentData, "Series", "series")),
+		strings.TrimSpace(torrentID),
+	}
+	for _, candidate := range candidates {
+		if candidate != "" {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func btnTorrentLink(torrentID string, torrentData map[string]any) string {
+	groupID := stringFromAny(firstValue(torrentData, "GroupID", "groupId"))
+	if groupID == "" || strings.TrimSpace(torrentID) == "" {
+		return ""
+	}
+	return "https://broadcasthe.net/torrents.php?id=" + groupID + "&torrentid=" + strings.TrimSpace(torrentID)
+}
+
+func btnResolution(torrentData map[string]any) string {
+	return stringFromAny(firstValue(torrentData, "Resolution", "resolution"))
+}
+
+func btnType(torrentData map[string]any) string {
+	return stringFromAny(firstValue(torrentData, "Source", "source", "Type", "type"))
+}
+
+func btnFlags(torrentData map[string]any) []string {
+	flags := make([]string, 0, 2)
+	for _, value := range []string{
+		stringFromAny(firstValue(torrentData, "HDR", "hdr")),
+		stringFromAny(firstValue(torrentData, "DolbyVision", "dolbyVision", "DV", "dv")),
+	} {
+		upper := strings.ToUpper(strings.TrimSpace(value))
+		switch upper {
+		case "", "0", "FALSE", "NO":
+			continue
+		case "1", "TRUE", "YES":
+			continue
+		}
+		flags = append(flags, upper)
+	}
+	return flags
+}
+
+func firstValue(values map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := values[key]; ok {
+			return value
+		}
+	}
+	return nil
+}

--- a/internal/dupechecking/btn_test.go
+++ b/internal/dupechecking/btn_test.go
@@ -1,0 +1,303 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package dupechecking
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestBTNHandlerSkipsWithoutAPIKey(t *testing.T) {
+	t.Parallel()
+
+	handler := btnHandler{cfg: config.Config{}}
+	entries, notes, err := handler.Search(context.Background(), api.PreparedMetadata{
+		SourcePath: "x",
+		ExternalIDs: api.ExternalIDs{
+			Category: "TV",
+		},
+	}, "BTN")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no entries, got %d", len(entries))
+	}
+	reason, ok := parseSkipReason(notes)
+	if !ok || reason != "missing api_key for tracker" {
+		t.Fatalf("expected missing api_key skip note, got %v", notes)
+	}
+}
+
+func TestBTNHandlerSkipsNonTV(t *testing.T) {
+	t.Parallel()
+
+	handler := btnHandler{cfg: configWithBTNAPIKey(), http: http.DefaultClient}
+	entries, notes, err := handler.Search(context.Background(), api.PreparedMetadata{
+		SourcePath: "x",
+		ExternalIDs: api.ExternalIDs{
+			Category: "MOVIE",
+		},
+	}, "BTN")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no entries, got %d", len(entries))
+	}
+	reason, ok := parseSkipReason(notes)
+	if !ok || reason != "BTN only supports TV dupe search" {
+		t.Fatalf("expected non-tv skip note, got %v", notes)
+	}
+}
+
+func TestBTNHandlerUsesTrackerIDFirst(t *testing.T) {
+	t.Parallel()
+
+	payloads := captureBTNPayloads(t, `{"result":{"torrents":{}}}`)
+	handler := btnHandler{cfg: configWithBTNAPIKey(), http: payloads.client}
+
+	_, notes, err := handler.Search(context.Background(), api.PreparedMetadata{
+		SourcePath: "x",
+		TrackerIDs: map[string]string{"btn": "1234"},
+		ExternalIDs: api.ExternalIDs{
+			Category: "TV",
+			IMDBID:   7654321,
+			TVDBID:   8899,
+		},
+		Release: api.ReleaseInfo{Title: "Ignored"},
+	}, "BTN")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(notes) != 0 {
+		t.Fatalf("expected no notes, got %v", notes)
+	}
+	filter := payloads.lastFilter(t)
+	assertBTNFilterValue(t, filter, "id", "1234")
+	if _, ok := filter["imdb"]; ok {
+		t.Fatalf("did not expect imdb when btn id is present: %#v", filter)
+	}
+	if _, ok := filter["tvdb"]; ok {
+		t.Fatalf("did not expect tvdb when btn id is present: %#v", filter)
+	}
+	if _, ok := filter["searchstr"]; ok {
+		t.Fatalf("did not expect searchstr when btn id is present: %#v", filter)
+	}
+}
+
+func TestBTNHandlerFallsBackToIMDb(t *testing.T) {
+	t.Parallel()
+
+	payloads := captureBTNPayloads(t, `{"result":{"torrents":{}}}`)
+	handler := btnHandler{cfg: configWithBTNAPIKey(), http: payloads.client}
+
+	_, _, err := handler.Search(context.Background(), api.PreparedMetadata{
+		SourcePath: "x",
+		ExternalIDs: api.ExternalIDs{
+			Category: "TV",
+			IMDBID:   1234567,
+		},
+	}, "BTN")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	filter := payloads.lastFilter(t)
+	assertBTNFilterValue(t, filter, "imdb", "tt1234567")
+}
+
+func TestBTNHandlerFallsBackToTVDB(t *testing.T) {
+	t.Parallel()
+
+	payloads := captureBTNPayloads(t, `{"result":{"torrents":{}}}`)
+	handler := btnHandler{cfg: configWithBTNAPIKey(), http: payloads.client}
+
+	_, _, err := handler.Search(context.Background(), api.PreparedMetadata{
+		SourcePath: "x",
+		ExternalIDs: api.ExternalIDs{
+			Category: "TV",
+			TVDBID:   998877,
+		},
+	}, "BTN")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	filter := payloads.lastFilter(t)
+	if got := intFromAny(filter["tvdb"]); got != 998877 {
+		t.Fatalf("expected tvdb 998877, got %#v", filter["tvdb"])
+	}
+}
+
+func TestBTNHandlerFallsBackToTitleSearch(t *testing.T) {
+	t.Parallel()
+
+	payloads := captureBTNPayloads(t, `{"result":{"torrents":{}}}`)
+	handler := btnHandler{cfg: configWithBTNAPIKey(), http: payloads.client}
+
+	_, _, err := handler.Search(context.Background(), api.PreparedMetadata{
+		SourcePath: "x",
+		ExternalIDs: api.ExternalIDs{
+			Category: "TV",
+		},
+		Release: api.ReleaseInfo{Title: "Example Show"},
+	}, "BTN")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	filter := payloads.lastFilter(t)
+	assertBTNFilterValue(t, filter, "searchstr", "Example Show")
+}
+
+func TestBTNHandlerNormalizesEntries(t *testing.T) {
+	t.Parallel()
+
+	payloads := captureBTNPayloads(t, `{"result":{"torrents":{"777":{"GroupID":"333","ReleaseName":"Example.Show.S01E01.1080p.WEB-DL.HDR.DV","Size":12345,"Resolution":"1080p","Source":"WEB-DL","HDR":"HDR10","DolbyVision":"DV"}}}}`)
+	handler := btnHandler{cfg: configWithBTNAPIKey(), http: payloads.client}
+
+	entries, notes, err := handler.Search(context.Background(), api.PreparedMetadata{
+		SourcePath: "x",
+		ExternalIDs: api.ExternalIDs{
+			Category: "TV",
+		},
+		Release: api.ReleaseInfo{Title: "Example Show"},
+	}, "BTN")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(notes) != 0 {
+		t.Fatalf("expected no notes, got %v", notes)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.Name != "Example.Show.S01E01.1080p.WEB-DL.HDR.DV" {
+		t.Fatalf("unexpected name: %#v", entry)
+	}
+	if entry.ID != "777" {
+		t.Fatalf("unexpected id: %#v", entry)
+	}
+	if entry.Link != "https://broadcasthe.net/torrents.php?id=333&torrentid=777" {
+		t.Fatalf("unexpected link: %#v", entry)
+	}
+	if !entry.SizeKnown || entry.SizeBytes != 12345 {
+		t.Fatalf("unexpected size fields: %#v", entry)
+	}
+	if entry.Res != "1080p" {
+		t.Fatalf("unexpected resolution: %#v", entry)
+	}
+	if entry.Type != "WEB-DL" {
+		t.Fatalf("unexpected type: %#v", entry)
+	}
+	if len(entry.Flags) != 2 || entry.Flags[0] != "HDR10" || entry.Flags[1] != "DV" {
+		t.Fatalf("unexpected flags: %#v", entry.Flags)
+	}
+}
+
+func TestBTNHandlerAPIErrorReturnsNoDupes(t *testing.T) {
+	t.Parallel()
+
+	payloads := captureBTNPayloads(t, `{"error":{"message":"bad request"}}`)
+	handler := btnHandler{cfg: configWithBTNAPIKey(), http: payloads.client}
+
+	entries, notes, err := handler.Search(context.Background(), api.PreparedMetadata{
+		SourcePath: "x",
+		ExternalIDs: api.ExternalIDs{
+			Category: "TV",
+		},
+		Release: api.ReleaseInfo{Title: "Example Show"},
+	}, "BTN")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no entries, got %d", len(entries))
+	}
+	if len(notes) != 0 {
+		t.Fatalf("expected no notes, got %v", notes)
+	}
+}
+
+type btnPayloadCapture struct {
+	client  *http.Client
+	payload map[string]any
+	mu      sync.Mutex
+}
+
+func captureBTNPayloads(t *testing.T, response string) *btnPayloadCapture {
+	t.Helper()
+
+	capture := &btnPayloadCapture{}
+	capture.client = &http.Client{
+		Transport: btnRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			_ = req.Body.Close()
+
+			capture.mu.Lock()
+			defer capture.mu.Unlock()
+			if err := json.Unmarshal(body, &capture.payload); err != nil {
+				return nil, err
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(response)),
+				Request:    req,
+			}, nil
+		}),
+	}
+	return capture
+}
+
+func (c *btnPayloadCapture) lastFilter(t *testing.T) map[string]any {
+	t.Helper()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	params, ok := c.payload["params"].([]any)
+	if !ok || len(params) < 2 {
+		t.Fatalf("expected JSON-RPC params, got %#v", c.payload)
+	}
+	filter, ok := params[1].(map[string]any)
+	if !ok {
+		t.Fatalf("expected filter map, got %#v", params[1])
+	}
+	return filter
+}
+
+func configWithBTNAPIKey() config.Config {
+	return config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"BTN": {APIKey: strings.Repeat("x", 30)},
+			},
+		},
+	}
+}
+
+func assertBTNFilterValue(t *testing.T, filter map[string]any, key string, want string) {
+	t.Helper()
+	if got := stringFromAny(filter[key]); got != want {
+		t.Fatalf("expected %s=%q, got %#v", key, want, filter)
+	}
+}
+
+type btnRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn btnRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}

--- a/internal/dupechecking/factory.go
+++ b/internal/dupechecking/factory.go
@@ -19,6 +19,7 @@ func buildHandlers(deps handlerDeps) map[string]searchHandler {
 	// Functional non-Unit3D handlers (first pass parity)
 	handlers["ANT"] = antHandler{cfg: deps.cfg, http: deps.http, logger: deps.logger}
 	handlers["BHD"] = bhdHandler{cfg: deps.cfg, http: deps.http, logger: deps.logger}
+	handlers["BTN"] = btnHandler{cfg: deps.cfg, http: deps.http}
 	handlers["HDB"] = hdbHandler{cfg: deps.cfg, http: deps.http, logger: deps.logger}
 	handlers["PTP"] = ptpHandler{cfg: deps.cfg, http: deps.http, logger: deps.logger}
 	handlers["BHDTV"] = bhdtvHandler{}

--- a/internal/dupechecking/factory_test.go
+++ b/internal/dupechecking/factory_test.go
@@ -14,7 +14,7 @@ func TestBuildHandlersCoversKnownTrackers(t *testing.T) {
 	handlers := buildHandlers(handlerDeps{cfg: config.Config{}})
 
 	known := []string{
-		"A4K", "ACM", "AITHER", "ANT", "AR", "ASC", "AZ", "BHD", "BHDTV", "BJS", "BLU", "BT", "CBR", "CZ", "DC", "DP", "EMUW", "FF", "FL", "FNP", "FRIKI", "GPW", "HDB", "HDS", "HDT", "HHD", "HUNO", "IHD", "IS", "ITT", "LCD", "LDU", "LST", "LT", "LUME", "MTV", "NBL", "OE", "OTW", "PHD", "PT", "PTP", "PTS", "PTT", "R4E", "RAS", "RF", "RTF", "SAM", "SHRI", "SP", "SPD", "STC", "THR", "TIK", "TL", "TLZ", "TOS", "TTR", "TVC", "ULCX", "UTP", "YUS",
+		"A4K", "ACM", "AITHER", "ANT", "AR", "ASC", "AZ", "BHD", "BHDTV", "BJS", "BLU", "BT", "BTN", "CBR", "CZ", "DC", "DP", "EMUW", "FF", "FL", "FNP", "FRIKI", "GPW", "HDB", "HDS", "HDT", "HHD", "HUNO", "IHD", "IS", "ITT", "LCD", "LDU", "LST", "LT", "LUME", "MTV", "NBL", "OE", "OTW", "PHD", "PT", "PTP", "PTS", "PTT", "R4E", "RAS", "RF", "RTF", "SAM", "SHRI", "SP", "SPD", "STC", "THR", "TIK", "TL", "TLZ", "TOS", "TTR", "TVC", "ULCX", "UTP", "YUS",
 	}
 	for _, tracker := range known {
 		if _, ok := handlers[tracker]; !ok {

--- a/internal/dupechecking/service_test.go
+++ b/internal/dupechecking/service_test.go
@@ -86,6 +86,38 @@ func TestCheckSkipsRuleFailures(t *testing.T) {
 	}
 }
 
+func TestCheckSkipsClaimRuleFailures(t *testing.T) {
+	t.Parallel()
+	svc := NewService(config.Config{}, api.NopLogger{})
+	meta := api.PreparedMetadata{
+		SourcePath: "/tmp/example",
+		TrackerRuleFailures: map[string][]api.RuleFailure{
+			"BTN": {{Rule: "claim_active", Reason: "BTN has an active claim for this release; approximately 11 hours remain in the 48-hour claim window"}},
+		},
+	}
+
+	summary, err := svc.Check(context.Background(), meta, []string{"BTN"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summary.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(summary.Results))
+	}
+	result := summary.Results[0]
+	if !result.Skipped {
+		t.Fatalf("expected skipped result")
+	}
+	if !strings.Contains(result.SkipReason, "active claim") {
+		t.Fatalf("expected claim skip reason, got %q", result.SkipReason)
+	}
+	if !strings.Contains(result.SkipReason, "11 hours remain") {
+		t.Fatalf("expected hours remaining in skip reason, got %q", result.SkipReason)
+	}
+	if len(result.SkipRules) != 1 || result.SkipRules[0] != "claim_active" {
+		t.Fatalf("expected claim_active skip rule, got %#v", result.SkipRules)
+	}
+}
+
 func TestCheckUnsupportedTrackerMarkedSkipped(t *testing.T) {
 	t.Parallel()
 	svc := NewService(config.Config{}, api.NopLogger{})

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -1165,6 +1165,9 @@ func (a *App) GetConfig() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if err := config.MergeMissingTrackerDefaults(cfg); err != nil {
+		return "", err
+	}
 	if strings.TrimSpace(cfg.MainSettings.DBPath) == "" {
 		cfg.MainSettings.DBPath = a.cfg.MainSettings.DBPath
 	}
@@ -1212,6 +1215,9 @@ func (a *App) SaveConfig(payload string) error {
 
 	cfg, err := config.ImportFromJSON(payload)
 	if err != nil {
+		return err
+	}
+	if err := config.MergeMissingTrackerDefaults(cfg); err != nil {
 		return err
 	}
 	if strings.TrimSpace(cfg.MainSettings.DBPath) == "" {

--- a/internal/guiapp/config.go
+++ b/internal/guiapp/config.go
@@ -141,6 +141,9 @@ func loadConfigFromDatabase(ctx context.Context, dbPath string) (config.Config, 
 	if err != nil {
 		return config.Config{}, err
 	}
+	if err := config.MergeMissingTrackerDefaults(loaded); err != nil {
+		return config.Config{}, err
+	}
 	if len(config.DisableUnsupportedTrackerImageRehosts(loaded)) > 0 {
 		if err := config.SaveToDatabase(ctx, loaded, repo); err != nil {
 			return config.Config{}, err

--- a/internal/guiapp/config_test.go
+++ b/internal/guiapp/config_test.go
@@ -49,3 +49,39 @@ func TestLoadConfigDisablesUnsupportedTrackerImageRehostFromDatabase(t *testing.
 		t.Fatal("expected unsupported TL img_rehost to be disabled during GUI config load")
 	}
 }
+
+func TestLoadConfigFromDatabaseBackfillsMissingTrackerDefaults(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "guiapp.db")
+	repo, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	if err := repo.Migrate(); err != nil {
+		_ = repo.Close()
+		t.Fatalf("migrate repo: %v", err)
+	}
+
+	cfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		_ = repo.Close()
+		t.Fatalf("load embedded config: %v", err)
+	}
+	cfg.MainSettings.DBPath = dbPath
+	delete(cfg.Trackers.Trackers, "BTN")
+
+	if err := config.SaveToDatabase(context.Background(), cfg, repo); err != nil {
+		_ = repo.Close()
+		t.Fatalf("save config: %v", err)
+	}
+	_ = repo.Close()
+
+	loaded, err := loadConfigFromDatabase(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("load config from database: %v", err)
+	}
+	if _, ok := loaded.Trackers.Trackers["BTN"]; !ok {
+		t.Fatal("expected BTN tracker to be backfilled during GUI config load")
+	}
+}

--- a/internal/metadata/tracker_claims.go
+++ b/internal/metadata/tracker_claims.go
@@ -23,6 +23,15 @@ import (
 )
 
 const trackerClaimsCacheTTL = 24 * time.Hour
+const trackerClaimRuleActive = "claim_active"
+
+type trackerClaimProvider interface {
+	cachePath(dbPath string, tracker string) (string, error)
+	cacheTTL() time.Duration
+	hasClaim(ctx context.Context, s *Service, tracker string, meta api.PreparedMetadata) (bool, error)
+}
+
+type apiTrackerClaimProvider struct{}
 
 type trackerClaimsCache struct {
 	LastUpdated string              `json:"last_updated"`
@@ -63,7 +72,13 @@ type trackerClaimsAttributes struct {
 func (s *Service) applyTrackerClaims(ctx context.Context, meta api.PreparedMetadata) (api.PreparedMetadata, error) {
 	resolved := uniqueUpperTrackers(trackersWithClaimChecks(meta))
 	if len(resolved) == 0 {
+		if s.logger != nil {
+			s.logger.Debugf("metadata: tracker claims skipped (no eligible trackers)")
+		}
 		return meta, nil
+	}
+	if s.logger != nil {
+		s.logger.Debugf("metadata: tracker claims evaluating trackers=%v", resolved)
 	}
 
 	for _, tracker := range resolved {
@@ -82,6 +97,10 @@ func (s *Service) applyTrackerClaims(ctx context.Context, meta api.PreparedMetad
 		}
 
 		meta.BlockedTrackers = addMetadataTrackerBlockReason(meta.BlockedTrackers, tracker, api.TrackerBlockReasonClaim)
+		meta.TrackerRuleFailures = addMetadataTrackerRuleFailure(meta.TrackerRuleFailures, tracker, api.RuleFailure{
+			Rule:   trackerClaimRuleActive,
+			Reason: trackerClaimFailureReason(tracker, meta, s),
+		})
 		if s.logger != nil {
 			s.logger.Warnf("metadata: tracker claim match found for %s", tracker)
 		}
@@ -91,16 +110,39 @@ func (s *Service) applyTrackerClaims(ctx context.Context, meta api.PreparedMetad
 }
 
 func (s *Service) hasTrackerClaim(ctx context.Context, tracker string, meta api.PreparedMetadata) (bool, error) {
-	if strings.EqualFold(strings.TrimSpace(tracker), "BTN") {
-		return s.hasBTNClaim(ctx, meta)
+	provider, ok := resolveTrackerClaimProvider(tracker)
+	if !ok {
+		return false, nil
 	}
+	return provider.hasClaim(ctx, s, tracker, meta)
+}
 
-	cachePath, err := trackerClaimsPath(s.cfg.MainSettings.DBPath, tracker)
+func resolveTrackerClaimProvider(tracker string) (trackerClaimProvider, bool) {
+	switch strings.ToUpper(strings.TrimSpace(tracker)) {
+	case "BTN":
+		return btnTrackerClaimProvider{}, true
+	case "AITHER":
+		return apiTrackerClaimProvider{}, true
+	default:
+		return nil, false
+	}
+}
+
+func (apiTrackerClaimProvider) cachePath(dbPath string, tracker string) (string, error) {
+	return trackerClaimsPath(dbPath, tracker)
+}
+
+func (apiTrackerClaimProvider) cacheTTL() time.Duration {
+	return trackerClaimsCacheTTL
+}
+
+func (p apiTrackerClaimProvider) hasClaim(ctx context.Context, s *Service, tracker string, meta api.PreparedMetadata) (bool, error) {
+	cachePath, err := p.cachePath(s.cfg.MainSettings.DBPath, tracker)
 	if err != nil {
 		return false, fmt.Errorf("metadata: tracker claims path %s: %w", tracker, err)
 	}
 
-	claims, err := s.loadTrackerClaims(ctx, tracker, cachePath)
+	claims, err := s.loadTrackerClaims(ctx, tracker, cachePath, p.cacheTTL())
 	if err != nil {
 		return false, err
 	}
@@ -132,8 +174,8 @@ func (s *Service) hasTrackerClaim(ctx context.Context, tracker string, meta api.
 	return false, nil
 }
 
-func (s *Service) loadTrackerClaims(ctx context.Context, tracker string, cachePath string) ([]trackerClaimEntry, error) {
-	if payload, ok := loadFreshTrackerClaimsCache(cachePath); ok {
+func (s *Service) loadTrackerClaims(ctx context.Context, tracker string, cachePath string, cacheTTL time.Duration) ([]trackerClaimEntry, error) {
+	if payload, ok := loadFreshTrackerClaimsCache(cachePath, cacheTTL); ok {
 		return payload.Claims, nil
 	}
 
@@ -147,9 +189,9 @@ func (s *Service) loadTrackerClaims(ctx context.Context, tracker string, cachePa
 	return claims, nil
 }
 
-func loadFreshTrackerClaimsCache(path string) (trackerClaimsCache, bool) {
+func loadFreshTrackerClaimsCache(path string, cacheTTL time.Duration) (trackerClaimsCache, bool) {
 	info, err := os.Stat(path)
-	if err != nil || time.Since(info.ModTime()) >= trackerClaimsCacheTTL {
+	if err != nil || time.Since(info.ModTime()) >= cacheTTL {
 		return trackerClaimsCache{}, false
 	}
 
@@ -374,7 +416,7 @@ func announceBaseURL(value string) string {
 }
 
 func trackersWithClaimChecks(meta api.PreparedMetadata) []string {
-	resolved := resolveTrackerCandidates(meta)
+	resolved := resolveClaimTrackerCandidates(meta)
 	if len(resolved) == 0 {
 		return nil
 	}
@@ -388,6 +430,16 @@ func trackersWithClaimChecks(meta api.PreparedMetadata) []string {
 		}
 	}
 	return selected
+}
+
+func resolveClaimTrackerCandidates(meta api.PreparedMetadata) []string {
+	values := make([]string, 0, len(meta.Trackers)+len(meta.MatchedTrackers)+len(meta.TrackerIDs))
+	values = append(values, meta.Trackers...)
+	values = append(values, meta.MatchedTrackers...)
+	for key := range meta.TrackerIDs {
+		values = append(values, key)
+	}
+	return uniqueUpperTrackers(values)
 }
 
 func uniqueUpperTrackers(values []string) []string {
@@ -425,6 +477,35 @@ func addMetadataTrackerBlockReason(blocked map[string][]api.TrackerBlockReason, 
 	}
 	blocked[name] = append(blocked[name], reason)
 	return blocked
+}
+
+func addMetadataTrackerRuleFailure(failures map[string][]api.RuleFailure, tracker string, failure api.RuleFailure) map[string][]api.RuleFailure {
+	name := strings.ToUpper(strings.TrimSpace(tracker))
+	rule := strings.TrimSpace(failure.Rule)
+	reason := strings.TrimSpace(failure.Reason)
+	if name == "" || (rule == "" && reason == "") {
+		return failures
+	}
+	if failures == nil {
+		failures = make(map[string][]api.RuleFailure)
+	}
+	for _, existing := range failures[name] {
+		if strings.EqualFold(strings.TrimSpace(existing.Rule), rule) && strings.EqualFold(strings.TrimSpace(existing.Reason), reason) {
+			return failures
+		}
+	}
+	failures[name] = append(failures[name], api.RuleFailure{Rule: rule, Reason: reason})
+	return failures
+}
+
+func trackerClaimFailureReason(tracker string, meta api.PreparedMetadata, s *Service) string {
+	name := strings.ToUpper(strings.TrimSpace(tracker))
+	switch name {
+	case "BTN":
+		return btnClaimFailureReason(meta, s.btnClaimWindowGraceHours())
+	default:
+		return name + " has an active claim for this release"
+	}
 }
 
 func containsTrackerClaimValue(values []string, target string) bool {

--- a/internal/metadata/tracker_claims_btn.go
+++ b/internal/metadata/tracker_claims_btn.go
@@ -35,16 +35,18 @@ const (
 )
 
 var (
-	btnLineBreakPattern  = regexp.MustCompile(`(?i)<br\s*/?>`)
-	btnTagPattern        = regexp.MustCompile(`(?s)<[^>]*>`)
-	btnAKAExtractPattern = regexp.MustCompile(`(?i)\(\s*aka\s*:\s*([^\)]*?)\)`)
-	btnSxxExxCutPattern  = regexp.MustCompile(`(?i)\bS\d{1,2}E\d{1,3}\b`)
-	btnSeasonCutPattern  = regexp.MustCompile(`(?i)\bS\d{1,2}\b`)
-	btnDateCutPattern    = regexp.MustCompile(`\b\d{4}[\-\.]\d{2}[\-\.]\d{2}\b`)
-	btnNonAlnumPattern   = regexp.MustCompile(`[^a-z0-9]+`)
-	btnSpacePattern      = regexp.MustCompile(`\s+`)
-	btnTime24Pattern     = regexp.MustCompile(`^(\d{1,2}):(\d{2})(?::(\d{2}))?$`)
-	btnTime12Pattern     = regexp.MustCompile(`^(\d{1,2}):(\d{2})\s*([AaPp][Mm])$`)
+	btnLineBreakPattern       = regexp.MustCompile(`(?i)<br\s*/?>`)
+	btnTagPattern             = regexp.MustCompile(`(?s)<[^>]*>`)
+	btnAKAExtractPattern      = regexp.MustCompile(`(?i)\(\s*aka\s*:\s*([^\)]*?)\)`)
+	btnSxxExxCutPattern       = regexp.MustCompile(`(?i)\bS\d{1,2}E\d{1,3}\b`)
+	btnSeasonCutPattern       = regexp.MustCompile(`(?i)\bS\d{1,2}\b`)
+	btnDateCutPattern         = regexp.MustCompile(`\b\d{4}[\-\.]\d{2}[\-\.]\d{2}\b`)
+	btnNonAlnumPattern        = regexp.MustCompile(`[^a-z0-9]+`)
+	btnSpacePattern           = regexp.MustCompile(`\s+`)
+	btnTime24Pattern          = regexp.MustCompile(`^(\d{1,2}):(\d{2})(?::(\d{2}))?$`)
+	btnTime12Pattern          = regexp.MustCompile(`^(\d{1,2}):(\d{2})\s*([AaPp][Mm])$`)
+	btnClaimedPostTableRegex  = regexp.MustCompile(`(?is)<table[^>]*id=["']` + btnClaimedShowsPostID + `["'][^>]*>(.*?)</table>`)
+	btnClaimedContentDivRegex = regexp.MustCompile(`(?is)<div[^>]*(?:id=["']content1405482["'][^>]*|class=["'][^"']*\bpostcontent\b[^"']*["'][^>]*)>(.*?)</div>`)
 )
 
 type btnClaimedShowsCache struct {
@@ -142,6 +144,7 @@ func (s *Service) fetchBTNClaimedTitles(ctx context.Context) (map[string]struct{
 	client := &http.Client{Timeout: 30 * time.Second, Jar: jar}
 
 	_ = s.loginBTNForClaims(ctx, client)
+	mirrorBTNCookiesForClaimedThread(client)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, btnClaimedShowsURL, nil)
 	if err != nil {
@@ -202,7 +205,8 @@ func (s *Service) loginBTNForClaims(ctx context.Context, client *http.Client) er
 }
 
 func extractBTNClaimedShows(rawHTML string) map[string]struct{} {
-	normalized := btnLineBreakPattern.ReplaceAllString(rawHTML, "\n")
+	scopedHTML := extractBTNClaimedPostHTML(rawHTML)
+	normalized := btnLineBreakPattern.ReplaceAllString(scopedHTML, "\n")
 	normalized = btnTagPattern.ReplaceAllString(normalized, "")
 	normalized = html.UnescapeString(normalized)
 
@@ -237,6 +241,20 @@ func extractBTNClaimedShows(rawHTML string) map[string]struct{} {
 		}
 	}
 	return out
+}
+
+func extractBTNClaimedPostHTML(rawHTML string) string {
+	if strings.TrimSpace(rawHTML) == "" {
+		return rawHTML
+	}
+	if tableMatch := btnClaimedPostTableRegex.FindStringSubmatch(rawHTML); len(tableMatch) > 1 {
+		scoped := tableMatch[1]
+		if contentMatch := btnClaimedContentDivRegex.FindStringSubmatch(scoped); len(contentMatch) > 1 {
+			return contentMatch[1]
+		}
+		return scoped
+	}
+	return rawHTML
 }
 
 func matchBTNClaimedTitle(meta api.PreparedMetadata, claimed map[string]struct{}) (bool, string) {
@@ -479,6 +497,44 @@ func parseOptionalInt(value any) int {
 		}
 	}
 	return 0
+}
+
+func mirrorBTNCookiesForClaimedThread(client *http.Client) {
+	if client == nil || client.Jar == nil {
+		return
+	}
+
+	backupURL, backupErr := url.Parse("https://backup.landof.tv/")
+	broadcastURL, broadcastErr := url.Parse("https://broadcasthe.net/")
+	if backupErr != nil || broadcastErr != nil {
+		return
+	}
+
+	backupCookies := client.Jar.Cookies(backupURL)
+	if len(backupCookies) == 0 {
+		return
+	}
+
+	mirrored := make([]*http.Cookie, 0, len(backupCookies)*2)
+	for _, cookie := range backupCookies {
+		if cookie == nil || strings.TrimSpace(cookie.Name) == "" {
+			continue
+		}
+		copied := *cookie
+		copied.Domain = "broadcasthe.net"
+		if copied.Path == "" {
+			copied.Path = "/"
+		}
+		mirrored = append(mirrored, &copied)
+
+		dotted := copied
+		dotted.Domain = ".broadcasthe.net"
+		mirrored = append(mirrored, &dotted)
+	}
+	if len(mirrored) == 0 {
+		return
+	}
+	client.Jar.SetCookies(broadcastURL, mirrored)
 }
 
 func encodeForm(values map[string]string) string {

--- a/internal/metadata/tracker_claims_btn.go
+++ b/internal/metadata/tracker_claims_btn.go
@@ -4,7 +4,12 @@
 package metadata
 
 import (
+	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha1" //nolint:gosec // TOTP interoperability requires SHA-1.
+	"encoding/base32"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,32 +26,37 @@ import (
 	"strings"
 	"time"
 
+	htmlnode "golang.org/x/net/html"
+
+	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/pathutil"
-	"github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
 const (
+	btnSiteBaseURL             = "https://broadcasthe.net"
+	btnBackupBaseURL           = "https://backup.landof.tv"
+	btnUserPath                = "/user.php"
+	btnLoginPath               = "/login.php"
 	btnClaimedShowsURL         = "https://broadcasthe.net/forums.php?action=viewthread&threadid=30793"
 	btnClaimedShowsPostID      = "post1405482"
-	btnClaimedShowsCacheTTL    = 24 * time.Hour
+	btnClaimedShowsCacheTTL    = 48 * time.Hour
 	btnClaimWindowBaseHours    = 48
 	btnClaimWindowDefaultGrace = 24
 )
 
 var (
-	btnLineBreakPattern       = regexp.MustCompile(`(?i)<br\s*/?>`)
-	btnTagPattern             = regexp.MustCompile(`(?s)<[^>]*>`)
-	btnAKAExtractPattern      = regexp.MustCompile(`(?i)\(\s*aka\s*:\s*([^\)]*?)\)`)
-	btnSxxExxCutPattern       = regexp.MustCompile(`(?i)\bS\d{1,2}E\d{1,3}\b`)
-	btnSeasonCutPattern       = regexp.MustCompile(`(?i)\bS\d{1,2}\b`)
-	btnDateCutPattern         = regexp.MustCompile(`\b\d{4}[\-\.]\d{2}[\-\.]\d{2}\b`)
-	btnNonAlnumPattern        = regexp.MustCompile(`[^a-z0-9]+`)
-	btnSpacePattern           = regexp.MustCompile(`\s+`)
-	btnTime24Pattern          = regexp.MustCompile(`^(\d{1,2}):(\d{2})(?::(\d{2}))?$`)
-	btnTime12Pattern          = regexp.MustCompile(`^(\d{1,2}):(\d{2})\s*([AaPp][Mm])$`)
-	btnClaimedPostTableRegex  = regexp.MustCompile(`(?is)<table[^>]*id=["']` + btnClaimedShowsPostID + `["'][^>]*>(.*?)</table>`)
-	btnClaimedContentDivRegex = regexp.MustCompile(`(?is)<div[^>]*(?:id=["']content1405482["'][^>]*|class=["'][^"']*\bpostcontent\b[^"']*["'][^>]*)>(.*?)</div>`)
+	btnLineBreakPattern  = regexp.MustCompile(`(?i)<br\s*/?>`)
+	btnTagPattern        = regexp.MustCompile(`(?s)<[^>]*>`)
+	btnAKAExtractPattern = regexp.MustCompile(`(?i)\(\s*aka\s*:\s*([^\)]*?)\)`)
+	btnSxxExxCutPattern  = regexp.MustCompile(`(?i)\bS\d{1,2}E\d{1,3}\b`)
+	btnSeasonCutPattern  = regexp.MustCompile(`(?i)\bS\d{1,2}\b`)
+	btnDateCutPattern    = regexp.MustCompile(`\b\d{4}[\-\.]\d{2}[\-\.]\d{2}\b`)
+	btnNonAlnumPattern   = regexp.MustCompile(`[^a-z0-9]+`)
+	btnSpacePattern      = regexp.MustCompile(`\s+`)
+	btnTime24Pattern     = regexp.MustCompile(`^(\d{1,2}):(\d{2})(?::(\d{2}))?$`)
+	btnTime12Pattern     = regexp.MustCompile(`^(\d{1,2}):(\d{2})\s*([AaPp][Mm])$`)
 )
 
 type btnClaimedShowsCache struct {
@@ -56,12 +66,30 @@ type btnClaimedShowsCache struct {
 	Titles    []string `json:"titles"`
 }
 
-func (s *Service) hasBTNClaim(ctx context.Context, meta api.PreparedMetadata) (bool, error) {
+type btnTrackerClaimProvider struct{}
+
+func (btnTrackerClaimProvider) cachePath(dbPath string, tracker string) (string, error) {
+	return trackerClaimsPath(dbPath, tracker)
+}
+
+func (btnTrackerClaimProvider) cacheTTL() time.Duration {
+	return btnClaimedShowsCacheTTL
+}
+
+func (p btnTrackerClaimProvider) hasClaim(ctx context.Context, s *Service, tracker string, meta api.PreparedMetadata) (bool, error) {
 	if !isTVCategory(meta) {
+		if s.logger != nil {
+			s.logger.Debugf("metadata: BTN claims skipped for non-TV content")
+		}
 		return false, nil
 	}
 
-	claimedTitles, err := s.loadBTNClaimedTitles(ctx)
+	cachePath, err := p.cachePath(s.cfg.MainSettings.DBPath, tracker)
+	if err != nil {
+		return false, fmt.Errorf("metadata: BTN claims cache path: %w", err)
+	}
+
+	claimedTitles, err := s.loadBTNClaimedTitles(ctx, cachePath, p.cacheTTL())
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Warnf("metadata: BTN claim list unavailable: %v", err)
@@ -69,11 +97,20 @@ func (s *Service) hasBTNClaim(ctx context.Context, meta api.PreparedMetadata) (b
 		return false, nil
 	}
 	if len(claimedTitles) == 0 {
+		if s.logger != nil {
+			s.logger.Debugf("metadata: BTN claims loaded 0 titles")
+		}
 		return false, nil
+	}
+	if s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims loaded %d titles", len(claimedTitles))
 	}
 
 	matched, matchedTitle := matchBTNClaimedTitle(meta, claimedTitles)
 	if !matched {
+		if s.logger != nil {
+			s.logger.Debugf("metadata: BTN claims found no title match for release=%q", meta.ReleaseName)
+		}
 		return false, nil
 	}
 
@@ -112,28 +149,48 @@ func (s *Service) btnClaimWindowGraceHours() int {
 	return parsed
 }
 
-func (s *Service) loadBTNClaimedTitles(ctx context.Context) (map[string]struct{}, error) {
-	cachePath, err := btnClaimedShowsCachePath(s.cfg.MainSettings.DBPath)
-	if err != nil {
-		return nil, fmt.Errorf("metadata: BTN claims cache path: %w", err)
+func (s *Service) loadBTNClaimedTitles(ctx context.Context, cachePath string, cacheTTL time.Duration) (map[string]struct{}, error) {
+	cached, fetchedAt, cacheErr := readBTNClaimedCache(cachePath)
+	if cacheErr != nil {
+		if s.logger != nil && !errors.Is(cacheErr, os.ErrNotExist) {
+			s.logger.Warnf("metadata: BTN claims cache read failed path=%s err=%v", cachePath, cacheErr)
+		}
+	} else if s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims cache loaded path=%s titles=%d fetched_at=%d", cachePath, len(cached), fetchedAt)
 	}
-
-	cached, fetchedAt, _ := readBTNClaimedCache(cachePath)
-	if len(cached) > 0 && time.Since(time.Unix(fetchedAt, 0)) < btnClaimedShowsCacheTTL {
+	if len(cached) > 0 && time.Since(time.Unix(fetchedAt, 0)) < cacheTTL {
+		if s.logger != nil {
+			s.logger.Debugf("metadata: BTN claims cache hit path=%s age=%s ttl=%s", cachePath, time.Since(time.Unix(fetchedAt, 0)).Round(time.Second), cacheTTL)
+		}
 		return cached, nil
+	}
+	if s.logger != nil {
+		if len(cached) == 0 {
+			s.logger.Debugf("metadata: BTN claims cache miss path=%s", cachePath)
+		} else {
+			s.logger.Debugf("metadata: BTN claims cache stale path=%s age=%s ttl=%s", cachePath, time.Since(time.Unix(fetchedAt, 0)).Round(time.Second), cacheTTL)
+		}
 	}
 
 	fresh, fetchErr := s.fetchBTNClaimedTitles(ctx)
 	if fetchErr == nil && len(fresh) > 0 {
 		if err := writeBTNClaimedCache(cachePath, fresh); err != nil && s.logger != nil {
 			s.logger.Warnf("metadata: BTN claims cache write failed: %v", err)
+		} else if s.logger != nil {
+			s.logger.Debugf("metadata: BTN claims cache saved path=%s titles=%d", cachePath, len(fresh))
 		}
 		return fresh, nil
+	}
+	if fetchErr == nil && len(fresh) == 0 && s.logger != nil {
+		s.logger.Warnf("metadata: BTN claims fetch succeeded but returned no titles")
 	}
 	if fetchErr != nil && s.logger != nil {
 		s.logger.Warnf("metadata: BTN claims fetch failed; falling back to cache: %v", fetchErr)
 	}
 	if len(cached) > 0 {
+		if s.logger != nil {
+			s.logger.Debugf("metadata: BTN claims using cached titles after fetch failure path=%s titles=%d", cachePath, len(cached))
+		}
 		return cached, nil
 	}
 	return nil, fetchErr
@@ -143,65 +200,328 @@ func (s *Service) fetchBTNClaimedTitles(ctx context.Context) (map[string]struct{
 	jar, _ := cookiejar.New(nil)
 	client := &http.Client{Timeout: 30 * time.Second, Jar: jar}
 
-	_ = s.loginBTNForClaims(ctx, client)
+	if s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims fetch starting url=%s", btnClaimedShowsURL)
+	}
+	if err := s.loadBTNCookiesForClaims(client); err != nil {
+		if s.logger != nil {
+			s.logger.Warnf("metadata: BTN claims cookie load failed: %v", err)
+		}
+	} else if s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims cookie load completed")
+	}
+	isLoggedIn, err := s.btnClaimsSessionValid(ctx, client)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warnf("metadata: BTN claims session validation failed: %v", err)
+		}
+	} else if s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims session valid=%t", isLoggedIn)
+	}
+	if !isLoggedIn {
+		if err := s.loginBTNForClaims(ctx, client); err != nil {
+			if s.logger != nil {
+				s.logger.Warnf("metadata: BTN claims login failed: %v", err)
+			}
+			return nil, err
+		} else if s.logger != nil {
+			s.logger.Debugf("metadata: BTN claims login completed")
+		}
+	} else if s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims login skipped; existing session is valid")
+	}
+	if !isLoggedIn && s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims continuing after login attempt")
+	}
 	mirrorBTNCookiesForClaimedThread(client)
+	if s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims mirrored cookies for broadcasthe thread")
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, btnClaimedShowsURL, nil)
 	if err != nil {
+		if s.logger != nil {
+			s.logger.Warnf("metadata: BTN claims request build failed: %v", err)
+		}
 		return nil, err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		if s.logger != nil {
+			s.logger.Warnf("metadata: BTN claims fetch request failed: %v", err)
+		}
 		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if s.logger != nil {
+			s.logger.Warnf("metadata: BTN claims fetch returned status=%d", resp.StatusCode)
+		}
 		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	if s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims fetch returned status=%d", resp.StatusCode)
 	}
 
 	payload, err := ioReadAllLimit(resp, 1<<20)
 	if err != nil {
+		if s.logger != nil {
+			s.logger.Warnf("metadata: BTN claims response read failed: %v", err)
+		}
 		return nil, err
 	}
-	return extractBTNClaimedShows(string(payload)), nil
+	titles := extractBTNClaimedShows(string(payload))
+	if s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims parsed %d titles from claimed thread", len(titles))
+	}
+	return titles, nil
 }
 
 func (s *Service) loginBTNForClaims(ctx context.Context, client *http.Client) error {
 	entry, ok := trackerConfigFor(s.cfg, "BTN")
 	if !ok {
+		if s.logger != nil {
+			s.logger.Debugf("metadata: BTN claims login skipped; tracker not configured")
+		}
 		return nil
 	}
-	baseURL := strings.TrimRight(strings.TrimSpace(entry.URL), "/")
-	if baseURL == "" {
-		baseURL = "https://backup.landof.tv"
-	}
+	baseURL := resolveBTNLoginBaseURL(entry)
 	username := strings.TrimSpace(entry.Username)
 	password := strings.TrimSpace(entry.Password)
 	if username == "" || password == "" {
+		if s.logger != nil {
+			s.logger.Debugf("metadata: BTN claims login skipped; missing username or password")
+		}
 		return nil
+	}
+	if s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims login attempting with configured credentials")
 	}
 
 	values := map[string]string{
 		"username":   username,
 		"password":   password,
 		"keeplogged": "1",
+		"login":      "Log In!",
+	}
+	if code, err := resolveBTNClaims2FACode(strings.TrimSpace(entry.OTPURI)); err == nil && code != "" {
+		values["code"] = code
+	} else if err != nil && s.logger != nil {
+		s.logger.Warnf("metadata: BTN claims TOTP generation failed: %v", err)
 	}
 	encoded := encodeForm(values)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/login.php", strings.NewReader(encoded))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(baseURL, "/")+btnLoginPath, strings.NewReader(encoded))
 	if err != nil {
+		if s.logger != nil {
+			s.logger.Warnf("metadata: BTN claims login request build failed: %v", err)
+		}
 		return err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("User-Agent", "upbrr")
 	resp, err := client.Do(req)
 	if err != nil {
+		if s.logger != nil {
+			s.logger.Warnf("metadata: BTN claims login request failed: %v", err)
+		}
 		return err
 	}
 	_ = resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		if s.logger != nil {
+			s.logger.Warnf("metadata: BTN claims login returned status=%d", resp.StatusCode)
+		}
 		return fmt.Errorf("login status %d", resp.StatusCode)
 	}
+	if s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims login returned status=%d", resp.StatusCode)
+	}
+	if valid, err := s.btnClaimsSessionValid(ctx, client); err != nil {
+		if s.logger != nil {
+			s.logger.Warnf("metadata: BTN claims post-login validation failed: %v", err)
+		}
+		return err
+	} else if !valid {
+		return errors.New("BTN login failed to establish a valid session")
+	}
+	if s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims login established a valid session; leaving cookie file unchanged")
+	}
 	return nil
+}
+
+func resolveBTNLoginBaseURL(entry config.TrackerConfig) string {
+	if baseURL := sanitizeBTNWebBaseURL(entry.URL); baseURL != "" {
+		return baseURL
+	}
+	if baseURL := sanitizeBTNWebBaseURL(entry.AnnounceURL); baseURL != "" {
+		return baseURL
+	}
+	if baseURL := sanitizeBTNWebBaseURL(entry.MyAnnounceURL); baseURL != "" {
+		return baseURL
+	}
+
+	return btnSiteBaseURL
+}
+
+func (s *Service) loadBTNCookiesForClaims(client *http.Client) error {
+	if client == nil || client.Jar == nil {
+		return nil
+	}
+
+	candidates := commonhttp.CookiePathCandidates(s.cfg.MainSettings.DBPath, "BTN", ".txt")
+	if len(candidates) == 0 {
+		if s.logger != nil {
+			s.logger.Debugf("metadata: BTN claims cookie load skipped; no cookie path candidates")
+		}
+		return nil
+	}
+
+	cookies, err := commonhttp.LoadNetscapeCookies(candidates[0], "")
+	if err != nil {
+		return err
+	}
+
+	if err := setBTNJarCookiesFromNetscape(client, btnSiteBaseURL, cookies); err != nil {
+		return err
+	}
+	if err := setBTNJarCookiesFromNetscape(client, btnBackupBaseURL, cookies); err != nil {
+		return err
+	}
+
+	if s.logger != nil {
+		s.logger.Debugf("metadata: BTN claims loaded %d cookies from file %s", len(cookies), candidates[0])
+	}
+	return nil
+}
+
+func setBTNJarCookiesFromNetscape(client *http.Client, rawURL string, values []*http.Cookie) error {
+	if client == nil || client.Jar == nil || len(values) == 0 {
+		return nil
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+
+	jarCookies := make([]*http.Cookie, 0, len(values))
+	for _, cookie := range values {
+		if cookie == nil || strings.TrimSpace(cookie.Name) == "" || strings.TrimSpace(cookie.Value) == "" {
+			continue
+		}
+		copied := *cookie
+		copied.Domain = parsed.Hostname()
+		if strings.TrimSpace(copied.Path) == "" {
+			copied.Path = "/"
+		}
+		jarCookies = append(jarCookies, &copied)
+	}
+	if len(jarCookies) == 0 {
+		return nil
+	}
+
+	client.Jar.SetCookies(parsed, jarCookies)
+	return nil
+}
+
+func (s *Service) btnClaimsSessionValid(ctx context.Context, client *http.Client) (bool, error) {
+	if client == nil {
+		return false, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, btnSiteBaseURL+btnUserPath, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("User-Agent", "upbrr")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	finalURL := ""
+	if resp.Request != nil && resp.Request.URL != nil {
+		finalURL = resp.Request.URL.String()
+	}
+	if strings.Contains(strings.ToLower(finalURL), strings.ToLower(btnLoginPath)) {
+		return false, nil
+	}
+	return resp.StatusCode >= 200 && resp.StatusCode < 400, nil
+}
+
+func resolveBTNClaims2FACode(otpURI string) (string, error) {
+	trimmed := strings.TrimSpace(otpURI)
+	if trimmed == "" {
+		return "", errors.New("otp_uri not configured")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", err
+	}
+	secret := strings.TrimSpace(parsed.Query().Get("secret"))
+	if secret == "" {
+		return "", errors.New("otp_uri missing secret")
+	}
+	period := 30
+	if value := strings.TrimSpace(parsed.Query().Get("period")); value != "" {
+		if parsedValue, parseErr := strconv.Atoi(value); parseErr == nil && parsedValue > 0 {
+			period = parsedValue
+		}
+	}
+	decoder := base32.StdEncoding.WithPadding(base32.NoPadding)
+	secretBytes, err := decoder.DecodeString(strings.ToUpper(secret))
+	if err != nil {
+		return "", err
+	}
+	counter := uint64(time.Now().Unix() / int64(period))
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, counter)
+	mac := hmac.New(sha1.New, secretBytes)
+	_, _ = mac.Write(buf)
+	hash := mac.Sum(nil)
+	offset := hash[len(hash)-1] & 0x0f
+	code := (int(hash[offset])&0x7f)<<24 | int(hash[offset+1])<<16 | int(hash[offset+2])<<8 | int(hash[offset+3])
+	return fmt.Sprintf("%06d", code%1000000), nil
+}
+
+func sanitizeBTNWebBaseURL(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Host == "" {
+		return ""
+	}
+	if parsed.Scheme == "" {
+		parsed.Scheme = "https"
+	}
+
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	switch host {
+	case "", "landof.tv":
+		return ""
+	case "broadcasthe.net", "www.broadcasthe.net":
+		host = "broadcasthe.net"
+	default:
+		return ""
+	}
+
+	lowerPath := strings.ToLower(strings.TrimSpace(parsed.Path))
+	if lowerPath != "" && lowerPath != "/" {
+		return ""
+	}
+
+	parsed.Host = host
+	parsed.Path = ""
+	parsed.RawPath = ""
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return strings.TrimRight(parsed.String(), "/")
 }
 
 func extractBTNClaimedShows(rawHTML string) map[string]struct{} {
@@ -247,14 +567,93 @@ func extractBTNClaimedPostHTML(rawHTML string) string {
 	if strings.TrimSpace(rawHTML) == "" {
 		return rawHTML
 	}
-	if tableMatch := btnClaimedPostTableRegex.FindStringSubmatch(rawHTML); len(tableMatch) > 1 {
-		scoped := tableMatch[1]
-		if contentMatch := btnClaimedContentDivRegex.FindStringSubmatch(scoped); len(contentMatch) > 1 {
-			return contentMatch[1]
-		}
-		return scoped
+
+	doc, err := htmlnode.Parse(strings.NewReader(rawHTML))
+	if err != nil {
+		return rawHTML
 	}
+
+	scope := findBTNHTMLNode(doc, func(node *htmlnode.Node) bool {
+		return node.Type == htmlnode.ElementNode && node.Data == "table" && btnHTMLNodeID(node) == btnClaimedShowsPostID
+	})
+	if scope == nil {
+		return rawHTML
+	}
+
+	content := findBTNHTMLNode(scope, func(node *htmlnode.Node) bool {
+		if node.Type != htmlnode.ElementNode || node.Data != "div" {
+			return false
+		}
+		if btnHTMLNodeID(node) == "content1405482" {
+			return true
+		}
+		return btnHTMLNodeHasClass(node, "postcontent")
+	})
+	if content != nil {
+		if rendered := renderBTNHTMLChildren(content); rendered != "" {
+			return rendered
+		}
+	}
+
+	if rendered := renderBTNHTMLChildren(scope); rendered != "" {
+		return rendered
+	}
+
 	return rawHTML
+}
+
+func findBTNHTMLNode(root *htmlnode.Node, match func(*htmlnode.Node) bool) *htmlnode.Node {
+	if root == nil {
+		return nil
+	}
+	if match(root) {
+		return root
+	}
+	for child := root.FirstChild; child != nil; child = child.NextSibling {
+		if found := findBTNHTMLNode(child, match); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func btnHTMLNodeID(node *htmlnode.Node) string {
+	return strings.TrimSpace(btnHTMLAttr(node, "id"))
+}
+
+func btnHTMLNodeHasClass(node *htmlnode.Node, className string) bool {
+	classes := strings.Fields(strings.TrimSpace(btnHTMLAttr(node, "class")))
+	for _, candidate := range classes {
+		if strings.EqualFold(candidate, className) {
+			return true
+		}
+	}
+	return false
+}
+
+func btnHTMLAttr(node *htmlnode.Node, key string) string {
+	if node == nil {
+		return ""
+	}
+	for _, attr := range node.Attr {
+		if strings.EqualFold(attr.Key, key) {
+			return attr.Val
+		}
+	}
+	return ""
+}
+
+func renderBTNHTMLChildren(node *htmlnode.Node) string {
+	if node == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		if err := htmlnode.Render(&buf, child); err != nil {
+			return ""
+		}
+	}
+	return buf.String()
 }
 
 func matchBTNClaimedTitle(meta api.PreparedMetadata, claimed map[string]struct{}) (bool, string) {
@@ -408,6 +807,24 @@ func btnClaimWindowExpired(meta api.PreparedMetadata, graceHours int) (bool, int
 	return hoursSinceAir > float64(thresholdHours), thresholdHours, hoursSinceAir
 }
 
+func btnClaimFailureReason(meta api.PreparedMetadata, graceHours int) string {
+	expired, thresholdHours, hoursSinceAir := btnClaimWindowExpired(meta, graceHours)
+	if expired {
+		return "BTN claim window has expired"
+	}
+	if thresholdHours <= 0 {
+		return "BTN has an active claim for this release"
+	}
+	if hoursSinceAir <= 0 {
+		return fmt.Sprintf("BTN has an active claim for this release; up to %d hours remain in the claim window", thresholdHours)
+	}
+	hoursRemaining := int(float64(thresholdHours) - hoursSinceAir + 0.999999999)
+	if hoursRemaining < 1 {
+		hoursRemaining = 1
+	}
+	return fmt.Sprintf("BTN has an active claim for this release; approximately %d hours remain in the %d-hour claim window", hoursRemaining, thresholdHours)
+}
+
 func parseBTNTime(value string) (time.Time, bool) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -436,10 +853,6 @@ func parseBTNTime(value string) (time.Time, bool) {
 		}
 	}
 	return time.Time{}, false
-}
-
-func btnClaimedShowsCachePath(dbPath string) (string, error) {
-	return db.FileInSubdir(dbPath, "cache", filepath.Join("banned", "BTN_claimed_shows.json"))
 }
 
 func readBTNClaimedCache(path string) (map[string]struct{}, int64, error) {

--- a/internal/metadata/tracker_data.go
+++ b/internal/metadata/tracker_data.go
@@ -608,7 +608,7 @@ func configuredTrackers(cfg api.Config) ([]string, []string) {
 		}
 		configured = append(configured, upper)
 	}
-	if len(strings.TrimSpace(cfg.Metadata.BTNAPI)) >= minTrackerTokenLen {
+	if len(config.ResolveBTNAPIToken(cfg)) >= minTrackerTokenLen {
 		configured = append(configured, "BTN")
 	}
 	configured = uniqueSorted(configured)
@@ -624,10 +624,10 @@ func filterConfiguredTrackers(cfg api.Config, trackers []string, logger api.Logg
 	filtered := make([]string, 0, len(trackers))
 	for _, tracker := range trackers {
 		if strings.EqualFold(strings.TrimSpace(tracker), "BTN") {
-			if len(strings.TrimSpace(cfg.Metadata.BTNAPI)) >= minTrackerTokenLen {
+			if len(config.ResolveBTNAPIToken(cfg)) >= minTrackerTokenLen {
 				filtered = append(filtered, tracker)
 			} else if logger != nil {
-				logger.Debugf("metadata: tracker %s missing metadata.btn_api token", tracker)
+				logger.Debugf("metadata: tracker %s missing BTN api token", tracker)
 			}
 			continue
 		}

--- a/internal/metadata/tracker_data_test.go
+++ b/internal/metadata/tracker_data_test.go
@@ -5,6 +5,8 @@ package metadata
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -400,6 +402,235 @@ func TestApplyTrackerClaimsDoesNotBlockOnSemanticMismatch(t *testing.T) {
 	}
 }
 
+func TestApplyTrackerClaimsUsesRequestedBTNWhenTrackerIDsContainDifferentTracker(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	cfg := config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(tempDir, "db.sqlite")},
+	}
+
+	svc := NewService(&fakeRepo{}, WithConfig(cfg))
+
+	cachePath := filepath.Join(tempDir, "cache", "banned", "BTN_claimed_releases.json")
+	if err := writeBTNClaimedCacheFixture(cachePath, time.Now().Unix(), map[string]struct{}{
+		normalizeBTNTitle("Australian Survivor"): {},
+	}); err != nil {
+		t.Fatalf("write btn claims cache: %v", err)
+	}
+
+	meta := api.PreparedMetadata{
+		SourcePath:       `D:\TV\Australian.Survivor.S14E19.1080p.WEB-DL.AAC2.0.H.264-WH.mkv`,
+		Trackers:         []string{"BTN"},
+		TrackerIDs:       map[string]string{"tvv": "12345"},
+		TVDBAiredDate:    time.Now().Add(-12 * time.Hour).UTC().Format("2006-01-02"),
+		TVDBAirsTime:     "20:00",
+		TVDBAirsTimezone: "UTC",
+		SeasonInt:        14,
+		EpisodeInt:       19,
+		ReleaseName:      "Australian Survivor S14E19 Sold the Dream 1080p WEB-DL AAC 2.0-WH",
+		Filename:         "Australian.Survivor.S14E19.1080p.WEB-DL.AAC2.0.H.264-WH.mkv",
+		ExternalMetadata: api.ExternalMetadata{
+			TVDB: &api.TVDBMetadata{Name: "Australian Survivor"},
+		},
+	}
+
+	result, err := svc.applyTrackerClaims(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("apply tracker claims: %v", err)
+	}
+	if got := result.BlockedTrackers["BTN"]; len(got) != 1 || got[0] != api.TrackerBlockReasonClaim {
+		t.Fatalf("expected BTN claim block, got %#v", result.BlockedTrackers)
+	}
+	failures := result.TrackerRuleFailures["BTN"]
+	if len(failures) != 1 {
+		t.Fatalf("expected BTN claim rule failure, got %#v", result.TrackerRuleFailures)
+	}
+	if failures[0].Rule != trackerClaimRuleActive {
+		t.Fatalf("expected BTN claim rule %q, got %#v", trackerClaimRuleActive, failures)
+	}
+	if !strings.Contains(strings.ToLower(failures[0].Reason), "hours remain") {
+		t.Fatalf("expected BTN claim failure reason to include hours remaining, got %#v", failures)
+	}
+}
+
+func TestResolveTrackerClaimProviderSupportsKnownTrackers(t *testing.T) {
+	t.Parallel()
+
+	btnProvider, ok := resolveTrackerClaimProvider("btn")
+	if !ok {
+		t.Fatalf("expected BTN provider")
+	}
+	if _, ok := btnProvider.(btnTrackerClaimProvider); !ok {
+		t.Fatalf("expected BTN provider type, got %T", btnProvider)
+	}
+
+	aitherProvider, ok := resolveTrackerClaimProvider("AITHER")
+	if !ok {
+		t.Fatalf("expected AITHER provider")
+	}
+	if _, ok := aitherProvider.(apiTrackerClaimProvider); !ok {
+		t.Fatalf("expected API provider type, got %T", aitherProvider)
+	}
+
+	if _, ok := resolveTrackerClaimProvider("PTP"); ok {
+		t.Fatalf("did not expect provider for unsupported tracker")
+	}
+}
+
+func TestBTNTrackerClaimProviderUsesSharedCachePathAnd48HourTTL(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	provider := btnTrackerClaimProvider{}
+
+	cachePath, err := provider.cachePath(filepath.Join(tempDir, "db.sqlite"), "BTN")
+	if err != nil {
+		t.Fatalf("cache path: %v", err)
+	}
+
+	expected := filepath.Join(tempDir, "cache", "banned", "BTN_claimed_releases.json")
+	if cachePath != expected {
+		t.Fatalf("expected cache path %q, got %q", expected, cachePath)
+	}
+	if provider.cacheTTL() != 48*time.Hour {
+		t.Fatalf("expected BTN cache ttl 48h, got %s", provider.cacheTTL())
+	}
+}
+
+func TestLoadBTNClaimedTitlesUsesFreshCacheWithin48Hours(t *testing.T) {
+	tempDir := t.TempDir()
+	cachePath := filepath.Join(tempDir, "cache", "banned", "BTN_claimed_releases.json")
+	cached := map[string]struct{}{normalizeBTNTitle("Cached Show"): {}}
+	if err := writeBTNClaimedCacheFixture(cachePath, time.Now().Add(-47*time.Hour).Unix(), cached); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	clientCalls := 0
+	restore := swapDefaultTransport(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		clientCalls++
+		return nil, context.Canceled
+	}))
+	defer restore()
+
+	svc := NewService(&fakeRepo{}, WithConfig(config.Config{}))
+	claimed, err := svc.loadBTNClaimedTitles(context.Background(), cachePath, 48*time.Hour)
+	if err != nil {
+		t.Fatalf("load btn claimed titles: %v", err)
+	}
+	if clientCalls != 0 {
+		t.Fatalf("expected fresh cache to avoid fetch, got %d requests", clientCalls)
+	}
+	if _, ok := claimed[normalizeBTNTitle("Cached Show")]; !ok {
+		t.Fatalf("expected cached title, got %#v", claimed)
+	}
+}
+
+func TestLoadBTNClaimedTitlesRefetchesAfter48Hours(t *testing.T) {
+	tempDir := t.TempDir()
+	cachePath := filepath.Join(tempDir, "cache", "banned", "BTN_claimed_releases.json")
+	cached := map[string]struct{}{normalizeBTNTitle("Cached Show"): {}}
+	if err := writeBTNClaimedCacheFixture(cachePath, time.Now().Add(-49*time.Hour).Unix(), cached); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	clientCalls := 0
+	restore := swapDefaultTransport(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		clientCalls++
+		body := io.NopCloser(strings.NewReader(`
+			<table id="post1405482">
+			  <tr><td><div id="content1405482" class="postcontent">
+			    <strong>Current Shows:</strong><br>
+			    Fresh Show -- BTN<br>
+			  </div></td></tr>
+			</table>`))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       body,
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}))
+	defer restore()
+
+	svc := NewService(&fakeRepo{}, WithConfig(config.Config{}))
+	claimed, err := svc.loadBTNClaimedTitles(context.Background(), cachePath, 48*time.Hour)
+	if err != nil {
+		t.Fatalf("load btn claimed titles: %v", err)
+	}
+	if clientCalls != 2 {
+		t.Fatalf("expected stale cache to trigger session validation and fetch, got %d requests", clientCalls)
+	}
+	if _, ok := claimed[normalizeBTNTitle("Fresh Show")]; !ok {
+		t.Fatalf("expected refetched title, got %#v", claimed)
+	}
+
+	cacheData, err := os.ReadFile(cachePath)
+	if err != nil {
+		t.Fatalf("read cache: %v", err)
+	}
+	if !strings.Contains(string(cacheData), "fresh show") {
+		t.Fatalf("expected refreshed cache data, got %s", string(cacheData))
+	}
+}
+
+func TestFetchBTNClaimedTitlesStopsAfterLoginFailure(t *testing.T) {
+	tempDir := t.TempDir()
+	cfg := config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(tempDir, "db.sqlite")},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"BTN": {
+					Username: "user",
+					Password: "pass",
+				},
+			},
+		},
+	}
+
+	requests := make([]string, 0, 3)
+	restore := swapDefaultTransport(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		requests = append(requests, req.URL.String())
+		switch {
+		case strings.Contains(req.URL.String(), "/user.php"):
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("login required")),
+				Header:     make(http.Header),
+				Request: &http.Request{
+					URL: mustParseURL(t, "https://broadcasthe.net/login.php"),
+				},
+			}, nil
+		case strings.Contains(req.URL.String(), "/login.php"):
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader("forbidden")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		default:
+			t.Fatalf("unexpected request to %s", req.URL.String())
+			return nil, nil
+		}
+	}))
+	defer restore()
+
+	svc := NewService(&fakeRepo{}, WithConfig(cfg))
+	claimed, err := svc.fetchBTNClaimedTitles(context.Background())
+	if err == nil {
+		t.Fatalf("expected login failure")
+	}
+	if len(claimed) != 0 {
+		t.Fatalf("expected no claimed titles, got %#v", claimed)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("expected session validation and login request only, got %d requests: %v", len(requests), requests)
+	}
+	if strings.Contains(strings.Join(requests, " "), "forums.php") {
+		t.Fatalf("did not expect claimed-thread fetch after login failure, got %v", requests)
+	}
+}
+
 func TestEnrichTrackerDataSkipsLookupWhenStoredFresh(t *testing.T) {
 	repo := &fakeRepo{}
 	lookup := &stubTrackerLookup{}
@@ -684,6 +915,46 @@ func TestExtractBTNClaimedShowsScopesToClaimedPost(t *testing.T) {
 	}
 }
 
+func TestExtractBTNClaimedShowsParsesNestedClaimedPostContent(t *testing.T) {
+	t.Parallel()
+
+	html := `
+	<div>
+	  <table id="post1405482">
+	    <tr>
+	      <td>
+	        <div id="content1405482" class="postcontent">
+	          <div>
+	            <strong>Current Shows:</strong><br>
+	            Example Show (aka: Alt Name) -- BTN<br>
+	            <div class="note">Some nested wrapper</div>
+	            Another Show -- BTN<br>
+	          </div>
+	          <div>
+	            <strong>Upcoming Shows:</strong><br>
+	            Future Show -- BTN<br>
+	          </div>
+	        </div>
+	      </td>
+	    </tr>
+	  </table>
+	</div>`
+
+	claimed := extractBTNClaimedShows(html)
+	if _, ok := claimed[normalizeBTNTitle("Example Show")]; !ok {
+		t.Fatalf("expected example show to be extracted, got %#v", claimed)
+	}
+	if _, ok := claimed[normalizeBTNTitle("Alt Name")]; !ok {
+		t.Fatalf("expected alias to be extracted, got %#v", claimed)
+	}
+	if _, ok := claimed[normalizeBTNTitle("Another Show")]; !ok {
+		t.Fatalf("expected nested-row show to be extracted, got %#v", claimed)
+	}
+	if _, ok := claimed[normalizeBTNTitle("Future Show")]; ok {
+		t.Fatalf("did not expect upcoming show to be extracted, got %#v", claimed)
+	}
+}
+
 func TestMirrorBTNCookiesForClaimedThreadCopiesBackupDomainSession(t *testing.T) {
 	t.Parallel()
 
@@ -717,6 +988,55 @@ func TestMirrorBTNCookiesForClaimedThreadCopiesBackupDomainSession(t *testing.T)
 	}
 	if !found {
 		t.Fatalf("expected mirrored session cookie, got %#v", broadcastCookies)
+	}
+}
+
+func TestMirrorBTNCookiesForClaimedThreadKeepsDistinctCookies(t *testing.T) {
+	t.Parallel()
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	client := &http.Client{Jar: jar}
+
+	backupURL := mustParseURL(t, "https://backup.landof.tv/")
+	broadcastURL := mustParseURL(t, "https://broadcasthe.net/")
+	client.Jar.SetCookies(backupURL, []*http.Cookie{
+		{
+			Name:   "session",
+			Value:  "abc123",
+			Domain: "backup.landof.tv",
+			Path:   "/",
+		},
+		{
+			Name:   "authkey",
+			Value:  "xyz789",
+			Domain: "backup.landof.tv",
+			Path:   "/",
+		},
+	})
+
+	mirrorBTNCookiesForClaimedThread(client)
+
+	broadcastCookies := client.Jar.Cookies(broadcastURL)
+	if len(broadcastCookies) < 2 {
+		t.Fatalf("expected mirrored cookies for broadcasthe.net, got %#v", broadcastCookies)
+	}
+
+	valuesByName := make(map[string]string, len(broadcastCookies))
+	for _, cookie := range broadcastCookies {
+		valuesByName[cookie.Name] = cookie.Value
+	}
+
+	if valuesByName["session"] != "abc123" {
+		t.Fatalf("expected mirrored session cookie, got %#v", valuesByName)
+	}
+	if valuesByName["authkey"] != "xyz789" {
+		t.Fatalf("expected mirrored authkey cookie, got %#v", valuesByName)
+	}
+	if len(valuesByName) < 2 {
+		t.Fatalf("expected distinct mirrored cookies, got %#v", valuesByName)
 	}
 }
 
@@ -755,4 +1075,41 @@ func mustParseURL(t *testing.T, raw string) *url.URL {
 		t.Fatalf("parse url %q: %v", raw, err)
 	}
 	return parsed
+}
+
+type roundTripperFunc func(req *http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func swapDefaultTransport(transport http.RoundTripper) func() {
+	original := http.DefaultTransport
+	http.DefaultTransport = transport
+	return func() {
+		http.DefaultTransport = original
+	}
+}
+
+func writeBTNClaimedCacheFixture(path string, fetchedAt int64, titles map[string]struct{}) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+
+	serializedTitles := make([]string, 0, len(titles))
+	for title := range titles {
+		serializedTitles = append(serializedTitles, title)
+	}
+
+	payload, err := json.MarshalIndent(btnClaimedShowsCache{
+		FetchedAt: fetchedAt,
+		SourceURL: btnClaimedShowsURL,
+		PostID:    btnClaimedShowsPostID,
+		Titles:    serializedTitles,
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, payload, 0o600)
 }

--- a/internal/metadata/tracker_data_test.go
+++ b/internal/metadata/tracker_data_test.go
@@ -6,7 +6,9 @@ package metadata
 import (
 	"context"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -442,9 +444,9 @@ func TestEnrichTrackerDataDeprioritizesBTNWhenKeepingImages(t *testing.T) {
 	}
 	longToken := strings.Repeat("a", minTrackerTokenLen)
 	cfg := config.Config{
-		Metadata: config.MetadataConfig{BTNAPI: strings.Repeat("b", minTrackerTokenLen)},
 		Trackers: config.TrackersConfig{
 			Trackers: map[string]config.TrackerConfig{
+				"BTN": {APIKey: strings.Repeat("b", minTrackerTokenLen)},
 				"BHD": {APIKey: longToken, BhdRSSKey: longToken},
 			},
 		},
@@ -488,9 +490,9 @@ func TestEnrichTrackerDataKeepsBTNAsFallbackWhenKeepingImages(t *testing.T) {
 	}
 	longToken := strings.Repeat("a", minTrackerTokenLen)
 	cfg := config.Config{
-		Metadata: config.MetadataConfig{BTNAPI: strings.Repeat("b", minTrackerTokenLen)},
 		Trackers: config.TrackersConfig{
 			Trackers: map[string]config.TrackerConfig{
+				"BTN": {APIKey: strings.Repeat("b", minTrackerTokenLen)},
 				"BHD": {APIKey: longToken, BhdRSSKey: longToken},
 			},
 		},
@@ -648,6 +650,76 @@ func TestExtractBTNClaimedShowsParsesCurrentSection(t *testing.T) {
 	}
 }
 
+func TestExtractBTNClaimedShowsScopesToClaimedPost(t *testing.T) {
+	t.Parallel()
+
+	html := `
+	<div>
+	  <strong>Current Shows:</strong><br>
+	  Wrong Show -- BTN<br>
+	</div>
+	<table id="post1405482">
+	  <tr>
+	    <td>
+	      <div id="content1405482" class="postcontent">
+	        <strong>Current Shows:</strong><br>
+	        Example Show -- BTN<br>
+	        Another Show (aka: Alt Name) -- BTN<br>
+	        Upcoming Shows:<br>
+	        Ignored Show -- BTN
+	      </div>
+	    </td>
+	  </tr>
+	</table>`
+
+	claimed := extractBTNClaimedShows(html)
+	if _, ok := claimed[normalizeBTNTitle("Example Show")]; !ok {
+		t.Fatalf("expected scoped example show to be extracted, got %#v", claimed)
+	}
+	if _, ok := claimed[normalizeBTNTitle("Alt Name")]; !ok {
+		t.Fatalf("expected scoped AKA alias to be extracted, got %#v", claimed)
+	}
+	if _, ok := claimed[normalizeBTNTitle("Wrong Show")]; ok {
+		t.Fatalf("did not expect out-of-post show to be extracted, got %#v", claimed)
+	}
+}
+
+func TestMirrorBTNCookiesForClaimedThreadCopiesBackupDomainSession(t *testing.T) {
+	t.Parallel()
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	client := &http.Client{Jar: jar}
+
+	backupURL := mustParseURL(t, "https://backup.landof.tv/")
+	broadcastURL := mustParseURL(t, "https://broadcasthe.net/")
+	client.Jar.SetCookies(backupURL, []*http.Cookie{{
+		Name:   "session",
+		Value:  "abc123",
+		Domain: "backup.landof.tv",
+		Path:   "/",
+	}})
+
+	mirrorBTNCookiesForClaimedThread(client)
+
+	broadcastCookies := client.Jar.Cookies(broadcastURL)
+	if len(broadcastCookies) == 0 {
+		t.Fatalf("expected mirrored cookies for broadcasthe.net")
+	}
+	found := false
+	for _, cookie := range broadcastCookies {
+		if cookie.Name == "session" && cookie.Value == "abc123" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected mirrored session cookie, got %#v", broadcastCookies)
+	}
+}
+
 func TestBTNClaimWindowExpiredUsesAiredDateAndTimezone(t *testing.T) {
 	t.Parallel()
 
@@ -673,4 +745,14 @@ func TestBTNClaimWindowExpiredUsesAiredDateAndTimezone(t *testing.T) {
 	if threshold != 48 {
 		t.Fatalf("expected threshold 48h when explicit air time is present, got %d", threshold)
 	}
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse url %q: %v", raw, err)
+	}
+	return parsed
 }

--- a/internal/trackerdata/btn.go
+++ b/internal/trackerdata/btn.go
@@ -9,12 +9,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
+
+	"github.com/autobrr/upbrr/internal/config"
 )
 
 func (c *Client) lookupBTN(ctx context.Context, trackerID string) (Result, error) {
-	apiToken := strings.TrimSpace(c.cfg.Metadata.BTNAPI)
-	if len(apiToken) < minTokenLength || strings.TrimSpace(trackerID) == "" {
+	apiToken := config.ResolveBTNAPIToken(c.cfg)
+	if len(apiToken) < minTokenLength || trackerID == "" {
 		return Result{}, nil
 	}
 

--- a/internal/trackerdata/client_test.go
+++ b/internal/trackerdata/client_test.go
@@ -48,7 +48,9 @@ func TestLookupBTN(t *testing.T) {
 	defer server.Close()
 
 	cfg := config.Config{
-		Metadata: config.MetadataConfig{BTNAPI: strings.Repeat("a", 30)},
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"BTN": {APIKey: strings.Repeat("a", 30)},
+		}},
 	}
 	client := NewClient(cfg, api.NopLogger{}, server.Client())
 	client.btnURL = server.URL + "/btn"

--- a/internal/trackers/catalog.go
+++ b/internal/trackers/catalog.go
@@ -19,6 +19,7 @@ var knownTrackers = map[string]struct{}{
 	"BHDTV":  {},
 	"BJS":    {},
 	"BT":     {},
+	"BTN":    {},
 	"CZ":     {},
 	"DC":     {},
 	"FF":     {},

--- a/internal/trackers/impl/btn/definition.go
+++ b/internal/trackers/impl/btn/definition.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -60,8 +61,8 @@ func validateBTNRequest(req trackers.UploadRequest) error {
 	if !strings.EqualFold(strings.TrimSpace(req.Meta.ExternalIDs.Category), "TV") && !strings.EqualFold(strings.TrimSpace(req.Meta.MediaInfoCategory), "TV") {
 		return errors.New("trackers: BTN only supports TV uploads")
 	}
-	if strings.TrimSpace(req.AppConfig.Metadata.BTNAPI) == "" {
-		return errors.New("trackers: BTN requires metadata.btn_api")
+	if strings.TrimSpace(config.ResolveBTNAPIToken(req.AppConfig)) == "" {
+		return errors.New("trackers: BTN requires trackers.BTN.api_key")
 	}
 	if strings.TrimSpace(req.TrackerConfig.Username) == "" || strings.TrimSpace(req.TrackerConfig.Password) == "" {
 		return errors.New("trackers: BTN missing username/password")

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -205,7 +205,7 @@ func newUploadContext(req trackers.UploadRequest) (uploadContext, error) {
 	ctx := uploadContext{
 		baseURL:   baseURL,
 		uploadURL: baseURL + btnUploadPath,
-		apiToken:  strings.TrimSpace(req.AppConfig.Metadata.BTNAPI),
+		apiToken:  config.ResolveBTNAPIToken(req.AppConfig),
 		apiURL:    resolveBTNAPIURL(req.TrackerConfig),
 		client:    client,
 	}

--- a/internal/trackers/impl/btn/upload_integration_test.go
+++ b/internal/trackers/impl/btn/upload_integration_test.go
@@ -126,7 +126,9 @@ func TestBTNUploadEndToEndSuccess(t *testing.T) {
 		},
 		AppConfig: config.Config{
 			MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(tempDir, "db.sqlite")},
-			Metadata:     config.MetadataConfig{BTNAPI: strings.Repeat("x", 30)},
+			Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+				"BTN": {APIKey: strings.Repeat("x", 30)},
+			}},
 		},
 	}
 
@@ -324,7 +326,9 @@ func TestBTNUploadFallsBackToAPIResolution(t *testing.T) {
 		},
 		AppConfig: config.Config{
 			MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(tempDir, "db.sqlite")},
-			Metadata:     config.MetadataConfig{BTNAPI: strings.Repeat("x", 30)},
+			Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+				"BTN": {APIKey: strings.Repeat("x", 30)},
+			}},
 		},
 	}
 


### PR DESCRIPTION
add tracker backfill into config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full BTN tracker support across UI, config defaults, search matching, dupe-checking, and upload flows; missing BTN defaults are auto-backfilled.

* **Bug Fixes**
  * Improved BTN claimed-show extraction, cookie/session handling and mirroring across domains, cache behaviour, and tracker URL matching.

* **Tests**
  * Expanded tests covering config merging, BTN token resolution, claimed-title handling, search matching, dupechecks, and related integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->