### PR TITLE
fix: harden upload and web input handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ WAILS_CLI := go run github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
 GO_TEST_FLAGS := -race -v -timeout 20m
 GOLANGCI_FLAGS := --timeout=5m
 GO_CHANGED_FILES := $(shell git diff --name-only --diff-filter=ACMR HEAD -- '*.go')
-GO_CHANGED_PKGS := $(sort $(patsubst %/,%,$(dir $(GO_CHANGED_FILES))))
+GO_CHANGED_PKGS := $(addprefix ./,$(sort $(patsubst %/,%,$(dir $(GO_CHANGED_FILES)))))
 
 help:
 	@echo Build

--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"sort"
 	"strings"
@@ -123,7 +124,7 @@ func runInteractiveCLIPath(ctx context.Context, coreSvc api.Core, baseArgs []str
 	req.TrackerQuestionnaireAnswers = questionnaireAnswers
 
 	_, err = coreSvc.RunUploadPrepared(ctx, req)
-	return fmt.Errorf("upbrr: %w", err)
+	return wrapUpbrrError(err)
 }
 
 func runSiteCheckCLIPath(ctx context.Context, coreSvc api.Core, opts cliOptions, visited map[string]bool, sourcePath string, screens int) error {
@@ -132,6 +133,9 @@ func runSiteCheckCLIPath(ctx context.Context, coreSvc api.Core, opts cliOptions,
 		return err
 	}
 
+	if _, err := coreSvc.FetchMetadataPreview(ctx, req); err != nil {
+		return fmt.Errorf("upbrr: %w", err)
+	}
 	review, err := coreSvc.BuildUploadReview(ctx, req)
 	if err != nil {
 		return fmt.Errorf("upbrr: %w", err)
@@ -178,6 +182,9 @@ func promptTrackerQuestionnaires(reader *bufio.Reader, review api.UploadReview, 
 		for _, field := range tracker.Questionnaire.Fields {
 			defaultValue := strings.TrimSpace(field.Value)
 			if opts.Unattended && !opts.UnattendedConfirm {
+				if field.Required && defaultValue == "" {
+					return nil, false, fmt.Errorf("upbrr: unattended upload requires %s questionnaire value for %s", questionnaireFieldLabel(field), tracker.Tracker)
+				}
 				values[field.Key] = defaultValue
 				continue
 			}
@@ -192,7 +199,7 @@ func promptTrackerQuestionnaires(reader *bufio.Reader, review api.UploadReview, 
 				}
 				value = strings.TrimSpace(value)
 				if field.Required && value == "" {
-					fmt.Printf("%s is required.\n", strings.TrimSpace(field.Label))
+					fmt.Printf("%s is required.\n", questionnaireFieldLabel(field))
 					continue
 				}
 				values[field.Key] = value
@@ -208,6 +215,14 @@ func promptTrackerQuestionnaires(reader *bufio.Reader, review api.UploadReview, 
 		return nil, false, nil
 	}
 	return answers, changed, nil
+}
+
+func questionnaireFieldLabel(field api.TrackerQuestionnaireField) string {
+	label := strings.TrimSpace(field.Label)
+	if label != "" {
+		return label
+	}
+	return strings.TrimSpace(field.Key)
 }
 
 func runDoubleDupeCheck(ctx context.Context, reader *bufio.Reader, coreSvc api.Core, req api.Request, trackers []string) ([]string, error) {
@@ -252,10 +267,7 @@ func runDoubleDupeCheck(ctx context.Context, reader *bufio.Reader, coreSvc api.C
 }
 
 func buildQuestionnairePrompt(field api.TrackerQuestionnaireField) string {
-	label := strings.TrimSpace(field.Label)
-	if label == "" {
-		label = strings.TrimSpace(field.Key)
-	}
+	label := questionnaireFieldLabel(field)
 	parts := []string{label}
 	if field.Help != "" {
 		parts = append(parts, field.Help)
@@ -490,8 +502,6 @@ func promptLine(reader *bufio.Reader, prompt string) (string, error) {
 
 func copyVisited(input map[string]bool) map[string]bool {
 	cloned := make(map[string]bool, len(input))
-	for key, value := range input {
-		cloned[key] = value
-	}
+	maps.Copy(cloned, input)
 	return cloned
 }

--- a/cmd/upbrr/interactive_test.go
+++ b/cmd/upbrr/interactive_test.go
@@ -1,0 +1,317 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestRunInteractiveCLIPathReturnsNilAfterSuccessfulUpload(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &cliCoreForTest{
+		review: api.UploadReview{Trackers: []api.TrackerReview{{Tracker: "BLU"}}},
+	}
+	err := runInteractiveCLIPath(context.Background(), coreSvc, nil, cliOptions{Unattended: true}, map[string]bool{}, "movie.mkv", 1)
+	if err != nil {
+		t.Fatalf("runInteractiveCLIPath: %v", err)
+	}
+	if coreSvc.runUploadPreparedCalls != 1 {
+		t.Fatalf("expected one prepared upload, got %d", coreSvc.runUploadPreparedCalls)
+	}
+}
+
+func TestRunSiteCheckCLIPathSeedsMetadataBeforeReview(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &cliCoreForTest{}
+	if err := runSiteCheckCLIPath(context.Background(), coreSvc, cliOptions{SiteCheck: true}, map[string]bool{}, "movie.mkv", 1); err != nil {
+		t.Fatalf("runSiteCheckCLIPath: %v", err)
+	}
+	if got := strings.Join(coreSvc.callOrder, ","); got != "preview,review" {
+		t.Fatalf("expected preview before review, got %s", got)
+	}
+}
+
+func TestPrepareCLIUploadMetadataSeedsEachPath(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &cliCoreForTest{}
+	req := api.Request{Paths: []string{"one.mkv", "two.mkv"}}
+	if err := prepareCLIUploadMetadata(context.Background(), coreSvc, req); err != nil {
+		t.Fatalf("prepareCLIUploadMetadata: %v", err)
+	}
+	if len(coreSvc.previewPaths) != 2 || coreSvc.previewPaths[0] != "one.mkv" || coreSvc.previewPaths[1] != "two.mkv" {
+		t.Fatalf("unexpected preview paths: %#v", coreSvc.previewPaths)
+	}
+}
+
+func TestPromptTrackerQuestionnairesRejectsBlankRequiredUnattendedDefault(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := promptTrackerQuestionnaires(bufio.NewReader(strings.NewReader("")), api.UploadReview{
+		Trackers: []api.TrackerReview{{
+			Tracker: "ANT",
+			Questionnaire: &api.TrackerQuestionnaire{Fields: []api.TrackerQuestionnaireField{{
+				Key:      "type",
+				Label:    "ANT Type",
+				Required: true,
+			}}},
+		}},
+	}, cliOptions{Unattended: true})
+	if err == nil {
+		t.Fatal("expected unattended required questionnaire error")
+	}
+	if !strings.Contains(err.Error(), "unattended upload requires ANT Type questionnaire value for ANT") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleBDMVPlaylistSelectionDoesNotPromptInUnattendedMode(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	bdmvPath := filepath.Join(root, "BDMV")
+	if err := os.Mkdir(bdmvPath, 0o755); err != nil {
+		t.Fatalf("mkdir BDMV: %v", err)
+	}
+	coreSvc := &cliCoreForTest{
+		playlistSelectionErr: internalerrors.ErrNotFound,
+		playlists: []api.PlaylistInfo{
+			{File: "00001.mpls", Duration: 7200, Score: 1},
+			{File: "00002.mpls", Duration: 7100, Score: 0.9},
+		},
+	}
+
+	err := handleBDMVPlaylistSelection(context.Background(), []string{root}, coreSvc, config.Config{}, api.NopLogger{}, cliOptions{Unattended: true})
+	if err == nil {
+		t.Fatal("expected unattended playlist selection error")
+	}
+	if !strings.Contains(err.Error(), "unattended BDMV upload requires a saved playlist selection") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleBDMVPlaylistSelectionAllowsUnattendedUseLargestPlaylist(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	bdmvPath := filepath.Join(root, "BDMV")
+	if err := os.Mkdir(bdmvPath, 0o755); err != nil {
+		t.Fatalf("mkdir BDMV: %v", err)
+	}
+	coreSvc := &cliCoreForTest{
+		playlistSelectionErr: internalerrors.ErrNotFound,
+		playlists: []api.PlaylistInfo{
+			{File: "00001.mpls", Duration: 7200, Score: 1},
+			{File: "00002.mpls", Duration: 7100, Score: 0.9},
+		},
+	}
+
+	err := handleBDMVPlaylistSelection(context.Background(), []string{root}, coreSvc, config.Config{
+		Metadata: config.MetadataConfig{UseLargestPlaylist: true},
+	}, api.NopLogger{}, cliOptions{Unattended: true})
+	if err != nil {
+		t.Fatalf("handleBDMVPlaylistSelection: %v", err)
+	}
+	if len(coreSvc.savedPlaylists) != 1 || coreSvc.savedPlaylists[0] != "00001.mpls" {
+		t.Fatalf("unexpected saved playlists: %#v", coreSvc.savedPlaylists)
+	}
+}
+
+func TestHandleBDMVPlaylistSelectionReturnsSaveErrorInUnattendedUseLargestPlaylist(t *testing.T) {
+	t.Parallel()
+
+	saveErr := errors.New("save failed")
+	root := t.TempDir()
+	bdmvPath := filepath.Join(root, "BDMV")
+	if err := os.Mkdir(bdmvPath, 0o755); err != nil {
+		t.Fatalf("mkdir BDMV: %v", err)
+	}
+	coreSvc := &cliCoreForTest{
+		playlistSelectionErr: internalerrors.ErrNotFound,
+		playlists: []api.PlaylistInfo{
+			{File: "00001.mpls", Duration: 7200, Score: 1},
+		},
+		savePlaylistErr: saveErr,
+	}
+
+	err := handleBDMVPlaylistSelection(context.Background(), []string{root}, coreSvc, config.Config{
+		Metadata: config.MetadataConfig{UseLargestPlaylist: true},
+	}, api.NopLogger{}, cliOptions{Unattended: true})
+	if !errors.Is(err, saveErr) {
+		t.Fatalf("expected save error, got %v", err)
+	}
+}
+
+func TestHandleBDMVPlaylistSelectionReturnsSaveErrorInUnattendedSinglePlaylist(t *testing.T) {
+	t.Parallel()
+
+	saveErr := errors.New("save failed")
+	root := t.TempDir()
+	bdmvPath := filepath.Join(root, "BDMV")
+	if err := os.Mkdir(bdmvPath, 0o755); err != nil {
+		t.Fatalf("mkdir BDMV: %v", err)
+	}
+	coreSvc := &cliCoreForTest{
+		playlistSelectionErr: internalerrors.ErrNotFound,
+		playlists: []api.PlaylistInfo{
+			{File: "00001.mpls", Duration: 7200, Score: 1},
+		},
+		savePlaylistErr: saveErr,
+	}
+
+	err := handleBDMVPlaylistSelection(context.Background(), []string{root}, coreSvc, config.Config{}, api.NopLogger{}, cliOptions{Unattended: true})
+	if !errors.Is(err, saveErr) {
+		t.Fatalf("expected save error, got %v", err)
+	}
+}
+
+type cliCoreForTest struct {
+	review                 api.UploadReview
+	callOrder              []string
+	previewPaths           []string
+	runUploadPreparedCalls int
+	playlistSelectionErr   error
+	playlists              []api.PlaylistInfo
+	savedPlaylists         []string
+	savePlaylistErr        error
+}
+
+func (c *cliCoreForTest) RunUpload(context.Context, api.Request) (api.Result, error) {
+	return api.Result{}, nil
+}
+
+func (c *cliCoreForTest) RunUploadPrepared(context.Context, api.Request) (api.Result, error) {
+	c.runUploadPreparedCalls++
+	return api.Result{UploadedCount: 1}, nil
+}
+
+func (c *cliCoreForTest) FetchMetadataPreview(_ context.Context, req api.Request) (api.MetadataPreview, error) {
+	c.callOrder = append(c.callOrder, "preview")
+	if len(req.Paths) > 0 {
+		c.previewPaths = append(c.previewPaths, req.Paths[0])
+	}
+	return api.MetadataPreview{}, nil
+}
+
+func (c *cliCoreForTest) FetchDescriptionBuilderPreview(context.Context, api.Request) (api.DescriptionBuilderPreview, error) {
+	return api.DescriptionBuilderPreview{}, nil
+}
+
+func (c *cliCoreForTest) FetchDescriptionBuilderGroupPreview(context.Context, api.Request) (api.DescriptionBuilderGroup, error) {
+	return api.DescriptionBuilderGroup{}, nil
+}
+
+func (c *cliCoreForTest) FetchPreparationPreview(context.Context, api.Request) (api.PreparationPreview, error) {
+	return api.PreparationPreview{}, nil
+}
+
+func (c *cliCoreForTest) FetchTrackerDryRunPreview(context.Context, api.Request) (api.TrackerDryRunPreview, error) {
+	return api.TrackerDryRunPreview{}, nil
+}
+
+func (c *cliCoreForTest) CheckDupes(context.Context, api.Request) (api.DupeCheckSummary, error) {
+	return api.DupeCheckSummary{}, nil
+}
+
+func (c *cliCoreForTest) BuildUploadReview(context.Context, api.Request) (api.UploadReview, error) {
+	c.callOrder = append(c.callOrder, "review")
+	return c.review, nil
+}
+
+func (c *cliCoreForTest) FetchScreenshotPlan(context.Context, api.Request) (api.ScreenshotPlan, error) {
+	return api.ScreenshotPlan{}, nil
+}
+
+func (c *cliCoreForTest) GenerateScreenshots(context.Context, api.Request, []api.ScreenshotSelection, api.ScreenshotPurpose) (api.ScreenshotResult, error) {
+	return api.ScreenshotResult{}, nil
+}
+
+func (c *cliCoreForTest) PreviewScreenshotFrame(context.Context, api.Request, float64) (api.ScreenshotPreview, error) {
+	return api.ScreenshotPreview{}, nil
+}
+
+func (c *cliCoreForTest) DeleteScreenshot(context.Context, api.Request, string) error {
+	return nil
+}
+
+func (c *cliCoreForTest) DeleteTrackerImageURL(context.Context, api.Request, string) error {
+	return nil
+}
+
+func (c *cliCoreForTest) SaveFinalScreenshotSelections(context.Context, api.Request, []api.ScreenshotImage) error {
+	return nil
+}
+
+func (c *cliCoreForTest) ListUploadCandidates(context.Context, api.Request) ([]api.ScreenshotImage, error) {
+	return nil, nil
+}
+
+func (c *cliCoreForTest) ListUploadedImages(context.Context, api.Request) ([]api.UploadedImageLink, error) {
+	return nil, nil
+}
+
+func (c *cliCoreForTest) UploadImages(context.Context, api.Request, string, []api.ScreenshotImage) (api.UploadImagesResult, error) {
+	return api.UploadImagesResult{}, nil
+}
+
+func (c *cliCoreForTest) DeleteUploadedImage(context.Context, api.Request, string, string) error {
+	return nil
+}
+
+func (c *cliCoreForTest) ImportMenuImages(context.Context, api.Request, []string) error {
+	return nil
+}
+
+func (c *cliCoreForTest) DiscoverPlaylists(context.Context, string) ([]api.PlaylistInfo, error) {
+	return c.playlists, nil
+}
+
+func (c *cliCoreForTest) SavePlaylistSelection(_ context.Context, _ string, playlists []string, _ bool) error {
+	c.savedPlaylists = append(c.savedPlaylists[:0], playlists...)
+	return c.savePlaylistErr
+}
+
+func (c *cliCoreForTest) LoadPlaylistSelection(context.Context, string) (api.PlaylistSelection, error) {
+	return api.PlaylistSelection{}, c.playlistSelectionErr
+}
+
+func (c *cliCoreForTest) ListHistory(context.Context) ([]api.HistoryEntry, error) {
+	return nil, nil
+}
+
+func (c *cliCoreForTest) GetHistoryOverview(context.Context, string) (api.HistoryOverview, error) {
+	return api.HistoryOverview{}, nil
+}
+
+func (c *cliCoreForTest) DeleteHistoryRelease(context.Context, string) error {
+	return nil
+}
+
+func (c *cliCoreForTest) DeleteAllHistoryReleases(context.Context) (int, error) {
+	return 0, nil
+}
+
+func (c *cliCoreForTest) RenderDescription(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (c *cliCoreForTest) SaveDescriptionOverride(context.Context, api.Request, string) (api.DescriptionBuilderGroup, error) {
+	return api.DescriptionBuilderGroup{}, nil
+}
+
+func (c *cliCoreForTest) Close() error {
+	return nil
+}

--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -247,11 +247,16 @@ func run() error {
 	}
 
 	// Handle BDMV playlist selection before upload
-	handleBDMVPlaylistSelection(ctx, paths, coreSvc, cfg, logger)
+	if err := handleBDMVPlaylistSelection(ctx, paths, coreSvc, cfg, logger, opts); err != nil {
+		return exitError(1, err)
+	}
 
 	if opts.UploadOnly {
 		uploadReq, err := buildCLIRequest(opts, visitedFlags, paths, screens)
 		if err != nil {
+			return exitError(1, err)
+		}
+		if err := prepareCLIUploadMetadata(ctx, coreSvc, uploadReq); err != nil {
 			return exitError(1, err)
 		}
 		if opts.Debug {
@@ -630,9 +635,21 @@ func deleteCLIStoredReleases(ctx context.Context, coreSvc api.Core, paths []stri
 	}
 	return nil
 }
-func handleBDMVPlaylistSelection(ctx context.Context, paths []string, coreSvc api.Core, cfg config.Config, logger api.Logger) {
+
+func prepareCLIUploadMetadata(ctx context.Context, coreSvc api.Core, req api.Request) error {
+	for _, sourcePath := range req.Paths {
+		singleReq := req
+		singleReq.Paths = []string{sourcePath}
+		if _, err := coreSvc.FetchMetadataPreview(ctx, singleReq); err != nil {
+			return fmt.Errorf("upbrr: %w", err)
+		}
+	}
+	return nil
+}
+
+func handleBDMVPlaylistSelection(ctx context.Context, paths []string, coreSvc api.Core, cfg config.Config, logger api.Logger, opts cliOptions) error {
 	if len(paths) == 0 {
-		return
+		return nil
 	}
 
 	for _, path := range paths {
@@ -673,18 +690,28 @@ func handleBDMVPlaylistSelection(ctx context.Context, paths []string, coreSvc ap
 
 			playlists, err := coreSvc.DiscoverPlaylists(ctx, absPath)
 			if err != nil {
+				if opts.Unattended && !opts.UnattendedConfirm {
+					return fmt.Errorf("upbrr: unattended BDMV playlist discovery failed for %s: %w", absPath, err)
+				}
 				logger.Warnf("cli: discover playlists: %v", err)
 				continue
 			}
 
-			if len(playlists) > 0 {
-				// Save the best (highest-scoring) playlist
-				selected := []string{playlists[0].File}
-				if err := coreSvc.SavePlaylistSelection(ctx, absPath, selected, false); err != nil {
-					logger.Warnf("cli: save playlist selection: %v", err)
-				} else {
-					logger.Infof("cli: auto-selected playlist %s (score: %.2f)", playlists[0].File, playlists[0].Score)
+			if len(playlists) == 0 {
+				if opts.Unattended && !opts.UnattendedConfirm {
+					return fmt.Errorf("upbrr: unattended BDMV upload found no playlists for %s", absPath)
 				}
+				continue
+			}
+			// Save the best (highest-scoring) playlist
+			selected := []string{playlists[0].File}
+			if err := coreSvc.SavePlaylistSelection(ctx, absPath, selected, false); err != nil {
+				if opts.Unattended && !opts.UnattendedConfirm {
+					return fmt.Errorf("upbrr: unattended BDMV playlist selection save failed for %s: %w", absPath, err)
+				}
+				logger.Warnf("cli: save playlist selection: %v", err)
+			} else {
+				logger.Infof("cli: auto-selected playlist %s (score: %.2f)", playlists[0].File, playlists[0].Score)
 			}
 			continue
 		}
@@ -693,33 +720,42 @@ func handleBDMVPlaylistSelection(ctx context.Context, paths []string, coreSvc ap
 		logger.Infof("cli: discovering playlists for %s", absPath)
 		playlists, err := coreSvc.DiscoverPlaylists(ctx, absPath)
 		if err != nil {
+			if opts.Unattended && !opts.UnattendedConfirm {
+				return fmt.Errorf("upbrr: unattended BDMV playlist discovery failed for %s: %w", absPath, err)
+			}
 			logger.Warnf("cli: discover playlists: %v", err)
 			continue
 		}
 
 		if len(playlists) == 0 {
+			if opts.Unattended && !opts.UnattendedConfirm {
+				return fmt.Errorf("upbrr: unattended BDMV upload found no playlists for %s", absPath)
+			}
 			logger.Warnf("cli: no playlists found for %s", absPath)
 			continue
 		}
 
 		logger.Infof("cli: found %d playlists", len(playlists))
+		if opts.Unattended && !opts.UnattendedConfirm && len(playlists) > 1 {
+			return fmt.Errorf("upbrr: unattended BDMV upload requires a saved playlist selection or use_largest_playlist for %s", absPath)
+		}
 
 		// Display top playlists and prompt user
 		if len(playlists) == 1 {
 			fmt.Printf("[*] Only one playlist found: %s (%.0fs, score: %.2f)\n", playlists[0].File, playlists[0].Duration, playlists[0].Score)
 			fmt.Printf("[*] Auto-selecting...\n")
 			if err := coreSvc.SavePlaylistSelection(ctx, absPath, []string{playlists[0].File}, false); err != nil {
+				if opts.Unattended && !opts.UnattendedConfirm {
+					return fmt.Errorf("upbrr: unattended BDMV playlist selection save failed for %s: %w", absPath, err)
+				}
 				logger.Warnf("cli: save playlist selection: %v", err)
 			}
 		} else {
 			// Display top 5 playlists
-			topCount := len(playlists)
-			if topCount > 5 {
-				topCount = 5
-			}
+			topCount := min(len(playlists), 5)
 
 			fmt.Printf("\nAvailable playlists for %s:\n", absPath)
-			for i := 0; i < topCount; i++ {
+			for i := range topCount {
 				p := playlists[i]
 				durationStr := formatDuration(p.Duration)
 				fmt.Printf("[%d] %s (%s, score: %.2f)\n", i, p.File, durationStr, p.Score)
@@ -747,7 +783,7 @@ func handleBDMVPlaylistSelection(ctx context.Context, paths []string, coreSvc ap
 				input = strings.TrimSpace(input)
 				if strings.ToLower(input) == "all" {
 					var selected []string
-					for i := 0; i < topCount; i++ {
+					for i := range topCount {
 						selected = append(selected, playlists[i].File)
 					}
 					if err := coreSvc.SavePlaylistSelection(ctx, absPath, selected, true); err != nil {
@@ -787,6 +823,7 @@ func handleBDMVPlaylistSelection(ctx context.Context, paths []string, coreSvc ap
 			}
 		}
 	}
+	return nil
 }
 
 func formatDuration(seconds float64) string {

--- a/gui/frontend/src/pages/description_builder/index.test.tsx
+++ b/gui/frontend/src/pages/description_builder/index.test.tsx
@@ -1,0 +1,58 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { DescriptionBuilderPreview } from "../../types";
+import DescriptionBuilderPage from "./index";
+
+describe("DescriptionBuilderPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not decode sanitized attribute entities before rendering", () => {
+    const builderPreview = {
+      SourcePath: "C:/media/Movie.mkv",
+      Groups: [
+        {
+          GroupKey: "unit3d",
+          Trackers: ["BLU"],
+          RawDescription: "raw",
+          RawDescriptionHTML: `<img src="http://invalid.invalid/&#34; onerror=&#34;alert(1)" />`,
+          HasOverride: false,
+          ImageHost: { Status: "", SelectedHost: "", AllowedHosts: [], Warnings: [] },
+        },
+      ],
+    } as unknown as DescriptionBuilderPreview;
+
+    const { container } = render(
+      <DescriptionBuilderPage
+        path="C:/media/Movie.mkv"
+        builderPreview={builderPreview}
+        builderRawByGroup={{}}
+        builderRenderedByGroup={{}}
+        builderExpandedGroups={{ unit3d: true }}
+        builderLoading={false}
+        builderSaving={false}
+        builderRenderLoading={false}
+        builderRefreshing={false}
+        builderError=""
+        builderSaved=""
+        refreshDescriptionBuilder={vi.fn()}
+        setBuilderRawByGroup={vi.fn()}
+        setBuilderDirtyByGroup={vi.fn()}
+        setBuilderExpandedGroups={vi.fn()}
+        resetBuilderDescription={vi.fn()}
+        renderBuilderDescription={vi.fn()}
+        saveBuilderDescription={vi.fn()}
+      />,
+    );
+
+    const image = container.querySelector(".tracker-description.rendered img");
+    expect(image).toBeInstanceOf(HTMLImageElement);
+    expect(image?.getAttribute("onerror")).toBeNull();
+    expect(image?.getAttribute("src")).toContain(`" onerror="alert(1)`);
+  });
+});

--- a/gui/frontend/src/pages/description_builder/index.tsx
+++ b/gui/frontend/src/pages/description_builder/index.tsx
@@ -26,16 +26,6 @@ type Props = {
   saveBuilderDescription: (groupKey: string) => void;
 };
 
-const decodeHtmlEntities = (value: string) => {
-  if (!value) return value;
-  if (!value.includes("&lt;") && !value.includes("&gt;") && !value.includes("&#")) {
-    return value;
-  }
-  const textarea = document.createElement("textarea");
-  textarea.innerHTML = value;
-  return textarea.value;
-};
-
 const groupLabel = (groupKey: string, trackers: string[]) => {
   if (trackers.length > 0) return trackers.join(", ");
   if (groupKey === "unit3d") return "Unit3D";
@@ -222,7 +212,7 @@ export default function DescriptionBuilderPage(props: Props) {
                       <div
                         className="tracker-description rendered"
                         onClick={handleExternalLinkClick}
-                        dangerouslySetInnerHTML={{ __html: decodeHtmlEntities(renderedHTML) }}
+                        dangerouslySetInnerHTML={{ __html: renderedHTML }}
                       />
                     ) : (
                       <p className="muted">No rendered preview yet.</p>

--- a/gui/frontend/src/pages/tracker_data/index.test.tsx
+++ b/gui/frontend/src/pages/tracker_data/index.test.tsx
@@ -1,0 +1,52 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { MetadataPreview } from "../../types";
+import TrackerDataPage from "./index";
+
+describe("TrackerDataPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not decode sanitized attribute entities before rendering", () => {
+    const preview = {
+      TrackerData: [
+        {
+          Tracker: "BLU",
+          TrackerID: "1",
+          TorrentURL: "",
+          InfoHash: "",
+          TMDBID: 0,
+          IMDBID: 0,
+          TVDBID: 0,
+          MALID: 0,
+          Category: "",
+          Description: "raw",
+          DescriptionHTML: `<img src="http://invalid.invalid/&#34; onerror=&#34;alert(1)" />`,
+          ImageURLs: [],
+          Filename: "",
+          Matched: false,
+          UpdatedAt: "",
+        },
+      ],
+    } as unknown as MetadataPreview;
+
+    const { container } = render(
+      <TrackerDataPage
+        preview={preview}
+        renderedDescriptions={{ "BLU-0": true }}
+        setRenderedDescriptions={vi.fn()}
+        setLightboxImage={vi.fn()}
+        setLightboxAlt={vi.fn()}
+      />,
+    );
+
+    const image = container.querySelector(".tracker-description.rendered img");
+    expect(image).toBeInstanceOf(HTMLImageElement);
+    expect(image?.getAttribute("onerror")).toBeNull();
+  });
+});

--- a/gui/frontend/src/pages/tracker_data/index.tsx
+++ b/gui/frontend/src/pages/tracker_data/index.tsx
@@ -15,16 +15,6 @@ type Props = {
   setLightboxAlt: Dispatch<SetStateAction<string>>;
 };
 
-const decodeHtmlEntities = (value: string) => {
-  if (!value) return value;
-  if (!value.includes("&lt;") && !value.includes("&gt;") && !value.includes("&#")) {
-    return value;
-  }
-  const textarea = document.createElement("textarea");
-  textarea.innerHTML = value;
-  return textarea.value;
-};
-
 export default function TrackerDataPage(props: Props) {
   const {
     preview,
@@ -76,7 +66,7 @@ export default function TrackerDataPage(props: Props) {
             const trackerKey = `${item.Tracker}-${index}`;
             const isRendered =
               Boolean(renderedDescriptions[trackerKey]) && Boolean(item.DescriptionHTML);
-            const renderedHTML = isRendered ? decodeHtmlEntities(item.DescriptionHTML) : "";
+            const renderedHTML = isRendered ? item.DescriptionHTML : "";
             const isPrimary = index === trackerDataOrdered.primaryIndex;
             return (
               <details

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -1439,10 +1440,8 @@ func appendUniqueNormalizedTracker(trackersList []string, tracker string) []stri
 	if name == "" {
 		return trackersList
 	}
-	for _, existing := range trackersList {
-		if existing == name {
-			return trackersList
-		}
+	if slices.Contains(trackersList, name) {
+		return trackersList
 	}
 	return append(trackersList, name)
 }
@@ -3041,9 +3040,7 @@ func deepCopyQuestionnaireAnswers(input map[string]map[string]string) map[string
 	cloned := make(map[string]map[string]string, len(input))
 	for tracker, values := range input {
 		inner := make(map[string]string, len(values))
-		for key, value := range values {
-			inner[key] = value
-		}
+		maps.Copy(inner, values)
 		cloned[tracker] = inner
 	}
 	return cloned
@@ -3221,23 +3218,23 @@ func deepCopyIMDBAKAs(items []api.IMDBAKA) []api.IMDBAKA {
 	return cloned
 }
 
-func deepCopyStringInterfaceMap(input map[string]interface{}) map[string]interface{} {
+func deepCopyStringInterfaceMap(input map[string]any) map[string]any {
 	if len(input) == 0 {
 		return nil
 	}
-	cloned := make(map[string]interface{}, len(input))
+	cloned := make(map[string]any, len(input))
 	for key, value := range input {
 		cloned[key] = deepCopyInterfaceValue(value)
 	}
 	return cloned
 }
 
-func deepCopyInterfaceValue(value interface{}) interface{} {
+func deepCopyInterfaceValue(value any) any {
 	switch typed := value.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		return deepCopyStringInterfaceMap(typed)
-	case []interface{}:
-		cloned := make([]interface{}, len(typed))
+	case []any:
+		cloned := make([]any, len(typed))
 		for idx, item := range typed {
 			cloned[idx] = deepCopyInterfaceValue(item)
 		}
@@ -3339,9 +3336,10 @@ func (c *Core) LoadPlaylistSelection(ctx context.Context, sourcePath string) (ap
 		return api.PlaylistSelection{}, errors.New("core: repository not initialized")
 	}
 
-	c.logger.Debugf("core: loading playlist selection for %q", sourcePath)
+	normalizedPath := filepath.ToSlash(filepath.Clean(sourcePath))
+	c.logger.Debugf("core: loading playlist selection for %q (normalized: %q)", sourcePath, normalizedPath)
 
-	selection, err := c.repo.GetPlaylistSelection(ctx, sourcePath)
+	selection, err := c.repo.GetPlaylistSelection(ctx, normalizedPath)
 	if err != nil {
 		if errors.Is(err, internalerrors.ErrNotFound) {
 			c.logger.Debugf("core: no playlist selection found for %q", sourcePath)

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,10 +20,6 @@ import (
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
-
-func ptr[T any](v T) *T {
-	return &v
-}
 
 func containsCoreString(values []string, target string) bool {
 	for _, value := range values {
@@ -56,6 +53,62 @@ func TestFirstRequestedTracker(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoadPlaylistSelectionUsesNormalizedSourcePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		sourcePath string
+	}{
+		{name: "native", sourcePath: filepath.Join("media", "Movie", "BDMV")},
+		{name: "posix", sourcePath: "media/Movie/BDMV"},
+		{name: "windows", sourcePath: `media\Movie\BDMV`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			normalizedPath := filepath.ToSlash(filepath.Clean(tt.sourcePath))
+			repo := &playlistSelectionRepo{
+				selectionByPath: map[string]db.PlaylistSelection{
+					normalizedPath: {
+						SourcePath:        normalizedPath,
+						SelectedPlaylists: []string{"00001.mpls"},
+					},
+				},
+			}
+			core := &Core{repo: repo, logger: api.NopLogger{}}
+
+			selection, err := core.LoadPlaylistSelection(context.Background(), tt.sourcePath)
+			if err != nil {
+				t.Fatalf("LoadPlaylistSelection: %v", err)
+			}
+			if repo.loadedPath != normalizedPath {
+				t.Fatalf("expected normalized lookup path %q, got %q", normalizedPath, repo.loadedPath)
+			}
+			if len(selection.SelectedPlaylists) != 1 || selection.SelectedPlaylists[0] != "00001.mpls" {
+				t.Fatalf("unexpected playlist selection: %#v", selection)
+			}
+		})
+	}
+}
+
+type playlistSelectionRepo struct {
+	stubRepo
+	loadedPath      string
+	selectionByPath map[string]db.PlaylistSelection
+}
+
+func (r *playlistSelectionRepo) GetPlaylistSelection(_ context.Context, sourcePath string) (db.PlaylistSelection, error) {
+	r.loadedPath = sourcePath
+	selection, ok := r.selectionByPath[sourcePath]
+	if !ok {
+		return db.PlaylistSelection{}, internalerrors.ErrNotFound
+	}
+	return selection, nil
 }
 
 func TestBuildDescriptionBuilderGroupAddsBHDMediaInfoPreviewOnly(t *testing.T) {
@@ -1392,13 +1445,7 @@ func TestFetchMetadataPreviewRunsPathedSearchWithSourceURLOverride(t *testing.T)
 	if got := cached.TrackerIDs["aither"]; got != "111" {
 		t.Fatalf("expected source lookup tracker id preserved, got %q", got)
 	}
-	foundBLU := false
-	for _, tracker := range cached.MatchedTrackers {
-		if tracker == "BLU" {
-			foundBLU = true
-			break
-		}
-	}
+	foundBLU := slices.Contains(cached.MatchedTrackers, "BLU")
 	if !foundBLU {
 		t.Fatalf("expected BLU to be tracked as existing in client, got %v", cached.MatchedTrackers)
 	}
@@ -1459,12 +1506,12 @@ func TestExportGUICachedPreparedMetaExactSignature(t *testing.T) {
 
 	prepared := api.PreparedMetadata{
 		SourcePath:           "/tmp/a",
-		ReleaseNameOverrides: api.ReleaseNameOverrides{Edition: ptr("Exact Match")},
+		ReleaseNameOverrides: api.ReleaseNameOverrides{Edition: new("Exact Match")},
 	}
 	req := api.Request{
 		Paths:                []string{"/tmp/a"},
 		Mode:                 api.ModeGUI,
-		ReleaseNameOverrides: api.ReleaseNameOverrides{Edition: ptr("Exact Match")},
+		ReleaseNameOverrides: api.ReleaseNameOverrides{Edition: new("Exact Match")},
 	}
 	if err := core.ImportPreparedMetadataForGUI(context.Background(), req, prepared); err != nil {
 		t.Fatalf("import prepared metadata for gui: %v", err)
@@ -1511,7 +1558,7 @@ func TestExportGUICachedPreparedMetaFallsBackForNonExternalSignedOverrides(t *te
 	exported, ok, err := core.ExportGUICachedPreparedMeta(context.Background(), api.Request{
 		Paths:                []string{"/tmp/a"},
 		Mode:                 api.ModeGUI,
-		ReleaseNameOverrides: api.ReleaseNameOverrides{Edition: ptr("Later UI edit")},
+		ReleaseNameOverrides: api.ReleaseNameOverrides{Edition: new("Later UI edit")},
 	})
 	if err != nil {
 		t.Fatalf("export gui cached prepared meta: %v", err)
@@ -1648,8 +1695,8 @@ func TestExportGUICachedPreparedMetaReturnsIsolatedCopy(t *testing.T) {
 		Release: api.ReleaseInfo{
 			Codec: []string{"x264"},
 		},
-		BDInfo: map[string]interface{}{
-			"playlists": []interface{}{"00001", "00002"},
+		BDInfo: map[string]any{
+			"playlists": []any{"00001", "00002"},
 		},
 	}
 	if err := core.ImportPreparedMetadataForGUI(context.Background(), api.Request{
@@ -1675,7 +1722,7 @@ func TestExportGUICachedPreparedMetaReturnsIsolatedCopy(t *testing.T) {
 	exported.TrackerQuestionnaireAnswers["AITHER"]["season"] = "2"
 	exported.TrackerRuleFailures["AITHER"][0].Rule = "rule_b"
 	exported.Release.Codec[0] = "x265"
-	exportedPlaylists, ok := exported.BDInfo["playlists"].([]interface{})
+	exportedPlaylists, ok := exported.BDInfo["playlists"].([]any)
 	if !ok {
 		t.Fatalf("expected exported BDInfo playlists to be []interface{}, got %T", exported.BDInfo["playlists"])
 	}
@@ -1700,7 +1747,7 @@ func TestExportGUICachedPreparedMetaReturnsIsolatedCopy(t *testing.T) {
 	if cached.Release.Codec[0] != "x264" {
 		t.Fatalf("expected cached release info to remain isolated, got %#v", cached.Release)
 	}
-	cachedPlaylists, ok := cached.BDInfo["playlists"].([]interface{})
+	cachedPlaylists, ok := cached.BDInfo["playlists"].([]any)
 	if !ok {
 		t.Fatalf("expected cached BDInfo playlists to be []interface{}, got %T", cached.BDInfo["playlists"])
 	}
@@ -1742,7 +1789,7 @@ func TestExportGUICachedPreparedMetaConcurrentCopiesStayIsolated(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for idx := 0; idx < 16; idx++ {
+	for idx := range 16 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/internal/core/upload_review.go
+++ b/internal/core/upload_review.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/autobrr/upbrr/internal/config"
@@ -414,9 +416,7 @@ func cloneStringMap(values map[string]string) map[string]string {
 		return nil
 	}
 	cloned := make(map[string]string, len(values))
-	for key, value := range values {
-		cloned[key] = value
-	}
+	maps.Copy(cloned, values)
 	return cloned
 }
 
@@ -451,9 +451,7 @@ func cloneTrackerQuestionnaireAnswers(input map[string]map[string]string) map[st
 			continue
 		}
 		inner := make(map[string]string, len(values))
-		for key, value := range values {
-			inner[key] = value
-		}
+		maps.Copy(inner, values)
 		cloned[tracker] = inner
 	}
 	return cloned
@@ -524,10 +522,8 @@ func addTrackerBlockReason(blocked map[string][]api.TrackerBlockReason, tracker 
 	if blocked == nil {
 		blocked = make(map[string][]api.TrackerBlockReason)
 	}
-	for _, existing := range blocked[name] {
-		if existing == reason {
-			return blocked
-		}
+	if slices.Contains(blocked[name], reason) {
+		return blocked
 	}
 	blocked[name] = append(blocked[name], reason)
 	return blocked

--- a/internal/trackers/impl/ptp/definition_test.go
+++ b/internal/trackers/impl/ptp/definition_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
@@ -237,6 +238,11 @@ func TestRehostPosterToSelectedHostUploadsPoster(t *testing.T) {
 		_, _ = w.Write([]byte("poster-bytes"))
 	}))
 	defer posterServer.Close()
+	originalClientFactory := newPosterHTTPClient
+	newPosterHTTPClient = posterServer.Client
+	t.Cleanup(func() {
+		newPosterHTTPClient = originalClientFactory
+	})
 
 	images := &stubPTPImageHosting{
 		uploaded: []api.UploadedImageLink{{
@@ -272,6 +278,53 @@ func TestRehostPosterToSelectedHostUploadsPoster(t *testing.T) {
 	}
 	if string(body) != "poster-bytes" {
 		t.Fatalf("unexpected poster body %q", string(body))
+	}
+}
+
+func TestRehostPosterToSelectedHostRejectsLoopbackPoster(t *testing.T) {
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "Movie.mkv")
+	if err := os.WriteFile(sourcePath, []byte("movie"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	posterServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("poster-bytes"))
+	}))
+	defer posterServer.Close()
+
+	images := &stubPTPImageHosting{
+		uploaded: []api.UploadedImageLink{{
+			Host:   "ptpimg",
+			RawURL: "https://ptpimg.me/rehosted.png",
+		}},
+	}
+	got := rehostPosterToSelectedHost(context.Background(), trackers.UploadRequest{
+		Meta: api.PreparedMetadata{
+			SourcePath: sourcePath,
+		},
+		AppConfig: config.Config{MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(tmp, "ua.db")}},
+		Logger:    api.NopLogger{},
+		Images:    images,
+	}, posterServer.URL+"/poster")
+
+	if got != posterServer.URL+"/poster" {
+		t.Fatalf("expected original poster URL after blocked rehost, got %q", got)
+	}
+	if len(images.images) != 0 {
+		t.Fatalf("expected no upload for blocked loopback poster")
+	}
+}
+
+func TestIsPublicPosterIPRejectsPrivateRanges(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"127.0.0.1", "10.0.0.1", "192.168.1.20", "169.254.1.1", "::1", "fc00::1"} {
+		if isPublicPosterIP(netip.MustParseAddr(value)) {
+			t.Fatalf("expected %s to be rejected", value)
+		}
+	}
+	if !isPublicPosterIP(netip.MustParseAddr("93.184.216.34")) {
+		t.Fatal("expected public address to be accepted")
 	}
 }
 

--- a/internal/trackers/impl/ptp/upload.go
+++ b/internal/trackers/impl/ptp/upload.go
@@ -15,8 +15,10 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/http/cookiejar"
+	"net/netip"
 	"net/url"
 	"os"
 	"path" //nolint:depguard // Reads poster URL path extension, not local filesystem extension.
@@ -53,8 +55,22 @@ const (
 )
 
 var (
-	ptpAntiCsrfPattern = regexp.MustCompile(`data-AntiCsrfToken="([^"]+)"`)
-	ptpSuccessPattern  = regexp.MustCompile(`torrents\.php\?id=(\d+)&torrentid=(\d+)`)
+	ptpAntiCsrfPattern     = regexp.MustCompile(`data-AntiCsrfToken="([^"]+)"`)
+	ptpSuccessPattern      = regexp.MustCompile(`torrents\.php\?id=(\d+)&torrentid=(\d+)`)
+	newPosterHTTPClient    = newPublicPosterHTTPClient
+	reservedPosterPrefixes = []netip.Prefix{
+		netip.MustParsePrefix("0.0.0.0/8"),
+		netip.MustParsePrefix("100.64.0.0/10"),
+		netip.MustParsePrefix("192.0.0.0/24"),
+		netip.MustParsePrefix("192.0.2.0/24"),
+		netip.MustParsePrefix("198.18.0.0/15"),
+		netip.MustParsePrefix("198.51.100.0/24"),
+		netip.MustParsePrefix("203.0.113.0/24"),
+		netip.MustParsePrefix("240.0.0.0/4"),
+		netip.MustParsePrefix("2001:db8::/32"),
+		netip.MustParsePrefix("fc00::/7"),
+		netip.MustParsePrefix("fe80::/10"),
+	}
 )
 
 type uploadState struct {
@@ -419,6 +435,9 @@ func rehostPosterToSelectedHost(ctx context.Context, req trackers.UploadRequest,
 }
 
 func downloadPoster(ctx context.Context, meta api.PreparedMetadata, dbPath string, imageURL string) (string, error) {
+	if err := validatePosterURL(imageURL); err != nil {
+		return "", err
+	}
 	tmpRoot, err := db.Subdir(dbPath, "tmp")
 	if err != nil {
 		return "", fmt.Errorf("trackers: %w", err)
@@ -434,7 +453,7 @@ func downloadPoster(ctx context.Context, meta api.PreparedMetadata, dbPath strin
 	}
 	httpReq.Header.Set("User-Agent", ptpUserAgent)
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := newPosterHTTPClient()
 	resp, err := client.Do(httpReq)
 	if err != nil {
 		return "", fmt.Errorf("poster download: %w", err)
@@ -481,6 +500,79 @@ func posterExtension(imageURL string, contentType string) string {
 	default:
 		return ".jpg"
 	}
+}
+
+func validatePosterURL(rawURL string) error {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return fmt.Errorf("poster URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return errors.New("poster URL must use http or https")
+	}
+	if strings.TrimSpace(parsed.Hostname()) == "" {
+		return errors.New("poster URL host is required")
+	}
+	return nil
+}
+
+func newPublicPosterHTTPClient() *http.Client {
+	dialer := &net.Dialer{Timeout: 30 * time.Second}
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network string, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, fmt.Errorf("poster dial address: %w", err)
+			}
+			target, err := resolvePublicPosterAddress(ctx, host, port)
+			if err != nil {
+				return nil, err
+			}
+			return dialer.DialContext(ctx, network, target)
+		},
+	}
+	return &http.Client{Timeout: 30 * time.Second, Transport: transport}
+}
+
+func resolvePublicPosterAddress(ctx context.Context, host string, port string) (string, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		addr, ok := netip.AddrFromSlice(ip)
+		if !ok || !isPublicPosterIP(addr.Unmap()) {
+			return "", fmt.Errorf("poster host %q resolves to non-public IP", host)
+		}
+		return net.JoinHostPort(addr.String(), port), nil
+	}
+	resolved, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return "", fmt.Errorf("poster DNS lookup %q: %w", host, err)
+	}
+	for _, candidate := range resolved {
+		addr, ok := netip.AddrFromSlice(candidate.IP)
+		if !ok {
+			continue
+		}
+		addr = addr.Unmap()
+		if isPublicPosterIP(addr) {
+			return net.JoinHostPort(addr.String(), port), nil
+		}
+	}
+	return "", fmt.Errorf("poster host %q has no public IP addresses", host)
+}
+
+func isPublicPosterIP(ip netip.Addr) bool {
+	if !ip.IsValid() || !ip.IsGlobalUnicast() || ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsInterfaceLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() {
+		return false
+	}
+	return !ipInPrefixes(ip, reservedPosterPrefixes)
+}
+
+func ipInPrefixes(ip netip.Addr, prefixes []netip.Prefix) bool {
+	for _, prefix := range prefixes {
+		if prefix.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 func logPosterRehostFailure(logger api.Logger, host string, err error) {
@@ -715,7 +807,7 @@ func buildMultipartPayload(fields map[string]string, torrentPath string, fileFie
 	slices.Sort(keys)
 	for _, key := range keys {
 		if key == "artist[]" {
-			for _, value := range strings.Split(fields[key], "\n") {
+			for value := range strings.SplitSeq(fields[key], "\n") {
 				if strings.TrimSpace(value) == "" {
 					continue
 				}
@@ -727,7 +819,7 @@ func buildMultipartPayload(fields map[string]string, torrentPath string, fileFie
 			continue
 		}
 		if key == "subtitles[]" || key == "trumpable[]" {
-			for _, value := range strings.Split(fields[key], ",") {
+			for value := range strings.SplitSeq(fields[key], ",") {
 				trimmed := strings.TrimSpace(value)
 				if trimmed == "" {
 					continue
@@ -1200,7 +1292,7 @@ func resolveDirectors(meta api.PreparedMetadata) []string {
 func resolveTags(meta api.PreparedMetadata) string {
 	values := make([]string, 0, 8)
 	if meta.ExternalMetadata.TMDB != nil {
-		for _, item := range strings.Split(meta.ExternalMetadata.TMDB.Genres, ",") {
+		for item := range strings.SplitSeq(meta.ExternalMetadata.TMDB.Genres, ",") {
 			trimmed := strings.ToLower(strings.TrimSpace(item))
 			if trimmed != "" {
 				values = append(values, trimmed)
@@ -1208,7 +1300,7 @@ func resolveTags(meta api.PreparedMetadata) string {
 		}
 	}
 	if len(values) == 0 && strings.TrimSpace(meta.Release.Genre) != "" {
-		for _, item := range strings.Split(meta.Release.Genre, ",") {
+		for item := range strings.SplitSeq(meta.Release.Genre, ",") {
 			trimmed := strings.ToLower(strings.TrimSpace(item))
 			if trimmed != "" {
 				values = append(values, trimmed)

--- a/internal/webserver/app_routes.go
+++ b/internal/webserver/app_routes.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -478,7 +480,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 	}))
 
-	mux.HandleFunc("/api/app/ImportMenuImages", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
+	mux.HandleFunc("/api/app/ImportMenuImages", s.requireSession(func(w http.ResponseWriter, r *http.Request, current session) {
 		var req struct {
 			Path          string
 			Overrides     api.ExternalIDOverrides
@@ -489,7 +491,21 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		if err := s.backend.ImportMenuImages(req.Path, req.Overrides, req.NameOverrides, req.Paths); err != nil {
+		policy, err := s.webBrowsePolicy(current)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		if !policy.AllowUnrestricted && len(policy.Roots) == 0 {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "web browse root is not configured"})
+			return
+		}
+		importPaths, err := menuImportPathsWithinBrowsePolicy(req.Paths, policy)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		if err := s.backend.ImportMenuImages(req.Path, req.Overrides, req.NameOverrides, importPaths); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
@@ -905,6 +921,77 @@ func (s *Server) webBrowsePolicy(current session) (webBrowsePolicy, error) {
 		return webBrowsePolicy{}, err
 	}
 	return webBrowsePolicy{Roots: roots}, nil
+}
+
+func menuImportPathsWithinBrowsePolicy(paths []string, policy webBrowsePolicy) ([]string, error) {
+	if policy.AllowUnrestricted {
+		return paths, nil
+	}
+	filtered := make([]string, 0, len(paths))
+	for _, rawPath := range paths {
+		resolvedPath, info, err := resolveMenuImportPath(rawPath)
+		if err != nil {
+			return nil, err
+		}
+		if !pathWithinBrowseRoots(resolvedPath, policy.Roots) {
+			return nil, fmt.Errorf("menu image path %q is outside configured web browse roots", rawPath)
+		}
+		if !info.IsDir() {
+			filtered = append(filtered, resolvedPath)
+			continue
+		}
+		entries, err := os.ReadDir(resolvedPath)
+		if err != nil {
+			return nil, fmt.Errorf("read menu dir %s: %w", resolvedPath, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			entryPath := filepath.Join(resolvedPath, entry.Name())
+			entryResolved, entryInfo, err := resolveMenuImportPath(entryPath)
+			if err != nil {
+				return nil, err
+			}
+			if entryInfo.IsDir() {
+				continue
+			}
+			if !pathWithinBrowseRoots(entryResolved, policy.Roots) {
+				return nil, fmt.Errorf("menu image path %q is outside configured web browse roots", entryPath)
+			}
+			filtered = append(filtered, entryResolved)
+		}
+	}
+	return filtered, nil
+}
+
+func resolveMenuImportPath(rawPath string) (string, os.FileInfo, error) {
+	trimmed := strings.TrimSpace(rawPath)
+	if trimmed == "" {
+		return "", nil, errors.New("menu image path is required")
+	}
+	candidate, err := filepath.Abs(filepath.Clean(trimmed))
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve menu path %s: %w", trimmed, err)
+	}
+	resolved, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve menu path symlinks %s: %w", trimmed, err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", nil, fmt.Errorf("stat menu path %s: %w", resolved, err)
+	}
+	return resolved, info, nil
+}
+
+func pathWithinBrowseRoots(candidate string, roots []string) bool {
+	for _, root := range roots {
+		if pathutil.IsWithinRoot(root, candidate) {
+			return true
+		}
+	}
+	return false
 }
 
 func writeAppError(w http.ResponseWriter, err error) {

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -994,9 +994,7 @@ func (b *Backend) StartLogStream(sessionID string) (string, error) {
 	b.streams[streamID] = session
 	b.streamMu.Unlock()
 
-	b.streamWG.Add(1)
-	go func() {
-		defer b.streamWG.Done()
+	b.streamWG.Go(func() {
 		defer close(session.done)
 		for {
 			select {
@@ -1010,7 +1008,7 @@ func (b *Backend) StartLogStream(sessionID string) (string, error) {
 				return
 			}
 		}
-	}()
+	})
 
 	return streamID, nil
 }

--- a/internal/webserver/browse_test.go
+++ b/internal/webserver/browse_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -528,6 +529,189 @@ func TestBrowseDirectoryRouteRequiresWebBrowsePolicy(t *testing.T) {
 	}
 	if !strings.Contains(recorder.Body.String(), "web browse root is not configured") {
 		t.Fatalf("expected browse policy error, got %s", recorder.Body.String())
+	}
+}
+
+func TestMenuImportPathsWithinBrowsePolicyRejectsOutsideRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "menu.png")
+	if err := os.WriteFile(outside, []byte("png"), 0o600); err != nil {
+		t.Fatalf("write outside image: %v", err)
+	}
+
+	_, err := menuImportPathsWithinBrowsePolicy([]string{outside}, webBrowsePolicy{Roots: []string{root}})
+	if err == nil {
+		t.Fatal("expected outside browse root error")
+	}
+	if !strings.Contains(err.Error(), "outside configured web browse roots") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMenuImportPathsWithinBrowsePolicyAllowsInsideRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	inside := filepath.Join(root, "menu.png")
+	if err := os.WriteFile(inside, []byte("png"), 0o600); err != nil {
+		t.Fatalf("write inside image: %v", err)
+	}
+
+	paths, err := menuImportPathsWithinBrowsePolicy([]string{inside}, webBrowsePolicy{Roots: []string{root}})
+	if err != nil {
+		t.Fatalf("menuImportPathsWithinBrowsePolicy: %v", err)
+	}
+	if len(paths) != 1 || filepath.Clean(paths[0]) != filepath.Clean(inside) {
+		t.Fatalf("unexpected import paths: %#v", paths)
+	}
+}
+
+func TestMenuImportPathsWithinBrowsePolicyAdditionalScenarios(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name      string
+		setup     func(t *testing.T) ([]string, webBrowsePolicy, []string)
+		wantErr   string
+		exactPath bool
+	}
+
+	toWindowsPath := func(t *testing.T, path string) string {
+		t.Helper()
+		if runtime.GOOS != "windows" {
+			t.Skip("Windows-style local paths are only valid on Windows")
+		}
+		return strings.ReplaceAll(filepath.ToSlash(path), "/", `\`)
+	}
+
+	tests := []testCase{
+		{
+			name: "directory import posix path",
+			setup: func(t *testing.T) ([]string, webBrowsePolicy, []string) {
+				t.Helper()
+				root := t.TempDir()
+				dir := filepath.Join(root, "menus")
+				if err := os.Mkdir(dir, 0o755); err != nil {
+					t.Fatalf("mkdir menu dir: %v", err)
+				}
+				first := filepath.Join(dir, "one.png")
+				second := filepath.Join(dir, "two.jpg")
+				subdir := filepath.Join(dir, "nested")
+				if err := os.WriteFile(first, []byte("png"), 0o600); err != nil {
+					t.Fatalf("write first image: %v", err)
+				}
+				if err := os.WriteFile(second, []byte("jpg"), 0o600); err != nil {
+					t.Fatalf("write second image: %v", err)
+				}
+				if err := os.Mkdir(subdir, 0o755); err != nil {
+					t.Fatalf("mkdir nested dir: %v", err)
+				}
+				return []string{filepath.ToSlash(dir)}, webBrowsePolicy{Roots: []string{root}}, []string{first, second}
+			},
+		},
+		{
+			name: "directory import windows path",
+			setup: func(t *testing.T) ([]string, webBrowsePolicy, []string) {
+				t.Helper()
+				root := t.TempDir()
+				dir := filepath.Join(root, "menus")
+				if err := os.Mkdir(dir, 0o755); err != nil {
+					t.Fatalf("mkdir menu dir: %v", err)
+				}
+				image := filepath.Join(dir, "one.png")
+				if err := os.WriteFile(image, []byte("png"), 0o600); err != nil {
+					t.Fatalf("write image: %v", err)
+				}
+				return []string{toWindowsPath(t, dir)}, webBrowsePolicy{Roots: []string{root}}, []string{image}
+			},
+		},
+		{
+			name: "symlink inside root points outside",
+			setup: func(t *testing.T) ([]string, webBrowsePolicy, []string) {
+				t.Helper()
+				root := t.TempDir()
+				outside := filepath.Join(t.TempDir(), "menu.png")
+				if err := os.WriteFile(outside, []byte("png"), 0o600); err != nil {
+					t.Fatalf("write outside image: %v", err)
+				}
+				link := filepath.Join(root, "linked.png")
+				if err := os.Symlink(outside, link); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+				return []string{link}, webBrowsePolicy{Roots: []string{root}}, nil
+			},
+			wantErr: "outside configured web browse roots",
+		},
+		{
+			name: "allow unrestricted returns original paths",
+			setup: func(t *testing.T) ([]string, webBrowsePolicy, []string) {
+				t.Helper()
+				path := filepath.Join(t.TempDir(), "missing.png")
+				return []string{path}, webBrowsePolicy{AllowUnrestricted: true}, []string{path}
+			},
+			exactPath: true,
+		},
+		{
+			name: "multiple roots accepts second root posix path",
+			setup: func(t *testing.T) ([]string, webBrowsePolicy, []string) {
+				t.Helper()
+				firstRoot := t.TempDir()
+				secondRoot := t.TempDir()
+				image := filepath.Join(secondRoot, "menu.png")
+				if err := os.WriteFile(image, []byte("png"), 0o600); err != nil {
+					t.Fatalf("write image: %v", err)
+				}
+				return []string{filepath.ToSlash(image)}, webBrowsePolicy{Roots: []string{firstRoot, secondRoot}}, []string{image}
+			},
+		},
+		{
+			name: "multiple roots accepts second root windows path",
+			setup: func(t *testing.T) ([]string, webBrowsePolicy, []string) {
+				t.Helper()
+				firstRoot := t.TempDir()
+				secondRoot := t.TempDir()
+				image := filepath.Join(secondRoot, "menu.png")
+				if err := os.WriteFile(image, []byte("png"), 0o600); err != nil {
+					t.Fatalf("write image: %v", err)
+				}
+				return []string{toWindowsPath(t, image)}, webBrowsePolicy{Roots: []string{firstRoot, secondRoot}}, []string{image}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths, policy, want := tt.setup(t)
+			got, err := menuImportPathsWithinBrowsePolicy(paths, policy)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("menuImportPathsWithinBrowsePolicy: %v", err)
+			}
+			if len(got) != len(want) {
+				t.Fatalf("expected %d paths, got %#v", len(want), got)
+			}
+			for i := range want {
+				if tt.exactPath {
+					if got[i] != want[i] {
+						t.Fatalf("expected path %q at index %d, got %q", want[i], i, got[i])
+					}
+					continue
+				}
+				if filepath.Clean(got[i]) != filepath.Clean(want[i]) {
+					t.Fatalf("expected path %q at index %d, got %q", want[i], i, got[i])
+				}
+			}
+		})
 	}
 }
 

--- a/internal/webserver/jobs.go
+++ b/internal/webserver/jobs.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"sort"
 	"strconv"
@@ -165,9 +166,7 @@ func cloneQuestionnaireAnswers(input map[string]map[string]string) map[string]ma
 	cloned := make(map[string]map[string]string, len(input))
 	for tracker, values := range input {
 		inner := make(map[string]string, len(values))
-		for key, value := range values {
-			inner[key] = value
-		}
+		maps.Copy(inner, values)
 		cloned[tracker] = inner
 	}
 	return cloned

--- a/internal/webserver/jobs_test.go
+++ b/internal/webserver/jobs_test.go
@@ -162,7 +162,7 @@ func TestPruneCompletedDupeJobsLockedKeepsNewestCompleted(t *testing.T) {
 	backend.dupes[active.id] = active
 
 	now := time.Now().UTC()
-	for idx := 0; idx < 3; idx++ {
+	for idx := range 3 {
 		id := fmt.Sprintf("dupe-%d", idx)
 		backend.dupes[id] = &dupeCheckJob{
 			id:         id,
@@ -196,7 +196,7 @@ func TestPruneCompletedUploadJobsLockedKeepsNewestCompleted(t *testing.T) {
 	backend.uploads[active.id] = active
 
 	now := time.Now().UTC()
-	for idx := 0; idx < 3; idx++ {
+	for idx := range 3 {
 		id := fmt.Sprintf("upload-%d", idx)
 		backend.uploads[id] = &trackerUploadJob{
 			id:         id,

--- a/internal/webserver/native_picker_windows.go
+++ b/internal/webserver/native_picker_windows.go
@@ -51,7 +51,7 @@ if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
 		return nil, err
 	}
 	var paths []string
-	for _, line := range strings.Split(output, "\n") {
+	for line := range strings.SplitSeq(output, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed != "" {
 			paths = append(paths, trimmed)

--- a/internal/webserver/routes.go
+++ b/internal/webserver/routes.go
@@ -107,6 +107,10 @@ func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request, _ sessi
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 		return
 	}
+	if !s.isLocalWebUIRequest(r) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "bootstrap is only available from localhost web sessions"})
+		return
+	}
 	if !s.allowAuthRequest(r) {
 		writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 		return

--- a/internal/webserver/routes_auth_test.go
+++ b/internal/webserver/routes_auth_test.go
@@ -88,6 +88,26 @@ func TestBootstrapRetainedSessionSetsPersistentCookie(t *testing.T) {
 	}
 }
 
+func TestBootstrapRejectsRemoteFirstRunRequest(t *testing.T) {
+	server := newAuthTestServer(t, filepath.Join(t.TempDir(), "state", "db.sqlite"))
+
+	body := `{"username":"admin","password":"very-secure-password","retainLogin":true}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/auth/bootstrap", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "192.168.1.20:7480"
+	req.RemoteAddr = "192.168.1.25:5000"
+
+	recorder := httptest.NewRecorder()
+	server.handleBootstrap(recorder, req, session{})
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("expected remote bootstrap to return 403, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "bootstrap is only available from localhost") {
+		t.Fatalf("unexpected bootstrap rejection: %s", recorder.Body.String())
+	}
+}
+
 func TestLoginUpgradesLegacyPasswordHash(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
 	server := newAuthTestServer(t, dbPath)

--- a/internal/webserver/shutdown_test.go
+++ b/internal/webserver/shutdown_test.go
@@ -150,12 +150,10 @@ func TestStopSessionLogStreamsStopsMatchingStreams(t *testing.T) {
 			stop:      make(chan struct{}),
 			done:      make(chan struct{}),
 		}
-		backend.streamWG.Add(1)
-		go func() {
-			defer backend.streamWG.Done()
+		backend.streamWG.Go(func() {
 			<-stream.stop
 			close(stream.done)
-		}()
+		})
 		return stream
 	}
 


### PR DESCRIPTION
- Hardens CLI upload flow: seeds metadata before review/upload-only, fails unattended on missing required questionnaire values, and prevents unsafe BDMV playlist fallthroughs.
- Hardens web inputs: localhost-only bootstrap, menu image imports restricted to configured browse roots with symlink resolution.
- Hardens PTP poster rehost: validates poster URLs and blocks loopback/private/reserved IP downloads.
- Fixes playlist selection lookup normalization.
- Removes unsafe frontend HTML entity decoding before rendered preview insertion.
- Fixes `make gofix-check-changed` package paths on Windows and applies Go 1.26 `go fix` drift.
- Adds Go/frontend regression tests for those paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML entity decoding vulnerability in rendered descriptions to prevent XSS attacks.
  * Added IP validation for poster downloads to restrict access to public addresses only.
  * Restricted bootstrap API endpoint to localhost access only.
  * Fixed path normalization for saved playlist selections.

* **New Features**
  * Added menu image import validation against configured browse policy.
  * Enhanced unattended mode error handling for BDMV playlist selection.
  * Added metadata preview validation step in site-check mode.

* **Tests**
  * Comprehensive test coverage for interactive CLI flows and questionnaire handling.
  * HTML sanitization and security validation tests.
  * Browse policy enforcement test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->