### PR TITLE
feat(web): add dev no-auth serve mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,9 @@ go run ./cmd/upbrr
 # Run the embedded web server:
 go run ./cmd/upbrr serve
 
+# Run the embedded web server without web auth for local frontend development:
+go run ./cmd/upbrr serve --dev-no-auth
+
 # Launch the Wails desktop GUI:
 go run ./cmd/upbrr --gui
 # or the dedicated GUI entrypoint:

--- a/cmd/upbrr/cli_options.go
+++ b/cmd/upbrr/cli_options.go
@@ -117,6 +117,7 @@ type cliOptions struct {
 
 type serveOptions struct {
 	ConfigPath string
+	DevNoAuth  bool
 }
 
 func parseCLIOptions(args []string) (cliOptions, map[string]bool, []string, error) {
@@ -425,6 +426,7 @@ func parseServeOptions(args []string) (serveOptions, map[string]bool, error) {
 	fs.SetOutput(io.Discard)
 
 	fs.StringVar(&opts.ConfigPath, "config", "", "Path to config file")
+	fs.BoolVar(&opts.DevNoAuth, "dev-no-auth", false, "Development only: serve web UI without web authentication on loopback hosts")
 
 	if err := fs.Parse(args); err != nil {
 		return serveOptions{}, nil, fmt.Errorf("parse serve options: %w", err)

--- a/cmd/upbrr/cli_options_test.go
+++ b/cmd/upbrr/cli_options_test.go
@@ -75,6 +75,19 @@ func TestParseCLIOptionsCompatibilityFlags(t *testing.T) {
 	}
 }
 
+func TestParseServeOptionsDevNoAuth(t *testing.T) {
+	opts, visited, err := parseServeOptions([]string{"--dev-no-auth"})
+	if err != nil {
+		t.Fatalf("parse serve options: %v", err)
+	}
+	if !opts.DevNoAuth {
+		t.Fatalf("expected dev-no-auth to parse, got %#v", opts)
+	}
+	if !visited["dev-no-auth"] {
+		t.Fatalf("expected dev-no-auth visited flag, got %#v", visited)
+	}
+}
+
 func TestParseCLIOptionsExportConfigPlaintext(t *testing.T) {
 	opts, visited, paths, err := parseCLIOptions([]string{"--export-config", "out.yaml", "--export-config-plaintext"})
 	if err != nil {

--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -399,10 +399,14 @@ func runServe(args []string) error {
 	if err := webserver.SaveCLIConfig(dbPath, webCfg); err != nil {
 		return fmt.Errorf("upbrr: %w", err)
 	}
+	if opts.DevNoAuth {
+		webCfg.OpenBrowser = false
+	}
 
 	server, err := webserver.New(webserver.Options{
-		Config:    cfg,
-		CLIConfig: webCfg,
+		Config:            cfg,
+		CLIConfig:         webCfg,
+		DevelopmentNoAuth: opts.DevNoAuth,
 	})
 	if err != nil {
 		return fmt.Errorf("upbrr: %w", err)

--- a/gui/frontend/wailsjs/go/models.ts
+++ b/gui/frontend/wailsjs/go/models.ts
@@ -2679,7 +2679,7 @@ export namespace imagehostpolicy {
 	
 	export class Metadata {
 	    UploadHosts: string[];
-	    TrackerUploadHosts: Record<string, Array<string>>;
+	    TrackerUploadHosts: Record<string, string[]>;
 	    OwnedHosts: Record<string, string>;
 	
 	    static createFrom(source: any = {}) {
@@ -2737,4 +2737,3 @@ export namespace logging {
 	}
 
 }
-

--- a/gui/frontend/wailsjs/go/models.ts
+++ b/gui/frontend/wailsjs/go/models.ts
@@ -2679,7 +2679,7 @@ export namespace imagehostpolicy {
 	
 	export class Metadata {
 	    UploadHosts: string[];
-	    TrackerUploadHosts: Record<string, string[]>;
+	    TrackerUploadHosts: Record<string, Array<string>>;
 	    OwnedHosts: Record<string, string>;
 	
 	    static createFrom(source: any = {}) {

--- a/internal/webserver/app_routes.go
+++ b/internal/webserver/app_routes.go
@@ -307,7 +307,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 		}
 	}))
 
-	mux.HandleFunc("/api/app/BrowseDirectory", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
+	mux.HandleFunc("/api/app/BrowseDirectory", s.requireSession(func(w http.ResponseWriter, r *http.Request, current session) {
 		if r.Method != http.MethodPost {
 			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 			return
@@ -317,7 +317,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		policy, err := s.webBrowsePolicy()
+		policy, err := s.webBrowsePolicy(current)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -833,7 +833,10 @@ type webBrowsePolicy struct {
 	AllowUnrestricted bool
 }
 
-func (s *Server) webBrowsePolicy() (webBrowsePolicy, error) {
+func (s *Server) webBrowsePolicy(current session) (webBrowsePolicy, error) {
+	if s != nil && s.isDevelopmentSession(current) {
+		return webBrowsePolicy{AllowUnrestricted: true}, nil
+	}
 	if s == nil || s.auth == nil {
 		return webBrowsePolicy{}, nil
 	}

--- a/internal/webserver/browse_test.go
+++ b/internal/webserver/browse_test.go
@@ -229,6 +229,73 @@ func TestBrowseFileRouteRejectsRemoteSessions(t *testing.T) {
 	}
 }
 
+func TestDevelopmentNoAuthAppRouteAllowsLoopbackWithCSRF(t *testing.T) {
+	picker := &stubNativePicker{filePath: `C:\Media\movie.mkv`}
+	server := &Server{
+		picker:            picker,
+		generalLimiter:    newFixedWindowLimiter(100, time.Minute),
+		developmentNoAuth: true,
+		developmentSession: session{
+			ID:        "dev-no-auth",
+			Username:  "dev",
+			CSRFToken: "dev-csrf",
+			ExpiresAt: time.Now().UTC().Add(time.Hour),
+		},
+	}
+	mux := http.NewServeMux()
+	server.registerAppRoutes(mux)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/app/BrowseFile", strings.NewReader(`{}`))
+	req.Host = "127.0.0.1:7480"
+	req.RemoteAddr = "127.0.0.1:5050"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://localhost:5173")
+	req.Header.Set("X-Csrf-Token", "dev-csrf")
+
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("browse file route returned %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if picker.fileCalls != 1 {
+		t.Fatalf("expected picker to be called once, got %d", picker.fileCalls)
+	}
+}
+
+func TestDevelopmentNoAuthAppRouteRejectsMissingCSRF(t *testing.T) {
+	picker := &stubNativePicker{filePath: `C:\Media\movie.mkv`}
+	server := &Server{
+		picker:            picker,
+		generalLimiter:    newFixedWindowLimiter(100, time.Minute),
+		developmentNoAuth: true,
+		developmentSession: session{
+			ID:        "dev-no-auth",
+			Username:  "dev",
+			CSRFToken: "dev-csrf",
+			ExpiresAt: time.Now().UTC().Add(time.Hour),
+		},
+	}
+	mux := http.NewServeMux()
+	server.registerAppRoutes(mux)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/app/BrowseFile", strings.NewReader(`{}`))
+	req.Host = "127.0.0.1:8080"
+	req.RemoteAddr = "127.0.0.1:5050"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://127.0.0.1:8080")
+
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("expected forbidden status, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if picker.fileCalls != 0 {
+		t.Fatalf("expected picker not to be called, got %d calls", picker.fileCalls)
+	}
+}
+
 func TestUIStateRoutePersistsSharedState(t *testing.T) {
 	repo, dbPath := openBrowseTestRepo(t)
 	server := testServerWithBackend(t, repo, config.Config{

--- a/internal/webserver/routes.go
+++ b/internal/webserver/routes.go
@@ -51,6 +51,20 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 }
 
 func (s *Server) handleAuthStatus(w http.ResponseWriter, r *http.Request, _ session) {
+	if current, ok := s.developmentCurrentSession(r); ok {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"authenticated":           true,
+			"needsSetup":              false,
+			"username":                current.Username,
+			"csrfToken":               current.CSRFToken,
+			"nativeBrowseEnabled":     s.nativeBrowseAvailable(r),
+			"browseRoot":              "",
+			"allowUnrestrictedBrowse": true,
+			"needsBrowsePolicy":       false,
+		})
+		return
+	}
+
 	exists, err := s.auth.Exists()
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -444,7 +458,7 @@ func (s *Server) requireSession(next func(http.ResponseWriter, *http.Request, se
 			return
 		}
 		if r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodOptions {
-			if !s.verifySameOrigin(r) || !s.verifyCSRF(r, current) {
+			if !s.verifySameOrigin(r, current) || !s.verifyCSRF(r, current) {
 				writeJSON(w, http.StatusForbidden, map[string]string{"error": "csrf validation failed"})
 				return
 			}
@@ -455,10 +469,31 @@ func (s *Server) requireSession(next func(http.ResponseWriter, *http.Request, se
 
 func (s *Server) currentSession(r *http.Request) (session, bool) {
 	cookie, err := r.Cookie(sessionCookieName)
-	if err != nil {
+	if err == nil && s.sessions != nil {
+		if current, ok := s.sessions.Get(cookie.Value); ok {
+			return current, true
+		}
+	}
+	return s.developmentCurrentSession(r)
+}
+
+func (s *Server) developmentCurrentSession(r *http.Request) (session, bool) {
+	if s == nil || !s.developmentNoAuth || !s.isLocalWebUIRequest(r) {
 		return session{}, false
 	}
-	return s.sessions.Get(cookie.Value)
+	current := s.developmentSession
+	if current.ID == "" || current.CSRFToken == "" {
+		return session{}, false
+	}
+	return current, true
+}
+
+func (s *Server) isDevelopmentSession(current session) bool {
+	return s != nil &&
+		s.developmentNoAuth &&
+		s.developmentSession.ID != "" &&
+		current.ID == s.developmentSession.ID &&
+		current.CSRFToken == s.developmentSession.CSRFToken
 }
 
 func (s *Server) writeSessionCookie(w http.ResponseWriter, r *http.Request, current session) {
@@ -493,7 +528,7 @@ func (s *Server) verifyCSRF(r *http.Request, current session) bool {
 	return token == current.CSRFToken
 }
 
-func (s *Server) verifySameOrigin(r *http.Request) bool {
+func (s *Server) verifySameOrigin(r *http.Request, current session) bool {
 	origin := strings.TrimSpace(r.Header.Get("Origin"))
 	if origin == "" {
 		origin = strings.TrimSpace(r.Header.Get("Referer"))
@@ -505,7 +540,21 @@ func (s *Server) verifySameOrigin(r *http.Request) bool {
 	if err != nil {
 		return false
 	}
-	return strings.EqualFold(parsed.Host, r.Host)
+	if strings.EqualFold(parsed.Host, r.Host) {
+		return true
+	}
+	return s.isDevelopmentSession(current) && isLoopbackHostPort(parsed.Host) && isLoopbackHostPort(r.Host)
+}
+
+func isLoopbackHostPort(host string) bool {
+	trimmed := strings.TrimSpace(host)
+	if trimmed == "" {
+		return false
+	}
+	if parsedHost, _, err := net.SplitHostPort(trimmed); err == nil {
+		trimmed = parsedHost
+	}
+	return isLoopbackHostname(strings.Trim(trimmed, "[]"))
 }
 
 func (s *Server) clientIP(r *http.Request) string {

--- a/internal/webserver/routes_auth_test.go
+++ b/internal/webserver/routes_auth_test.go
@@ -380,6 +380,85 @@ func TestAuthStatusMasksBrowseRootUntilAuthenticated(t *testing.T) {
 	}
 }
 
+func TestDevelopmentNoAuthStatusBypassesMissingAuthOnLoopback(t *testing.T) {
+	server := &Server{
+		developmentNoAuth: true,
+		developmentSession: session{
+			ID:        "dev-no-auth",
+			Username:  "dev",
+			CSRFToken: "dev-csrf",
+			ExpiresAt: time.Now().UTC().Add(time.Hour),
+		},
+		picker: &stubNativePicker{},
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/auth/status", nil)
+	req.Host = "127.0.0.1:7480"
+	req.RemoteAddr = "127.0.0.1:5000"
+
+	recorder := httptest.NewRecorder()
+	server.handleAuthStatus(recorder, req, session{})
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("handleAuthStatus returned %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var payload struct {
+		Authenticated           bool   `json:"authenticated"`
+		NeedsSetup              bool   `json:"needsSetup"`
+		Username                string `json:"username"`
+		CSRFToken               string `json:"csrfToken"`
+		AllowUnrestrictedBrowse bool   `json:"allowUnrestrictedBrowse"`
+		NeedsBrowsePolicy       bool   `json:"needsBrowsePolicy"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal auth status: %v", err)
+	}
+	if !payload.Authenticated || payload.NeedsSetup || payload.Username != "dev" || payload.CSRFToken != "dev-csrf" {
+		t.Fatalf("unexpected development auth status: %#v", payload)
+	}
+	if !payload.AllowUnrestrictedBrowse || payload.NeedsBrowsePolicy {
+		t.Fatalf("expected development auth status to skip browse policy setup, got %#v", payload)
+	}
+}
+
+func TestDevelopmentNoAuthStatusDoesNotBypassRemoteRequests(t *testing.T) {
+	store, err := newAuthStore(filepath.Join(t.TempDir(), "state", "db.sqlite"))
+	if err != nil {
+		t.Fatalf("newAuthStore: %v", err)
+	}
+	server := &Server{
+		auth:              store,
+		developmentNoAuth: true,
+		developmentSession: session{
+			ID:        "dev-no-auth",
+			Username:  "dev",
+			CSRFToken: "dev-csrf",
+			ExpiresAt: time.Now().UTC().Add(time.Hour),
+		},
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/auth/status", nil)
+	req.Host = "example.com:7480"
+	req.RemoteAddr = "192.168.1.10:5000"
+
+	recorder := httptest.NewRecorder()
+	server.handleAuthStatus(recorder, req, session{})
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("handleAuthStatus returned %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var payload struct {
+		Authenticated bool `json:"authenticated"`
+		NeedsSetup    bool `json:"needsSetup"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal auth status: %v", err)
+	}
+	if payload.Authenticated || !payload.NeedsSetup {
+		t.Fatalf("expected remote request to use normal auth status, got %#v", payload)
+	}
+}
+
 func TestLogoutRemovesRetainedSessionFromDisk(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
 	server := newAuthTestServer(t, dbPath)

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -113,7 +113,7 @@ func New(opts Options) (*Server, error) {
 }
 
 func isDevelopmentNoAuthHost(host string) bool {
-	return isLoopbackHostname(strings.Trim(strings.TrimSpace(host), "[]"))
+	return isLoopbackHostPort(host)
 }
 
 func (s *Server) Close() error {

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -26,28 +26,34 @@ import (
 )
 
 type Options struct {
-	Config    config.Config
-	CLIConfig CLIConfig
+	Config            config.Config
+	CLIConfig         CLIConfig
+	DevelopmentNoAuth bool
 }
 
 type Server struct {
-	cfg            config.Config
-	cliCfg         CLIConfig
-	backend        *Backend
-	picker         nativePicker
-	auth           *authStore
-	sessions       *sessionManager
-	hub            *eventHub
-	authLimiter    *fixedWindowLimiter
-	generalLimiter *fixedWindowLimiter
-	trustedProxies []*net.IPNet
-	server         *http.Server
-	assets         fs.FS
+	cfg                config.Config
+	cliCfg             CLIConfig
+	backend            *Backend
+	picker             nativePicker
+	auth               *authStore
+	sessions           *sessionManager
+	hub                *eventHub
+	authLimiter        *fixedWindowLimiter
+	generalLimiter     *fixedWindowLimiter
+	trustedProxies     []*net.IPNet
+	server             *http.Server
+	assets             fs.FS
+	developmentNoAuth  bool
+	developmentSession session
 }
 
 func New(opts Options) (*Server, error) {
 	cfg := opts.Config
 	cliCfg := normalizeCLIConfig(opts.CLIConfig)
+	if opts.DevelopmentNoAuth && !isDevelopmentNoAuthHost(cliCfg.Host) {
+		return nil, fmt.Errorf("webserver: --dev-no-auth requires a loopback host, got %q", cliCfg.Host)
+	}
 
 	hub := newEventHub()
 	authStore, err := newAuthStore(cfg.MainSettings.DBPath)
@@ -80,6 +86,19 @@ func New(opts Options) (*Server, error) {
 		trustedProxies: parseTrustedProxies(cliCfg.TrustedProxies),
 		assets:         assets,
 	}
+	if opts.DevelopmentNoAuth {
+		csrf, err := randomString(24)
+		if err != nil {
+			return nil, err
+		}
+		srv.developmentNoAuth = true
+		srv.developmentSession = session{
+			ID:        "dev-no-auth",
+			Username:  "dev",
+			CSRFToken: csrf,
+			ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		}
+	}
 	sessions.SetLogger(func(format string, args ...any) {
 		backend.logger.Warnf(format, args...)
 	})
@@ -91,6 +110,10 @@ func New(opts Options) (*Server, error) {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	return srv, nil
+}
+
+func isDevelopmentNoAuthHost(host string) bool {
+	return isLoopbackHostname(strings.Trim(strings.TrimSpace(host), "[]"))
 }
 
 func (s *Server) Close() error {

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package webserver
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewRejectsDevelopmentNoAuthOnNonLoopbackHost(t *testing.T) {
+	_, err := New(Options{
+		CLIConfig:         CLIConfig{Host: "0.0.0.0"},
+		DevelopmentNoAuth: true,
+	})
+	if err == nil {
+		t.Fatal("expected development no-auth on non-loopback host to fail")
+	}
+	if !strings.Contains(err.Error(), "--dev-no-auth requires a loopback host") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestIsDevelopmentNoAuthHost(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{host: "localhost", want: true},
+		{host: "127.0.0.1", want: true},
+		{host: "::1", want: true},
+		{host: "[::1]", want: true},
+		{host: "0.0.0.0", want: false},
+		{host: "::", want: false},
+		{host: "192.168.1.20", want: false},
+		{host: "example.com", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			t.Parallel()
+			if got := isDevelopmentNoAuthHost(tc.host); got != tc.want {
+				t.Fatalf("isDevelopmentNoAuthHost(%q) = %v, want %v", tc.host, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsLoopbackHostPort(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{host: "localhost:5173", want: true},
+		{host: "127.0.0.1:7480", want: true},
+		{host: "[::1]:7480", want: true},
+		{host: "0.0.0.0:7480", want: false},
+		{host: "192.168.1.20:7480", want: false},
+		{host: "example.com:7480", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			t.Parallel()
+			if got := isLoopbackHostPort(tc.host); got != tc.want {
+				t.Fatalf("isLoopbackHostPort(%q) = %v, want %v", tc.host, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -29,9 +29,11 @@ func TestIsDevelopmentNoAuthHost(t *testing.T) {
 		want bool
 	}{
 		{host: "localhost", want: true},
+		{host: "localhost:7480", want: true},
 		{host: "127.0.0.1", want: true},
 		{host: "::1", want: true},
 		{host: "[::1]", want: true},
+		{host: "[::1]:7480", want: true},
 		{host: "0.0.0.0", want: false},
 		{host: "::", want: false},
 		{host: "192.168.1.20", want: false},


### PR DESCRIPTION
Limit bypass to loopback dev sessions so Vite can use the embedded API without creating web auth.