### PR TITLE
refactor(screens): send screens to multiple hosts

### DIFF
--- a/cmd/upbrr/cli_options.go
+++ b/cmd/upbrr/cli_options.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/imagehostpolicy"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -814,12 +815,10 @@ func parseInfoHash(raw string) (string, error) {
 
 func parseImageHost(raw string) (string, error) {
 	trimmed := strings.ToLower(strings.TrimSpace(raw))
-	switch trimmed {
-	case "imgbb", "ptpimg", "imgbox", "pixhost", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "sharex", "utppm":
+	if imagehostpolicy.IsUploadHost(trimmed) && imagehostpolicy.OwnerForHost(trimmed) == "" {
 		return trimmed, nil
-	default:
-		return "", fmt.Errorf("invalid imghost %q", raw)
 	}
+	return "", fmt.Errorf("invalid imghost %q", raw)
 }
 
 func parseManualFrames(raw string) ([]int, error) {

--- a/cmd/upbrr/cli_options.go
+++ b/cmd/upbrr/cli_options.go
@@ -815,7 +815,7 @@ func parseInfoHash(raw string) (string, error) {
 func parseImageHost(raw string) (string, error) {
 	trimmed := strings.ToLower(strings.TrimSpace(raw))
 	switch trimmed {
-	case "imgbb", "ptpimg", "imgbox", "pixhost", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "utppm":
+	case "imgbb", "ptpimg", "imgbox", "pixhost", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "sharex", "utppm":
 		return trimmed, nil
 	default:
 		return "", fmt.Errorf("invalid imghost %q", raw)

--- a/cmd/upbrr/cli_options_test.go
+++ b/cmd/upbrr/cli_options_test.go
@@ -641,6 +641,9 @@ func TestParseCLIOptionsRejectsInvalidImageHost(t *testing.T) {
 	if _, _, _, err := parseCLIOptions([]string{"--imghost", "not-a-host", "movie.mkv"}); err == nil {
 		t.Fatal("expected invalid imghost to fail")
 	}
+	if _, _, _, err := parseCLIOptions([]string{"--imghost", "hdb", "movie.mkv"}); err == nil {
+		t.Fatal("expected tracker-owned hdb imghost to fail")
+	}
 }
 
 func TestBuildCLIRequestInfoHashOverrides(t *testing.T) {

--- a/cmd/upbrr/cli_options_test.go
+++ b/cmd/upbrr/cli_options_test.go
@@ -475,6 +475,9 @@ func TestPrintDryRunSummary(t *testing.T) {
 				ImageHost: api.ImageHostFeedback{
 					Reuploaded: true,
 					Message:    "reuploaded to imgbox",
+					Warnings: []api.ImageHostWarning{
+						{Host: "ptpimg", Message: "temporary failure"},
+					},
 				},
 			},
 			contains: []string{
@@ -482,6 +485,7 @@ func TestPrintDryRunSummary(t *testing.T) {
 				"Tracker release name: Movie.2024.1080p",
 				"Payload fields: category, name",
 				"Images: reuploaded to imgbox",
+				"Image host warning: ptpimg failed: temporary failure",
 			},
 		},
 		{

--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -397,10 +397,24 @@ func printDryRunSummary(entry api.TrackerDryRunEntry) {
 		sort.Strings(keys)
 		fmt.Printf("Payload fields: %s\n", strings.Join(keys, ", "))
 	}
-	if entry.ImageHost.Reuploaded {
-		if message := strings.TrimSpace(entry.ImageHost.Message); message != "" {
-			fmt.Printf("Images: %s\n", message)
+	if imageMessage := strings.TrimSpace(entry.ImageHost.Message); imageMessage != "" && (entry.ImageHost.Reuploaded || strings.EqualFold(entry.ImageHost.Status, "warning")) {
+		fmt.Printf("Images: %s\n", imageMessage)
+	}
+	for _, warning := range entry.ImageHost.Warnings {
+		host := strings.TrimSpace(warning.Host)
+		warningMessage := strings.TrimSpace(warning.Message)
+		if host == "" && warningMessage == "" {
+			continue
 		}
+		if host == "" {
+			fmt.Printf("Image host warning: %s\n", warningMessage)
+			continue
+		}
+		if warningMessage == "" {
+			fmt.Printf("Image host warning: %s failed\n", host)
+			continue
+		}
+		fmt.Printf("Image host warning: %s failed: %s\n", host, warningMessage)
 	}
 }
 

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -312,6 +312,7 @@ declare global {
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              trackers: string[],
               host: string,
               images: ScreenshotImage[],
             ) => Promise<UploadedImageLink[]>;
@@ -1229,6 +1230,13 @@ export default function App() {
     handleDeleteTrackerImageURL,
   } = screenshots;
 
+  const selectedUploadImageTrackers = useMemo(() => {
+    const validTrackers = new Set(trackerUploadItems.map((item) => item.name));
+    return Object.entries(releasePageTrackerSelection)
+      .filter(([name, selected]) => selected && validTrackers.has(name))
+      .map(([name]) => name);
+  }, [releasePageTrackerSelection, trackerUploadItems]);
+
   // Upload images workflow hook
   const uploadImages = useUploadImages({
     path,
@@ -1236,6 +1244,7 @@ export default function App() {
     releaseOverrideState,
     uploadCandidates: screenshots.uploadCandidates,
     configuredImageHosts,
+    selectedTrackers: selectedUploadImageTrackers,
   });
   const {
     refreshUploadedImages,

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -29,6 +29,7 @@ import type {
   ExternalIDs,
   HistoryEntry,
   HistoryOverview,
+  ImageHostPolicyMetadata,
   MetadataPreview,
   MetadataProgressUpdate,
   PreparationPreview,
@@ -49,6 +50,7 @@ import type {
   UIStateRecord,
   WebAuthStatus,
   UploadedImageLink,
+  UploadImagesResult,
 } from "./types";
 import { formatLabel, normalizeDefaultTrackerList } from "./utils/settings";
 
@@ -315,7 +317,7 @@ declare global {
               trackers: string[],
               host: string,
               images: ScreenshotImage[],
-            ) => Promise<UploadedImageLink[]>;
+            ) => Promise<UploadImagesResult>;
             DeleteUploadedImage: (path: string, imagePath: string, host: string) => Promise<void>;
             RenderDescription: (raw: string) => Promise<string>;
             SaveDescriptionOverride: (
@@ -347,6 +349,7 @@ declare global {
             GetLogExclusions: () => Promise<string[]>;
             UpdateLogExclusions: (patterns: string[]) => Promise<void>;
             ListKnownTrackers: () => Promise<string[]>;
+            GetImageHostPolicyMetadata: () => Promise<ImageHostPolicyMetadata>;
             ListHistory: () => Promise<HistoryEntry[]>;
             GetHistoryOverview: (sourcePath: string) => Promise<HistoryOverview>;
             DeleteHistoryRelease: (sourcePath: string) => Promise<void>;
@@ -4259,6 +4262,7 @@ export default function App() {
               setAllUploadSelections={uploadImages.setAllUploadSelections}
               handleUploadImages={uploadImages.handleUploadImages}
               uploadImagesError={uploadImages.uploadImagesError}
+              uploadImageFailures={uploadImages.uploadImageFailures}
               uploadCandidates={screenshots.uploadCandidates}
               uploadSelections={uploadImages.uploadSelections}
               toggleUploadSelection={uploadImages.toggleUploadSelection}

--- a/gui/frontend/src/hooks/useSettingsState.tsx
+++ b/gui/frontend/src/hooks/useSettingsState.tsx
@@ -3,7 +3,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import type { ConfigMap, ConfigValue, FieldMeta } from "../types";
+import type { ConfigMap, ConfigValue, FieldMeta, ImageHostPolicyMetadata } from "../types";
 import { formatLabel, normalizeDefaultTrackerList } from "../utils/settings";
 
 type SettingsSection = { key: string; jsonKey: string; label: string };
@@ -86,6 +86,15 @@ const imageHostOptions = [
 ];
 
 const trackerImageHostOptions = [...imageHostOptions, { value: "hdb", label: "HDB" }];
+const imageHostOptionLabels = new Map(
+  trackerImageHostOptions.map((option) => [option.value, option.label]),
+);
+const defaultOwnedImageHosts: Record<string, string> = { hdb: "HDB" };
+const normalizeImageHostValue = (value: string) => value.trim().toLowerCase();
+const imageHostOptionFor = (host: string) => {
+  const value = normalizeImageHostValue(host);
+  return { value, label: imageHostOptionLabels.get(value) ?? value };
+};
 
 const imageHostKeyMap: Record<string, string[]> = {
   imgbb: ["ImgBBAPI"],
@@ -629,6 +638,8 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
   const [configData, setConfigData] = useState<ConfigMap | null>(null);
   const [defaultConfig, setDefaultConfig] = useState<ConfigMap | null>(null);
   const [knownTrackers, setKnownTrackers] = useState<string[]>([]);
+  const [imageHostPolicyMetadata, setImageHostPolicyMetadata] =
+    useState<ImageHostPolicyMetadata | null>(null);
   const [knownTrackersLoading, setKnownTrackersLoading] = useState(false);
   const [trackerAddSelection, setTrackerAddSelection] = useState("");
   const [manualTrackerEntries, setManualTrackerEntries] = useState<Record<string, boolean>>({});
@@ -706,6 +717,44 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
     const option = imageHostOptions.find((entry) => entry.value === value);
     return option ? option.label : value;
   };
+
+  const buildImageHostOptions = useCallback((hosts: string[]) => {
+    const allowed = new Set(
+      hosts.map((host) => normalizeImageHostValue(host)).filter((host) => host.length > 0),
+    );
+    const ordered = imageHostOptions.filter(
+      (option) => option.value === "" || allowed.has(option.value),
+    );
+    const known = new Set(ordered.map((option) => option.value));
+    const extras = Array.from(allowed)
+      .filter((host) => !known.has(host))
+      .sort((left, right) => left.localeCompare(right))
+      .map(imageHostOptionFor);
+    return [...ordered, ...extras];
+  }, []);
+
+  const trackerOptionsForImageHost = useCallback(
+    (trackerName: string) => {
+      const trackerKey = trackerName.trim().toUpperCase();
+      if (!imageHostPolicyMetadata) {
+        return trackerKey === "HDB" ? trackerImageHostOptions : imageHostOptions;
+      }
+
+      const policyHosts = imageHostPolicyMetadata.TrackerUploadHosts?.[trackerKey];
+      const fallbackHosts =
+        imageHostPolicyMetadata.UploadHosts?.map((host) => normalizeImageHostValue(host)) ??
+        imageHostOptions.filter((option) => option.value).map((option) => option.value);
+      const ownerByHost = imageHostPolicyMetadata.OwnedHosts ?? defaultOwnedImageHosts;
+      const hosts = (policyHosts ?? fallbackHosts).filter((host) => {
+        const normalizedHost = normalizeImageHostValue(host);
+        const owner = ownerByHost[normalizedHost];
+        return !owner || owner.trim().toUpperCase() === trackerKey;
+      });
+
+      return buildImageHostOptions(hosts);
+    },
+    [buildImageHostOptions, imageHostPolicyMetadata],
+  );
 
   const updateConfigValue = (path: string[], value: ConfigValue) => {
     setConfigData((prev) => {
@@ -842,6 +891,19 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
     }
   }, [knownTrackersLoading]);
 
+  const loadImageHostPolicyMetadata = useCallback(async () => {
+    const getMetadata = globalThis.go?.guiapp?.App?.GetImageHostPolicyMetadata;
+    if (!getMetadata) return;
+    try {
+      const result = await getMetadata();
+      if (result && typeof result === "object") {
+        setImageHostPolicyMetadata(result);
+      }
+    } catch (err) {
+      setSettingsError(String(err));
+    }
+  }, []);
+
   const handleSaveSettings = async () => {
     clearSettingsStatus();
     const saveConfig = globalThis.go?.guiapp?.App?.SaveConfig;
@@ -892,6 +954,12 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
       loadKnownTrackers();
     }
   }, [activeTab, knownTrackers.length, knownTrackersLoading, loadKnownTrackers]);
+
+  useEffect(() => {
+    if (activeTab === "settings" && !imageHostPolicyMetadata) {
+      loadImageHostPolicyMetadata();
+    }
+  }, [activeTab, imageHostPolicyMetadata, loadImageHostPolicyMetadata]);
 
   useEffect(() => {
     if ((activeTab === "screenshots" || activeTab === "upload_images") && !configData) {
@@ -1290,7 +1358,7 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
       const trackerSchemaFor = (name: string) => {
         const imageHostField = {
           ...trackerFieldMeta.ImageHost,
-          options: name.trim().toUpperCase() === "HDB" ? trackerImageHostOptions : imageHostOptions,
+          options: trackerOptionsForImageHost(name),
         };
         const base = trackerSchemas[name] || trackerFallbackSchema;
         return [imageHostField, ...base.filter((meta) => meta.key !== "ImageHost")];

--- a/gui/frontend/src/hooks/useSettingsState.tsx
+++ b/gui/frontend/src/hooks/useSettingsState.tsx
@@ -85,6 +85,8 @@ const imageHostOptions = [
   { value: "utppm", label: "UTPPM" },
 ];
 
+const trackerImageHostOptions = [...imageHostOptions, { value: "hdb", label: "HDB" }];
+
 const imageHostKeyMap: Record<string, string[]> = {
   imgbb: ["ImgBBAPI"],
   ptpimg: ["PTPImgAPI"],
@@ -148,6 +150,10 @@ const trackerFieldMeta: Record<string, FieldMeta> = {
   CheckRequests: boolField("CheckRequests", { label: "Check requests", advanced: true }),
   FullMediainfo: boolField("FullMediainfo", { label: "Full mediainfo", advanced: true }),
   ImgRehost: boolField("ImgRehost", { label: "Image rehost", advanced: true }),
+  ImageHost: stringField("ImageHost", {
+    label: "Image host",
+    options: imageHostOptions,
+  }),
   UseSpanishTitle: boolField("UseSpanishTitle", { label: "Use Spanish title", advanced: true }),
   UseItalianTitle: boolField("UseItalianTitle", { label: "Use Italian title", advanced: true }),
   OTPURI: stringField("OTPURI", { label: "OTP URI", sensitive: true, advanced: true }),
@@ -943,6 +949,23 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
   const renderField = (label: string, value: ConfigValue, path: string[], meta?: FieldMeta) => {
     const displayLabel = meta?.label ?? formatLabel(label);
     const typeHint = meta?.type;
+    if (meta?.options && meta.options.length > 0) {
+      return (
+        <label className="settings-field" key={path.join(".")}>
+          <span>{displayLabel}</span>
+          <select
+            value={value === null ? "" : String(value ?? "")}
+            onChange={(event) => updateConfigValue(path, event.target.value)}
+          >
+            {meta.options.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      );
+    }
     if (typeHint === "boolean" || typeof value === "boolean") {
       return (
         <label className="settings-toggle" key={path.join(".")}>
@@ -1257,12 +1280,21 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
 
       const trackerFallbackSchema = [
         trackerFieldMeta.LinkDirName,
+        trackerFieldMeta.ImageHost,
         trackerFieldMeta.APIKey,
         trackerFieldMeta.AnnounceURL,
         trackerFieldMeta.Username,
         trackerFieldMeta.Password,
         trackerFieldMeta.Anon,
       ];
+      const trackerSchemaFor = (name: string) => {
+        const imageHostField = {
+          ...trackerFieldMeta.ImageHost,
+          options: name.trim().toUpperCase() === "HDB" ? trackerImageHostOptions : imageHostOptions,
+        };
+        const base = trackerSchemas[name] || trackerFallbackSchema;
+        return [imageHostField, ...base.filter((meta) => meta.key !== "ImageHost")];
+      };
 
       const buildDefault = (meta: FieldMeta) => {
         if (meta.type === "boolean") return false;
@@ -1383,7 +1415,7 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
                   const name = trackerAddSelection.trim();
                   if (!name) return;
                   if (!allEntrySet.has(name)) {
-                    const schema = trackerSchemas[name] || trackerFallbackSchema;
+                    const schema = trackerSchemaFor(name);
                     addConfigKey(["Trackers", "Trackers"], name, buildTrackerDefaults(schema));
                   }
                   setManualTrackerEntries((prev) => ({ ...prev, [name]: true }));
@@ -1401,8 +1433,8 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
               <p className="muted">No configured entries yet.</p>
             ) : (
               visibleEntries.map(([key, value]) => {
-                const schema = (trackerSchemas[key] || trackerFallbackSchema).filter(
-                  (meta): meta is FieldMeta => Boolean(meta),
+                const schema = trackerSchemaFor(key).filter((meta): meta is FieldMeta =>
+                  Boolean(meta),
                 );
                 return (
                   <details

--- a/gui/frontend/src/hooks/useUploadImages.ts
+++ b/gui/frontend/src/hooks/useUploadImages.ts
@@ -5,6 +5,7 @@ import { useState, useCallback, useMemo, useEffect } from "react";
 import type {
   ScreenshotPreviewImage,
   UploadedImageLink,
+  UploadImageHostFailure,
   ExternalIDOverrides,
   ReleaseNameOverrides,
 } from "../types";
@@ -34,6 +35,7 @@ export const useUploadImages = ({
   // State: Upload progress & results
   const [uploadImagesLoading, setUploadImagesLoading] = useState(false);
   const [uploadImagesError, setUploadImagesError] = useState("");
+  const [uploadImageFailures, setUploadImageFailures] = useState<UploadImageHostFailure[]>([]);
   const [uploadedImages, setUploadedImages] = useState<UploadedImageLink[]>([]);
   const [uploadedImageRecords, setUploadedImageRecords] = useState<UploadedImageLink[]>([]);
   const [uploadProgress, setUploadProgress] = useState<{ current: number; total: number }>({
@@ -146,6 +148,7 @@ export const useUploadImages = ({
   const handleUploadImages = useCallback(
     async (selected: ScreenshotPreviewImage[]) => {
       setUploadImagesError("");
+      setUploadImageFailures([]);
       const uploader = globalThis.go?.guiapp?.App?.UploadImages;
       if (!uploader) {
         setUploadImagesError("Image uploading is unavailable in this build.");
@@ -176,15 +179,36 @@ export const useUploadImages = ({
           uploadHost,
           selected.map((entry) => entry.image),
         );
-        const uploadedCount = result?.length || 0;
-        setUploadedImages(result || []);
+        const links = result?.Links || [];
+        const failures = result?.Failures || [];
+        const uploadedCount = new Set(links.map((link) => link.ImagePath).filter(Boolean)).size;
+        setUploadedImages(links);
+        setUploadImageFailures(failures);
+        if (failures.length > 0) {
+          const failedHosts = Array.from(
+            new Set(failures.map((failure) => failure.Host || "unknown host")),
+          ).join(", ");
+          setUploadImagesError(`Image upload failed for ${failedHosts}.`);
+        }
+        if (uploadedCount !== selected.length) {
+          console.error("Upload count mismatch", {
+            expectedCount: selected.length,
+            uploadedCount,
+          });
+          if (failures.length === 0) {
+            setUploadImagesError(
+              `Upload completed with an unexpected result count (expected ${selected.length}, got ${uploadedCount}).`,
+            );
+          }
+        }
         setUploadProgress({
           current: uploadedCount,
-          total: Math.max(selected.length, uploadedCount),
+          total: selected.length,
         });
         await refreshUploadedImages();
       } catch (err) {
         setUploadImagesError(String(err));
+        setUploadImageFailures([]);
         setUploadProgress({ current: 0, total: selected.length });
       } finally {
         setUploadImagesLoading(false);
@@ -246,6 +270,7 @@ export const useUploadImages = ({
     setUploadSelections({});
     setUploadImagesLoading(false);
     setUploadImagesError("");
+    setUploadImageFailures([]);
     setUploadedImages([]);
     setUploadedImageRecords([]);
     setUploadProgress({ current: 0, total: 0 });
@@ -257,6 +282,7 @@ export const useUploadImages = ({
     uploadSelections,
     uploadImagesLoading,
     uploadImagesError,
+    uploadImageFailures,
     uploadedImages,
     uploadedImageRecords,
     uploadedRecordByPath,

--- a/gui/frontend/src/hooks/useUploadImages.ts
+++ b/gui/frontend/src/hooks/useUploadImages.ts
@@ -16,6 +16,7 @@ interface UploadImagesHookProps {
   releaseOverrideState?: { overrides?: ReleaseNameOverrides };
   uploadCandidates?: ScreenshotPreviewImage[];
   configuredImageHosts?: string[];
+  selectedTrackers?: string[];
 }
 
 export const useUploadImages = ({
@@ -24,6 +25,7 @@ export const useUploadImages = ({
   releaseOverrideState,
   uploadCandidates = [],
   configuredImageHosts = [],
+  selectedTrackers = [],
 }: UploadImagesHookProps) => {
   // State: Host & selection
   const [uploadHost, setUploadHost] = useState<string>("");
@@ -170,11 +172,16 @@ export const useUploadImages = ({
           path.trim(),
           normalizeOverrides(idOverrideState?.overrides || {}),
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+          selectedTrackers,
           uploadHost,
           selected.map((entry) => entry.image),
         );
+        const uploadedCount = result?.length || 0;
         setUploadedImages(result || []);
-        setUploadProgress({ current: result?.length || 0, total: selected.length });
+        setUploadProgress({
+          current: uploadedCount,
+          total: Math.max(selected.length, uploadedCount),
+        });
         await refreshUploadedImages();
       } catch (err) {
         setUploadImagesError(String(err));
@@ -183,7 +190,14 @@ export const useUploadImages = ({
         setUploadImagesLoading(false);
       }
     },
-    [path, idOverrideState, releaseOverrideState, uploadHost, refreshUploadedImages],
+    [
+      path,
+      idOverrideState,
+      releaseOverrideState,
+      selectedTrackers,
+      uploadHost,
+      refreshUploadedImages,
+    ],
   );
 
   // Delete a single uploaded image record

--- a/gui/frontend/src/pages/description_builder/index.tsx
+++ b/gui/frontend/src/pages/description_builder/index.tsx
@@ -119,6 +119,7 @@ export default function DescriptionBuilderPage(props: Props) {
           const renderedHTML = builderRenderedByGroup[groupKey] ?? seededRendered;
           const expanded = builderExpandedGroups[groupKey] ?? false;
           const label = groupLabel(groupKey, group.Trackers || []);
+          const imageHostWarnings = group.ImageHost?.Warnings || [];
 
           return (
             <section className="panel builder-preview" key={reactKey}>
@@ -133,6 +134,20 @@ export default function DescriptionBuilderPage(props: Props) {
                   {group.ImageHost?.Reuploaded && group.ImageHost?.Message ? (
                     <p className="muted">{group.ImageHost.Message}</p>
                   ) : null}
+                  {group.ImageHost?.Status === "warning" && group.ImageHost?.Message ? (
+                    <p className="builder-image-warning">{group.ImageHost.Message}</p>
+                  ) : null}
+                  {imageHostWarnings.map((warning, index) => {
+                    const host = String(warning.Host || "").trim();
+                    const message = String(warning.Message || "").trim();
+                    if (!host && !message) return null;
+                    return (
+                      <p className="builder-image-warning" key={`${host || "host"}-${index}`}>
+                        {host ? `${host} failed` : "Image host warning"}
+                        {message ? `: ${message}` : ""}
+                      </p>
+                    );
+                  })}
                 </div>
                 <button
                   className="ghost"

--- a/gui/frontend/src/pages/description_builder/styles.css
+++ b/gui/frontend/src/pages/description_builder/styles.css
@@ -31,6 +31,22 @@
   margin-bottom: 9px;
 }
 
+.builder-image-warning {
+  margin: 0;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid rgba(245, 158, 11, 0.38);
+  background: rgba(245, 158, 11, 0.12);
+  color: #fde68a;
+  font-size: 0.82rem;
+  overflow-wrap: anywhere;
+}
+
+:root.light .builder-image-warning {
+  color: #92400e;
+  border-color: rgba(245, 158, 11, 0.35);
+}
+
 .builder-textarea {
   width: 100%;
   min-height: 187px;

--- a/gui/frontend/src/pages/tracker_upload/index.tsx
+++ b/gui/frontend/src/pages/tracker_upload/index.tsx
@@ -255,6 +255,9 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
             const showBadges = hasRuleSkip || hasDupes;
             const trackerStatus = trackerStatusMap[tracker.name];
             const dryRun = dryRunMap[normalizedTrackerName];
+            const imageHost = dryRun?.ImageHost;
+            const imageHostWarnings = imageHost?.Warnings || [];
+            const imageHostStatus = String(imageHost?.Status || "").toLowerCase();
             const questionnaire = dryRun?.Questionnaire;
             const questionnaireAnswers =
               trackerQuestionnaireAnswers[tracker.name.toUpperCase().trim()] || {};
@@ -330,6 +333,24 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
                       "Rule check failed. Enable override blocks to upload anyway."}
                   </p>
                 ) : null}
+                {imageHost?.Message &&
+                (imageHostWarnings.length > 0 || imageHostStatus === "warning") ? (
+                  <p className="upload-image-warning">{imageHost.Message}</p>
+                ) : null}
+                {imageHostWarnings.map((warning, index) => {
+                  const host = String(warning.Host || "").trim();
+                  const message = String(warning.Message || "").trim();
+                  if (!host && !message) return null;
+                  return (
+                    <p
+                      className="upload-image-warning"
+                      key={`${tracker.name}-${host || "host"}-${index}`}
+                    >
+                      {host ? `${host} failed` : "Image host warning"}
+                      {message ? `: ${message}` : ""}
+                    </p>
+                  );
+                })}
 
                 <details className="upload-details">
                   <summary>Dry run data</summary>

--- a/gui/frontend/src/pages/tracker_upload/styles.css
+++ b/gui/frontend/src/pages/tracker_upload/styles.css
@@ -112,6 +112,23 @@
   color: var(--text-muted);
 }
 
+.upload-image-warning {
+  margin: 0;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid rgba(245, 158, 11, 0.38);
+  background: rgba(245, 158, 11, 0.12);
+  color: #fde68a;
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+}
+
+:root.light .upload-image-warning {
+  background: rgba(245, 158, 11, 0.1);
+  color: #92400e;
+  border-color: rgba(245, 158, 11, 0.35);
+}
+
 .upload-badges {
   display: flex;
   align-items: center;

--- a/gui/frontend/src/pages/upload_images/index.tsx
+++ b/gui/frontend/src/pages/upload_images/index.tsx
@@ -130,7 +130,9 @@ export default function UploadImagesPage(props: Props) {
       <header className="upload-images-header">
         <p className="eyebrow">Image Hosting</p>
         <h1>Upload Images</h1>
-        <p className="subtitle">Select the screenshots to upload and choose the host.</p>
+        <p className="subtitle">
+          Select screenshots and upload every host needed by the active trackers.
+        </p>
       </header>
 
       <section className="panel upload-images-controls">
@@ -140,7 +142,7 @@ export default function UploadImagesPage(props: Props) {
         </div>
         <div className="upload-images-controls__row">
           <label className="settings-field">
-            <span>Upload host</span>
+            <span>Default upload host</span>
             <select
               value={uploadHost}
               onChange={(event) => setUploadHost(event.target.value)}
@@ -238,9 +240,8 @@ export default function UploadImagesPage(props: Props) {
                     className={`upload-images-toggle ${selected ? "selected" : ""}`}
                     type="button"
                     onClick={() => pathValue && toggleUploadSelection(pathValue)}
-                    disabled={isUploaded}
                   >
-                    {isUploaded ? "Uploaded" : selected ? "Selected" : "Select"}
+                    {selected ? "Selected" : isUploaded ? "Uploaded" : "Select"}
                   </button>
                   {isUploaded && imgLink ? (
                     <div className="upload-links">

--- a/gui/frontend/src/pages/upload_images/index.tsx
+++ b/gui/frontend/src/pages/upload_images/index.tsx
@@ -3,7 +3,12 @@
 
 import { useMemo } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import type { ScreenshotLinkedImage, ScreenshotPreviewImage, UploadedImageLink } from "../../types";
+import type {
+  ScreenshotLinkedImage,
+  ScreenshotPreviewImage,
+  UploadedImageLink,
+  UploadImageHostFailure,
+} from "../../types";
 import { handleExternalLinkClick } from "../../utils/externalLinks";
 import "./styles.css";
 
@@ -20,6 +25,7 @@ type Props = Readonly<{
   setAllUploadSelections: (value: boolean) => void;
   handleUploadImages: (selected: ScreenshotPreviewImage[]) => void;
   uploadImagesError: string;
+  uploadImageFailures: UploadImageHostFailure[];
   uploadCandidates: ScreenshotPreviewImage[];
   uploadSelections: Record<string, boolean>;
   toggleUploadSelection: (imagePath: string) => void;
@@ -44,6 +50,7 @@ export default function UploadImagesPage(props: Props) {
     setAllUploadSelections,
     handleUploadImages,
     uploadImagesError,
+    uploadImageFailures,
     uploadCandidates,
     uploadSelections,
     toggleUploadSelection,
@@ -97,6 +104,7 @@ export default function UploadImagesPage(props: Props) {
         SourcePath: "",
         ImagePath: link.Path,
         Host: hostKey,
+        UsageScope: "global",
         ImgURL: link.URL,
         RawURL: link.URL,
         WebURL: link.URL,
@@ -131,7 +139,7 @@ export default function UploadImagesPage(props: Props) {
         <p className="eyebrow">Image Hosting</p>
         <h1>Upload Images</h1>
         <p className="subtitle">
-          Select screenshots and upload every host needed by the active trackers.
+          Select screenshots and upload to every host needed by the active trackers.
         </p>
       </header>
 
@@ -195,6 +203,20 @@ export default function UploadImagesPage(props: Props) {
           </div>
         ) : null}
         {uploadImagesError ? <p className="error">{uploadImagesError}</p> : null}
+        {uploadImageFailures.length > 0 ? (
+          <div className="upload-images-failures">
+            {uploadImageFailures.map((failure, index) => {
+              const trackers = (failure.Trackers || []).filter(Boolean);
+              const trackerLabel = trackers.length > 0 ? ` Blocks: ${trackers.join(", ")}.` : "";
+              return (
+                <p className="error" key={`${failure.Host || "host"}-${index}`}>
+                  {failure.Host || "Image host"} failed: {failure.Message || "upload failed"}.
+                  {trackerLabel}
+                </p>
+              );
+            })}
+          </div>
+        ) : null}
       </section>
 
       {uploadCandidateCount === 0 ? (
@@ -241,7 +263,7 @@ export default function UploadImagesPage(props: Props) {
                     type="button"
                     onClick={() => pathValue && toggleUploadSelection(pathValue)}
                   >
-                    {selected ? "Selected" : isUploaded ? "Uploaded" : "Select"}
+                    {selected ? "Selected" : "Select"}
                   </button>
                   {isUploaded && imgLink ? (
                     <div className="upload-links">

--- a/gui/frontend/src/styles.css
+++ b/gui/frontend/src/styles.css
@@ -969,6 +969,16 @@ h2 {
   display: none;
 }
 
+.tracker-description.rendered .mediainfo__raw > summary {
+  cursor: pointer;
+  color: var(--accent-2);
+  font-weight: 600;
+}
+
+.tracker-description.rendered .mediainfo__raw > summary::marker {
+  color: var(--muted);
+}
+
 .tracker-description.rendered .comparison__details[open] > summary {
   position: fixed;
   top: 16px;
@@ -1180,16 +1190,6 @@ h2 {
 
 :root.light .tracker-description.rendered .mediainfo__raw pre {
   background: rgba(0, 0, 0, 0.05);
-}
-
-.tracker-description.rendered .mediainfo__raw > summary {
-  cursor: pointer;
-  color: var(--accent-2);
-  font-weight: 600;
-}
-
-.tracker-description.rendered .mediainfo__raw > summary::marker {
-  color: var(--muted);
 }
 
 .lightbox-overlay {

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -454,7 +454,13 @@ export type ImageHostFeedback = {
   Status: string;
   SelectedHost: string;
   AllowedHosts: string[];
+  Warnings?: ImageHostWarning[];
   Reuploaded: boolean;
+  Message: string;
+};
+
+export type ImageHostWarning = {
+  Host: string;
   Message: string;
 };
 
@@ -535,11 +541,24 @@ export type UploadedImageLink = {
   SourcePath: string;
   ImagePath: string;
   Host: string;
+  UsageScope: string;
   ImgURL: string;
   RawURL: string;
   WebURL: string;
   SizeBytes: number;
   UploadedAt: string;
+};
+
+export type UploadImageHostFailure = {
+  Host: string;
+  UsageScope: string;
+  Trackers: string[];
+  Message: string;
+};
+
+export type UploadImagesResult = {
+  Links: UploadedImageLink[];
+  Failures: UploadImageHostFailure[];
 };
 
 export type HistoryEntry = {
@@ -709,6 +728,11 @@ export type TrackerDryRunPreview = {
 
 export type ConfigValue = string | number | boolean | null | ConfigMap | ConfigValue[];
 export type ConfigMap = { [key: string]: ConfigValue };
+export type ImageHostPolicyMetadata = {
+  UploadHosts?: string[];
+  TrackerUploadHosts?: Record<string, string[]>;
+  OwnedHosts?: Record<string, string>;
+};
 export type FieldType = "string" | "number" | "boolean";
 export type FieldMeta = {
   key: string;

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -716,6 +716,7 @@ export type FieldMeta = {
   type?: FieldType;
   advanced?: boolean;
   sensitive?: boolean;
+  options?: Array<{ value: string; label: string }>;
 };
 
 export type ReleaseNameEditState = {

--- a/gui/frontend/src/utils/runtime.ts
+++ b/gui/frontend/src/utils/runtime.ts
@@ -403,6 +403,7 @@ export const initializeBrowserBridge = (token: string, browseEnabled = false) =>
         UpdateLogExclusions: (patterns: string[]) =>
           call("UpdateLogExclusions", { Patterns: patterns }),
         ListKnownTrackers: () => call("ListKnownTrackers"),
+        GetImageHostPolicyMetadata: () => call("GetImageHostPolicyMetadata"),
         ListHistory: () => call("ListHistory"),
         GetHistoryOverview: (sourcePath: string) =>
           call("GetHistoryOverview", { SourcePath: sourcePath }),

--- a/gui/frontend/src/utils/runtime.ts
+++ b/gui/frontend/src/utils/runtime.ts
@@ -305,6 +305,7 @@ export const initializeBrowserBridge = (token: string, browseEnabled = false) =>
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          trackers: string[],
           host: string,
           images: unknown,
         ) =>
@@ -312,6 +313,7 @@ export const initializeBrowserBridge = (token: string, browseEnabled = false) =>
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            Trackers: trackers,
             Host: host,
             Images: images,
           }),

--- a/gui/frontend/wailsjs/go/guiapp/App.d.ts
+++ b/gui/frontend/wailsjs/go/guiapp/App.d.ts
@@ -54,6 +54,8 @@ export function GetDupeCheckSnapshot(arg1:string):Promise<guiapp.DupeCheckSnapsh
 
 export function GetHistoryOverview(arg1:string):Promise<api.HistoryOverview>;
 
+export function GetImageHostPolicyMetadata():Promise<any>;
+
 export function GetLogExclusions():Promise<Array<string>>;
 
 export function GetLogPath():Promise<string>;
@@ -112,4 +114,4 @@ export function StopLogStream(arg1:string):Promise<void>;
 
 export function UpdateLogExclusions(arg1:Array<string>):Promise<void>;
 
-export function UploadImages(arg1:string,arg2:api.ExternalIDOverrides,arg3:api.ReleaseNameOverrides,arg4:Array<string>,arg5:string,arg6:Array<api.ScreenshotImage>):Promise<Array<api.UploadedImageLink>>;
+export function UploadImages(arg1:string,arg2:api.ExternalIDOverrides,arg3:api.ReleaseNameOverrides,arg4:Array<string>,arg5:string,arg6:Array<api.ScreenshotImage>):Promise<api.UploadImagesResult>;

--- a/gui/frontend/wailsjs/go/guiapp/App.d.ts
+++ b/gui/frontend/wailsjs/go/guiapp/App.d.ts
@@ -112,4 +112,4 @@ export function StopLogStream(arg1:string):Promise<void>;
 
 export function UpdateLogExclusions(arg1:Array<string>):Promise<void>;
 
-export function UploadImages(arg1:string,arg2:api.ExternalIDOverrides,arg3:api.ReleaseNameOverrides,arg4:string,arg5:Array<api.ScreenshotImage>):Promise<Array<api.UploadedImageLink>>;
+export function UploadImages(arg1:string,arg2:api.ExternalIDOverrides,arg3:api.ReleaseNameOverrides,arg4:Array<string>,arg5:string,arg6:Array<api.ScreenshotImage>):Promise<Array<api.UploadedImageLink>>;

--- a/gui/frontend/wailsjs/go/guiapp/App.js
+++ b/gui/frontend/wailsjs/go/guiapp/App.js
@@ -218,6 +218,6 @@ export function UpdateLogExclusions(arg1) {
   return window['go']['guiapp']['App']['UpdateLogExclusions'](arg1);
 }
 
-export function UploadImages(arg1, arg2, arg3, arg4, arg5) {
-  return window['go']['guiapp']['App']['UploadImages'](arg1, arg2, arg3, arg4, arg5);
+export function UploadImages(arg1, arg2, arg3, arg4, arg5, arg6) {
+  return window['go']['guiapp']['App']['UploadImages'](arg1, arg2, arg3, arg4, arg5, arg6);
 }

--- a/gui/frontend/wailsjs/go/guiapp/App.js
+++ b/gui/frontend/wailsjs/go/guiapp/App.js
@@ -102,6 +102,10 @@ export function GetHistoryOverview(arg1) {
   return window['go']['guiapp']['App']['GetHistoryOverview'](arg1);
 }
 
+export function GetImageHostPolicyMetadata() {
+  return window['go']['guiapp']['App']['GetImageHostPolicyMetadata']();
+}
+
 export function GetLogExclusions() {
   return window['go']['guiapp']['App']['GetLogExclusions']();
 }

--- a/gui/frontend/wailsjs/go/models.ts
+++ b/gui/frontend/wailsjs/go/models.ts
@@ -62,6 +62,7 @@ export namespace api {
 	    AllowedHosts: string[];
 	    Reuploaded: boolean;
 	    Message: string;
+	    Warnings: ImageHostWarning[];
 	
 	    static createFrom(source: any = {}) {
 	        return new ImageHostFeedback(source);
@@ -73,6 +74,39 @@ export namespace api {
 	        this.SelectedHost = source["SelectedHost"];
 	        this.AllowedHosts = source["AllowedHosts"];
 	        this.Reuploaded = source["Reuploaded"];
+	        this.Message = source["Message"];
+	        this.Warnings = this.convertValues(source["Warnings"], ImageHostWarning);
+	    }
+
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class ImageHostWarning {
+	    Host: string;
+	    Message: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new ImageHostWarning(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.Host = source["Host"];
 	        this.Message = source["Message"];
 	    }
 	}
@@ -1396,6 +1430,56 @@ export namespace api {
 		    return a;
 		}
 	}
+	export class UploadImageHostFailure {
+	    Host: string;
+	    UsageScope: string;
+	    Trackers: string[];
+	    Message: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new UploadImageHostFailure(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.Host = source["Host"];
+	        this.UsageScope = source["UsageScope"];
+	        this.Trackers = source["Trackers"];
+	        this.Message = source["Message"];
+	    }
+	}
+	export class UploadImagesResult {
+	    Links: UploadedImageLink[];
+	    Failures: UploadImageHostFailure[];
+	
+	    static createFrom(source: any = {}) {
+	        return new UploadImagesResult(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.Links = this.convertValues(source["Links"], UploadedImageLink);
+	        this.Failures = this.convertValues(source["Failures"], UploadImageHostFailure);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
 	export class ScreenshotFinalSelection {
 	    SourcePath: string;
 	    ImagePath: string;
@@ -2631,4 +2715,3 @@ export namespace logging {
 	}
 
 }
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -199,6 +199,7 @@ type TrackerConfig struct {
 	FullMediainfo       bool                   `yaml:"full_mediainfo" json:"FullMediainfo"`
 	UploaderName        string                 `yaml:"uploader_name" json:"UploaderName"`
 	ImgRehost           bool                   `yaml:"img_rehost" json:"ImgRehost"`
+	ImageHost           string                 `yaml:"image_host" json:"ImageHost"`
 	UseSpanishTitle     bool                   `yaml:"use_spanish_title" json:"UseSpanishTitle"`
 	UseItalianTitle     bool                   `yaml:"use_italian_title" json:"UseItalianTitle"`
 	OTPURI              string                 `yaml:"otp_uri" json:"OTPURI"`
@@ -291,11 +292,19 @@ func initTrackerSchema() {
 
 func trackerAllowedYAMLKeys(trackerName string) map[string]struct{} {
 	initTrackerSchema()
+	addGlobal := func(keys map[string]struct{}) map[string]struct{} {
+		keys["image_host"] = struct{}{}
+		return keys
+	}
 	if len(trackerSchema) == 0 {
 		return nil
 	}
 	if keys, ok := trackerSchema[trackerName]; ok {
-		return keys
+		clone := make(map[string]struct{}, len(keys)+1)
+		for key := range keys {
+			clone[key] = struct{}{}
+		}
+		return addGlobal(clone)
 	}
 	return nil
 }
@@ -660,6 +669,23 @@ var trackerImageRehostValidationHosts = map[string][]string{
 	"TVC": {"imgbb", "ptpimg", "imgbox", "pixhost", "bam", "onlyimage"},
 }
 
+var supportedTrackerImageHosts = map[string]struct{}{
+	"dalexni":      {},
+	"hdb":          {},
+	"imgbb":        {},
+	"imgbox":       {},
+	"lensdump":     {},
+	"onlyimage":    {},
+	"passtheimage": {},
+	"pixhost":      {},
+	"ptpimg":       {},
+	"ptscreens":    {},
+	"seedpool_cdn": {},
+	"sharex":       {},
+	"utppm":        {},
+	"zipline":      {},
+}
+
 func (c Config) Validate() error {
 	if c.MainSettings.TMDBAPI == "" {
 		return errors.New("config: main_settings.tmdb_api is required")
@@ -709,6 +735,19 @@ func (c Config) Validate() error {
 	}
 
 	for trackerName, trackerCfg := range c.Trackers.Trackers {
+		imageHost := strings.ToLower(strings.TrimSpace(trackerCfg.ImageHost))
+		if imageHost != "" {
+			if _, ok := supportedTrackerImageHosts[imageHost]; !ok {
+				return fmt.Errorf("config: trackers.%s.image_host %q is not supported", trackerName, trackerCfg.ImageHost)
+			}
+			if imageHost == "hdb" && !strings.EqualFold(strings.TrimSpace(trackerName), "HDB") {
+				return fmt.Errorf("config: trackers.%s.image_host %q is owned by HDB", trackerName, trackerCfg.ImageHost)
+			}
+			hosts := trackerImageRehostValidationHosts[strings.ToUpper(strings.TrimSpace(trackerName))]
+			if len(hosts) > 0 && !stringInListFold(imageHost, hosts) {
+				return fmt.Errorf("config: trackers.%s.image_host %q is not allowed for this tracker", trackerName, trackerCfg.ImageHost)
+			}
+		}
 		if !trackerCfg.ImgRehost {
 			continue
 		}
@@ -719,6 +758,16 @@ func (c Config) Validate() error {
 	}
 
 	return nil
+}
+
+func stringInListFold(value string, values []string) bool {
+	needle := strings.ToLower(strings.TrimSpace(value))
+	for _, item := range values {
+		if strings.ToLower(strings.TrimSpace(item)) == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func DisableUnsupportedTrackerImageRehosts(cfg *Config) []string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/autobrr/upbrr/internal/imagehostpolicy"
 )
 
 type Config struct {
@@ -656,36 +658,6 @@ type TorrentClientConfig struct {
 	VerifyWebUICertificate *bool    `yaml:"verify_webui_certificate"`
 }
 
-var trackerImageRehostValidationHosts = map[string][]string{
-	"A4K": {"ptpimg", "onlyimage", "imgbox", "ptscreens", "imgbb", "imgur", "postimg"},
-	"BHD": {"ptpimg", "imgbox", "imgbb", "pixhost", "bhd", "bam"},
-	"DC":  {"imgbox", "imgbb", "bhd", "imgur", "postimg", "sharex"},
-	"GPW": {"kshare", "pixhost", "ptpimg", "pterclub", "ilikeshots", "imgbox"},
-	"HDB": {"hdb"},
-	"MTV": {"ptpimg", "imgbox", "imgbb"},
-	"OE":  {"ptpimg", "imgbox", "imgbb", "onlyimage", "ptscreens", "passtheimage"},
-	"PTP": {"ptpimg", "pixhost"},
-	"STC": {"imgbox", "imgbb"},
-	"TVC": {"imgbb", "ptpimg", "imgbox", "pixhost", "bam", "onlyimage"},
-}
-
-var supportedTrackerImageHosts = map[string]struct{}{
-	"dalexni":      {},
-	"hdb":          {},
-	"imgbb":        {},
-	"imgbox":       {},
-	"lensdump":     {},
-	"onlyimage":    {},
-	"passtheimage": {},
-	"pixhost":      {},
-	"ptpimg":       {},
-	"ptscreens":    {},
-	"seedpool_cdn": {},
-	"sharex":       {},
-	"utppm":        {},
-	"zipline":      {},
-}
-
 func (c Config) Validate() error {
 	if c.MainSettings.TMDBAPI == "" {
 		return errors.New("config: main_settings.tmdb_api is required")
@@ -737,37 +709,27 @@ func (c Config) Validate() error {
 	for trackerName, trackerCfg := range c.Trackers.Trackers {
 		imageHost := strings.ToLower(strings.TrimSpace(trackerCfg.ImageHost))
 		if imageHost != "" {
-			if _, ok := supportedTrackerImageHosts[imageHost]; !ok {
+			if !imagehostpolicy.IsUploadHost(imageHost) {
 				return fmt.Errorf("config: trackers.%s.image_host %q is not supported", trackerName, trackerCfg.ImageHost)
 			}
-			if imageHost == "hdb" && !strings.EqualFold(strings.TrimSpace(trackerName), "HDB") {
-				return fmt.Errorf("config: trackers.%s.image_host %q is owned by HDB", trackerName, trackerCfg.ImageHost)
+			if owner := imagehostpolicy.OwnerForHost(imageHost); owner != "" && !strings.EqualFold(strings.TrimSpace(trackerName), owner) {
+				return fmt.Errorf("config: trackers.%s.image_host %q is owned by %s", trackerName, trackerCfg.ImageHost, owner)
 			}
-			hosts := trackerImageRehostValidationHosts[strings.ToUpper(strings.TrimSpace(trackerName))]
-			if len(hosts) > 0 && !stringInListFold(imageHost, hosts) {
+			policy := imagehostpolicy.ForTracker(trackerName, trackerCfg.ImgRehost)
+			if len(policy.AllowedHosts) > 0 && !imagehostpolicy.HostAllowed(imageHost, policy.AllowedHosts) {
 				return fmt.Errorf("config: trackers.%s.image_host %q is not allowed for this tracker", trackerName, trackerCfg.ImageHost)
 			}
 		}
 		if !trackerCfg.ImgRehost {
 			continue
 		}
-		hosts := trackerImageRehostValidationHosts[strings.ToUpper(strings.TrimSpace(trackerName))]
-		if len(hosts) == 0 {
+		policy := imagehostpolicy.ForTracker(trackerName, true)
+		if len(policy.AllowedHosts) == 0 {
 			return fmt.Errorf("config: trackers.%s.img_rehost requires a tracker image-host policy, but none is defined", trackerName)
 		}
 	}
 
 	return nil
-}
-
-func stringInListFold(value string, values []string) bool {
-	needle := strings.ToLower(strings.TrimSpace(value))
-	for _, item := range values {
-		if strings.ToLower(strings.TrimSpace(item)) == needle {
-			return true
-		}
-	}
-	return false
 }
 
 func DisableUnsupportedTrackerImageRehosts(cfg *Config) []string {
@@ -780,8 +742,8 @@ func DisableUnsupportedTrackerImageRehosts(cfg *Config) []string {
 		if !trackerCfg.ImgRehost {
 			continue
 		}
-		hosts := trackerImageRehostValidationHosts[strings.ToUpper(strings.TrimSpace(trackerName))]
-		if len(hosts) != 0 {
+		policy := imagehostpolicy.ForTracker(trackerName, true)
+		if len(policy.AllowedHosts) != 0 {
 			continue
 		}
 		trackerCfg.ImgRehost = false

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -112,6 +112,45 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "valid tracker image host",
+			cfg: Config{
+				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},
+				ScreenshotHandling: ScreenshotHandlingConfig{Screens: 1},
+				Trackers: TrackersConfig{
+					Trackers: map[string]TrackerConfig{
+						"PTP": {ImageHost: "ptpimg"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid unsupported tracker image host",
+			cfg: Config{
+				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},
+				ScreenshotHandling: ScreenshotHandlingConfig{Screens: 1},
+				Trackers: TrackersConfig{
+					Trackers: map[string]TrackerConfig{
+						"AITHER": {ImageHost: "imgur"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid tracker image host outside tracker policy",
+			cfg: Config{
+				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},
+				ScreenshotHandling: ScreenshotHandlingConfig{Screens: 1},
+				Trackers: TrackersConfig{
+					Trackers: map[string]TrackerConfig{
+						"PTP": {ImageHost: "imgbb"},
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -153,6 +192,7 @@ func TestTrackersConfigJSONFiltersToTrackerSchema(t *testing.T) {
 					APIKey:      "abc",
 					AnnounceURL: "https://should-not-be-here",
 					Username:    "should-not-be-here",
+					ImageHost:   "ptpimg",
 					Anon:        true,
 					Unknown: map[string]interface{}{
 						"CustomFlag": "keep",
@@ -198,6 +238,9 @@ func TestTrackersConfigJSONFiltersToTrackerSchema(t *testing.T) {
 	if _, exists := a4k["ModQ"]; !exists {
 		t.Fatalf("A4K should include ModQ from schema defaults")
 	}
+	if got := a4k["ImageHost"]; got != "ptpimg" {
+		t.Fatalf("A4K should include ImageHost, got %v", got)
+	}
 	if got := a4k["CustomFlag"]; got != "keep" {
 		t.Fatalf("custom key not preserved, got %v", got)
 	}
@@ -215,6 +258,7 @@ func TestTrackersConfigYAMLFiltersToTrackerSchema(t *testing.T) {
 				"A4K": {
 					APIKey:      "abc",
 					AnnounceURL: "https://should-not-be-here",
+					ImageHost:   "ptpimg",
 					Anon:        true,
 					Unknown: map[string]interface{}{
 						"custom_yaml": "keep",
@@ -242,6 +286,9 @@ func TestTrackersConfigYAMLFiltersToTrackerSchema(t *testing.T) {
 	}
 	if !regexp.MustCompile(`(?m)^\s*api_key:\s*\S+\s*$`).MatchString(text) {
 		t.Fatalf("A4K should include api_key with non-empty value in yaml export")
+	}
+	if !strings.Contains(text, "image_host: ptpimg") {
+		t.Fatalf("A4K should include image_host in yaml export")
 	}
 	if !strings.Contains(text, "custom_yaml: keep") {
 		t.Fatalf("unknown custom key should be preserved in yaml export")

--- a/internal/config/defaults/example.yaml
+++ b/internal/config/defaults/example.yaml
@@ -130,6 +130,7 @@ trackers:
   A4K:
     link_dir_name: ""
     api_key: ""
+    image_host: ""
     anon: false
     modq: false
   ACM:

--- a/internal/config/validate_penetration_test.go
+++ b/internal/config/validate_penetration_test.go
@@ -6,6 +6,8 @@ package config
 import (
 	"strings"
 	"testing"
+
+	"github.com/autobrr/upbrr/internal/imagehostpolicy"
 )
 
 // Validate is the CLI's fail-fast check. These tests target every failure
@@ -235,12 +237,12 @@ func TestValidateQuiRequiresProxy(t *testing.T) {
 func TestValidateAllImageRehostPoliciesAccepted(t *testing.T) {
 	t.Parallel()
 
-	for policy := range trackerImageRehostValidationHosts {
+	for trackerName := range imagehostpolicy.KnownTrackerPolicies() {
 		cfg := withBase(func(c *Config) {
-			c.Trackers.Trackers = map[string]TrackerConfig{policy: {ImgRehost: true}}
+			c.Trackers.Trackers = map[string]TrackerConfig{trackerName: {ImgRehost: true}}
 		})
 		if err := cfg.Validate(); err != nil {
-			t.Errorf("policy %s img_rehost should validate: %v", policy, err)
+			t.Errorf("tracker %s img_rehost should validate: %v", trackerName, err)
 		}
 	}
 }

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -930,7 +930,185 @@ func (c *Core) UploadImages(ctx context.Context, req api.Request, host string, i
 		meta = preparedMeta
 	}
 
-	return c.services.Images.Upload(ctx, meta, host, "global", images)
+	targets, err := c.resolveImageUploadTargets(req, host)
+	if err != nil {
+		return nil, err
+	}
+	return c.uploadImagesToTargets(ctx, meta, targets, images)
+}
+
+func (c *Core) resolveImageUploadTargets(req api.Request, host string) ([]trackers.ImageUploadTarget, error) {
+	normalizedHost := strings.ToLower(strings.TrimSpace(host))
+	if normalizedHost == "" {
+		return nil, internalerrors.ErrInvalidInput
+	}
+
+	trackerCfg := c.cfg
+	trackerCfg.Trackers.DefaultTrackers = nil
+	resolvedTrackers := trackers.ResolveTrackers(trackerCfg, req.Trackers, req.TrackersRemove, c.logger)
+	trackerTargets, err := trackers.ConfiguredImageUploadTargets(c.cfg, resolvedTrackers)
+	if err != nil {
+		return nil, err
+	}
+
+	targets := make([]trackers.ImageUploadTarget, 0, len(trackerTargets)+1)
+	seen := make(map[string]struct{}, len(trackerTargets)+1)
+	addTarget := func(target trackers.ImageUploadTarget) {
+		target.Host = strings.ToLower(strings.TrimSpace(target.Host))
+		target.UsageScope = normalizeImageUploadUsageScope(target.UsageScope)
+		if target.Host == "" {
+			return
+		}
+		key := target.Host + "\x00" + target.UsageScope
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		targets = append(targets, target)
+	}
+
+	if trackers.TrackerForOwnedImageHost(normalizedHost) == "" {
+		addTarget(trackers.ImageUploadTarget{Host: normalizedHost, UsageScope: "global"})
+	}
+	for _, target := range trackerTargets {
+		addTarget(target)
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("core: image host %q is tracker-scoped but no active tracker can use it", normalizedHost)
+	}
+	return targets, nil
+}
+
+func (c *Core) uploadImagesToTargets(ctx context.Context, meta api.PreparedMetadata, targets []trackers.ImageUploadTarget, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+	type uploadResult struct {
+		index int
+		host  string
+		links []api.UploadedImageLink
+		err   error
+	}
+
+	resultCh := make(chan uploadResult, len(targets))
+	var wg sync.WaitGroup
+	for idx, target := range targets {
+		wg.Add(1)
+		go func(idx int, target trackers.ImageUploadTarget) {
+			defer wg.Done()
+			uploaded, err := c.uploadImagesToTarget(ctx, meta, target, images)
+			resultCh <- uploadResult{
+				index: idx,
+				host:  strings.ToLower(strings.TrimSpace(target.Host)),
+				links: uploaded,
+				err:   err,
+			}
+		}(idx, target)
+	}
+	wg.Wait()
+	close(resultCh)
+
+	ordered := make([]uploadResult, len(targets))
+	for result := range resultCh {
+		ordered[result.index] = result
+	}
+
+	results := make([]api.UploadedImageLink, 0, len(images)*len(targets))
+	failures := make([]string, 0)
+	for _, result := range ordered {
+		results = append(results, result.links...)
+		if result.err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", result.host, result.err))
+		}
+	}
+	if len(failures) == 0 {
+		return results, nil
+	}
+	if len(results) > 0 {
+		c.logger.Warnf("core: image uploads completed with %d host failures and %d successful links: %s", len(failures), len(results), strings.Join(failures, "; "))
+		return results, nil
+	}
+	return nil, fmt.Errorf("core: image uploads failed for all hosts: %s", strings.Join(failures, "; "))
+}
+
+func (c *Core) uploadImagesToTarget(ctx context.Context, meta api.PreparedMetadata, target trackers.ImageUploadTarget, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+	target.Host = strings.ToLower(strings.TrimSpace(target.Host))
+	target.UsageScope = normalizeImageUploadUsageScope(target.UsageScope)
+	if c.repo == nil {
+		c.logger.Debugf("core: uploading images host=%s scope=%s count=%d", target.Host, target.UsageScope, len(images))
+		return c.services.Images.Upload(ctx, meta, target.Host, target.UsageScope, images)
+	}
+
+	existing, err := c.repo.ListUploadedImagesByPath(ctx, meta.SourcePath)
+	if err != nil {
+		return nil, err
+	}
+	existingByPath := uploadedImagesByPathForTarget(existing, target)
+	results := make([]api.UploadedImageLink, 0, len(images))
+	missing := make([]api.ScreenshotImage, 0, len(images))
+	for _, image := range images {
+		key := normalizedUploadImagePath(image.Path)
+		if key == "" {
+			missing = append(missing, image)
+			continue
+		}
+		if link, ok := existingByPath[key]; ok {
+			results = append(results, link)
+			continue
+		}
+		missing = append(missing, image)
+	}
+	if len(missing) == 0 {
+		c.logger.Debugf("core: reusing uploaded images host=%s scope=%s count=%d", target.Host, target.UsageScope, len(results))
+		return results, nil
+	}
+
+	c.logger.Debugf("core: uploading missing images host=%s scope=%s missing=%d reused=%d", target.Host, target.UsageScope, len(missing), len(results))
+	uploaded, err := c.services.Images.Upload(ctx, meta, target.Host, target.UsageScope, missing)
+	results = append(results, uploaded...)
+	return results, err
+}
+
+func uploadedImagesByPathForTarget(images []api.UploadedImageLink, target trackers.ImageUploadTarget) map[string]api.UploadedImageLink {
+	matches := make(map[string]api.UploadedImageLink, len(images))
+	for _, image := range images {
+		if !strings.EqualFold(strings.TrimSpace(image.Host), target.Host) {
+			continue
+		}
+		if !strings.EqualFold(normalizeImageUploadUsageScope(image.UsageScope), normalizeImageUploadUsageScope(target.UsageScope)) {
+			continue
+		}
+		key := normalizedUploadImagePath(image.ImagePath)
+		if key == "" {
+			continue
+		}
+		matches[key] = image
+	}
+	return matches
+}
+
+func normalizedUploadImagePath(pathValue string) string {
+	trimmed := strings.TrimSpace(pathValue)
+	if trimmed == "" {
+		return ""
+	}
+	absPath, err := filepath.Abs(trimmed)
+	if err != nil {
+		return filepath.Clean(trimmed)
+	}
+	return filepath.Clean(absPath)
+}
+
+func normalizeImageUploadUsageScope(scope string) string {
+	trimmed := strings.TrimSpace(scope)
+	if trimmed == "" || strings.EqualFold(trimmed, "global") {
+		return "global"
+	}
+	if strings.HasPrefix(strings.ToLower(trimmed), "tracker:") {
+		tracker := strings.ToUpper(strings.TrimSpace(trimmed[len("tracker:"):]))
+		if tracker == "" {
+			return "global"
+		}
+		return "tracker:" + tracker
+	}
+	return trimmed
 }
 
 func (c *Core) DeleteUploadedImage(ctx context.Context, req api.Request, imagePath string, host string) error {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -877,20 +878,20 @@ func (c *Core) ListUploadedImages(ctx context.Context, req api.Request) ([]api.U
 	return c.repo.ListUploadedImagesByPath(ctx, uniquePaths[0])
 }
 
-func (c *Core) UploadImages(ctx context.Context, req api.Request, host string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+func (c *Core) UploadImages(ctx context.Context, req api.Request, host string, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
 	if len(req.Paths) == 0 {
-		return nil, internalerrors.ErrInvalidInput
+		return api.UploadImagesResult{}, internalerrors.ErrInvalidInput
 	}
 	if c.services.Images == nil {
-		return nil, errors.New("core: image hosting service not configured")
+		return api.UploadImagesResult{}, errors.New("core: image hosting service not configured")
 	}
 	if len(images) == 0 {
-		return nil, internalerrors.ErrInvalidInput
+		return api.UploadImagesResult{}, internalerrors.ErrInvalidInput
 	}
 
 	normalizedPaths, err := c.services.Filesystem.ValidatePaths(ctx, req.Paths)
 	if err != nil {
-		return nil, err
+		return api.UploadImagesResult{}, err
 	}
 	uniquePaths := make([]string, 0, len(normalizedPaths))
 	seenPaths := make(map[string]struct{}, len(normalizedPaths))
@@ -902,13 +903,13 @@ func (c *Core) UploadImages(ctx context.Context, req api.Request, host string, i
 		uniquePaths = append(uniquePaths, path)
 	}
 	if len(uniquePaths) != 1 {
-		return nil, internalerrors.ErrInvalidInput
+		return api.UploadImagesResult{}, internalerrors.ErrInvalidInput
 	}
 
 	var meta api.PreparedMetadata
 	if req.Mode == api.ModeGUI {
 		if cached, ok, err := c.resolveGUICachedPreparedMeta(ctx, req, uniquePaths[0]); err != nil {
-			return nil, err
+			return api.UploadImagesResult{}, err
 		} else if ok {
 			meta = cached
 		} else {
@@ -917,7 +918,7 @@ func (c *Core) UploadImages(ctx context.Context, req api.Request, host string, i
 	} else {
 		options, err := c.applyDefaultOptions(req.Options)
 		if err != nil {
-			return nil, err
+			return api.UploadImagesResult{}, err
 		}
 		singleReq := req
 		singleReq.Paths = []string{uniquePaths[0]}
@@ -925,14 +926,14 @@ func (c *Core) UploadImages(ctx context.Context, req api.Request, host string, i
 
 		preparedMeta, err := c.services.Metadata.Prepare(ctx, singleReq)
 		if err != nil {
-			return nil, err
+			return api.UploadImagesResult{}, err
 		}
 		meta = preparedMeta
 	}
 
 	targets, err := c.resolveImageUploadTargets(req, host)
 	if err != nil {
-		return nil, err
+		return api.UploadImagesResult{}, err
 	}
 	return c.uploadImagesToTargets(ctx, meta, targets, images)
 }
@@ -952,18 +953,20 @@ func (c *Core) resolveImageUploadTargets(req api.Request, host string) ([]tracke
 	}
 
 	targets := make([]trackers.ImageUploadTarget, 0, len(trackerTargets)+1)
-	seen := make(map[string]struct{}, len(trackerTargets)+1)
+	seen := make(map[string]int, len(trackerTargets)+1)
 	addTarget := func(target trackers.ImageUploadTarget) {
-		target.Host = strings.ToLower(strings.TrimSpace(target.Host))
-		target.UsageScope = normalizeImageUploadUsageScope(target.UsageScope)
+		target = normalizeImageUploadTarget(target)
 		if target.Host == "" {
 			return
 		}
 		key := target.Host + "\x00" + target.UsageScope
-		if _, ok := seen[key]; ok {
+		if idx, ok := seen[key]; ok {
+			for _, tracker := range target.Trackers {
+				targets[idx].Trackers = appendUniqueNormalizedTracker(targets[idx].Trackers, tracker)
+			}
 			return
 		}
-		seen[key] = struct{}{}
+		seen[key] = len(targets)
 		targets = append(targets, target)
 	}
 
@@ -979,12 +982,12 @@ func (c *Core) resolveImageUploadTargets(req api.Request, host string) ([]tracke
 	return targets, nil
 }
 
-func (c *Core) uploadImagesToTargets(ctx context.Context, meta api.PreparedMetadata, targets []trackers.ImageUploadTarget, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+func (c *Core) uploadImagesToTargets(ctx context.Context, meta api.PreparedMetadata, targets []trackers.ImageUploadTarget, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
 	type uploadResult struct {
-		index int
-		host  string
-		links []api.UploadedImageLink
-		err   error
+		index  int
+		target trackers.ImageUploadTarget
+		links  []api.UploadedImageLink
+		err    error
 	}
 
 	resultCh := make(chan uploadResult, len(targets))
@@ -995,10 +998,10 @@ func (c *Core) uploadImagesToTargets(ctx context.Context, meta api.PreparedMetad
 			defer wg.Done()
 			uploaded, err := c.uploadImagesToTarget(ctx, meta, target, images)
 			resultCh <- uploadResult{
-				index: idx,
-				host:  strings.ToLower(strings.TrimSpace(target.Host)),
-				links: uploaded,
-				err:   err,
+				index:  idx,
+				target: normalizeImageUploadTarget(target),
+				links:  uploaded,
+				err:    err,
 			}
 		}(idx, target)
 	}
@@ -1011,21 +1014,55 @@ func (c *Core) uploadImagesToTargets(ctx context.Context, meta api.PreparedMetad
 	}
 
 	results := make([]api.UploadedImageLink, 0, len(images)*len(targets))
-	failures := make([]string, 0)
+	failures := make([]api.UploadImageHostFailure, 0)
+	failureMessages := make([]string, 0)
 	for _, result := range ordered {
 		results = append(results, result.links...)
 		if result.err != nil {
-			failures = append(failures, fmt.Sprintf("%s: %v", result.host, result.err))
+			failure := api.UploadImageHostFailure{
+				Host:       result.target.Host,
+				UsageScope: result.target.UsageScope,
+				Trackers:   slices.Clone(result.target.Trackers),
+				Message:    result.err.Error(),
+			}
+			failures = append(failures, failure)
+			failureMessages = append(failureMessages, fmt.Sprintf("%s: %v", result.target.Host, result.err))
 		}
 	}
 	if len(failures) == 0 {
-		return results, nil
+		return api.UploadImagesResult{Links: results}, nil
 	}
+	result := api.UploadImagesResult{Links: results, Failures: failures}
 	if len(results) > 0 {
-		c.logger.Warnf("core: image uploads completed with %d host failures and %d successful links: %s", len(failures), len(results), strings.Join(failures, "; "))
-		return results, nil
+		c.logger.Warnf("core: image uploads completed with %d host failures and %d successful links: %s", len(failures), len(results), strings.Join(failureMessages, "; "))
+		return result, nil
 	}
-	return nil, fmt.Errorf("core: image uploads failed for all hosts: %s", strings.Join(failures, "; "))
+	c.logger.Warnf("core: image uploads failed for all hosts: %s", strings.Join(failureMessages, "; "))
+	return result, nil
+}
+
+func normalizeImageUploadTarget(target trackers.ImageUploadTarget) trackers.ImageUploadTarget {
+	target.Host = strings.ToLower(strings.TrimSpace(target.Host))
+	target.UsageScope = normalizeImageUploadUsageScope(target.UsageScope)
+	trackersList := make([]string, 0, len(target.Trackers))
+	for _, tracker := range target.Trackers {
+		trackersList = appendUniqueNormalizedTracker(trackersList, tracker)
+	}
+	target.Trackers = trackersList
+	return target
+}
+
+func appendUniqueNormalizedTracker(trackersList []string, tracker string) []string {
+	name := strings.ToUpper(strings.TrimSpace(tracker))
+	if name == "" {
+		return trackersList
+	}
+	for _, existing := range trackersList {
+		if existing == name {
+			return trackersList
+		}
+	}
+	return append(trackersList, name)
 }
 
 func (c *Core) uploadImagesToTarget(ctx context.Context, meta api.PreparedMetadata, target trackers.ImageUploadTarget, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {

--- a/internal/core/upload_images_test.go
+++ b/internal/core/upload_images_test.go
@@ -6,6 +6,8 @@ package core
 import (
 	"context"
 	"errors"
+	"slices"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -34,6 +36,8 @@ func (s *stubImageHosting) ListCandidates(ctx context.Context, meta api.Prepared
 	if s.err != nil {
 		return nil, s.err
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.lastMeta = meta
 	return s.candidates, nil
 }
@@ -80,11 +84,11 @@ func TestUploadImagesWithoutCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if len(result) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(result))
+	if len(result.Links) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result.Links))
 	}
-	if result[0].Host != "imgbox" {
-		t.Fatalf("expected host imgbox, got %s", result[0].Host)
+	if result.Links[0].Host != "imgbox" {
+		t.Fatalf("expected host imgbox, got %s", result.Links[0].Host)
 	}
 }
 
@@ -205,8 +209,8 @@ func TestUploadImagesUploadsApplicableTrackerHosts(t *testing.T) {
 	if calledHosts["ptpimg"] != "global" {
 		t.Fatalf("expected configured PTP host ptpimg, got %#v", imageService.calls)
 	}
-	if len(result) != 2 {
-		t.Fatalf("expected result from both hosts, got %d", len(result))
+	if len(result.Links) != 2 {
+		t.Fatalf("expected result from both hosts, got %d", len(result.Links))
 	}
 }
 
@@ -249,7 +253,7 @@ func TestUploadImagesDoesNotUseBuiltInTrackerPreferredHosts(t *testing.T) {
 	if imageService.calls[0].host != "imgbox" {
 		t.Fatalf("expected selected host imgbox, got %#v", imageService.calls[0])
 	}
-	if len(result) != 1 || result[0].Host != "imgbox" {
+	if len(result.Links) != 1 || result.Links[0].Host != "imgbox" {
 		t.Fatalf("expected imgbox result only, got %#v", result)
 	}
 }
@@ -259,7 +263,6 @@ func TestUploadImagesUploadsHostsConcurrently(t *testing.T) {
 
 	images := []api.ScreenshotImage{{Path: "/tmp/img1.png"}}
 	bothStarted := make(chan struct{})
-	var once sync.Once
 	var startedMu sync.Mutex
 	started := 0
 	imageService := &stubImageHosting{
@@ -267,7 +270,7 @@ func TestUploadImagesUploadsHostsConcurrently(t *testing.T) {
 			startedMu.Lock()
 			started++
 			if started == 2 {
-				once.Do(func() { close(bothStarted) })
+				close(bothStarted)
 			}
 			startedMu.Unlock()
 
@@ -285,6 +288,8 @@ func TestUploadImagesUploadsHostsConcurrently(t *testing.T) {
 			Trackers: config.TrackersConfig{
 				Trackers: map[string]config.TrackerConfig{
 					"PTP": {ImageHost: "ptpimg"},
+					"MTV": {ImageHost: "ptpimg"},
+					"STC": {},
 				},
 			},
 		},
@@ -298,17 +303,17 @@ func TestUploadImagesUploadsHostsConcurrently(t *testing.T) {
 	result, err := core.UploadImages(context.Background(), api.Request{
 		Paths:    []string{"/tmp/source"},
 		Mode:     api.ModeGUI,
-		Trackers: []string{"PTP"},
+		Trackers: []string{"PTP", "MTV", "STC"},
 	}, "imgbox", images)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if len(result) != 2 {
+	if len(result.Links) != 2 {
 		t.Fatalf("expected both concurrent uploads to succeed, got %#v", result)
 	}
 }
 
-func TestUploadImagesReturnsSuccessfulHostsWhenOneHostFails(t *testing.T) {
+func TestUploadImagesReturnsHostFailuresWithSuccessfulLinks(t *testing.T) {
 	t.Parallel()
 
 	images := []api.ScreenshotImage{{Path: "/tmp/img1.png"}}
@@ -326,6 +331,8 @@ func TestUploadImagesReturnsSuccessfulHostsWhenOneHostFails(t *testing.T) {
 			Trackers: config.TrackersConfig{
 				Trackers: map[string]config.TrackerConfig{
 					"PTP": {ImageHost: "ptpimg"},
+					"MTV": {ImageHost: "ptpimg"},
+					"STC": {},
 				},
 			},
 		},
@@ -339,13 +346,26 @@ func TestUploadImagesReturnsSuccessfulHostsWhenOneHostFails(t *testing.T) {
 	result, err := core.UploadImages(context.Background(), api.Request{
 		Paths:    []string{"/tmp/source"},
 		Mode:     api.ModeGUI,
-		Trackers: []string{"PTP"},
+		Trackers: []string{"PTP", "MTV", "STC"},
 	}, "imgbox", images)
 	if err != nil {
 		t.Fatalf("expected partial host failure to return successful links, got %v", err)
 	}
-	if len(result) != 1 || result[0].Host != "imgbox" {
+	if len(result.Links) != 1 || result.Links[0].Host != "imgbox" {
 		t.Fatalf("expected only successful imgbox upload, got %#v", result)
+	}
+	if len(result.Failures) != 1 {
+		t.Fatalf("expected one host failure, got %#v", result.Failures)
+	}
+	failure := result.Failures[0]
+	if failure.Host != "ptpimg" || failure.Message != "ptpimg unavailable" {
+		t.Fatalf("expected ptpimg failure, got %#v", failure)
+	}
+	expectedTrackers := []string{"PTP", "MTV"}
+	sort.Strings(failure.Trackers)
+	sort.Strings(expectedTrackers)
+	if !slices.Equal(failure.Trackers, expectedTrackers) {
+		t.Fatalf("expected failure to block only linked trackers, got %#v", failure.Trackers)
 	}
 }
 

--- a/internal/core/upload_images_test.go
+++ b/internal/core/upload_images_test.go
@@ -5,7 +5,10 @@ package core
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/pkg/api"
@@ -16,6 +19,15 @@ type stubImageHosting struct {
 	uploaded   []api.UploadedImageLink
 	err        error
 	lastMeta   api.PreparedMetadata
+	mu         sync.Mutex
+	calls      []stubImageUploadCall
+	uploadFn   func(ctx context.Context, meta api.PreparedMetadata, host string, usageScope string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error)
+}
+
+type stubImageUploadCall struct {
+	host       string
+	usageScope string
+	images     []api.ScreenshotImage
 }
 
 func (s *stubImageHosting) ListCandidates(ctx context.Context, meta api.PreparedMetadata) ([]api.ScreenshotImage, error) {
@@ -30,7 +42,17 @@ func (s *stubImageHosting) Upload(ctx context.Context, meta api.PreparedMetadata
 	if s.err != nil {
 		return nil, s.err
 	}
+	s.mu.Lock()
 	s.lastMeta = meta
+	s.calls = append(s.calls, stubImageUploadCall{
+		host:       host,
+		usageScope: usageScope,
+		images:     append([]api.ScreenshotImage{}, images...),
+	})
+	s.mu.Unlock()
+	if s.uploadFn != nil {
+		return s.uploadFn(ctx, meta, host, usageScope, images)
+	}
 	return s.uploaded, nil
 }
 
@@ -133,4 +155,212 @@ func TestUploadImagesGUIFallbackReappliesReleaseOverrides(t *testing.T) {
 	if imageService.lastMeta.ReleaseNameOverrides.Edition == nil || *imageService.lastMeta.ReleaseNameOverrides.Edition != edition {
 		t.Fatalf("expected upload images to receive edition override, got %#v", imageService.lastMeta.ReleaseNameOverrides)
 	}
+}
+
+func TestUploadImagesUploadsApplicableTrackerHosts(t *testing.T) {
+	t.Parallel()
+
+	images := []api.ScreenshotImage{{Path: "/tmp/img1.png"}}
+	imageService := &stubImageHosting{
+		uploadFn: func(ctx context.Context, meta api.PreparedMetadata, host string, usageScope string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+			return uploadedImageLinksForHost(meta, host, usageScope, images), nil
+		},
+	}
+	core := &Core{
+		logger: api.NopLogger{},
+		cfg: config.Config{
+			Trackers: config.TrackersConfig{
+				Trackers: map[string]config.TrackerConfig{
+					"PTP": {ImageHost: "ptpimg"},
+					"STC": {},
+				},
+			},
+		},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{"/tmp/source"}},
+			Images:     imageService,
+		},
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+
+	result, err := core.UploadImages(context.Background(), api.Request{
+		Paths:    []string{"/tmp/source"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"PTP", "STC"},
+	}, "imgbox", images)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(imageService.calls) != 2 {
+		t.Fatalf("expected uploads to two hosts, got %d calls: %#v", len(imageService.calls), imageService.calls)
+	}
+	calledHosts := map[string]string{}
+	for _, call := range imageService.calls {
+		calledHosts[call.host] = call.usageScope
+	}
+	if calledHosts["imgbox"] != "global" {
+		t.Fatalf("expected selected host imgbox, got %#v", imageService.calls)
+	}
+	if calledHosts["ptpimg"] != "global" {
+		t.Fatalf("expected configured PTP host ptpimg, got %#v", imageService.calls)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected result from both hosts, got %d", len(result))
+	}
+}
+
+func TestUploadImagesDoesNotUseBuiltInTrackerPreferredHosts(t *testing.T) {
+	t.Parallel()
+
+	images := []api.ScreenshotImage{{Path: "/tmp/img1.png"}}
+	imageService := &stubImageHosting{
+		uploadFn: func(ctx context.Context, meta api.PreparedMetadata, host string, usageScope string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+			return uploadedImageLinksForHost(meta, host, usageScope, images), nil
+		},
+	}
+	core := &Core{
+		logger: api.NopLogger{},
+		cfg: config.Config{
+			Trackers: config.TrackersConfig{
+				Trackers: map[string]config.TrackerConfig{
+					"PTP": {},
+				},
+			},
+		},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{"/tmp/source"}},
+			Images:     imageService,
+		},
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+
+	result, err := core.UploadImages(context.Background(), api.Request{
+		Paths:    []string{"/tmp/source"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"PTP"},
+	}, "imgbox", images)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(imageService.calls) != 1 {
+		t.Fatalf("expected upload to selected host only, got %d calls: %#v", len(imageService.calls), imageService.calls)
+	}
+	if imageService.calls[0].host != "imgbox" {
+		t.Fatalf("expected selected host imgbox, got %#v", imageService.calls[0])
+	}
+	if len(result) != 1 || result[0].Host != "imgbox" {
+		t.Fatalf("expected imgbox result only, got %#v", result)
+	}
+}
+
+func TestUploadImagesUploadsHostsConcurrently(t *testing.T) {
+	t.Parallel()
+
+	images := []api.ScreenshotImage{{Path: "/tmp/img1.png"}}
+	bothStarted := make(chan struct{})
+	var once sync.Once
+	var startedMu sync.Mutex
+	started := 0
+	imageService := &stubImageHosting{
+		uploadFn: func(ctx context.Context, meta api.PreparedMetadata, host string, usageScope string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+			startedMu.Lock()
+			started++
+			if started == 2 {
+				once.Do(func() { close(bothStarted) })
+			}
+			startedMu.Unlock()
+
+			select {
+			case <-bothStarted:
+			case <-time.After(500 * time.Millisecond):
+				return nil, errors.New("second host did not start")
+			}
+			return uploadedImageLinksForHost(meta, host, usageScope, images), nil
+		},
+	}
+	core := &Core{
+		logger: api.NopLogger{},
+		cfg: config.Config{
+			Trackers: config.TrackersConfig{
+				Trackers: map[string]config.TrackerConfig{
+					"PTP": {ImageHost: "ptpimg"},
+				},
+			},
+		},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{"/tmp/source"}},
+			Images:     imageService,
+		},
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+
+	result, err := core.UploadImages(context.Background(), api.Request{
+		Paths:    []string{"/tmp/source"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"PTP"},
+	}, "imgbox", images)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected both concurrent uploads to succeed, got %#v", result)
+	}
+}
+
+func TestUploadImagesReturnsSuccessfulHostsWhenOneHostFails(t *testing.T) {
+	t.Parallel()
+
+	images := []api.ScreenshotImage{{Path: "/tmp/img1.png"}}
+	imageService := &stubImageHosting{
+		uploadFn: func(ctx context.Context, meta api.PreparedMetadata, host string, usageScope string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+			if host == "ptpimg" {
+				return nil, errors.New("ptpimg unavailable")
+			}
+			return uploadedImageLinksForHost(meta, host, usageScope, images), nil
+		},
+	}
+	core := &Core{
+		logger: api.NopLogger{},
+		cfg: config.Config{
+			Trackers: config.TrackersConfig{
+				Trackers: map[string]config.TrackerConfig{
+					"PTP": {ImageHost: "ptpimg"},
+				},
+			},
+		},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{"/tmp/source"}},
+			Images:     imageService,
+		},
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+
+	result, err := core.UploadImages(context.Background(), api.Request{
+		Paths:    []string{"/tmp/source"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"PTP"},
+	}, "imgbox", images)
+	if err != nil {
+		t.Fatalf("expected partial host failure to return successful links, got %v", err)
+	}
+	if len(result) != 1 || result[0].Host != "imgbox" {
+		t.Fatalf("expected only successful imgbox upload, got %#v", result)
+	}
+}
+
+func uploadedImageLinksForHost(meta api.PreparedMetadata, host string, usageScope string, images []api.ScreenshotImage) []api.UploadedImageLink {
+	result := make([]api.UploadedImageLink, 0, len(images))
+	for _, image := range images {
+		result = append(result, api.UploadedImageLink{
+			SourcePath: meta.SourcePath,
+			ImagePath:  image.Path,
+			Host:       host,
+			UsageScope: usageScope,
+			RawURL:     "https://" + host + "/raw.png",
+			ImgURL:     "https://" + host + "/img.png",
+			WebURL:     "https://" + host + "/web.png",
+		})
+	}
+	return result
 }

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -1021,7 +1021,7 @@ func (a *App) ListUploadedImages(path string, overrides api.ExternalIDOverrides,
 	return a.core.ListUploadedImages(ctx, req)
 }
 
-func (a *App) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, host string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+func (a *App) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, host string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
 	if a == nil || a.core == nil {
 		return nil, errors.New("app not initialized")
 	}
@@ -1052,6 +1052,7 @@ func (a *App) UploadImages(path string, overrides api.ExternalIDOverrides, nameO
 		},
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		Trackers:             append([]string{}, trackers...),
 	}
 
 	return a.core.UploadImages(ctx, req, host, images)

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -25,6 +25,7 @@ import (
 	"github.com/autobrr/upbrr/internal/core"
 	"github.com/autobrr/upbrr/internal/filesystem"
 	"github.com/autobrr/upbrr/internal/guishared"
+	"github.com/autobrr/upbrr/internal/imagehostpolicy"
 	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/paths"
 	"github.com/autobrr/upbrr/internal/redaction"
@@ -338,7 +339,7 @@ func (a *App) FetchMetadata(path string, sourceLookupURL string, overrides api.E
 	req := api.Request{
 		Paths:           []string{trimmedPath},
 		Mode:            api.ModeGUI,
-		Trackers:        trackers,
+		Trackers:        slices.Clone(trackers),
 		SourceLookupURL: strings.TrimSpace(sourceLookupURL),
 		Options: api.UploadOptions{
 			Screens:    a.cfg.ScreenshotHandling.Screens,
@@ -484,7 +485,7 @@ func (a *App) ResetMetadata(path string, sourceLookupURL string, overrides api.E
 	req := api.Request{
 		Paths:           []string{trimmedPath},
 		Mode:            api.ModeGUI,
-		Trackers:        trackers,
+		Trackers:        slices.Clone(trackers),
 		SourceLookupURL: strings.TrimSpace(sourceLookupURL),
 		Options: api.UploadOptions{
 			Screens:    a.cfg.ScreenshotHandling.Screens,
@@ -601,7 +602,7 @@ func (a *App) CheckDupes(path string, overrides api.ExternalIDOverrides, nameOve
 	req := api.Request{
 		Paths:    []string{trimmedPath},
 		Mode:     api.ModeGUI,
-		Trackers: trackers,
+		Trackers: slices.Clone(trackers),
 		Options: api.UploadOptions{
 			Screens:    a.cfg.ScreenshotHandling.Screens,
 			OnlyID:     a.cfg.Metadata.OnlyID,
@@ -633,7 +634,7 @@ func (a *App) FetchPreparation(path string, overrides api.ExternalIDOverrides, n
 	req := api.Request{
 		Paths:          []string{trimmedPath},
 		Mode:           api.ModeGUI,
-		Trackers:       trackers,
+		Trackers:       slices.Clone(trackers),
 		IgnoreDupesFor: normalizeTrackerList(ignoreDupesFor),
 		Options: api.UploadOptions{
 			Screens:    a.cfg.ScreenshotHandling.Screens,
@@ -692,7 +693,7 @@ func (a *App) FetchTrackerDryRun(path string, overrides api.ExternalIDOverrides,
 		Paths:                       []string{trimmedPath},
 		Mode:                        api.ModeGUI,
 		DescriptionGroups:           api.CloneDescriptionBuilderGroups(descriptionGroups),
-		Trackers:                    trackers,
+		Trackers:                    slices.Clone(trackers),
 		IgnoreDupesFor:              normalizeTrackerList(ignoreDupesFor),
 		IgnoreTrackerRuleFailures:   ignoreRuleFailures,
 		Options:                     buildRunUploadOptions(a.cfg, runOpts),
@@ -736,7 +737,7 @@ func (a *App) FetchDescriptionBuilder(path string, overrides api.ExternalIDOverr
 	req := api.Request{
 		Paths:          []string{path},
 		Mode:           api.ModeGUI,
-		Trackers:       trackers,
+		Trackers:       slices.Clone(trackers),
 		IgnoreDupesFor: normalizeTrackerList(ignoreDupesFor),
 		Options: api.UploadOptions{
 			Screens:    a.cfg.ScreenshotHandling.Screens,
@@ -786,7 +787,7 @@ func (a *App) SaveDescriptionOverride(path string, groupKey string, raw string, 
 		DescriptionOverrideGroup: strings.TrimSpace(groupKey),
 	}
 
-	req.Trackers = append([]string{}, trackers...)
+	req.Trackers = slices.Clone(trackers)
 	req.ExternalIDOverrides = overrides
 	req.ReleaseNameOverrides = nameOverrides
 
@@ -1021,18 +1022,18 @@ func (a *App) ListUploadedImages(path string, overrides api.ExternalIDOverrides,
 	return a.core.ListUploadedImages(ctx, req)
 }
 
-func (a *App) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, host string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+func (a *App) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, host string, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
 	if a == nil || a.core == nil {
-		return nil, errors.New("app not initialized")
+		return api.UploadImagesResult{}, errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
-		return nil, errors.New("path is required")
+		return api.UploadImagesResult{}, errors.New("path is required")
 	}
 	if strings.TrimSpace(host) == "" {
-		return nil, errors.New("host is required")
+		return api.UploadImagesResult{}, errors.New("host is required")
 	}
 	if len(images) == 0 {
-		return nil, errors.New("no images selected")
+		return api.UploadImagesResult{}, errors.New("no images selected")
 	}
 
 	ctx := a.ctx
@@ -1052,7 +1053,7 @@ func (a *App) UploadImages(path string, overrides api.ExternalIDOverrides, nameO
 		},
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
-		Trackers:             append([]string{}, trackers...),
+		Trackers:             slices.Clone(trackers),
 	}
 
 	return a.core.UploadImages(ctx, req, host, images)
@@ -1289,6 +1290,14 @@ func (a *App) ListKnownTrackers() ([]string, error) {
 	}
 
 	return trackers.KnownTrackers(), nil
+}
+
+func (a *App) GetImageHostPolicyMetadata() (imagehostpolicy.Metadata, error) {
+	if a == nil {
+		return imagehostpolicy.Metadata{}, errors.New("app not initialized")
+	}
+
+	return imagehostpolicy.PolicyMetadata(), nil
 }
 
 func (a *App) SaveConfig(payload string) error {

--- a/internal/guiapp/run_options_test.go
+++ b/internal/guiapp/run_options_test.go
@@ -99,8 +99,8 @@ func (c *closeCounterCore) ListUploadedImages(context.Context, api.Request) ([]a
 	return nil, nil
 }
 
-func (c *closeCounterCore) UploadImages(context.Context, api.Request, string, []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
-	return nil, nil
+func (c *closeCounterCore) UploadImages(ctx context.Context, req api.Request, host string, screenshots []api.ScreenshotImage) (api.UploadImagesResult, error) {
+	return api.UploadImagesResult{}, nil
 }
 
 func (c *closeCounterCore) DeleteUploadedImage(context.Context, api.Request, string, string) error {

--- a/internal/imagehostpolicy/policy.go
+++ b/internal/imagehostpolicy/policy.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package imagehostpolicy
+
+import (
+	"slices"
+	"strings"
+)
+
+type Policy struct {
+	AllowedHosts   []string
+	UploadHosts    []string
+	PreferredHosts []string
+	Required       bool
+}
+
+type Metadata struct {
+	UploadHosts        []string
+	TrackerUploadHosts map[string][]string
+	OwnedHosts         map[string]string
+}
+
+var trackerAllowedHosts = map[string][]string{
+	"A4K": {"ptpimg", "onlyimage", "imgbox", "ptscreens", "imgbb", "imgur", "postimg"},
+	"BHD": {"ptpimg", "imgbox", "imgbb", "pixhost", "bhd", "bam"},
+	"DC":  {"imgbox", "imgbb", "bhd", "imgur", "postimg", "sharex"},
+	"GPW": {"kshare", "pixhost", "ptpimg", "pterclub", "ilikeshots", "imgbox"},
+	"HDB": {"hdb"},
+	"MTV": {"ptpimg", "imgbox", "imgbb"},
+	"OE":  {"ptpimg", "imgbox", "imgbb", "onlyimage", "ptscreens", "passtheimage"},
+	"PTP": {"ptpimg", "pixhost"},
+	"STC": {"imgbox", "imgbb"},
+	"TVC": {"imgbb", "ptpimg", "imgbox", "pixhost", "bam", "onlyimage"},
+}
+
+var uploadHosts = map[string]struct{}{
+	"dalexni":      {},
+	"hdb":          {},
+	"imgbb":        {},
+	"imgbox":       {},
+	"lensdump":     {},
+	"onlyimage":    {},
+	"passtheimage": {},
+	"pixhost":      {},
+	"ptpimg":       {},
+	"ptscreens":    {},
+	"seedpool_cdn": {},
+	"sharex":       {},
+	"utppm":        {},
+	"zipline":      {},
+}
+
+var ownedHosts = map[string]string{
+	"hdb": "HDB",
+}
+
+func ForTracker(tracker string, imgRehost bool) Policy {
+	name := strings.ToUpper(strings.TrimSpace(tracker))
+	if name == "HDB" && !imgRehost {
+		return Policy{}
+	}
+	allowed, ok := trackerAllowedHosts[name]
+	if !ok {
+		return Policy{}
+	}
+	normalizedAllowed := normalizeUnique(allowed...)
+	return Policy{
+		AllowedHosts:   normalizedAllowed,
+		UploadHosts:    filterUploadHosts(normalizedAllowed),
+		PreferredHosts: filterUploadHosts(normalizedAllowed),
+		Required:       len(normalizedAllowed) > 0,
+	}
+}
+
+func KnownTrackerPolicies() map[string][]string {
+	out := make(map[string][]string, len(trackerAllowedHosts))
+	for tracker, hosts := range trackerAllowedHosts {
+		out[tracker] = append([]string(nil), hosts...)
+	}
+	return out
+}
+
+func PolicyMetadata() Metadata {
+	return Metadata{
+		UploadHosts:        KnownUploadHosts(),
+		TrackerUploadHosts: KnownTrackerUploadPolicies(),
+		OwnedHosts:         KnownOwnedHosts(),
+	}
+}
+
+func KnownUploadHosts() []string {
+	out := make([]string, 0, len(uploadHosts))
+	for host := range uploadHosts {
+		out = append(out, host)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func KnownTrackerUploadPolicies() map[string][]string {
+	out := make(map[string][]string, len(trackerAllowedHosts))
+	for tracker, hosts := range trackerAllowedHosts {
+		out[tracker] = filterUploadHosts(normalizeUnique(hosts...))
+	}
+	return out
+}
+
+func KnownOwnedHosts() map[string]string {
+	out := make(map[string]string, len(ownedHosts))
+	for host, tracker := range ownedHosts {
+		out[host] = tracker
+	}
+	return out
+}
+
+func IsUploadHost(host string) bool {
+	_, ok := uploadHosts[strings.ToLower(strings.TrimSpace(host))]
+	return ok
+}
+
+func OwnerForHost(host string) string {
+	return ownedHosts[strings.ToLower(strings.TrimSpace(host))]
+}
+
+func HostAllowed(host string, allowed []string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	needle := strings.ToLower(strings.TrimSpace(host))
+	for _, item := range allowed {
+		if strings.ToLower(strings.TrimSpace(item)) == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeUnique(hosts ...string) []string {
+	out := make([]string, 0, len(hosts))
+	seen := make(map[string]struct{}, len(hosts))
+	for _, host := range hosts {
+		trimmed := strings.ToLower(strings.TrimSpace(host))
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func filterUploadHosts(hosts []string) []string {
+	out := make([]string, 0, len(hosts))
+	for _, host := range hosts {
+		if IsUploadHost(host) {
+			out = append(out, strings.ToLower(strings.TrimSpace(host)))
+		}
+	}
+	return out
+}

--- a/internal/imagehostpolicy/policy_test.go
+++ b/internal/imagehostpolicy/policy_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package imagehostpolicy
+
+import "testing"
+
+func TestPolicyMetadataExposesOnlySupportedTrackerUploadHosts(t *testing.T) {
+	t.Parallel()
+
+	metadata := PolicyMetadata()
+	a4kHosts := metadata.TrackerUploadHosts["A4K"]
+
+	if !HostAllowed("ptpimg", a4kHosts) {
+		t.Fatalf("A4K upload hosts should include supported host ptpimg: %v", a4kHosts)
+	}
+	if HostAllowed("imgur", a4kHosts) {
+		t.Fatalf("A4K upload hosts should exclude unsupported policy host imgur: %v", a4kHosts)
+	}
+	if HostAllowed("postimg", a4kHosts) {
+		t.Fatalf("A4K upload hosts should exclude unsupported policy host postimg: %v", a4kHosts)
+	}
+}
+
+func TestPolicyMetadataDefensivelyCopiesOwnedHosts(t *testing.T) {
+	t.Parallel()
+
+	metadata := PolicyMetadata()
+	metadata.OwnedHosts["hdb"] = "OTHER"
+
+	if got := OwnerForHost("hdb"); got != "HDB" {
+		t.Fatalf("OwnerForHost(hdb) = %q, want HDB", got)
+	}
+}

--- a/internal/services/imagehosting/service.go
+++ b/internal/services/imagehosting/service.go
@@ -126,8 +126,11 @@ func (s *Service) Upload(ctx context.Context, meta api.PreparedMetadata, host st
 	if normalizedScope == "" {
 		normalizedScope = "global"
 	}
-	if owner := trackers.TrackerForOwnedImageHost(normalizedHost); owner != "" && !strings.EqualFold(normalizedScope, trackers.TrackerImageUsageScope(owner)) {
-		return nil, fmt.Errorf("image hosting: host %q is scoped to tracker %s", normalizedHost, owner)
+	if owner := trackers.TrackerForOwnedImageHost(normalizedHost); owner != "" {
+		expectedScope := trackers.TrackerImageUsageScope(owner)
+		if !strings.EqualFold(normalizedScope, expectedScope) {
+			return nil, fmt.Errorf("image hosting: host %q is scoped to tracker %s: expected scope %q, got %q", normalizedHost, owner, expectedScope, normalizedScope)
+		}
 	}
 	if len(images) == 0 {
 		return nil, internalerrors.ErrInvalidInput

--- a/internal/services/imagehosting/service.go
+++ b/internal/services/imagehosting/service.go
@@ -126,6 +126,9 @@ func (s *Service) Upload(ctx context.Context, meta api.PreparedMetadata, host st
 	if normalizedScope == "" {
 		normalizedScope = "global"
 	}
+	if owner := trackers.TrackerForOwnedImageHost(normalizedHost); owner != "" && !strings.EqualFold(normalizedScope, trackers.TrackerImageUsageScope(owner)) {
+		return nil, fmt.Errorf("image hosting: host %q is scoped to tracker %s", normalizedHost, owner)
+	}
 	if len(images) == 0 {
 		return nil, internalerrors.ErrInvalidInput
 	}

--- a/internal/services/imagehosting/service_test.go
+++ b/internal/services/imagehosting/service_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -285,6 +286,21 @@ func TestUploadImagesUnsupportedHost(t *testing.T) {
 	_, err := service.Upload(context.Background(), meta, "missing", "global", []api.ScreenshotImage{{Path: "x.png"}})
 	if err == nil {
 		t.Fatal("expected error for unsupported host")
+	}
+}
+
+func TestUploadImagesRejectsTrackerOwnedHostOutsideOwnerScope(t *testing.T) {
+	service := &Service{
+		logger:    api.NopLogger{},
+		uploaders: map[string]uploader{"hdb": &fakeUploader{}},
+	}
+	meta := api.PreparedMetadata{SourcePath: "source"}
+	_, err := service.Upload(context.Background(), meta, "hdb", "global", []api.ScreenshotImage{{Path: "x.png"}})
+	if err == nil {
+		t.Fatal("expected tracker-owned host outside owner scope to fail")
+	}
+	if !strings.Contains(err.Error(), "scoped to tracker HDB") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/services/imagehosting/service_test.go
+++ b/internal/services/imagehosting/service_test.go
@@ -294,8 +294,17 @@ func TestUploadImagesRejectsTrackerOwnedHostOutsideOwnerScope(t *testing.T) {
 		logger:    api.NopLogger{},
 		uploaders: map[string]uploader{"hdb": &fakeUploader{}},
 	}
+	tmp, err := os.CreateTemp("", "imagehosting-owned-host-*.png")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("close temp file: %v", err)
+	}
 	meta := api.PreparedMetadata{SourcePath: "source"}
-	_, err := service.Upload(context.Background(), meta, "hdb", "global", []api.ScreenshotImage{{Path: "x.png"}})
+	_, err = service.Upload(context.Background(), meta, "hdb", "global", []api.ScreenshotImage{{Path: tmpPath}})
 	if err == nil {
 		t.Fatal("expected tracker-owned host outside owner scope to fail")
 	}

--- a/internal/trackers/description_assets.go
+++ b/internal/trackers/description_assets.go
@@ -42,6 +42,68 @@ type preloadedDescriptionAssetData struct {
 	screenshotSlotsLoaded bool
 }
 
+func clonePreloadedDescriptionAssetData(preloaded *preloadedDescriptionAssetData) *preloadedDescriptionAssetData {
+	if preloaded == nil {
+		return nil
+	}
+	return &preloadedDescriptionAssetData{
+		descriptionOverrides:  cloneDescriptionOverrides(preloaded.descriptionOverrides),
+		groupDescriptions:     cloneStringMap(preloaded.groupDescriptions),
+		trackerDescriptions:   cloneStringMap(preloaded.trackerDescriptions),
+		ambiguousTrackers:     cloneStringSet(preloaded.ambiguousTrackers),
+		trackerRecords:        cloneTrackerMetadata(preloaded.trackerRecords),
+		selections:            append([]api.ScreenshotFinalSelection(nil), preloaded.selections...),
+		uploads:               append([]api.UploadedImageLink(nil), preloaded.uploads...),
+		screenshotSlots:       cloneScreenshotSlots(preloaded.screenshotSlots),
+		screenshotSlotsLoaded: preloaded.screenshotSlotsLoaded,
+	}
+}
+
+func cloneDescriptionOverrides(values map[string]api.DescriptionOverride) map[string]api.DescriptionOverride {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(map[string]api.DescriptionOverride, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneStringSet(values map[string]struct{}) map[string]struct{} {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(map[string]struct{}, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func cloneTrackerMetadata(records []api.TrackerMetadata) []api.TrackerMetadata {
+	if len(records) == 0 {
+		return nil
+	}
+	cloned := make([]api.TrackerMetadata, len(records))
+	for idx := range records {
+		cloned[idx] = records[idx]
+		cloned[idx].ImageURLs = append([]string(nil), records[idx].ImageURLs...)
+	}
+	return cloned
+}
+
 func DescriptionOverrideGroupForTracker(tracker string) string {
 	normalized := strings.ToUpper(strings.TrimSpace(tracker))
 	switch {

--- a/internal/trackers/description_assets_test.go
+++ b/internal/trackers/description_assets_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -145,10 +146,19 @@ func (s *stubRepo) ListScreenshotSlotsByPath(context.Context, string) ([]api.Scr
 	}
 	return s.screenshotSlots, nil
 }
-func (s *stubRepo) UpsertScreenshotSlotVariants(context.Context, string, []api.ScreenshotSlotVariant) error {
+func (s *stubRepo) UpsertScreenshotSlotVariants(_ context.Context, _ string, variants []api.ScreenshotSlotVariant) error {
+	for _, variant := range variants {
+		for idx := range s.screenshotSlots {
+			if s.screenshotSlots[idx].SlotOrder != variant.SlotOrder {
+				continue
+			}
+			s.screenshotSlots[idx].Variants = upsertVariant(s.screenshotSlots[idx].Variants, variant)
+		}
+	}
 	return nil
 }
-func (s *stubRepo) SaveUploadedImages(context.Context, string, string, []api.UploadedImageLink) error {
+func (s *stubRepo) SaveUploadedImages(_ context.Context, _ string, _ string, images []api.UploadedImageLink) error {
+	s.uploads = append(s.uploads, images...)
 	return nil
 }
 func (s *stubRepo) ListUploadedImagesByPath(context.Context, string) ([]api.UploadedImageLink, error) {
@@ -173,6 +183,9 @@ func (s *stubRepo) PurgeContentData(context.Context, string) error              
 type stubImageService struct {
 	uploads map[string][]api.UploadedImageLink
 	errs    map[string]error
+	mu      sync.Mutex
+	calls   []string
+	repo    *stubRepo
 }
 
 func (s *stubImageService) ListCandidates(context.Context, api.PreparedMetadata) ([]api.ScreenshotImage, error) {
@@ -180,6 +193,9 @@ func (s *stubImageService) ListCandidates(context.Context, api.PreparedMetadata)
 }
 
 func (s *stubImageService) Upload(_ context.Context, meta api.PreparedMetadata, host string, usageScope string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+	s.mu.Lock()
+	s.calls = append(s.calls, host)
+	s.mu.Unlock()
 	if err := s.errs[host]; err != nil {
 		return nil, err
 	}
@@ -188,6 +204,11 @@ func (s *stubImageService) Upload(_ context.Context, meta api.PreparedMetadata, 
 			if strings.TrimSpace(links[idx].UsageScope) == "" {
 				links[idx].UsageScope = usageScope
 			}
+		}
+		if s.repo != nil {
+			s.mu.Lock()
+			s.repo.uploads = append(s.repo.uploads, links...)
+			s.mu.Unlock()
 		}
 		return links, nil
 	}
@@ -202,6 +223,11 @@ func (s *stubImageService) Upload(_ context.Context, meta api.PreparedMetadata, 
 			RawURL:     fmt.Sprintf("https://%s/%d.png", host, idx),
 			WebURL:     fmt.Sprintf("https://%s/%d", host, idx),
 		})
+	}
+	if s.repo != nil {
+		s.mu.Lock()
+		s.repo.uploads = append(s.repo.uploads, results...)
+		s.mu.Unlock()
 	}
 	return results, nil
 }

--- a/internal/trackers/description_assets_test.go
+++ b/internal/trackers/description_assets_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 type stubRepo struct {
+	mu                  sync.Mutex
 	trackerRecords      []api.TrackerMetadata
 	trackerRecordsErr   error
 	trackerRecordsCalls int
@@ -61,6 +62,8 @@ func (s *stubRepo) SaveReleaseNameOverrides(context.Context, string, api.Release
 }
 func (s *stubRepo) DeleteReleaseNameOverrides(context.Context, string) error { return nil }
 func (s *stubRepo) GetDescriptionOverride(_ context.Context, _ string, groupKey string) (api.DescriptionOverride, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.overrideCalls++
 	if s.descriptionOverride == "" {
 		return api.DescriptionOverride{}, internalerrors.ErrNotFound
@@ -75,6 +78,8 @@ func (s *stubRepo) GetDescriptionOverride(_ context.Context, _ string, groupKey 
 	return api.DescriptionOverride{SourcePath: "/tmp/source", GroupKey: s.overrideGroupKey, Description: s.descriptionOverride}, nil
 }
 func (s *stubRepo) ListDescriptionOverridesByPath(context.Context, string) ([]api.DescriptionOverride, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.overrideCalls++
 	if s.descriptionOverride == "" {
 		return nil, internalerrors.ErrNotFound
@@ -95,6 +100,8 @@ func (s *stubRepo) ListPendingUploads(context.Context) ([]api.UploadRecord, erro
 	return nil, nil
 }
 func (s *stubRepo) CreateUploadRecord(_ context.Context, record api.UploadRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.createdUploads = append(s.createdUploads, record)
 	return nil
 }
@@ -113,11 +120,13 @@ func (s *stubRepo) GetTrackerTimestamp(context.Context, string) (time.Time, erro
 func (s *stubRepo) SaveTrackerTimestamp(context.Context, api.TrackerTimestamp) error { return nil }
 func (s *stubRepo) SaveTrackerMetadata(context.Context, api.TrackerMetadata) error   { return nil }
 func (s *stubRepo) ListTrackerMetadataByPath(context.Context, string) ([]api.TrackerMetadata, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.trackerRecordsCalls++
 	if s.trackerRecordsErr != nil {
 		return nil, s.trackerRecordsErr
 	}
-	return s.trackerRecords, nil
+	return cloneTrackerMetadata(s.trackerRecords), nil
 }
 func (s *stubRepo) SaveScreenshot(context.Context, api.Screenshot) error { return nil }
 func (s *stubRepo) ListScreenshotsByPath(context.Context, string) ([]api.Screenshot, error) {
@@ -128,25 +137,33 @@ func (s *stubRepo) SaveFinalSelections(context.Context, string, []api.Screenshot
 	return nil
 }
 func (s *stubRepo) ListFinalSelections(context.Context, string) ([]api.ScreenshotFinalSelection, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.selectionsCalls++
 	if s.selectionsErr != nil {
 		return nil, s.selectionsErr
 	}
-	return s.selections, nil
+	return append([]api.ScreenshotFinalSelection(nil), s.selections...), nil
 }
 func (s *stubRepo) DeleteFinalSelection(context.Context, string) error { return nil }
 func (s *stubRepo) ReplaceScreenshotSlots(_ context.Context, _ string, slots []api.ScreenshotSlot) error {
-	s.screenshotSlots = append([]api.ScreenshotSlot(nil), slots...)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.screenshotSlots = cloneScreenshotSlots(slots)
 	return nil
 }
 func (s *stubRepo) ListScreenshotSlotsByPath(context.Context, string) ([]api.ScreenshotSlot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.screenshotSlotCalls++
 	if s.screenshotSlotsErr != nil {
 		return nil, s.screenshotSlotsErr
 	}
-	return s.screenshotSlots, nil
+	return cloneScreenshotSlots(s.screenshotSlots), nil
 }
 func (s *stubRepo) UpsertScreenshotSlotVariants(_ context.Context, _ string, variants []api.ScreenshotSlotVariant) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for _, variant := range variants {
 		for idx := range s.screenshotSlots {
 			if s.screenshotSlots[idx].SlotOrder != variant.SlotOrder {
@@ -158,17 +175,23 @@ func (s *stubRepo) UpsertScreenshotSlotVariants(_ context.Context, _ string, var
 	return nil
 }
 func (s *stubRepo) SaveUploadedImages(_ context.Context, _ string, _ string, images []api.UploadedImageLink) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.uploads = append(s.uploads, images...)
 	return nil
 }
 func (s *stubRepo) ListUploadedImagesByPath(context.Context, string) ([]api.UploadedImageLink, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.uploadsCalls++
 	if s.uploadsErr != nil {
 		return nil, s.uploadsErr
 	}
-	return s.uploads, nil
+	return append([]api.UploadedImageLink(nil), s.uploads...), nil
 }
 func (s *stubRepo) DeleteUploadedImage(_ context.Context, _ string, imagePath string, host string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.deletedUploads = append(s.deletedUploads, host+":"+imagePath)
 	return nil
 }
@@ -195,20 +218,23 @@ func (s *stubImageService) ListCandidates(context.Context, api.PreparedMetadata)
 func (s *stubImageService) Upload(_ context.Context, meta api.PreparedMetadata, host string, usageScope string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
 	s.mu.Lock()
 	s.calls = append(s.calls, host)
+	err := s.errs[host]
+	links, ok := s.uploads[host]
+	links = append([]api.UploadedImageLink(nil), links...)
 	s.mu.Unlock()
-	if err := s.errs[host]; err != nil {
+	if err != nil {
 		return nil, err
 	}
-	if links, ok := s.uploads[host]; ok {
+	if ok {
 		for idx := range links {
 			if strings.TrimSpace(links[idx].UsageScope) == "" {
 				links[idx].UsageScope = usageScope
 			}
 		}
 		if s.repo != nil {
-			s.mu.Lock()
+			s.repo.mu.Lock()
 			s.repo.uploads = append(s.repo.uploads, links...)
-			s.mu.Unlock()
+			s.repo.mu.Unlock()
 		}
 		return links, nil
 	}
@@ -225,9 +251,9 @@ func (s *stubImageService) Upload(_ context.Context, meta api.PreparedMetadata, 
 		})
 	}
 	if s.repo != nil {
-		s.mu.Lock()
+		s.repo.mu.Lock()
 		s.repo.uploads = append(s.repo.uploads, results...)
-		s.mu.Unlock()
+		s.repo.mu.Unlock()
 	}
 	return results, nil
 }
@@ -1011,6 +1037,87 @@ func TestEnsureDescriptionImageHostReuploadsForRequiredTracker(t *testing.T) {
 		if screenshot.Host != "ptpimg" {
 			t.Fatalf("expected all rehosted screenshots to use ptpimg, got %#v", resolution.screenshots)
 		}
+	}
+}
+
+func TestEnsureDescriptionImageHostFallsBackAfterConfiguredHostFailure(t *testing.T) {
+	repo := &stubRepo{
+		selections: []api.ScreenshotFinalSelection{
+			{SourcePath: "/tmp/source", ImagePath: "/tmp/a.png", Order: 0},
+			{SourcePath: "/tmp/source", ImagePath: "/tmp/b.png", Order: 1},
+		},
+	}
+	meta := api.PreparedMetadata{SourcePath: "/tmp/source"}
+	images := &stubImageService{
+		errs: map[string]error{"ptpimg": errors.New("ptpimg unavailable")},
+	}
+
+	resolution, err := ensureDescriptionImageHost(
+		context.Background(),
+		"PTP",
+		meta,
+		config.Config{},
+		config.TrackerConfig{ImageHost: "ptpimg"},
+		repo,
+		images,
+		api.NopLogger{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolution.blocking {
+		t.Fatalf("expected fallback success not to block")
+	}
+	if resolution.feedback.SelectedHost != "pixhost" {
+		t.Fatalf("expected pixhost fallback, got %#v", resolution.feedback)
+	}
+	if len(resolution.feedback.Warnings) != 1 || resolution.feedback.Warnings[0].Host != "ptpimg" {
+		t.Fatalf("expected ptpimg warning, got %#v", resolution.feedback.Warnings)
+	}
+	if len(images.calls) != 2 || images.calls[0] != "ptpimg" || images.calls[1] != "pixhost" {
+		t.Fatalf("expected ptpimg then pixhost calls, got %#v", images.calls)
+	}
+}
+
+func TestEnsureDescriptionImageHostBlocksWhenAllUploadHostsFail(t *testing.T) {
+	repo := &stubRepo{
+		selections: []api.ScreenshotFinalSelection{
+			{SourcePath: "/tmp/source", ImagePath: "/tmp/a.png", Order: 0},
+			{SourcePath: "/tmp/source", ImagePath: "/tmp/b.png", Order: 1},
+		},
+	}
+	meta := api.PreparedMetadata{SourcePath: "/tmp/source"}
+	images := &stubImageService{
+		errs: map[string]error{
+			"ptpimg":  errors.New("ptpimg unavailable"),
+			"pixhost": errors.New("pixhost unavailable"),
+		},
+	}
+
+	resolution, err := ensureDescriptionImageHost(
+		context.Background(),
+		"PTP",
+		meta,
+		config.Config{},
+		config.TrackerConfig{},
+		repo,
+		images,
+		api.NopLogger{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resolution.blocking {
+		t.Fatalf("expected all failed upload hosts to block")
+	}
+	if resolution.feedback.Status != "warning" {
+		t.Fatalf("expected warning feedback, got %#v", resolution.feedback)
+	}
+	if len(resolution.feedback.Warnings) != 2 {
+		t.Fatalf("expected one warning per failed host, got %#v", resolution.feedback.Warnings)
+	}
+	if len(resolution.screenshots) != 0 {
+		t.Fatalf("expected no screenshots after all hosts fail, got %#v", resolution.screenshots)
 	}
 }
 

--- a/internal/trackers/image_host_policy.go
+++ b/internal/trackers/image_host_policy.go
@@ -8,48 +8,25 @@ import (
 	"strings"
 
 	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/imagehostpolicy"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
 type imageHostPolicy struct {
-	allowed   []string
-	preferred []string
-	required  bool
+	allowed     []string
+	uploadHosts []string
+	preferred   []string
+	required    bool
 }
 
 type ImageUploadTarget struct {
 	Host       string
 	UsageScope string
+	Trackers   []string
 }
 
 func policyForTracker(tracker string, trackerCfg config.TrackerConfig) imageHostPolicy {
-	switch strings.ToUpper(strings.TrimSpace(tracker)) {
-	case "A4K":
-		return newImageHostPolicy(true, "ptpimg", "onlyimage", "imgbox", "ptscreens", "imgbb", "imgur", "postimg")
-	case "BHD":
-		return newImageHostPolicy(true, "ptpimg", "imgbox", "imgbb", "pixhost", "bhd", "bam")
-	case "DC":
-		return newImageHostPolicy(true, "imgbox", "imgbb", "bhd", "imgur", "postimg", "sharex")
-	case "GPW":
-		return newImageHostPolicy(true, "kshare", "pixhost", "ptpimg", "pterclub", "ilikeshots", "imgbox")
-	case "HDB":
-		if trackerCfg.ImgRehost {
-			return newImageHostPolicy(true, "hdb")
-		}
-		return imageHostPolicy{}
-	case "MTV":
-		return newImageHostPolicy(true, "ptpimg", "imgbox", "imgbb")
-	case "OE":
-		return newImageHostPolicy(true, "ptpimg", "imgbox", "imgbb", "onlyimage", "ptscreens", "passtheimage")
-	case "PTP":
-		return newImageHostPolicy(true, "ptpimg", "pixhost")
-	case "STC":
-		return newImageHostPolicy(true, "imgbox", "imgbb")
-	case "TVC":
-		return newImageHostPolicy(true, "imgbb", "ptpimg", "imgbox", "pixhost", "bam", "onlyimage")
-	default:
-		return imageHostPolicy{}
-	}
+	return policyFromShared(imagehostpolicy.ForTracker(tracker, trackerCfg.ImgRehost))
 }
 
 func applyImageHostOverrides(tracker string, policy imageHostPolicy, overrides api.ImageHostOverrides) (imageHostPolicy, error) {
@@ -63,23 +40,16 @@ func applyImageHostOverrides(tracker string, policy imageHostPolicy, overrides a
 	if owner := trackerForOwnedHost(host); owner != "" && !strings.EqualFold(owner, tracker) {
 		return imageHostPolicy{}, fmt.Errorf("trackers: %s image host override %q is owned by %s", strings.TrimSpace(tracker), host, owner)
 	}
+	if !supportedUploadImageHost(host) {
+		return imageHostPolicy{}, fmt.Errorf("trackers: %s image host override %q is unsupported", strings.TrimSpace(tracker), host)
+	}
 	if len(policy.allowed) == 0 {
 		return newImageHostPolicy(true, host), nil
 	}
-	for _, allowed := range policy.allowed {
-		if allowed != host {
-			continue
-		}
-		preferred := []string{host}
-		for _, existing := range policy.preferred {
-			if existing == host {
-				continue
-			}
-			preferred = append(preferred, existing)
-		}
-		policy.preferred = preferred
-		return policy, nil
+	if !hostAllowed(host, policy.allowed) {
+		return imageHostPolicy{}, fmt.Errorf("trackers: %s image host override %q is not allowed (allowed: %s)", strings.TrimSpace(tracker), host, strings.Join(policy.allowed, ", "))
 	}
+	policy.preferred = prependHost(host, policy.preferred)
 	return policy, nil
 }
 
@@ -98,12 +68,16 @@ func resolveImageHostPolicy(tracker string, trackerCfg config.TrackerConfig, ove
 	if len(policy.allowed) > 0 && !hostAllowed(host, policy.allowed) {
 		return imageHostPolicy{}, fmt.Errorf("trackers: %s configured image_host %q is not allowed", strings.TrimSpace(tracker), trackerCfg.ImageHost)
 	}
-	return forceImageHostPolicy(policy, host), nil
+	if len(policy.allowed) == 0 {
+		return newImageHostPolicy(true, host), nil
+	}
+	policy.preferred = prependHost(host, policy.preferred)
+	return policy, nil
 }
 
 func RequiredImageUploadTargets(appCfg config.Config, trackerNames []string, overrides api.ImageHostOverrides) ([]ImageUploadTarget, error) {
 	targets := make([]ImageUploadTarget, 0, len(trackerNames))
-	seen := make(map[string]struct{}, len(trackerNames))
+	seen := make(map[string]int, len(trackerNames))
 	for _, tracker := range trackerNames {
 		name := strings.ToUpper(strings.TrimSpace(tracker))
 		if name == "" {
@@ -118,15 +92,19 @@ func RequiredImageUploadTargets(appCfg config.Config, trackerNames []string, ove
 		if host == "" {
 			continue
 		}
-		scope := usageScopeForHost(name, host)
+		scope := usageScopeForHost(host)
+		// Use a null-byte separator to build an unambiguous host+scope dedupe key.
+		// Host/scope values are expected not to contain \x00, avoiding concat collisions.
 		key := host + "\x00" + scope
-		if _, ok := seen[key]; ok {
+		if idx, ok := seen[key]; ok {
+			targets[idx].Trackers = appendUniqueTracker(targets[idx].Trackers, name)
 			continue
 		}
-		seen[key] = struct{}{}
+		seen[key] = len(targets)
 		targets = append(targets, ImageUploadTarget{
 			Host:       host,
 			UsageScope: scope,
+			Trackers:   []string{name},
 		})
 	}
 	return targets, nil
@@ -134,7 +112,7 @@ func RequiredImageUploadTargets(appCfg config.Config, trackerNames []string, ove
 
 func ConfiguredImageUploadTargets(appCfg config.Config, trackerNames []string) ([]ImageUploadTarget, error) {
 	targets := make([]ImageUploadTarget, 0, len(trackerNames))
-	seen := make(map[string]struct{}, len(trackerNames))
+	seen := make(map[string]int, len(trackerNames))
 	for _, tracker := range trackerNames {
 		name := strings.ToUpper(strings.TrimSpace(tracker))
 		if name == "" {
@@ -152,15 +130,19 @@ func ConfiguredImageUploadTargets(appCfg config.Config, trackerNames []string) (
 		if host == "" {
 			continue
 		}
-		scope := usageScopeForHost(name, host)
+		scope := usageScopeForHost(host)
+		// Use a null-byte separator to build an unambiguous host+scope dedupe key.
+		// Host/scope values are expected not to contain \x00, avoiding concat collisions.
 		key := host + "\x00" + scope
-		if _, ok := seen[key]; ok {
+		if idx, ok := seen[key]; ok {
+			targets[idx].Trackers = appendUniqueTracker(targets[idx].Trackers, name)
 			continue
 		}
-		seen[key] = struct{}{}
+		seen[key] = len(targets)
 		targets = append(targets, ImageUploadTarget{
 			Host:       host,
 			UsageScope: scope,
+			Trackers:   []string{name},
 		})
 	}
 	return targets, nil
@@ -181,25 +163,8 @@ func trackerConfigForImageHostPolicy(appCfg config.Config, tracker string) confi
 	return config.TrackerConfig{}
 }
 
-func forceImageHostPolicy(policy imageHostPolicy, host string) imageHostPolicy {
-	normalized := strings.ToLower(strings.TrimSpace(host))
-	if normalized == "" {
-		return policy
-	}
-	return imageHostPolicy{
-		allowed:   []string{normalized},
-		preferred: []string{normalized},
-		required:  true,
-	}
-}
-
 func supportedUploadImageHost(host string) bool {
-	switch strings.ToLower(strings.TrimSpace(host)) {
-	case "dalexni", "hdb", "imgbb", "imgbox", "lensdump", "onlyimage", "passtheimage", "pixhost", "ptpimg", "ptscreens", "seedpool_cdn", "sharex", "utppm", "zipline":
-		return true
-	default:
-		return false
-	}
+	return imagehostpolicy.IsUploadHost(host)
 }
 
 func newImageHostPolicy(required bool, hosts ...string) imageHostPolicy {
@@ -217,8 +182,55 @@ func newImageHostPolicy(required bool, hosts ...string) imageHostPolicy {
 		normalized = append(normalized, trimmed)
 	}
 	return imageHostPolicy{
-		allowed:   normalized,
-		preferred: append([]string{}, normalized...),
-		required:  required,
+		allowed:     normalized,
+		uploadHosts: uploadHostsFor(normalized),
+		preferred:   uploadHostsFor(normalized),
+		required:    required,
 	}
+}
+
+func policyFromShared(policy imagehostpolicy.Policy) imageHostPolicy {
+	return imageHostPolicy{
+		allowed:     append([]string(nil), policy.AllowedHosts...),
+		uploadHosts: append([]string(nil), policy.UploadHosts...),
+		preferred:   append([]string(nil), policy.PreferredHosts...),
+		required:    policy.Required,
+	}
+}
+
+func uploadHostsFor(hosts []string) []string {
+	out := make([]string, 0, len(hosts))
+	for _, host := range hosts {
+		if supportedUploadImageHost(host) {
+			out = append(out, strings.ToLower(strings.TrimSpace(host)))
+		}
+	}
+	return out
+}
+
+func prependHost(host string, hosts []string) []string {
+	normalized := strings.ToLower(strings.TrimSpace(host))
+	if normalized == "" {
+		return hosts
+	}
+	preferred := []string{normalized}
+	for _, existing := range hosts {
+		if strings.EqualFold(existing, normalized) {
+			continue
+		}
+		preferred = append(preferred, existing)
+	}
+	return preferred
+}
+
+func appendUniqueTracker(trackers []string, tracker string) []string {
+	if tracker == "" {
+		return trackers
+	}
+	for _, existing := range trackers {
+		if existing == tracker {
+			return trackers
+		}
+	}
+	return append(trackers, tracker)
 }

--- a/internal/trackers/image_host_policy.go
+++ b/internal/trackers/image_host_policy.go
@@ -4,6 +4,7 @@
 package trackers
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/autobrr/upbrr/internal/config"
@@ -14,6 +15,11 @@ type imageHostPolicy struct {
 	allowed   []string
 	preferred []string
 	required  bool
+}
+
+type ImageUploadTarget struct {
+	Host       string
+	UsageScope string
 }
 
 func policyForTracker(tracker string, trackerCfg config.TrackerConfig) imageHostPolicy {
@@ -46,17 +52,19 @@ func policyForTracker(tracker string, trackerCfg config.TrackerConfig) imageHost
 	}
 }
 
-func applyImageHostOverrides(policy imageHostPolicy, overrides api.ImageHostOverrides) imageHostPolicy {
+func applyImageHostOverrides(tracker string, policy imageHostPolicy, overrides api.ImageHostOverrides) (imageHostPolicy, error) {
 	if overrides.PreferredHost == nil {
-		return policy
+		return policy, nil
 	}
 	host := strings.ToLower(strings.TrimSpace(*overrides.PreferredHost))
 	if host == "" {
-		return policy
+		return policy, nil
+	}
+	if owner := trackerForOwnedHost(host); owner != "" && !strings.EqualFold(owner, tracker) {
+		return imageHostPolicy{}, fmt.Errorf("trackers: %s image host override %q is owned by %s", strings.TrimSpace(tracker), host, owner)
 	}
 	if len(policy.allowed) == 0 {
-		policy.preferred = []string{host}
-		return policy
+		return newImageHostPolicy(true, host), nil
 	}
 	for _, allowed := range policy.allowed {
 		if allowed != host {
@@ -70,9 +78,128 @@ func applyImageHostOverrides(policy imageHostPolicy, overrides api.ImageHostOver
 			preferred = append(preferred, existing)
 		}
 		policy.preferred = preferred
+		return policy, nil
+	}
+	return policy, nil
+}
+
+func resolveImageHostPolicy(tracker string, trackerCfg config.TrackerConfig, overrides api.ImageHostOverrides) (imageHostPolicy, error) {
+	policy := policyForTracker(tracker, trackerCfg)
+	host := strings.ToLower(strings.TrimSpace(trackerCfg.ImageHost))
+	if host == "" {
+		return applyImageHostOverrides(tracker, policy, overrides)
+	}
+	if !supportedUploadImageHost(host) {
+		return imageHostPolicy{}, fmt.Errorf("trackers: %s configured image_host %q is unsupported", strings.TrimSpace(tracker), trackerCfg.ImageHost)
+	}
+	if owner := trackerForOwnedHost(host); owner != "" && !strings.EqualFold(owner, tracker) {
+		return imageHostPolicy{}, fmt.Errorf("trackers: %s configured image_host %q is owned by %s", strings.TrimSpace(tracker), trackerCfg.ImageHost, owner)
+	}
+	if len(policy.allowed) > 0 && !hostAllowed(host, policy.allowed) {
+		return imageHostPolicy{}, fmt.Errorf("trackers: %s configured image_host %q is not allowed", strings.TrimSpace(tracker), trackerCfg.ImageHost)
+	}
+	return forceImageHostPolicy(policy, host), nil
+}
+
+func RequiredImageUploadTargets(appCfg config.Config, trackerNames []string, overrides api.ImageHostOverrides) ([]ImageUploadTarget, error) {
+	targets := make([]ImageUploadTarget, 0, len(trackerNames))
+	seen := make(map[string]struct{}, len(trackerNames))
+	for _, tracker := range trackerNames {
+		name := strings.ToUpper(strings.TrimSpace(tracker))
+		if name == "" {
+			continue
+		}
+		trackerCfg := trackerConfigForImageHostPolicy(appCfg, name)
+		policy, err := resolveImageHostPolicy(name, trackerCfg, overrides)
+		if err != nil {
+			return nil, err
+		}
+		host := preferredHost(policy)
+		if host == "" {
+			continue
+		}
+		scope := usageScopeForHost(name, host)
+		key := host + "\x00" + scope
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		targets = append(targets, ImageUploadTarget{
+			Host:       host,
+			UsageScope: scope,
+		})
+	}
+	return targets, nil
+}
+
+func ConfiguredImageUploadTargets(appCfg config.Config, trackerNames []string) ([]ImageUploadTarget, error) {
+	targets := make([]ImageUploadTarget, 0, len(trackerNames))
+	seen := make(map[string]struct{}, len(trackerNames))
+	for _, tracker := range trackerNames {
+		name := strings.ToUpper(strings.TrimSpace(tracker))
+		if name == "" {
+			continue
+		}
+		trackerCfg := trackerConfigForImageHostPolicy(appCfg, name)
+		if strings.TrimSpace(trackerCfg.ImageHost) == "" {
+			continue
+		}
+		policy, err := resolveImageHostPolicy(name, trackerCfg, api.ImageHostOverrides{})
+		if err != nil {
+			return nil, err
+		}
+		host := preferredHost(policy)
+		if host == "" {
+			continue
+		}
+		scope := usageScopeForHost(name, host)
+		key := host + "\x00" + scope
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		targets = append(targets, ImageUploadTarget{
+			Host:       host,
+			UsageScope: scope,
+		})
+	}
+	return targets, nil
+}
+
+func trackerConfigForImageHostPolicy(appCfg config.Config, tracker string) config.TrackerConfig {
+	if len(appCfg.Trackers.Trackers) == 0 {
+		return config.TrackerConfig{}
+	}
+	if cfg, ok := appCfg.Trackers.Trackers[tracker]; ok {
+		return cfg
+	}
+	for name, cfg := range appCfg.Trackers.Trackers {
+		if strings.EqualFold(strings.TrimSpace(name), tracker) {
+			return cfg
+		}
+	}
+	return config.TrackerConfig{}
+}
+
+func forceImageHostPolicy(policy imageHostPolicy, host string) imageHostPolicy {
+	normalized := strings.ToLower(strings.TrimSpace(host))
+	if normalized == "" {
 		return policy
 	}
-	return policy
+	return imageHostPolicy{
+		allowed:   []string{normalized},
+		preferred: []string{normalized},
+		required:  true,
+	}
+}
+
+func supportedUploadImageHost(host string) bool {
+	switch strings.ToLower(strings.TrimSpace(host)) {
+	case "dalexni", "hdb", "imgbb", "imgbox", "lensdump", "onlyimage", "passtheimage", "pixhost", "ptpimg", "ptscreens", "seedpool_cdn", "sharex", "utppm", "zipline":
+		return true
+	default:
+		return false
+	}
 }
 
 func newImageHostPolicy(required bool, hosts ...string) imageHostPolicy {

--- a/internal/trackers/image_host_policy_test.go
+++ b/internal/trackers/image_host_policy_test.go
@@ -10,80 +10,119 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-func TestResolveImageHostPolicyTrackerHostOverridesCLIHost(t *testing.T) {
+func TestResolveImageHostPolicy(t *testing.T) {
 	t.Parallel()
 
-	preferred := "imgbb"
-	policy, err := resolveImageHostPolicy("OE", config.TrackerConfig{ImageHost: "ptpimg"}, api.ImageHostOverrides{
-		PreferredHost: &preferred,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	preferredImgBB := "imgbb"
+	preferredHDB := "hdb"
+	tests := []struct {
+		name             string
+		tracker          string
+		cfg              config.TrackerConfig
+		overrides        api.ImageHostOverrides
+		wantPreferred    string
+		wantAllowedCount int
+		wantErr          bool
+	}{
+		{
+			name:    "tracker host prefers over cli host",
+			tracker: "OE",
+			cfg:     config.TrackerConfig{ImageHost: "ptpimg"},
+			overrides: api.ImageHostOverrides{
+				PreferredHost: &preferredImgBB,
+			},
+			wantPreferred:    "ptpimg",
+			wantAllowedCount: -1,
+		},
+		{
+			name:    "cli host applies when tracker host empty",
+			tracker: "OE",
+			cfg:     config.TrackerConfig{},
+			overrides: api.ImageHostOverrides{
+				PreferredHost: &preferredImgBB,
+			},
+			wantPreferred:    "imgbb",
+			wantAllowedCount: -1,
+		},
+		{
+			name:             "configured host for no policy tracker",
+			tracker:          "AITHER",
+			cfg:              config.TrackerConfig{ImageHost: "imgbox"},
+			overrides:        api.ImageHostOverrides{},
+			wantPreferred:    "imgbox",
+			wantAllowedCount: 1,
+		},
+		{
+			name:             "rejects owned cli host for other tracker",
+			tracker:          "AITHER",
+			cfg:              config.TrackerConfig{},
+			overrides:        api.ImageHostOverrides{PreferredHost: &preferredHDB},
+			wantAllowedCount: -1,
+			wantErr:          true,
+		},
+		{
+			name:             "allows owned cli host for owner",
+			tracker:          "HDB",
+			cfg:              config.TrackerConfig{},
+			overrides:        api.ImageHostOverrides{PreferredHost: &preferredHDB},
+			wantPreferred:    "hdb",
+			wantAllowedCount: -1,
+		},
 	}
-	if got := preferredHost(policy); got != "ptpimg" {
-		t.Fatalf("expected tracker image_host to win, got %q", got)
-	}
-	if len(policy.allowed) != 1 || policy.allowed[0] != "ptpimg" {
-		t.Fatalf("expected hard ptpimg policy, got %#v", policy)
-	}
-}
 
-func TestResolveImageHostPolicyCLIHostAppliesWhenTrackerHostEmpty(t *testing.T) {
-	t.Parallel()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	preferred := "imgbb"
-	policy, err := resolveImageHostPolicy("OE", config.TrackerConfig{}, api.ImageHostOverrides{
-		PreferredHost: &preferred,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got := preferredHost(policy); got != "imgbb" {
-		t.Fatalf("expected CLI image host to be preferred, got %q", got)
-	}
-	if len(policy.allowed) <= 1 {
-		t.Fatalf("expected CLI override to preserve allowed fallback hosts, got %#v", policy)
-	}
-}
+			policy, err := resolveImageHostPolicy(tc.tracker, tc.cfg, tc.overrides)
+			if (err != nil) != tc.wantErr {
+				if tc.wantErr {
+					t.Fatal("expected owned host override to fail for other tracker")
+				}
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantErr {
+				return
+			}
 
-func TestResolveImageHostPolicyConfiguredHostForNoPolicyTracker(t *testing.T) {
-	t.Parallel()
+			if tc.wantPreferred != "" {
+				got := preferredHost(policy)
+				switch tc.name {
+				case "tracker host prefers over cli host":
+					if got != tc.wantPreferred {
+						t.Fatalf("expected tracker image_host to win, got %q", got)
+					}
+				case "cli host applies when tracker host empty":
+					if got != tc.wantPreferred {
+						t.Fatalf("expected CLI image host to be preferred, got %q", got)
+					}
+				case "configured host for no policy tracker":
+					if got != tc.wantPreferred {
+						t.Fatalf("expected configured host imgbox, got %q", got)
+					}
+				case "allows owned cli host for owner":
+					if got != tc.wantPreferred {
+						t.Fatalf("expected owned host for owner tracker, got %q", got)
+					}
+				}
+			}
 
-	policy, err := resolveImageHostPolicy("AITHER", config.TrackerConfig{ImageHost: "imgbox"}, api.ImageHostOverrides{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got := preferredHost(policy); got != "imgbox" {
-		t.Fatalf("expected configured host imgbox, got %q", got)
-	}
-	if len(policy.allowed) != 1 || policy.allowed[0] != "imgbox" {
-		t.Fatalf("expected configured no-policy tracker host to be required, got %#v", policy)
-	}
-}
-
-func TestResolveImageHostPolicyRejectsOwnedCLIHostForOtherTracker(t *testing.T) {
-	t.Parallel()
-
-	preferred := "hdb"
-	_, err := resolveImageHostPolicy("AITHER", config.TrackerConfig{}, api.ImageHostOverrides{
-		PreferredHost: &preferred,
-	})
-	if err == nil {
-		t.Fatal("expected owned host override to fail for other tracker")
-	}
-}
-
-func TestResolveImageHostPolicyAllowsOwnedCLIHostForOwner(t *testing.T) {
-	t.Parallel()
-
-	preferred := "hdb"
-	policy, err := resolveImageHostPolicy("HDB", config.TrackerConfig{}, api.ImageHostOverrides{
-		PreferredHost: &preferred,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got := preferredHost(policy); got != "hdb" {
-		t.Fatalf("expected owned host for owner tracker, got %q", got)
+			switch tc.name {
+			case "tracker host prefers over cli host":
+				if len(policy.allowed) <= 1 {
+					t.Fatalf("expected tracker image_host to preserve fallback hosts, got %#v", policy)
+				}
+			case "cli host applies when tracker host empty":
+				if len(policy.allowed) <= 1 {
+					t.Fatalf("expected CLI override to preserve allowed fallback hosts, got %#v", policy)
+				}
+			default:
+				if tc.wantAllowedCount >= 0 {
+					if len(policy.allowed) != tc.wantAllowedCount || (tc.wantAllowedCount == 1 && policy.allowed[0] != "imgbox") {
+						t.Fatalf("expected configured no-policy tracker host to be required, got %#v", policy)
+					}
+				}
+			}
+		})
 	}
 }

--- a/internal/trackers/image_host_policy_test.go
+++ b/internal/trackers/image_host_policy_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackers
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestResolveImageHostPolicyTrackerHostOverridesCLIHost(t *testing.T) {
+	t.Parallel()
+
+	preferred := "imgbb"
+	policy, err := resolveImageHostPolicy("OE", config.TrackerConfig{ImageHost: "ptpimg"}, api.ImageHostOverrides{
+		PreferredHost: &preferred,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := preferredHost(policy); got != "ptpimg" {
+		t.Fatalf("expected tracker image_host to win, got %q", got)
+	}
+	if len(policy.allowed) != 1 || policy.allowed[0] != "ptpimg" {
+		t.Fatalf("expected hard ptpimg policy, got %#v", policy)
+	}
+}
+
+func TestResolveImageHostPolicyCLIHostAppliesWhenTrackerHostEmpty(t *testing.T) {
+	t.Parallel()
+
+	preferred := "imgbb"
+	policy, err := resolveImageHostPolicy("OE", config.TrackerConfig{}, api.ImageHostOverrides{
+		PreferredHost: &preferred,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := preferredHost(policy); got != "imgbb" {
+		t.Fatalf("expected CLI image host to be preferred, got %q", got)
+	}
+	if len(policy.allowed) <= 1 {
+		t.Fatalf("expected CLI override to preserve allowed fallback hosts, got %#v", policy)
+	}
+}
+
+func TestResolveImageHostPolicyConfiguredHostForNoPolicyTracker(t *testing.T) {
+	t.Parallel()
+
+	policy, err := resolveImageHostPolicy("AITHER", config.TrackerConfig{ImageHost: "imgbox"}, api.ImageHostOverrides{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := preferredHost(policy); got != "imgbox" {
+		t.Fatalf("expected configured host imgbox, got %q", got)
+	}
+	if len(policy.allowed) != 1 || policy.allowed[0] != "imgbox" {
+		t.Fatalf("expected configured no-policy tracker host to be required, got %#v", policy)
+	}
+}
+
+func TestResolveImageHostPolicyRejectsOwnedCLIHostForOtherTracker(t *testing.T) {
+	t.Parallel()
+
+	preferred := "hdb"
+	_, err := resolveImageHostPolicy("AITHER", config.TrackerConfig{}, api.ImageHostOverrides{
+		PreferredHost: &preferred,
+	})
+	if err == nil {
+		t.Fatal("expected owned host override to fail for other tracker")
+	}
+}
+
+func TestResolveImageHostPolicyAllowsOwnedCLIHostForOwner(t *testing.T) {
+	t.Parallel()
+
+	preferred := "hdb"
+	policy, err := resolveImageHostPolicy("HDB", config.TrackerConfig{}, api.ImageHostOverrides{
+		PreferredHost: &preferred,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := preferredHost(policy); got != "hdb" {
+		t.Fatalf("expected owned host for owner tracker, got %q", got)
+	}
+}

--- a/internal/trackers/image_host_resolution.go
+++ b/internal/trackers/image_host_resolution.go
@@ -23,6 +23,7 @@ type descriptionImageHostResolution struct {
 	screenshots []api.ScreenshotImage
 	feedback    api.ImageHostFeedback
 	usageScope  string
+	blocking    bool
 }
 
 func ensureDescriptionImageHost(
@@ -125,11 +126,18 @@ func ensureDescriptionImageHostWithData(
 	}
 
 	var lastErr error
-	for _, host := range policy.preferred {
-		usageScope := usageScopeForHost(tracker, host)
+	for _, host := range uploadAttemptHosts(policy) {
+		usageScope := usageScopeForHost(host)
 		uploaded, err := images.Upload(ctx, meta, host, usageScope, sourceImages)
 		if err != nil {
 			lastErr = err
+			if len(uploaded) > 0 {
+				cleanupUploadedImages(ctx, repo, meta.SourcePath, uploaded, logger)
+			}
+			feedback.Warnings = append(feedback.Warnings, api.ImageHostWarning{
+				Host:    host,
+				Message: err.Error(),
+			})
 			if logger != nil {
 				logger.Warnf("trackers: image host upload failed tracker=%s host=%s: %v", tracker, host, err)
 			}
@@ -147,6 +155,14 @@ func ensureDescriptionImageHostWithData(
 		}
 		if len(screenshots) == 0 {
 			cleanupUploadedImages(ctx, repo, meta.SourcePath, uploaded, logger)
+			message := "upload did not produce usable screenshots"
+			feedback.Warnings = append(feedback.Warnings, api.ImageHostWarning{
+				Host:    host,
+				Message: message,
+			})
+			if logger != nil {
+				logger.Warnf("trackers: image host upload produced no usable screenshots tracker=%s host=%s", tracker, host)
+			}
 			continue
 		}
 		if err := upsertScreenshotVariantsFromUploads(ctx, repo, meta.SourcePath, slots, uploaded); err != nil {
@@ -159,20 +175,24 @@ func ensureDescriptionImageHostWithData(
 		feedback.SelectedHost = host
 		feedback.Reuploaded = true
 		if usageScope == globalImageUsageScope {
-			feedback.Message = fmt.Sprintf("Uploaded screenshots to %s for %s image-host requirements.", host, tracker)
+			feedback.Message = uploadSuccessMessage(tracker, host, "", feedback.Warnings)
 		} else {
-			feedback.Message = fmt.Sprintf("Uploaded tracker-scoped screenshots to %s for %s.", host, tracker)
+			feedback.Message = uploadSuccessMessage(tracker, host, usageScope, feedback.Warnings)
 		}
 		return descriptionImageHostResolution{screenshots: screenshots, feedback: feedback, usageScope: usageScope}, nil
 	}
 
 	feedback.Status = "warning"
-	if lastErr != nil {
-		feedback.Message = fmt.Sprintf("%s could not upload screenshots to an allowed host (%s): %v", tracker, strings.Join(policy.allowed, ", "), lastErr)
-	} else {
-		feedback.Message = fmt.Sprintf("%s could not find an allowed screenshot host (%s).", tracker, strings.Join(policy.allowed, ", "))
+	attemptHosts := strings.Join(uploadAttemptHosts(policy), ", ")
+	if attemptHosts == "" {
+		attemptHosts = "none"
 	}
-	return descriptionImageHostResolution{feedback: feedback}, nil
+	if lastErr != nil {
+		feedback.Message = fmt.Sprintf("%s could not upload screenshots to an allowed upload host (%s): %v", tracker, attemptHosts, lastErr)
+	} else {
+		feedback.Message = fmt.Sprintf("%s could not find an allowed screenshot host to upload to (%s).", tracker, attemptHosts)
+	}
+	return descriptionImageHostResolution{feedback: feedback, blocking: true}, nil
 }
 
 func cleanupUploadedImages(ctx context.Context, repo api.MetadataRepository, sourcePath string, uploaded []api.UploadedImageLink, logger api.Logger) {
@@ -215,6 +235,70 @@ func buildReuseMessage(tracker string, host string, usageScope string, fallback 
 		return fmt.Sprintf("Using allowed fallback host %s for %s.", host, tracker)
 	}
 	return fmt.Sprintf("Using %s screenshots for %s.", host, tracker)
+}
+
+func uploadSuccessMessage(tracker string, host string, usageScope string, warnings []api.ImageHostWarning) string {
+	failedHosts := failedImageHostNames(warnings)
+	if normalizeUsageScope(usageScope) == trackerImageUsageScope(tracker) {
+		if len(failedHosts) > 0 {
+			return fmt.Sprintf("Uploaded tracker-scoped screenshots to %s for %s after %s failed.", host, tracker, strings.Join(failedHosts, ", "))
+		}
+		return fmt.Sprintf("Uploaded tracker-scoped screenshots to %s for %s.", host, tracker)
+	}
+	if len(failedHosts) > 0 {
+		return fmt.Sprintf("Uploaded screenshots to fallback host %s for %s after %s failed.", host, tracker, strings.Join(failedHosts, ", "))
+	}
+	return fmt.Sprintf("Uploaded screenshots to %s for %s image-host requirements.", host, tracker)
+}
+
+func failedImageHostNames(warnings []api.ImageHostWarning) []string {
+	if len(warnings) == 0 {
+		return nil
+	}
+	hosts := make([]string, 0, len(warnings))
+	seen := make(map[string]struct{}, len(warnings))
+	for _, warning := range warnings {
+		host := strings.ToLower(strings.TrimSpace(warning.Host))
+		if host == "" {
+			continue
+		}
+		if _, ok := seen[host]; ok {
+			continue
+		}
+		seen[host] = struct{}{}
+		hosts = append(hosts, host)
+	}
+	return hosts
+}
+
+func uploadAttemptHosts(policy imageHostPolicy) []string {
+	if len(policy.preferred) == 0 {
+		return nil
+	}
+	allowedUploads := make(map[string]struct{}, len(policy.uploadHosts))
+	for _, host := range policy.uploadHosts {
+		normalized := strings.ToLower(strings.TrimSpace(host))
+		if normalized != "" {
+			allowedUploads[normalized] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(policy.preferred))
+	seen := make(map[string]struct{}, len(policy.preferred))
+	for _, host := range policy.preferred {
+		normalized := strings.ToLower(strings.TrimSpace(host))
+		if normalized == "" {
+			continue
+		}
+		if _, ok := allowedUploads[normalized]; !ok {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	return out
 }
 
 func resolveTrackerScreenshotsForAllowedHost(urls []string, policy imageHostPolicy) ([]api.ScreenshotImage, string) {

--- a/internal/trackers/image_host_resolution.go
+++ b/internal/trackers/image_host_resolution.go
@@ -49,7 +49,10 @@ func ensureDescriptionImageHostWithData(
 	logger api.Logger,
 	preloaded *preloadedDescriptionAssetData,
 ) (descriptionImageHostResolution, error) {
-	policy := applyImageHostOverrides(policyForTracker(tracker, trackerCfg), meta.ImageHostOverrides)
+	policy, err := resolveImageHostPolicy(tracker, trackerCfg, meta.ImageHostOverrides)
+	if err != nil {
+		return descriptionImageHostResolution{}, err
+	}
 	feedback := api.ImageHostFeedback{
 		Status:       "reused",
 		AllowedHosts: append([]string{}, policy.allowed...),

--- a/internal/trackers/image_host_scope.go
+++ b/internal/trackers/image_host_scope.go
@@ -53,6 +53,14 @@ func trackerForOwnedHost(host string) string {
 	return trackerOwnedImageHosts[normalized]
 }
 
+func TrackerForOwnedImageHost(host string) string {
+	return trackerForOwnedHost(host)
+}
+
+func TrackerImageUsageScope(tracker string) string {
+	return trackerImageUsageScope(tracker)
+}
+
 func uploadEligibleForTracker(scope string, tracker string) bool {
 	scope = normalizeUsageScope(scope)
 	if scope == globalImageUsageScope {

--- a/internal/trackers/image_host_scope.go
+++ b/internal/trackers/image_host_scope.go
@@ -3,13 +3,13 @@
 
 package trackers
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/autobrr/upbrr/internal/imagehostpolicy"
+)
 
 const globalImageUsageScope = "global"
-
-var trackerOwnedImageHosts = map[string]string{
-	"hdb": "HDB",
-}
 
 func normalizeUsageScope(scope string) string {
 	trimmed := strings.TrimSpace(scope)
@@ -37,26 +37,24 @@ func trackerImageUsageScope(tracker string) string {
 	return "tracker:" + trimmed
 }
 
-func usageScopeForHost(tracker string, host string) string {
+func usageScopeForHost(host string) string {
 	owner := trackerForOwnedHost(host)
 	if owner == "" {
 		return globalImageUsageScope
-	}
-	if strings.EqualFold(owner, tracker) {
-		return trackerImageUsageScope(owner)
 	}
 	return trackerImageUsageScope(owner)
 }
 
 func trackerForOwnedHost(host string) string {
-	normalized := strings.ToLower(strings.TrimSpace(host))
-	return trackerOwnedImageHosts[normalized]
+	return imagehostpolicy.OwnerForHost(host)
 }
 
+// TrackerForOwnedImageHost returns the owning tracker name for the provided image host string, or an empty string when unowned.
 func TrackerForOwnedImageHost(host string) string {
 	return trackerForOwnedHost(host)
 }
 
+// TrackerImageUsageScope returns the normalized image usage scope string for the provided tracker name.
 func TrackerImageUsageScope(tracker string) string {
 	return trackerImageUsageScope(tracker)
 }

--- a/internal/trackers/service.go
+++ b/internal/trackers/service.go
@@ -36,6 +36,8 @@ type trackerUploadResult struct {
 	notImplemented bool
 }
 
+type imageHostPreflight map[string]descriptionImageHostResolution
+
 func NewService(cfg config.Config, logger api.Logger, repo db.MetadataRepository) *Service {
 	return NewServiceWithRegistryAndImages(cfg, logger, repo, nil, nil)
 }
@@ -189,7 +191,8 @@ func (s *Service) Upload(ctx context.Context, meta api.PreparedMetadata) (api.Up
 			recordMu.Unlock()
 		}
 
-		results, err := s.uploadTrackersConcurrently(ctx, meta, trackers)
+		preflight := s.preflightDescriptionImageHosts(ctx, meta, trackers)
+		results, err := s.uploadTrackersConcurrently(ctx, meta, trackers, preflight)
 		if err != nil {
 			finalizePending("canceled")
 			return api.UploadSummary{}, err
@@ -240,7 +243,8 @@ func (s *Service) Upload(ctx context.Context, meta api.PreparedMetadata) (api.Up
 		return summary, nil
 	}
 
-	results, err := s.uploadTrackersConcurrently(ctx, meta, trackers)
+	preflight := s.preflightDescriptionImageHosts(ctx, meta, trackers)
+	results, err := s.uploadTrackersConcurrently(ctx, meta, trackers, preflight)
 	if err != nil {
 		return api.UploadSummary{}, err
 	}
@@ -285,7 +289,7 @@ func (s *Service) Upload(ctx context.Context, meta api.PreparedMetadata) (api.Up
 	return summary, nil
 }
 
-func (s *Service) uploadTrackersConcurrently(ctx context.Context, meta api.PreparedMetadata, trackers []string) ([]trackerUploadResult, error) {
+func (s *Service) uploadTrackersConcurrently(ctx context.Context, meta api.PreparedMetadata, trackers []string, preflight imageHostPreflight) ([]trackerUploadResult, error) {
 	workerCount := s.maxConcurrentTrackerUploads(len(trackers))
 	results := make([]trackerUploadResult, len(trackers))
 	if workerCount <= 0 {
@@ -316,12 +320,16 @@ func (s *Service) uploadTrackersConcurrently(ctx context.Context, meta api.Prepa
 
 			trackerCfg, _ := trackerConfigFor(s.cfg, tracker)
 			trackerCfg = applyTrackerConfigOverrides(trackerCfg, meta.TrackerConfigOverrides)
-			resolution, err := ensureDescriptionImageHost(ctx, tracker, meta, s.cfg, trackerCfg, s.repo, s.images, s.logger)
-			if err != nil {
-				s.logger.Warnf("trackers: description image host resolution failed for %s: %v", tracker, err)
-				result.err = err
-				results[idx] = result
-				continue
+			resolution, ok := preflight[strings.ToUpper(strings.TrimSpace(tracker))]
+			if !ok {
+				var err error
+				resolution, err = ensureDescriptionImageHost(ctx, tracker, meta, s.cfg, trackerCfg, s.repo, s.images, s.logger)
+				if err != nil {
+					s.logger.Warnf("trackers: description image host resolution failed for %s: %v", tracker, err)
+					result.err = err
+					results[idx] = result
+					continue
+				}
 			}
 			assets, err := ResolveDescriptionAssets(ctx, tracker, meta, s.repo, s.logger)
 			if err != nil {
@@ -392,6 +400,104 @@ func (s *Service) maxConcurrentTrackerUploads(total int) int {
 		return total
 	}
 	return limit
+}
+
+func (s *Service) preflightDescriptionImageHosts(ctx context.Context, meta api.PreparedMetadata, trackers []string) imageHostPreflight {
+	if len(trackers) == 0 || s.registry == nil {
+		return nil
+	}
+
+	preloaded, err := preloadDescriptionAssetData(ctx, meta, s.repo)
+	if err != nil {
+		s.logger.Warnf("trackers: image host preflight preload failed for %s: %v", meta.SourcePath, err)
+		preloaded = nil
+	}
+
+	type preflightEntry struct {
+		tracker    string
+		trackerCfg config.TrackerConfig
+		targetKey  string
+	}
+
+	entries := make([]preflightEntry, 0, len(trackers))
+	representatives := make(map[string]preflightEntry)
+	for _, tracker := range trackers {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		if _, ok := s.registry.Lookup(tracker); !ok {
+			continue
+		}
+		trackerCfg, _ := trackerConfigFor(s.cfg, tracker)
+		trackerCfg = applyTrackerConfigOverrides(trackerCfg, meta.TrackerConfigOverrides)
+		targetKey := ""
+		policy, err := resolveImageHostPolicy(tracker, trackerCfg, meta.ImageHostOverrides)
+		if err != nil {
+			s.logger.Warnf("trackers: image host preflight failed for %s: %v", tracker, err)
+			continue
+		}
+		if host := preferredHost(policy); host != "" {
+			targetKey = strings.ToLower(strings.TrimSpace(host)) + "\x00" + normalizeUsageScope(usageScopeForHost(tracker, host))
+		}
+		entry := preflightEntry{
+			tracker:    tracker,
+			trackerCfg: trackerCfg,
+			targetKey:  targetKey,
+		}
+		entries = append(entries, entry)
+		if targetKey != "" {
+			if _, ok := representatives[targetKey]; !ok {
+				representatives[targetKey] = entry
+			}
+		}
+	}
+
+	resolutions := make(imageHostPreflight, len(entries))
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
+	for _, entry := range representatives {
+		wg.Add(1)
+		go func(entry preflightEntry) {
+			defer wg.Done()
+			resolution, err := ensureDescriptionImageHostWithData(ctx, entry.tracker, meta, s.cfg, entry.trackerCfg, s.repo, s.images, s.logger, nil)
+			if err != nil {
+				s.logger.Warnf("trackers: image host preflight failed for %s: %v", entry.tracker, err)
+				return
+			}
+			mu.Lock()
+			resolutions[strings.ToUpper(strings.TrimSpace(entry.tracker))] = resolution
+			mu.Unlock()
+		}(entry)
+	}
+	wg.Wait()
+
+	if len(representatives) > 0 {
+		refreshed, err := preloadDescriptionAssetData(ctx, meta, s.repo)
+		if err != nil {
+			s.logger.Warnf("trackers: image host preflight reload failed for %s: %v", meta.SourcePath, err)
+		} else {
+			preloaded = refreshed
+		}
+	}
+
+	for _, entry := range entries {
+		key := strings.ToUpper(strings.TrimSpace(entry.tracker))
+		if _, ok := resolutions[key]; ok {
+			continue
+		}
+		resolution, err := ensureDescriptionImageHostWithData(ctx, entry.tracker, meta, s.cfg, entry.trackerCfg, s.repo, s.images, s.logger, preloaded)
+		if err != nil {
+			s.logger.Warnf("trackers: image host preflight failed for %s: %v", entry.tracker, err)
+			continue
+		}
+		resolutions[key] = resolution
+	}
+	return resolutions
 }
 
 func (s *Service) BuildPreparation(ctx context.Context, meta api.PreparedMetadata, trackersList []string) (api.PreparationPreview, error) {

--- a/internal/trackers/service.go
+++ b/internal/trackers/service.go
@@ -331,6 +331,16 @@ func (s *Service) uploadTrackersConcurrently(ctx context.Context, meta api.Prepa
 					continue
 				}
 			}
+			if resolution.blocking {
+				message := strings.TrimSpace(resolution.feedback.Message)
+				if message == "" {
+					message = "image-host requirements could not be met"
+				}
+				s.logger.Warnf("trackers: skipping %s due to image host failure: %s", tracker, message)
+				result.err = errors.New(message)
+				results[idx] = result
+				continue
+			}
 			assets, err := ResolveDescriptionAssets(ctx, tracker, meta, s.repo, s.logger)
 			if err != nil {
 				result.err = err
@@ -440,7 +450,7 @@ func (s *Service) preflightDescriptionImageHosts(ctx context.Context, meta api.P
 			continue
 		}
 		if host := preferredHost(policy); host != "" {
-			targetKey = strings.ToLower(strings.TrimSpace(host)) + "\x00" + normalizeUsageScope(usageScopeForHost(tracker, host))
+			targetKey = strings.ToLower(strings.TrimSpace(host)) + "\x00" + normalizeUsageScope(usageScopeForHost(host))
 		}
 		entry := preflightEntry{
 			tracker:    tracker,
@@ -461,10 +471,14 @@ func (s *Service) preflightDescriptionImageHosts(ctx context.Context, meta api.P
 		wg sync.WaitGroup
 	)
 	for _, entry := range representatives {
+		preloadedCopy := clonePreloadedDescriptionAssetData(preloaded)
 		wg.Add(1)
-		go func(entry preflightEntry) {
+		go func(entry preflightEntry, preloadedCopy *preloadedDescriptionAssetData) {
 			defer wg.Done()
-			resolution, err := ensureDescriptionImageHostWithData(ctx, entry.tracker, meta, s.cfg, entry.trackerCfg, s.repo, s.images, s.logger, nil)
+			if ctx.Err() != nil {
+				return
+			}
+			resolution, err := ensureDescriptionImageHostWithData(ctx, entry.tracker, meta, s.cfg, entry.trackerCfg, s.repo, s.images, s.logger, preloadedCopy)
 			if err != nil {
 				s.logger.Warnf("trackers: image host preflight failed for %s: %v", entry.tracker, err)
 				return
@@ -472,7 +486,7 @@ func (s *Service) preflightDescriptionImageHosts(ctx context.Context, meta api.P
 			mu.Lock()
 			resolutions[strings.ToUpper(strings.TrimSpace(entry.tracker))] = resolution
 			mu.Unlock()
-		}(entry)
+		}(entry, preloadedCopy)
 	}
 	wg.Wait()
 
@@ -722,6 +736,13 @@ func (s *Service) BuildUploadDryRun(ctx context.Context, meta api.PreparedMetada
 			s.logger.Warnf("trackers: dry-run image host resolution failed for %s: %v", tracker, err)
 			entry.Status = "error"
 			entry.Message = err.Error()
+			results = append(results, entry)
+			continue
+		}
+		if resolution.blocking {
+			entry.Status = "blocked"
+			entry.Message = resolution.feedback.Message
+			entry.ImageHost = resolution.feedback
 			results = append(results, entry)
 			continue
 		}

--- a/internal/trackers/service_test.go
+++ b/internal/trackers/service_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -347,6 +348,64 @@ func TestUploadAggregatesUploadedTorrentArtifacts(t *testing.T) {
 	}
 	if summary.UploadedTorrents[0].DownloadURL != "https://aither.cc/torrent/download/374352.382" {
 		t.Fatalf("unexpected download URL: %q", summary.UploadedTorrents[0].DownloadURL)
+	}
+}
+
+func TestUploadPreflightsMultipleConfiguredImageHostsOnce(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	for _, definition := range []Definition{
+		stubUploadArtifactDefinition{name: "PTP"},
+		stubUploadArtifactDefinition{name: "STC"},
+	} {
+		if err := registry.Register(definition); err != nil {
+			t.Fatalf("register stub: %v", err)
+		}
+	}
+
+	repo := &stubRepo{
+		selections: []api.ScreenshotFinalSelection{
+			{SourcePath: "/tmp/source", ImagePath: "/tmp/a.png", Order: 0},
+			{SourcePath: "/tmp/source", ImagePath: "/tmp/b.png", Order: 1},
+		},
+	}
+	images := &stubImageService{repo: repo}
+	cfg := config.Config{
+		Trackers: config.TrackersConfig{
+			DefaultTrackers: config.CSVList{"PTP", "STC"},
+			Trackers: map[string]config.TrackerConfig{
+				"PTP": {ImageHost: "ptpimg"},
+				"STC": {ImageHost: "imgbox"},
+			},
+		},
+	}
+	svc := NewServiceWithRegistryAndImages(cfg, nil, repo, registry, images)
+
+	summary, err := svc.Upload(context.Background(), api.PreparedMetadata{SourcePath: "/tmp/source"})
+	if err != nil {
+		t.Fatalf("unexpected upload error: %v", err)
+	}
+	if summary.Uploaded != 2 {
+		t.Fatalf("expected 2 tracker uploads, got %d", summary.Uploaded)
+	}
+	firstRunCalls := append([]string{}, images.calls...)
+	sort.Strings(firstRunCalls)
+	if got := strings.Join(firstRunCalls, ","); got != "imgbox,ptpimg" {
+		t.Fatalf("expected one upload per configured host, got %q", got)
+	}
+
+	summary, err = svc.Upload(context.Background(), api.PreparedMetadata{SourcePath: "/tmp/source"})
+	if err != nil {
+		t.Fatalf("unexpected second upload error: %v", err)
+	}
+	if summary.Uploaded != 2 {
+		t.Fatalf("expected 2 tracker uploads on second run, got %d", summary.Uploaded)
+	}
+	secondRunCalls := append([]string{}, images.calls...)
+	sort.Strings(secondRunCalls)
+	if got := strings.Join(secondRunCalls, ","); got != "imgbox,ptpimg" {
+		t.Fatalf("expected existing host variants to be reused on second run, got calls %q", got)
 	}
 }
 

--- a/internal/trackers/service_test.go
+++ b/internal/trackers/service_test.go
@@ -251,6 +251,44 @@ func TestBuildUploadDryRunUsesBuilder(t *testing.T) {
 	}
 }
 
+func TestBuildUploadDryRunBlocksWhenImageHostFallbacksFail(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	if err := registry.Register(stubDryRunDefinition{name: "PTP"}); err != nil {
+		t.Fatalf("register stub: %v", err)
+	}
+
+	repo := &stubRepo{
+		selections: []api.ScreenshotFinalSelection{
+			{SourcePath: "/tmp/source", ImagePath: "/tmp/a.png", Order: 0},
+			{SourcePath: "/tmp/source", ImagePath: "/tmp/b.png", Order: 1},
+		},
+	}
+	images := &stubImageService{
+		errs: map[string]error{
+			"ptpimg":  errors.New("ptpimg unavailable"),
+			"pixhost": errors.New("pixhost unavailable"),
+		},
+	}
+	svc := NewServiceWithRegistryAndImages(config.Config{}, nil, repo, registry, images)
+
+	entries, err := svc.BuildUploadDryRun(context.Background(), api.PreparedMetadata{SourcePath: "/tmp/source"}, []string{"PTP"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.Status != "blocked" {
+		t.Fatalf("expected blocked dry run, got %#v", entry)
+	}
+	if entry.ImageHost.Status != "warning" || len(entry.ImageHost.Warnings) != 2 {
+		t.Fatalf("expected image host warnings to be attached, got %#v", entry.ImageHost)
+	}
+}
+
 func TestBuildUploadDryRunIncludesRuleFailedTrackersWhenOverrideEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/webserver/app_routes.go
+++ b/internal/webserver/app_routes.go
@@ -605,6 +605,15 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 		writeJSON(w, http.StatusOK, value)
 	}))
 
+	mux.HandleFunc("/api/app/GetImageHostPolicyMetadata", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
+		value, err := s.backend.GetImageHostPolicyMetadata()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, value)
+	}))
+
 	mux.HandleFunc("/api/app/ListHistory", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		value, err := s.backend.ListHistory()
 		if err != nil {

--- a/internal/webserver/app_routes.go
+++ b/internal/webserver/app_routes.go
@@ -499,6 +499,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			Path          string
 			Overrides     api.ExternalIDOverrides
 			NameOverrides api.ReleaseNameOverrides
+			Trackers      []string
 			Host          string
 			Images        []api.ScreenshotImage
 		}
@@ -506,7 +507,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.UploadImages(req.Path, req.Overrides, req.NameOverrides, req.Host, req.Images)
+		value, err := s.backend.UploadImages(req.Path, req.Overrides, req.NameOverrides, req.Trackers, req.Host, req.Images)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -23,6 +23,7 @@ import (
 	"github.com/autobrr/upbrr/internal/filesystem"
 	"github.com/autobrr/upbrr/internal/guiapp"
 	"github.com/autobrr/upbrr/internal/guishared"
+	"github.com/autobrr/upbrr/internal/imagehostpolicy"
 	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/paths"
 	"github.com/autobrr/upbrr/internal/services/bdinfo"
@@ -201,7 +202,7 @@ func (b *Backend) FetchMetadata(sessionID string, path string, sourceLookupURL s
 	req := api.Request{
 		Paths:           []string{trimmedPath},
 		Mode:            api.ModeGUI,
-		Trackers:        trackersList,
+		Trackers:        append([]string{}, trackersList...),
 		SourceLookupURL: strings.TrimSpace(sourceLookupURL),
 		Options: api.UploadOptions{
 			Screens:    b.cfg.ScreenshotHandling.Screens,
@@ -306,7 +307,7 @@ func (b *Backend) ResetMetadata(sessionID string, path string, sourceLookupURL s
 	req := api.Request{
 		Paths:           []string{trimmedPath},
 		Mode:            api.ModeGUI,
-		Trackers:        trackersList,
+		Trackers:        append([]string{}, trackersList...),
 		SourceLookupURL: strings.TrimSpace(sourceLookupURL),
 		Options: api.UploadOptions{
 			Screens:    b.cfg.ScreenshotHandling.Screens,
@@ -329,7 +330,7 @@ func (b *Backend) CheckDupes(path string, overrides api.ExternalIDOverrides, nam
 	req := api.Request{
 		Paths:    []string{strings.TrimSpace(path)},
 		Mode:     api.ModeGUI,
-		Trackers: trackersList,
+		Trackers: append([]string{}, trackersList...),
 		Options: api.UploadOptions{
 			Screens:    b.cfg.ScreenshotHandling.Screens,
 			OnlyID:     b.cfg.Metadata.OnlyID,
@@ -350,7 +351,7 @@ func (b *Backend) FetchPreparation(sessionID string, path string, overrides api.
 	req := api.Request{
 		Paths:          []string{strings.TrimSpace(path)},
 		Mode:           api.ModeGUI,
-		Trackers:       trackersList,
+		Trackers:       append([]string{}, trackersList...),
 		IgnoreDupesFor: normalizeTrackerList(ignoreDupesFor),
 		Options: api.UploadOptions{
 			Screens:    b.cfg.ScreenshotHandling.Screens,
@@ -394,7 +395,7 @@ func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides ap
 		Paths:                       []string{strings.TrimSpace(path)},
 		Mode:                        api.ModeGUI,
 		DescriptionGroups:           api.CloneDescriptionBuilderGroups(descriptionGroups),
-		Trackers:                    trackersList,
+		Trackers:                    append([]string{}, trackersList...),
 		IgnoreDupesFor:              normalizeTrackerList(ignoreDupesFor),
 		IgnoreTrackerRuleFailures:   ignoreRuleFailures,
 		Options:                     buildRunUploadOptions(b.cfg, runOpts),
@@ -427,7 +428,7 @@ func (b *Backend) FetchDescriptionBuilder(path string, overrides api.ExternalIDO
 	req := api.Request{
 		Paths:          []string{strings.TrimSpace(path)},
 		Mode:           api.ModeGUI,
-		Trackers:       trackersList,
+		Trackers:       append([]string{}, trackersList...),
 		IgnoreDupesFor: normalizeTrackerList(ignoreDupesFor),
 		Options: api.UploadOptions{
 			Screens:    b.cfg.ScreenshotHandling.Screens,
@@ -727,9 +728,9 @@ func (b *Backend) ListUploadedImages(path string, overrides api.ExternalIDOverri
 	})
 }
 
-func (b *Backend) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, host string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+func (b *Backend) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, host string, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
 	if err := b.requireCore(); err != nil {
-		return nil, err
+		return api.UploadImagesResult{}, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
@@ -743,7 +744,7 @@ func (b *Backend) UploadImages(path string, overrides api.ExternalIDOverrides, n
 		},
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
-		Trackers:             append([]string{}, trackers...),
+		Trackers:             append([]string{}, trackersList...),
 	}, host, images)
 }
 
@@ -888,6 +889,10 @@ func (b *Backend) ImportConfig(fileName, fileContent string) (string, []string, 
 
 func (b *Backend) ListKnownTrackers() ([]string, error) {
 	return trackers.KnownTrackers(), nil
+}
+
+func (b *Backend) GetImageHostPolicyMetadata() (imagehostpolicy.Metadata, error) {
+	return imagehostpolicy.PolicyMetadata(), nil
 }
 
 func (b *Backend) ListHistory() ([]api.HistoryEntry, error) {

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -727,7 +727,7 @@ func (b *Backend) ListUploadedImages(path string, overrides api.ExternalIDOverri
 	})
 }
 
-func (b *Backend) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, host string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+func (b *Backend) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, host string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
 	if err := b.requireCore(); err != nil {
 		return nil, err
 	}
@@ -743,6 +743,7 @@ func (b *Backend) UploadImages(path string, overrides api.ExternalIDOverrides, n
 		},
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		Trackers:             append([]string{}, trackers...),
 	}, host, images)
 }
 

--- a/internal/webserver/jobs_test.go
+++ b/internal/webserver/jobs_test.go
@@ -85,8 +85,8 @@ func (c *preparedMetaTestCore) ListUploadedImages(context.Context, api.Request) 
 	return nil, nil
 }
 
-func (c *preparedMetaTestCore) UploadImages(context.Context, api.Request, string, []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
-	return nil, nil
+func (c *preparedMetaTestCore) UploadImages(context.Context, api.Request, string, []api.ScreenshotImage) (api.UploadImagesResult, error) {
+	return api.UploadImagesResult{}, nil
 }
 
 func (c *preparedMetaTestCore) DeleteUploadedImage(context.Context, api.Request, string, string) error {

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -115,7 +115,7 @@ type Core interface {
 	SaveFinalScreenshotSelections(ctx context.Context, req Request, images []ScreenshotImage) error
 	ListUploadCandidates(ctx context.Context, req Request) ([]ScreenshotImage, error)
 	ListUploadedImages(ctx context.Context, req Request) ([]UploadedImageLink, error)
-	UploadImages(ctx context.Context, req Request, host string, images []ScreenshotImage) ([]UploadedImageLink, error)
+	UploadImages(ctx context.Context, req Request, host string, images []ScreenshotImage) (UploadImagesResult, error)
 	DeleteUploadedImage(ctx context.Context, req Request, imagePath string, host string) error
 	DiscoverPlaylists(ctx context.Context, sourcePath string) ([]PlaylistInfo, error)
 	SavePlaylistSelection(ctx context.Context, sourcePath string, playlists []string, useAll bool) error

--- a/pkg/api/description_groups.go
+++ b/pkg/api/description_groups.go
@@ -14,6 +14,7 @@ func CloneDescriptionBuilderGroups(groups []DescriptionBuilderGroup) []Descripti
 		cloned[idx] = group
 		cloned[idx].Trackers = append([]string(nil), group.Trackers...)
 		cloned[idx].ImageHost.AllowedHosts = append([]string(nil), group.ImageHost.AllowedHosts...)
+		cloned[idx].ImageHost.Warnings = append([]ImageHostWarning(nil), group.ImageHost.Warnings...)
 	}
 	return cloned
 }

--- a/pkg/api/preview.go
+++ b/pkg/api/preview.go
@@ -98,8 +98,14 @@ type ImageHostFeedback struct {
 	Status       string
 	SelectedHost string
 	AllowedHosts []string
+	Warnings     []ImageHostWarning
 	Reuploaded   bool
 	Message      string
+}
+
+type ImageHostWarning struct {
+	Host    string
+	Message string
 }
 
 type DescriptionImageHostStatus struct {

--- a/pkg/api/uploaded_images.go
+++ b/pkg/api/uploaded_images.go
@@ -16,3 +16,26 @@ type UploadedImageLink struct {
 	SizeBytes  int64
 	UploadedAt time.Time
 }
+
+// UploadImageHostFailure describes a single host-level image upload failure
+// returned in UploadImagesResult when one or more target hosts fail.
+// Host is the failed image host name.
+// UsageScope is the upload scope targeted for that host.
+// Trackers lists trackers blocked by this host failure.
+// Message contains the host failure reason.
+type UploadImageHostFailure struct {
+	Host       string
+	UsageScope string
+	Trackers   []string
+	Message    string
+}
+
+// UploadImagesResult aggregates image upload outcomes across target hosts.
+// Links contains successfully uploaded image links and is populated when one
+// or more host uploads succeed.
+// Failures contains host-level upload failures and is populated when one or
+// more target hosts fail.
+type UploadImagesResult struct {
+	Links    []UploadedImageLink
+	Failures []UploadImageHostFailure
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-tracker image-host selection in settings and upload UI.
  * Uploads may target multiple tracker-specific hosts and return per-host results.

* **Improvements**
  * Concurrent, deduplicated uploads across configured hosts.
  * UI shows per-host upload failures/warnings and improved dry-run blocking for bad hosts.
  * Description builder and tracker pages render image-host warnings with clearer messaging.

* **Bug Fixes**
  * Stronger validation/enforcement for tracker-owned image hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->