### PR TITLE
fix(screenshots): fix capture planning

### DIFF
--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -1268,10 +1268,8 @@ export default function App() {
     livePreviewImage,
     setLivePreviewImage,
     livePreviewRequestId,
-    screenshotsEnabled,
     setScreenshotPlan,
     setScreenshotSelections,
-    setScreenshotsEnabled,
     screenshotsSettingsSaving,
     setScreenshotsSettingsSaving,
     setShowFrameSelections,
@@ -1361,9 +1359,6 @@ export default function App() {
       if (state.prepPreview) setPrepPreview({ ...emptyPreparation, ...state.prepPreview });
       if (state.screenshotPlan !== undefined) setScreenshotPlan(state.screenshotPlan);
       if (state.screenshotSelections) setScreenshotSelections(state.screenshotSelections);
-      if (typeof state.screenshotsEnabled === "boolean") {
-        setScreenshotsEnabled(state.screenshotsEnabled);
-      }
       if (typeof state.showFrameSelections === "boolean") {
         setShowFrameSelections(state.showFrameSelections);
       }
@@ -1393,7 +1388,6 @@ export default function App() {
       setFinalResult,
       setScreenshotPlan,
       setScreenshotSelections,
-      setScreenshotsEnabled,
       setShowFrameSelections,
       setUploadHost,
       setUploadSelections,
@@ -1618,7 +1612,6 @@ export default function App() {
       prepPreview,
       screenshotPlan: screenshots.screenshotPlan,
       screenshotSelections: screenshots.screenshotSelections,
-      screenshotsEnabled: screenshots.screenshotsEnabled,
       showFrameSelections: screenshots.showFrameSelections,
       finalResult: screenshots.finalResult,
       deletedTrackerImages: screenshots.deletedTrackerImages,
@@ -1704,7 +1697,6 @@ export default function App() {
     prepPreview,
     screenshots.screenshotPlan,
     screenshots.screenshotSelections,
-    screenshots.screenshotsEnabled,
     screenshots.showFrameSelections,
     screenshots.finalResult,
     screenshots.deletedTrackerImages,
@@ -1823,7 +1815,6 @@ export default function App() {
       prepPreview,
       screenshotPlan: screenshots.screenshotPlan,
       screenshotSelections: screenshots.screenshotSelections,
-      screenshotsEnabled: screenshots.screenshotsEnabled,
       showFrameSelections: screenshots.showFrameSelections,
       finalResult: screenshots.finalResult,
       deletedTrackerImages: screenshots.deletedTrackerImages,
@@ -1860,7 +1851,6 @@ export default function App() {
       prepPreview,
       screenshots.screenshotPlan,
       screenshots.screenshotSelections,
-      screenshots.screenshotsEnabled,
       screenshots.showFrameSelections,
       screenshots.finalResult,
       screenshots.deletedTrackerImages,
@@ -2975,10 +2965,6 @@ export default function App() {
 
   const runLivePreviewAt = async (timestampSeconds: number) => {
     setLivePreviewError("");
-    if (!screenshotsEnabled) {
-      setLivePreviewError("Enable screenshot capture to generate previews.");
-      return;
-    }
     if (!path.trim()) {
       setLivePreviewError("Please select a file or folder.");
       return;
@@ -3034,10 +3020,6 @@ export default function App() {
 
   const handlePreviewSelection = async (selection: ScreenshotSelection) => {
     screenshots.setScreenshotsError("");
-    if (!screenshotsEnabled) {
-      screenshots.setScreenshotsError("Enable screenshot capture to generate previews.");
-      return;
-    }
     if (!path.trim()) {
       screenshots.setScreenshotsError("Please select a file or folder.");
       return;
@@ -3070,10 +3052,6 @@ export default function App() {
 
   const handleCapturePreviewFrame = async () => {
     screenshots.setScreenshotsError("");
-    if (!screenshotsEnabled) {
-      screenshots.setScreenshotsError("Enable screenshot capture to save previews.");
-      return;
-    }
     if (!path.trim()) {
       screenshots.setScreenshotsError("Please select a file or folder.");
       return;
@@ -3204,10 +3182,6 @@ export default function App() {
 
   const handleGenerateScreenshots = async () => {
     screenshots.setScreenshotsError("");
-    if (!screenshotsEnabled) {
-      screenshots.setScreenshotsError("Enable screenshot capture to generate screenshots.");
-      return;
-    }
     if (!path.trim()) {
       screenshots.setScreenshotsError("Please select a file or folder.");
       return;
@@ -4288,8 +4262,6 @@ export default function App() {
               screenshotPlan={screenshots.screenshotPlan}
               screenshotsLoading={screenshots.screenshotsLoading}
               screenshotsError={screenshots.screenshotsError}
-              screenshotsEnabled={screenshotsEnabled}
-              setScreenshotsEnabled={setScreenshotsEnabled}
               loadScreenshotPlan={screenshots.loadScreenshotPlan}
               handleGenerateScreenshots={handleGenerateScreenshots}
               screenshotConfig={screenshotConfig}

--- a/gui/frontend/src/hooks/useScreenshots.ts
+++ b/gui/frontend/src/hooks/useScreenshots.ts
@@ -32,7 +32,6 @@ export const useScreenshots = ({
   // State: UI controls
   const [screenshotsLoading, setScreenshotsLoading] = useState(false);
   const [screenshotsError, setScreenshotsError] = useState("");
-  const [screenshotsEnabled, setScreenshotsEnabled] = useState(false);
   const [screenshotsSettingsSaving, setScreenshotsSettingsSaving] = useState(false);
   const [showFrameSelections, setShowFrameSelections] = useState(false);
 
@@ -680,7 +679,6 @@ export const useScreenshots = ({
     setScreenshotSelections([]);
     setScreenshotsLoading(false);
     setScreenshotsError("");
-    setScreenshotsEnabled(false);
     setShowFrameSelections(false);
     setPreviewLoadingIndex(null);
     setPreviewImages([]);
@@ -747,7 +745,6 @@ export const useScreenshots = ({
     screenshotSelections,
     screenshotsLoading,
     screenshotsError,
-    screenshotsEnabled,
     screenshotsSettingsSaving,
     showFrameSelections,
     livePreviewSeconds,
@@ -777,7 +774,6 @@ export const useScreenshots = ({
     setScreenshotSelections,
     setScreenshotsLoading,
     setScreenshotsError,
-    setScreenshotsEnabled,
     setScreenshotsSettingsSaving,
     setShowFrameSelections,
     setLivePreviewSeconds,

--- a/gui/frontend/src/pages/screenshots/index.tsx
+++ b/gui/frontend/src/pages/screenshots/index.tsx
@@ -18,8 +18,6 @@ type Props = Readonly<{
   screenshotPlan: ScreenshotPlan | null;
   screenshotsLoading: boolean;
   screenshotsError: string;
-  screenshotsEnabled: boolean;
-  setScreenshotsEnabled: Dispatch<SetStateAction<boolean>>;
   loadScreenshotPlan: (revealSelections?: boolean) => void;
   handleGenerateScreenshots: () => void;
   screenshotConfig: ConfigMap | null;
@@ -77,8 +75,6 @@ export default function ScreenshotsPage(props: Props) {
     screenshotPlan,
     screenshotsLoading,
     screenshotsError,
-    screenshotsEnabled,
-    setScreenshotsEnabled,
     loadScreenshotPlan,
     handleGenerateScreenshots,
     screenshotConfig,
@@ -129,6 +125,7 @@ export default function ScreenshotsPage(props: Props) {
     finalResult,
     handleDeleteAllFinalImages,
   } = props;
+  const previewTimingDisabled = previewDuration <= 0 || previewFrameRate <= 0;
 
   return (
     <section className="screens-panel">
@@ -155,14 +152,6 @@ export default function ScreenshotsPage(props: Props) {
           ) : null}
         </div>
         <div className="screens-actions__buttons">
-          <div className="screens-toggle">
-            <span>Enable capture</span>
-            <Switch
-              aria-label="Enable capture"
-              checked={screenshotsEnabled}
-              onChange={(event) => setScreenshotsEnabled(event.target.checked)}
-            />
-          </div>
           <button
             className="ghost"
             type="button"
@@ -175,7 +164,7 @@ export default function ScreenshotsPage(props: Props) {
             className="primary"
             type="button"
             onClick={handleGenerateScreenshots}
-            disabled={screenshotsLoading || !path.trim() || !screenshotsEnabled}
+            disabled={screenshotsLoading || !path.trim()}
           >
             {screenshotsLoading ? "Capturing..." : "Generate screenshots"}
           </button>
@@ -354,7 +343,6 @@ export default function ScreenshotsPage(props: Props) {
                   onChange={(event) =>
                     setLivePreviewSeconds(clampPreviewSeconds(Number(event.target.value)))
                   }
-                  disabled={!screenshotsEnabled}
                 />
               </label>
               <label className="screens-field">
@@ -371,7 +359,6 @@ export default function ScreenshotsPage(props: Props) {
                       setLivePreviewSeconds(0);
                     }
                   }}
-                  disabled={!screenshotsEnabled}
                 />
               </label>
               <div className="screens-preview__slider">
@@ -384,7 +371,7 @@ export default function ScreenshotsPage(props: Props) {
                   onChange={(event) =>
                     setLivePreviewSeconds(clampPreviewSeconds(Number(event.target.value)))
                   }
-                  disabled={!screenshotsEnabled || previewDuration <= 0}
+                  disabled={previewTimingDisabled}
                 />
                 <div className="screens-preview__meta">
                   <span className="muted">Duration: {previewDuration.toFixed(1)}s</span>
@@ -396,7 +383,7 @@ export default function ScreenshotsPage(props: Props) {
                   className="ghost"
                   type="button"
                   onClick={() => stepLivePreview(-1)}
-                  disabled={!screenshotsEnabled}
+                  disabled={previewTimingDisabled}
                 >
                   Prev frame
                 </button>
@@ -404,7 +391,7 @@ export default function ScreenshotsPage(props: Props) {
                   className="ghost"
                   type="button"
                   onClick={() => stepLivePreview(1)}
-                  disabled={!screenshotsEnabled}
+                  disabled={previewTimingDisabled}
                 >
                   Next frame
                 </button>
@@ -412,7 +399,7 @@ export default function ScreenshotsPage(props: Props) {
                   className="ghost"
                   type="button"
                   onClick={runLivePreview}
-                  disabled={!screenshotsEnabled || livePreviewLoading}
+                  disabled={previewTimingDisabled || livePreviewLoading}
                 >
                   {livePreviewLoading ? "Loading..." : "Run preview"}
                 </button>
@@ -420,7 +407,7 @@ export default function ScreenshotsPage(props: Props) {
                   className="primary"
                   type="button"
                   onClick={handleCapturePreviewFrame}
-                  disabled={!screenshotsEnabled || liveCaptureLoading}
+                  disabled={previewTimingDisabled || liveCaptureLoading}
                 >
                   {liveCaptureLoading ? "Capturing..." : "Capture preview"}
                 </button>
@@ -638,7 +625,7 @@ export default function ScreenshotsPage(props: Props) {
                   className="ghost"
                   type="button"
                   onClick={() => handlePreviewSelection(selection)}
-                  disabled={!screenshotsEnabled || previewLoadingIndex === selection.Index}
+                  disabled={previewLoadingIndex === selection.Index}
                 >
                   {previewLoadingIndex === selection.Index ? "Previewing..." : "Preview"}
                 </button>

--- a/gui/frontend/src/styles.css
+++ b/gui/frontend/src/styles.css
@@ -137,8 +137,7 @@ body {
   font-weight: 500;
 }
 
-.settings-toggle,
-.screens-toggle {
+.settings-toggle {
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -962,7 +962,6 @@ export type UIState = {
   prepPreview?: PreparationPreview;
   screenshotPlan?: ScreenshotPlan | null;
   screenshotSelections?: ScreenshotSelection[];
-  screenshotsEnabled?: boolean;
   showFrameSelections?: boolean;
   previewImages?: ScreenshotPreviewImage[];
   existingImages?: ScreenshotPreviewImage[];

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -207,7 +207,8 @@ func TestPrepareBDMVMultiPlaylistUsesFullScanAndDerivesSummaries(t *testing.T) {
 		playlistSelectionPath: filepath.ToSlash(filepath.Clean(filepath.Join(sourcePath, "BDMV"))),
 	}
 	cfg := config.Config{MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(base, "db.sqlite")}}
-	service := NewService(repo, WithMediaInfoExporter(&stubMediaInfo{}), WithSceneDetector(stubSceneDetector{}), WithConfig(cfg), WithBDInfoService(bdinfo.New(api.NopLogger{})))
+	mediaInfo := &recordingMediaInfo{}
+	service := NewService(repo, WithMediaInfoExporter(mediaInfo), WithSceneDetector(stubSceneDetector{}), WithConfig(cfg), WithBDInfoService(bdinfo.New(api.NopLogger{})))
 
 	originalDiscover := discoverBDMVPlaylists
 	originalParse := parseBDMVPlaylist
@@ -324,8 +325,12 @@ func TestPrepareBDMVMultiPlaylistUsesFullScanAndDerivesSummaries(t *testing.T) {
 	if playlistScans != 0 {
 		t.Fatalf("expected 0 playlist scans, got %d", playlistScans)
 	}
-	if got, want := meta.VideoPath, filepath.Join(bdmvPath, "STREAM", "00003.m2ts"); got != want {
+	wantMainFile := filepath.Join(bdmvPath, "STREAM", "00003.m2ts")
+	if got, want := meta.VideoPath, wantMainFile; got != want {
 		t.Fatalf("expected main file %q, got %q", want, got)
+	}
+	if mediaInfo.request.VideoPath != wantMainFile {
+		t.Fatalf("expected mediainfo target %q, got %q", wantMainFile, mediaInfo.request.VideoPath)
 	}
 	wantFiles := []string{
 		filepath.Join(bdmvPath, "STREAM", "00001.m2ts"),
@@ -856,6 +861,15 @@ type stubRepo struct {
 type stubMediaInfo struct{}
 
 func (stubMediaInfo) Export(context.Context, mediainfo.Request) (mediainfo.Result, error) {
+	return mediainfo.Result{}, nil
+}
+
+type recordingMediaInfo struct {
+	request mediainfo.Request
+}
+
+func (r *recordingMediaInfo) Export(_ context.Context, req mediainfo.Request) (mediainfo.Result, error) {
+	r.request = req
 	return mediainfo.Result{}, nil
 }
 

--- a/internal/services/screenshots/helpers.go
+++ b/internal/services/screenshots/helpers.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -35,6 +36,8 @@ type mediaInfoDoc struct {
 	} `json:"media"`
 }
 
+var durationTokenPattern = regexp.MustCompile(`(?i)(\d+(?:\.\d+)?)\s*(milliseconds?|msecs?|ms|hours?|hrs?|h|minutes?|mins?|min|seconds?|secs?|sec|s)\b`)
+
 func resolveVideoInfo(ctx context.Context, meta api.PreparedMetadata, tmpRoot string) (videoInfo, error) {
 	info := videoInfo{}
 
@@ -55,6 +58,12 @@ func resolveVideoInfo(ctx context.Context, meta api.PreparedMetadata, tmpRoot st
 	}
 
 	if strings.EqualFold(strings.TrimSpace(meta.DiscType), "BDMV") {
+		if filePath, ok, err := selectBDMVFileFromMetadata(ctx, meta); err != nil {
+			return info, err
+		} else if ok {
+			info.SourcePath = filePath
+		}
+
 		bdinfo, err := loadBDInfo(tmpRoot, meta)
 		if err != nil {
 			return info, err
@@ -66,8 +75,11 @@ func resolveVideoInfo(ctx context.Context, meta api.PreparedMetadata, tmpRoot st
 			if info.FrameRate <= 0 {
 				info.FrameRate = parseFPS(bdinfo)
 			}
-			if filePath, err := selectBDMVFile(ctx, meta.SourcePath, bdinfo); err == nil {
-				info.SourcePath = filePath
+			if info.SourcePath == "" {
+				filePath, err := selectBDMVFile(ctx, meta.SourcePath, bdinfo)
+				if err == nil {
+					info.SourcePath = filePath
+				}
 			}
 		}
 	}
@@ -97,6 +109,12 @@ func resolveVideoSource(ctx context.Context, meta api.PreparedMetadata, tmpRoot 
 	}
 
 	if strings.EqualFold(strings.TrimSpace(meta.DiscType), "BDMV") {
+		if filePath, ok, err := selectBDMVFileFromMetadata(ctx, meta); err != nil {
+			return "", err
+		} else if ok {
+			return filePath, nil
+		}
+
 		bdinfo, err := loadBDInfo(tmpRoot, meta)
 		if err != nil {
 			return "", err
@@ -119,6 +137,83 @@ func resolveVideoSource(ctx context.Context, meta api.PreparedMetadata, tmpRoot 
 	}
 
 	return basePath, nil
+}
+
+func selectBDMVFileFromMetadata(ctx context.Context, meta api.PreparedMetadata) (string, bool, error) {
+	if fileName := largestSelectedBDMVPlaylistItem(meta.SelectedBDMVPlaylists); fileName != "" {
+		if videoPath := strings.TrimSpace(meta.VideoPath); videoPath != "" && strings.EqualFold(filepath.Base(videoPath), fileName) {
+			return videoPath, true, nil
+		}
+
+		filePath, err := findBDMVFile(ctx, meta.SourcePath, fileName)
+		if err != nil {
+			return "", false, err
+		}
+		return filePath, true, nil
+	}
+
+	if videoPath := strings.TrimSpace(meta.VideoPath); videoPath != "" {
+		return videoPath, true, nil
+	}
+
+	return "", false, nil
+}
+
+func largestSelectedBDMVPlaylistItem(playlists []api.PlaylistInfo) string {
+	largestFile := ""
+	largestSize := int64(-1)
+	for _, playlist := range playlists {
+		for _, item := range playlist.Items {
+			fileName := strings.TrimSpace(item.File)
+			if fileName == "" || item.Size <= largestSize {
+				continue
+			}
+			largestFile = fileName
+			largestSize = item.Size
+		}
+	}
+	if largestSize <= 0 {
+		return ""
+	}
+	return largestFile
+}
+
+func findBDMVFile(ctx context.Context, root string, fileName string) (string, error) {
+	trimmedRoot := strings.TrimSpace(root)
+	if trimmedRoot == "" {
+		return "", errors.New("screenshots: BDMV root required")
+	}
+	trimmedFile := strings.TrimSpace(fileName)
+	if trimmedFile == "" {
+		return "", errors.New("screenshots: BDMV file required")
+	}
+
+	var found string
+	walkErr := filepath.WalkDir(trimmedRoot, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context canceled: %w", ctx.Err())
+		default:
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if strings.EqualFold(entry.Name(), trimmedFile) {
+			found = path
+			return errFound
+		}
+		return nil
+	})
+	if walkErr != nil && !errors.Is(walkErr, context.Canceled) && !errors.Is(walkErr, errFound) {
+		return "", fmt.Errorf("screenshots: scan BDMV files: %w", walkErr)
+	}
+	if found == "" {
+		return "", errors.New("screenshots: BDMV file not found")
+	}
+	return found, nil
 }
 
 func loadMediaInfoDoc(path string) (mediaInfoDoc, error) {
@@ -254,14 +349,38 @@ func parseDurationValue(value string) float64 {
 	if strings.Contains(trimmed, ":") {
 		return parseDurationSeconds(trimmed)
 	}
+	if seconds := parseDurationTokens(trimmed); seconds > 0 {
+		return seconds
+	}
 	seconds := parseFloat(trimmed)
 	if seconds <= 0 {
 		return 0
 	}
-	if seconds > 10000 {
-		return seconds / 1000
-	}
 	return seconds
+}
+
+func parseDurationTokens(value string) float64 {
+	var total float64
+	for _, match := range durationTokenPattern.FindAllStringSubmatch(value, -1) {
+		if len(match) != 3 {
+			continue
+		}
+		amount := parseFloat(match[1])
+		if amount <= 0 {
+			continue
+		}
+		switch strings.ToLower(match[2]) {
+		case "h", "hr", "hrs", "hour", "hours":
+			total += amount * 3600
+		case "m", "min", "mins", "minute", "minutes":
+			total += amount * 60
+		case "s", "sec", "secs", "second", "seconds":
+			total += amount
+		case "ms", "msec", "msecs", "millisecond", "milliseconds":
+			total += amount / 1000
+		}
+	}
+	return total
 }
 
 func parseDurationSeconds(value string) float64 {
@@ -370,32 +489,7 @@ func selectBDMVFile(ctx context.Context, root string, info *discparse.BDInfo) (s
 		return "", errors.New("screenshots: no bdinfo file selected")
 	}
 
-	var found string
-	walkErr := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("context canceled: %w", ctx.Err())
-		default:
-		}
-		if entry.IsDir() {
-			return nil
-		}
-		if strings.EqualFold(entry.Name(), longest) {
-			found = path
-			return errFound
-		}
-		return nil
-	})
-	if walkErr != nil && !errors.Is(walkErr, context.Canceled) && !errors.Is(walkErr, errFound) {
-		return "", fmt.Errorf("screenshots: scan bdinfo files: %w", walkErr)
-	}
-	if found == "" {
-		return "", errors.New("screenshots: bdinfo file not found")
-	}
-	return found, nil
+	return findBDMVFile(ctx, root, longest)
 }
 
 func selectDVDVOB(ctx context.Context, root string) (string, error) {

--- a/internal/services/screenshots/helpers_test.go
+++ b/internal/services/screenshots/helpers_test.go
@@ -4,7 +4,10 @@
 package screenshots
 
 import (
+	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/autobrr/upbrr/pkg/api"
@@ -53,6 +56,127 @@ func TestBuildManualFrameSelections(t *testing.T) {
 	}
 	if selections[1].TimestampSeconds != 20 {
 		t.Fatalf("expected second timestamp 20, got %f", selections[1].TimestampSeconds)
+	}
+}
+
+func TestParseDurationValueKeepsLargeMediaInfoSeconds(t *testing.T) {
+	got := parseDurationValue("10571.090286852")
+	if got < 10571.09 || got > 10571.10 {
+		t.Fatalf("expected MediaInfo seconds to stay near 10571.09, got %f", got)
+	}
+}
+
+func TestParseDurationValueParsesMediaInfoText(t *testing.T) {
+	got := parseDurationValue("2 h 56 min 11 s")
+	want := 10571.0
+	if got != want {
+		t.Fatalf("expected %f seconds, got %f", want, got)
+	}
+}
+
+func TestBuildScreenshotSelectionsUsesLongMediaInfoDuration(t *testing.T) {
+	duration := parseDurationValue("10571.090286852")
+	selections := buildScreenshotSelections(5, duration, 23.976, api.PreparedMetadata{})
+	if len(selections) != 5 {
+		t.Fatalf("expected 5 selections, got %d", len(selections))
+	}
+	if selections[0].Frame <= 300 {
+		t.Fatalf("expected first frame above 300 for long runtime, got %#v", selections[0])
+	}
+}
+
+func TestFilterScreenshotsMatchingSelectionsRejectsStaleTimestamps(t *testing.T) {
+	selections := []api.ScreenshotSelection{
+		{Index: 0, TimestampSeconds: 528.5, Frame: 12671},
+		{Index: 1, TimestampSeconds: 2322.0, Frame: 55671},
+	}
+	images := []api.ScreenshotImage{
+		{Index: 0, TimestampSeconds: 0.5, Path: "stale.png"},
+		{Index: 1, TimestampSeconds: 2322.1, Path: "current.png"},
+	}
+
+	filtered := filterScreenshotsMatchingSelections(images, selections, 23.976)
+	if len(filtered) != 1 {
+		t.Fatalf("expected only one matching screenshot, got %#v", filtered)
+	}
+	if filtered[0].Path != "current.png" {
+		t.Fatalf("expected current screenshot, got %#v", filtered[0])
+	}
+}
+
+func TestResolveVideoInfoPrefersLargestSelectedBDMVPlaylistFile(t *testing.T) {
+	root := t.TempDir()
+	streamDir := filepath.Join(root, "BDMV", "STREAM")
+	if err := os.MkdirAll(streamDir, 0o700); err != nil {
+		t.Fatalf("mkdir stream dir: %v", err)
+	}
+	small := filepath.Join(streamDir, "00001.m2ts")
+	large := filepath.Join(streamDir, "00002.m2ts")
+	for _, path := range []string{small, large} {
+		if err := os.WriteFile(path, []byte("m2ts"), 0o600); err != nil {
+			t.Fatalf("write stream file: %v", err)
+		}
+	}
+
+	meta := api.PreparedMetadata{
+		SourcePath: root,
+		DiscType:   "BDMV",
+		VideoPath:  small,
+		SelectedBDMVPlaylists: []api.PlaylistInfo{
+			{
+				File: "00001.MPLS",
+				Items: []api.PlaylistItem{
+					{File: "00001.m2ts", Size: 100},
+					{File: "00002.m2ts", Size: 200},
+				},
+			},
+		},
+	}
+
+	info, err := resolveVideoInfo(context.Background(), meta, "")
+	if err != nil {
+		t.Fatalf("resolve video info: %v", err)
+	}
+	if info.SourcePath != large {
+		t.Fatalf("expected largest playlist m2ts %q, got %q", large, info.SourcePath)
+	}
+}
+
+func TestResolveVideoSourcePrefersLargestSelectedBDMVPlaylistFile(t *testing.T) {
+	root := t.TempDir()
+	streamDir := filepath.Join(root, "BDMV", "STREAM")
+	if err := os.MkdirAll(streamDir, 0o700); err != nil {
+		t.Fatalf("mkdir stream dir: %v", err)
+	}
+	small := filepath.Join(streamDir, "00001.m2ts")
+	large := filepath.Join(streamDir, "00002.m2ts")
+	for _, path := range []string{small, large} {
+		if err := os.WriteFile(path, []byte("m2ts"), 0o600); err != nil {
+			t.Fatalf("write stream file: %v", err)
+		}
+	}
+
+	meta := api.PreparedMetadata{
+		SourcePath: root,
+		DiscType:   "BDMV",
+		VideoPath:  small,
+		SelectedBDMVPlaylists: []api.PlaylistInfo{
+			{
+				File: "00001.MPLS",
+				Items: []api.PlaylistItem{
+					{File: "00001.m2ts", Size: 100},
+					{File: "00002.m2ts", Size: 200},
+				},
+			},
+		},
+	}
+
+	got, err := resolveVideoSource(context.Background(), meta, "")
+	if err != nil {
+		t.Fatalf("resolve video source: %v", err)
+	}
+	if got != large {
+		t.Fatalf("expected largest playlist m2ts %q, got %q", large, got)
 	}
 }
 

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -104,8 +104,14 @@ func (s *Service) Plan(ctx context.Context, meta api.PreparedMetadata, count int
 		return api.ScreenshotPlan{}, fmt.Errorf("screenshots: %w", err)
 	}
 
+	baselineSelections := manualSelections
+	if len(baselineSelections) == 0 {
+		baselineSelections = buildScreenshotSelections(total, plan.DurationSeconds, plan.FrameRate, meta)
+	}
+	base := screenshotBaseName(meta)
+	baselineByIndex := screenshotSelectionsByIndex(baselineSelections)
+
 	// Load existing screenshots from database that still exist on disk.
-	var existingTimestamps []float64
 	var missingIndexTimestamps []float64
 	var existingIndices map[int]struct{}
 	if s.repo != nil {
@@ -113,7 +119,6 @@ func (s *Service) Plan(ctx context.Context, meta api.PreparedMetadata, count int
 		if err != nil {
 			s.logger.Debugf("screenshots: failed to load existing screenshots: %v", err)
 		} else {
-			existingTimestamps = make([]float64, 0, len(dbScreenshots))
 			existingIndices = make(map[int]struct{}, len(dbScreenshots))
 			kept := 0
 			for _, shot := range dbScreenshots {
@@ -124,11 +129,16 @@ func (s *Service) Plan(ctx context.Context, meta api.PreparedMetadata, count int
 				if info, statErr := os.Stat(pathValue); statErr != nil || info.IsDir() {
 					continue
 				}
-				existingTimestamps = append(existingTimestamps[:len(existingTimestamps):len(existingTimestamps)], shot.Timestamp)
-				if index, ok := parseScreenshotIndexStrict(pathValue, screenshotBaseName(meta)); ok {
-					existingIndices[index] = struct{}{}
+				timestamp := shot.Timestamp
+				if timestamp <= 0 {
+					timestamp = parseScreenshotTimestamp(pathValue, base)
+				}
+				if index, ok := parseScreenshotIndexStrict(pathValue, base); ok {
+					if selection, found := baselineByIndex[index]; found && screenshotTimestampMatchesSelection(timestamp, selection, plan.FrameRate) {
+						existingIndices[index] = struct{}{}
+					}
 				} else {
-					missingIndexTimestamps = append(missingIndexTimestamps, shot.Timestamp)
+					missingIndexTimestamps = append(missingIndexTimestamps, timestamp)
 				}
 				kept++
 			}
@@ -136,10 +146,6 @@ func (s *Service) Plan(ctx context.Context, meta api.PreparedMetadata, count int
 		}
 	}
 
-	baselineSelections := manualSelections
-	if len(baselineSelections) == 0 {
-		baselineSelections = buildScreenshotSelections(total, plan.DurationSeconds, plan.FrameRate, meta)
-	}
 	if existingIndices == nil {
 		existingIndices = make(map[int]struct{})
 	}
@@ -159,7 +165,9 @@ func (s *Service) Plan(ctx context.Context, meta api.PreparedMetadata, count int
 				}
 			}
 			if bestIndex >= 0 {
-				existingIndices[bestIndex] = struct{}{}
+				if selection, found := baselineByIndex[bestIndex]; found && screenshotTimestampMatchesSelection(existingTs, selection, plan.FrameRate) {
+					existingIndices[bestIndex] = struct{}{}
+				}
 			}
 		}
 	}
@@ -177,14 +185,13 @@ func (s *Service) Plan(ctx context.Context, meta api.PreparedMetadata, count int
 
 	plan.SuggestedSelections = suggestions
 
-	base := screenshotBaseName(meta)
-	plan.ExistingScreenshots = listExistingScreens(tmpDir, base)
+	plan.ExistingScreenshots = filterScreenshotsMatchingSelections(listExistingScreens(tmpDir, base), baselineSelections, plan.FrameRate)
 	plan.TrackerImageLinks = buildTrackerImageLinks(meta, tmpDir)
 	plan.ExistingTrackerScreenshots = filterUnlinkedTrackerScreens(
 		listTrackerScreens(tmpDir, base),
 		plan.TrackerImageLinks,
 	)
-	plan.FinalSelections = s.loadFinalSelections(ctx, meta, tmpDir)
+	plan.FinalSelections = filterScreenshotsMatchingSelections(s.loadFinalSelections(ctx, meta, tmpDir), baselineSelections, plan.FrameRate)
 
 	// Automatically include tracker images in final selections
 	plan.FinalSelections = mergeTrackerImagesIntoFinalSelections(plan.FinalSelections, plan.TrackerImageLinks)
@@ -683,6 +690,45 @@ func selectionTimestamp(selection api.ScreenshotSelection, frameRate float64) fl
 		ts = float64(selection.Frame) / frameRate
 	}
 	return ts
+}
+
+func screenshotSelectionsByIndex(selections []api.ScreenshotSelection) map[int]api.ScreenshotSelection {
+	byIndex := make(map[int]api.ScreenshotSelection, len(selections))
+	for _, selection := range selections {
+		byIndex[selection.Index] = selection
+	}
+	return byIndex
+}
+
+func screenshotTimestampMatchesSelection(timestamp float64, selection api.ScreenshotSelection, frameRate float64) bool {
+	expected := selectionTimestamp(selection, frameRate)
+	if timestamp <= 0 || expected <= 0 {
+		return false
+	}
+	tolerance := 0.5
+	if frameRate > 0 {
+		frameTolerance := 1 / frameRate
+		if frameTolerance > tolerance {
+			tolerance = frameTolerance
+		}
+	}
+	return abs(timestamp-expected) <= tolerance
+}
+
+func filterScreenshotsMatchingSelections(images []api.ScreenshotImage, selections []api.ScreenshotSelection, frameRate float64) []api.ScreenshotImage {
+	if len(images) == 0 || len(selections) == 0 {
+		return nil
+	}
+	byIndex := screenshotSelectionsByIndex(selections)
+	filtered := make([]api.ScreenshotImage, 0, len(images))
+	for _, image := range images {
+		selection, ok := byIndex[image.Index]
+		if !ok || !screenshotTimestampMatchesSelection(image.TimestampSeconds, selection, frameRate) {
+			continue
+		}
+		filtered = append(filtered, image)
+	}
+	return filtered
 }
 
 func listExistingScreens(tmpDir, base string) []api.ScreenshotImage {


### PR DESCRIPTION
Use selected playlist m2ts, keep MediaInfo durations in seconds, ignore stale screenshots when plans change, and remove capture toggle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Removed the "Enable capture" toggle from screenshot settings.

* **Improvements**
  * Enhanced screenshot selection logic with more precise timestamp matching and index validation.
  * Improved duration parsing for video metadata.
  * Better handling of BDMV playlist file selection.

* **Tests**
  * Added comprehensive tests for screenshot selection, timestamp validation, and video file handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/upbrr/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->