### PR TITLE
fix(runtime): apply saved config immediately

### DIFF
--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -1288,15 +1288,18 @@ func (a *App) SaveConfig(payload string) error {
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("gui: %w", err)
 	}
+	runtimeCfg := *cfg
+	config.ApplyEnvOverrides(&runtimeCfg)
+	runtimeCfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
+	if err := runtimeCfg.Validate(); err != nil {
+		return fmt.Errorf("gui: %w", err)
+	}
 
 	ctx := a.runtimeContext()
 	if err := config.SaveToDatabase(ctx, cfg, a.repo); err != nil {
 		return fmt.Errorf("gui: %w", err)
 	}
 
-	runtimeCfg := *cfg
-	config.ApplyEnvOverrides(&runtimeCfg)
-	runtimeCfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
 	return a.applyConfig(runtimeCfg)
 }
 
@@ -1517,14 +1520,18 @@ func (a *App) ImportConfig() (ImportResult, error) {
 	if err := cfg.Validate(); err != nil {
 		return ImportResult{}, fmt.Errorf("validate imported config: %w", err)
 	}
+	runtimeCfg := *cfg
+	config.ApplyEnvOverrides(&runtimeCfg)
+	runtimeCfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
+	if err := runtimeCfg.Validate(); err != nil {
+		return ImportResult{}, fmt.Errorf("validate imported config: %w", err)
+	}
 
 	if err := config.SaveToDatabase(ctx, cfg, a.repo); err != nil {
 		return ImportResult{}, fmt.Errorf("gui: %w", err)
 	}
 
-	config.ApplyEnvOverrides(cfg)
-	cfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
-	if err := a.applyConfig(*cfg); err != nil {
+	if err := a.applyConfig(runtimeCfg); err != nil {
 		return ImportResult{}, err
 	}
 

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -41,6 +41,7 @@ const metadataProgressEvent = "metadata:progress"
 
 type App struct {
 	runtimeCtx  *appRuntimeContext
+	runtimeMu   sync.RWMutex
 	cfg         config.Config
 	core        api.Core
 	coreInitErr error
@@ -134,14 +135,15 @@ func (a *App) shutdown(_ context.Context) {
 	a.stopAllLogStreams()
 	a.stopAllDupeJobs()
 	a.stopAllUploadJobs()
-	if a.core != nil {
-		_ = a.core.Close()
+	rt := a.runtimeSnapshot()
+	if rt.core != nil {
+		_ = rt.core.Close()
 	}
 	if a.repo != nil {
 		_ = a.repo.Close()
 	}
-	if a.logger != nil {
-		_ = a.logger.Close()
+	if rt.logger != nil {
+		_ = rt.logger.Close()
 	}
 }
 
@@ -237,7 +239,7 @@ func (a *App) BrowseDirectory(path string, mode string) (api.BrowseDirectoryResp
 	if a == nil {
 		return api.BrowseDirectoryResponse{}, errors.New("app not initialized")
 	}
-	fallback := guishared.BrowseDirectoryFallback(a.cfg.MainSettings.DBPath)
+	fallback := guishared.BrowseDirectoryFallback(a.currentConfig().MainSettings.DBPath)
 	return wrapGUIResult(guishared.BrowseDirectory(api.BrowseDirectoryRequest{Path: path, Mode: mode}, fallback))
 }
 
@@ -365,17 +367,13 @@ func (a *App) FetchMetadata(path string, sourceLookupURL string, overrides api.E
 		Mode:            api.ModeGUI,
 		Trackers:        slices.Clone(trackers),
 		SourceLookupURL: strings.TrimSpace(sourceLookupURL),
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Options:         a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIResult(a.core.FetchMetadataPreview(progressCtx, req))
+	return wrapGUIResult(a.currentCore().FetchMetadataPreview(progressCtx, req))
 }
 
 func (a *App) SelectBlurayCandidate(path string, releaseID string) (api.MetadataPreview, error) {
@@ -388,7 +386,7 @@ func (a *App) SelectBlurayCandidate(path string, releaseID string) (api.Metadata
 	if strings.TrimSpace(releaseID) == "" {
 		return api.MetadataPreview{}, errors.New("release ID is required")
 	}
-	selector, ok := a.core.(blurayCandidateSelector)
+	selector, ok := a.currentCore().(blurayCandidateSelector)
 	if !ok {
 		return api.MetadataPreview{}, errors.New("blu-ray candidate selection is unavailable in this build")
 	}
@@ -409,8 +407,9 @@ func (a *App) ResetMetadata(path string, sourceLookupURL string, overrides api.E
 	if trimmedPath == "" {
 		return api.MetadataPreview{}, errors.New("path is required")
 	}
-	if a.logger != nil {
-		a.logger.Infof("gui: reset metadata started path=%s", trimmedPath)
+	logger := a.currentLogger()
+	if logger != nil {
+		logger.Infof("gui: reset metadata started path=%s", trimmedPath)
 	}
 
 	ctx := a.runtimeContext()
@@ -426,7 +425,7 @@ func (a *App) ResetMetadata(path string, sourceLookupURL string, overrides api.E
 		runtime.EventsEmit(ctx, metadataProgressEvent, update)
 	})
 
-	tmpRoot, err := db.Subdir(a.cfg.MainSettings.DBPath, "tmp")
+	tmpRoot, err := db.Subdir(a.currentConfig().MainSettings.DBPath, "tmp")
 	if err != nil {
 		return api.MetadataPreview{}, fmt.Errorf("reset metadata: resolve tmp dir: %w", err)
 	}
@@ -456,8 +455,8 @@ func (a *App) ResetMetadata(path string, sourceLookupURL string, overrides api.E
 		artifactPaths = append(artifactPaths, image.ImagePath)
 	}
 	artifactPaths = slices.Compact(artifactPaths)
-	if a.logger != nil {
-		a.logger.Debugf("gui: reset metadata collected artifacts path=%s files=%d", trimmedPath, len(artifactPaths))
+	if logger != nil {
+		logger.Debugf("gui: reset metadata collected artifacts path=%s files=%d", trimmedPath, len(artifactPaths))
 	}
 
 	tmpDirs := make(map[string]struct{})
@@ -490,16 +489,16 @@ func (a *App) ResetMetadata(path string, sourceLookupURL string, overrides api.E
 	if err := a.repo.PurgeContentData(ctx, trimmedPath); err != nil {
 		return api.MetadataPreview{}, fmt.Errorf("reset metadata: purge sqlite: %w", err)
 	}
-	if a.logger != nil {
-		a.logger.Infof("gui: reset metadata sqlite purge completed path=%s", trimmedPath)
+	if logger != nil {
+		logger.Infof("gui: reset metadata sqlite purge completed path=%s", trimmedPath)
 	}
 
 	removedFiles := 0
 	for _, filePath := range artifactPaths {
 		removed, err := removeIfWithinRoot(tmpRoot, filePath, false)
 		if err != nil {
-			if a.logger != nil {
-				a.logger.Warnf("gui: reset metadata remove file failed %q: %v", filePath, err)
+			if logger != nil {
+				logger.Warnf("gui: reset metadata remove file failed %q: %v", filePath, err)
 			}
 			continue
 		}
@@ -511,8 +510,8 @@ func (a *App) ResetMetadata(path string, sourceLookupURL string, overrides api.E
 	for dir := range tmpDirs {
 		removed, err := removeIfWithinRoot(tmpRoot, dir, true)
 		if err != nil {
-			if a.logger != nil {
-				a.logger.Warnf("gui: reset metadata remove tmp dir failed %q: %v", dir, err)
+			if logger != nil {
+				logger.Warnf("gui: reset metadata remove tmp dir failed %q: %v", dir, err)
 			}
 			continue
 		}
@@ -520,8 +519,8 @@ func (a *App) ResetMetadata(path string, sourceLookupURL string, overrides api.E
 			removedDirs++
 		}
 	}
-	if a.logger != nil {
-		a.logger.Infof("gui: reset metadata artifacts cleaned path=%s files_removed=%d dirs_removed=%d", trimmedPath, removedFiles, removedDirs)
+	if logger != nil {
+		logger.Infof("gui: reset metadata artifacts cleaned path=%s files_removed=%d dirs_removed=%d", trimmedPath, removedFiles, removedDirs)
 	}
 
 	req := api.Request{
@@ -529,21 +528,17 @@ func (a *App) ResetMetadata(path string, sourceLookupURL string, overrides api.E
 		Mode:            api.ModeGUI,
 		Trackers:        slices.Clone(trackers),
 		SourceLookupURL: strings.TrimSpace(sourceLookupURL),
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Options:         a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
-	preview, err := a.core.FetchMetadataPreview(progressCtx, req)
+	preview, err := a.currentCore().FetchMetadataPreview(progressCtx, req)
 	if err != nil {
 		return api.MetadataPreview{}, fmt.Errorf("gui: %w", err)
 	}
-	if a.logger != nil {
-		a.logger.Infof("gui: reset metadata completed path=%s release=%s", trimmedPath, strings.TrimSpace(preview.ReleaseName))
+	if logger != nil {
+		logger.Infof("gui: reset metadata completed path=%s release=%s", trimmedPath, strings.TrimSpace(preview.ReleaseName))
 	}
 	return preview, nil
 }
@@ -627,7 +622,7 @@ func pathWithinRoot(root string, target string) bool {
 }
 
 func (a *App) CheckDupes(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string) (api.DupeCheckSummary, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return api.DupeCheckSummary{}, errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -643,21 +638,17 @@ func (a *App) CheckDupes(path string, overrides api.ExternalIDOverrides, nameOve
 		Paths:    []string{trimmedPath},
 		Mode:     api.ModeGUI,
 		Trackers: slices.Clone(trackers),
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Options:  a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIResult(a.core.CheckDupes(ctx, req))
+	return wrapGUIResult(a.currentCore().CheckDupes(ctx, req))
 }
 
 func (a *App) FetchPreparation(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string) (api.PreparationPreview, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return api.PreparationPreview{}, errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -674,12 +665,8 @@ func (a *App) FetchPreparation(path string, overrides api.ExternalIDOverrides, n
 		Mode:           api.ModeGUI,
 		Trackers:       slices.Clone(trackers),
 		IgnoreDupesFor: normalizeTrackerList(ignoreDupesFor),
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Options:        a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
@@ -694,7 +681,7 @@ func (a *App) FetchPreparation(path string, overrides api.ExternalIDOverrides, n
 		})
 	})
 
-	return wrapGUIResult(a.core.FetchPreparationPreview(progressCtx, req))
+	return wrapGUIResult(a.currentCore().FetchPreparationPreview(progressCtx, req))
 }
 
 func (a *App) FetchTrackerDryRun(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, runLogLevel string) (api.TrackerDryRunPreview, error) {
@@ -732,13 +719,13 @@ func (a *App) FetchTrackerDryRun(path string, overrides api.ExternalIDOverrides,
 		Trackers:                    slices.Clone(trackers),
 		IgnoreDupesFor:              normalizeTrackerList(ignoreDupesFor),
 		IgnoreTrackerRuleFailures:   false,
-		Options:                     buildRunUploadOptions(a.cfg, runOpts),
+		Options:                     buildRunUploadOptions(a.currentConfig(), runOpts),
 		ExternalIDOverrides:         overrides,
 		ReleaseNameOverrides:        nameOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(questionnaireAnswers),
 	}
 	req.Options.DryRun = true
-	if err := guishared.SeedRunCorePreparedMeta(ctx, a.core, runCore, req); err != nil {
+	if err := guishared.SeedRunCorePreparedMeta(ctx, a.currentCore(), runCore, req); err != nil {
 		return api.TrackerDryRunPreview{}, fmt.Errorf("gui: %w", err)
 	}
 
@@ -759,7 +746,7 @@ func (a *App) FetchTrackerDryRun(path string, overrides api.ExternalIDOverrides,
 }
 
 func (a *App) FetchDescriptionBuilder(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string) (api.DescriptionBuilderPreview, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return api.DescriptionBuilderPreview{}, errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -775,21 +762,17 @@ func (a *App) FetchDescriptionBuilder(path string, overrides api.ExternalIDOverr
 		Mode:           api.ModeGUI,
 		Trackers:       slices.Clone(trackers),
 		IgnoreDupesFor: normalizeTrackerList(ignoreDupesFor),
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Options:        a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIResult(a.core.FetchDescriptionBuilderPreview(ctx, req))
+	return wrapGUIResult(a.currentCore().FetchDescriptionBuilderPreview(ctx, req))
 }
 
 func (a *App) RenderDescription(raw string) (string, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return "", errors.New("app not initialized")
 	}
 
@@ -797,11 +780,11 @@ func (a *App) RenderDescription(raw string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 
-	return wrapGUIResult(a.core.RenderDescription(ctx, raw))
+	return wrapGUIResult(a.currentCore().RenderDescription(ctx, raw))
 }
 
 func (a *App) SaveDescriptionOverride(path string, groupKey string, raw string, trackers []string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) (api.DescriptionBuilderGroup, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return api.DescriptionBuilderGroup{}, errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -822,11 +805,11 @@ func (a *App) SaveDescriptionOverride(path string, groupKey string, raw string, 
 	req.ExternalIDOverrides = overrides
 	req.ReleaseNameOverrides = nameOverrides
 
-	return wrapGUIResult(a.core.SaveDescriptionOverride(ctx, req, raw))
+	return wrapGUIResult(a.currentCore().SaveDescriptionOverride(ctx, req, raw))
 }
 
 func (a *App) DiscoverPlaylists(path string) ([]api.PlaylistInfo, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return nil, errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -837,11 +820,11 @@ func (a *App) DiscoverPlaylists(path string) ([]api.PlaylistInfo, error) {
 	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 
-	return wrapGUIResult(a.core.DiscoverPlaylists(ctx, path))
+	return wrapGUIResult(a.currentCore().DiscoverPlaylists(ctx, path))
 }
 
 func (a *App) SavePlaylistSelection(path string, playlists []string, useAll bool) error {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -852,11 +835,11 @@ func (a *App) SavePlaylistSelection(path string, playlists []string, useAll bool
 	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 
-	return wrapGUIError(a.core.SavePlaylistSelection(ctx, path, playlists, useAll))
+	return wrapGUIError(a.currentCore().SavePlaylistSelection(ctx, path, playlists, useAll))
 }
 
 func (a *App) LoadPlaylistSelection(path string) (api.PlaylistSelection, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return api.PlaylistSelection{}, errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -867,7 +850,7 @@ func (a *App) LoadPlaylistSelection(path string) (api.PlaylistSelection, error) 
 	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 
-	return wrapGUIResult(a.core.LoadPlaylistSelection(ctx, path))
+	return wrapGUIResult(a.currentCore().LoadPlaylistSelection(ctx, path))
 }
 
 func (a *App) ListHistory() ([]api.HistoryEntry, error) {
@@ -898,7 +881,7 @@ func (a *App) GetHistoryOverview(sourcePath string) (api.HistoryOverview, error)
 }
 
 func (a *App) DeleteHistoryRelease(sourcePath string) error {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return errors.New("app not initialized")
 	}
 	trimmedPath := strings.TrimSpace(sourcePath)
@@ -909,14 +892,14 @@ func (a *App) DeleteHistoryRelease(sourcePath string) error {
 	ctx := a.runtimeContext()
 	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
-	if err := a.core.DeleteHistoryRelease(ctx, trimmedPath); err != nil {
+	if err := a.currentCore().DeleteHistoryRelease(ctx, trimmedPath); err != nil {
 		return fmt.Errorf("delete history release: %w", err)
 	}
 	return nil
 }
 
 func (a *App) FetchScreenshotPlan(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) (api.ScreenshotPlan, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return api.ScreenshotPlan{}, errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -928,23 +911,19 @@ func (a *App) FetchScreenshotPlan(path string, overrides api.ExternalIDOverrides
 	defer cancel()
 
 	req := api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIResult(a.core.FetchScreenshotPlan(ctx, req))
+	return wrapGUIResult(a.currentCore().FetchScreenshotPlan(ctx, req))
 }
 
 func (a *App) GenerateScreenshots(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, selections []api.ScreenshotSelection, purpose api.ScreenshotPurpose) (api.ScreenshotResult, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return api.ScreenshotResult{}, errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -956,23 +935,19 @@ func (a *App) GenerateScreenshots(path string, overrides api.ExternalIDOverrides
 	defer cancel()
 
 	req := api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIResult(a.core.GenerateScreenshots(ctx, req, selections, purpose))
+	return wrapGUIResult(a.currentCore().GenerateScreenshots(ctx, req, selections, purpose))
 }
 
 func (a *App) ListUploadCandidates(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) ([]api.ScreenshotImage, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return nil, errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -984,23 +959,19 @@ func (a *App) ListUploadCandidates(path string, overrides api.ExternalIDOverride
 	defer cancel()
 
 	req := api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIResult(a.core.ListUploadCandidates(ctx, req))
+	return wrapGUIResult(a.currentCore().ListUploadCandidates(ctx, req))
 }
 
 func (a *App) ListUploadedImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) ([]api.UploadedImageLink, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return nil, errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -1012,23 +983,19 @@ func (a *App) ListUploadedImages(path string, overrides api.ExternalIDOverrides,
 	defer cancel()
 
 	req := api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIResult(a.core.ListUploadedImages(ctx, req))
+	return wrapGUIResult(a.currentCore().ListUploadedImages(ctx, req))
 }
 
 func (a *App) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, host string, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return api.UploadImagesResult{}, errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -1046,24 +1013,20 @@ func (a *App) UploadImages(path string, overrides api.ExternalIDOverrides, nameO
 	defer cancel()
 
 	req := api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 		Trackers:             slices.Clone(trackers),
 	}
 
-	return wrapGUIResult(a.core.UploadImages(ctx, req, host, images))
+	return wrapGUIResult(a.currentCore().UploadImages(ctx, req, host, images))
 }
 
 func (a *App) DeleteUploadedImage(path string, imagePath string, host string) error {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -1085,11 +1048,11 @@ func (a *App) DeleteUploadedImage(path string, imagePath string, host string) er
 		Mode:  api.ModeGUI,
 	}
 
-	return wrapGUIError(a.core.DeleteUploadedImage(ctx, req, imagePath, host))
+	return wrapGUIError(a.currentCore().DeleteUploadedImage(ctx, req, imagePath, host))
 }
 
 func (a *App) PreviewScreenshotFrame(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, timestampSeconds float64) (string, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return "", errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -1101,19 +1064,15 @@ func (a *App) PreviewScreenshotFrame(path string, overrides api.ExternalIDOverri
 	defer cancel()
 
 	req := api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	preview, err := a.core.PreviewScreenshotFrame(ctx, req, timestampSeconds)
+	preview, err := a.currentCore().PreviewScreenshotFrame(ctx, req, timestampSeconds)
 	if err != nil {
 		return "", fmt.Errorf("gui: %w", err)
 	}
@@ -1125,7 +1084,7 @@ func (a *App) PreviewScreenshotFrame(path string, overrides api.ExternalIDOverri
 }
 
 func (a *App) DeleteScreenshot(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, imagePath string) error {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -1140,23 +1099,19 @@ func (a *App) DeleteScreenshot(path string, overrides api.ExternalIDOverrides, n
 	defer cancel()
 
 	req := api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIError(a.core.DeleteScreenshot(ctx, req, imagePath))
+	return wrapGUIError(a.currentCore().DeleteScreenshot(ctx, req, imagePath))
 }
 
 func (a *App) DeleteTrackerImageURL(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, url string) error {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -1171,23 +1126,19 @@ func (a *App) DeleteTrackerImageURL(path string, overrides api.ExternalIDOverrid
 	defer cancel()
 
 	req := api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIError(a.core.DeleteTrackerImageURL(ctx, req, url))
+	return wrapGUIError(a.currentCore().DeleteTrackerImageURL(ctx, req, url))
 }
 
 func (a *App) SaveFinalScreenshotSelections(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, images []api.ScreenshotImage) error {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -1199,23 +1150,19 @@ func (a *App) SaveFinalScreenshotSelections(path string, overrides api.ExternalI
 	defer cancel()
 
 	req := api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIError(a.core.SaveFinalScreenshotSelections(ctx, req, images))
+	return wrapGUIError(a.currentCore().SaveFinalScreenshotSelections(ctx, req, images))
 }
 
 func (a *App) ImportMenuImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, paths []string) error {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return errors.New("app not initialized")
 	}
 	if strings.TrimSpace(path) == "" {
@@ -1227,19 +1174,15 @@ func (a *App) ImportMenuImages(path string, overrides api.ExternalIDOverrides, n
 	defer cancel()
 
 	req := api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: a.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIError(a.core.ImportMenuImages(ctx, req, paths))
+	return wrapGUIError(a.currentCore().ImportMenuImages(ctx, req, paths))
 }
 
 func (a *App) ReadScreenshotImage(path string) (string, error) {
@@ -1276,7 +1219,7 @@ func (a *App) GetConfig() (string, error) {
 		return "", fmt.Errorf("gui: %w", err)
 	}
 	if strings.TrimSpace(cfg.MainSettings.DBPath) == "" {
-		cfg.MainSettings.DBPath = a.cfg.MainSettings.DBPath
+		cfg.MainSettings.DBPath = a.currentConfig().MainSettings.DBPath
 	}
 	if cfg.Trackers.Trackers == nil {
 		cfg.Trackers.Trackers = map[string]config.TrackerConfig{}
@@ -1335,10 +1278,11 @@ func (a *App) SaveConfig(payload string) error {
 	if err := config.MergeMissingTrackerDefaults(cfg); err != nil {
 		return fmt.Errorf("gui: %w", err)
 	}
+	currentCfg := a.currentConfig()
 	if strings.TrimSpace(cfg.MainSettings.DBPath) == "" {
-		cfg.MainSettings.DBPath = a.cfg.MainSettings.DBPath
+		cfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
 	}
-	if cfg.MainSettings.DBPath != a.cfg.MainSettings.DBPath {
+	if cfg.MainSettings.DBPath != currentCfg.MainSettings.DBPath {
 		return errors.New("changing main_settings.db_path requires restart and is not supported in the GUI")
 	}
 	if err := cfg.Validate(); err != nil {
@@ -1350,7 +1294,10 @@ func (a *App) SaveConfig(payload string) error {
 		return fmt.Errorf("gui: %w", err)
 	}
 
-	return a.applyConfig(*cfg)
+	runtimeCfg := *cfg
+	config.ApplyEnvOverrides(&runtimeCfg)
+	runtimeCfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
+	return a.applyConfig(runtimeCfg)
 }
 
 // isDialogCancelledErr reports whether err is the result of the user closing a
@@ -1422,7 +1369,7 @@ func (a *App) allowUnencryptedExport() (bool, error) {
 		return false, errors.New("app not initialized")
 	}
 
-	dbPath := strings.TrimSpace(a.cfg.MainSettings.DBPath)
+	dbPath := strings.TrimSpace(a.currentConfig().MainSettings.DBPath)
 	if dbPath == "" {
 		return false, nil
 	}
@@ -1460,7 +1407,7 @@ func (a *App) GetWebAuthStatus() (WebAuthStatus, error) {
 		return WebAuthStatus{}, errors.New("app not initialized")
 	}
 
-	dbPath := strings.TrimSpace(a.cfg.MainSettings.DBPath)
+	dbPath := strings.TrimSpace(a.currentConfig().MainSettings.DBPath)
 	if dbPath == "" {
 		return WebAuthStatus{
 			CanCreate: false,
@@ -1492,8 +1439,8 @@ func (a *App) GetWebAuthStatus() (WebAuthStatus, error) {
 		if record, loadErr := authmaterial.LoadRecordFromDBPath(dbPath); loadErr == nil {
 			status.BrowseRoot = record.BrowseRoot
 			status.AllowUnrestrictedBrowse = record.AllowUnrestrictedBrowse
-		} else if a.logger != nil {
-			a.logger.Debugf(
+		} else if logger := a.currentLogger(); logger != nil {
+			logger.Debugf(
 				"gui: web auth browse policy record unavailable db_path=%s error=%s",
 				redaction.RedactValue(dbPath, nil),
 				redaction.RedactValue(loadErr.Error(), nil),
@@ -1518,7 +1465,7 @@ func (a *App) CreateWebAuth(username string, password string) (WebAuthStatus, er
 		return WebAuthStatus{}, errors.New("app not initialized")
 	}
 
-	dbPath := strings.TrimSpace(a.cfg.MainSettings.DBPath)
+	dbPath := strings.TrimSpace(a.currentConfig().MainSettings.DBPath)
 	if dbPath == "" {
 		return WebAuthStatus{}, errors.New("database path is not configured")
 	}
@@ -1564,7 +1511,8 @@ func (a *App) ImportConfig() (ImportResult, error) {
 		return ImportResult{}, fmt.Errorf("gui: %w", err)
 	}
 
-	cfg.MainSettings.DBPath = a.cfg.MainSettings.DBPath
+	currentCfg := a.currentConfig()
+	cfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
 
 	if err := cfg.Validate(); err != nil {
 		return ImportResult{}, fmt.Errorf("validate imported config: %w", err)
@@ -1575,6 +1523,7 @@ func (a *App) ImportConfig() (ImportResult, error) {
 	}
 
 	config.ApplyEnvOverrides(cfg)
+	cfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
 	if err := a.applyConfig(*cfg); err != nil {
 		return ImportResult{}, err
 	}
@@ -1593,13 +1542,7 @@ func (a *App) applyConfig(cfg config.Config) error {
 		return fmt.Errorf("gui: %w", err)
 	}
 
-	oldCore := a.core
-	oldLogger := a.logger
-
-	a.core = rt.Core
-	a.coreInitErr = nil
-	a.logger = rt.Logger
-	a.cfg = cfg
+	oldCore, oldLogger := a.replaceRuntime(cfg, rt.Core, rt.Logger)
 	a.rebindLogStreams(oldLogger, rt.Logger)
 
 	if oldCore != nil {
@@ -1613,16 +1556,8 @@ func (a *App) applyConfig(cfg config.Config) error {
 }
 
 func (a *App) requireCore() error {
-	if a == nil {
-		return errors.New("app not initialized")
-	}
-	if a.core != nil {
-		return nil
-	}
-	if a.coreInitErr != nil {
-		return fmt.Errorf("core unavailable: %w", a.coreInitErr)
-	}
-	return errors.New("core not initialized")
+	_, err := a.requireRuntime()
+	return err
 }
 
 func (a *App) requireHistoryRepo() error {

--- a/internal/guiapp/app_core_test.go
+++ b/internal/guiapp/app_core_test.go
@@ -117,6 +117,56 @@ func TestSaveConfigAppliesRuntimeConfigImmediately(t *testing.T) {
 	}
 }
 
+func TestSaveConfigRejectsInvalidEnvRuntimeConfig(t *testing.T) {
+	t.Setenv("UA_DEFAULT_SCREENS", "0")
+
+	repoPath := filepath.Join(t.TempDir(), "save-config-env.db")
+	repo, err := db.OpenWithLogger(repoPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repo: %v", err)
+	}
+
+	initial := config.Config{
+		MainSettings:       config.MainSettingsConfig{TMDBAPI: "x", DBPath: repoPath},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+		Logging:            config.LoggingConfig{Level: "info"},
+	}
+	app := &App{
+		cfg:  initial,
+		repo: repo,
+	}
+
+	updated := initial
+	updated.ScreenshotHandling.Screens = 4
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	err = app.SaveConfig(payload)
+	if err == nil {
+		t.Fatal("expected env-derived runtime validation error")
+	}
+	if !strings.Contains(err.Error(), "screenshot_handling.screens") {
+		t.Fatalf("expected screens validation error, got %v", err)
+	}
+	if got := app.currentConfig().ScreenshotHandling.Screens; got != 1 {
+		t.Fatalf("expected runtime config to remain unchanged, got screens=%d", got)
+	}
+	if app.currentCore() != nil {
+		t.Fatal("expected runtime core not to be rebuilt")
+	}
+	if _, loadErr := config.LoadFromDatabase(context.Background(), repo); loadErr == nil {
+		t.Fatal("expected invalid runtime config to be rejected before database save")
+	}
+}
+
 func TestListHistoryUsesRepositoryWhenCoreDisabled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/guiapp/app_core_test.go
+++ b/internal/guiapp/app_core_test.go
@@ -56,6 +56,67 @@ func TestFetchMetadataPropagatesSkipAutoTorrentSetting(t *testing.T) {
 	}
 }
 
+func TestSaveConfigAppliesRuntimeConfigImmediately(t *testing.T) {
+	t.Parallel()
+
+	repoPath := filepath.Join(t.TempDir(), "save-config.db")
+	repo, err := db.OpenWithLogger(repoPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repo: %v", err)
+	}
+	initial := config.Config{
+		MainSettings:       config.MainSettingsConfig{TMDBAPI: "x", DBPath: repoPath},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+		Logging:            config.LoggingConfig{Level: "info"},
+	}
+	app := &App{
+		cfg:  initial,
+		repo: repo,
+	}
+	t.Cleanup(func() {
+		if coreSvc := app.currentCore(); coreSvc != nil {
+			_ = coreSvc.Close()
+		}
+		if logger := app.currentLogger(); logger != nil {
+			_ = logger.Close()
+		}
+	})
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	updated.Metadata.OnlyID = true
+	updated.ScreenshotHandling.Screens = 4
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	if err := app.SaveConfig(payload); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	runtimeCfg := app.currentConfig()
+	if !runtimeCfg.Metadata.SkipAutoTorrent || !runtimeCfg.Metadata.OnlyID {
+		t.Fatalf("expected metadata settings applied, got %#v", runtimeCfg.Metadata)
+	}
+	if runtimeCfg.ScreenshotHandling.Screens != 4 {
+		t.Fatalf("expected screenshots=4, got %d", runtimeCfg.ScreenshotHandling.Screens)
+	}
+	if app.currentCore() == nil {
+		t.Fatal("expected runtime core to be rebuilt")
+	}
+	options := buildRunUploadOptions(runtimeCfg, runOptions{})
+	if !options.SkipAutoTorrent || !options.OnlyID || options.Screens != 4 {
+		t.Fatalf("expected upload options from saved config, got %#v", options)
+	}
+}
+
 func TestListHistoryUsesRepositoryWhenCoreDisabled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/guiapp/dupe_jobs.go
+++ b/internal/guiapp/dupe_jobs.go
@@ -62,7 +62,7 @@ type dupeCheckJob struct {
 }
 
 func (a *App) StartDupeCheck(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string) (string, error) {
-	if a == nil || a.core == nil {
+	if a == nil || a.currentCore() == nil {
 		return "", errors.New("app not initialized")
 	}
 	trimmedPath := strings.TrimSpace(path)
@@ -153,7 +153,7 @@ func (a *App) CancelDupeCheck(jobID string) error {
 }
 
 func (a *App) runDupeCheckJob(ctx context.Context, eventCtx context.Context, job *dupeCheckJob) {
-	if a == nil || a.core == nil || job == nil {
+	if a == nil || a.currentCore() == nil || job == nil {
 		return
 	}
 
@@ -170,17 +170,13 @@ func (a *App) runDupeCheckJob(ctx context.Context, eventCtx context.Context, job
 		Paths:    []string{job.sourcePath},
 		Mode:     api.ModeGUI,
 		Trackers: job.trackers,
-		Options: api.UploadOptions{
-			Screens:         a.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: a.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          a.cfg.Metadata.OnlyID,
-			KeepImages:      a.cfg.Metadata.KeepImages,
-		},
+		Options:  a.baseUploadOptions(),
+
 		ExternalIDOverrides:  job.overrides,
 		ReleaseNameOverrides: job.nameOverrides,
 	}
 
-	summary, err := a.core.CheckDupes(progressCtx, req)
+	summary, err := a.currentCore().CheckDupes(progressCtx, req)
 
 	job.mu.Lock()
 	job.finishedAt = time.Now().UTC()

--- a/internal/guiapp/logging.go
+++ b/internal/guiapp/logging.go
@@ -40,18 +40,19 @@ func (a *App) GetLogPath() (string, error) {
 	if a == nil {
 		return "", errors.New("app not initialized")
 	}
-	return wrapGUIResult(logging.LogPath(a.cfg.MainSettings.DBPath))
+	return wrapGUIResult(logging.LogPath(a.currentConfig().MainSettings.DBPath))
 }
 
 func (a *App) GetRecentLogs(limit int) ([]logging.Entry, error) {
-	if a == nil || a.logger == nil {
+	logger := a.currentLogger()
+	if logger == nil {
 		return nil, errors.New("logger not initialized")
 	}
-	return a.logger.Recent(limit), nil
+	return logger.Recent(limit), nil
 }
 
 func (a *App) StartLogStream() (string, error) {
-	if a == nil || a.logger == nil {
+	if a == nil || a.currentLogger() == nil {
 		return "", errors.New("logger not initialized")
 	}
 
@@ -126,12 +127,13 @@ func (a *App) UpdateLogExclusions(patterns []string) error {
 }
 
 func (a *App) startStreamLocked(session *logStreamSession) {
-	if session == nil || a.logger == nil {
+	logger := a.currentLogger()
+	if session == nil || logger == nil {
 		return
 	}
 
-	subID, ch := a.logger.Subscribe(0)
-	session.logger = a.logger
+	subID, ch := logger.Subscribe(0)
+	session.logger = logger
 	session.subID = subID
 
 	ctx := a.runtimeContext()

--- a/internal/guiapp/run_options.go
+++ b/internal/guiapp/run_options.go
@@ -43,21 +43,22 @@ func (a *App) buildRunOptions(debug bool, runLogLevel string) (runOptions, error
 }
 
 func (a *App) buildRunCore(opts runOptions) (api.Core, *logging.Logger, error) {
-	if err := a.requireCore(); err != nil {
+	rt, err := a.requireRuntime()
+	if err != nil {
 		return nil, nil, err
 	}
 	if a.repo == nil {
 		return nil, nil, errors.New("config repository not initialized")
 	}
 
-	effectiveLogLevel := logging.ResolveEffectiveLevel(a.cfg.Logging.Level, opts.RunLogLevel, opts.Debug)
-	logger, err := logging.NewWithLevel(a.cfg.Logging, a.cfg.MainSettings.DBPath, effectiveLogLevel)
+	effectiveLogLevel := logging.ResolveEffectiveLevel(rt.cfg.Logging.Level, opts.RunLogLevel, opts.Debug)
+	logger, err := logging.NewWithLevel(rt.cfg.Logging, rt.cfg.MainSettings.DBPath, effectiveLogLevel)
 	if err != nil {
 		return nil, nil, fmt.Errorf("gui: %w", err)
 	}
 
 	coreSvc, err := core.New(api.CoreDependencies{
-		Config: a.cfg,
+		Config: rt.cfg,
 		Logger: logger,
 		Services: api.ServiceSet{
 			Filesystem: filesystem.NewValidator(),
@@ -72,10 +73,16 @@ func (a *App) buildRunCore(opts runOptions) (api.Core, *logging.Logger, error) {
 	return coreSvc, logger, nil
 }
 func buildRunUploadOptions(cfg config.Config, opts runOptions) api.UploadOptions {
+	options := buildBaseUploadOptions(cfg)
+	options.Debug = opts.Debug
+	// buildRunUploadOptions keeps runOptions legacy behavior: options.DryRun follows opts.Debug so debug runs stay non-uploading.
+	options.DryRun = opts.Debug
+	options.RunLogLevel = opts.RunLogLevel
+	return options
+}
+
+func buildBaseUploadOptions(cfg config.Config) api.UploadOptions {
 	return api.UploadOptions{
-		Debug:           opts.Debug,
-		DryRun:          opts.Debug,
-		RunLogLevel:     opts.RunLogLevel,
 		Screens:         cfg.ScreenshotHandling.Screens,
 		SkipAutoTorrent: cfg.Metadata.SkipAutoTorrent,
 		OnlyID:          cfg.Metadata.OnlyID,

--- a/internal/guiapp/runtime_snapshot.go
+++ b/internal/guiapp/runtime_snapshot.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package guiapp
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/logging"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+type appRuntimeSnapshot struct {
+	cfg         config.Config
+	core        api.Core
+	coreInitErr error
+	logger      *logging.Logger
+}
+
+func (a *App) runtimeSnapshot() appRuntimeSnapshot {
+	if a == nil {
+		return appRuntimeSnapshot{}
+	}
+	a.runtimeMu.RLock()
+	defer a.runtimeMu.RUnlock()
+	return appRuntimeSnapshot{
+		cfg:         a.cfg,
+		core:        a.core,
+		coreInitErr: a.coreInitErr,
+		logger:      a.logger,
+	}
+}
+
+func (a *App) requireRuntime() (appRuntimeSnapshot, error) {
+	if a == nil {
+		return appRuntimeSnapshot{}, errors.New("app not initialized")
+	}
+	rt := a.runtimeSnapshot()
+	if rt.core != nil {
+		return rt, nil
+	}
+	if rt.coreInitErr != nil {
+		return appRuntimeSnapshot{}, fmt.Errorf("core unavailable: %w", rt.coreInitErr)
+	}
+	return appRuntimeSnapshot{}, errors.New("core not initialized")
+}
+
+func (a *App) currentConfig() config.Config {
+	if a == nil {
+		return config.Config{}
+	}
+	a.runtimeMu.RLock()
+	defer a.runtimeMu.RUnlock()
+	return a.cfg
+}
+
+func (a *App) currentLogger() *logging.Logger {
+	if a == nil {
+		return nil
+	}
+	a.runtimeMu.RLock()
+	defer a.runtimeMu.RUnlock()
+	return a.logger
+}
+
+func (a *App) currentCore() api.Core {
+	if a == nil {
+		return nil
+	}
+	a.runtimeMu.RLock()
+	defer a.runtimeMu.RUnlock()
+	return a.core
+}
+
+func (a *App) baseUploadOptions() api.UploadOptions {
+	return buildBaseUploadOptions(a.currentConfig())
+}
+
+func (a *App) replaceRuntime(cfg config.Config, core api.Core, logger *logging.Logger) (api.Core, *logging.Logger) {
+	a.runtimeMu.Lock()
+	defer a.runtimeMu.Unlock()
+	oldCore := a.core
+	oldLogger := a.logger
+	a.core = core
+	a.coreInitErr = nil
+	a.logger = logger
+	a.cfg = cfg
+	return oldCore, oldLogger
+}

--- a/internal/guiapp/upload_jobs.go
+++ b/internal/guiapp/upload_jobs.go
@@ -144,7 +144,7 @@ func (a *App) StartTrackerUpload(path string, overrides api.ExternalIDOverrides,
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
-	if err := guishared.SeedRunCorePreparedMeta(baseCtx, a.core, runCore, seedReq); err != nil {
+	if err := guishared.SeedRunCorePreparedMeta(baseCtx, a.currentCore(), runCore, seedReq); err != nil {
 		_ = runCore.Close()
 		_ = runLogger.Close()
 		return "", fmt.Errorf("gui: %w", err)
@@ -396,7 +396,7 @@ func (a *App) runSingleTrackerUpload(ctx context.Context, job *trackerUploadJob,
 		Trackers:                    []string{tracker},
 		IgnoreDupesFor:              append([]string(nil), job.ignoreDupesFor...),
 		IgnoreTrackerRuleFailures:   false,
-		Options:                     buildRunUploadOptions(a.cfg, job.runOptions),
+		Options:                     buildRunUploadOptions(a.currentConfig(), job.runOptions),
 		ExternalIDOverrides:         job.overrides,
 		ReleaseNameOverrides:        job.nameOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(job.questionnaireAnswers),

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -35,6 +35,7 @@ import (
 const previewTimeout = 30 * time.Minute
 
 type Backend struct {
+	runtimeMu   sync.RWMutex
 	cfg         config.Config
 	core        api.Core
 	coreInitErr error
@@ -136,29 +137,22 @@ func (b *Backend) Close() error {
 	b.stopAllLogStreams()
 	b.stopAllDupeJobs()
 	b.stopAllUploadJobs()
-	if b.core != nil {
-		_ = b.core.Close()
+	rt := b.runtimeSnapshot()
+	if rt.core != nil {
+		_ = rt.core.Close()
 	}
 	if b.repo != nil {
 		_ = b.repo.Close()
 	}
-	if b.logger != nil {
-		_ = b.logger.Close()
+	if rt.logger != nil {
+		_ = rt.logger.Close()
 	}
 	return nil
 }
 
 func (b *Backend) requireCore() error {
-	if b == nil {
-		return errors.New("backend not initialized")
-	}
-	if b.core != nil {
-		return nil
-	}
-	if b.coreInitErr != nil {
-		return fmt.Errorf("core unavailable: %w", b.coreInitErr)
-	}
-	return errors.New("core not initialized")
+	_, err := b.requireRuntime()
+	return err
 }
 
 func (b *Backend) requireHistoryRepo() error {
@@ -203,18 +197,14 @@ func (b *Backend) FetchMetadata(sessionID string, path string, sourceLookupURL s
 		Mode:            api.ModeGUI,
 		Trackers:        append([]string{}, trackersList...),
 		SourceLookupURL: strings.TrimSpace(sourceLookupURL),
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+		Options:         b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 		ConfirmBDMVRescan:    confirmBDMVRescan,
 	}
 
-	return wrapWebResult(b.core.FetchMetadataPreview(progressCtx, req))
+	return wrapWebResult(b.currentCore().FetchMetadataPreview(progressCtx, req))
 }
 
 type blurayCandidateSelector interface {
@@ -231,7 +221,7 @@ func (b *Backend) SelectBlurayCandidate(path string, releaseID string) (api.Meta
 	if err := b.requireCore(); err != nil {
 		return api.MetadataPreview{}, err
 	}
-	selector, ok := b.core.(blurayCandidateSelector)
+	selector, ok := b.currentCore().(blurayCandidateSelector)
 	if !ok {
 		return api.MetadataPreview{}, errors.New("blu-ray candidate selection is unavailable in this build")
 	}
@@ -264,7 +254,7 @@ func (b *Backend) ResetMetadata(sessionID string, path string, sourceLookupURL s
 		b.hub.Emit(sessionID, "metadata:progress", update)
 	})
 
-	tmpRoot, err := db.Subdir(b.cfg.MainSettings.DBPath, "tmp")
+	tmpRoot, err := db.Subdir(b.currentConfig().MainSettings.DBPath, "tmp")
 	if err != nil {
 		return api.MetadataPreview{}, fmt.Errorf("reset metadata: resolve tmp dir: %w", err)
 	}
@@ -332,17 +322,13 @@ func (b *Backend) ResetMetadata(sessionID string, path string, sourceLookupURL s
 		Mode:            api.ModeGUI,
 		Trackers:        append([]string{}, trackersList...),
 		SourceLookupURL: strings.TrimSpace(sourceLookupURL),
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+		Options:         b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 		ConfirmBDMVRescan:    confirmBDMVRescan,
 	}
-	return wrapWebResult(b.core.FetchMetadataPreview(progressCtx, req))
+	return wrapWebResult(b.currentCore().FetchMetadataPreview(progressCtx, req))
 }
 
 func (b *Backend) CheckDupes(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string) (api.DupeCheckSummary, error) {
@@ -355,16 +341,12 @@ func (b *Backend) CheckDupes(path string, overrides api.ExternalIDOverrides, nam
 		Paths:    []string{strings.TrimSpace(path)},
 		Mode:     api.ModeGUI,
 		Trackers: append([]string{}, trackersList...),
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+		Options:  b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
-	return wrapWebResult(b.core.CheckDupes(ctx, req))
+	return wrapWebResult(b.currentCore().CheckDupes(ctx, req))
 }
 
 func (b *Backend) FetchPreparation(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, ignoreDupesFor []string) (api.PreparationPreview, error) {
@@ -378,12 +360,8 @@ func (b *Backend) FetchPreparation(sessionID string, path string, overrides api.
 		Mode:           api.ModeGUI,
 		Trackers:       append([]string{}, trackersList...),
 		IgnoreDupesFor: normalizeTrackerList(ignoreDupesFor),
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+		Options:        b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
@@ -396,7 +374,7 @@ func (b *Backend) FetchPreparation(sessionID string, path string, overrides api.
 			"line": line,
 		})
 	})
-	return wrapWebResult(b.core.FetchPreparationPreview(progressCtx, req))
+	return wrapWebResult(b.currentCore().FetchPreparationPreview(progressCtx, req))
 }
 
 func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, runLogLevel string) (api.TrackerDryRunPreview, error) {
@@ -424,13 +402,13 @@ func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides ap
 		Trackers:                    append([]string{}, trackersList...),
 		IgnoreDupesFor:              normalizeTrackerList(ignoreDupesFor),
 		IgnoreTrackerRuleFailures:   false,
-		Options:                     buildRunUploadOptions(b.cfg, runOpts),
+		Options:                     buildRunUploadOptions(b.currentConfig(), runOpts),
 		ExternalIDOverrides:         overrides,
 		ReleaseNameOverrides:        nameOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(questionnaireAnswers),
 	}
 	req.Options.DryRun = true
-	if err := guishared.SeedRunCorePreparedMeta(ctx, b.core, runCore, req); err != nil {
+	if err := guishared.SeedRunCorePreparedMeta(ctx, b.currentCore(), runCore, req); err != nil {
 		return api.TrackerDryRunPreview{}, fmt.Errorf("web: %w", err)
 	}
 	progressCtx := api.WithUploadProgressReporter(ctx, func(update api.UploadProgressUpdate) {
@@ -459,16 +437,12 @@ func (b *Backend) FetchDescriptionBuilder(path string, overrides api.ExternalIDO
 		Mode:           api.ModeGUI,
 		Trackers:       append([]string{}, trackersList...),
 		IgnoreDupesFor: normalizeTrackerList(ignoreDupesFor),
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+		Options:        b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
-	return wrapWebResult(b.core.FetchDescriptionBuilderPreview(ctx, req))
+	return wrapWebResult(b.currentCore().FetchDescriptionBuilderPreview(ctx, req))
 }
 
 func (b *Backend) RenderDescription(raw string) (string, error) {
@@ -477,7 +451,7 @@ func (b *Backend) RenderDescription(raw string) (string, error) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebResult(b.core.RenderDescription(ctx, raw))
+	return wrapWebResult(b.currentCore().RenderDescription(ctx, raw))
 }
 
 func (b *Backend) SaveDescriptionOverride(path string, groupKey string, raw string, trackers []string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) (api.DescriptionBuilderGroup, error) {
@@ -486,7 +460,7 @@ func (b *Backend) SaveDescriptionOverride(path string, groupKey string, raw stri
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebResult(b.core.SaveDescriptionOverride(ctx, api.Request{
+	return wrapWebResult(b.currentCore().SaveDescriptionOverride(ctx, api.Request{
 		Paths:                    []string{strings.TrimSpace(path)},
 		Mode:                     api.ModeGUI,
 		DescriptionOverrideGroup: strings.TrimSpace(groupKey),
@@ -502,7 +476,7 @@ func (b *Backend) DiscoverPlaylists(path string) ([]api.PlaylistInfo, error) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebResult(b.core.DiscoverPlaylists(ctx, path))
+	return wrapWebResult(b.currentCore().DiscoverPlaylists(ctx, path))
 }
 
 func (b *Backend) SavePlaylistSelection(path string, playlists []string, useAll bool) error {
@@ -511,7 +485,7 @@ func (b *Backend) SavePlaylistSelection(path string, playlists []string, useAll 
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebError(b.core.SavePlaylistSelection(ctx, path, playlists, useAll))
+	return wrapWebError(b.currentCore().SavePlaylistSelection(ctx, path, playlists, useAll))
 }
 
 func (b *Backend) LoadPlaylistSelection(path string) (api.PlaylistSelection, error) {
@@ -520,7 +494,7 @@ func (b *Backend) LoadPlaylistSelection(path string) (api.PlaylistSelection, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebResult(b.core.LoadPlaylistSelection(ctx, path))
+	return wrapWebResult(b.currentCore().LoadPlaylistSelection(ctx, path))
 }
 
 func (b *Backend) ListUIStates() (api.UIStateList, error) {
@@ -564,7 +538,7 @@ func (b *Backend) BrowseDirectory(path string, mode string) (api.BrowseDirectory
 	if b == nil {
 		return api.BrowseDirectoryResponse{}, errors.New("backend not initialized")
 	}
-	fallback := guishared.BrowseDirectoryFallback(b.cfg.MainSettings.DBPath)
+	fallback := guishared.BrowseDirectoryFallback(b.currentConfig().MainSettings.DBPath)
 	return wrapWebResult(guishared.BrowseDirectory(api.BrowseDirectoryRequest{Path: path, Mode: mode}, fallback))
 }
 
@@ -572,7 +546,7 @@ func (b *Backend) BrowseDirectoryWithinRoot(path string, mode string, root strin
 	if b == nil {
 		return api.BrowseDirectoryResponse{}, errors.New("backend not initialized")
 	}
-	fallback := guishared.BrowseDirectoryFallback(b.cfg.MainSettings.DBPath)
+	fallback := guishared.BrowseDirectoryFallback(b.currentConfig().MainSettings.DBPath)
 	return wrapWebResult(guishared.BrowseDirectoryWithinRoot(api.BrowseDirectoryRequest{Path: path, Mode: mode}, fallback, root))
 }
 
@@ -580,7 +554,7 @@ func (b *Backend) BrowseDirectoryWithinRoots(path string, mode string, roots []s
 	if b == nil {
 		return api.BrowseDirectoryResponse{}, errors.New("backend not initialized")
 	}
-	fallback := guishared.BrowseDirectoryFallback(b.cfg.MainSettings.DBPath)
+	fallback := guishared.BrowseDirectoryFallback(b.currentConfig().MainSettings.DBPath)
 	return wrapWebResult(guishared.BrowseDirectoryWithinRoots(api.BrowseDirectoryRequest{Path: path, Mode: mode}, fallback, roots))
 }
 
@@ -591,18 +565,14 @@ func (b *Backend) FetchScreenshotPlan(path string, overrides api.ExternalIDOverr
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
 	req := api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
-	return wrapWebResult(b.core.FetchScreenshotPlan(ctx, req))
+	return wrapWebResult(b.currentCore().FetchScreenshotPlan(ctx, req))
 }
 
 func (b *Backend) GenerateScreenshots(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, selections []api.ScreenshotSelection, purpose api.ScreenshotPurpose) (api.ScreenshotResult, error) {
@@ -612,18 +582,14 @@ func (b *Backend) GenerateScreenshots(path string, overrides api.ExternalIDOverr
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
 	req := api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
-	return wrapWebResult(b.core.GenerateScreenshots(ctx, req, selections, purpose))
+	return wrapWebResult(b.currentCore().GenerateScreenshots(ctx, req, selections, purpose))
 }
 
 func (b *Backend) PreviewScreenshotFrame(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, timestampSeconds float64) (string, error) {
@@ -633,18 +599,14 @@ func (b *Backend) PreviewScreenshotFrame(path string, overrides api.ExternalIDOv
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
 	req := api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
-	preview, err := b.core.PreviewScreenshotFrame(ctx, req, timestampSeconds)
+	preview, err := b.currentCore().PreviewScreenshotFrame(ctx, req, timestampSeconds)
 	if err != nil {
 		return "", fmt.Errorf("web: %w", err)
 	}
@@ -657,15 +619,11 @@ func (b *Backend) DeleteScreenshot(path string, overrides api.ExternalIDOverride
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebError(b.core.DeleteScreenshot(ctx, api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+	return wrapWebError(b.currentCore().DeleteScreenshot(ctx, api.Request{
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}, imagePath))
@@ -677,15 +635,11 @@ func (b *Backend) DeleteTrackerImageURL(path string, overrides api.ExternalIDOve
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebError(b.core.DeleteTrackerImageURL(ctx, api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+	return wrapWebError(b.currentCore().DeleteTrackerImageURL(ctx, api.Request{
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}, imageURL))
@@ -697,15 +651,11 @@ func (b *Backend) SaveFinalScreenshotSelections(path string, overrides api.Exter
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebError(b.core.SaveFinalScreenshotSelections(ctx, api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+	return wrapWebError(b.currentCore().SaveFinalScreenshotSelections(ctx, api.Request{
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}, images))
@@ -717,15 +667,11 @@ func (b *Backend) ImportMenuImages(path string, overrides api.ExternalIDOverride
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebError(b.core.ImportMenuImages(ctx, api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+	return wrapWebError(b.currentCore().ImportMenuImages(ctx, api.Request{
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}, paths))
@@ -752,15 +698,11 @@ func (b *Backend) ListUploadCandidates(path string, overrides api.ExternalIDOver
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebResult(b.core.ListUploadCandidates(ctx, api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+	return wrapWebResult(b.currentCore().ListUploadCandidates(ctx, api.Request{
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}))
@@ -772,15 +714,11 @@ func (b *Backend) ListUploadedImages(path string, overrides api.ExternalIDOverri
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebResult(b.core.ListUploadedImages(ctx, api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+	return wrapWebResult(b.currentCore().ListUploadedImages(ctx, api.Request{
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}))
@@ -792,15 +730,11 @@ func (b *Backend) UploadImages(path string, overrides api.ExternalIDOverrides, n
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebResult(b.core.UploadImages(ctx, api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeGUI,
-		Options: api.UploadOptions{
-			Screens:         b.cfg.ScreenshotHandling.Screens,
-			SkipAutoTorrent: b.cfg.Metadata.SkipAutoTorrent,
-			OnlyID:          b.cfg.Metadata.OnlyID,
-			KeepImages:      b.cfg.Metadata.KeepImages,
-		},
+	return wrapWebResult(b.currentCore().UploadImages(ctx, api.Request{
+		Paths:   []string{path},
+		Mode:    api.ModeGUI,
+		Options: b.baseUploadOptions(),
+
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 		Trackers:             append([]string{}, trackersList...),
@@ -813,7 +747,7 @@ func (b *Backend) DeleteUploadedImage(path string, imagePath string, host string
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebError(b.core.DeleteUploadedImage(ctx, api.Request{
+	return wrapWebError(b.currentCore().DeleteUploadedImage(ctx, api.Request{
 		Paths: []string{path},
 		Mode:  api.ModeGUI,
 	}, imagePath, host))
@@ -861,7 +795,7 @@ func (b *Backend) exportableConfig() (*config.Config, error) {
 		return nil, fmt.Errorf("web: %w", err)
 	}
 	if strings.TrimSpace(cfg.MainSettings.DBPath) == "" {
-		cfg.MainSettings.DBPath = b.cfg.MainSettings.DBPath
+		cfg.MainSettings.DBPath = b.currentConfig().MainSettings.DBPath
 	}
 	if cfg.Trackers.Trackers == nil {
 		cfg.Trackers.Trackers = map[string]config.TrackerConfig{}
@@ -873,7 +807,7 @@ func (b *Backend) exportableConfig() (*config.Config, error) {
 }
 
 func (b *Backend) allowUnencryptedExport() (bool, error) {
-	material, err := authmaterial.LoadFromDBPath(b.cfg.MainSettings.DBPath)
+	material, err := authmaterial.LoadFromDBPath(b.currentConfig().MainSettings.DBPath)
 	if err == nil {
 		return material.AllowUnencryptedExport, nil
 	}
@@ -891,10 +825,14 @@ func (b *Backend) SaveConfig(payload string) error {
 	if err != nil {
 		return fmt.Errorf("web: %w", err)
 	}
-	if strings.TrimSpace(cfg.MainSettings.DBPath) == "" {
-		cfg.MainSettings.DBPath = b.cfg.MainSettings.DBPath
+	if err := config.MergeMissingTrackerDefaults(cfg); err != nil {
+		return fmt.Errorf("web: %w", err)
 	}
-	if cfg.MainSettings.DBPath != b.cfg.MainSettings.DBPath {
+	currentCfg := b.currentConfig()
+	if strings.TrimSpace(cfg.MainSettings.DBPath) == "" {
+		cfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
+	}
+	if cfg.MainSettings.DBPath != currentCfg.MainSettings.DBPath {
 		return errors.New("changing main_settings.db_path requires restart")
 	}
 	if err := cfg.Validate(); err != nil {
@@ -903,7 +841,10 @@ func (b *Backend) SaveConfig(payload string) error {
 	if err := config.SaveToDatabase(context.Background(), cfg, b.repo); err != nil {
 		return fmt.Errorf("web: %w", err)
 	}
-	return b.applyConfig(*cfg)
+	runtimeCfg := *cfg
+	config.ApplyEnvOverrides(&runtimeCfg)
+	runtimeCfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
+	return b.applyConfig(runtimeCfg)
 }
 
 const configImportMaxBytes = importer.MaxFileBytes
@@ -924,7 +865,8 @@ func (b *Backend) ImportConfig(fileName, fileContent string) (string, []string, 
 		return "", nil, fmt.Errorf("web: %w", err)
 	}
 
-	cfg.MainSettings.DBPath = b.cfg.MainSettings.DBPath
+	currentCfg := b.currentConfig()
+	cfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
 
 	if err := cfg.Validate(); err != nil {
 		return "", nil, fmt.Errorf("validate imported config: %w", err)
@@ -935,6 +877,7 @@ func (b *Backend) ImportConfig(fileName, fileContent string) (string, []string, 
 	}
 
 	config.ApplyEnvOverrides(cfg)
+	cfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
 	if err := b.applyConfig(*cfg); err != nil {
 		return "", nil, err
 	}
@@ -981,18 +924,19 @@ func (b *Backend) DeleteHistoryRelease(sourcePath string) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebError(b.core.DeleteHistoryRelease(ctx, strings.TrimSpace(sourcePath)))
+	return wrapWebError(b.currentCore().DeleteHistoryRelease(ctx, strings.TrimSpace(sourcePath)))
 }
 
 func (b *Backend) GetLogPath() (string, error) {
-	return wrapWebResult(logging.LogPath(b.cfg.MainSettings.DBPath))
+	return wrapWebResult(logging.LogPath(b.currentConfig().MainSettings.DBPath))
 }
 
 func (b *Backend) GetRecentLogs(limit int) ([]logging.Entry, error) {
-	if b.logger == nil {
+	logger := b.currentLogger()
+	if logger == nil {
 		return nil, errors.New("logger not initialized")
 	}
-	return b.logger.Recent(limit), nil
+	return logger.Recent(limit), nil
 }
 
 func (b *Backend) GetLogExclusions() ([]string, error) {
@@ -1020,7 +964,8 @@ func (b *Backend) UpdateLogExclusions(patterns []string) error {
 }
 
 func (b *Backend) StartLogStream(sessionID string) (string, error) {
-	if b.logger == nil {
+	logger := b.currentLogger()
+	if logger == nil {
 		return "", errors.New("logger not initialized")
 	}
 	streamID, err := randomString(12)
@@ -1033,8 +978,8 @@ func (b *Backend) StartLogStream(sessionID string) (string, error) {
 		stop:      make(chan struct{}),
 		done:      make(chan struct{}),
 	}
-	subID, ch := b.logger.Subscribe(0)
-	session.logger = b.logger
+	subID, ch := logger.Subscribe(0)
+	session.logger = logger
 	session.subID = subID
 
 	b.streamMu.Lock()
@@ -1112,16 +1057,17 @@ func (b *Backend) buildRunOptions(debug bool, runLogLevel string) (runOptions, e
 }
 
 func (b *Backend) buildRunCore(opts runOptions) (api.Core, *logging.Logger, error) {
-	if err := b.requireCore(); err != nil {
+	rt, err := b.requireRuntime()
+	if err != nil {
 		return nil, nil, err
 	}
-	effectiveLogLevel := logging.ResolveEffectiveLevel(b.cfg.Logging.Level, opts.RunLogLevel, opts.Debug)
-	logger, err := logging.NewWithLevel(b.cfg.Logging, b.cfg.MainSettings.DBPath, effectiveLogLevel)
+	effectiveLogLevel := logging.ResolveEffectiveLevel(rt.cfg.Logging.Level, opts.RunLogLevel, opts.Debug)
+	logger, err := logging.NewWithLevel(rt.cfg.Logging, rt.cfg.MainSettings.DBPath, effectiveLogLevel)
 	if err != nil {
 		return nil, nil, fmt.Errorf("web: %w", err)
 	}
 	coreSvc, err := core.New(api.CoreDependencies{
-		Config: b.cfg,
+		Config: rt.cfg,
 		Logger: logger,
 		Services: api.ServiceSet{
 			Filesystem: filesystem.NewValidator(),
@@ -1157,12 +1103,7 @@ func (b *Backend) applyConfig(cfg config.Config) error {
 	if err != nil {
 		return fmt.Errorf("web: %w", err)
 	}
-	oldCore := b.core
-	oldLogger := b.logger
-	b.core = rt.Core
-	b.coreInitErr = nil
-	b.logger = rt.Logger
-	b.cfg = cfg
+	oldCore, oldLogger := b.replaceRuntime(cfg, rt.Core, rt.Logger)
 	if oldCore != nil {
 		_ = oldCore.Close()
 	}
@@ -1173,11 +1114,11 @@ func (b *Backend) applyConfig(cfg config.Config) error {
 }
 
 func (b *Backend) isPathWithinManagedDirs(candidate string) bool {
-	tmpDir, err := db.Subdir(b.cfg.MainSettings.DBPath, "tmp")
+	tmpDir, err := db.Subdir(b.currentConfig().MainSettings.DBPath, "tmp")
 	if err == nil && pathWithinRoot(tmpDir, candidate) {
 		return true
 	}
-	logPath, err := logging.LogPath(b.cfg.MainSettings.DBPath)
+	logPath, err := logging.LogPath(b.currentConfig().MainSettings.DBPath)
 	if err == nil && pathWithinRoot(filepath.Dir(logPath), candidate) {
 		return true
 	}

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -838,12 +838,15 @@ func (b *Backend) SaveConfig(payload string) error {
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("web: %w", err)
 	}
-	if err := config.SaveToDatabase(context.Background(), cfg, b.repo); err != nil {
-		return fmt.Errorf("web: %w", err)
-	}
 	runtimeCfg := *cfg
 	config.ApplyEnvOverrides(&runtimeCfg)
 	runtimeCfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
+	if err := runtimeCfg.Validate(); err != nil {
+		return fmt.Errorf("web: %w", err)
+	}
+	if err := config.SaveToDatabase(context.Background(), cfg, b.repo); err != nil {
+		return fmt.Errorf("web: %w", err)
+	}
 	return b.applyConfig(runtimeCfg)
 }
 
@@ -871,14 +874,18 @@ func (b *Backend) ImportConfig(fileName, fileContent string) (string, []string, 
 	if err := cfg.Validate(); err != nil {
 		return "", nil, fmt.Errorf("validate imported config: %w", err)
 	}
+	runtimeCfg := *cfg
+	config.ApplyEnvOverrides(&runtimeCfg)
+	runtimeCfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
+	if err := runtimeCfg.Validate(); err != nil {
+		return "", nil, fmt.Errorf("validate imported config: %w", err)
+	}
 
 	if err := config.SaveToDatabase(context.Background(), cfg, b.repo); err != nil {
 		return "", nil, fmt.Errorf("web: %w", err)
 	}
 
-	config.ApplyEnvOverrides(cfg)
-	cfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
-	if err := b.applyConfig(*cfg); err != nil {
+	if err := b.applyConfig(runtimeCfg); err != nil {
 		return "", nil, err
 	}
 

--- a/internal/webserver/backend_repo_test.go
+++ b/internal/webserver/backend_repo_test.go
@@ -197,6 +197,69 @@ func TestBackendFetchMetadataPropagatesSkipAutoTorrentSetting(t *testing.T) {
 	}
 }
 
+func TestBackendSaveConfigAppliesRuntimeConfigImmediately(t *testing.T) {
+	t.Parallel()
+
+	repoPath := filepath.Join(t.TempDir(), "backend-save-config.db")
+	repo, err := db.OpenWithLogger(repoPath, nil)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repo: %v", err)
+	}
+
+	initial := config.Config{
+		MainSettings:       config.MainSettingsConfig{TMDBAPI: "x", DBPath: repoPath},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+		Logging:            config.LoggingConfig{Level: "info"},
+	}
+	backend := &Backend{
+		cfg:  initial,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+	t.Cleanup(func() {
+		if coreSvc := backend.currentCore(); coreSvc != nil {
+			_ = coreSvc.Close()
+		}
+		if logger := backend.currentLogger(); logger != nil {
+			_ = logger.Close()
+		}
+	})
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	updated.Metadata.KeepImages = true
+	updated.ScreenshotHandling.Screens = 5
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	if err := backend.SaveConfig(payload); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	runtimeCfg := backend.currentConfig()
+	if !runtimeCfg.Metadata.SkipAutoTorrent || !runtimeCfg.Metadata.KeepImages {
+		t.Fatalf("expected metadata settings applied, got %#v", runtimeCfg.Metadata)
+	}
+	if runtimeCfg.ScreenshotHandling.Screens != 5 {
+		t.Fatalf("expected screenshots=5, got %d", runtimeCfg.ScreenshotHandling.Screens)
+	}
+	if backend.currentCore() == nil {
+		t.Fatal("expected runtime core to be rebuilt")
+	}
+	options := buildRunUploadOptions(runtimeCfg, runOptions{})
+	if !options.SkipAutoTorrent || !options.KeepImages || options.Screens != 5 {
+		t.Fatalf("expected upload options from saved config, got %#v", options)
+	}
+}
+
 func TestBuildRunUploadOptionsPropagatesSkipAutoTorrent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/webserver/backend_repo_test.go
+++ b/internal/webserver/backend_repo_test.go
@@ -260,6 +260,57 @@ func TestBackendSaveConfigAppliesRuntimeConfigImmediately(t *testing.T) {
 	}
 }
 
+func TestBackendSaveConfigRejectsInvalidEnvRuntimeConfig(t *testing.T) {
+	t.Setenv("UA_DEFAULT_SCREENS", "0")
+
+	repoPath := filepath.Join(t.TempDir(), "backend-save-config-env.db")
+	repo, err := db.OpenWithLogger(repoPath, nil)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repo: %v", err)
+	}
+
+	initial := config.Config{
+		MainSettings:       config.MainSettingsConfig{TMDBAPI: "x", DBPath: repoPath},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+		Logging:            config.LoggingConfig{Level: "info"},
+	}
+	backend := &Backend{
+		cfg:  initial,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	updated := initial
+	updated.ScreenshotHandling.Screens = 5
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	err = backend.SaveConfig(payload)
+	if err == nil {
+		t.Fatal("expected env-derived runtime validation error")
+	}
+	if !strings.Contains(err.Error(), "screenshot_handling.screens") {
+		t.Fatalf("expected screens validation error, got %v", err)
+	}
+	if got := backend.currentConfig().ScreenshotHandling.Screens; got != 1 {
+		t.Fatalf("expected runtime config to remain unchanged, got screens=%d", got)
+	}
+	if backend.currentCore() != nil {
+		t.Fatal("expected runtime core not to be rebuilt")
+	}
+	if _, loadErr := config.LoadFromDatabase(context.Background(), repo); loadErr == nil {
+		t.Fatal("expected invalid runtime config to be rejected before database save")
+	}
+}
+
 func TestBuildRunUploadOptionsPropagatesSkipAutoTorrent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/webserver/jobs.go
+++ b/internal/webserver/jobs.go
@@ -284,12 +284,12 @@ func (b *Backend) runDupeCheckJob(ctx context.Context, job *dupeCheckJob) {
 		Paths:                []string{job.sourcePath},
 		Mode:                 api.ModeGUI,
 		Trackers:             job.trackers,
-		Options:              buildBaseMetadataOptions(b.cfg),
+		Options:              b.baseUploadOptions(),
 		ExternalIDOverrides:  job.overrides,
 		ReleaseNameOverrides: job.nameOverrides,
 	}
 
-	summary, err := b.core.CheckDupes(progressCtx, req)
+	summary, err := b.currentCore().CheckDupes(progressCtx, req)
 	job.mu.Lock()
 	job.finishedAt = time.Now().UTC()
 	job.cancel = nil
@@ -422,7 +422,7 @@ func (b *Backend) StartTrackerUpload(sessionID string, path string, overrides ap
 	}
 	seedCtx, cancel := context.WithTimeout(context.Background(), seedPreparedMetaTimeout)
 	defer cancel()
-	if err := guishared.SeedRunCorePreparedMeta(seedCtx, b.core, runCore, seedReq); err != nil {
+	if err := guishared.SeedRunCorePreparedMeta(seedCtx, b.currentCore(), runCore, seedReq); err != nil {
 		_ = runCore.Close()
 		_ = runLogger.Close()
 		return "", fmt.Errorf("web: %w", err)
@@ -658,7 +658,7 @@ func (b *Backend) runSingleTrackerUpload(ctx context.Context, job *trackerUpload
 		Trackers:                    []string{tracker},
 		IgnoreDupesFor:              append([]string(nil), job.ignoreDupesFor...),
 		IgnoreTrackerRuleFailures:   false,
-		Options:                     buildRunUploadOptions(b.cfg, job.runOptions),
+		Options:                     buildRunUploadOptions(b.currentConfig(), job.runOptions),
 		ExternalIDOverrides:         job.overrides,
 		ReleaseNameOverrides:        job.nameOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(job.questionnaireAnswers),

--- a/internal/webserver/runtime_snapshot.go
+++ b/internal/webserver/runtime_snapshot.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package webserver
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/logging"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+type backendRuntimeSnapshot struct {
+	cfg         config.Config
+	core        api.Core
+	coreInitErr error
+	logger      *logging.Logger
+}
+
+func (b *Backend) runtimeSnapshot() backendRuntimeSnapshot {
+	if b == nil {
+		return backendRuntimeSnapshot{}
+	}
+	b.runtimeMu.RLock()
+	defer b.runtimeMu.RUnlock()
+	return backendRuntimeSnapshot{
+		cfg:         b.cfg,
+		core:        b.core,
+		coreInitErr: b.coreInitErr,
+		logger:      b.logger,
+	}
+}
+
+func (b *Backend) requireRuntime() (backendRuntimeSnapshot, error) {
+	if b == nil {
+		return backendRuntimeSnapshot{}, errors.New("backend not initialized")
+	}
+	rt := b.runtimeSnapshot()
+	if rt.core != nil {
+		return rt, nil
+	}
+	if rt.coreInitErr != nil {
+		return backendRuntimeSnapshot{}, fmt.Errorf("core unavailable: %w", rt.coreInitErr)
+	}
+	return backendRuntimeSnapshot{}, errors.New("core not initialized")
+}
+
+func (b *Backend) currentConfig() config.Config {
+	if b == nil {
+		return config.Config{}
+	}
+	b.runtimeMu.RLock()
+	defer b.runtimeMu.RUnlock()
+	return b.cfg
+}
+
+func (b *Backend) currentCore() api.Core {
+	if b == nil {
+		return nil
+	}
+	b.runtimeMu.RLock()
+	defer b.runtimeMu.RUnlock()
+	return b.core
+}
+
+func (b *Backend) currentLogger() *logging.Logger {
+	if b == nil {
+		return nil
+	}
+	b.runtimeMu.RLock()
+	defer b.runtimeMu.RUnlock()
+	return b.logger
+}
+
+func (b *Backend) baseUploadOptions() api.UploadOptions {
+	return buildBaseMetadataOptions(b.currentConfig())
+}
+
+func (b *Backend) replaceRuntime(cfg config.Config, core api.Core, logger *logging.Logger) (api.Core, *logging.Logger) {
+	b.runtimeMu.Lock()
+	defer b.runtimeMu.Unlock()
+	oldCore := b.core
+	oldLogger := b.logger
+	b.core = core
+	b.coreInitErr = nil
+	b.logger = logger
+	b.cfg = cfg
+	return oldCore, oldLogger
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration changes now apply immediately and consistently across uploads, dupe checks, history, logs, and playlist flows; invalid environment-derived configs are rejected before being applied.

* **New Features**
  * Runtime state is swapped atomically so active operations use a consistent, snapshot view of config/core/logger.

* **Tests**
  * Added tests verifying immediate config application and rejection of invalid env-overridden runtime configs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/upbrr/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->