### PR TITLE
chore(lint): add path portability policy

### DIFF
--- a/.github/workflows/golangci-lint.yml22
+++ b/.github/workflows/golangci-lint.yml22
@@ -12,9 +12,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pathpolicy:
+    name: pathpolicy (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run path portability policy
+        run: go run ./cmd/pathpolicy
+
   golangci:
+    name: golangci-lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: pathpolicy
 
     steps:
       - name: Checkout

--- a/.github/workflows/logpolicy.yml22
+++ b/.github/workflows/logpolicy.yml22
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test.yml22
+++ b/.github/workflows/test.yml22
@@ -39,9 +39,16 @@ jobs:
         run: go run ./cmd/commitmsgcheck --from "$BASE_SHA" --to "$HEAD_SHA"
 
   test-go:
-    name: Go tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    name: Go tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
 
     steps:
       - name: Checkout
@@ -54,7 +61,7 @@ jobs:
           cache: true
 
       - name: Run Go tests
-        run: make test-go
+        run: go test -race -v -timeout 20m ./...
 
   test-frontend:
     name: Frontend checks

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - canonicalheader
     - contextcheck
     - copyloopvar
+    - depguard
     - durationcheck
     - errname
     - errchkjson
@@ -72,6 +73,13 @@ linters:
         - alltime
         - hardlink
         - hardlinked
+
+    depguard:
+      rules:
+        local-filesystem-paths:
+          deny:
+            - pkg: "path$"
+              desc: use filepath for local filesystem paths; path is allowed only for slash-delimited URL, torrent, or API payload paths
 
   exclusions:
     generated: lax

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Source Of Truth
 
-- Contributor setup, platform notes, Makefile targets, build commands, tests, hooks, and commit format live in `CONTRIBUTING.md`.
-- Tool wiring lives in `Makefile`, `lefthook.yml`, `.golangci.yml`, `gui/frontend/package.json`, and `.github/workflows/*.yml`.
-- When docs disagree, prefer tool config over prose. Update prose instead of copying stale commands.
+- Contributor setup/platform notes/Makefile targets/build commands/tests/hooks/commit format: `CONTRIBUTING.md`.
+- Tool wiring: `Makefile`, `lefthook.yml`, `.golangci.yml`, `gui/frontend/package.json`, `.github/workflows/*.yml`.
+- Docs disagree? Tool config wins. Update prose; don't copy stale commands.
 
 ## Quick Commands
 
@@ -13,59 +13,69 @@ make help               # Show supported targets
 make backend            # Fast build sanity check
 make test-go            # Full Go tests with race detector
 make test-frontend      # Frontend lint/dead-code/type/unit/format checks
-make lint               # Full Go lint
+make lint               # Path policy + full Go lint
 make logpolicy          # Logging policy check
+make pathpolicy         # Path portability policy check
 make precommit          # Lefthook pre-commit
 make prepush            # Lefthook pre-push
 make gofix-check-changed # Inspect Go fix drift on changed packages
 git diff --check        # Whitespace/conflict-marker check
 ```
 
-Use `CONTRIBUTING.md` for full command reference and platform details. Use narrow package/file checks first, then expand when touching shared behavior or release surfaces.
+Use `CONTRIBUTING.md` for full command reference/platform details. Start narrow package/file checks; expand for shared behavior or release surfaces.
 
 ## Code Quality
 
-- Match repo style. Keep changes narrow. Fix root causes, not symptoms.
-- New Go code must satisfy enabled `.golangci.yml` linters and formatters. Avoid broad `nolint`.
-- Active checks include `noctx`, `contextcheck`, `containedctx`, `wrapcheck`, `revive`, `forcetypeassert`, `unparam`, `usetesting`, and `gosec`.
-- Use context-aware APIs. Propagate context where meaningful; terminate it deliberately when crossing into root/background work.
-- Wrap external-package errors where lint requires it. Handle errors by returning, wrapping, logging with useful context, or making intentional ignore paths obvious.
+- Match repo style. Narrow changes. Fix root cause, not symptoms.
+- New Go code must satisfy `.golangci.yml` linters/formatters. Avoid broad `nolint`.
+- Active checks: `depguard`, `noctx`, `contextcheck`, `containedctx`, `wrapcheck`, `revive`, `forcetypeassert`, `unparam`, `usetesting`, `gosec`, `logpolicy`, `pathpolicy`.
+- Use context-aware APIs. Propagate context where meaningful; terminate deliberately crossing root/background work.
+- Wrap external-package errors where lint requires. Handle errors by return/wrap/log useful context, or make intentional ignore obvious.
 - Avoid unchecked type assertions. Use `testing` helpers in tests. Justify narrow `nolint` at source.
-- Frontend changes must keep TypeScript, ESLint, Stylelint, and dead-code checks clean. Do not weaken rules or bypass type errors.
-- For embedded frontend visual checks, rebuild/sync embedded assets and rebuild the CLI binary before browser automation. Use the main embedded server port (`7480`) with `dist/upbrr.exe serve --dev-no-auth`; do not use the Vite-only dev server on `5173` for embedded parity checks. Stop the embedded server after inspection.
+- Frontend: keep TypeScript, ESLint, Stylelint, dead-code clean. Don't weaken rules or bypass type errors.
+- Embedded frontend visual checks: rebuild/sync embedded assets + CLI before browser automation. Use main embedded port `7480` with `dist/upbrr.exe serve --dev-no-auth`; avoid Vite-only `5173` for embedded parity. Stop server after inspection.
+
+## Path Portability
+
+- Use `filepath` for local filesystem paths. Use `path` only for slash-delimited torrent paths, URLs, or API payloads explicitly defined to use `/`.
+- Torrent/API -> local filesystem boundary: validate slash paths first, then convert deliberately with `filepath.FromSlash`.
+- Security/path traversal checks reject POSIX + Windows absolute/escaping forms on every OS: leading `/`, leading `\`, drive-letter paths, UNC paths, `..` segments.
+- Tests must not build local paths with hardcoded OS-rooted literals. Use `t.TempDir`, `filepath.Join`, `filepath.ToSlash` for cross-platform assertions.
+- `cmd/pathpolicy` flags hardcoded OS-rooted literals in `filepath` calls, string-built local paths, `path` on local paths, `filepath` on URL/API slash paths, slash-data filesystem calls, and slash assertions without `filepath.ToSlash`.
+- Legit stdlib `path` imports require import-local `//nolint:depguard // <slash-data reason>`. Rare `pathpolicy` cases require `//pathpolicy:allow <reason>` on same/previous line. Fix source first; don't weaken checkers.
 
 ## Logging
 
-- Add logs where they explain meaningful state, decisions, failures, retries, or user-visible outcomes. Improve touched functions when practical and relevant.
-- Treat `cmd/logpolicy` as logging contract. Fix flagged log messages or levels at source; do not weaken checker or move noise sideways.
-- Redact secrets and user-sensitive data with `internal/redaction/redaction.go`.
-- Never log credentials, tokens, API keys, passkeys, cookies, or secret-bearing payloads without repository redaction standard.
-- Keep levels purposeful: `INFO` for concise user-facing upload progress/outcomes, `DEBUG` for troubleshooting context, `TRACE` for high-fidelity operational flow.
+- Add logs for meaningful state, decisions, failures, retries, user-visible outcomes. Improve touched funcs when relevant.
+- Treat `cmd/logpolicy` as logging contract. Fix flagged logs/levels at source; don't weaken checker or move noise sideways.
+- Redact secrets/user-sensitive data with `internal/redaction/redaction.go`.
+- Never log credentials, tokens, API keys, passkeys, cookies, or secret-bearing payloads without repo redaction standard.
+- Levels: `INFO` concise user-facing upload progress/outcomes; `DEBUG` troubleshooting context; `TRACE` high-fidelity operational flow.
 
 ## Go Fix
 
-- Do not apply `go fix` wholesale without review.
+- Don't apply `go fix` wholesale without review.
 - Prefer `make gofix-check-changed` and package-scoped `go fix -omitzero=false <packages>`.
-- Keep `omitzero` disabled unless a change explicitly reviews JSON output semantics.
+- Keep `omitzero` disabled unless change explicitly reviews JSON output semantics.
 
 ## Product Invariants
 
-- Shared behavior spans CLI, Wails GUI, and embedded web-serving mode. Preserve parity in request construction, options, and upload behavior where practical.
-- App targets Windows, Linux, and macOS. Avoid OS-specific path, process, filesystem, archive, or build assumptions unless intentionally platform-gated.
-- Preserve `api.Mode` usage. Keep CLI, Wails GUI, and embedded web flows aligned with request types under `pkg/api` and shared core behavior under `internal`.
-- Upload options, tracker overrides, retries, and execution flags should be checked from CLI and GUI entrypoints when shared.
-- SQLite databases may be shared across branches during development. Keep migrations compatible with permissive cross-branch use.
-- Migrations must be additive, forward-only, and idempotent where practical. Prefer guarded table/index creation, additive columns, and safe backfills. Avoid destructive drop/rename/tighten changes older branches may still read.
+- Shared behavior spans CLI, Wails GUI, embedded web-serving mode. Preserve parity in request construction, options, upload behavior where practical.
+- App targets Windows, Linux, macOS. Avoid OS-specific path/process/filesystem/archive/build assumptions unless intentionally platform-gated.
+- Preserve `api.Mode` usage. Align CLI, Wails GUI, embedded web flows with request types under `pkg/api` and shared core behavior under `internal`.
+- Upload options, tracker overrides, retries, execution flags: check CLI + GUI entrypoints when shared.
+- SQLite DBs may be shared across branches during dev. Keep migrations compatible with permissive cross-branch use.
+- Migrations additive, forward-only, idempotent where practical. Prefer guarded table/index creation, additive columns, safe backfills. Avoid destructive drop/rename/tighten changes older branches may still read.
 
 ## Unattended Safety
 
-- Treat unattended and unattended-confirm flows as safety-critical. They must remain non-blocking and conservative.
-- Do not add interactive prompts, hidden confirmations, or ambiguous fallthrough behavior in unattended paths.
-- If unattended mode cannot choose safely, prefer dry-run, site-check, explicit skip, or clear failure over uncertain upload.
-- Preserve invariants: site-check implies dry-run; debug implies safe non-upload behavior; unattended flows keep current questionnaire/default-selection behavior unless change updates those rules everywhere.
-- Preserve safe skip and override behavior for dupes, rule failures, screenshot/image-host uploads, torrent injection, and retries. If one shared surface supports skip/override, keep parity in other shared surface.
+- Unattended/unattended-confirm flows safety-critical. Keep non-blocking + conservative.
+- No interactive prompts, hidden confirmations, ambiguous fallthrough in unattended paths.
+- If unattended cannot choose safely, prefer dry-run, site-check, explicit skip, or clear failure over uncertain upload.
+- Preserve invariants: site-check implies dry-run; debug implies safe non-upload; unattended flows keep current questionnaire/default-selection behavior unless change updates rules everywhere.
+- Preserve safe skip/override for dupes, rule failures, screenshot/image-host uploads, torrent injection, retries. If one shared surface supports skip/override, keep parity in other shared surface.
 
 ## Scope Notes
 
-- Do not duplicate detailed contributor workflow from `CONTRIBUTING.md` here. Link or summarize only agent-critical deltas.
-- If change affects one area, run smallest relevant checks. If change crosses backend, frontend, GUI, packaging, or unattended execution, expand validation.
+- Don't duplicate detailed contributor workflow from `CONTRIBUTING.md`; link/summarize agent-critical deltas only.
+- If change affects one area, run smallest relevant checks. If change crosses backend/frontend/GUI/packaging/unattended execution, expand validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Source Of Truth
 
 - Contributor setup/platform notes/Makefile targets/build commands/tests/hooks/commit format: `CONTRIBUTING.md`.
-- Tool wiring: `Makefile`, `lefthook.yml`, `.golangci.yml`, `gui/frontend/package.json`, `.github/workflows/*.yml`.
+- Tool wiring: `Makefile`, `lefthook.yml`, `.golangci.yml`, `gui/frontend/package.json`, `.github/workflows/*`.
 - Docs disagree? Tool config wins. Update prose; don't copy stale commands.
 
 ## Quick Commands
@@ -40,8 +40,9 @@ Use `CONTRIBUTING.md` for full command reference/platform details. Start narrow 
 - Use `filepath` for local filesystem paths. Use `path` only for slash-delimited torrent paths, URLs, or API payloads explicitly defined to use `/`.
 - Torrent/API -> local filesystem boundary: validate slash paths first, then convert deliberately with `filepath.FromSlash`.
 - Security/path traversal checks reject POSIX + Windows absolute/escaping forms on every OS: leading `/`, leading `\`, drive-letter paths, UNC paths, `..` segments.
+- Use `internal/pathutil.IsWithinRoot` / `SamePath` for local root containment/equality. Do not add ad-hoc `filepath.Rel` + string-prefix guards.
 - Tests must not build local paths with hardcoded OS-rooted literals. Use `t.TempDir`, `filepath.Join`, `filepath.ToSlash` for cross-platform assertions.
-- `cmd/pathpolicy` flags hardcoded OS-rooted literals in `filepath` calls, string-built local paths, `path` on local paths, `filepath` on URL/API slash paths, slash-data filesystem calls, and slash assertions without `filepath.ToSlash`.
+- `cmd/pathpolicy` flags hardcoded OS-rooted literals in `filepath` calls, string-built local paths, `path` on local paths, `filepath` on URL/API slash paths, slash-data filesystem calls, slash assertions without `filepath.ToSlash`, and ad-hoc local path guards outside `internal/pathutil`.
 - Legit stdlib `path` imports require import-local `//nolint:depguard // <slash-data reason>`. Rare `pathpolicy` cases require `//pathpolicy:allow <reason>` on same/previous line. Fix source first; don't weaken checkers.
 
 ## Logging

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ lefthook install
 What runs when:
 
 - `pre-commit` — on **staged files only**: `prettier --write` (gui/frontend), `eslint` (gui/frontend/src), `golangci-lint fmt` (Go), `go run ./cmd/logpolicy` (when `internal/**` Go files change), and `go run ./cmd/pathpolicy` (when Go files change). Formatters auto-re-stage their fixes.
-- `pre-push` — full-project TypeScript typecheck and `make lint`, which runs the path-portability checker before golangci-lint. CI also runs frontend lint, dead-code, and formatting checks.
+- `pre-push` — full-project TypeScript typecheck and `make lint`, which runs the path-portability checker before golangci-lint. These checks run locally without CI. Disabled workflow templates under `.github/workflows/*.yml22` mirror the Go test/pathpolicy OS matrix for later CI re-enable.
 - `commit-msg` — `go run ./cmd/commitmsgcheck` enforces [Conventional Commits](https://www.conventionalcommits.org/) without requiring Node.js or `pnpm install`.
 
 Makefile shortcuts:
@@ -184,7 +184,7 @@ make gui              # Wails GUI with current embedded assets
 
 ## Tests and checks
 
-Run the same checks CI runs:
+Run the local checks before pushing:
 
 ```sh
 make test-go            # Go tests with race detector
@@ -221,12 +221,13 @@ upbrr targets Windows, Linux, and macOS. Do not assume POSIX path behavior in Go
 - Use `path` only for slash-delimited data formats, such as torrent-internal file names, URLs, or API payloads defined to use `/`.
 - At boundaries between torrent/API paths and local filesystem paths, normalize deliberately: validate slash paths first, then convert with `filepath.FromSlash`.
 - Security/path traversal checks must reject both POSIX and Windows absolute or escaping forms on every OS: leading `/`, leading `\`, drive-letter paths, UNC paths, and `..` segments.
+- Use `internal/pathutil.IsWithinRoot` and `internal/pathutil.SamePath` for local root containment and path equality. Do not add ad-hoc `filepath.Rel` plus string-prefix guards; `pathpolicy` rejects those helper names outside `internal/pathutil`.
 - Tests should not assert raw `"/foo/"` substrings against local filesystem paths. Use `filepath.ToSlash(path)` for cross-platform assertions, or build expected paths with `filepath.Join`.
 - Tests should not pass hardcoded OS-rooted literals such as `C:\...`, `\\server\share`, or `/tmp/...` into `filepath` calls. Use `t.TempDir` or existing path variables.
 - Do not build local filesystem paths with string concatenation, `fmt.Sprintf`, or `strings.Join(..., "/")`. Use `filepath.Join`.
 - Use `path.Base`, `path.Ext`, and related `path` APIs for URL/API paths. Use `filepath.Base`, `filepath.Ext`, and related `filepath` APIs for local paths. Legit stdlib `path` imports need import-local `//nolint:depguard // <slash-data reason>`.
 
-`make pathpolicy` runs the repo-local AST checker for hardcoded OS-rooted literals in `filepath` calls, string-built local paths, wrong `path`/`filepath` package use, slash-data filesystem calls, and slash assertions without `filepath.ToSlash`. Rare intentional checker exceptions need `//pathpolicy:allow <reason>` on the same or previous line. `make lint`, pre-commit, and pre-push run it automatically.
+`make pathpolicy` runs the repo-local AST checker for hardcoded OS-rooted literals in `filepath` calls, string-built local paths, wrong `path`/`filepath` package use, slash-data filesystem calls, slash assertions without `filepath.ToSlash`, and ad-hoc local path guard helpers outside `internal/pathutil`. Rare intentional checker exceptions need `//pathpolicy:allow <reason>` on the same or previous line. `make lint`, pre-commit, and pre-push run it automatically.
 
 ## AI agent instructions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Notes:
 
 ## Git hooks (Lefthook)
 
-All contributors should install the git hooks once. They run Prettier, ESLint, golangci-lint, the log-policy checker, and the repo's commit-message validator locally so issues surface before CI sees them.
+All contributors should install the git hooks once. They run Prettier, ESLint, golangci-lint, the log-policy checker, the path-portability checker, and the repo's commit-message validator locally so issues surface before CI sees them.
 
 ```sh
 # Go-only contributors (no Node required):
@@ -73,8 +73,8 @@ lefthook install
 
 What runs when:
 
-- `pre-commit` — on **staged files only**: `prettier --write` (gui/frontend), `eslint` (gui/frontend/src), `golangci-lint fmt` (Go), `go run ./cmd/logpolicy` (when `internal/**` Go files change). Formatters auto-re-stage their fixes.
-- `pre-push` — full-project TypeScript typecheck and Go lint. CI also runs frontend lint, dead-code, and formatting checks.
+- `pre-commit` — on **staged files only**: `prettier --write` (gui/frontend), `eslint` (gui/frontend/src), `golangci-lint fmt` (Go), `go run ./cmd/logpolicy` (when `internal/**` Go files change), and `go run ./cmd/pathpolicy` (when Go files change). Formatters auto-re-stage their fixes.
+- `pre-push` — full-project TypeScript typecheck and `make lint`, which runs the path-portability checker before golangci-lint. CI also runs frontend lint, dead-code, and formatting checks.
 - `commit-msg` — `go run ./cmd/commitmsgcheck` enforces [Conventional Commits](https://www.conventionalcommits.org/) without requiring Node.js or `pnpm install`.
 
 Makefile shortcuts:
@@ -189,8 +189,9 @@ Run the same checks CI runs:
 ```sh
 make test-go            # Go tests with race detector
 make test-frontend      # Frontend checks including Vitest
-make lint
+make lint               # Path policy, then golangci-lint
 make logpolicy
+make pathpolicy
 ```
 
 Useful focused checks:
@@ -211,6 +212,21 @@ Alternatively, `make precommit` and `make prepush` run the configured Lefthook c
 - Tracker-specific code lives primarily under `internal/trackers/impl`. Shared tracker behaviour goes in `internal/trackers`, not in the impls.
 - `pkg/api` holds request/response types shared across surfaces.
 - The repo currently includes generated and built assets in a few locations; review changes carefully and avoid committing build output by accident.
+
+### Path portability
+
+upbrr targets Windows, Linux, and macOS. Do not assume POSIX path behavior in Go code or tests unless the value is explicitly a torrent-internal path, URL path, or remote API payload path.
+
+- Use `filepath.Join`, `filepath.Clean`, `filepath.Rel`, `filepath.Separator`, and related `filepath` APIs for local filesystem paths.
+- Use `path` only for slash-delimited data formats, such as torrent-internal file names, URLs, or API payloads defined to use `/`.
+- At boundaries between torrent/API paths and local filesystem paths, normalize deliberately: validate slash paths first, then convert with `filepath.FromSlash`.
+- Security/path traversal checks must reject both POSIX and Windows absolute or escaping forms on every OS: leading `/`, leading `\`, drive-letter paths, UNC paths, and `..` segments.
+- Tests should not assert raw `"/foo/"` substrings against local filesystem paths. Use `filepath.ToSlash(path)` for cross-platform assertions, or build expected paths with `filepath.Join`.
+- Tests should not pass hardcoded OS-rooted literals such as `C:\...`, `\\server\share`, or `/tmp/...` into `filepath` calls. Use `t.TempDir` or existing path variables.
+- Do not build local filesystem paths with string concatenation, `fmt.Sprintf`, or `strings.Join(..., "/")`. Use `filepath.Join`.
+- Use `path.Base`, `path.Ext`, and related `path` APIs for URL/API paths. Use `filepath.Base`, `filepath.Ext`, and related `filepath` APIs for local paths. Legit stdlib `path` imports need import-local `//nolint:depguard // <slash-data reason>`.
+
+`make pathpolicy` runs the repo-local AST checker for hardcoded OS-rooted literals in `filepath` calls, string-built local paths, wrong `path`/`filepath` package use, slash-data filesystem calls, and slash assertions without `filepath.ToSlash`. Rare intentional checker exceptions need `//pathpolicy:allow <reason>` on the same or previous line. `make lint`, pre-commit, and pre-push run it automatically.
 
 ## AI agent instructions
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build backend frontend frontend-bundle gui dev dev-frontend test test-go test-frontend lint lint-json logpolicy precommit prepush fmt fmt-go fmt-frontend gofix gofix-check gofix-changed gofix-check-changed commitmsg-check clean
+.PHONY: help build backend frontend frontend-bundle gui dev dev-frontend test test-go test-frontend lint lint-json logpolicy pathpolicy precommit prepush fmt fmt-go fmt-frontend gofix gofix-check gofix-changed gofix-check-changed commitmsg-check clean
 
 ifeq ($(OS),Windows_NT)
 EXE := .exe
@@ -41,9 +41,10 @@ help:
 	@echo   make test-frontend      Run frontend lint/type/format/dead-code/unit checks
 	@$(BLANK)
 	@echo Linting
-	@echo   make lint               Run full Go lint
+	@echo   make lint               Run path policy and full Go lint
 	@echo   make lint-json          Write Go lint JSON to lint-report.json
 	@echo   make logpolicy          Run logging policy check
+	@echo   make pathpolicy         Run path portability policy check
 	@$(BLANK)
 	@echo Pre-commit
 	@echo   make precommit          Run Lefthook pre-commit
@@ -96,7 +97,7 @@ test-frontend:
 	pnpm --dir gui/frontend run test:unit
 	pnpm --dir gui/frontend run format:check
 
-lint:
+lint: pathpolicy
 	golangci-lint run $(GOLANGCI_FLAGS) ./...
 
 lint-json:
@@ -104,6 +105,9 @@ lint-json:
 
 logpolicy:
 	go run ./cmd/logpolicy
+
+pathpolicy:
+	go run ./cmd/pathpolicy
 
 precommit:
 	lefthook run pre-commit

--- a/cmd/pathpolicy/main.go
+++ b/cmd/pathpolicy/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/autobrr/upbrr/internal/pathpolicy"
+)
+
+func main() {
+	os.Exit(run(os.Stdout, os.Stderr, os.Getwd, pathpolicy.CheckRepository))
+}
+
+func run(stdout io.Writer, stderr io.Writer, getwd func() (string, error), check func(string) ([]pathpolicy.Violation, error)) int {
+	root, err := getwd()
+	if err != nil {
+		fmt.Fprintf(stderr, "pathpolicy: determine working directory: %v\n", err)
+		return 1
+	}
+
+	violations, err := check(root)
+	if err != nil {
+		fmt.Fprintf(stderr, "pathpolicy: %v\n", err)
+		return 1
+	}
+	if len(violations) == 0 {
+		fmt.Fprintln(stdout, "pathpolicy: no issues found")
+		return 0
+	}
+
+	for _, violation := range violations {
+		fmt.Fprintf(stderr, "%s:%d:%d: %s\n", violation.File, violation.Line, violation.Column, violation.Message)
+	}
+	return 1
+}

--- a/cmd/pathpolicy/main_test.go
+++ b/cmd/pathpolicy/main_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/pathpolicy"
+)
+
+func TestRunPrintsSuccessWhenNoIssuesFound(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := run(&stdout, &stderr, func() (string, error) {
+		return "repo", nil
+	}, func(root string) ([]pathpolicy.Violation, error) {
+		if root != "repo" {
+			t.Fatalf("unexpected root: %s", root)
+		}
+		return nil, nil
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if got := stdout.String(); got != "pathpolicy: no issues found\n" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("unexpected stderr: %q", got)
+	}
+}
+
+func TestRunPrintsViolationsToStderr(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := run(&stdout, &stderr, func() (string, error) {
+		return "repo", nil
+	}, func(string) ([]pathpolicy.Violation, error) {
+		return []pathpolicy.Violation{{
+			File:    "internal/example_test.go",
+			Line:    12,
+			Column:  4,
+			Message: "bad path",
+		}}, nil
+	})
+
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitCode)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+	if got := stderr.String(); got != "internal/example_test.go:12:4: bad path\n" {
+		t.Fatalf("unexpected stderr: %q", got)
+	}
+}
+
+func TestRunPrintsCheckerErrorsToStderr(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := run(&stdout, &stderr, func() (string, error) {
+		return "repo", nil
+	}, func(string) ([]pathpolicy.Violation, error) {
+		return nil, errors.New("boom")
+	})
+
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitCode)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "pathpolicy: boom\n") {
+		t.Fatalf("unexpected stderr: %q", got)
+	}
+}
+
+func TestRunPrintsGetwdErrorsToStderr(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := run(&stdout, &stderr, func() (string, error) {
+		return "", errors.New("cwd")
+	}, func(string) ([]pathpolicy.Violation, error) {
+		return nil, nil
+	})
+
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitCode)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "pathpolicy: determine working directory: cwd\n") {
+		t.Fatalf("unexpected stderr: %q", got)
+	}
+}

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
+	"path" //nolint:depguard // Builds URL paths, not local filesystem paths.
 	"path/filepath"
 	"reflect"
 	"slices"

--- a/internal/core/history_cleanup.go
+++ b/internal/core/history_cleanup.go
@@ -13,6 +13,7 @@ import (
 
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/paths"
+	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -195,7 +196,7 @@ func resolveContentTmpRoot(tmpRoot string, candidate string) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	if !pathWithinRoot(absTmpRoot, absCandidate) {
+	if !pathutil.IsWithinRoot(absTmpRoot, absCandidate) {
 		return "", false
 	}
 	rel, err := filepath.Rel(absTmpRoot, absCandidate)
@@ -225,7 +226,7 @@ func removeIfWithinRoot(root string, target string, recursive bool) (bool, error
 	if absTarget == absRoot {
 		return false, nil
 	}
-	if !pathWithinRoot(absRoot, absTarget) {
+	if !pathutil.IsWithinRoot(absRoot, absTarget) {
 		return false, nil
 	}
 	if recursive {
@@ -264,15 +265,4 @@ func removeIfWithinRoots(roots []string, target string, recursive bool) (bool, e
 		}
 	}
 	return false, nil
-}
-
-func pathWithinRoot(root string, target string) bool {
-	rel, err := filepath.Rel(root, target)
-	if err != nil {
-		return false
-	}
-	if rel == "." {
-		return true
-	}
-	return !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".." && !filepath.IsAbs(rel)
 }

--- a/internal/core/history_cleanup.go
+++ b/internal/core/history_cleanup.go
@@ -223,7 +223,7 @@ func removeIfWithinRoot(root string, target string, recursive bool) (bool, error
 	if err != nil {
 		return false, fmt.Errorf("cleanup history artifact: resolve target path: %w", err)
 	}
-	if absTarget == absRoot {
+	if pathutil.SamePath(absRoot, absTarget) {
 		return false, nil
 	}
 	if !pathutil.IsWithinRoot(absRoot, absTarget) {

--- a/internal/core/history_cleanup_test.go
+++ b/internal/core/history_cleanup_test.go
@@ -161,3 +161,31 @@ func TestCoreDeleteAllHistoryReleasesPurgesEveryStoredPath(t *testing.T) {
 		t.Fatalf("unexpected purged paths: %#v", repo.purgedPaths)
 	}
 }
+
+func TestRemoveIfWithinRootKeepsAliasedRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sentinel := filepath.Join(root, "sentinel.txt")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	alias := filepath.Join(root, "self")
+	if err := os.Symlink(root, alias); err != nil {
+		t.Skipf("symlink unavailable on this host: %v", err)
+	}
+
+	removed, err := removeIfWithinRoot(root, alias, true)
+	if err != nil {
+		t.Fatalf("remove aliased root: %v", err)
+	}
+	if removed {
+		t.Fatalf("expected aliased root to be kept")
+	}
+	if _, err := os.Lstat(alias); err != nil {
+		t.Fatalf("expected alias to remain: %v", err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("expected root contents to remain: %v", err)
+	}
+}

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -584,7 +584,7 @@ func removeIfWithinRoot(root string, target string, recursive bool) (bool, error
 	if err != nil {
 		return false, fmt.Errorf("cleanup path: resolve target path: %w", err)
 	}
-	if absTarget == absRoot {
+	if pathutil.SamePath(absRoot, absTarget) {
 		return false, nil
 	}
 	if !pathutil.IsWithinRoot(absRoot, absTarget) {

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -28,6 +28,7 @@ import (
 	"github.com/autobrr/upbrr/internal/imagehostpolicy"
 	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/paths"
+	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/internal/services/bdinfo"
 	"github.com/autobrr/upbrr/internal/services/db"
@@ -556,7 +557,7 @@ func resolveContentTmpRoot(tmpRoot string, candidate string) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	if !pathWithinRoot(absTmpRoot, absCandidate) {
+	if !pathutil.IsWithinRoot(absTmpRoot, absCandidate) {
 		return "", false
 	}
 	rel, err := filepath.Rel(absTmpRoot, absCandidate)
@@ -586,7 +587,7 @@ func removeIfWithinRoot(root string, target string, recursive bool) (bool, error
 	if absTarget == absRoot {
 		return false, nil
 	}
-	if !pathWithinRoot(absRoot, absTarget) {
+	if !pathutil.IsWithinRoot(absRoot, absTarget) {
 		return false, nil
 	}
 	if recursive {
@@ -608,17 +609,6 @@ func removeIfWithinRoot(root string, target string, recursive bool) (bool, error
 		return false, nil
 	}
 	return true, nil
-}
-
-func pathWithinRoot(root string, target string) bool {
-	rel, err := filepath.Rel(root, target)
-	if err != nil {
-		return false
-	}
-	if rel == "." {
-		return true
-	}
-	return !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".." && !filepath.IsAbs(rel)
 }
 
 func (a *App) CheckDupes(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string) (api.DupeCheckSummary, error) {

--- a/internal/guishared/browse_directory.go
+++ b/internal/guishared/browse_directory.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/filesystem"
+	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -111,7 +112,7 @@ func browseDirectoryWithinRoots(req api.BrowseDirectoryRequest, fallbackPath str
 		itemPath := filepath.Join(current, entry.Name())
 		if root != "" {
 			itemRealPath, err := filepath.EvalSymlinks(itemPath)
-			if err != nil || !pathWithin(root, itemRealPath) {
+			if err != nil || !pathutil.IsWithinRoot(root, itemRealPath) {
 				continue
 			}
 		}
@@ -160,7 +161,7 @@ func normalizedBrowseRoots(rootPaths []string) ([]string, error) {
 		}
 		duplicate := false
 		for _, existing := range roots {
-			if samePath(existing, root) {
+			if pathutil.SamePath(existing, root) {
 				duplicate = true
 				break
 			}
@@ -230,18 +231,18 @@ func browseConfiguredRoots(mode string, roots []string) api.BrowseDirectoryRespo
 }
 
 func parentPathWithinRoot(current string, root string) string {
-	if root != "" && samePath(current, root) {
+	if root != "" && pathutil.SamePath(current, root) {
 		return ""
 	}
 	parent := parentPath(current)
-	if root != "" && !pathWithin(root, parent) {
+	if root != "" && !pathutil.IsWithinRoot(root, parent) {
 		return ""
 	}
 	return parent
 }
 
 func parentPathWithinRoots(current string, root string, roots []string) string {
-	if len(roots) > 1 && root != "" && samePath(current, root) {
+	if len(roots) > 1 && root != "" && pathutil.SamePath(current, root) {
 		return ""
 	}
 	return parentPathWithinRoot(current, root)
@@ -249,7 +250,7 @@ func parentPathWithinRoots(current string, root string, roots []string) string {
 
 func containingRoot(roots []string, target string) string {
 	for _, root := range roots {
-		if pathWithin(root, target) {
+		if pathutil.IsWithinRoot(root, target) {
 			return root
 		}
 	}
@@ -265,29 +266,6 @@ func parentPath(current string) string {
 		return current
 	}
 	return parent
-}
-
-func pathWithin(root string, target string) bool {
-	if strings.TrimSpace(root) == "" {
-		return true
-	}
-	if samePath(root, target) {
-		return true
-	}
-	rel, err := filepath.Rel(root, target)
-	if err != nil {
-		return false
-	}
-	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
-}
-
-func samePath(left string, right string) bool {
-	left = filepath.Clean(left)
-	right = filepath.Clean(right)
-	if runtime.GOOS == "windows" {
-		return strings.EqualFold(left, right)
-	}
-	return left == right
 }
 
 func browseWindowsRoots(mode string) api.BrowseDirectoryResponse {

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -1178,7 +1178,7 @@ func safeWriteFile(dir string, path string, data []byte) error {
 	cleanDir := filepath.Clean(dir)
 	cleanPath := filepath.Clean(path)
 	rel, err := filepath.Rel(cleanDir, cleanPath)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
 		return fmt.Errorf("path traversal detected: %s is not within %s", path, dir)
 	}
 	//nolint:gosec // Path is validated against path traversal using filepath.Rel.

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -1080,6 +1080,33 @@ func assertFileContains(t *testing.T, path string, want string) {
 	}
 }
 
+func TestSafeWriteFileRejectsCrossPlatformTraversal(t *testing.T) {
+	root := t.TempDir()
+	if err := safeWriteFile(root, filepath.Join(root, "ok.txt"), []byte("ok")); err != nil {
+		t.Fatalf("expected safe write to succeed: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "posix absolute", path: "/outside.txt"},
+		{name: "windows rooted", path: `\outside.txt`},
+		{name: "windows drive absolute", path: `C:\outside.txt`},
+		{name: "windows drive relative", path: `C:outside.txt`},
+		{name: "windows unc", path: `\\server\share\outside.txt`},
+		{name: "parent escape", path: filepath.Join(root, "..", "outside.txt")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := safeWriteFile(root, tt.path, []byte("bad")); err == nil {
+				t.Fatalf("expected traversal error for %q", tt.path)
+			}
+		})
+	}
+}
+
 func writeBDMVSummaryFixture(t *testing.T, tmpDir string, playlist string, extSummary string) {
 	t.Helper()
 	summaryPath := paths.BDMVSummaryPath(tmpDir, playlist)

--- a/internal/metadata/tracker_artifacts.go
+++ b/internal/metadata/tracker_artifacts.go
@@ -14,7 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
+	"path" //nolint:depguard // Extracts URL path components from tracker image URLs.
 	"path/filepath"
 	"strings"
 	"sync"

--- a/internal/pathpolicy/checker.go
+++ b/internal/pathpolicy/checker.go
@@ -252,7 +252,7 @@ func (c *checker) checkFilepathCall(name string, call *ast.CallExpr) {
 	}
 	for _, arg := range call.Args {
 		if hasSlashDataPathSignal(arg) {
-			c.addViolation(arg.Pos(), "slash-delimited URL/API paths must use path APIs or filepath.FromSlash at local filesystem boundaries")
+			c.addViolation(arg.Pos(), "slash-delimited torrent/API/URL paths must use path APIs or filepath.FromSlash at local filesystem boundaries")
 		}
 	}
 }
@@ -335,6 +335,13 @@ func (c *checker) checkBinary(expr *ast.BinaryExpr) {
 		}
 		if hasLocalPathSignal(expr) && !hasSlashDataSignal(expr) {
 			c.addViolation(expr.Pos(), "use filepath.Join instead of string concatenation to build local filesystem paths")
+		}
+	case token.EQL, token.NEQ:
+		if c.relPath == "internal/pathutil/pathutil.go" {
+			return
+		}
+		if isRootTargetPathEquality(expr.X, expr.Y) {
+			c.addViolation(expr.Pos(), "use pathutil.SamePath instead of lexical equality for local filesystem root/target paths")
 		}
 	default:
 		return
@@ -592,7 +599,7 @@ func isLocalPathName(name string) bool {
 	if lower == "" || isSlashDataName(lower) {
 		return false
 	}
-	if strings.Contains(lower, "filepath") || strings.Contains(lower, "dbpath") || strings.Contains(lower, "sourcepath") || strings.Contains(lower, "targetpath") || strings.Contains(lower, "outputpath") || strings.Contains(lower, "artifactpath") || strings.Contains(lower, "configpath") || strings.Contains(lower, "torrentpath") || strings.Contains(lower, "mediainfopath") {
+	if strings.Contains(lower, "filepath") || strings.Contains(lower, "dbpath") || strings.Contains(lower, "sourcepath") || strings.Contains(lower, "targetpath") || strings.Contains(lower, "outputpath") || strings.Contains(lower, "artifactpath") || strings.Contains(lower, "configpath") || strings.Contains(lower, "mediainfopath") {
 		return true
 	}
 	if strings.Contains(lower, "pathparts") || strings.Contains(lower, "fileparts") || strings.Contains(lower, "dirparts") {
@@ -609,6 +616,7 @@ func isLocalPathName(name string) bool {
 func isSlashDataPathName(name string) bool {
 	lower := strings.ToLower(strings.TrimSpace(name))
 	return strings.Contains(lower, "slashpath") ||
+		strings.Contains(lower, "torrentcontentpath") ||
 		strings.Contains(lower, "apipath") ||
 		strings.Contains(lower, "urlpath") ||
 		strings.Contains(lower, "remotepath") ||
@@ -661,4 +669,43 @@ func isAdHocPathGuardName(name string) bool {
 	default:
 		return false
 	}
+}
+
+func isRootTargetPathEquality(left ast.Expr, right ast.Expr) bool {
+	leftName, leftOK := rootTargetPathName(left)
+	rightName, rightOK := rootTargetPathName(right)
+	if !leftOK || !rightOK {
+		return false
+	}
+	return isRootPathName(leftName) && isTargetPathName(rightName) ||
+		isTargetPathName(leftName) && isRootPathName(rightName)
+}
+
+func rootTargetPathName(expr ast.Expr) (string, bool) {
+	switch typed := expr.(type) {
+	case *ast.Ident:
+		return pathGuardEqualityName(typed.Name)
+	case *ast.SelectorExpr:
+		return pathGuardEqualityName(typed.Sel.Name)
+	}
+	return "", false
+}
+
+func pathGuardEqualityName(name string) (string, bool) {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" || isSlashDataName(lower) {
+		return "", false
+	}
+	if isRootPathName(lower) || isTargetPathName(lower) || isLocalPathName(lower) {
+		return lower, true
+	}
+	return "", false
+}
+
+func isRootPathName(name string) bool {
+	return strings.Contains(name, "root")
+}
+
+func isTargetPathName(name string) bool {
+	return strings.Contains(name, "target") || strings.Contains(name, "candidate")
 }

--- a/internal/pathpolicy/checker.go
+++ b/internal/pathpolicy/checker.go
@@ -1,0 +1,643 @@
+package pathpolicy
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var checkedFilepathCalls = map[string]struct{}{
+	"Abs":       {},
+	"Base":      {},
+	"Clean":     {},
+	"Dir":       {},
+	"Ext":       {},
+	"FromSlash": {},
+	"Glob":      {},
+	"IsAbs":     {},
+	"Join":      {},
+	"Rel":       {},
+	"ToSlash":   {},
+}
+
+var checkedPathCalls = map[string]struct{}{
+	"Base":  {},
+	"Clean": {},
+	"Dir":   {},
+	"Ext":   {},
+	"IsAbs": {},
+	"Join":  {},
+}
+
+var filesystemCalls = map[string]map[string]struct{}{
+	"os": {
+		"Create":    {},
+		"Mkdir":     {},
+		"MkdirAll":  {},
+		"Open":      {},
+		"OpenFile":  {},
+		"ReadFile":  {},
+		"Remove":    {},
+		"RemoveAll": {},
+		"Rename":    {},
+		"Stat":      {},
+		"WriteFile": {},
+	},
+}
+
+type Violation struct {
+	File    string
+	Line    int
+	Column  int
+	Message string
+}
+
+type allowComment struct {
+	line int
+	used bool
+}
+
+type checker struct {
+	fset       *token.FileSet
+	aliases    map[string]string
+	relPath    string
+	isTest     bool
+	allows     map[int]*allowComment
+	allowList  []*allowComment
+	violations []Violation
+}
+
+func CheckRepository(root string) ([]Violation, error) {
+	if _, err := os.Stat(root); err != nil {
+		return nil, fmt.Errorf("pathpolicy: stat repository root: %w", err)
+	}
+
+	violations := make([]Violation, 0)
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if shouldSkipDir(entry.Name()) && path != root {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" {
+			return nil
+		}
+
+		fileViolations, err := checkFile(fset, root, path)
+		if err != nil {
+			return err
+		}
+		violations = append(violations, fileViolations...)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pathpolicy: walk repository: %w", err)
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].File != violations[j].File {
+			return violations[i].File < violations[j].File
+		}
+		if violations[i].Line != violations[j].Line {
+			return violations[i].Line < violations[j].Line
+		}
+		return violations[i].Column < violations[j].Column
+	})
+
+	return violations, nil
+}
+
+func checkFile(fset *token.FileSet, root string, path string) ([]Violation, error) {
+	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	relPath, err := filepath.Rel(root, path)
+	if err != nil {
+		relPath = path
+	}
+	relPath = filepath.ToSlash(relPath)
+
+	c := &checker{
+		fset:    fset,
+		aliases: importAliases(file),
+		relPath: relPath,
+		isTest:  strings.HasSuffix(path, "_test.go"),
+		allows:  make(map[int]*allowComment),
+	}
+	c.collectAllows(file)
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.CallExpr:
+			c.checkCall(typed)
+		case *ast.BinaryExpr:
+			c.checkBinary(typed)
+		}
+		return true
+	})
+	c.finishAllows()
+
+	return c.violations, nil
+}
+
+func (c *checker) collectAllows(file *ast.File) {
+	for _, group := range file.Comments {
+		for _, comment := range group.List {
+			body := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(comment.Text, "//"), "/*"))
+			body = strings.TrimSuffix(body, "*/")
+			if !strings.HasPrefix(body, "pathpolicy:allow") {
+				continue
+			}
+			reason := strings.TrimSpace(strings.TrimPrefix(body, "pathpolicy:allow"))
+			if reason == "" {
+				c.violations = append(c.violations, violationAt(c.fset, c.relPath, comment.Pos(), "pathpolicy allow comment requires a reason"))
+				continue
+			}
+			line := c.fset.Position(comment.Pos()).Line
+			allow := &allowComment{line: line}
+			c.allowList = append(c.allowList, allow)
+			c.allows[line] = allow
+			c.allows[line+1] = allow
+		}
+	}
+}
+
+func (c *checker) finishAllows() {
+	for _, allow := range c.allowList {
+		if !allow.used {
+			c.violations = append(c.violations, Violation{
+				File:    c.relPath,
+				Line:    allow.line,
+				Column:  1,
+				Message: "unused pathpolicy allow comment",
+			})
+		}
+	}
+}
+
+func (c *checker) checkCall(call *ast.CallExpr) {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+
+	packageName, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return
+	}
+	importPath := c.aliases[packageName.Name]
+	switch importPath {
+	case "path/filepath":
+		c.checkFilepathCall(selector.Sel.Name, call)
+	case "path":
+		c.checkPathCall(selector.Sel.Name, call)
+	case "fmt":
+		if selector.Sel.Name == "Sprintf" {
+			c.checkSprintf(call)
+		}
+	case "strings":
+		switch selector.Sel.Name {
+		case "Join":
+			c.checkStringsJoin(call)
+		case "Contains", "HasPrefix", "HasSuffix":
+			c.checkStringPathAssertion(call)
+		}
+	default:
+		if methods, ok := filesystemCalls[importPath]; ok {
+			if _, checked := methods[selector.Sel.Name]; checked {
+				c.checkFilesystemCall(call)
+			}
+		}
+	}
+}
+
+func (c *checker) checkFilepathCall(name string, call *ast.CallExpr) {
+	if _, checked := checkedFilepathCalls[name]; !checked {
+		return
+	}
+
+	for _, arg := range call.Args {
+		if value, ok := stringLiteralValue(arg); ok && isHardcodedLocalRoot(value) {
+			c.addViolation(arg.Pos(), "avoid hardcoded OS-rooted local paths in filepath calls; build local paths from t.TempDir or existing variables")
+		}
+	}
+
+	if name == "FromSlash" || name == "ToSlash" {
+		return
+	}
+	for _, arg := range call.Args {
+		if hasSlashDataPathSignal(arg) {
+			c.addViolation(arg.Pos(), "slash-delimited URL/API paths must use path APIs or filepath.FromSlash at local filesystem boundaries")
+		}
+	}
+}
+
+func (c *checker) checkPathCall(name string, call *ast.CallExpr) {
+	if _, checked := checkedPathCalls[name]; !checked {
+		return
+	}
+	for _, arg := range call.Args {
+		if hasLocalPathSignal(arg) && !hasSlashDataSignal(arg) {
+			c.addViolation(arg.Pos(), "use filepath for local filesystem paths; path is only for slash-delimited data")
+		}
+	}
+}
+
+func (c *checker) checkSprintf(call *ast.CallExpr) {
+	if len(call.Args) == 0 {
+		return
+	}
+	format, ok := stringLiteralValue(call.Args[0])
+	if !ok || !isPathBuildingFormat(format) {
+		return
+	}
+	if hasSlashDataSignal(call) {
+		return
+	}
+	for _, arg := range call.Args[1:] {
+		if hasLocalPathSignal(arg) {
+			c.addViolation(call.Pos(), "use filepath.Join instead of fmt.Sprintf to build local filesystem paths")
+			return
+		}
+	}
+}
+
+func (c *checker) checkStringsJoin(call *ast.CallExpr) {
+	if len(call.Args) != 2 {
+		return
+	}
+	separator, ok := stringLiteralValue(call.Args[1])
+	if !ok || separator != "/" && separator != `\` {
+		return
+	}
+	if hasLocalPathSignal(call.Args[0]) && !hasSlashDataSignal(call.Args[0]) {
+		c.addViolation(call.Pos(), "use filepath.Join instead of strings.Join to build local filesystem paths")
+	}
+}
+
+func (c *checker) checkStringPathAssertion(call *ast.CallExpr) {
+	if !c.isTest || len(call.Args) < 2 {
+		return
+	}
+	if isFilepathToSlashCall(call.Args[0]) {
+		return
+	}
+	value, ok := stringLiteralValue(call.Args[1])
+	if !ok || !isHardcodedLocalRoot(value) {
+		return
+	}
+	if hasLocalPathSignal(call.Args[0]) {
+		c.addViolation(call.Args[1].Pos(), "normalize local paths with filepath.ToSlash before slash-based test assertions")
+	}
+}
+
+func (c *checker) checkFilesystemCall(call *ast.CallExpr) {
+	if len(call.Args) == 0 {
+		return
+	}
+	firstArg := call.Args[0]
+	if hasSlashDataPathSignal(firstArg) {
+		c.addViolation(firstArg.Pos(), "convert slash-delimited data with filepath.FromSlash before local filesystem calls")
+	}
+}
+
+func (c *checker) checkBinary(expr *ast.BinaryExpr) {
+	//nolint:exhaustive // Path policy only cares about string concatenation.
+	switch expr.Op {
+	case token.ADD:
+		if !containsPathSeparatorLiteral(expr) {
+			return
+		}
+		if hasLocalPathSignal(expr) && !hasSlashDataSignal(expr) {
+			c.addViolation(expr.Pos(), "use filepath.Join instead of string concatenation to build local filesystem paths")
+		}
+	default:
+		return
+	}
+}
+
+func (c *checker) addViolation(pos token.Pos, message string) {
+	line := c.fset.Position(pos).Line
+	if allow, ok := c.allows[line]; ok {
+		allow.used = true
+		return
+	}
+
+	c.violations = append(c.violations, violationAt(c.fset, c.relPath, pos, message))
+}
+
+func shouldSkipDir(name string) bool {
+	switch name {
+	case ".git", "dist", "node_modules", "vendor":
+		return true
+	default:
+		return false
+	}
+}
+
+func importAliases(file *ast.File) map[string]string {
+	aliases := make(map[string]string, len(file.Imports))
+	for _, spec := range file.Imports {
+		pathValue, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			continue
+		}
+		name := filepath.Base(pathValue)
+		if spec.Name != nil {
+			name = spec.Name.Name
+		}
+		aliases[name] = pathValue
+	}
+	return aliases
+}
+
+func stringLiteralValue(expr ast.Expr) (string, bool) {
+	literal, ok := expr.(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(literal.Value)
+	if err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func violationAt(fset *token.FileSet, file string, pos token.Pos, message string) Violation {
+	position := fset.Position(pos)
+	return Violation{
+		File:    file,
+		Line:    position.Line,
+		Column:  position.Column,
+		Message: message,
+	}
+}
+
+func isPathBuildingFormat(format string) bool {
+	if strings.Contains(format, "://") {
+		return false
+	}
+	return strings.Contains(format, "%s/") ||
+		strings.Contains(format, "/%s") ||
+		strings.Contains(format, `%s\`) ||
+		strings.Contains(format, `\%s`)
+}
+
+func isHardcodedLocalRoot(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return false
+	}
+	if strings.HasPrefix(trimmed, `\\`) || strings.HasPrefix(trimmed, `\`) {
+		return true
+	}
+	if hasWindowsDrivePrefix(trimmed) {
+		return true
+	}
+
+	slashPath := strings.ReplaceAll(trimmed, `\`, "/")
+	for _, root := range []string{"/tmp", "/home", "/media", "/custom"} {
+		//pathpolicy:allow checking slash-normalized roots
+		if slashPath == root || strings.HasPrefix(slashPath, root+"/") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasWindowsDrivePrefix(value string) bool {
+	if len(value) < 2 || value[1] != ':' {
+		return false
+	}
+	return (value[0] >= 'A' && value[0] <= 'Z') || (value[0] >= 'a' && value[0] <= 'z')
+}
+
+func containsPathSeparatorLiteral(expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if found {
+			return false
+		}
+		value, ok := stringLiteralValueFromNode(node)
+		if ok && (strings.Contains(value, "/") || strings.Contains(value, `\`)) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func isFilepathToSlashCall(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "ToSlash" {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && pkg.Name == "filepath"
+}
+
+func hasLocalPathSignal(expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if found {
+			return false
+		}
+		switch typed := node.(type) {
+		case *ast.Ident:
+			if isLocalPathName(typed.Name) {
+				found = true
+				return false
+			}
+		case *ast.SelectorExpr:
+			if isLocalPathName(typed.Sel.Name) {
+				found = true
+				return false
+			}
+		case *ast.CallExpr:
+			if isLocalPathCall(typed) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func hasSlashDataPathSignal(expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if found {
+			return false
+		}
+		switch typed := node.(type) {
+		case *ast.Ident:
+			if isSlashDataPathName(typed.Name) {
+				found = true
+				return false
+			}
+		case *ast.SelectorExpr:
+			if isSlashDataSelector(typed) {
+				found = true
+				return false
+			}
+			if isSlashDataPathName(typed.Sel.Name) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func hasSlashDataSignal(expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if found {
+			return false
+		}
+		if value, ok := stringLiteralValueFromNode(node); ok {
+			if strings.Contains(value, "://") {
+				found = true
+				return false
+			}
+			return true
+		}
+		switch typed := node.(type) {
+		case *ast.Ident:
+			if isSlashDataName(typed.Name) {
+				found = true
+				return false
+			}
+		case *ast.SelectorExpr:
+			if isSlashDataSelector(typed) {
+				found = true
+				return false
+			}
+			if isSlashDataName(typed.Sel.Name) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func stringLiteralValueFromNode(node ast.Node) (string, bool) {
+	expr, ok := node.(ast.Expr)
+	if !ok {
+		return "", false
+	}
+	return stringLiteralValue(expr)
+}
+
+func isLocalPathCall(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if ok {
+		if selector.Sel.Name == "TempDir" {
+			return true
+		}
+		if pkg, ok := selector.X.(*ast.Ident); ok {
+			switch pkg.Name + "." + selector.Sel.Name {
+			case "os.TempDir", "os.UserHomeDir", "os.Getwd":
+				return true
+			}
+			if pkg.Name == "filepath" {
+				return true
+			}
+		}
+		return isLocalPathName(selector.Sel.Name)
+	}
+	if ident, ok := call.Fun.(*ast.Ident); ok {
+		return isLocalPathName(ident.Name)
+	}
+	return false
+}
+
+func isLocalPathName(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "" || isSlashDataName(lower) {
+		return false
+	}
+	if strings.Contains(lower, "filepath") || strings.Contains(lower, "dbpath") || strings.Contains(lower, "sourcepath") || strings.Contains(lower, "targetpath") || strings.Contains(lower, "outputpath") || strings.Contains(lower, "artifactpath") || strings.Contains(lower, "configpath") || strings.Contains(lower, "torrentpath") || strings.Contains(lower, "mediainfopath") {
+		return true
+	}
+	if strings.Contains(lower, "pathparts") || strings.Contains(lower, "fileparts") || strings.Contains(lower, "dirparts") {
+		return true
+	}
+	for _, signal := range []string{"dir", "root", "folder", "file", "tmp", "temp", "watch", "browse", "destination"} {
+		if strings.Contains(lower, signal) {
+			return true
+		}
+	}
+	return false
+}
+
+func isSlashDataPathName(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	return strings.Contains(lower, "slashpath") ||
+		strings.Contains(lower, "apipath") ||
+		strings.Contains(lower, "urlpath") ||
+		strings.Contains(lower, "remotepath") ||
+		strings.Contains(lower, "payloadpath") ||
+		strings.Contains(lower, "requestpath") ||
+		strings.Contains(lower, "responsepath")
+}
+
+func isSlashDataName(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if isSlashDataPathName(lower) {
+		return true
+	}
+	for _, signal := range []string{"url", "uri", "endpoint", "route", "href", "html", "bbcode", "desc", "description", "announce", "domain", "host", "link", "web", "raw", "img", "image", "api", "query", "request", "response", "cookie", "form"} {
+		if strings.Contains(lower, signal) {
+			return true
+		}
+	}
+	return false
+}
+
+func isSlashDataSelector(selector *ast.SelectorExpr) bool {
+	if selector.Sel.Name != "Path" && selector.Sel.Name != "RawPath" && selector.Sel.Name != "EscapedPath" {
+		return false
+	}
+	return selectorChainHasName(selector.X, "url") ||
+		selectorChainHasName(selector.X, "uri") ||
+		selectorChainHasName(selector.X, "parsed") ||
+		selectorChainHasName(selector.X, "request") ||
+		selectorChainHasName(selector.X, "response") ||
+		selectorChainHasName(selector.X, "req") ||
+		selectorChainHasName(selector.X, "resp")
+}
+
+func selectorChainHasName(expr ast.Expr, needle string) bool {
+	switch typed := expr.(type) {
+	case *ast.Ident:
+		return strings.Contains(strings.ToLower(typed.Name), needle)
+	case *ast.SelectorExpr:
+		return strings.Contains(strings.ToLower(typed.Sel.Name), needle) || selectorChainHasName(typed.X, needle)
+	default:
+		return false
+	}
+}

--- a/internal/pathpolicy/checker.go
+++ b/internal/pathpolicy/checker.go
@@ -141,6 +141,8 @@ func checkFile(fset *token.FileSet, root string, path string) ([]Violation, erro
 
 	ast.Inspect(file, func(node ast.Node) bool {
 		switch typed := node.(type) {
+		case *ast.FuncDecl:
+			c.checkFuncDecl(typed)
 		case *ast.CallExpr:
 			c.checkCall(typed)
 		case *ast.BinaryExpr:
@@ -151,6 +153,16 @@ func checkFile(fset *token.FileSet, root string, path string) ([]Violation, erro
 	c.finishAllows()
 
 	return c.violations, nil
+}
+
+func (c *checker) checkFuncDecl(fn *ast.FuncDecl) {
+	if fn.Name == nil || !isAdHocPathGuardName(fn.Name.Name) {
+		return
+	}
+	if c.relPath == "internal/pathutil/pathutil.go" {
+		return
+	}
+	c.addViolation(fn.Name.Pos(), "use internal/pathutil for local path containment/equality instead of ad hoc filepath.Rel/string checks")
 }
 
 func (c *checker) collectAllows(file *ast.File) {
@@ -637,6 +649,15 @@ func selectorChainHasName(expr ast.Expr, needle string) bool {
 		return strings.Contains(strings.ToLower(typed.Name), needle)
 	case *ast.SelectorExpr:
 		return strings.Contains(strings.ToLower(typed.Sel.Name), needle) || selectorChainHasName(typed.X, needle)
+	default:
+		return false
+	}
+}
+
+func isAdHocPathGuardName(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "iswithinroot", "ispathwithinroot", "pathwithinroot", "pathwithin", "samepath":
+		return true
 	default:
 		return false
 	}

--- a/internal/pathpolicy/checker_test.go
+++ b/internal/pathpolicy/checker_test.go
@@ -190,6 +190,50 @@ func check(dbPath string) bool {
 	}
 }
 
+func TestCheckRepositoryFlagsAdHocPathGuards(t *testing.T) {
+	root := t.TempDir()
+	writeSample(t, root, "internal/sample/sample.go", `package sample
+
+func pathWithinRoot(root string, target string) bool {
+	return root == target
+}
+
+func samePath(left string, right string) bool {
+	return left == right
+}
+`)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d: %#v", len(violations), violations)
+	}
+	messages := strings.Join(violationMessages(violations), "\n")
+	if !strings.Contains(messages, "internal/pathutil") {
+		t.Fatalf("expected pathutil violation, got %q", messages)
+	}
+}
+
+func TestCheckRepositoryAllowsPathutilPathGuards(t *testing.T) {
+	root := t.TempDir()
+	writeSample(t, root, "internal/pathutil/pathutil.go", `package pathutil
+
+func IsWithinRoot(root string, target string) bool {
+	return root == target
+}
+`)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
 func TestCheckRepositoryAllowsIntentionalPathPolicyComments(t *testing.T) {
 	root := t.TempDir()
 	writeSample(t, root, "internal/sample/sample_test.go", `package sample

--- a/internal/pathpolicy/checker_test.go
+++ b/internal/pathpolicy/checker_test.go
@@ -1,0 +1,256 @@
+package pathpolicy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckRepositoryFlagsHardcodedRootsInFilepathCalls(t *testing.T) {
+	root := t.TempDir()
+	writeSample(t, root, "internal/sample/sample_test.go", `package sample
+
+import "path/filepath"
+
+func check() {
+	_ = filepath.Join("C:\\shared", "file.mkv")
+	_ = filepath.Join("\\\\server\\share", "file.mkv")
+	_ = filepath.Clean("/tmp/file.mkv")
+}
+`)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 3 {
+		t.Fatalf("expected 3 violations, got %d: %#v", len(violations), violations)
+	}
+	for _, violation := range violations {
+		if !strings.Contains(violation.Message, "hardcoded OS-rooted local paths") {
+			t.Fatalf("unexpected violation message: %q", violation.Message)
+		}
+	}
+}
+
+func TestCheckRepositoryAllowsSlashFixturesOutsideFilepathCalls(t *testing.T) {
+	root := t.TempDir()
+	writeSample(t, root, "internal/sample/sample_test.go", `package sample
+
+import "path/filepath"
+
+func check(base string) {
+	_ = filepath.Join(base, "file.mkv")
+	_ = "/media/file.mkv"
+	_ = "https://example.invalid/path/file.mkv"
+	_ = "C:\\fixture\\file.mkv"
+}
+`)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
+func TestCheckRepositoryAllowsURLPathsInFilepathCalls(t *testing.T) {
+	root := t.TempDir()
+	writeSample(t, root, "internal/sample/sample_test.go", `package sample
+
+import "path/filepath"
+
+func check() {
+	_ = filepath.Join("/api", "v1")
+	_ = filepath.Join("/upload", "file")
+}
+`)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
+func TestCheckRepositoryFlagsLocalPathStringBuilders(t *testing.T) {
+	root := t.TempDir()
+	writeSample(t, root, "internal/sample/sample_test.go", `package sample
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func check(t *testing.T, dbPath string, fileParts []string) {
+	_ = t.TempDir() + "/upbrr.db"
+	_ = dbPath + "\\state.db"
+	_ = fmt.Sprintf("%s/%s", dbPath, "state.db")
+	_ = strings.Join(fileParts, "/")
+}
+`)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 4 {
+		t.Fatalf("expected 4 violations, got %d: %#v", len(violations), violations)
+	}
+	messages := strings.Join(violationMessages(violations), "\n")
+	for _, want := range []string{"string concatenation", "fmt.Sprintf", "strings.Join"} {
+		if !strings.Contains(messages, want) {
+			t.Fatalf("expected %q violation, got %q", want, messages)
+		}
+	}
+}
+
+func TestCheckRepositoryFlagsWrongPathPackageForPathKind(t *testing.T) {
+	root := t.TempDir()
+	writeSample(t, root, "internal/sample/sample.go", `package sample
+
+import (
+	"net/url"
+	"path"
+	"path/filepath"
+)
+
+func check(state struct{ torrentPath string }, raw string) {
+	_ = path.Base(state.torrentPath)
+	parsed, _ := url.Parse(raw)
+	_ = filepath.Base(parsed.Path)
+}
+`)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d: %#v", len(violations), violations)
+	}
+	messages := strings.Join(violationMessages(violations), "\n")
+	if !strings.Contains(messages, "use filepath for local filesystem paths") {
+		t.Fatalf("expected path package violation, got %q", messages)
+	}
+	if !strings.Contains(messages, "slash-delimited URL/API paths") {
+		t.Fatalf("expected filepath slash-data violation, got %q", messages)
+	}
+}
+
+func TestCheckRepositoryFlagsFilesystemCallsWithSlashData(t *testing.T) {
+	root := t.TempDir()
+	writeSample(t, root, "internal/sample/sample.go", `package sample
+
+import "os"
+
+func check(apiPath string) {
+	_, _ = os.ReadFile(apiPath)
+}
+`)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "filepath.FromSlash") {
+		t.Fatalf("expected FromSlash violation, got %q", violations[0].Message)
+	}
+}
+
+func TestCheckRepositoryFlagsSlashAssertionsAgainstLocalPaths(t *testing.T) {
+	root := t.TempDir()
+	writeSample(t, root, "internal/sample/sample_test.go", `package sample
+
+import "strings"
+
+func check(dbPath string) bool {
+	return strings.Contains(dbPath, "/tmp/upbrr.db")
+}
+`)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "filepath.ToSlash") {
+		t.Fatalf("expected ToSlash violation, got %q", violations[0].Message)
+	}
+}
+
+func TestCheckRepositoryAllowsIntentionalPathPolicyComments(t *testing.T) {
+	root := t.TempDir()
+	writeSample(t, root, "internal/sample/sample_test.go", `package sample
+
+import "testing"
+
+func check(t *testing.T) string {
+	//pathpolicy:allow exercising checker fixture
+	return t.TempDir() + "/upbrr.db"
+}
+`)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
+func TestCheckRepositoryFlagsInvalidPathPolicyAllows(t *testing.T) {
+	root := t.TempDir()
+	writeSample(t, root, "internal/sample/sample.go", `package sample
+
+//pathpolicy:allow
+func blankReason() {}
+
+//pathpolicy:allow no longer needed
+func stale() {}
+`)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d: %#v", len(violations), violations)
+	}
+	messages := strings.Join(violationMessages(violations), "\n")
+	if !strings.Contains(messages, "requires a reason") || !strings.Contains(messages, "unused") {
+		t.Fatalf("expected invalid allow violations, got %q", messages)
+	}
+}
+
+func violationMessages(violations []Violation) []string {
+	messages := make([]string, 0, len(violations))
+	for _, violation := range violations {
+		messages = append(messages, violation.Message)
+	}
+	return messages
+}
+
+func writeSample(t *testing.T, root string, path string, content string) {
+	t.Helper()
+
+	fullPath := filepath.Join(root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatalf("mkdir sample dir: %v", err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+}

--- a/internal/pathpolicy/checker_test.go
+++ b/internal/pathpolicy/checker_test.go
@@ -111,6 +111,21 @@ func check(t *testing.T, dbPath string, fileParts []string) {
 	}
 }
 
+func TestPathSignalClassifiesTorrentPaths(t *testing.T) {
+	if isLocalPathName("torrentPath") {
+		t.Fatalf("torrentPath should not be classified as a local path signal")
+	}
+	if isLocalPathName("torrentContentPath") {
+		t.Fatalf("torrentContentPath should not be classified as a local path signal")
+	}
+	if !isSlashDataPathName("torrentContentPath") {
+		t.Fatalf("torrentContentPath should be classified as slash-delimited data")
+	}
+	if !isLocalPathName("torrentFilePath") {
+		t.Fatalf("torrentFilePath should remain classified as a local path signal")
+	}
+}
+
 func TestCheckRepositoryFlagsWrongPathPackageForPathKind(t *testing.T) {
 	root := t.TempDir()
 	writeSample(t, root, "internal/sample/sample.go", `package sample
@@ -121,10 +136,13 @@ import (
 	"path/filepath"
 )
 
-func check(state struct{ torrentPath string }, raw string) {
+func check(state struct{ torrentPath string }, torrentContentPath string, torrentFilePath string, raw string) {
 	_ = path.Base(state.torrentPath)
+	_ = path.Base(torrentContentPath)
+	_ = path.Base(torrentFilePath)
 	parsed, _ := url.Parse(raw)
 	_ = filepath.Base(parsed.Path)
+	_ = filepath.Base(torrentContentPath)
 }
 `)
 
@@ -132,14 +150,14 @@ func check(state struct{ torrentPath string }, raw string) {
 	if err != nil {
 		t.Fatalf("CheckRepository returned error: %v", err)
 	}
-	if len(violations) != 2 {
-		t.Fatalf("expected 2 violations, got %d: %#v", len(violations), violations)
+	if len(violations) != 3 {
+		t.Fatalf("expected 3 violations, got %d: %#v", len(violations), violations)
 	}
 	messages := strings.Join(violationMessages(violations), "\n")
 	if !strings.Contains(messages, "use filepath for local filesystem paths") {
 		t.Fatalf("expected path package violation, got %q", messages)
 	}
-	if !strings.Contains(messages, "slash-delimited URL/API paths") {
+	if !strings.Contains(messages, "slash-delimited torrent/API/URL paths") {
 		t.Fatalf("expected filepath slash-data violation, got %q", messages)
 	}
 }
@@ -195,7 +213,7 @@ func TestCheckRepositoryFlagsAdHocPathGuards(t *testing.T) {
 	writeSample(t, root, "internal/sample/sample.go", `package sample
 
 func pathWithinRoot(root string, target string) bool {
-	return root == target
+	return len(root) <= len(target)
 }
 
 func samePath(left string, right string) bool {
@@ -213,6 +231,27 @@ func samePath(left string, right string) bool {
 	messages := strings.Join(violationMessages(violations), "\n")
 	if !strings.Contains(messages, "internal/pathutil") {
 		t.Fatalf("expected pathutil violation, got %q", messages)
+	}
+}
+
+func TestCheckRepositoryFlagsLexicalRootTargetPathEquality(t *testing.T) {
+	root := t.TempDir()
+	writeSample(t, root, "internal/sample/sample.go", `package sample
+
+func check(absRoot string, absTarget string) bool {
+	return absTarget == absRoot
+}
+`)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "pathutil.SamePath") {
+		t.Fatalf("expected SamePath violation, got %q", violations[0].Message)
 	}
 }
 
@@ -294,7 +333,7 @@ func writeSample(t *testing.T, root string, path string, content string) {
 	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
 		t.Fatalf("mkdir sample dir: %v", err)
 	}
-	if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 }

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -4,7 +4,7 @@
 package pathutil
 
 import (
-	"path"
+	"path" //nolint:depguard // Normalizes slash-style metadata paths, not local filesystem paths.
 	"strings"
 )
 

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -5,6 +5,8 @@ package pathutil
 
 import (
 	"path" //nolint:depguard // Normalizes slash-style metadata paths, not local filesystem paths.
+	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -28,4 +30,86 @@ func Base(value string) string {
 		return ""
 	}
 	return path.Base(cleaned)
+}
+
+// IsWithinRoot reports whether target resolves to root or a descendant of root.
+// It first checks lexical paths, then repeats the check with symlinks resolved
+// through the nearest existing path prefix so missing child paths under a
+// symlink cannot escape the root.
+func IsWithinRoot(root string, target string) bool {
+	rootAbs, ok := cleanAbs(root)
+	if !ok {
+		return false
+	}
+	targetAbs, ok := cleanAbs(target)
+	if !ok {
+		return false
+	}
+	if !isWithinCleanRoot(rootAbs, targetAbs) {
+		return false
+	}
+
+	rootReal, rootOK := evalExistingPrefix(rootAbs)
+	targetReal, targetOK := evalExistingPrefix(targetAbs)
+	if !rootOK || !targetOK {
+		return true
+	}
+	return isWithinCleanRoot(rootReal, targetReal)
+}
+
+// SamePath compares local filesystem paths with the host OS path semantics.
+func SamePath(left string, right string) bool {
+	leftAbs, leftOK := cleanAbs(left)
+	rightAbs, rightOK := cleanAbs(right)
+	if !leftOK || !rightOK {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(leftAbs, rightAbs)
+	}
+	return leftAbs == rightAbs
+}
+
+func cleanAbs(value string) (string, bool) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", false
+	}
+	abs, err := filepath.Abs(filepath.Clean(trimmed))
+	if err != nil {
+		return "", false
+	}
+	return filepath.Clean(abs), true
+}
+
+func isWithinCleanRoot(root string, target string) bool {
+	if filepath.VolumeName(root) != filepath.VolumeName(target) {
+		return false
+	}
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}
+
+func evalExistingPrefix(value string) (string, bool) {
+	cleaned := filepath.Clean(value)
+	current := cleaned
+	missing := make([]string, 0)
+	for {
+		resolved, ok := resolveExistingPath(current)
+		if ok {
+			for idx := len(missing) - 1; idx >= 0; idx-- {
+				resolved = filepath.Join(resolved, missing[idx])
+			}
+			return filepath.Clean(resolved), true
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", false
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
 }

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -64,10 +64,29 @@ func SamePath(left string, right string) bool {
 	if !leftOK || !rightOK {
 		return false
 	}
-	if runtime.GOOS == "windows" {
-		return strings.EqualFold(leftAbs, rightAbs)
+	if sameCleanPath(leftAbs, rightAbs) {
+		return true
 	}
-	return leftAbs == rightAbs
+	leftReal, leftRealOK := evalExistingPrefix(leftAbs)
+	rightReal, rightRealOK := evalExistingPrefix(rightAbs)
+	return leftRealOK && rightRealOK && sameCleanPath(leftReal, rightReal)
+}
+
+func sameCleanPath(left string, right string) bool {
+	left = normalizeCleanLocalPath(left)
+	right = normalizeCleanLocalPath(right)
+	if filepath.VolumeName(left) != filepath.VolumeName(right) {
+		return false
+	}
+	return left == right
+}
+
+func normalizeCleanLocalPath(value string) string {
+	cleaned := filepath.Clean(value)
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(cleaned)
+	}
+	return cleaned
 }
 
 func cleanAbs(value string) (string, bool) {
@@ -83,6 +102,8 @@ func cleanAbs(value string) (string, bool) {
 }
 
 func isWithinCleanRoot(root string, target string) bool {
+	root = normalizeCleanLocalPath(root)
+	target = normalizeCleanLocalPath(target)
 	if filepath.VolumeName(root) != filepath.VolumeName(target) {
 		return false
 	}

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -3,32 +3,90 @@
 
 package pathutil
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
-func TestBaseHandlesMixedPlatformPaths(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{name: "windows file", input: `D:\Movies\Movie.Name.2024.mkv`, want: "Movie.Name.2024.mkv"},
-		{name: "windows dir", input: `D:\Movies\1982 - Fitzcarraldo [DVD9.PAL]`, want: "1982 - Fitzcarraldo [DVD9.PAL]"},
-		{name: "posix file", input: `/media/movies/Movie.Name.2024.mkv`, want: "Movie.Name.2024.mkv"},
-		{name: "mixed separators", input: `D:\Movies/subdir\Movie.Name.2024.mkv`, want: "Movie.Name.2024.mkv"},
-		{name: "bare name", input: `Movie.Name.2024.mkv`, want: "Movie.Name.2024.mkv"},
+func TestIsWithinRootAllowsRootAndChildren(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	child := filepath.Join(root, "child", "file.txt")
+
+	if !IsWithinRoot(root, root) {
+		t.Fatalf("expected root to be within itself")
 	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := Base(tc.input); got != tc.want {
-				t.Fatalf("Base(%q) = %q, want %q", tc.input, got, tc.want)
-			}
-		})
+	if !IsWithinRoot(root, child) {
+		t.Fatalf("expected child path to be within root")
 	}
 }
 
-func TestCleanNormalizesSeparators(t *testing.T) {
-	if got := Clean(`D:\Movies\subdir\Movie.Name.2024.mkv`); got != "D:/Movies/subdir/Movie.Name.2024.mkv" {
-		t.Fatalf("unexpected cleaned path: %q", got)
+func TestIsWithinRootRejectsSiblingAndParentEscapes(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+
+	if IsWithinRoot(root, filepath.Join(parent, "root-sibling")) {
+		t.Fatalf("expected sibling prefix path to be outside root")
+	}
+	if IsWithinRoot(root, filepath.Join(root, "..", "outside")) {
+		t.Fatalf("expected parent escape path to be outside root")
+	}
+}
+
+func TestIsWithinRootRejectsSymlinkEscapes(t *testing.T) {
+	t.Parallel()
+
+	root, outside := setupEscapeDirs(t)
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unavailable on this host: %v", err)
+	}
+
+	assertEscapingLinkRejected(t, root, link)
+}
+
+func setupEscapeDirs(t *testing.T) (string, string) {
+	t.Helper()
+
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	outside := filepath.Join(parent, "outside")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	if err := os.Mkdir(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	return root, outside
+}
+
+func assertEscapingLinkRejected(t *testing.T, root string, link string) {
+	t.Helper()
+
+	if IsWithinRoot(root, link) {
+		t.Fatalf("expected escaping link to be outside root")
+	}
+	if IsWithinRoot(root, filepath.Join(link, "missing.txt")) {
+		t.Fatalf("expected missing child under escaping symlink to be outside root")
+	}
+}
+
+func TestSamePathUsesHostSemantics(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	left := filepath.Join(root, "file.txt")
+	if !SamePath(left, filepath.Clean(left)) {
+		t.Fatalf("expected clean equivalent paths to match")
+	}
+	if SamePath(left, filepath.Join(root, "other.txt")) {
+		t.Fatalf("expected different paths not to match")
 	}
 }

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -90,3 +90,21 @@ func TestSamePathUsesHostSemantics(t *testing.T) {
 		t.Fatalf("expected different paths not to match")
 	}
 }
+
+func TestSamePathResolvesSymlinkAliases(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+	root := filepath.Join(parent, "root")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	alias := filepath.Join(parent, "root-alias")
+	if err := os.Symlink(root, alias); err != nil {
+		t.Skipf("symlink unavailable on this host: %v", err)
+	}
+
+	if !SamePath(root, alias) {
+		t.Fatalf("expected symlink alias to match root")
+	}
+}

--- a/internal/pathutil/pathutil_windows_test.go
+++ b/internal/pathutil/pathutil_windows_test.go
@@ -60,3 +60,35 @@ func TestIsWithinRootRejectsWindowsJunctionEscapes(t *testing.T) {
 
 	assertEscapingLinkRejected(t, root, link)
 }
+
+func TestIsWithinRootAllowsWindowsCaseVariants(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	child := filepath.Join(root, "ChildDir")
+	if err := os.Mkdir(child, 0o755); err != nil {
+		t.Fatalf("mkdir child: %v", err)
+	}
+
+	rootVariant := swapASCIIPathCase(root)
+	childVariant := swapASCIIPathCase(child)
+	if !IsWithinRoot(rootVariant, childVariant) {
+		t.Fatalf("expected case-variant child path to be within root")
+	}
+	if !SamePath(root, rootVariant) {
+		t.Fatalf("expected case-variant root paths to match")
+	}
+}
+
+func swapASCIIPathCase(value string) string {
+	swapped := []byte(value)
+	for idx, char := range swapped {
+		switch {
+		case char >= 'a' && char <= 'z':
+			swapped[idx] = char - 'a' + 'A'
+		case char >= 'A' && char <= 'Z':
+			swapped[idx] = char - 'A' + 'a'
+		}
+	}
+	return string(swapped)
+}

--- a/internal/pathutil/pathutil_windows_test.go
+++ b/internal/pathutil/pathutil_windows_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build windows
+
+package pathutil
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestIsWithinRootRejectsWindowsDirectorySymlinkEscapes(t *testing.T) {
+	t.Parallel()
+
+	root, outside := setupEscapeDirs(t)
+	link := filepath.Join(root, "dir-link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("directory symlink unavailable on this host: %v", err)
+	}
+
+	assertEscapingLinkRejected(t, root, link)
+}
+
+func TestIsWithinRootRejectsWindowsFileSymlinkEscapes(t *testing.T) {
+	t.Parallel()
+
+	root, outside := setupEscapeDirs(t)
+	target := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(target, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("write outside target: %v", err)
+	}
+	link := filepath.Join(root, "secret-link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("file symlink unavailable on this host: %v", err)
+	}
+
+	assertEscapingLinkRejected(t, root, link)
+}
+
+func TestIsWithinRootRejectsWindowsJunctionEscapes(t *testing.T) {
+	t.Parallel()
+
+	root, outside := setupEscapeDirs(t)
+	link := filepath.Join(root, "junction")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "cmd.exe", "/d", "/c", "mklink", "/J", link, outside)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Skipf("junction unavailable on this host: %v: %s", err, output)
+	}
+	t.Cleanup(func() {
+		_ = os.Remove(link)
+	})
+
+	assertEscapingLinkRejected(t, root, link)
+}

--- a/internal/pathutil/realpath.go
+++ b/internal/pathutil/realpath.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build !windows
+
+package pathutil
+
+import "path/filepath"
+
+func resolveExistingPath(value string) (string, bool) {
+	resolved, err := filepath.EvalSymlinks(value)
+	if err != nil {
+		return "", false
+	}
+	return resolved, true
+}

--- a/internal/pathutil/realpath_windows.go
+++ b/internal/pathutil/realpath_windows.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build windows
+
+package pathutil
+
+import (
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+const finalPathBufferSize uint32 = windows.MAX_LONG_PATH
+
+func resolveExistingPath(value string) (string, bool) {
+	pathPtr, err := windows.UTF16PtrFromString(value)
+	if err != nil {
+		return "", false
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		windows.FILE_READ_ATTRIBUTES,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return "", false
+	}
+	defer func() {
+		_ = windows.CloseHandle(handle)
+	}()
+
+	buffer := make([]uint16, finalPathBufferSize)
+	n, err := windows.GetFinalPathNameByHandle(handle, &buffer[0], finalPathBufferSize, 0)
+	if err != nil || n == 0 {
+		return "", false
+	}
+	if n >= finalPathBufferSize {
+		return "", false
+	}
+
+	resolved := windows.UTF16ToString(buffer[:n])
+	return filepath.Clean(trimWindowsFinalPathPrefix(resolved)), true
+}
+
+func trimWindowsFinalPathPrefix(value string) string {
+	trimmed := strings.TrimPrefix(value, `\\?\`)
+	if strings.HasPrefix(trimmed, `UNC\`) {
+		return `\\` + strings.TrimPrefix(trimmed, `UNC\`)
+	}
+	return trimmed
+}

--- a/internal/services/db/sqlite_test.go
+++ b/internal/services/db/sqlite_test.go
@@ -409,7 +409,7 @@ func TestSQLiteRepositoryConcurrentMigrateAndAccessOnDisk(t *testing.T) {
 			}
 			ctx := context.Background()
 			for item := 0; item < 10; item++ {
-				sourcePath := filepath.Join("C:\\shared", fmt.Sprintf("release-%d-%d.mkv", idx, item))
+				sourcePath := testStoredPath("shared", fmt.Sprintf("release-%d-%d.mkv", idx, item))
 				if err := repo.Save(ctx, FileMetadata{
 					Path:      sourcePath,
 					Title:     fmt.Sprintf("Title %d-%d", idx, item),
@@ -439,7 +439,7 @@ func TestSQLiteRepositoryConcurrentMigrateAndAccessOnDisk(t *testing.T) {
 	ctx := context.Background()
 	for idx := range repos {
 		for item := 0; item < 10; item++ {
-			sourcePath := filepath.Join("C:\\shared", fmt.Sprintf("release-%d-%d.mkv", idx, item))
+			sourcePath := testStoredPath("shared", fmt.Sprintf("release-%d-%d.mkv", idx, item))
 			if _, err := repos[0].GetByPath(ctx, sourcePath); err != nil {
 				t.Fatalf("get %s: %v", sourcePath, err)
 			}
@@ -465,7 +465,7 @@ func TestSQLiteRepositoryConcurrentReadsOnDisk(t *testing.T) {
 
 	ctx := context.Background()
 	for i := 0; i < 25; i++ {
-		sourcePath := filepath.Join("C:\\reads", fmt.Sprintf("release-%d.mkv", i))
+		sourcePath := testStoredPath("reads", fmt.Sprintf("release-%d.mkv", i))
 		if err := writerRepo.Save(ctx, FileMetadata{
 			Path:      sourcePath,
 			Title:     fmt.Sprintf("Title %d", i),
@@ -498,7 +498,7 @@ func TestSQLiteRepositoryConcurrentReadsOnDisk(t *testing.T) {
 			defer wg.Done()
 			<-start
 			for item := 0; item < 25; item++ {
-				sourcePath := filepath.Join("C:\\reads", fmt.Sprintf("release-%d.mkv", item))
+				sourcePath := testStoredPath("reads", fmt.Sprintf("release-%d.mkv", item))
 				got, err := repo.GetByPath(ctx, sourcePath)
 				if err != nil {
 					errCh <- fmt.Errorf("reader %d get %d: %w", idx, item, err)
@@ -556,7 +556,7 @@ func TestSQLiteRepositoryReadsOverlapWithWriteTransaction(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	sourcePath := filepath.Join("C:\\overlap", "release.mkv")
+	sourcePath := testStoredPath("overlap", "release.mkv")
 	if err := writerRepo.Save(ctx, FileMetadata{
 		Path:      sourcePath,
 		Title:     "Before",
@@ -682,7 +682,7 @@ func TestIsBusyErrorUnwrapsSQLiteErrors(t *testing.T) {
 	}()
 
 	err = contendingRepo.Save(ctx, FileMetadata{
-		Path:      filepath.Join("C:\\locked", "file.mkv"),
+		Path:      testStoredPath("locked", "file.mkv"),
 		Title:     "Locked",
 		UpdatedAt: time.Now().UTC(),
 	})
@@ -1810,4 +1810,8 @@ func intPtr(value int) *int {
 func boolPtr(value bool) *bool {
 	ptrValue := value
 	return &ptrValue
+}
+
+func testStoredPath(parts ...string) string {
+	return filepath.ToSlash(filepath.Join(parts...))
 }

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -12,7 +12,7 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
-	"path"
+	"path" //nolint:depguard // Extracts URL path components from screenshot URLs.
 	"path/filepath"
 	"runtime"
 	"sort"

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path" //nolint:depguard // Extracts URL path components from screenshot URLs.
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -25,6 +24,7 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/paths"
+	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/services/imagehost"
 	"github.com/autobrr/upbrr/pkg/api"
@@ -563,7 +563,7 @@ func (s *Service) removeTrackerImageReference(ctx context.Context, meta api.Prep
 			}
 			candidate := filepath.Join(tmpDir, trackerDir, fileName)
 			candidateAbs, err := filepath.Abs(candidate)
-			if err == nil && pathsEqual(candidateAbs, absTarget) {
+			if err == nil && pathutil.SamePath(candidateAbs, absTarget) {
 				removed = true
 				if s.logger != nil {
 					s.logger.Tracef("screenshots: tracker image match tracker=%s file=%s", strings.TrimSpace(record.Tracker), candidateAbs)
@@ -626,15 +626,6 @@ func retrySQLiteBusy(ctx context.Context, attempts int, fn func() error) error {
 
 func isSQLiteBusyError(err error) bool {
 	return db.IsBusyError(err)
-}
-
-func pathsEqual(left string, right string) bool {
-	left = filepath.Clean(left)
-	right = filepath.Clean(right)
-	if runtime.GOOS == "windows" {
-		return strings.EqualFold(left, right)
-	}
-	return left == right
 }
 
 func (s *Service) SaveFinalSelections(ctx context.Context, meta api.PreparedMetadata, images []api.ScreenshotImage) error {
@@ -869,10 +860,10 @@ func isPathWithinDir(root string, target string) bool {
 	if err != nil {
 		return false
 	}
-	if targetAbs == rootAbs {
+	if pathutil.SamePath(rootAbs, targetAbs) {
 		return true
 	}
-	return strings.HasPrefix(targetAbs, rootAbs+string(os.PathSeparator))
+	return pathutil.IsWithinRoot(rootAbs, targetAbs)
 }
 
 func selectionSourceLabel(img api.ScreenshotImage) string {

--- a/internal/trackerdata/unit3d.go
+++ b/internal/trackerdata/unit3d.go
@@ -15,7 +15,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path"
+	"path" //nolint:depguard // Builds Unit3D API URL paths, not local filesystem paths.
 	"strconv"
 	"strings"
 	"sync"

--- a/internal/trackers/image_host_resolution.go
+++ b/internal/trackers/image_host_resolution.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
+	"path" //nolint:depguard // Extracts URL path components from image host URLs.
 	"path/filepath"
 	"strings"
 

--- a/internal/trackers/impl/ar/upload_test.go
+++ b/internal/trackers/impl/ar/upload_test.go
@@ -5,6 +5,7 @@ package ar
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -52,7 +53,7 @@ func TestPersistLoginCookiesAllowsPlaintextFallbackWhenAuthHelperUnavailable(t *
 	t.Parallel()
 
 	logger := &captureLogger{}
-	err := persistLoginCookies(context.Background(), t.TempDir()+"/upbrr.db", logger, nil)
+	err := persistLoginCookies(context.Background(), filepath.Join(t.TempDir(), "upbrr.db"), logger, nil)
 	if err != nil {
 		t.Fatalf("expected plaintext fallback, got %v", err)
 	}

--- a/internal/trackers/impl/azfamily/payload.go
+++ b/internal/trackers/impl/azfamily/payload.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path" //nolint:depguard // Extracts response URL path basename, not local filesystem basename.
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -237,7 +238,7 @@ func screenshotBytes(ctx context.Context, client *http.Client, shot api.Screensh
 	if err != nil {
 		return nil, "", fmt.Errorf("trackers: read screenshot response body: %w", err)
 	}
-	filename := filepath.Base(strings.TrimSpace(resp.Request.URL.Path))
+	filename := path.Base(strings.TrimSpace(resp.Request.URL.Path))
 	if filename == "" || filename == "." || filename == "/" {
 		filename = "screenshot.png"
 	}

--- a/internal/trackers/impl/ptp/upload.go
+++ b/internal/trackers/impl/ptp/upload.go
@@ -19,6 +19,7 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"os"
+	"path" //nolint:depguard // Reads poster URL path extension, not local filesystem extension.
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -464,7 +465,7 @@ func downloadPoster(ctx context.Context, meta api.PreparedMetadata, dbPath strin
 
 func posterExtension(imageURL string, contentType string) string {
 	if parsed, err := url.Parse(imageURL); err == nil {
-		switch ext := strings.ToLower(filepath.Ext(parsed.Path)); ext {
+		switch ext := strings.ToLower(path.Ext(parsed.Path)); ext {
 		case ".jpg", ".jpeg", ".png", ".webp":
 			return ext
 		}

--- a/internal/trackers/impl/tvc/upload.go
+++ b/internal/trackers/impl/tvc/upload.go
@@ -12,7 +12,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path"
+	"path" //nolint:depguard // Extracts tracker response URL path basename.
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -56,7 +57,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	}
 	body, contentType, err := commonhttp.BuildMultipartPayload(state.fields, []commonhttp.FileField{{
 		FieldName: "torrent",
-		FileName:  path.Base(state.torrentPath),
+		FileName:  filepath.Base(state.torrentPath),
 		Path:      state.torrentPath,
 	}})
 	if err != nil {

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path" //nolint:depguard // Parses Unit3D URL path IDs, not local filesystem paths.
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -296,7 +297,7 @@ func extractUnit3DTorrentID(raw string) string {
 
 	parsed, err := url.Parse(trimmed)
 	if err == nil {
-		base := filepath.Base(parsed.Path)
+		base := path.Base(parsed.Path)
 		if id := extractLeadingNumericToken(base); id != "" {
 			return id
 		}
@@ -305,7 +306,7 @@ func extractUnit3DTorrentID(raw string) string {
 		}
 	}
 
-	if id := extractLeadingNumericToken(filepath.Base(trimmed)); id != "" {
+	if id := extractLeadingNumericToken(path.Base(trimmed)); id != "" {
 		return id
 	}
 

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -26,6 +26,7 @@ import (
 	"github.com/autobrr/upbrr/internal/imagehostpolicy"
 	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/paths"
+	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/internal/services/bdinfo"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
@@ -1122,11 +1123,11 @@ func (b *Backend) applyConfig(cfg config.Config) error {
 
 func (b *Backend) isPathWithinManagedDirs(candidate string) bool {
 	tmpDir, err := db.Subdir(b.currentConfig().MainSettings.DBPath, "tmp")
-	if err == nil && pathWithinRoot(tmpDir, candidate) {
+	if err == nil && pathutil.IsWithinRoot(tmpDir, candidate) {
 		return true
 	}
 	logPath, err := logging.LogPath(b.currentConfig().MainSettings.DBPath)
-	if err == nil && pathWithinRoot(filepath.Dir(logPath), candidate) {
+	if err == nil && pathutil.IsWithinRoot(filepath.Dir(logPath), candidate) {
 		return true
 	}
 	return false
@@ -1145,7 +1146,7 @@ func resolveContentTmpRoot(tmpRoot string, candidate string) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	if !pathWithinRoot(absTmpRoot, absCandidate) {
+	if !pathutil.IsWithinRoot(absTmpRoot, absCandidate) {
 		return "", false
 	}
 	rel, err := filepath.Rel(absTmpRoot, absCandidate)
@@ -1172,7 +1173,7 @@ func removeIfWithinRoot(root string, target string, recursive bool) error {
 	if err != nil {
 		return fmt.Errorf("cleanup path: resolve target path: %w", err)
 	}
-	if absTarget == absRoot || !pathWithinRoot(absRoot, absTarget) {
+	if absTarget == absRoot || !pathutil.IsWithinRoot(absRoot, absTarget) {
 		return nil
 	}
 	if recursive {
@@ -1191,17 +1192,6 @@ func removeIfWithinRoot(root string, target string, recursive bool) error {
 		return fmt.Errorf("cleanup path: remove target: %w", err)
 	}
 	return nil
-}
-
-func pathWithinRoot(root string, target string) bool {
-	rel, err := filepath.Rel(root, target)
-	if err != nil {
-		return false
-	}
-	if rel == "." {
-		return true
-	}
-	return !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".." && !filepath.IsAbs(rel)
 }
 
 func errorsIsNotFound(err error) bool {

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -1173,7 +1173,7 @@ func removeIfWithinRoot(root string, target string, recursive bool) error {
 	if err != nil {
 		return fmt.Errorf("cleanup path: resolve target path: %w", err)
 	}
-	if absTarget == absRoot || !pathutil.IsWithinRoot(absRoot, absTarget) {
+	if pathutil.SamePath(absRoot, absTarget) || !pathutil.IsWithinRoot(absRoot, absTarget) {
 		return nil
 	}
 	if recursive {

--- a/internal/webserver/routes.go
+++ b/internal/webserver/routes.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
+	"path" //nolint:depguard // Cleans HTTP route paths, not local filesystem paths.
 	"path/filepath"
 	"runtime"
 	"strings"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,7 +6,7 @@ min_version: 2.1.0
 
 # Execution model:
 # - Top-level jobs (frontend, go) run in parallel — they touch disjoint file sets.
-# - Within each group, jobs are piped so format runs before lint/logpolicy reads the file.
+# - Within each group, jobs are piped so format runs before lint/policy checks read the file.
 # - stage_fixed re-stages formatter output; lefthook serializes the git index updates.
 
 pre-commit:
@@ -48,6 +48,11 @@ pre-commit:
             run: go run ./cmd/logpolicy
             fail_text: "Log policy check failed. Review log lines added/changed under internal/."
 
+          - name: pathpolicy
+            glob: "**/*.go"
+            run: go run ./cmd/pathpolicy
+            fail_text: "Path policy check failed. Avoid hardcoded OS-rooted local paths in filepath calls."
+
 pre-push:
   parallel: true
   jobs:
@@ -59,8 +64,8 @@ pre-push:
 
     - name: go-lint
       glob: "**/*.go"
-      run: golangci-lint run --timeout=5m ./...
-      fail_text: "golangci-lint failed. Run `golangci-lint run --timeout=5m ./...` locally."
+      run: make lint
+      fail_text: "Go lint failed. Run `make lint` locally."
 
 commit-msg:
   jobs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repository path-portability checker CLI to validate cross-platform path handling.

* **Documentation**
  * Updated contributor and agent guides with path portability rules, new quick commands, and guidance for local checks and hook behavior.

* **Chores**
  * Enforced path-policy in linting, hooks, Make targets, and CI workflows.

* **Tests**
  * Expanded test coverage for path-policy, path utilities, symlink/OS edge cases, and CLI behavior.

* **Bug Fixes**
  * Strengthened path traversal protections and related safety checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/upbrr/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->