### PR TITLE
fix(cli): print usage options instead of returning help requested error

### DIFF
--- a/cmd/upbrr/cli_options.go
+++ b/cmd/upbrr/cli_options.go
@@ -124,6 +124,11 @@ func parseCLIOptions(args []string) (cliOptions, map[string]bool, []string, erro
 	fs := flag.NewFlagSet("upbrr", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stdout, "Usage: upbrr [options] <path...>\n\nOptions:\n")
+		fs.PrintDefaults()
+	}
+
 	fs.StringVar(&opts.ConfigPath, "config", "", "Path to config file")
 	fs.BoolVar(&opts.ShowVersion, "version", false, "Show version and exit")
 	fs.StringVar(&opts.QueueName, "queue", "", "Process an entire folder queue")
@@ -267,6 +272,10 @@ func parseCLIOptions(args []string) (cliOptions, map[string]bool, []string, erro
 	fs.StringVar(&opts.Channel, "channel", "", "Override SPD channel")
 
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			fs.SetOutput(os.Stdout)
+			fs.Usage()
+		}
 		return cliOptions{}, nil, nil, err
 	}
 
@@ -424,9 +433,18 @@ func parseServeOptions(args []string) (serveOptions, map[string]bool, error) {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stdout, "Usage: upbrr serve [options]\n\nOptions:\n")
+		fs.PrintDefaults()
+	}
+
 	fs.StringVar(&opts.ConfigPath, "config", "", "Path to config file")
 
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			fs.SetOutput(os.Stdout)
+			fs.Usage()
+		}
 		return serveOptions{}, nil, err
 	}
 

--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -83,6 +84,9 @@ func run() error {
 
 	opts, visitedFlags, paths, err := parseCLIOptions(os.Args[1:])
 	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
 		return exitError(2, err)
 	}
 
@@ -369,6 +373,9 @@ func promptAuthPassword(stdin io.Reader, reader *bufio.Reader, stdout io.Writer,
 func runServe(args []string) error {
 	opts, visitedFlags, err := parseServeOptions(args)
 	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
 		return err
 	}
 

--- a/cmd/upbrr/main_test.go
+++ b/cmd/upbrr/main_test.go
@@ -218,3 +218,71 @@ func TestRunExportConfigPlaintextExportsPlainSecrets(t *testing.T) {
 		t.Fatalf("expected plaintext export without encrypted envelopes, got %s", exported)
 	}
 }
+
+func TestRunHelpRequestedExitsCleanly(t *testing.T) {
+	oldArgs := os.Args
+	oldStdout := os.Stdout
+	defer func() {
+		os.Args = oldArgs
+		os.Stdout = oldStdout
+	}()
+
+	tmpDir := t.TempDir()
+	stdoutPath := filepath.Join(tmpDir, "stdout.txt")
+	stdoutFile, err := os.Create(stdoutPath)
+	if err != nil {
+		t.Fatalf("create stdout fixture: %v", err)
+	}
+	defer stdoutFile.Close()
+	os.Stdout = stdoutFile
+
+	os.Args = []string{"upbrr", "-h"}
+	if err := run(); err != nil {
+		t.Fatalf("expected run with -h to return nil, got %v", err)
+	}
+
+	stdoutFile.Close()
+	raw, err := os.ReadFile(stdoutPath)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+
+	output := string(raw)
+	if !strings.Contains(output, "Usage: upbrr [options]") {
+		t.Fatalf("expected output to contain Usage instructions, got %s", output)
+	}
+}
+
+func TestRunServeHelpRequestedExitsCleanly(t *testing.T) {
+	oldArgs := os.Args
+	oldStdout := os.Stdout
+	defer func() {
+		os.Args = oldArgs
+		os.Stdout = oldStdout
+	}()
+
+	tmpDir := t.TempDir()
+	stdoutPath := filepath.Join(tmpDir, "stdout.txt")
+	stdoutFile, err := os.Create(stdoutPath)
+	if err != nil {
+		t.Fatalf("create stdout fixture: %v", err)
+	}
+	defer stdoutFile.Close()
+	os.Stdout = stdoutFile
+
+	os.Args = []string{"upbrr", "serve", "-h"}
+	if err := run(); err != nil {
+		t.Fatalf("expected run with serve -h to return nil, got %v", err)
+	}
+
+	stdoutFile.Close()
+	raw, err := os.ReadFile(stdoutPath)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+
+	output := string(raw)
+	if !strings.Contains(output, "Usage: upbrr serve [options]") {
+		t.Fatalf("expected output to contain Usage instructions, got %s", output)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved help flag (`-h`) handling for the main command and `serve` subcommand to properly display usage information and format help output.

* **Tests**
  * Added test coverage to verify help flag behavior exits cleanly and displays correct usage headers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/upbrr/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->