### PR TITLE
fix(metadata): refresh client tracker data

### DIFF
--- a/internal/clients/search.go
+++ b/internal/clients/search.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/autobrr/upbrr/internal/config"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
@@ -48,6 +49,10 @@ var (
 	unit3dTrackerIDPattern = regexp.MustCompile(`/(\d+)`)
 	trackerIDPatterns      = buildTrackerIDPatterns()
 )
+
+var trackerIDCommentAliases = map[string][]string{
+	"rf": {"https://reelflix.xyz"},
+}
 
 var trackerURLPatterns = map[string][]string{
 	"acm":    {"https://eiga.moi"},
@@ -133,6 +138,7 @@ func buildTrackerIDPatterns() map[string]trackerPattern {
 		"btn": {url: "https://broadcasthe.net", pattern: regexp.MustCompile(`id=(\d+)`)},
 		"bhd": {url: "https://beyond-hd.me", pattern: regexp.MustCompile(`details/(\d+)`)},
 		"ptp": {url: "passthepopcorn.me", pattern: regexp.MustCompile(`torrentid=(\d+)`)},
+		"rtf": {url: "https://retroflix.club", pattern: regexp.MustCompile(`(?i)retroflix\.club/browse/t/(\d+)`)},
 	}
 
 	for _, tracker := range trackers.Unit3DTrackers() {
@@ -145,6 +151,10 @@ func buildTrackerIDPatterns() map[string]trackerPattern {
 			continue
 		}
 		patterns[key] = trackerPattern{url: strings.ToLower(baseURL), pattern: unit3dTrackerIDPattern}
+	}
+	if pattern, ok := patterns["rf"]; ok {
+		pattern.pattern = regexp.MustCompile(`(?i)reelflix\.(?:cc|xyz)/torrents/(\d+)`)
+		patterns["rf"] = pattern
 	}
 
 	return patterns
@@ -410,7 +420,7 @@ func (s *Service) searchQbitClient(ctx context.Context, name string, clientCfg c
 		default:
 		}
 
-		if !torrentNameMatches(torrent.Name, meta) {
+		if !torrentMatchesMeta(torrent, meta) {
 			continue
 		}
 		nameMatched++
@@ -516,7 +526,26 @@ func buildSearchTerm(meta api.PreparedMetadata) string {
 	}
 	search := strings.ReplaceAll(base, "[", ".")
 	search = strings.ReplaceAll(search, "]", ".")
-	return search
+	return sanitizeSearchTerm(search)
+}
+
+func sanitizeSearchTerm(value string) string {
+	var builder strings.Builder
+	for _, r := range value {
+		if unicode.IsSymbol(r) {
+			continue
+		}
+		builder.WriteRune(r)
+	}
+	return strings.TrimSpace(builder.String())
+}
+
+func torrentMatchesMeta(torrent qbittorrent.Torrent, meta api.PreparedMetadata) bool {
+	if torrentNameMatches(torrent.Name, meta) {
+		return true
+	}
+	contentBase := pathutil.Base(torrent.ContentPath)
+	return contentBase != "" && torrentNameMatches(contentBase, meta)
 }
 
 func torrentNameMatches(name string, meta api.PreparedMetadata) bool {
@@ -526,9 +555,28 @@ func torrentNameMatches(name string, meta api.PreparedMetadata) bool {
 	base := pathutil.Base(meta.SourcePath)
 	if meta.DiscType == "" && len(meta.FileList) == 1 {
 		fileBase := pathutil.Base(meta.FileList[0])
-		return strings.EqualFold(name, fileBase) || strings.EqualFold(name, base)
+		return torrentNameEquals(name, fileBase) || torrentNameEquals(name, base)
 	}
-	return strings.EqualFold(name, base)
+	return torrentNameEquals(name, base)
+}
+
+func torrentNameEquals(left string, right string) bool {
+	if strings.EqualFold(strings.TrimSpace(left), strings.TrimSpace(right)) {
+		return true
+	}
+	leftCanonical := canonicalTorrentName(left)
+	rightCanonical := canonicalTorrentName(right)
+	return leftCanonical != "" && rightCanonical != "" && leftCanonical == rightCanonical
+}
+
+func canonicalTorrentName(value string) string {
+	var builder strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(value)) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			builder.WriteRune(r)
+		}
+	}
+	return builder.String()
 }
 
 func searchProxyTorrents(ctx context.Context, client *http.Client, proxyBase, searchTerm string) ([]qbittorrent.Torrent, error) {
@@ -688,12 +736,12 @@ func extractTrackerMatches(comment string, trackerURLs []string, hasWorkingTrack
 	trackerFound := false
 	lowerComment := strings.ToLower(comment)
 
-	for _, trackerID := range priority {
+	for _, trackerID := range trackerIDExtractionOrder(priority) {
 		pattern, ok := trackerIDPatterns[trackerID]
 		if !ok {
 			continue
 		}
-		if !hasWorkingTracker || !strings.Contains(lowerComment, strings.ToLower(pattern.url)) {
+		if !hasWorkingTracker || !trackerPatternMatchesComment(trackerID, lowerComment, pattern) {
 			continue
 		}
 		match := pattern.pattern.FindStringSubmatch(comment)
@@ -715,6 +763,48 @@ func extractTrackerMatches(comment string, trackerURLs []string, hasWorkingTrack
 	}
 
 	return matches, trackerFound
+}
+
+func trackerIDExtractionOrder(priority []string) []string {
+	seen := make(map[string]struct{}, len(priority)+len(trackerIDPatterns))
+	ordered := make([]string, 0, len(priority)+len(trackerIDPatterns))
+	for _, trackerID := range priority {
+		key := strings.ToLower(strings.TrimSpace(trackerID))
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		ordered = append(ordered, key)
+	}
+
+	keys := make([]string, 0, len(trackerIDPatterns))
+	for key := range trackerIDPatterns {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		ordered = append(ordered, key)
+	}
+	return ordered
+}
+
+func trackerPatternMatchesComment(trackerID string, lowerComment string, pattern trackerPattern) bool {
+	if strings.Contains(lowerComment, strings.ToLower(pattern.url)) {
+		return true
+	}
+	for _, alias := range trackerIDCommentAliases[strings.ToLower(strings.TrimSpace(trackerID))] {
+		if strings.Contains(lowerComment, strings.ToLower(strings.TrimSpace(alias))) {
+			return true
+		}
+	}
+	return false
 }
 
 func matchTrackerURLs(trackerURLs []string) []string {
@@ -1267,7 +1357,7 @@ func validateTorrentPaths(meta api.PreparedMetadata, info metainfo.Info) (bool, 
 	if meta.DiscType != "" {
 		common := commonPath(torrentFiles)
 		base := pathutil.Base(metaPath)
-		if base != "" && strings.Contains(strings.ToLower(common), strings.ToLower(base)) {
+		if torrentPathContainsSourceBase(common, base) {
 			return true, false
 		}
 		return false, false
@@ -1292,6 +1382,19 @@ func validateTorrentPaths(meta api.PreparedMetadata, info metainfo.Info) (bool, 
 	}
 
 	return false, false
+}
+
+func torrentPathContainsSourceBase(path string, base string) bool {
+	trimmedBase := strings.TrimSpace(base)
+	if trimmedBase == "" {
+		return false
+	}
+	if strings.Contains(strings.ToLower(path), strings.ToLower(trimmedBase)) {
+		return true
+	}
+	canonicalPath := canonicalTorrentName(path)
+	canonicalBase := canonicalTorrentName(trimmedBase)
+	return canonicalPath != "" && canonicalBase != "" && strings.Contains(canonicalPath, canonicalBase)
 }
 
 func buildTorrentFileList(info metainfo.Info) []string {

--- a/internal/clients/search_test.go
+++ b/internal/clients/search_test.go
@@ -147,6 +147,86 @@ func TestSearchPathedTorrentsProxyPrefersPieceSize(t *testing.T) {
 	}
 }
 
+func TestSearchPathedTorrentsProxyStripsSymbolsFromSearch(t *testing.T) {
+	t.Parallel()
+
+	searchQueries := make([]string, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/torrents/search":
+			search := r.URL.Query().Get("search")
+			searchQueries = append(searchQueries, search)
+			if strings.Contains(search, "\u2122") {
+				_ = json.NewEncoder(w).Encode([]qbittorrent.Torrent{})
+				return
+			}
+			items := []qbittorrent.Torrent{
+				{
+					Hash:        strings.Repeat("a", 40),
+					Name:        "Fixture Title 2024 2160p AUS UHD Blu-ray DV HDR HEVC DTS-HD MA 5.1-FixtureGroup",
+					Tracker:     "https://tracker.beyond-hd.me/announce/redacted",
+					Comment:     "https://beyond-hd.me/details/10001",
+					Trackers:    []qbittorrent.TorrentTracker{{Url: "https://tracker.beyond-hd.me/announce/redacted", Status: qbittorrent.TrackerStatusOK}},
+					NumComplete: 2,
+				},
+				{
+					Hash:        strings.Repeat("b", 40),
+					Name:        "Fixture Title 2024 2160p AUS UHD Blu-ray DV HDR HEVC DTS-HD MA 5.1-FixtureGroup",
+					Tracker:     "https://passthepopcorn.me/announce/redacted",
+					Comment:     "https://passthepopcorn.me/torrents.php?id=100&torrentid=10002",
+					Trackers:    []qbittorrent.TorrentTracker{{Url: "https://passthepopcorn.me/announce/redacted", Status: qbittorrent.TrackerStatusOK}},
+					NumComplete: 1,
+				},
+			}
+			_ = json.NewEncoder(w).Encode(items)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	cfg := config.Config{
+		MainSettings: config.MainSettingsConfig{TMDBAPI: "x", DBPath: t.TempDir()},
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "qbit",
+			SearchClients: config.CSVList{"qbit"},
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:        "qui",
+				QuiProxyURL: server.URL,
+			},
+		},
+	}
+
+	svc := NewService(cfg, api.NopLogger{})
+	result, err := svc.SearchPathedTorrents(context.Background(), api.PreparedMetadata{
+		SourcePath: `D:\Movies\Fixture Title 2024 2160p AUS UHD Blu-ray DV HDR HEVC DTS-HD MA 5.1-FixtureGroup` + "\u2122",
+		DiscType:   "BDMV",
+	})
+	if err != nil {
+		t.Fatalf("search pathed torrents: %v", err)
+	}
+	if len(searchQueries) != 1 {
+		t.Fatalf("expected one proxy search, got %d", len(searchQueries))
+	}
+	if strings.Contains(searchQueries[0], "\u2122") {
+		t.Fatalf("expected proxy search term without trademark symbol, got %q", searchQueries[0])
+	}
+	if result.TrackerIDs["bhd"] != "10001" {
+		t.Fatalf("expected BHD tracker id, got %q", result.TrackerIDs["bhd"])
+	}
+	if result.TrackerIDs["ptp"] != "10002" {
+		t.Fatalf("expected PTP tracker id, got %q", result.TrackerIDs["ptp"])
+	}
+	if !containsString(result.MatchedTrackers, "BHD") {
+		t.Fatalf("expected BHD in matched trackers, got %v", result.MatchedTrackers)
+	}
+	if !containsString(result.MatchedTrackers, "PTP") {
+		t.Fatalf("expected PTP in matched trackers, got %v", result.MatchedTrackers)
+	}
+}
+
 func TestMatchTrackerURLsMatchesBTNLandOfTVAnnounce(t *testing.T) {
 	t.Parallel()
 
@@ -162,6 +242,115 @@ func TestEnsureMatchedTrackersForKnownIDsAddsBTN(t *testing.T) {
 	matched := ensureMatchedTrackersForKnownIDs(nil, map[string]string{"btn": "2202392"})
 	if !containsString(matched, "BTN") {
 		t.Fatalf("expected BTN in matched trackers, got %v", matched)
+	}
+}
+
+func TestExtractTrackerMatchesHandlesReelFlixAliasComment(t *testing.T) {
+	t.Parallel()
+
+	matches, found := extractTrackerMatches(
+		"https://reelflix.xyz/torrents/10003",
+		[]string{"https://reelflix.cc/announce/redacted"},
+		true,
+		[]string{"rf"},
+	)
+
+	if !found {
+		t.Fatalf("expected RF tracker match")
+	}
+	if len(matches) != 1 || matches[0].ID != "rf" || matches[0].TrackerID != "10003" {
+		t.Fatalf("expected RF tracker id 10003, got %#v", matches)
+	}
+}
+
+func TestExtractTrackerMatchesHandlesRetroFlixBrowseComment(t *testing.T) {
+	t.Parallel()
+
+	matches, found := extractTrackerMatches(
+		"https://retroflix.club/browse/t/10004",
+		[]string{"http://peer.retroflix.club/announce.php?passkey=redacted"},
+		true,
+		[]string{"rtf"},
+	)
+
+	if !found {
+		t.Fatalf("expected RTF tracker match")
+	}
+	if len(matches) != 1 || matches[0].ID != "rtf" || matches[0].TrackerID != "10004" {
+		t.Fatalf("expected RTF tracker id 10004, got %#v", matches)
+	}
+}
+
+func TestExtractTrackerMatchesIncludesPatternsOutsidePriority(t *testing.T) {
+	t.Parallel()
+
+	matches, found := extractTrackerMatches(
+		"https://retroflix.club/browse/t/10004",
+		[]string{"http://peer.retroflix.club/announce.php?passkey=redacted"},
+		true,
+		trackers.TrackerPriority(),
+	)
+
+	if !found {
+		t.Fatalf("expected RTF tracker match")
+	}
+	if len(matches) != 1 || matches[0].ID != "rtf" || matches[0].TrackerID != "10004" {
+		t.Fatalf("expected RTF tracker id 10004, got %#v", matches)
+	}
+}
+
+func TestTorrentMatchesMetaAllowsSymbolDrift(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{
+		SourcePath: `D:\Movies\Fixture Title 2024 2160p AUS UHD Blu-ray DV HDR HEVC DTS-HD MA 5.1-FixtureGroup` + "\u2122",
+		DiscType:   "BDMV",
+	}
+	torrent := qbittorrent.Torrent{
+		Name: "Fixture Title 2024 2160p AUS UHD Blu-ray DV HDR HEVC DTS-HD MA 5.1-FixtureGroup",
+	}
+
+	if !torrentMatchesMeta(torrent, meta) {
+		t.Fatalf("expected trademark-only name drift to match")
+	}
+}
+
+func TestTorrentMatchesMetaAllowsSeparatorDrift(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{
+		SourcePath: `/tmp/Movie.Title.2024`,
+		FileList:   []string{`/tmp/Movie.Title.2024.mkv`},
+	}
+	torrent := qbittorrent.Torrent{Name: "Movie Title 2024.mkv"}
+
+	if !torrentMatchesMeta(torrent, meta) {
+		t.Fatalf("expected separator-only file name drift to match")
+	}
+}
+
+func TestTorrentMatchesMetaRejectsExtraTokens(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{SourcePath: `/tmp/Movie.Title.2024`}
+	torrent := qbittorrent.Torrent{Name: "Movie Title 2024 Remux"}
+
+	if torrentMatchesMeta(torrent, meta) {
+		t.Fatalf("expected extra torrent name tokens to be rejected")
+	}
+}
+
+func TestTorrentMatchesMetaUsesContentPathBasename(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{SourcePath: `/tmp/Movie.Title.2024`}
+	torrent := qbittorrent.Torrent{
+		Name:        "Tracker renamed folder",
+		ContentPath: `/downloads/Movie Title 2024`,
+	}
+
+	if !torrentMatchesMeta(torrent, meta) {
+		t.Fatalf("expected content path basename to match")
 	}
 }
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -436,23 +436,21 @@ func (c *Core) CheckDupes(ctx context.Context, req api.Request) (api.DupeCheckSu
 			return fmt.Errorf("core: %w", searchErr)
 		}
 
+		if applyTrackerData {
+			resetPreparedClientData(&meta, singleReq)
+		}
 		meta.FoundTrackerMatch = meta.FoundTrackerMatch || searchResult.FoundTrackerMatch
 		meta.MatchedTrackers = mergeTrackerRemovals(meta.MatchedTrackers, searchResult.MatchedTrackers)
 		meta.TrackersRemove = mergeTrackerRemovals(meta.TrackersRemove, searchResult.MatchedTrackers)
+		markTrackerDataMatches(&meta, searchResult.MatchedTrackers)
 
 		if !applyTrackerData {
 			return nil
 		}
 
-		if searchResult.InfoHash == "" && len(searchResult.TorrentComments) == 0 {
+		if !applyPathedTorrentData(&meta, searchResult) {
 			return nil
 		}
-		meta.InfoHash = searchResult.InfoHash
-		meta.ClientTorrentPath = searchResult.TorrentPath
-		meta.TrackerIDs = searchResult.TrackerIDs
-		meta.TorrentComments = searchResult.TorrentComments
-		meta.PieceSizeConstraint = searchResult.PieceSizeConstraint
-		meta.FoundPreferredPiece = searchResult.FoundPreferredPiece
 		return nil
 	}
 
@@ -463,18 +461,18 @@ func (c *Core) CheckDupes(ctx context.Context, req api.Request) (api.DupeCheckSu
 			return api.DupeCheckSummary{}, err
 		}
 	case storedApplied:
-		c.logger.Debugf("core: running pathed search for tracker presence with stored tracker data present for %s", meta.SourcePath)
-		if err := runPathedSearch(false); err != nil {
+		c.logger.Debugf("core: running pathed search with stored tracker data present for %s", meta.SourcePath)
+		if err := runPathedSearch(true); err != nil {
 			return api.DupeCheckSummary{}, err
 		}
 	case meta.StoredDataFresh:
 		if meta.InfoHash == "" && meta.StoredInfoHash != "" {
 			meta.InfoHash = meta.StoredInfoHash
-			c.logger.Debugf("core: using stored infohash before pathed tracker-presence search for %s", meta.SourcePath)
+			c.logger.Debugf("core: using stored infohash before pathed search for %s", meta.SourcePath)
 		} else {
-			c.logger.Debugf("core: running pathed search for tracker presence with fresh stored metadata snapshot for %s", meta.SourcePath)
+			c.logger.Debugf("core: running pathed search with fresh stored metadata snapshot for %s", meta.SourcePath)
 		}
-		if err := runPathedSearch(false); err != nil {
+		if err := runPathedSearch(true); err != nil {
 			return api.DupeCheckSummary{}, err
 		}
 	default:
@@ -1668,20 +1666,18 @@ func (c *Core) FetchMetadataPreview(ctx context.Context, req api.Request) (api.M
 		if searchErr != nil {
 			return fmt.Errorf("core: %w", searchErr)
 		}
+		if applyTrackerData {
+			resetPreparedClientData(&meta, singleReq)
+		}
 		meta.FoundTrackerMatch = meta.FoundTrackerMatch || searchResult.FoundTrackerMatch
 		meta.MatchedTrackers = mergeTrackerRemovals(meta.MatchedTrackers, searchResult.MatchedTrackers)
 		meta.TrackersRemove = mergeTrackerRemovals(meta.TrackersRemove, searchResult.MatchedTrackers)
+		markTrackerDataMatches(&meta, searchResult.MatchedTrackers)
 		if !applyTrackerData {
 			c.logger.Debugf("core: pathed search merged tracker presence only for %s", meta.SourcePath)
 			return nil
 		}
-		if searchResult.InfoHash != "" || len(searchResult.TorrentComments) > 0 {
-			meta.InfoHash = searchResult.InfoHash
-			meta.ClientTorrentPath = searchResult.TorrentPath
-			meta.TrackerIDs = searchResult.TrackerIDs
-			meta.TorrentComments = searchResult.TorrentComments
-			meta.PieceSizeConstraint = searchResult.PieceSizeConstraint
-			meta.FoundPreferredPiece = searchResult.FoundPreferredPiece
+		if applyPathedTorrentData(&meta, searchResult) {
 			c.logger.Debugf("core: pathed torrents resolved for %s", meta.SourcePath)
 		} else {
 			c.logger.Debugf("core: pathed search returned no matches for %s", meta.SourcePath)
@@ -1696,18 +1692,18 @@ func (c *Core) FetchMetadataPreview(ctx context.Context, req api.Request) (api.M
 			return api.MetadataPreview{}, err
 		}
 	case storedApplied:
-		c.logger.Debugf("core: running pathed search for tracker presence with stored tracker data present for %s", meta.SourcePath)
-		if err := runPathedSearch(false); err != nil {
+		c.logger.Debugf("core: running pathed search with stored tracker data present for %s", meta.SourcePath)
+		if err := runPathedSearch(true); err != nil {
 			return api.MetadataPreview{}, err
 		}
 	case meta.StoredDataFresh:
 		if meta.InfoHash == "" && meta.StoredInfoHash != "" {
 			meta.InfoHash = meta.StoredInfoHash
-			c.logger.Debugf("core: using stored infohash before pathed tracker-presence search for %s", meta.SourcePath)
+			c.logger.Debugf("core: using stored infohash before pathed search for %s", meta.SourcePath)
 		} else {
-			c.logger.Debugf("core: running pathed search for tracker presence with fresh stored metadata snapshot for %s", meta.SourcePath)
+			c.logger.Debugf("core: running pathed search with fresh stored metadata snapshot for %s", meta.SourcePath)
 		}
-		if err := runPathedSearch(false); err != nil {
+		if err := runPathedSearch(true); err != nil {
 			return api.MetadataPreview{}, err
 		}
 	case meta.InfoHash != "":
@@ -1830,7 +1826,7 @@ func (c *Core) FetchPreparationPreview(ctx context.Context, req api.Request) (ap
 		if cached, ok, err := c.resolveGUICachedPreparedMeta(ctx, req, uniquePaths[0]); err != nil {
 			return api.PreparationPreview{}, err
 		} else if ok {
-			resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, req.TrackersRemove, c.logger)
+			resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, cached.TrackersRemove, c.logger)
 			c.logger.Debugf("core: preparation resolved trackers %v", resolvedTrackers)
 			return wrapCoreResult(c.services.Trackers.BuildPreparation(ctx, cached, resolvedTrackers))
 		}
@@ -1856,7 +1852,7 @@ func (c *Core) FetchPreparationPreview(ctx context.Context, req api.Request) (ap
 		c.storeDupeCache(meta.SourcePath, overrideSignature(meta.ExternalIDOverrides, meta.ReleaseNameOverrides, meta.MetadataOverrides, meta.TrackerConfigOverrides, meta.TrackerSiteOverrides, meta.ClientOverrides, meta.TorrentOverrides, meta.ImageHostOverrides, meta.ScreenshotOverrides), meta)
 	}
 
-	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, req.TrackersRemove, c.logger)
+	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, meta.TrackersRemove, c.logger)
 	c.logger.Debugf("core: preparation resolved trackers %v", resolvedTrackers)
 	return wrapCoreResult(c.services.Trackers.BuildPreparation(ctx, meta, resolvedTrackers))
 }
@@ -1948,7 +1944,7 @@ func (c *Core) FetchTrackerDryRunPreview(ctx context.Context, req api.Request) (
 	}
 	meta.TorrentPath = torrent.Path
 
-	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, req.TrackersRemove, c.logger)
+	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, meta.TrackersRemove, c.logger)
 	entries, err := c.services.Trackers.BuildUploadDryRun(ctx, meta, resolvedTrackers)
 	if err != nil {
 		return api.TrackerDryRunPreview{}, fmt.Errorf("core: %w", err)
@@ -2069,7 +2065,7 @@ func (c *Core) FetchDescriptionBuilderPreview(ctx context.Context, req api.Reque
 		return api.DescriptionBuilderPreview{}, err
 	}
 
-	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, req.TrackersRemove, c.logger)
+	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, meta.TrackersRemove, c.logger)
 	prep, err := c.services.Trackers.BuildPreparation(ctx, meta, resolvedTrackers)
 	if err != nil {
 		c.logger.Errorf("core: description builder preparation failed source=%s: %v", meta.SourcePath, err)
@@ -2316,7 +2312,7 @@ func (c *Core) FetchDescriptionBuilderGroupPreview(ctx context.Context, req api.
 
 	resolvedTrackers := req.Trackers
 	if len(resolvedTrackers) == 0 {
-		resolvedTrackers = trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, req.TrackersRemove, c.logger)
+		resolvedTrackers = trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, meta.TrackersRemove, c.logger)
 	}
 	prep, err := c.services.Trackers.BuildPreparation(ctx, meta, resolvedTrackers)
 	if err != nil {
@@ -2560,6 +2556,79 @@ func (c *Core) applyStoredTrackerData(ctx context.Context, meta *api.PreparedMet
 	}
 
 	return true, nil
+}
+
+func resetPreparedClientData(meta *api.PreparedMetadata, req api.Request) {
+	if meta == nil {
+		return
+	}
+	meta.FoundTrackerMatch = false
+	meta.MatchedTrackers = nil
+	meta.TrackersRemove = mergeTrackerRemovals(nil, req.TrackersRemove)
+	meta.TorrentComments = nil
+	meta.ClientTorrentPath = ""
+	meta.PieceSizeConstraint = ""
+	meta.FoundPreferredPiece = ""
+	meta.InfoHash = cachedInfoHash(*meta)
+	meta.TrackerIDs = cloneStringMap(req.TrackerIDOverrides)
+	applyTorrentOverridesToPreparedMeta(meta)
+	for idx := range meta.TrackerData {
+		meta.TrackerData[idx].Matched = false
+	}
+}
+
+func cachedInfoHash(meta api.PreparedMetadata) string {
+	if value := strings.TrimSpace(meta.StoredInfoHash); value != "" {
+		return value
+	}
+	for _, record := range meta.TrackerData {
+		if value := strings.TrimSpace(record.InfoHash); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func markTrackerDataMatches(meta *api.PreparedMetadata, matchedTrackers []string) {
+	if meta == nil || len(matchedTrackers) == 0 || len(meta.TrackerData) == 0 {
+		return
+	}
+	for idx := range meta.TrackerData {
+		if matchedTrackerForUpload(matchedTrackers, meta.TrackerData[idx].Tracker) {
+			meta.TrackerData[idx].Matched = true
+		}
+	}
+}
+
+func applyPathedTorrentData(meta *api.PreparedMetadata, searchResult api.ClientSearchResult) bool {
+	if meta == nil || !hasPathedTorrentData(searchResult) {
+		return false
+	}
+	if infoHash := strings.TrimSpace(searchResult.InfoHash); infoHash != "" {
+		meta.InfoHash = infoHash
+	}
+	if torrentPath := strings.TrimSpace(searchResult.TorrentPath); torrentPath != "" {
+		meta.ClientTorrentPath = torrentPath
+	}
+	if len(searchResult.TrackerIDs) > 0 {
+		meta.TrackerIDs = mergeTrackerIDOverrides(searchResult.TrackerIDs, meta.TrackerIDs)
+	}
+	if len(searchResult.TorrentComments) > 0 {
+		meta.TorrentComments = append([]api.TorrentMatch{}, searchResult.TorrentComments...)
+	}
+	meta.PieceSizeConstraint = searchResult.PieceSizeConstraint
+	meta.FoundPreferredPiece = searchResult.FoundPreferredPiece
+	meta.StoredDataFresh = false
+	return true
+}
+
+func hasPathedTorrentData(searchResult api.ClientSearchResult) bool {
+	return strings.TrimSpace(searchResult.InfoHash) != "" ||
+		strings.TrimSpace(searchResult.TorrentPath) != "" ||
+		len(searchResult.TrackerIDs) > 0 ||
+		len(searchResult.TorrentComments) > 0 ||
+		strings.TrimSpace(searchResult.PieceSizeConstraint) != "" ||
+		strings.TrimSpace(searchResult.FoundPreferredPiece) != ""
 }
 
 func (c *Core) getDupeCache(path string, signature string) (api.PreparedMetadata, bool) {
@@ -4177,7 +4246,7 @@ func (c *Core) resolveCanonicalDescriptionGroups(ctx context.Context, meta api.P
 		return nil, errors.New("core: tracker service not configured")
 	}
 
-	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, req.TrackersRemove, c.logger)
+	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, meta.TrackersRemove, c.logger)
 	prep, err := c.services.Trackers.BuildPreparation(ctx, meta, resolvedTrackers)
 	if err != nil {
 		return nil, fmt.Errorf("core: %w", err)

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -24,6 +24,15 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
+func containsCoreString(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), strings.TrimSpace(target)) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestFirstRequestedTracker(t *testing.T) {
 	t.Parallel()
 
@@ -757,12 +766,25 @@ func TestRunUploadSkipsPathedSearchWithFreshStoredSnapshot(t *testing.T) {
 func TestFetchMetadataPreviewRunsPathedSearchWithStoredTrackerData(t *testing.T) {
 	t.Parallel()
 
-	client := &stubClient{}
+	client := &stubClient{searchResult: api.ClientSearchResult{
+		InfoHash: "abc123",
+		TrackerIDs: map[string]string{
+			"aither": "111",
+		},
+		FoundTrackerMatch: true,
+		TorrentComments: []api.TorrentMatch{{
+			Hash: "abc123",
+			Name: "Fixture Title 2024 BluRay 1080p DTS x264-FixtureGroup",
+		}},
+		MatchedTrackers: []string{"AITHER"},
+		TorrentPath:     "/downloads/Fixture Title",
+	}}
+	metaSvc := &stubMeta{}
 	core, err := New(api.CoreDependencies{
 		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
 		Services: api.ServiceSet{
 			Filesystem: &stubFS{},
-			Metadata:   &stubMeta{},
+			Metadata:   metaSvc,
 			Clients:    client,
 		},
 		Repository: trackerRepo{},
@@ -779,7 +801,22 @@ func TestFetchMetadataPreviewRunsPathedSearchWithStoredTrackerData(t *testing.T)
 		t.Fatalf("fetch metadata preview: %v", err)
 	}
 	if client.searchCalls != 1 {
-		t.Fatalf("expected pathed search to run once for tracker presence, got %d calls", client.searchCalls)
+		t.Fatalf("expected pathed search to run once for fresh client data, got %d calls", client.searchCalls)
+	}
+	if metaSvc.enrichCalls != 1 {
+		t.Fatalf("expected tracker enrichment once, got %d calls", metaSvc.enrichCalls)
+	}
+	if got := metaSvc.enrichMeta.TrackerIDs["aither"]; got != "111" {
+		t.Fatalf("expected fresh AITHER tracker id, got %q", got)
+	}
+	if got := metaSvc.enrichMeta.TrackerIDs["blu"]; got != "" {
+		t.Fatalf("expected stale stored BLU tracker id cleared, got %q", got)
+	}
+	if containsCoreString(metaSvc.enrichMeta.MatchedTrackers, "BLU") {
+		t.Fatalf("expected stale stored BLU match cleared, got %v", metaSvc.enrichMeta.MatchedTrackers)
+	}
+	if !containsCoreString(metaSvc.enrichMeta.TrackersRemove, "AITHER") {
+		t.Fatalf("expected fresh AITHER removal, got %v", metaSvc.enrichMeta.TrackersRemove)
 	}
 }
 
@@ -882,6 +919,277 @@ func TestFetchMetadataPreviewRunsPathedSearchWithFreshStoredSnapshot(t *testing.
 	}
 	if client.searchCalls != 1 {
 		t.Fatalf("expected pathed search to run once for tracker presence, got %d calls", client.searchCalls)
+	}
+}
+
+func TestFetchMetadataPreviewUsesPathedTrackerDataWithFreshStoredSnapshot(t *testing.T) {
+	t.Parallel()
+
+	client := &stubClient{searchResult: api.ClientSearchResult{
+		InfoHash: "abc123",
+		TrackerIDs: map[string]string{
+			"aither": "111",
+		},
+		FoundTrackerMatch: true,
+		TorrentComments: []api.TorrentMatch{{
+			Hash: "abc123",
+			Name: "Fixture Title 2024 BluRay 1080p DTS x264-FixtureGroup",
+		}},
+		MatchedTrackers: []string{"AITHER"},
+		TorrentPath:     "/downloads/Fixture Title",
+	}}
+	metaSvc := &stubMeta{prepared: api.PreparedMetadata{
+		StoredDataFresh: true,
+	}}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   metaSvc,
+			Clients:    client,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	_, err = core.FetchMetadataPreview(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	})
+	if err != nil {
+		t.Fatalf("fetch metadata preview: %v", err)
+	}
+	if client.searchCalls != 1 {
+		t.Fatalf("expected pathed search to run once, got %d calls", client.searchCalls)
+	}
+	if metaSvc.enrichCalls != 1 {
+		t.Fatalf("expected tracker enrichment once, got %d calls", metaSvc.enrichCalls)
+	}
+	if metaSvc.enrichMeta.StoredDataFresh {
+		t.Fatalf("expected client torrent data to invalidate fresh snapshot for tracker enrichment")
+	}
+	if got := metaSvc.enrichMeta.TrackerIDs["aither"]; got != "111" {
+		t.Fatalf("expected pathed tracker id, got %q", got)
+	}
+	if got := metaSvc.enrichMeta.InfoHash; got != "abc123" {
+		t.Fatalf("expected pathed infohash, got %q", got)
+	}
+	if len(metaSvc.enrichMeta.TorrentComments) != 1 {
+		t.Fatalf("expected pathed torrent comments, got %d", len(metaSvc.enrichMeta.TorrentComments))
+	}
+	if !metaSvc.enrichMeta.FoundTrackerMatch {
+		t.Fatalf("expected tracker match flag")
+	}
+}
+
+func TestFetchMetadataPreviewUsesPathedPieceGuidanceWithFreshStoredSnapshot(t *testing.T) {
+	t.Parallel()
+
+	client := &stubClient{searchResult: api.ClientSearchResult{
+		PieceSizeConstraint: "16MiB",
+		FoundPreferredPiece: "16MiB",
+	}}
+	metaSvc := &stubMeta{prepared: api.PreparedMetadata{
+		StoredDataFresh: true,
+	}}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   metaSvc,
+			Clients:    client,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	_, err = core.FetchMetadataPreview(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	})
+	if err != nil {
+		t.Fatalf("fetch metadata preview: %v", err)
+	}
+	if client.searchCalls != 1 {
+		t.Fatalf("expected pathed search to run once, got %d calls", client.searchCalls)
+	}
+	if metaSvc.enrichCalls != 1 {
+		t.Fatalf("expected tracker enrichment once, got %d calls", metaSvc.enrichCalls)
+	}
+	if metaSvc.enrichMeta.StoredDataFresh {
+		t.Fatalf("expected piece guidance to invalidate fresh snapshot for tracker enrichment")
+	}
+	if got := metaSvc.enrichMeta.PieceSizeConstraint; got != "16MiB" {
+		t.Fatalf("expected piece size constraint from pathed search, got %q", got)
+	}
+	if got := metaSvc.enrichMeta.FoundPreferredPiece; got != "16MiB" {
+		t.Fatalf("expected preferred piece from pathed search, got %q", got)
+	}
+	if got := metaSvc.enrichMeta.InfoHash; got != "" {
+		t.Fatalf("expected no infohash required for piece guidance, got %q", got)
+	}
+	if len(metaSvc.enrichMeta.TrackerIDs) != 0 {
+		t.Fatalf("expected no tracker ids required for piece guidance, got %#v", metaSvc.enrichMeta.TrackerIDs)
+	}
+	if len(metaSvc.enrichMeta.TorrentComments) != 0 {
+		t.Fatalf("expected no torrent comments required for piece guidance, got %#v", metaSvc.enrichMeta.TorrentComments)
+	}
+}
+
+func TestApplyPathedTorrentDataAppliesPieceGuidanceOnly(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{StoredDataFresh: true}
+
+	if !applyPathedTorrentData(&meta, api.ClientSearchResult{
+		PieceSizeConstraint: "16MiB",
+		FoundPreferredPiece: "16MiB",
+	}) {
+		t.Fatalf("expected piece guidance to count as pathed torrent data")
+	}
+	if meta.StoredDataFresh {
+		t.Fatalf("expected piece guidance to invalidate stored snapshot")
+	}
+	if meta.PieceSizeConstraint != "16MiB" {
+		t.Fatalf("expected piece constraint copied, got %q", meta.PieceSizeConstraint)
+	}
+	if meta.FoundPreferredPiece != "16MiB" {
+		t.Fatalf("expected preferred piece copied, got %q", meta.FoundPreferredPiece)
+	}
+}
+
+func TestCheckDupesUsesPathedTrackerDataWithFreshStoredSnapshot(t *testing.T) {
+	t.Parallel()
+
+	client := &stubClient{searchResult: api.ClientSearchResult{
+		InfoHash: "abc123",
+		TrackerIDs: map[string]string{
+			"aither": "111",
+		},
+		FoundTrackerMatch: true,
+		TorrentComments: []api.TorrentMatch{{
+			Hash: "abc123",
+			Name: "Fixture Title 2024 BluRay 1080p DTS x264-FixtureGroup",
+		}},
+		MatchedTrackers: []string{"AITHER"},
+	}}
+	dupes := &stubDupes{}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata: &stubMeta{prepared: api.PreparedMetadata{
+				StoredDataFresh: true,
+			}},
+			Clients: client,
+			Dupes:   dupes,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	_, err = core.CheckDupes(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeCLI,
+	})
+	if err != nil {
+		t.Fatalf("check dupes: %v", err)
+	}
+	if client.searchCalls != 1 {
+		t.Fatalf("expected pathed search to run once, got %d calls", client.searchCalls)
+	}
+	if dupes.lastMeta.StoredDataFresh {
+		t.Fatalf("expected client torrent data to invalidate fresh snapshot for dupe metadata")
+	}
+	if got := dupes.lastMeta.TrackerIDs["aither"]; got != "111" {
+		t.Fatalf("expected pathed tracker id, got %q", got)
+	}
+	if got := dupes.lastMeta.InfoHash; got != "abc123" {
+		t.Fatalf("expected pathed infohash, got %q", got)
+	}
+}
+
+func TestFetchPreparationPreviewUsesCachedClientDataForCachedMeta(t *testing.T) {
+	t.Parallel()
+
+	client := &stubClient{}
+	metaSvc := &stubMeta{}
+	trackerSvc := &stubTrackers{}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   metaSvc,
+			Clients:    client,
+			Trackers:   trackerSvc,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	sourcePath := "/tmp/a"
+	core.storeDupeCache(sourcePath, "", api.PreparedMetadata{
+		SourcePath:        sourcePath,
+		Paths:             []string{sourcePath},
+		Mode:              api.ModeGUI,
+		Trackers:          []string{"AITHER", "RF", "BLU"},
+		MatchedTrackers:   []string{"AITHER", "RF"},
+		TrackersRemove:    []string{"AITHER", "RF"},
+		FoundTrackerMatch: true,
+		TrackerIDs: map[string]string{
+			"aither": "111",
+			"rf":     "222",
+		},
+	})
+
+	_, err = core.FetchPreparationPreview(context.Background(), api.Request{
+		Paths:    []string{sourcePath},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER", "RF", "BLU"},
+	})
+	if err != nil {
+		t.Fatalf("fetch preparation preview: %v", err)
+	}
+	if client.searchCalls != 0 {
+		t.Fatalf("expected cached preparation to skip fresh client search, got %d calls", client.searchCalls)
+	}
+	if metaSvc.enrichCalls != 0 {
+		t.Fatalf("expected cached preparation to skip tracker enrichment, got %d calls", metaSvc.enrichCalls)
+	}
+	if trackerSvc.prepCalls != 1 {
+		t.Fatalf("expected preparation build once, got %d calls", trackerSvc.prepCalls)
+	}
+	if got := trackerSvc.lastMeta.TrackerIDs["aither"]; got != "111" {
+		t.Fatalf("expected cached AITHER tracker id, got %q", got)
+	}
+	if got := trackerSvc.lastMeta.TrackerIDs["rf"]; got != "222" {
+		t.Fatalf("expected cached RF tracker id, got %q", got)
+	}
+	if !containsCoreString(trackerSvc.lastMeta.MatchedTrackers, "AITHER") {
+		t.Fatalf("expected cached AITHER match, got %v", trackerSvc.lastMeta.MatchedTrackers)
+	}
+	if !containsCoreString(trackerSvc.lastMeta.MatchedTrackers, "RF") {
+		t.Fatalf("expected cached RF match, got %v", trackerSvc.lastMeta.MatchedTrackers)
+	}
+	if !containsCoreString(trackerSvc.lastMeta.TrackersRemove, "AITHER") {
+		t.Fatalf("expected cached AITHER removal, got %v", trackerSvc.lastMeta.TrackersRemove)
+	}
+	if !containsCoreString(trackerSvc.lastMeta.TrackersRemove, "RF") {
+		t.Fatalf("expected cached RF removal, got %v", trackerSvc.lastMeta.TrackersRemove)
+	}
+	if containsCoreString(trackerSvc.lastTrackers, "AITHER") {
+		t.Fatalf("expected matched tracker excluded from preparation, got %v", trackerSvc.lastTrackers)
+	}
+	if containsCoreString(trackerSvc.lastTrackers, "RF") {
+		t.Fatalf("expected RF excluded from preparation, got %v", trackerSvc.lastTrackers)
 	}
 }
 
@@ -2465,10 +2773,13 @@ func (s stubFS) ValidatePaths(_ context.Context, paths []string) ([]string, erro
 
 type stubMeta struct {
 	calls        int
+	enrichCalls  int
 	refreshCalls int
 	resolveCalls int
 	options      api.UploadOptions
 	prepared     api.PreparedMetadata
+	enrichMeta   api.PreparedMetadata
+	enriched     api.PreparedMetadata
 	resolved     api.PreparedMetadata
 }
 
@@ -2500,6 +2811,11 @@ func (s *stubMeta) RefreshPreparedMetadata(_ context.Context, meta api.PreparedM
 }
 
 func (s *stubMeta) EnrichTrackerData(_ context.Context, meta api.PreparedMetadata) (api.PreparedMetadata, error) {
+	s.enrichCalls++
+	s.enrichMeta = meta
+	if strings.TrimSpace(s.enriched.SourcePath) != "" {
+		return s.enriched, nil
+	}
 	return meta, nil
 }
 
@@ -2600,10 +2916,12 @@ func (s *stubDupes) Check(_ context.Context, meta api.PreparedMetadata, trackers
 }
 
 type stubTrackers struct {
-	calls       int
-	dryRunCalls int
-	lastMeta    api.PreparedMetadata
-	summary     api.UploadSummary
+	calls        int
+	prepCalls    int
+	dryRunCalls  int
+	lastMeta     api.PreparedMetadata
+	lastTrackers []string
+	summary      api.UploadSummary
 }
 
 func (s *stubTrackers) Upload(_ context.Context, meta api.PreparedMetadata) (api.UploadSummary, error) {
@@ -2625,12 +2943,16 @@ func (s *stubTrackers) Upload(_ context.Context, meta api.PreparedMetadata) (api
 	return s.summary, nil
 }
 
-func (s *stubTrackers) BuildPreparation(context.Context, api.PreparedMetadata, []string) (api.PreparationPreview, error) {
+func (s *stubTrackers) BuildPreparation(_ context.Context, meta api.PreparedMetadata, trackers []string) (api.PreparationPreview, error) {
+	s.prepCalls++
+	s.lastMeta = meta
+	s.lastTrackers = append([]string{}, trackers...)
 	return api.PreparationPreview{}, nil
 }
 
-func (s *stubTrackers) BuildUploadDryRun(_ context.Context, meta api.PreparedMetadata, _ []string) ([]api.TrackerDryRunEntry, error) {
+func (s *stubTrackers) BuildUploadDryRun(_ context.Context, meta api.PreparedMetadata, trackers []string) ([]api.TrackerDryRunEntry, error) {
 	s.dryRunCalls++
 	s.lastMeta = meta
+	s.lastTrackers = append([]string{}, trackers...)
 	return []api.TrackerDryRunEntry{}, nil
 }

--- a/internal/core/upload_review.go
+++ b/internal/core/upload_review.go
@@ -90,7 +90,7 @@ func (c *Core) BuildUploadReview(ctx context.Context, req api.Request) (api.Uplo
 		return api.UploadReview{}, fmt.Errorf("core: upload review requires prepared metadata for %s", uniquePaths[0])
 	}
 
-	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, singleReq.Trackers, singleReq.TrackersRemove, c.logger)
+	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, singleReq.Trackers, meta.TrackersRemove, c.logger)
 
 	dupeResults := make(map[string]api.DupeCheckResult)
 	if singleReq.SkipDupeCheck {
@@ -219,6 +219,9 @@ func applyRequestToPreparedMetaBeforeRefresh(meta api.PreparedMetadata, req api.
 
 func applyRequestToPreparedMetaWithDerivedFields(meta api.PreparedMetadata, req api.Request, cfg config.Config, logger api.Logger, rebuildDerivedFields bool) api.PreparedMetadata {
 	meta = deepCopyPreparedMetadata(meta)
+	existingTrackerIDs := cloneStringMap(meta.TrackerIDs)
+	existingTrackersRemove := append([]string{}, meta.TrackersRemove...)
+	existingMatchedTrackers := append([]string{}, meta.MatchedTrackers...)
 	meta.Mode = req.Mode
 	meta.Options = req.Options
 	meta.Paths = append([]string{}, req.Paths...)
@@ -226,8 +229,9 @@ func applyRequestToPreparedMetaWithDerivedFields(meta api.PreparedMetadata, req 
 		meta.DescriptionGroups = api.CloneDescriptionBuilderGroups(req.DescriptionGroups)
 	}
 	meta.Trackers = append([]string{}, req.Trackers...)
-	meta.TrackersRemove = append([]string{}, req.TrackersRemove...)
-	meta.TrackerIDs = cloneStringMap(req.TrackerIDOverrides)
+	meta.TrackersRemove = mergeTrackerRemovals(req.TrackersRemove, existingTrackersRemove)
+	meta.TrackersRemove = mergeTrackerRemovals(meta.TrackersRemove, existingMatchedTrackers)
+	meta.TrackerIDs = mergeTrackerIDOverrides(existingTrackerIDs, req.TrackerIDOverrides)
 	meta.DescriptionOverride = strings.TrimSpace(req.DescriptionOverrideRaw)
 	meta.MetadataOverrides = req.MetadataOverrides
 	meta.TrackerConfigOverrides = req.TrackerConfigOverrides
@@ -254,6 +258,35 @@ func applyRequestToPreparedMetaWithDerivedFields(meta api.PreparedMetadata, req 
 		meta.BlockedTrackers = removeTrackerBlockReasonForTrackers(meta.BlockedTrackers, api.TrackerBlockReasonDupe, req.IgnoreDupesFor)
 	}
 	return meta
+}
+
+func mergeTrackerIDOverrides(existing map[string]string, overrides map[string]string) map[string]string {
+	normalizedExisting := make(map[string]string, len(existing))
+	for key, value := range existing {
+		trimmedKey := strings.ToLower(strings.TrimSpace(key))
+		trimmedValue := strings.TrimSpace(value)
+		if trimmedKey == "" || trimmedValue == "" {
+			continue
+		}
+		normalizedExisting[trimmedKey] = trimmedValue
+	}
+
+	merged := cloneStringMap(normalizedExisting)
+	if merged == nil {
+		merged = make(map[string]string)
+	}
+	for key, value := range overrides {
+		trimmedKey := strings.ToLower(strings.TrimSpace(key))
+		trimmedValue := strings.TrimSpace(value)
+		if trimmedKey == "" || trimmedValue == "" {
+			continue
+		}
+		merged[trimmedKey] = trimmedValue
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
 }
 
 func (c *Core) applyRequestToCachedPreparedMeta(ctx context.Context, meta api.PreparedMetadata, req api.Request) (api.PreparedMetadata, error) {

--- a/internal/core/upload_review_test.go
+++ b/internal/core/upload_review_test.go
@@ -368,3 +368,34 @@ func TestApplyRequestToPreparedMetaDoesNotMutateCachedExternalMetadata(t *testin
 		t.Fatalf("expected request-scoped metadata override to apply, got %#v", result.ExternalMetadata)
 	}
 }
+
+func TestMergeTrackerIDOverridesNormalizesExistingKeys(t *testing.T) {
+	t.Parallel()
+
+	spacedExistingKey := " AITHER "
+	spacedOverrideKey := " RF "
+	existing := map[string]string{
+		spacedExistingKey: " 10001 ",
+		"RF":              " ",
+		"":                "10002",
+	}
+	overrides := map[string]string{
+		"aither":          "20001",
+		spacedOverrideKey: " 20002 ",
+	}
+
+	merged := mergeTrackerIDOverrides(existing, overrides)
+
+	if len(merged) != 2 {
+		t.Fatalf("expected two normalized tracker ids, got %#v", merged)
+	}
+	if got := merged["aither"]; got != "20001" {
+		t.Fatalf("expected override to replace normalized existing id, got %q", got)
+	}
+	if got := merged["rf"]; got != "20002" {
+		t.Fatalf("expected normalized override id, got %q", got)
+	}
+	if _, ok := merged[" AITHER "]; ok {
+		t.Fatalf("expected unnormalized existing key removed, got %#v", merged)
+	}
+}


### PR DESCRIPTION
Use fresh pathed client data during metadata preparation so cached snapshots do not miss newly matched trackers.

Normalize client search around symbol drift and preserve cached tracker removals for later steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search functionality to properly handle special characters and unicode symbols in search queries.
  * Enhanced torrent matching to better tolerate name variations, including trademark symbols and separator differences.
  * Refined tracker identification and alias recognition for more reliable matching.
  * Strengthened path validation for disc-type sources with fallback canonicalization.

* **Refactor**
  * Optimized metadata enrichment and tracker resolution workflows for improved accuracy.

* **Tests**
  * Added comprehensive test coverage for search sanitization, tracker matching, and metadata enrichment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/upbrr/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->