### PR TITLE
fix(trackers): group exact matching descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ git diff --check        # Whitespace/conflict-marker check
 ```
 
 Use `CONTRIBUTING.md` for full command reference/platform details. Start narrow package/file checks; expand for shared behavior or release surfaces.
+Before committing code changes, run targeted tests plus any broader hook that can catch unstaged/full-repo issues. For Go changes touching lint-sensitive code, run `make prepush` or `make lint` before final commit; `make precommit` alone is not full validation.
 
 ## Code Quality
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.55.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.45.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -69,7 +70,6 @@ require (
 	github.com/wailsapp/go-webview2 v1.0.22 // indirect
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/internal/services/imagehosting/service.go
+++ b/internal/services/imagehosting/service.go
@@ -489,8 +489,11 @@ func syncScreenshotSlotVariants(ctx context.Context, repo api.MetadataRepository
 		return trackers.SlotUploadAttachmentResult{}, nil
 	}
 	slots, err := repo.ListScreenshotSlotsByPath(ctx, sourcePath)
-	if err != nil || len(slots) == 0 {
+	if err != nil {
 		return trackers.SlotUploadAttachmentResult{}, fmt.Errorf("image hosting: %w", err)
+	}
+	if len(slots) == 0 {
+		return trackers.SlotUploadAttachmentResult{}, nil
 	}
 	summary := trackers.ApplyUploadedVariantsToSlots(slots, uploaded)
 	if summary.FallbackMatched > 0 {

--- a/internal/trackers/description_assets.go
+++ b/internal/trackers/description_assets.go
@@ -369,7 +369,7 @@ func matchingPreparationDescriptionGroupKeys(groups []api.DescriptionBuilderGrou
 		if key == "" {
 			continue
 		}
-		if !descriptionGroupMatchesTracker(group, canonicalGroup) {
+		if !descriptionGroupMatchesTracker(group, canonicalGroup, normalizedTracker) {
 			continue
 		}
 		_, host, usageScope := parsePreparationDescriptionGroupKey(key)
@@ -399,9 +399,21 @@ func matchingPreparationDescriptionGroupKeys(groups []api.DescriptionBuilderGrou
 	return keys
 }
 
-func descriptionGroupMatchesTracker(group api.DescriptionBuilderGroup, canonicalGroup string) bool {
+func descriptionGroupMatchesTracker(group api.DescriptionBuilderGroup, canonicalGroup string, tracker string) bool {
 	baseGroup, _, _ := parsePreparationDescriptionGroupKey(group.GroupKey)
-	return strings.EqualFold(strings.TrimSpace(baseGroup), canonicalGroup)
+	if !strings.EqualFold(strings.TrimSpace(baseGroup), canonicalGroup) {
+		return false
+	}
+	if len(group.Trackers) == 0 {
+		return true
+	}
+	normalizedTracker := strings.ToUpper(strings.TrimSpace(tracker))
+	for _, candidate := range group.Trackers {
+		if strings.ToUpper(strings.TrimSpace(candidate)) == normalizedTracker {
+			return true
+		}
+	}
+	return false
 }
 
 func parsePreparationDescriptionGroupKey(groupKey string) (string, string, string) {

--- a/internal/trackers/description_assets_test.go
+++ b/internal/trackers/description_assets_test.go
@@ -417,6 +417,34 @@ func TestResolveDescriptionAssetsLoadsStoredCompositeGroupOverride(t *testing.T)
 	}
 }
 
+func TestResolveDescriptionAssetsUsesTrackerMatchedVariantGroup(t *testing.T) {
+	meta := api.PreparedMetadata{
+		DescriptionGroups: []api.DescriptionBuilderGroup{
+			{
+				GroupKey:       "unit3d",
+				Trackers:       []string{"AITHER"},
+				RawDescription: "aither raw description",
+			},
+			{
+				GroupKey:       "unit3d|variant:2|global",
+				Trackers:       []string{"HHD"},
+				RawDescription: "hhd raw description",
+			},
+		},
+	}
+
+	assets, err := ResolveDescriptionAssets(context.Background(), "HHD", meta, nil, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if assets.Description != "hhd raw description" {
+		t.Fatalf("expected HHD variant group description, got %q", assets.Description)
+	}
+	if !assets.Override {
+		t.Fatalf("expected variant group description to be treated as override")
+	}
+}
+
 func TestResolveDescriptionAssetsDoesNotFallbackToLegacyDefaultGroupOverride(t *testing.T) {
 	repo := &stubRepo{
 		descriptionOverride: "legacy default desc",

--- a/internal/trackers/description_assets_test.go
+++ b/internal/trackers/description_assets_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -14,6 +16,8 @@ import (
 
 	"github.com/autobrr/upbrr/internal/config"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	"github.com/autobrr/upbrr/internal/paths"
+	dbsvc "github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -1146,6 +1150,66 @@ func TestEnsureDescriptionImageHostReusesAllowedHost(t *testing.T) {
 	}
 	if resolution.feedback.Reuploaded {
 		t.Fatal("expected screenshots to be reused")
+	}
+}
+
+func TestEnsureDescriptionImageHostReusesUploadedRecordsBeforeUploading(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "source.mkv")
+	dbPath := filepath.Join(t.TempDir(), "db.sqlite")
+	meta := api.PreparedMetadata{
+		SourcePath: sourcePath,
+		TrackerData: []api.TrackerMetadata{{
+			Tracker:   "HHD",
+			ImageURLs: []string{"https://source.example/screen1.png", "https://source.example/screen2.png"},
+		}},
+	}
+	tmpRoot, err := dbsvc.Subdir(dbPath, "tmp")
+	if err != nil {
+		t.Fatalf("tmp root: %v", err)
+	}
+	releaseDir, _, err := paths.ReleaseTempDir(tmpRoot, meta, sourcePath)
+	if err != nil {
+		t.Fatalf("release temp dir: %v", err)
+	}
+	firstPath := filepath.Join(releaseDir, "hhd", buildTrackerArtifactImageName(meta.TrackerData[0].ImageURLs[0], 0))
+	secondPath := filepath.Join(releaseDir, "hhd", buildTrackerArtifactImageName(meta.TrackerData[0].ImageURLs[1], 1))
+	if err := os.MkdirAll(filepath.Dir(firstPath), 0o700); err != nil {
+		t.Fatalf("tracker artifact dir: %v", err)
+	}
+	for _, pathValue := range []string{firstPath, secondPath} {
+		if err := os.WriteFile(pathValue, []byte("image"), 0o600); err != nil {
+			t.Fatalf("write local image: %v", err)
+		}
+	}
+	repo := &stubRepo{
+		uploads: []api.UploadedImageLink{
+			{SourcePath: sourcePath, ImagePath: firstPath, Host: "pixhost", UsageScope: "global", ImgURL: "https://pixhost/1.png", RawURL: "https://pixhost/raw1.png", WebURL: "https://pixhost/view1"},
+			{SourcePath: sourcePath, ImagePath: secondPath, Host: "pixhost", UsageScope: "global", ImgURL: "https://pixhost/2.png", RawURL: "https://pixhost/raw2.png", WebURL: "https://pixhost/view2"},
+		},
+	}
+	images := &stubImageService{}
+
+	resolution, err := ensureDescriptionImageHost(
+		context.Background(),
+		"HHD",
+		meta,
+		config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}},
+		config.TrackerConfig{ImageHost: "pixhost"},
+		repo,
+		images,
+		api.NopLogger{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(images.calls) != 0 {
+		t.Fatalf("expected existing uploaded records to be reused without upload, got calls %v", images.calls)
+	}
+	if resolution.feedback.SelectedHost != "pixhost" {
+		t.Fatalf("expected pixhost reuse, got %q", resolution.feedback.SelectedHost)
+	}
+	if len(resolution.screenshots) != 2 {
+		t.Fatalf("expected two reused screenshots, got %d", len(resolution.screenshots))
 	}
 }
 

--- a/internal/trackers/image_host_resolution.go
+++ b/internal/trackers/image_host_resolution.go
@@ -49,6 +49,7 @@ func ensureDescriptionImageHostWithData(
 	images api.ImageHostingService,
 	logger api.Logger,
 	preloaded *preloadedDescriptionAssetData,
+	preferredHosts ...string,
 ) (descriptionImageHostResolution, error) {
 	policy, err := resolveImageHostPolicy(tracker, trackerCfg, meta.ImageHostOverrides)
 	if err != nil {
@@ -71,7 +72,11 @@ func ensureDescriptionImageHostWithData(
 	}
 
 	if len(policy.allowed) == 0 {
-		screenshots, host, usageScope, err := selectScreenshotsFromSlots(tracker, slots, imageHostPolicy{})
+		selectionPolicy := imageHostPolicy{}
+		if host := firstPreferredDescriptionImageHost(preferredHosts); host != "" {
+			selectionPolicy.preferred = []string{host}
+		}
+		screenshots, host, usageScope, err := selectScreenshotsFromSlots(tracker, slots, selectionPolicy)
 		if err != nil {
 			return descriptionImageHostResolution{}, err
 		}
@@ -112,6 +117,19 @@ func ensureDescriptionImageHostWithData(
 		feedback.Status = "warning"
 		feedback.Message = fmt.Sprintf("%s requires screenshots from %s, but no local screenshots are available to rehost.", tracker, strings.Join(policy.allowed, ", "))
 		return descriptionImageHostResolution{feedback: feedback}, nil
+	}
+
+	for _, host := range uploadAttemptHosts(policy) {
+		usageScope := usageScopeForHost(host)
+		screenshots, err := reusableUploadedScreenshotsForHost(ctx, tracker, meta, repo, preloaded, host, usageScope, sourceImages)
+		if err != nil {
+			return descriptionImageHostResolution{}, err
+		}
+		if len(screenshots) > 0 {
+			feedback.SelectedHost = host
+			feedback.Message = buildReuseMessage(tracker, host, usageScope, host != preferredHost(policy))
+			return descriptionImageHostResolution{screenshots: screenshots, feedback: feedback, usageScope: usageScope}, nil
+		}
 	}
 
 	if images == nil {
@@ -193,6 +211,78 @@ func ensureDescriptionImageHostWithData(
 		feedback.Message = fmt.Sprintf("%s could not find an allowed screenshot host to upload to (%s).", tracker, attemptHosts)
 	}
 	return descriptionImageHostResolution{feedback: feedback, blocking: true}, nil
+}
+
+func firstPreferredDescriptionImageHost(hosts []string) string {
+	for _, host := range hosts {
+		normalized := strings.ToLower(strings.TrimSpace(host))
+		if normalized != "" {
+			return normalized
+		}
+	}
+	return ""
+}
+
+func reusableUploadedScreenshotsForHost(
+	ctx context.Context,
+	tracker string,
+	meta api.PreparedMetadata,
+	repo api.MetadataRepository,
+	preloaded *preloadedDescriptionAssetData,
+	host string,
+	usageScope string,
+	sourceImages []api.ScreenshotImage,
+) ([]api.ScreenshotImage, error) {
+	if repo == nil || len(sourceImages) == 0 {
+		return nil, nil
+	}
+	uploads, err := uploadedImagesFromSource(ctx, meta, repo, preloaded)
+	if err != nil {
+		if errorsIsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	byPath := make(map[string]api.UploadedImageLink, len(uploads))
+	for _, upload := range uploads {
+		if !strings.EqualFold(strings.TrimSpace(upload.Host), strings.TrimSpace(host)) {
+			continue
+		}
+		if !strings.EqualFold(normalizeUsageScope(upload.UsageScope), normalizeUsageScope(usageScope)) {
+			continue
+		}
+		if !uploadEligibleForTracker(upload.UsageScope, tracker) {
+			continue
+		}
+		pathValue := strings.TrimSpace(upload.ImagePath)
+		if pathValue == "" || strings.TrimSpace(upload.ImgURL) == "" {
+			continue
+		}
+		byPath[pathValue] = upload
+	}
+	if len(byPath) == 0 {
+		return nil, nil
+	}
+	screenshots := make([]api.ScreenshotImage, 0, len(sourceImages))
+	for _, image := range sourceImages {
+		pathValue := strings.TrimSpace(image.Path)
+		if pathValue == "" {
+			return nil, nil
+		}
+		upload, ok := byPath[pathValue]
+		if !ok {
+			return nil, nil
+		}
+		screenshots = append(screenshots, api.ScreenshotImage{
+			Index:  image.Index,
+			Path:   pathValue,
+			Host:   strings.TrimSpace(upload.Host),
+			ImgURL: strings.TrimSpace(upload.ImgURL),
+			RawURL: strings.TrimSpace(upload.RawURL),
+			WebURL: strings.TrimSpace(upload.WebURL),
+		})
+	}
+	return screenshots, nil
 }
 
 func cleanupUploadedImages(ctx context.Context, repo api.MetadataRepository, sourcePath string, uploaded []api.UploadedImageLink, logger api.Logger) {

--- a/internal/trackers/service.go
+++ b/internal/trackers/service.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strconv"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -665,6 +665,8 @@ func (s *Service) BuildPreparation(ctx context.Context, meta api.PreparedMetadat
 		results = append(results, *entry)
 	}
 
+	results = stabilizePreparationDescriptionGroupKeys(results)
+
 	return api.PreparationPreview{SourcePath: meta.SourcePath, Descriptions: results}, nil
 }
 
@@ -1031,9 +1033,72 @@ func preparationVariantGroupKey(groupKey string, variant int) string {
 		if host == "" {
 			host = "variant"
 		}
-		return strings.TrimSpace(parts[0]) + "|" + host + "#" + strconv.Itoa(variant) + "|" + strings.TrimSpace(parts[2])
+		return fmt.Sprintf("%s|%s#%d|%s", strings.TrimSpace(parts[0]), host, variant, strings.TrimSpace(parts[2]))
 	}
-	return trimmed + "|variant:" + strconv.Itoa(variant) + "|" + globalImageUsageScope
+	return fmt.Sprintf("%s|variant:%d|%s", trimmed, variant, globalImageUsageScope)
+}
+
+func stabilizePreparationDescriptionGroupKeys(descriptions []api.PreparationDescription) []api.PreparationDescription {
+	if len(descriptions) < 2 {
+		return descriptions
+	}
+
+	countByBase := make(map[string]int, len(descriptions))
+	for _, entry := range descriptions {
+		baseGroup, _, _ := parsePreparationDescriptionGroupKey(entry.GroupKey)
+		if baseGroup == "" {
+			baseGroup = strings.ToLower(strings.TrimSpace(entry.GroupKey))
+		}
+		if baseGroup == "" {
+			continue
+		}
+		countByBase[baseGroup]++
+	}
+
+	for idx := range descriptions {
+		baseGroup, _, _ := parsePreparationDescriptionGroupKey(descriptions[idx].GroupKey)
+		if baseGroup == "" {
+			baseGroup = strings.ToLower(strings.TrimSpace(descriptions[idx].GroupKey))
+		}
+		if baseGroup == "" || countByBase[baseGroup] <= 1 {
+			continue
+		}
+		descriptions[idx].GroupKey = stablePreparationDescriptionGroupKey(baseGroup, descriptions[idx].Trackers)
+	}
+	return descriptions
+}
+
+func stablePreparationDescriptionGroupKey(baseGroup string, trackers []string) string {
+	base := strings.TrimSpace(baseGroup)
+	normalized := normalizedPreparationGroupTrackers(trackers)
+	if len(normalized) == 0 {
+		return preparationGroupKey(base, "variant", globalImageUsageScope)
+	}
+	if len(normalized) == 1 {
+		return preparationGroupKey(base, strings.ToLower(normalized[0]), trackerImageUsageScope(normalized[0]))
+	}
+	return preparationGroupKey(base, strings.ToLower(strings.Join(normalized, "+")), globalImageUsageScope)
+}
+
+func normalizedPreparationGroupTrackers(trackers []string) []string {
+	if len(trackers) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(trackers))
+	normalized := make([]string, 0, len(trackers))
+	for _, tracker := range trackers {
+		value := strings.ToUpper(strings.TrimSpace(tracker))
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	return normalized
 }
 
 func normalizeTrackers(values []string) []string {

--- a/internal/trackers/service.go
+++ b/internal/trackers/service.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -629,26 +631,15 @@ func (s *Service) BuildPreparation(ctx context.Context, meta api.PreparedMetadat
 		}
 		groupKey = preparationGroupKey(groupKey, resolution.feedback.SelectedHost, resolution.usageScope)
 
-		entry, exists := grouped[groupKey]
-		switch {
-		case !exists:
-			entry = &api.PreparationDescription{
-				GroupKey:           groupKey,
-				Trackers:           []string{},
-				RawDescription:     strings.TrimSpace(assets.Description),
-				RawDescriptionHTML: description.Render(strings.TrimSpace(assets.Description)),
-				Description:        descriptionText,
-				DescriptionHTML:    description.Render(descriptionText),
-				HasOverride:        assets.Override,
-				ImageHost:          resolution.feedback,
-			}
-			grouped[groupKey] = entry
-			order = append(order, groupKey)
-		case entry.Description != descriptionText:
-			s.logger.Warnf("trackers: preparation group %s description mismatch (tracker=%s)", groupKey, tracker)
-		case entry.RawDescription != strings.TrimSpace(assets.Description):
-			s.logger.Warnf("trackers: preparation group %s raw description mismatch (tracker=%s)", groupKey, tracker)
+		candidate := api.PreparationDescription{
+			RawDescription:     strings.TrimSpace(assets.Description),
+			RawDescriptionHTML: description.Render(strings.TrimSpace(assets.Description)),
+			Description:        descriptionText,
+			DescriptionHTML:    description.Render(descriptionText),
+			HasOverride:        assets.Override,
+			ImageHost:          resolution.feedback,
 		}
+		entry := preparationDescriptionGroup(grouped, &order, groupKey, candidate)
 
 		entry.Trackers = append(entry.Trackers, tracker)
 		if entry.ImageHost.Status == "" {
@@ -985,6 +976,64 @@ func preparationGroupKey(group string, host string, usageScope string) string {
 		return trimmedGroup
 	}
 	return trimmedGroup + "|" + trimmedHost + "|" + trimmedScope
+}
+
+func preparationDescriptionGroup(grouped map[string]*api.PreparationDescription, order *[]string, groupKey string, candidate api.PreparationDescription) *api.PreparationDescription {
+	baseKey := strings.TrimSpace(groupKey)
+	if baseKey == "" {
+		baseKey = "description"
+	}
+
+	if entry, ok := grouped[baseKey]; ok && preparationDescriptionsMatch(*entry, candidate) {
+		return entry
+	}
+	if _, ok := grouped[baseKey]; !ok {
+		return addPreparationDescriptionGroup(grouped, order, baseKey, candidate)
+	}
+
+	for variant := 2; ; variant++ {
+		key := preparationVariantGroupKey(baseKey, variant)
+		if entry, ok := grouped[key]; ok && preparationDescriptionsMatch(*entry, candidate) {
+			return entry
+		}
+		if _, ok := grouped[key]; !ok {
+			return addPreparationDescriptionGroup(grouped, order, key, candidate)
+		}
+	}
+}
+
+func addPreparationDescriptionGroup(grouped map[string]*api.PreparationDescription, order *[]string, groupKey string, candidate api.PreparationDescription) *api.PreparationDescription {
+	entry := candidate
+	entry.GroupKey = groupKey
+	entry.Trackers = []string{}
+	grouped[groupKey] = &entry
+	*order = append(*order, groupKey)
+	return &entry
+}
+
+func preparationDescriptionsMatch(left api.PreparationDescription, right api.PreparationDescription) bool {
+	return left.RawDescription == right.RawDescription &&
+		left.RawDescriptionHTML == right.RawDescriptionHTML &&
+		left.Description == right.Description &&
+		left.DescriptionHTML == right.DescriptionHTML &&
+		left.HasOverride == right.HasOverride &&
+		reflect.DeepEqual(left.ImageHost, right.ImageHost)
+}
+
+func preparationVariantGroupKey(groupKey string, variant int) string {
+	trimmed := strings.TrimSpace(groupKey)
+	if variant <= 1 {
+		return trimmed
+	}
+	parts := strings.SplitN(trimmed, "|", 3)
+	if len(parts) == 3 {
+		host := strings.TrimSpace(parts[1])
+		if host == "" {
+			host = "variant"
+		}
+		return strings.TrimSpace(parts[0]) + "|" + host + "#" + strconv.Itoa(variant) + "|" + strings.TrimSpace(parts[2])
+	}
+	return trimmed + "|variant:" + strconv.Itoa(variant) + "|" + globalImageUsageScope
 }
 
 func normalizeTrackers(values []string) []string {

--- a/internal/trackers/service.go
+++ b/internal/trackers/service.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -544,6 +543,7 @@ func (s *Service) BuildPreparation(ctx context.Context, meta api.PreparedMetadat
 		s.logger.Warnf("trackers: preparation preload failed for %s: %v", meta.SourcePath, err)
 		preloaded = nil
 	}
+	preferredImageHosts := preparationImageHostPreferences(s.cfg, meta, resolved, s.logger)
 
 	grouped := make(map[string]*api.PreparationDescription)
 	order := make([]string, 0, len(resolved))
@@ -594,7 +594,18 @@ func (s *Service) BuildPreparation(ctx context.Context, meta api.PreparedMetadat
 		}
 		trackerCfg := trackerConfigFor(s.cfg, tracker)
 		trackerCfg = applyTrackerConfigOverrides(trackerCfg, meta.TrackerConfigOverrides)
-		resolution, err := ensureDescriptionImageHostWithData(ctx, tracker, meta, s.cfg, trackerCfg, s.repo, s.images, s.logger, preloaded)
+		resolution, err := ensureDescriptionImageHostWithData(
+			ctx,
+			tracker,
+			meta,
+			s.cfg,
+			trackerCfg,
+			s.repo,
+			s.images,
+			s.logger,
+			preloaded,
+			preferredImageHosts[strings.ToUpper(strings.TrimSpace(tracker))],
+		)
 		if err != nil {
 			s.logger.Warnf("trackers: preparation image host resolution failed for %s: %v", tracker, err)
 			placeholder("", tracker, fmt.Sprintf("image host error: %v", err))
@@ -642,9 +653,7 @@ func (s *Service) BuildPreparation(ctx context.Context, meta api.PreparedMetadat
 		entry := preparationDescriptionGroup(grouped, &order, groupKey, candidate)
 
 		entry.Trackers = append(entry.Trackers, tracker)
-		if entry.ImageHost.Status == "" {
-			entry.ImageHost = resolution.feedback
-		}
+		entry.ImageHost = mergePreparationImageHostFeedback(entry.ImageHost, resolution.feedback)
 		if descriptionText == "" {
 			placeholderCount++
 		} else {
@@ -668,6 +677,39 @@ func (s *Service) BuildPreparation(ctx context.Context, meta api.PreparedMetadat
 	results = stabilizePreparationDescriptionGroupKeys(results)
 
 	return api.PreparationPreview{SourcePath: meta.SourcePath, Descriptions: results}, nil
+}
+
+func preparationImageHostPreferences(appCfg config.Config, meta api.PreparedMetadata, trackers []string, logger api.Logger) map[string]string {
+	if meta.ImageHostOverrides.PreferredHost != nil {
+		return nil
+	}
+	targets, err := NeededImageUploadTargets(appCfg, trackers, "")
+	if err != nil {
+		if logger != nil {
+			logger.Warnf("trackers: preparation image host target resolution failed: %v", err)
+		}
+		return nil
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+	preferred := make(map[string]string, len(trackers))
+	for _, target := range targets {
+		host := strings.ToLower(strings.TrimSpace(target.Host))
+		if host == "" {
+			continue
+		}
+		for _, tracker := range target.Trackers {
+			name := strings.ToUpper(strings.TrimSpace(tracker))
+			if name == "" {
+				continue
+			}
+			if _, exists := preferred[name]; !exists {
+				preferred[name] = host
+			}
+		}
+	}
+	return preferred
 }
 
 func (s *Service) BuildUploadDryRun(ctx context.Context, meta api.PreparedMetadata, trackersList []string) ([]api.TrackerDryRunEntry, error) {
@@ -985,6 +1027,9 @@ func preparationDescriptionGroup(grouped map[string]*api.PreparationDescription,
 	if baseKey == "" {
 		baseKey = "description"
 	}
+	if entry := matchingUnit3DPreparationDescriptionGroup(grouped, *order, baseKey, candidate); entry != nil {
+		return entry
+	}
 
 	if entry, ok := grouped[baseKey]; ok && preparationDescriptionsMatch(*entry, candidate) {
 		return entry
@@ -1004,6 +1049,31 @@ func preparationDescriptionGroup(grouped map[string]*api.PreparationDescription,
 	}
 }
 
+func matchingUnit3DPreparationDescriptionGroup(grouped map[string]*api.PreparationDescription, order []string, groupKey string, candidate api.PreparationDescription) *api.PreparationDescription {
+	if preparationDescriptionBaseGroup(groupKey) != "unit3d" {
+		return nil
+	}
+	for _, key := range order {
+		if preparationDescriptionBaseGroup(key) != "unit3d" {
+			continue
+		}
+		entry := grouped[key]
+		if entry == nil || !preparationDescriptionsMatch(*entry, candidate) {
+			continue
+		}
+		return entry
+	}
+	return nil
+}
+
+func preparationDescriptionBaseGroup(groupKey string) string {
+	baseGroup, _, _ := parsePreparationDescriptionGroupKey(groupKey)
+	if baseGroup == "" {
+		baseGroup = strings.ToLower(strings.TrimSpace(groupKey))
+	}
+	return baseGroup
+}
+
 func addPreparationDescriptionGroup(grouped map[string]*api.PreparationDescription, order *[]string, groupKey string, candidate api.PreparationDescription) *api.PreparationDescription {
 	entry := candidate
 	entry.GroupKey = groupKey
@@ -1015,11 +1085,124 @@ func addPreparationDescriptionGroup(grouped map[string]*api.PreparationDescripti
 
 func preparationDescriptionsMatch(left api.PreparationDescription, right api.PreparationDescription) bool {
 	return left.RawDescription == right.RawDescription &&
-		left.RawDescriptionHTML == right.RawDescriptionHTML &&
 		left.Description == right.Description &&
-		left.DescriptionHTML == right.DescriptionHTML &&
-		left.HasOverride == right.HasOverride &&
-		reflect.DeepEqual(left.ImageHost, right.ImageHost)
+		left.HasOverride == right.HasOverride
+}
+
+func mergePreparationImageHostFeedback(left api.ImageHostFeedback, right api.ImageHostFeedback) api.ImageHostFeedback {
+	if left.Status == "" {
+		return right
+	}
+	if right.Status == "" {
+		return left
+	}
+
+	merged := left
+	if imageHostStatusRank(right.Status) > imageHostStatusRank(merged.Status) {
+		merged.Status = right.Status
+	}
+	if strings.TrimSpace(merged.SelectedHost) == "" {
+		merged.SelectedHost = strings.TrimSpace(right.SelectedHost)
+	} else if strings.TrimSpace(right.SelectedHost) != "" && !strings.EqualFold(strings.TrimSpace(merged.SelectedHost), strings.TrimSpace(right.SelectedHost)) {
+		merged.SelectedHost = ""
+	}
+	merged.AllowedHosts = appendUniqueStrings(merged.AllowedHosts, right.AllowedHosts)
+	merged.Warnings = appendUniqueImageHostWarnings(merged.Warnings, right.Warnings)
+	merged.Reuploaded = merged.Reuploaded || right.Reuploaded
+
+	leftMessage := strings.TrimSpace(merged.Message)
+	rightMessage := strings.TrimSpace(right.Message)
+	switch {
+	case leftMessage == "":
+		merged.Message = rightMessage
+	case rightMessage == "" || leftMessage == rightMessage:
+		merged.Message = leftMessage
+	default:
+		merged.Message = "Multiple image-host states apply to this description group."
+	}
+
+	return merged
+}
+
+func imageHostStatusRank(status string) int {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "warning":
+		return 3
+	case "reuploaded":
+		return 2
+	case "reused":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func appendUniqueStrings(values []string, additions []string) []string {
+	if len(additions) == 0 {
+		return values
+	}
+	seen := make(map[string]struct{}, len(values)+len(additions))
+	out := make([]string, 0, len(values)+len(additions))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, trimmed)
+	}
+	for _, value := range additions {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func appendUniqueImageHostWarnings(values []api.ImageHostWarning, additions []api.ImageHostWarning) []api.ImageHostWarning {
+	if len(additions) == 0 {
+		return values
+	}
+	seen := make(map[string]struct{}, len(values)+len(additions))
+	out := make([]api.ImageHostWarning, 0, len(values)+len(additions))
+	for _, value := range values {
+		host := strings.TrimSpace(value.Host)
+		message := strings.TrimSpace(value.Message)
+		if host == "" && message == "" {
+			continue
+		}
+		key := strings.ToLower(host) + "\x00" + message
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, api.ImageHostWarning{Host: host, Message: message})
+	}
+	for _, value := range additions {
+		host := strings.TrimSpace(value.Host)
+		message := strings.TrimSpace(value.Message)
+		if host == "" && message == "" {
+			continue
+		}
+		key := strings.ToLower(host) + "\x00" + message
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, api.ImageHostWarning{Host: host, Message: message})
+	}
+	return out
 }
 
 func preparationVariantGroupKey(groupKey string, variant int) string {

--- a/internal/trackers/service_test.go
+++ b/internal/trackers/service_test.go
@@ -398,6 +398,29 @@ func TestBuildPreparationSplitsSameGroupWhenDescriptionDiffers(t *testing.T) {
 	if got := strings.Join(preview.Descriptions[1].Trackers, ","); got != "HHD" {
 		t.Fatalf("expected second group to contain HHD, got %q", got)
 	}
+	if preview.Descriptions[0].GroupKey != "unit3d|aither|tracker:AITHER" {
+		t.Fatalf("expected stable AITHER group key, got %q", preview.Descriptions[0].GroupKey)
+	}
+	if preview.Descriptions[1].GroupKey != "unit3d|hhd|tracker:HHD" {
+		t.Fatalf("expected stable HHD group key, got %q", preview.Descriptions[1].GroupKey)
+	}
+
+	reversed, err := svc.BuildPreparation(context.Background(), api.PreparedMetadata{}, []string{"HHD", "AITHER"})
+	if err != nil {
+		t.Fatalf("unexpected reversed error: %v", err)
+	}
+	groupKeyByTracker := make(map[string]string, len(reversed.Descriptions))
+	for _, group := range reversed.Descriptions {
+		for _, tracker := range group.Trackers {
+			groupKeyByTracker[tracker] = group.GroupKey
+		}
+	}
+	if groupKeyByTracker["AITHER"] != "unit3d|aither|tracker:AITHER" {
+		t.Fatalf("expected reversed AITHER stable group key, got %q", groupKeyByTracker["AITHER"])
+	}
+	if groupKeyByTracker["HHD"] != "unit3d|hhd|tracker:HHD" {
+		t.Fatalf("expected reversed HHD stable group key, got %q", groupKeyByTracker["HHD"])
+	}
 }
 
 func TestBuildPreparationSplitsSameGroupWhenRawDescriptionDiffers(t *testing.T) {

--- a/internal/trackers/service_test.go
+++ b/internal/trackers/service_test.go
@@ -181,6 +181,34 @@ func (s stubPreparationDefinition) BuildDescription(context.Context, Description
 	return DescriptionResult{Group: s.group, Description: s.description}, nil
 }
 
+type hostAwareDescriptionDefinition struct {
+	name  string
+	group string
+}
+
+func (s hostAwareDescriptionDefinition) Name() string {
+	return s.name
+}
+
+func (s hostAwareDescriptionDefinition) Upload(context.Context, UploadRequest) (api.UploadSummary, error) {
+	return api.UploadSummary{Uploaded: 1}, nil
+}
+
+func (s hostAwareDescriptionDefinition) BuildDescription(_ context.Context, req DescriptionRequest) (DescriptionResult, error) {
+	host := "none"
+	if req.Assets != nil && len(req.Assets.Screenshots) > 0 {
+		host = strings.ToLower(strings.TrimSpace(req.Assets.Screenshots[0].Host))
+		if host == "" {
+			host = "none"
+		}
+	}
+
+	return DescriptionResult{
+		Group:       s.group,
+		Description: "unit3d screenshot host: " + host,
+	}, nil
+}
+
 func (testHDBPreparationDefinition) Name() string {
 	return "HDB"
 }
@@ -460,7 +488,7 @@ func TestBuildPreparationSplitsSameGroupWhenRawDescriptionDiffers(t *testing.T) 
 	}
 }
 
-func TestBuildPreparationSplitsSameGroupWhenImageHostFeedbackDiffers(t *testing.T) {
+func TestBuildPreparationGroupsSameDescriptionWhenImageHostFeedbackDiffers(t *testing.T) {
 	t.Parallel()
 
 	registry := NewRegistry()
@@ -478,14 +506,197 @@ func TestBuildPreparationSplitsSameGroupWhenImageHostFeedbackDiffers(t *testing.
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(preview.Descriptions) != 2 {
-		t.Fatalf("expected image-host feedback mismatch to split, got %d groups", len(preview.Descriptions))
+	if len(preview.Descriptions) != 1 {
+		t.Fatalf("expected matching descriptions to group despite image-host feedback mismatch, got %d groups", len(preview.Descriptions))
 	}
-	if len(preview.Descriptions[0].ImageHost.AllowedHosts) != 0 {
-		t.Fatalf("expected AITHER image host policy to be empty, got %#v", preview.Descriptions[0].ImageHost)
+	if got := strings.Join(preview.Descriptions[0].Trackers, ","); got != "AITHER,PTP" {
+		t.Fatalf("expected both trackers in group, got %q", got)
 	}
-	if len(preview.Descriptions[1].ImageHost.AllowedHosts) == 0 {
+	if len(preview.Descriptions[0].ImageHost.AllowedHosts) == 0 {
 		t.Fatalf("expected PTP image host policy to be captured")
+	}
+}
+
+func TestBuildPreparationGroupsUnit3DWhenImageHostMessageOnlyDiffers(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	for _, definition := range []Definition{
+		stubPreparationDefinition{name: "AITHER", group: "unit3d", description: "same description"},
+		stubPreparationDefinition{name: "HHD", group: "unit3d", description: "same description"},
+	} {
+		if err := registry.Register(definition); err != nil {
+			t.Fatalf("register stub: %v", err)
+		}
+	}
+
+	cfg := config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"AITHER": {ImageHost: "imgbox", ImgRehost: true},
+				"HHD":    {ImageHost: "imgbox", ImgRehost: true},
+			},
+		},
+	}
+	repo := &stubRepo{}
+	svc := NewServiceWithRegistry(cfg, nil, repo, registry)
+	sourcePath := filepath.Join(t.TempDir(), "source.mkv")
+	preview, err := svc.BuildPreparation(context.Background(), api.PreparedMetadata{SourcePath: sourcePath}, []string{"AITHER", "HHD"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(preview.Descriptions) != 1 {
+		t.Fatalf("expected image-host message-only diff to group, got %d groups", len(preview.Descriptions))
+	}
+	if got := strings.Join(preview.Descriptions[0].Trackers, ","); got != "AITHER,HHD" {
+		t.Fatalf("expected both unit3d trackers in group, got %q", got)
+	}
+	if preview.Descriptions[0].ImageHost.Status != "warning" {
+		t.Fatalf("expected image host warning status, got %q", preview.Descriptions[0].ImageHost.Status)
+	}
+	if len(preview.Descriptions[0].ImageHost.AllowedHosts) != 1 || preview.Descriptions[0].ImageHost.AllowedHosts[0] != "imgbox" {
+		t.Fatalf("expected allowed host imgbox policy to be preserved, got %#v", preview.Descriptions[0].ImageHost.AllowedHosts)
+	}
+}
+
+func TestBuildPreparationUnit3DGroupsOnConfiguredHostPreference(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	for _, definition := range []Definition{
+		hostAwareDescriptionDefinition{name: "HHD", group: "unit3d"},
+		hostAwareDescriptionDefinition{name: "LUME", group: "unit3d"},
+		hostAwareDescriptionDefinition{name: "RAS", group: "unit3d"},
+	} {
+		if err := registry.Register(definition); err != nil {
+			t.Fatalf("register stub: %v", err)
+		}
+	}
+
+	sourcePath := filepath.Join(t.TempDir(), "source.mkv")
+	imagePath := filepath.Join(t.TempDir(), "screen.png")
+	olderUpload := time.Now().Add(-time.Hour)
+	newerUpload := time.Now()
+	repo := &stubRepo{
+		screenshotSlots: []api.ScreenshotSlot{
+			{
+				SourcePath:          sourcePath,
+				SlotOrder:           0,
+				SourceKind:          screenshotSlotSourceSelection,
+				ImagePath:           imagePath,
+				RenderInScreenshots: true,
+				Variants: []api.ScreenshotSlotVariant{
+					{
+						SourcePath: sourcePath,
+						SlotOrder:  0,
+						Host:       "pixhost",
+						UsageScope: globalImageUsageScope,
+						ImagePath:  imagePath,
+						ImgURL:     "https://pixhost/old.png",
+						RawURL:     "https://pixhost/raw-old.png",
+						WebURL:     "https://pixhost/old",
+						UploadedAt: olderUpload,
+					},
+					{
+						SourcePath: sourcePath,
+						SlotOrder:  0,
+						Host:       "imgbb",
+						UsageScope: globalImageUsageScope,
+						ImagePath:  imagePath,
+						ImgURL:     "https://imgbb/new.png",
+						RawURL:     "https://imgbb/raw-new.png",
+						WebURL:     "https://imgbb/new",
+						UploadedAt: newerUpload,
+					},
+				},
+			},
+		},
+		uploads: []api.UploadedImageLink{
+			{
+				Host:       "pixhost",
+				UsageScope: globalImageUsageScope,
+				ImagePath:  imagePath,
+				ImgURL:     "https://pixhost/old.png",
+				RawURL:     "https://pixhost/raw-old.png",
+				WebURL:     "https://pixhost/old",
+				UploadedAt: olderUpload,
+			},
+			{
+				Host:       "imgbb",
+				UsageScope: globalImageUsageScope,
+				ImagePath:  imagePath,
+				ImgURL:     "https://imgbb/new.png",
+				RawURL:     "https://imgbb/raw-new.png",
+				WebURL:     "https://imgbb/new",
+				UploadedAt: newerUpload,
+			},
+		},
+	}
+
+	cfg := config.Config{
+		ImageHosting: config.ImageHostingConfig{
+			Host1: "pixhost",
+			Host2: "imgbb",
+		},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"HHD": {ImageHost: "pixhost", ImgRehost: true},
+			},
+		},
+	}
+	svc := NewServiceWithRegistry(cfg, nil, repo, registry)
+	preview, err := svc.BuildPreparation(context.Background(), api.PreparedMetadata{SourcePath: sourcePath}, []string{"HHD", "LUME", "RAS"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(preview.Descriptions) != 1 {
+		t.Fatalf("expected configured-host preference to collapse HHD+LUME+RAS into one group, got %d", len(preview.Descriptions))
+	}
+	if got := strings.Join(preview.Descriptions[0].Trackers, ","); got != "HHD,LUME,RAS" {
+		t.Fatalf("expected both unit3d trackers in group, got %q", got)
+	}
+	if preview.Descriptions[0].GroupKey != "unit3d|pixhost|global" {
+		t.Fatalf("expected preferred pixhost group key, got %q", preview.Descriptions[0].GroupKey)
+	}
+	if preview.Descriptions[0].Description != "unit3d screenshot host: pixhost" {
+		t.Fatalf("expected host-resolved description, got %q", preview.Descriptions[0].Description)
+	}
+}
+
+func TestPreparationDescriptionGroupMergesUnit3DHostVariantsWhenDescriptionMatches(t *testing.T) {
+	t.Parallel()
+
+	grouped := make(map[string]*api.PreparationDescription)
+	order := make([]string, 0, 2)
+	first := api.PreparationDescription{
+		RawDescription:     "raw",
+		RawDescriptionHTML: "<p>raw</p>",
+		Description:        "same description",
+		DescriptionHTML:    "<p>same description</p>",
+		ImageHost:          api.ImageHostFeedback{Status: "reused", SelectedHost: "pixhost", AllowedHosts: []string{"pixhost"}},
+	}
+	second := first
+	second.ImageHost = api.ImageHostFeedback{Status: "reused", SelectedHost: "imgbb", AllowedHosts: []string{"imgbb"}}
+	second.RawDescriptionHTML = "<div>raw</div>"
+	second.DescriptionHTML = "<div>same description</div>"
+
+	firstEntry := preparationDescriptionGroup(grouped, &order, "unit3d|pixhost|global", first)
+	firstEntry.Trackers = append(firstEntry.Trackers, "HHD")
+	secondEntry := preparationDescriptionGroup(grouped, &order, "unit3d|imgbb|global", second)
+	secondEntry.Trackers = append(secondEntry.Trackers, "LUME")
+	secondEntry.ImageHost = mergePreparationImageHostFeedback(secondEntry.ImageHost, second.ImageHost)
+
+	if firstEntry != secondEntry {
+		t.Fatal("expected matching unit3d descriptions to share one group across image-host key variants")
+	}
+	if len(order) != 1 {
+		t.Fatalf("expected one ordered group, got %d", len(order))
+	}
+	if got := strings.Join(firstEntry.Trackers, ","); got != "HHD,LUME" {
+		t.Fatalf("expected both trackers in merged group, got %q", got)
+	}
+	if len(firstEntry.ImageHost.AllowedHosts) != 2 {
+		t.Fatalf("expected merged image host policy data, got %#v", firstEntry.ImageHost.AllowedHosts)
 	}
 }
 

--- a/internal/trackers/service_test.go
+++ b/internal/trackers/service_test.go
@@ -338,6 +338,134 @@ func TestBuildUploadDryRunNoBuilderMarkedUnsupported(t *testing.T) {
 	}
 }
 
+func TestBuildPreparationGroupsExactMatchingUnit3DDescriptions(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	for _, definition := range []Definition{
+		stubPreparationDefinition{name: "AITHER", group: "unit3d", description: "same description"},
+		stubPreparationDefinition{name: "HHD", group: "unit3d", description: "same description"},
+	} {
+		if err := registry.Register(definition); err != nil {
+			t.Fatalf("register stub: %v", err)
+		}
+	}
+
+	svc := NewServiceWithRegistry(config.Config{}, nil, nil, registry)
+	preview, err := svc.BuildPreparation(context.Background(), api.PreparedMetadata{}, []string{"AITHER", "HHD"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(preview.Descriptions) != 1 {
+		t.Fatalf("expected exact matching unit3d descriptions to group, got %d groups", len(preview.Descriptions))
+	}
+	group := preview.Descriptions[0]
+	if group.GroupKey != "unit3d" {
+		t.Fatalf("expected canonical unit3d group key, got %q", group.GroupKey)
+	}
+	if got := strings.Join(group.Trackers, ","); got != "AITHER,HHD" {
+		t.Fatalf("expected both trackers in group, got %q", got)
+	}
+}
+
+func TestBuildPreparationSplitsSameGroupWhenDescriptionDiffers(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	for _, definition := range []Definition{
+		stubPreparationDefinition{name: "AITHER", group: "unit3d", description: "aither description"},
+		stubPreparationDefinition{name: "HHD", group: "unit3d", description: "hhd description"},
+	} {
+		if err := registry.Register(definition); err != nil {
+			t.Fatalf("register stub: %v", err)
+		}
+	}
+
+	svc := NewServiceWithRegistry(config.Config{}, nil, nil, registry)
+	preview, err := svc.BuildPreparation(context.Background(), api.PreparedMetadata{}, []string{"AITHER", "HHD"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(preview.Descriptions) != 2 {
+		t.Fatalf("expected mismatched descriptions to split, got %d groups", len(preview.Descriptions))
+	}
+	if preview.Descriptions[0].GroupKey == preview.Descriptions[1].GroupKey {
+		t.Fatalf("expected unique group keys, got %q", preview.Descriptions[0].GroupKey)
+	}
+	if got := strings.Join(preview.Descriptions[0].Trackers, ","); got != "AITHER" {
+		t.Fatalf("expected first group to contain AITHER, got %q", got)
+	}
+	if got := strings.Join(preview.Descriptions[1].Trackers, ","); got != "HHD" {
+		t.Fatalf("expected second group to contain HHD, got %q", got)
+	}
+}
+
+func TestBuildPreparationSplitsSameGroupWhenRawDescriptionDiffers(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	for _, definition := range []Definition{
+		stubPreparationDefinition{name: "AITHER", group: "unit3d", description: "same final description"},
+		stubPreparationDefinition{name: "BLU", group: "unit3d", description: "same final description"},
+	} {
+		if err := registry.Register(definition); err != nil {
+			t.Fatalf("register stub: %v", err)
+		}
+	}
+
+	sourcePath := filepath.Join(t.TempDir(), "source.mkv")
+	repo := &stubRepo{
+		trackerRecords: []api.TrackerMetadata{
+			{Tracker: "AITHER", Description: "aither raw description"},
+			{Tracker: "BLU", Description: "blu raw description"},
+		},
+	}
+
+	svc := NewServiceWithRegistry(config.Config{}, nil, repo, registry)
+	preview, err := svc.BuildPreparation(context.Background(), api.PreparedMetadata{SourcePath: sourcePath}, []string{"AITHER", "BLU"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(preview.Descriptions) != 2 {
+		t.Fatalf("expected raw description mismatch to split, got %d groups", len(preview.Descriptions))
+	}
+	if preview.Descriptions[0].RawDescription != "aither raw description" {
+		t.Fatalf("expected AITHER raw description, got %q", preview.Descriptions[0].RawDescription)
+	}
+	if preview.Descriptions[1].RawDescription != "blu raw description" {
+		t.Fatalf("expected BLU raw description, got %q", preview.Descriptions[1].RawDescription)
+	}
+}
+
+func TestBuildPreparationSplitsSameGroupWhenImageHostFeedbackDiffers(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	for _, definition := range []Definition{
+		stubPreparationDefinition{name: "AITHER", group: "shared", description: "same description"},
+		stubPreparationDefinition{name: "PTP", group: "shared", description: "same description"},
+	} {
+		if err := registry.Register(definition); err != nil {
+			t.Fatalf("register stub: %v", err)
+		}
+	}
+
+	svc := NewServiceWithRegistry(config.Config{}, nil, nil, registry)
+	preview, err := svc.BuildPreparation(context.Background(), api.PreparedMetadata{}, []string{"AITHER", "PTP"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(preview.Descriptions) != 2 {
+		t.Fatalf("expected image-host feedback mismatch to split, got %d groups", len(preview.Descriptions))
+	}
+	if len(preview.Descriptions[0].ImageHost.AllowedHosts) != 0 {
+		t.Fatalf("expected AITHER image host policy to be empty, got %#v", preview.Descriptions[0].ImageHost)
+	}
+	if len(preview.Descriptions[1].ImageHost.AllowedHosts) == 0 {
+		t.Fatalf("expected PTP image host policy to be captured")
+	}
+}
+
 func TestApplyTrackerConfigOverrides(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Description matching now respects tracker-specific variants and groups; preparation previews split or merge correctly when descriptions or image-host details differ.
  * Image-host selection reuses already-uploaded screenshots and treats “no screenshot slots” as a non-error case.
* **Tests**
  * Added unit tests covering grouping, description selection, raw-description preservation, and image-host behaviors.
* **Documentation**
  * Clarified contributor guidance to run broader pre-push checks (e.g., make prepush or make lint) for certain Go changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->