### PR TITLE
Tighten logpolicy for auth-sensitive logs

### DIFF
--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -248,6 +248,18 @@ func checkFile(fset *token.FileSet, root string, path string) ([]Violation, erro
 				}
 			}
 		}
+		for _, arg := range call.Args[1:] {
+			if isUnsafeUsernameLikeExpr(arg, sanitizedVars) {
+				violations = append(violations, violationAt(fset, relPath, arg.Pos(), "username log arguments must be redacted before logging"))
+			}
+		}
+		if isAuthSensitiveFormat(lowerFormat) {
+			for _, arg := range call.Args[1:] {
+				if isRawErrorLikeExpr(arg) {
+					violations = append(violations, violationAt(fset, relPath, arg.Pos(), "auth-sensitive log arguments must not include raw errors; log a stable incident code and operator-safe context instead"))
+				}
+			}
+		}
 
 		return true
 	})
@@ -366,6 +378,78 @@ func isUnsafeBodyLikeExpr(expr ast.Expr, sanitizedVars map[string]struct{}) bool
 	return unsafe
 }
 
+func isUnsafeUsernameLikeExpr(expr ast.Expr, sanitizedVars map[string]struct{}) bool {
+	if containsRedactionCall(expr) {
+		return false
+	}
+	if isExplicitlySanitizedExpr(expr) {
+		return false
+	}
+	unsafe := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.Ident:
+			if _, safe := sanitizedVars[typed.Name]; safe {
+				return false
+			}
+			if isSensitiveUsernameName(typed.Name) {
+				unsafe = true
+				return false
+			}
+		case *ast.SelectorExpr:
+			if isSensitiveUsernameName(typed.Sel.Name) {
+				unsafe = true
+				return false
+			}
+		}
+		return true
+	})
+	return unsafe
+}
+
+func isRawErrorLikeExpr(expr ast.Expr) bool {
+	if isExplicitlySanitizedExpr(expr) {
+		return false
+	}
+	raw := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.Ident:
+			if isErrorLikeName(typed.Name) {
+				raw = true
+				return false
+			}
+		case *ast.SelectorExpr:
+			if isErrorLikeName(typed.Sel.Name) {
+				raw = true
+				return false
+			}
+		case *ast.CallExpr:
+			if selector, ok := typed.Fun.(*ast.SelectorExpr); ok && selector.Sel.Name == "Error" {
+				raw = true
+				return false
+			}
+		}
+		return true
+	})
+	return raw
+}
+
+func isExplicitlySanitizedExpr(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return strings.HasPrefix(strings.ToLower(strings.TrimSpace(fun.Name)), "redact")
+	case *ast.SelectorExpr:
+		return strings.HasPrefix(strings.ToLower(strings.TrimSpace(fun.Sel.Name)), "redact")
+	default:
+		return false
+	}
+}
+
 func importAliases(file *ast.File) map[string]string {
 	aliases := make(map[string]string, len(file.Imports))
 	for _, spec := range file.Imports {
@@ -417,6 +501,33 @@ func isRawBodyStringConversion(expr ast.Expr) bool {
 func isSuspiciousBodyName(name string) bool {
 	lower := strings.ToLower(strings.TrimSpace(name))
 	return lower == "body" || lower == "payload" || strings.HasSuffix(lower, "body") || strings.HasSuffix(lower, "payload") || strings.Contains(lower, "bodystr") || strings.Contains(lower, "bodypreview")
+}
+
+func isSensitiveUsernameName(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	return lower == "username" || strings.HasSuffix(lower, "username") || strings.Contains(lower, ".username")
+}
+
+func isErrorLikeName(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	return lower == "err" || lower == "error" || strings.HasSuffix(lower, "err") || strings.HasSuffix(lower, "error")
+}
+
+func isAuthSensitiveFormat(lowerFormat string) bool {
+	authSignals := []string{
+		"auth upgrade",
+		"login upgrade",
+		"credential",
+		"refresh credentials",
+		"protected data rewrap",
+		"pending auth upgrade",
+	}
+	for _, signal := range authSignals {
+		if strings.Contains(lowerFormat, signal) {
+			return true
+		}
+	}
+	return false
 }
 
 func infoLevelHygieneViolations(lowerFormat string, trimmedFormat string) []string {

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -193,6 +193,144 @@ func check(log logger, body []byte) {
 	}
 }
 
+func TestCheckRepositoryFlagsRawUsernameLogging(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal", "sample"), 0o755); err != nil {
+		t.Fatalf("mkdir internal sample: %v", err)
+	}
+
+	content := `package sample
+
+type user struct{ Username string }
+type logger struct{}
+
+func (logger) Errorf(string, ...any) {}
+
+func check(log logger, current user) {
+	log.Errorf("auth upgrade failed username=%s", current.Username)
+}
+`
+
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "username log arguments") {
+		t.Fatalf("expected username redaction violation, got %q", violations[0].Message)
+	}
+}
+
+func TestCheckRepositoryAllowsRedactedUsernameLogging(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal", "sample"), 0o755); err != nil {
+		t.Fatalf("mkdir internal sample: %v", err)
+	}
+
+	content := `package sample
+
+import redaction "github.com/autobrr/upbrr/internal/redaction"
+
+type user struct{ Username string }
+type logger struct{}
+
+func (logger) Errorf(string, ...any) {}
+
+func check(log logger, current user) {
+	username := redaction.RedactValue(current.Username, nil)
+	log.Errorf("auth upgrade failed username=%s", username)
+}
+`
+
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
+func TestCheckRepositoryFlagsRawErrorsInAuthSensitiveLogs(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal", "sample"), 0o755); err != nil {
+		t.Fatalf("mkdir internal sample: %v", err)
+	}
+
+	content := `package sample
+
+type logger struct{}
+
+func (logger) Errorf(string, ...any) {}
+
+func check(log logger, err error) {
+	log.Errorf("auth upgrade failed incident=%s: %v", "auth_upgrade_failed", err)
+}
+`
+
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "auth-sensitive log arguments") {
+		t.Fatalf("expected auth-sensitive raw error violation, got %q", violations[0].Message)
+	}
+}
+
+func TestCheckRepositoryAllowsStableCodesInAuthSensitiveLogs(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal", "sample"), 0o755); err != nil {
+		t.Fatalf("mkdir internal sample: %v", err)
+	}
+
+	content := `package sample
+
+import redaction "github.com/autobrr/upbrr/internal/redaction"
+
+type user struct{ Username string }
+type logger struct{}
+
+func (logger) Errorf(string, ...any) {}
+
+func check(log logger, current user) {
+	log.Errorf(
+		"auth upgrade failed incident=%s username=%s",
+		"auth_upgrade_failed",
+		redaction.RedactValue(current.Username, nil),
+	)
+}
+`
+
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
 func TestCheckRepositoryFlagsInfofErrorOrientedMessages(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "internal", "sample"), 0o755); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logging validation to detect unredacted username and error data in logger calls.
  * Strengthened authentication-sensitive log format checks to enforce proper data sanitization.
  * Expanded test coverage for redaction behavior in logging policy compliance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->