### PR TITLE
fix: torrent file handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,19 +22,31 @@ make gofix-check-changed # Inspect Go fix drift on changed packages
 git diff --check        # Whitespace/conflict-marker check
 ```
 
-Use `CONTRIBUTING.md` for full command reference/platform details. Start narrow package/file checks; expand for shared behavior or release surfaces.
-Before committing code changes, run targeted tests plus `make precommit`. It runs the staged Lefthook pre-commit hook, whitespace checks, changed-package Go fix drift, full Go lint/path policy, log policy, and frontend lint/dead-code/type/unit/format checks. For Go behavior changes, also run focused `go test` or `make test-go` as risk requires.
+Use `CONTRIBUTING.md` for full command ref/platform details. Start narrow package/file checks; expand for shared behavior/release surfaces.
+Before commit code changes, run targeted tests + `make precommit`; before push, run `make prepush`. `make precommit` runs staged Lefthook pre-commit hook, whitespace checks, changed-package Go fix drift, full Go lint/path policy, log policy, frontend lint/dead-code/type/unit/format checks. Does not run Go tests. For Go behavior changes, also run focused `go test` or `make test-go` as risk requires.
+For Go changes, prefer running `make lint` or `make prepush` before committing when practical; pre-push runs full `golangci-lint ./...` and can catch wrapcheck/depguard issues not surfaced by the staged pre-commit hook. If pre-push fails after a commit, fix the exact checker output, rerun `make prepush`, then amend the commit.
+
+## Repository Topology
+
+- CLI entry/options/interactive flow: `cmd/upbrr`.
+- Wails desktop entry: `gui`; React UI: `gui/frontend`; Wails backend: `internal/guiapp`.
+- Embedded web backend + API routes: `internal/webserver`.
+- Shared orchestration: `internal/core`; shared req/res contracts: `pkg/api`.
+- Services under `internal/services`; tracker defs/shared tracker logic under `internal/trackers`; concrete tracker impls under `internal/trackers/impl`.
 
 ## Code Quality
 
 - Match repo style. Narrow changes. Fix root cause, not symptoms.
-- New Go code must satisfy `.golangci.yml` linters/formatters. Avoid broad `nolint`.
-- Active checks: `depguard`, `noctx`, `contextcheck`, `containedctx`, `wrapcheck`, `revive`, `forcetypeassert`, `unparam`, `usetesting`, `gosec`, `logpolicy`, `pathpolicy`.
-- Use context-aware APIs. Propagate context where meaningful; terminate deliberately crossing root/background work.
+- New Go code must satisfy `.golangci.yml` linters/formatters. Treat `.golangci.yml` as linter source of truth. Avoid broad `nolint`.
+- Use context-aware APIs. Propagate context where meaningful; terminate deliberately across root/background work.
 - Wrap external-package errors where lint requires. Handle errors by return/wrap/log useful context, or make intentional ignore obvious.
 - Avoid unchecked type assertions. Use `testing` helpers in tests. Justify narrow `nolint` at source.
-- Frontend: keep TypeScript, ESLint, Stylelint, dead-code clean. Don't weaken rules or bypass type errors.
+- Go tests creating files with `os.WriteFile` should use `0o600` or tighter perms unless broader mode bits are behavior under test.
+- Frontend: keep TypeScript, ESLint, Stylelint, dead-code clean. Don't weaken rules or bypass type errors. CSS changes require `pnpm --dir gui/frontend run lint:style`; `make test-frontend` does not run Stylelint.
+- Frontend styling: new/touched UI should prefer Tailwind utilities for local layout/spacing. Keep custom CSS for shared states, theme vars, cross-cutting selectors, or when utilities hurt JSX readability.
+- React effects: use `useEffect` only to sync external systems: DOM, subscriptions, network, browser APIs. Avoid derived state in effects; calculate during render or use `useMemo` for costly work. Put user-driven logic in handlers. Prefer `key` or render-time adjustment for state resets. Fetch effects need cleanup/abort guards for stale responses.
 - Embedded frontend visual checks: rebuild/sync embedded assets + CLI before browser automation. Use main embedded port `7480` with `dist/upbrr.exe serve --dev-no-auth`; avoid Vite-only `5173` for embedded parity. Stop server after inspection.
+- Frontend build caveat: `make frontend` / `make frontend-bundle` builds `gui/frontend/dist` only. Does not sync `internal/guiapp/assets` or rebuild CLI. `make gui` uses current embedded assets and can hide stale frontend output.
 
 ## Path Portability
 
@@ -43,13 +55,13 @@ Before committing code changes, run targeted tests plus `make precommit`. It run
 - Security/path traversal checks reject POSIX + Windows absolute/escaping forms on every OS: leading `/`, leading `\`, drive-letter paths, UNC paths, `..` segments.
 - Use `internal/pathutil.IsWithinRoot` / `SamePath` for local root containment/equality. Do not add ad-hoc `filepath.Rel` + string-prefix guards.
 - Tests must not build local paths with hardcoded OS-rooted literals. Use `t.TempDir`, `filepath.Join`, `filepath.ToSlash` for cross-platform assertions.
-- `cmd/pathpolicy` flags hardcoded OS-rooted literals in `filepath` calls, string-built local paths, `path` on local paths, `filepath` on URL/API slash paths, slash-data filesystem calls, slash assertions without `filepath.ToSlash`, and ad-hoc local path guards outside `internal/pathutil`.
+- `cmd/pathpolicy` flags hardcoded OS-rooted literals in `filepath` calls, string-built local paths (`fmt.Sprintf`, `strings.Join`, `+`), `path` on local paths, `filepath` on URL/API slash paths, slash-data filesystem calls, slash assertions without `filepath.ToSlash`, and ad-hoc local path guards outside `internal/pathutil`.
 - Legit stdlib `path` imports require import-local `//nolint:depguard // <slash-data reason>`. Rare `pathpolicy` cases require `//pathpolicy:allow <reason>` on same/previous line. Fix source first; don't weaken checkers.
 
 ## Logging
 
 - Add logs for meaningful state, decisions, failures, retries, user-visible outcomes. Improve touched funcs when relevant.
-- Treat `cmd/logpolicy` as logging contract. Fix flagged logs/levels at source; don't weaken checker or move noise sideways.
+- Treat `cmd/logpolicy` as logging contract. Checks non-test Go under `internal/**`, rejects stdlib print/log calls + low-context log formats, enforces level hygiene. Fix flagged logs/levels at source; don't weaken checker or move noise sideways.
 - Redact secrets/user-sensitive data with `internal/redaction/redaction.go`.
 - Never log credentials, tokens, API keys, passkeys, cookies, or secret-bearing payloads without repo redaction standard.
 - Levels: `INFO` concise user-facing upload progress/outcomes; `DEBUG` troubleshooting context; `TRACE` high-fidelity operational flow.
@@ -62,12 +74,30 @@ Before committing code changes, run targeted tests plus `make precommit`. It run
 
 ## Product Invariants
 
-- Shared behavior spans CLI, Wails GUI, embedded web-serving mode. Preserve parity in request construction, options, upload behavior where practical.
+- Shared behavior spans CLI, Wails GUI, embedded web-serving mode. Preserve parity in req construction, options, upload behavior where practical.
 - App targets Windows, Linux, macOS. Avoid OS-specific path/process/filesystem/archive/build assumptions unless intentionally platform-gated.
-- Preserve `api.Mode` usage. Align CLI, Wails GUI, embedded web flows with request types under `pkg/api` and shared core behavior under `internal`.
+- Preserve `api.Mode` usage. Align CLI, Wails GUI, embedded web flows with req types under `pkg/api` and shared core behavior under `internal`.
 - Upload options, tracker overrides, retries, execution flags: check CLI + GUI entrypoints when shared.
+- API/runtime parity: changes to `pkg/api.Request`, `UploadOptions`, `PreparedMetadata`, dry-run/upload review, questionnaire answers, description groups, or upload options must check CLI req builders, Wails methods, web routes/backend/jobs, frontend runtime bridge, and TS types.
 - SQLite DBs may be shared across branches during dev. Keep migrations compatible with permissive cross-branch use.
 - Migrations additive, forward-only, idempotent where practical. Prefer guarded table/index creation, additive columns, safe backfills. Avoid destructive drop/rename/tighten changes older branches may still read.
+- Migration IDs stable. Do not rename/reuse shipped IDs. Use narrow `dependsOn` instead of assuming contiguous global versions. Keep `schema_migrations` branch-friendly and preserve legacy `user_version` bridge compatibility when needed.
+- Runtime config mutable after `SaveConfig` / `applyConfig`. Wails `App` and web `Backend` config/core/logger protected by `runtimeMu`; read via `currentConfig()`, `requireRuntime()`, or runtime snapshot once per request/job; reuse snapshot. Do not read `App.cfg` / `Backend.cfg` directly outside runtime helpers. Treat `Server.cfg` as startup-only state; request-time values like tracker favicon URL, DB/log/tmp paths, upload options, logger/core handles should come from backend runtime snapshot/current config.
+
+## Domain Guardrails
+
+- Tracker changes often need sync across `internal/trackers/impl/*`, `internal/trackers/impl/registry.go`, `internal/trackers/catalog.go`, `internal/trackers/unit3dmeta`, `internal/config/defaults/example.yaml`, and dupe/source-lookup/image-host policy tests.
+- Config schema changes need `internal/config.Config`, embedded defaults, import/export paths, env overrides when relevant, settings UI/web parity, and secret redaction/encryption review.
+- Runtime bridge changes involving `globalThis.go.guiapp.App` need matching Wails `internal/guiapp` methods, web `/api/app/*` routes, browser bridge req shapes, and unit/embedded browser verification.
+- Generated/built output exists locally and mostly ignored. Do not commit `dist/`, `gui/frontend/dist`, `gui/build/bin`, generated Wails bindings, or populated `internal/guiapp/assets` unless deliberately updating generated artifacts.
+- GitHub workflow note: `.github/workflows/*.yml` files active; `.yml22` files disabled templates. Keep Makefile, scripts, CONTRIBUTING, workflow version pins aligned, esp Wails and pnpm.
+
+## Focused Validation
+
+- CLI/shared behavior: `go test -race -v -timeout 20m ./cmd/upbrr ./internal/core ./pkg/api`.
+- GUI/web/API parity: `go test -race -v -timeout 20m ./internal/guiapp ./internal/webserver ./internal/guishared ./pkg/api`.
+- Frontend runtime/API bridge: `pnpm --dir gui/frontend run test:unit` plus `pnpm --dir gui/frontend run typecheck`.
+- CSS-only frontend changes: add `pnpm --dir gui/frontend run lint:style`.
 
 ## Unattended Safety
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,112 +2,80 @@
 
 ## Source Of Truth
 
-- Contributor setup/platform notes/Makefile targets/build commands/tests/hooks/commit format: `CONTRIBUTING.md`.
+- Contributor setup, supported platforms, hook install, commit format, and detailed command docs: `CONTRIBUTING.md`.
 - Tool wiring: `Makefile`, `lefthook.yml`, `.golangci.yml`, `gui/frontend/package.json`, `.github/workflows/*`.
-- Docs disagree? Tool config wins. Update prose; don't copy stale commands.
+- Docs disagree? Tool config wins. Update stale prose; don't copy command detail.
+- Token hygiene: read `CONTRIBUTING.md` by targeted section only when setup, hooks, commit format, or full command detail is needed.
 
 ## Quick Commands
 
 ```bash
-make help               # Show supported targets
-make backend            # Fast build sanity check
-make test-go            # Full Go tests with race detector
-make test-frontend      # Frontend lint/dead-code/type/unit/format checks
-make lint               # Path policy + full Go lint
-make logpolicy          # Logging policy check
-make pathpolicy         # Path portability policy check
-make precommit          # Strong local validation before commit
+make help               # supported targets
+make backend            # fast CLI build sanity
+make test-go            # full Go race tests
+make test-frontend      # frontend lint/dead-code/type/unit/format
+make lint               # path policy + full Go lint
+make logpolicy          # logging policy
+make pathpolicy         # path portability policy
+make precommit          # strong local validation before commit; no Go tests
 make prepush            # Lefthook pre-push
-make gofix-check-changed # Inspect Go fix drift on changed packages
-git diff --check        # Whitespace/conflict-marker check
+make gofix-check-changed # inspect Go fix drift
+git diff --check        # whitespace/conflict markers
 ```
 
-Use `CONTRIBUTING.md` for full command ref/platform details. Start narrow package/file checks; expand for shared behavior/release surfaces.
-Before commit code changes, run targeted tests + `make precommit`; before push, run `make prepush`. `make precommit` runs staged Lefthook pre-commit hook, whitespace checks, changed-package Go fix drift, full Go lint/path policy, log policy, frontend lint/dead-code/type/unit/format checks. Does not run Go tests. For Go behavior changes, also run focused `go test` or `make test-go` as risk requires.
-For Go changes, prefer running `make lint` or `make prepush` before committing when practical; pre-push runs full `golangci-lint ./...` and can catch wrapcheck/depguard issues not surfaced by the staged pre-commit hook. If pre-push fails after a commit, fix the exact checker output, rerun `make prepush`, then amend the commit.
+Start narrow; expand for shared behavior, release, GUI/web parity, or safety-sensitive changes. Before commit: targeted tests + `make precommit`; Go behavior also needs focused `go test` or `make test-go` as risk requires. Before push: `make prepush`.
 
-## Repository Topology
+## Repository Map
 
-- CLI entry/options/interactive flow: `cmd/upbrr`.
-- Wails desktop entry: `gui`; React UI: `gui/frontend`; Wails backend: `internal/guiapp`.
-- Embedded web backend + API routes: `internal/webserver`.
-- Shared orchestration: `internal/core`; shared req/res contracts: `pkg/api`.
-- Services under `internal/services`; tracker defs/shared tracker logic under `internal/trackers`; concrete tracker impls under `internal/trackers/impl`.
+- CLI `cmd/upbrr`; Wails `gui`, `internal/guiapp`; frontend `gui/frontend`; embedded web/API `internal/webserver`; core `internal/core`; API contracts `pkg/api`; services `internal/services`; trackers `internal/trackers`, `internal/trackers/impl`.
 
-## Code Quality
+## Code Rules
 
-- Match repo style. Narrow changes. Fix root cause, not symptoms.
-- New Go code must satisfy `.golangci.yml` linters/formatters. Treat `.golangci.yml` as linter source of truth. Avoid broad `nolint`.
-- Use context-aware APIs. Propagate context where meaningful; terminate deliberately across root/background work.
-- Wrap external-package errors where lint requires. Handle errors by return/wrap/log useful context, or make intentional ignore obvious.
-- Avoid unchecked type assertions. Use `testing` helpers in tests. Justify narrow `nolint` at source.
-- Go tests creating files with `os.WriteFile` should use `0o600` or tighter perms unless broader mode bits are behavior under test.
-- Frontend: keep TypeScript, ESLint, Stylelint, dead-code clean. Don't weaken rules or bypass type errors. CSS changes require `pnpm --dir gui/frontend run lint:style`; `make test-frontend` does not run Stylelint.
-- Frontend styling: new/touched UI should prefer Tailwind utilities for local layout/spacing. Keep custom CSS for shared states, theme vars, cross-cutting selectors, or when utilities hurt JSX readability.
-- React effects: use `useEffect` only to sync external systems: DOM, subscriptions, network, browser APIs. Avoid derived state in effects; calculate during render or use `useMemo` for costly work. Put user-driven logic in handlers. Prefer `key` or render-time adjustment for state resets. Fetch effects need cleanup/abort guards for stale responses.
-- Embedded frontend visual checks: rebuild/sync embedded assets + CLI before browser automation. Use main embedded port `7480` with `dist/upbrr.exe serve --dev-no-auth`; avoid Vite-only `5173` for embedded parity. Stop server after inspection.
-- Frontend build caveat: `make frontend` / `make frontend-bundle` builds `gui/frontend/dist` only. Does not sync `internal/guiapp/assets` or rebuild CLI. `make gui` uses current embedded assets and can hide stale frontend output.
+- Match repo style; narrow changes; fix root cause; keep tests for changed behavior.
+- Go: satisfy `.golangci.yml`; avoid broad `nolint`; wrap external/interface errors where lint requires; avoid unchecked assertions; use `testing` helpers; test file writes use `0o600` unless mode bits are under test.
+- Context/logging: use context-aware APIs where meaningful. Log meaningful state/decisions/failures/retries/outcomes. No stdlib print/log under `internal/**`; satisfy `cmd/logpolicy`; redact via `internal/redaction/redaction.go`; never log credentials/tokens/API keys/cookies/secret payloads. Levels: `INFO` user-facing outcomes, `DEBUG` troubleshooting, `TRACE` high-fidelity flow.
+- Go fix: no wholesale `go fix`. Prefer `make gofix-check-changed`, then package-scoped `go fix -omitzero=false <packages>`. Keep `omitzero` disabled unless JSON semantics were reviewed.
+
+## Frontend Rules
+
+- Keep TypeScript, ESLint, Stylelint, dead-code clean. Don't weaken rules.
+- Prefer Tailwind utilities for touched local layout/spacing; keep CSS for shared/theme/cross-cutting selectors or JSX readability.
+- `useEffect` only for external sync. Avoid derived state in effects; render/`useMemo` instead; handlers own user actions; fetch effects need cleanup/abort guards.
+- CSS changes require `pnpm --dir gui/frontend run lint:style`; `make test-frontend` omits Stylelint.
+- Embedded visual checks: rebuild/sync embedded assets + CLI, serve `dist/upbrr.exe serve --dev-no-auth` at `http://localhost:7480`; avoid Vite `5173`; stop server after inspection.
+- Build caveat: `make frontend`/`make frontend-bundle` update `gui/frontend/dist` only; no asset sync/CLI rebuild. `make gui` uses current embedded assets.
 
 ## Path Portability
 
-- Use `filepath` for local filesystem paths. Use `path` only for slash-delimited torrent paths, URLs, or API payloads explicitly defined to use `/`.
-- Torrent/API -> local filesystem boundary: validate slash paths first, then convert deliberately with `filepath.FromSlash`.
-- Security/path traversal checks reject POSIX + Windows absolute/escaping forms on every OS: leading `/`, leading `\`, drive-letter paths, UNC paths, `..` segments.
-- Use `internal/pathutil.IsWithinRoot` / `SamePath` for local root containment/equality. Do not add ad-hoc `filepath.Rel` + string-prefix guards.
-- Tests must not build local paths with hardcoded OS-rooted literals. Use `t.TempDir`, `filepath.Join`, `filepath.ToSlash` for cross-platform assertions.
-- `cmd/pathpolicy` flags hardcoded OS-rooted literals in `filepath` calls, string-built local paths (`fmt.Sprintf`, `strings.Join`, `+`), `path` on local paths, `filepath` on URL/API slash paths, slash-data filesystem calls, slash assertions without `filepath.ToSlash`, and ad-hoc local path guards outside `internal/pathutil`.
-- Legit stdlib `path` imports require import-local `//nolint:depguard // <slash-data reason>`. Rare `pathpolicy` cases require `//pathpolicy:allow <reason>` on same/previous line. Fix source first; don't weaken checkers.
-
-## Logging
-
-- Add logs for meaningful state, decisions, failures, retries, user-visible outcomes. Improve touched funcs when relevant.
-- Treat `cmd/logpolicy` as logging contract. Checks non-test Go under `internal/**`, rejects stdlib print/log calls + low-context log formats, enforces level hygiene. Fix flagged logs/levels at source; don't weaken checker or move noise sideways.
-- Redact secrets/user-sensitive data with `internal/redaction/redaction.go`.
-- Never log credentials, tokens, API keys, passkeys, cookies, or secret-bearing payloads without repo redaction standard.
-- Levels: `INFO` concise user-facing upload progress/outcomes; `DEBUG` troubleshooting context; `TRACE` high-fidelity operational flow.
-
-## Go Fix
-
-- Don't apply `go fix` wholesale without review.
-- Prefer `make gofix-check-changed` and package-scoped `go fix -omitzero=false <packages>`.
-- Keep `omitzero` disabled unless change explicitly reviews JSON output semantics.
+- Local FS paths use `filepath`; slash-data (torrent paths, URLs, API payload paths) use `path` only with import-local `//nolint:depguard // <reason>`.
+- Slash-data -> local FS: validate slash path, then `filepath.FromSlash`.
+- Reject POSIX + Windows escapes on every OS: leading `/`, leading `\`, drive letters, UNC, `..`.
+- Use `internal/pathutil.IsWithinRoot` / `SamePath`; no ad-hoc `filepath.Rel` + prefix guards.
+- Tests: `t.TempDir`, `filepath.Join`, `filepath.ToSlash`; no hardcoded OS-rooted literals/raw slash assertions for local FS.
+- `cmd/pathpolicy` flags wrong path APIs, string-built local paths, slash-data FS calls/assertions, and ad-hoc guards. Rare exceptions need `//pathpolicy:allow <reason>` same/previous line.
 
 ## Product Invariants
 
-- Shared behavior spans CLI, Wails GUI, embedded web-serving mode. Preserve parity in req construction, options, upload behavior where practical.
-- App targets Windows, Linux, macOS. Avoid OS-specific path/process/filesystem/archive/build assumptions unless intentionally platform-gated.
-- Preserve `api.Mode` usage. Align CLI, Wails GUI, embedded web flows with req types under `pkg/api` and shared core behavior under `internal`.
-- Upload options, tracker overrides, retries, execution flags: check CLI + GUI entrypoints when shared.
-- API/runtime parity: changes to `pkg/api.Request`, `UploadOptions`, `PreparedMetadata`, dry-run/upload review, questionnaire answers, description groups, or upload options must check CLI req builders, Wails methods, web routes/backend/jobs, frontend runtime bridge, and TS types.
-- SQLite DBs may be shared across branches during dev. Keep migrations compatible with permissive cross-branch use.
-- Migrations additive, forward-only, idempotent where practical. Prefer guarded table/index creation, additive columns, safe backfills. Avoid destructive drop/rename/tighten changes older branches may still read.
-- Migration IDs stable. Do not rename/reuse shipped IDs. Use narrow `dependsOn` instead of assuming contiguous global versions. Keep `schema_migrations` branch-friendly and preserve legacy `user_version` bridge compatibility when needed.
-- Runtime config mutable after `SaveConfig` / `applyConfig`. Wails `App` and web `Backend` config/core/logger protected by `runtimeMu`; read via `currentConfig()`, `requireRuntime()`, or runtime snapshot once per request/job; reuse snapshot. Do not read `App.cfg` / `Backend.cfg` directly outside runtime helpers. Treat `Server.cfg` as startup-only state; request-time values like tracker favicon URL, DB/log/tmp paths, upload options, logger/core handles should come from backend runtime snapshot/current config.
+- Preserve CLI, Wails GUI, embedded web parity. App targets Windows/Linux/macOS; avoid OS assumptions unless platform-gated.
+- Preserve `api.Mode`; align requests/options/upload behavior/tracker overrides/retries/execution flags across entrypoints.
+- API/runtime parity: changes to `pkg/api.Request`, `UploadOptions`, `PreparedMetadata`, dry-run/upload review, questionnaire answers, description groups, or upload options must check CLI builders, Wails methods, web routes/jobs, frontend bridge, and TS types.
+- SQLite migrations: additive, forward-only, idempotent where practical; stable IDs; no destructive drop/rename/tighten; narrow `dependsOn`; preserve `schema_migrations` + legacy `user_version` bridge.
+- Runtime config mutable after `SaveConfig` / `applyConfig`: read Wails/web config/core/logger via `currentConfig()`, `requireRuntime()`, or snapshots; don't read `App.cfg`/`Backend.cfg` directly outside helpers. `Server.cfg` is startup-only.
+- Unattended/unattended-confirm is safety-critical: no prompts/hidden confirms/ambiguous fallthrough. If unsafe, prefer dry-run, site-check, explicit skip, or clear failure. Preserve skip/override parity for dupes, rule failures, image-host uploads, torrent injection, and retries.
 
 ## Domain Guardrails
 
-- Tracker changes often need sync across `internal/trackers/impl/*`, `internal/trackers/impl/registry.go`, `internal/trackers/catalog.go`, `internal/trackers/unit3dmeta`, `internal/config/defaults/example.yaml`, and dupe/source-lookup/image-host policy tests.
-- Config schema changes need `internal/config.Config`, embedded defaults, import/export paths, env overrides when relevant, settings UI/web parity, and secret redaction/encryption review.
+- Tracker changes often touch `internal/trackers/impl/*`, `internal/trackers/impl/registry.go`, `internal/trackers/catalog.go`, `internal/trackers/unit3dmeta`, `internal/config/defaults/example.yaml`, and policy tests.
+- Config schema changes need `internal/config.Config`, embedded defaults, import/export, env overrides as relevant, settings UI/web parity, and secret redaction/encryption review.
 - Runtime bridge changes involving `globalThis.go.guiapp.App` need matching Wails `internal/guiapp` methods, web `/api/app/*` routes, browser bridge req shapes, and unit/embedded browser verification.
 - Generated/built output exists locally and mostly ignored. Do not commit `dist/`, `gui/frontend/dist`, `gui/build/bin`, generated Wails bindings, or populated `internal/guiapp/assets` unless deliberately updating generated artifacts.
-- GitHub workflow note: `.github/workflows/*.yml` files active; `.yml22` files disabled templates. Keep Makefile, scripts, CONTRIBUTING, workflow version pins aligned, esp Wails and pnpm.
+- `.github/workflows/*.yml` files are active; `.yml22` files are disabled templates. Keep Makefile, scripts, `CONTRIBUTING.md`, workflow pins, Wails, and pnpm aligned.
 
-## Focused Validation
+## Validation Matrix
 
 - CLI/shared behavior: `go test -race -v -timeout 20m ./cmd/upbrr ./internal/core ./pkg/api`.
 - GUI/web/API parity: `go test -race -v -timeout 20m ./internal/guiapp ./internal/webserver ./internal/guishared ./pkg/api`.
 - Frontend runtime/API bridge: `pnpm --dir gui/frontend run test:unit` plus `pnpm --dir gui/frontend run typecheck`.
-- CSS-only frontend changes: add `pnpm --dir gui/frontend run lint:style`.
-
-## Unattended Safety
-
-- Unattended/unattended-confirm flows safety-critical. Keep non-blocking + conservative.
-- No interactive prompts, hidden confirmations, ambiguous fallthrough in unattended paths.
-- If unattended cannot choose safely, prefer dry-run, site-check, explicit skip, or clear failure over uncertain upload.
-- Preserve invariants: site-check implies dry-run; debug implies safe non-upload; unattended flows keep current questionnaire/default-selection behavior unless change updates rules everywhere.
-- Preserve safe skip/override for dupes, rule failures, screenshot/image-host uploads, torrent injection, retries. If one shared surface supports skip/override, keep parity in other shared surface.
-
-## Scope Notes
-
-- Don't duplicate detailed contributor workflow from `CONTRIBUTING.md`; link/summarize agent-critical deltas only.
-- If change affects one area, run smallest relevant checks. If change crosses backend/frontend/GUI/packaging/unattended execution, expand validation.
+- CSS-only frontend changes: `pnpm --dir gui/frontend run lint:style`.
+- Go lint/path/log changes: `make lint`, `make logpolicy`, `make pathpolicy`, plus `make gofix-check-changed` for changed Go packages.
+- Cross-area or pre-commit confidence: `make precommit`; before push: `make prepush`.

--- a/internal/torrent/service.go
+++ b/internal/torrent/service.go
@@ -4,12 +4,15 @@
 package torrent
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -17,7 +20,9 @@ import (
 	mkbrr "github.com/autobrr/mkbrr/torrent"
 
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	"github.com/autobrr/upbrr/internal/filesystem"
 	"github.com/autobrr/upbrr/internal/paths"
+	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -124,11 +129,22 @@ func (s *Service) Create(ctx context.Context, meta api.PreparedMetadata) (api.To
 		return api.TorrentResult{}, fmt.Errorf("torrent: no reusable torrent found with nohash enabled: %w", internalerrors.ErrNotFound)
 	}
 
-	if _, err := os.Stat(source); err != nil {
+	createSpec, err := resolveCreateSpec(meta, source, s.tmpRoot)
+	if err != nil {
+		return api.TorrentResult{}, err
+	}
+	if createSpec.cleanupPath != "" {
+		defer func() {
+			if err := os.RemoveAll(createSpec.cleanupPath); err != nil {
+				s.logger.Warnf("torrent: failed to remove staging path %s: %v", createSpec.cleanupPath, err)
+			}
+		}()
+	}
+	if _, err := os.Stat(createSpec.path); err != nil {
 		if os.IsNotExist(err) {
-			return api.TorrentResult{}, fmt.Errorf("torrent: path %q: %w", source, internalerrors.ErrNotFound)
+			return api.TorrentResult{}, fmt.Errorf("torrent: path %q: %w", createSpec.path, internalerrors.ErrNotFound)
 		}
-		return api.TorrentResult{}, fmt.Errorf("torrent: path %q: %w", source, err)
+		return api.TorrentResult{}, fmt.Errorf("torrent: path %q: %w", createSpec.path, err)
 	}
 
 	select {
@@ -152,16 +168,22 @@ func (s *Service) Create(ctx context.Context, meta api.PreparedMetadata) (api.To
 	emitTorrentProgress(ctx, meta, "running", "Creating torrent with mkbrr")
 
 	info, err := mkbrr.Create(mkbrr.CreateOptions{
-		Path:             source,
+		Path:             createSpec.path,
+		Name:             createSpec.name,
 		OutputPath:       outputPath,
 		IsPrivate:        true,
 		MaxPieceLength:   &pieceOptions.maxPieceExp,
 		PieceLengthExp:   pieceOptions.pieceExp,
+		IncludePatterns:  createSpec.includePatterns,
 		ProgressCallback: torrentProgressCallback(ctx, meta),
 	})
 	if err != nil {
 		emitTorrentProgress(ctx, meta, "failed", "Torrent creation failed")
-		return api.TorrentResult{}, fmt.Errorf("torrent: create %q: %w", source, err)
+		return api.TorrentResult{}, fmt.Errorf("torrent: create %q: %w", createSpec.path, err)
+	}
+	if err := validateTorrentContent(info.Path, meta); err != nil {
+		emitTorrentProgress(ctx, meta, "failed", "Torrent validation failed")
+		return api.TorrentResult{}, fmt.Errorf("torrent: validate created torrent %q: %w", info.Path, err)
 	}
 	s.logger.Debugf("torrent: created torrent %s", info.Path)
 	emitTorrentProgress(ctx, meta, "completed", "Torrent ready")
@@ -240,7 +262,7 @@ func torrentOverrideEnabled(value *bool) bool {
 
 func validateCandidateTorrent(path string, policy *trackerTorrentPolicy, meta api.PreparedMetadata, logger api.Logger) error {
 	if policy == nil {
-		return nil
+		return validateTorrentContent(path, meta)
 	}
 	if err := policy.validateTorrent(path, meta); err != nil {
 		if logger != nil {
@@ -248,7 +270,575 @@ func validateCandidateTorrent(path string, policy *trackerTorrentPolicy, meta ap
 		}
 		return err
 	}
+	if err := validateTorrentContent(path, meta); err != nil {
+		if logger != nil {
+			logger.Warnf("torrent: skipping mismatched torrent %s: %v", path, err)
+		}
+		return err
+	}
 	return nil
+}
+
+type createSpec struct {
+	path            string
+	name            string
+	includePatterns []string
+	cleanupPath     string
+}
+
+type contentFile struct {
+	path   string
+	length int64
+}
+
+func resolveCreateSpec(meta api.PreparedMetadata, source string, tmpRoot string) (createSpec, error) {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return createSpec{}, internalerrors.ErrInvalidInput
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return createSpec{}, fmt.Errorf("torrent: path %q: %w", source, internalerrors.ErrNotFound)
+		}
+		return createSpec{}, fmt.Errorf("torrent: path %q: %w", source, err)
+	}
+	if !info.IsDir() {
+		return createSpec{path: source}, nil
+	}
+
+	if strings.TrimSpace(meta.DiscType) != "" {
+		return createSpec{path: normalizeDiscSource(source)}, nil
+	}
+
+	wanted, err := wantedFilesWithin(source, meta.FileList)
+	if err != nil {
+		return createSpec{}, err
+	}
+	if len(wanted) == 1 {
+		return createSpec{path: wanted[0]}, nil
+	}
+	if len(wanted) > 1 {
+		if needsWantedFileStaging(source, wanted) {
+			stagedRoot, cleanupPath, err := stageWantedFiles(tmpRoot, source, wanted)
+			if err != nil {
+				return createSpec{}, err
+			}
+			return createSpec{
+				path:        stagedRoot,
+				name:        filepath.Base(filepath.Clean(source)),
+				cleanupPath: cleanupPath,
+			}, nil
+		}
+		include, err := includePatternsForFiles(source, wanted)
+		if err != nil {
+			return createSpec{}, err
+		}
+		return createSpec{
+			path:            source,
+			name:            filepath.Base(filepath.Clean(source)),
+			includePatterns: include,
+		}, nil
+	}
+
+	return createSpec{path: source}, nil
+}
+
+func normalizeDiscSource(source string) string {
+	cleaned := filepath.Clean(source)
+	switch strings.ToUpper(filepath.Base(cleaned)) {
+	case "BDMV", "VIDEO_TS", "HVDVD_TS":
+		return filepath.Dir(cleaned)
+	default:
+		return source
+	}
+}
+
+func mkbrrIgnoredPath(rel string, isDir bool) bool {
+	lowerRel := strings.ToLower(filepath.ToSlash(rel))
+	if lowerRel == "@eadir" || strings.HasPrefix(lowerRel, "@eadir/") ||
+		strings.HasSuffix(lowerRel, "/@eadir") || strings.Contains(lowerRel, "/@eadir/") {
+		return true
+	}
+	if isDir {
+		return false
+	}
+	return strings.HasSuffix(lowerRel, ".torrent") ||
+		strings.HasSuffix(lowerRel, ".ds_store") ||
+		strings.HasSuffix(lowerRel, "thumbs.db") ||
+		strings.HasSuffix(lowerRel, "desktop.ini") ||
+		strings.HasSuffix(lowerRel, "zone.identifier")
+}
+
+func wantedFilesWithin(root string, files []string) ([]string, error) {
+	if len(files) == 0 {
+		return nil, nil
+	}
+	cleanRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("torrent: resolve source root: %w", err)
+	}
+	wanted := make([]string, 0, len(files))
+	seen := make(map[string]struct{}, len(files))
+	for _, file := range files {
+		trimmed := strings.TrimSpace(file)
+		if trimmed == "" {
+			continue
+		}
+		absFile, err := filepath.Abs(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("torrent: resolve wanted file: %w", err)
+		}
+		if err := ensureWithinRoot(cleanRoot, absFile); err != nil {
+			return nil, err
+		}
+		info, err := os.Stat(absFile)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("torrent: stat wanted file %q: %w", absFile, err)
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		cleanFile := filepath.Clean(absFile)
+		if _, ok := seen[cleanFile]; ok {
+			continue
+		}
+		seen[cleanFile] = struct{}{}
+		wanted = append(wanted, cleanFile)
+	}
+	sort.Strings(wanted)
+	return wanted, nil
+}
+
+func includePatternsForFiles(root string, files []string) ([]string, error) {
+	cleanRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("torrent: resolve source root: %w", err)
+	}
+	include := make([]string, 0, len(files))
+	for _, file := range files {
+		absFile, err := filepath.Abs(file)
+		if err != nil {
+			return nil, fmt.Errorf("torrent: resolve wanted file: %w", err)
+		}
+		if err := ensureWithinRoot(cleanRoot, absFile); err != nil {
+			return nil, err
+		}
+		rel, err := filepath.Rel(cleanRoot, absFile)
+		if err != nil {
+			return nil, fmt.Errorf("torrent: wanted file relative path: %w", err)
+		}
+		slashRel := filepath.ToSlash(rel)
+		if strings.Contains(slashRel, ",") {
+			return nil, fmt.Errorf("torrent: wanted file %q requires staging", slashRel)
+		}
+		include = append(include, globLiteral(slashRel))
+	}
+	return include, nil
+}
+
+func needsWantedFileStaging(root string, files []string) bool {
+	cleanRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	for _, file := range files {
+		absFile, err := filepath.Abs(file)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(cleanRoot, absFile)
+		if err == nil && strings.Contains(filepath.ToSlash(rel), ",") {
+			return true
+		}
+	}
+	return false
+}
+
+func stageWantedFiles(tmpRoot string, root string, files []string) (string, string, error) {
+	if strings.TrimSpace(tmpRoot) == "" {
+		return "", "", errors.New("torrent: tmp root is required for staged wanted files")
+	}
+	rootName, err := safeTorrentRootName(root)
+	if err != nil {
+		return "", "", err
+	}
+	stageParent, err := os.MkdirTemp(tmpRoot, "wanted-files-*")
+	if err != nil {
+		return "", "", fmt.Errorf("torrent: create wanted file staging dir: %w", err)
+	}
+	stagedRoot := filepath.Join(stageParent, rootName)
+	cleanRoot, err := filepath.Abs(root)
+	if err != nil {
+		_ = os.RemoveAll(stageParent)
+		return "", "", fmt.Errorf("torrent: resolve source root: %w", err)
+	}
+	for _, file := range files {
+		absFile, err := filepath.Abs(file)
+		if err != nil {
+			_ = os.RemoveAll(stageParent)
+			return "", "", fmt.Errorf("torrent: resolve wanted file: %w", err)
+		}
+		rel, err := filepath.Rel(cleanRoot, absFile)
+		if err != nil {
+			_ = os.RemoveAll(stageParent)
+			return "", "", fmt.Errorf("torrent: wanted file relative path: %w", err)
+		}
+		dst := filepath.Join(stagedRoot, rel)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+			_ = os.RemoveAll(stageParent)
+			return "", "", fmt.Errorf("torrent: create wanted file staging parent: %w", err)
+		}
+		if err := os.Link(absFile, dst); err != nil {
+			if copyErr := filesystem.CopyFile(absFile, dst); copyErr != nil {
+				_ = os.RemoveAll(stageParent)
+				return "", "", fmt.Errorf("torrent: stage wanted file %q: link: %w; copy: %w", absFile, err, copyErr)
+			}
+		}
+	}
+	return stagedRoot, stageParent, nil
+}
+
+func safeTorrentRootName(root string) (string, error) {
+	cleanRoot := filepath.Clean(root)
+	rootName := filepath.Base(cleanRoot)
+	if rootName == "" || rootName == "." || rootName == string(filepath.Separator) || filepath.IsAbs(rootName) {
+		return "", fmt.Errorf("torrent: invalid source root name %q", root)
+	}
+	return rootName, nil
+}
+
+func ensureWithinRoot(root string, child string) error {
+	root = filepath.Clean(root)
+	child = filepath.Clean(child)
+	if pathutil.SamePath(root, child) || !pathutil.IsWithinRoot(root, child) {
+		return fmt.Errorf("torrent: wanted file %q is outside source root %q", child, root)
+	}
+	return nil
+}
+
+func globLiteral(value string) string {
+	var builder strings.Builder
+	for _, r := range value {
+		switch r {
+		case '[':
+			builder.WriteString("[[]")
+		case '*', '?', '{', '}':
+			builder.WriteRune('[')
+			builder.WriteRune(r)
+			builder.WriteRune(']')
+		default:
+			builder.WriteRune(r)
+		}
+	}
+	return "{" + builder.String() + "}"
+}
+
+func validateTorrentContent(path string, meta api.PreparedMetadata) error {
+	expected, ok, err := expectedTorrentContent(meta)
+	if err != nil {
+		return err
+	}
+	expectedName, nameOK, err := expectedTorrentName(meta)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	torrentMeta, err := metainfo.LoadFromFile(path)
+	if err != nil {
+		return fmt.Errorf("torrent: read candidate metadata: %w", err)
+	}
+	info, err := torrentMeta.UnmarshalInfo()
+	if err != nil {
+		return fmt.Errorf("torrent: unmarshal candidate info: %w", err)
+	}
+	if nameOK && !strings.EqualFold(info.BestName(), expectedName) {
+		return errors.New("torrent: candidate name mismatch")
+	}
+	actual := torrentContentPaths(info)
+	if len(actual) == 0 {
+		return errors.New("torrent: candidate has no files")
+	}
+	if !sameContentSet(actual, expected) {
+		return errors.New("torrent: candidate content mismatch")
+	}
+	if err := validateTorrentPieces(info, meta); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateTorrentPieces(info metainfo.Info, meta api.PreparedMetadata) error {
+	if info.PieceLength <= 0 || len(info.Pieces) == 0 {
+		return errors.New("torrent: candidate piece hashes unavailable")
+	}
+	generated := info
+	if err := generated.GeneratePieces(func(file metainfo.FileInfo) (io.ReadCloser, error) {
+		return openTorrentContentFile(meta, file)
+	}); err != nil {
+		return fmt.Errorf("torrent: generate candidate piece hashes: %w", err)
+	}
+	if !bytes.Equal(generated.Pieces, info.Pieces) {
+		return errors.New("torrent: candidate piece hash mismatch")
+	}
+	return nil
+}
+
+func openTorrentContentFile(meta api.PreparedMetadata, file metainfo.FileInfo) (io.ReadCloser, error) {
+	source := strings.TrimSpace(meta.SourcePath)
+	if source == "" || strings.EqualFold(filepath.Ext(source), ".torrent") {
+		return nil, errors.New("torrent: source unavailable for piece validation")
+	}
+	if strings.TrimSpace(meta.DiscType) != "" {
+		return openTorrentFileWithinRoot(normalizeDiscSource(source), file)
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil, fmt.Errorf("torrent: stat source %q: %w", source, err)
+	}
+	if !info.IsDir() {
+		openedFile, err := os.Open(source)
+		if err != nil {
+			return nil, fmt.Errorf("torrent: open source file %q: %w", source, err)
+		}
+		return openedFile, nil
+	}
+	if len(meta.FileList) == 0 {
+		return openTorrentFileWithinRoot(source, file)
+	}
+	wanted, err := wantedFilesWithin(source, meta.FileList)
+	if err != nil {
+		return nil, err
+	}
+	if len(wanted) == 1 {
+		openedFile, err := os.Open(wanted[0])
+		if err != nil {
+			return nil, fmt.Errorf("torrent: open wanted file %q: %w", wanted[0], err)
+		}
+		return openedFile, nil
+	}
+	return openTorrentFileWithinRoot(source, file)
+}
+
+func openTorrentFileWithinRoot(root string, file metainfo.FileInfo) (io.ReadCloser, error) {
+	parts := file.BestPath()
+	if len(parts) == 0 {
+		return nil, errors.New("torrent: candidate file path missing")
+	}
+	localParts := make([]string, 0, len(parts)+1)
+	localParts = append(localParts, root)
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." || filepath.IsAbs(part) || strings.ContainsAny(part, `/\`) {
+			return nil, fmt.Errorf("torrent: invalid candidate file path segment %q", part)
+		}
+		localParts = append(localParts, part)
+	}
+	localPath := filepath.Join(localParts...)
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("torrent: resolve source root: %w", err)
+	}
+	absPath, err := filepath.Abs(localPath)
+	if err != nil {
+		return nil, fmt.Errorf("torrent: resolve candidate file: %w", err)
+	}
+	if err := ensureWithinRoot(absRoot, absPath); err != nil {
+		return nil, err
+	}
+	fileHandle, err := os.Open(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("torrent: open candidate file %q: %w", absPath, err)
+	}
+	return fileHandle, nil
+}
+
+func expectedTorrentContent(meta api.PreparedMetadata) ([]contentFile, bool, error) {
+	source := strings.TrimSpace(meta.SourcePath)
+	if source == "" || strings.EqualFold(filepath.Ext(source), ".torrent") {
+		return nil, false, nil
+	}
+	if strings.TrimSpace(meta.DiscType) != "" {
+		root := normalizeDiscSource(source)
+		expected, err := diskContentPaths(root)
+		return expected, true, err
+	}
+	info, err := os.Stat(source)
+	if err == nil && !info.IsDir() {
+		return []contentFile{{path: filepath.Base(source), length: info.Size()}}, true, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("torrent: stat source %q: %w", source, err)
+	}
+	if len(meta.FileList) == 0 {
+		expected, err := diskContentPaths(source)
+		return expected, true, err
+	}
+	wanted, err := wantedFilesWithin(source, meta.FileList)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(wanted) == 0 {
+		return nil, false, errors.New("torrent: no valid wanted files")
+	}
+	if len(wanted) == 1 {
+		info, err := os.Stat(wanted[0])
+		if err != nil {
+			return nil, false, fmt.Errorf("torrent: stat wanted file %q: %w", wanted[0], err)
+		}
+		return []contentFile{{path: filepath.Base(wanted[0]), length: info.Size()}}, true, nil
+	}
+	expected := make([]contentFile, 0, len(wanted))
+	root, err := filepath.Abs(source)
+	if err != nil {
+		return nil, false, fmt.Errorf("torrent: resolve source root: %w", err)
+	}
+	for _, file := range wanted {
+		rel, err := filepath.Rel(root, file)
+		if err != nil {
+			return nil, false, fmt.Errorf("torrent: wanted file relative path: %w", err)
+		}
+		info, err := os.Stat(file)
+		if err != nil {
+			return nil, false, fmt.Errorf("torrent: stat wanted file %q: %w", file, err)
+		}
+		expected = append(expected, contentFile{path: filepath.ToSlash(rel), length: info.Size()})
+	}
+	return expected, true, nil
+}
+
+func expectedTorrentName(meta api.PreparedMetadata) (string, bool, error) {
+	source := strings.TrimSpace(meta.SourcePath)
+	if source == "" || strings.EqualFold(filepath.Ext(source), ".torrent") {
+		return "", false, nil
+	}
+	if strings.TrimSpace(meta.DiscType) != "" {
+		return filepath.Base(filepath.Clean(normalizeDiscSource(source))), true, nil
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return "", false, fmt.Errorf("torrent: stat source %q: %w", source, err)
+	}
+	if !info.IsDir() {
+		return filepath.Base(source), true, nil
+	}
+	if len(meta.FileList) == 0 {
+		return filepath.Base(filepath.Clean(source)), true, nil
+	}
+	wanted, err := wantedFilesWithin(source, meta.FileList)
+	if err != nil {
+		return "", false, err
+	}
+	if len(wanted) == 0 {
+		return "", false, errors.New("torrent: no valid wanted files")
+	}
+	if len(wanted) == 1 {
+		return filepath.Base(wanted[0]), true, nil
+	}
+	return filepath.Base(filepath.Clean(source)), true, nil
+}
+
+func torrentContentPaths(info metainfo.Info) []contentFile {
+	files := info.UpvertedFiles()
+	if len(files) == 0 {
+		return nil
+	}
+	result := make([]contentFile, 0, len(files))
+	for _, file := range files {
+		parts := file.BestPath()
+		if len(parts) == 0 {
+			result = append(result, contentFile{path: info.BestName(), length: file.Length})
+			continue
+		}
+		result = append(result, contentFile{path: strings.Join(parts, "/"), length: file.Length})
+	}
+	return result
+}
+
+func diskContentPaths(root string) ([]contentFile, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("torrent: stat disc root %q: %w", root, err)
+	}
+	if !info.IsDir() {
+		return []contentFile{{path: filepath.Base(root), length: info.Size()}}, nil
+	}
+	paths := make([]contentFile, 0)
+	err = filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if os.IsNotExist(walkErr) {
+				return nil
+			}
+			return walkErr
+		}
+		if entry.IsDir() {
+			if path != root {
+				rel, err := filepath.Rel(root, path)
+				if err != nil {
+					return fmt.Errorf("disc relative path: %w", err)
+				}
+				if mkbrrIgnoredPath(rel, true) {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return fmt.Errorf("disc relative path: %w", err)
+		}
+		if mkbrrIgnoredPath(rel, false) {
+			return nil
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("disc file info: %w", err)
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		paths = append(paths, contentFile{path: filepath.ToSlash(rel), length: info.Size()})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("torrent: walk disc root %q: %w", root, err)
+	}
+	sortContentFiles(paths)
+	return paths, nil
+}
+
+func sameContentSet(left []contentFile, right []contentFile) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	leftCopy := append([]contentFile{}, left...)
+	rightCopy := append([]contentFile{}, right...)
+	sortContentFiles(leftCopy)
+	sortContentFiles(rightCopy)
+	for idx := range leftCopy {
+		if !strings.EqualFold(leftCopy[idx].path, rightCopy[idx].path) || leftCopy[idx].length != rightCopy[idx].length {
+			return false
+		}
+	}
+	return true
+}
+
+func sortContentFiles(files []contentFile) {
+	sort.Slice(files, func(left int, right int) bool {
+		leftPath := strings.ToLower(files[left].path)
+		rightPath := strings.ToLower(files[right].path)
+		if leftPath == rightPath {
+			return files[left].length < files[right].length
+		}
+		return leftPath < rightPath
+	})
 }
 
 func TempTorrentPath(tmpRoot string, meta api.PreparedMetadata, source string) (string, error) {

--- a/internal/torrent/service.go
+++ b/internal/torrent/service.go
@@ -11,11 +11,13 @@ import (
 	"io"
 	"math"
 	"os"
+	slashpath "path" //nolint:depguard // Formats torrent-internal slash-delimited metainfo paths.
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/anacrolix/torrent/merkle"
 	"github.com/anacrolix/torrent/metainfo"
 	mkbrr "github.com/autobrr/mkbrr/torrent"
 
@@ -345,13 +347,7 @@ func resolveCreateSpec(meta api.PreparedMetadata, source string, tmpRoot string)
 }
 
 func normalizeDiscSource(source string) string {
-	cleaned := filepath.Clean(source)
-	switch strings.ToUpper(filepath.Base(cleaned)) {
-	case "BDMV", "VIDEO_TS", "HVDVD_TS":
-		return filepath.Dir(cleaned)
-	default:
-		return source
-	}
+	return filepath.Clean(source)
 }
 
 func mkbrrIgnoredPath(rel string, isDir bool) bool {
@@ -395,12 +391,12 @@ func wantedFilesWithin(root string, files []string) ([]string, error) {
 		info, err := os.Stat(absFile)
 		if err != nil {
 			if os.IsNotExist(err) {
-				continue
+				return nil, fmt.Errorf("torrent: wanted file %q: %w", absFile, internalerrors.ErrNotFound)
 			}
 			return nil, fmt.Errorf("torrent: stat wanted file %q: %w", absFile, err)
 		}
 		if !info.Mode().IsRegular() {
-			continue
+			return nil, fmt.Errorf("torrent: wanted file %q is not a regular file", absFile)
 		}
 		cleanFile := filepath.Clean(absFile)
 		if _, ok := seen[cleanFile]; ok {
@@ -557,7 +553,7 @@ func validateTorrentContent(path string, meta api.PreparedMetadata) error {
 	if err != nil {
 		return fmt.Errorf("torrent: unmarshal candidate info: %w", err)
 	}
-	if nameOK && !strings.EqualFold(info.BestName(), expectedName) {
+	if nameOK && info.BestName() != expectedName {
 		return errors.New("torrent: candidate name mismatch")
 	}
 	actual := torrentContentPaths(info)
@@ -574,6 +570,14 @@ func validateTorrentContent(path string, meta api.PreparedMetadata) error {
 }
 
 func validateTorrentPieces(info metainfo.Info, meta api.PreparedMetadata) error {
+	if info.HasV2() {
+		if err := validateTorrentV2Pieces(info, meta); err != nil {
+			return err
+		}
+		if !info.HasV1() {
+			return nil
+		}
+	}
 	if info.PieceLength <= 0 || len(info.Pieces) == 0 {
 		return errors.New("torrent: candidate piece hashes unavailable")
 	}
@@ -587,6 +591,56 @@ func validateTorrentPieces(info metainfo.Info, meta api.PreparedMetadata) error 
 		return errors.New("torrent: candidate piece hash mismatch")
 	}
 	return nil
+}
+
+func validateTorrentV2Pieces(info metainfo.Info, meta api.PreparedMetadata) error {
+	if info.PieceLength <= 0 {
+		return errors.New("torrent: candidate v2 piece length unavailable")
+	}
+	for _, file := range info.UpvertedFiles() {
+		if file.Length == 0 && !file.PiecesRoot.Ok {
+			continue
+		}
+		if !file.PiecesRoot.Ok {
+			return errors.New("torrent: candidate v2 pieces root unavailable")
+		}
+		root, err := torrentV2FileRoot(meta, file)
+		if err != nil {
+			return err
+		}
+		if root != file.PiecesRoot.Value {
+			return errors.New("torrent: candidate v2 pieces root mismatch")
+		}
+	}
+	return nil
+}
+
+func torrentV2FileRoot(meta api.PreparedMetadata, file metainfo.FileInfo) ([32]byte, error) {
+	openedFile, err := openTorrentContentFile(meta, file)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	defer openedFile.Close()
+
+	hash := merkle.NewHash()
+	written, err := io.CopyN(hash, openedFile, file.Length)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("torrent: hash candidate v2 file %q: %w", torrentFilePath(file), err)
+	}
+	if written != file.Length {
+		return [32]byte{}, fmt.Errorf("torrent: hash candidate v2 file %q: expected %d bytes, got %d", torrentFilePath(file), file.Length, written)
+	}
+	var root [32]byte
+	copy(root[:], hash.Sum(nil))
+	return root, nil
+}
+
+func torrentFilePath(file metainfo.FileInfo) string {
+	parts := file.BestPath()
+	if len(parts) == 0 {
+		return ""
+	}
+	return slashpath.Join(parts...)
 }
 
 func openTorrentContentFile(meta api.PreparedMetadata, file metainfo.FileInfo) (io.ReadCloser, error) {
@@ -823,7 +877,7 @@ func sameContentSet(left []contentFile, right []contentFile) bool {
 	sortContentFiles(leftCopy)
 	sortContentFiles(rightCopy)
 	for idx := range leftCopy {
-		if !strings.EqualFold(leftCopy[idx].path, rightCopy[idx].path) || leftCopy[idx].length != rightCopy[idx].length {
+		if leftCopy[idx].path != rightCopy[idx].path || leftCopy[idx].length != rightCopy[idx].length {
 			return false
 		}
 	}
@@ -832,12 +886,10 @@ func sameContentSet(left []contentFile, right []contentFile) bool {
 
 func sortContentFiles(files []contentFile) {
 	sort.Slice(files, func(left int, right int) bool {
-		leftPath := strings.ToLower(files[left].path)
-		rightPath := strings.ToLower(files[right].path)
-		if leftPath == rightPath {
+		if files[left].path == files[right].path {
 			return files[left].length < files[right].length
 		}
-		return leftPath < rightPath
+		return files[left].path < files[right].path
 	})
 }
 

--- a/internal/torrent/service_test.go
+++ b/internal/torrent/service_test.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"errors"
 	"os"
+	slashpath "path" //nolint:depguard // Joins torrent-internal slash-delimited metainfo paths.
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -134,6 +136,155 @@ func TestCreateHonorsMaxPieceSizeOverride(t *testing.T) {
 	}
 	if info.PieceLength > 1<<20 {
 		t.Fatalf("expected piece length <= 1 MiB, got %d", info.PieceLength)
+	}
+}
+
+func TestCreateFolderWithSingleWantedVideoHashesFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sourceDir := filepath.Join(dir, "Movie.2026.1080p.WEB-DL-GRP")
+	video := filepath.Join(sourceDir, "Movie.2026.1080p.WEB-DL-GRP.mkv")
+	writeTestFile(t, video, "video")
+	writeTestFile(t, filepath.Join(sourceDir, "proof.jpg"), "proof")
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	result, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath: sourceDir,
+		VideoPath:  video,
+		FileList:   []string{video},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	name, files := loadTorrentShape(t, result.Path)
+	if name != filepath.Base(video) {
+		t.Fatalf("expected single-file torrent name %q, got %q", filepath.Base(video), name)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected single-file torrent file list to be empty, got %#v", files)
+	}
+}
+
+func TestCreateFolderPackUsesWantedFileList(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := filepath.Join(t.TempDir(), "Show.S01.1080p.WEB-DL-GRP")
+	episode1 := filepath.Join(sourceDir, "Show.S01E01.mkv")
+	episode2 := filepath.Join(sourceDir, "Show.S01E02.mkv")
+	writeTestFile(t, episode1, "episode 1")
+	writeTestFile(t, episode2, "episode 2")
+	writeTestFile(t, filepath.Join(sourceDir, "sample.mkv"), "sample")
+	writeTestFile(t, filepath.Join(sourceDir, "proof.jpg"), "proof")
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	result, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath: sourceDir,
+		VideoPath:  episode1,
+		FileList:   []string{episode1, episode2},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	name, files := loadTorrentShape(t, result.Path)
+	if name != filepath.Base(sourceDir) {
+		t.Fatalf("expected torrent root name %q, got %q", filepath.Base(sourceDir), name)
+	}
+	assertStringSliceEqual(t, files, []string{"Show.S01E01.mkv", "Show.S01E02.mkv"})
+}
+
+func TestCreateFolderPackEscapesWantedFilePatterns(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := filepath.Join(t.TempDir(), "Show.S01.1080p.WEB-DL-GRP")
+	episode1 := filepath.Join(sourceDir, "Show, [S01E01].mkv")
+	episode2 := filepath.Join(sourceDir, "Show.{S01E02}.mkv")
+	writeTestFile(t, episode1, "episode 1")
+	writeTestFile(t, episode2, "episode 2")
+	writeTestFile(t, filepath.Join(sourceDir, "Showx [S01E01].mkv"), "ambiguous extra")
+	writeTestFile(t, filepath.Join(sourceDir, "Show.S01E03.mkv"), "extra")
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	result, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath: sourceDir,
+		VideoPath:  episode1,
+		FileList:   []string{episode1, episode2},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	_, files := loadTorrentShape(t, result.Path)
+	assertStringSliceEqual(t, files, []string{"Show, [S01E01].mkv", "Show.{S01E02}.mkv"})
+}
+
+func TestCreateDiscFolderIgnoresWantedFileList(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := filepath.Join(t.TempDir(), "Movie.2026.COMPLETE.BLURAY-GRP")
+	stream := filepath.Join(sourceDir, "BDMV", "STREAM", "00001.m2ts")
+	writeTestFile(t, stream, "stream")
+	writeTestFile(t, filepath.Join(sourceDir, "BDMV", "PLAYLIST", "00001.mpls"), "playlist")
+	writeTestFile(t, filepath.Join(sourceDir, "CERTIFICATE", "id.bdmv"), "certificate")
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	result, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath: sourceDir,
+		DiscType:   "BDMV",
+		VideoPath:  stream,
+		FileList:   []string{stream},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	name, files := loadTorrentShape(t, result.Path)
+	if name != filepath.Base(sourceDir) {
+		t.Fatalf("expected torrent root name %q, got %q", filepath.Base(sourceDir), name)
+	}
+	assertStringSliceEqual(t, files, []string{
+		"BDMV/PLAYLIST/00001.mpls",
+		"BDMV/STREAM/00001.m2ts",
+		"CERTIFICATE/id.bdmv",
+	})
+}
+
+func TestCreateFolderSkipsMkbrrIgnoredFilesInValidation(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := filepath.Join(t.TempDir(), "Movie.2026.1080p.WEB-DL-GRP")
+	writeTestFile(t, filepath.Join(sourceDir, "Movie.2026.1080p.WEB-DL-GRP.mkv"), "video")
+	writeTestFile(t, filepath.Join(sourceDir, "desktop.ini"), "ignored")
+	writeTestFile(t, filepath.Join(sourceDir, ".ds_store"), "ignored")
+	writeTestFile(t, filepath.Join(sourceDir, "thumbs.db"), "ignored")
+	writeTestFile(t, filepath.Join(sourceDir, "sample.torrent"), "ignored")
+	writeTestFile(t, filepath.Join(sourceDir, "movie.mkv.zone.identifier"), "ignored")
+	writeTestFile(t, filepath.Join(sourceDir, "@eaDir", "metadata.bin"), "ignored")
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	result, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath: sourceDir,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	_, files := loadTorrentShape(t, result.Path)
+	assertStringSliceEqual(t, files, []string{"Movie.2026.1080p.WEB-DL-GRP.mkv"})
+}
+
+func TestSafeTorrentRootNameRejectsFilesystemRoot(t *testing.T) {
+	t.Parallel()
+
+	root := string(filepath.Separator)
+	if volume := filepath.VolumeName(t.TempDir()); volume != "" {
+		root = volume + string(filepath.Separator)
+	}
+
+	if _, err := safeTorrentRootName(root); err == nil {
+		t.Fatalf("expected filesystem root to be rejected")
 	}
 }
 
@@ -320,9 +471,8 @@ func TestCreatePrefersClientTorrentOverAssociatedTempTorrent(t *testing.T) {
 	}
 	createTestTorrent(t, source, tmpTorrentPath)
 
-	clientSource := filepath.Join(sourceDir, "client.bin")
 	clientTorrentPath := filepath.Join(sourceDir, "client.torrent")
-	createTestTorrent(t, clientSource, clientTorrentPath)
+	createTestTorrent(t, source, clientTorrentPath)
 
 	meta.ClientTorrentPath = clientTorrentPath
 	result, err := service.Create(context.Background(), meta)
@@ -334,6 +484,140 @@ func TestCreatePrefersClientTorrentOverAssociatedTempTorrent(t *testing.T) {
 	}
 	if result.InfoHash == "" {
 		t.Fatalf("expected info hash to be populated")
+	}
+}
+
+func TestCreateRejectsMismatchedClientTorrent(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	source := filepath.Join(sourceDir, "video.mkv")
+	writeTestFile(t, source, "source-data")
+
+	tmpRoot := t.TempDir()
+	service := NewService(api.NopLogger{}, tmpRoot)
+	meta := api.PreparedMetadata{SourcePath: source}
+
+	tmpTorrentPath, err := TempTorrentPath(tmpRoot, meta, source)
+	if err != nil {
+		t.Fatalf("temp torrent path: %v", err)
+	}
+	createTestTorrent(t, source, tmpTorrentPath)
+
+	clientSource := filepath.Join(sourceDir, "client.bin")
+	clientTorrentPath := filepath.Join(sourceDir, "client.torrent")
+	createTestTorrent(t, clientSource, clientTorrentPath)
+
+	meta.ClientTorrentPath = clientTorrentPath
+	result, err := service.Create(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Path != tmpTorrentPath {
+		t.Fatalf("expected mismatched client torrent to be skipped for temp torrent %s, got %s", tmpTorrentPath, result.Path)
+	}
+}
+
+func TestCreateRejectsSameNameDifferentSizeClientTorrent(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	source := filepath.Join(sourceDir, "video.mkv")
+	writeTestFile(t, source, "source-data")
+
+	clientDir := filepath.Join(sourceDir, "client")
+	clientSource := filepath.Join(clientDir, "video.mkv")
+	writeTestFile(t, clientSource, "different-size-source-data")
+	clientTorrentPath := filepath.Join(sourceDir, "client.torrent")
+	createTestTorrentFromExisting(t, clientSource, clientTorrentPath)
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	result, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath:        source,
+		ClientTorrentPath: clientTorrentPath,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Path == clientTorrentPath {
+		t.Fatalf("expected same-name different-size client torrent to be skipped")
+	}
+}
+
+func TestCreateRejectsSameNameSameSizeDifferentContentClientTorrent(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	source := filepath.Join(sourceDir, "video.mkv")
+	writeTestFile(t, source, "source-data")
+
+	clientDir := filepath.Join(sourceDir, "client")
+	clientSource := filepath.Join(clientDir, "video.mkv")
+	writeTestFile(t, clientSource, "source-evil")
+	clientTorrentPath := filepath.Join(sourceDir, "client.torrent")
+	createTestTorrentFromExisting(t, clientSource, clientTorrentPath)
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	result, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath:        source,
+		ClientTorrentPath: clientTorrentPath,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Path == clientTorrentPath {
+		t.Fatalf("expected same-name same-size different-content client torrent to be skipped")
+	}
+}
+
+func TestCreateRejectsDifferentRootClientTorrent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sourceDir := filepath.Join(dir, "Show.S01.1080p.WEB-DL-GRP")
+	episode1 := filepath.Join(sourceDir, "Show.S01E01.mkv")
+	episode2 := filepath.Join(sourceDir, "Show.S01E02.mkv")
+	writeTestFile(t, episode1, "episode 1")
+	writeTestFile(t, episode2, "episode 2")
+
+	clientDir := filepath.Join(dir, "Other.Show.S01.1080p.WEB-DL-GRP")
+	writeTestFile(t, filepath.Join(clientDir, "Show.S01E01.mkv"), "episode 1")
+	writeTestFile(t, filepath.Join(clientDir, "Show.S01E02.mkv"), "episode 2")
+	clientTorrentPath := filepath.Join(dir, "client.torrent")
+	createTestTorrentFromExisting(t, clientDir, clientTorrentPath)
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	result, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath:        sourceDir,
+		VideoPath:         episode1,
+		FileList:          []string{episode1, episode2},
+		ClientTorrentPath: clientTorrentPath,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Path == clientTorrentPath {
+		t.Fatalf("expected different-root client torrent to be skipped")
+	}
+}
+
+func TestCreateRejectsWantedFileOutsideRoot(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := filepath.Join(t.TempDir(), "Movie.2026.1080p.WEB-DL-GRP")
+	video := filepath.Join(sourceDir, "Movie.2026.1080p.WEB-DL-GRP.mkv")
+	writeTestFile(t, video, "video")
+	outside := filepath.Join(t.TempDir(), "outside.mkv")
+	writeTestFile(t, outside, "outside")
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	_, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath: sourceDir,
+		VideoPath:  video,
+		FileList:   []string{outside},
+	})
+	if err == nil {
+		t.Fatalf("expected outside wanted file to be rejected")
 	}
 }
 
@@ -498,6 +782,58 @@ func createTestTorrent(t *testing.T, sourcePath, torrentPath string) {
 	})
 	if err != nil {
 		t.Fatalf("create torrent: %v", err)
+	}
+}
+
+func createTestTorrentFromExisting(t *testing.T, sourcePath, torrentPath string) {
+	t.Helper()
+
+	_, err := mkbrr.Create(mkbrr.CreateOptions{
+		Path:       sourcePath,
+		OutputPath: torrentPath,
+		IsPrivate:  true,
+	})
+	if err != nil {
+		t.Fatalf("create torrent: %v", err)
+	}
+}
+
+func writeTestFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("make parent dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func loadTorrentShape(t *testing.T, torrentPath string) (string, []string) {
+	t.Helper()
+
+	torrentMeta, err := metainfo.LoadFromFile(torrentPath)
+	if err != nil {
+		t.Fatalf("load torrent: %v", err)
+	}
+	info, err := torrentMeta.UnmarshalInfo()
+	if err != nil {
+		t.Fatalf("unmarshal info: %v", err)
+	}
+	files := make([]string, 0, len(info.Files))
+	for _, file := range info.Files {
+		//pathpolicy:allow torrent metainfo paths are slash-delimited data
+		files = append(files, slashpath.Join(file.BestPath()...))
+	}
+	slices.Sort(files)
+	return info.BestName(), files
+}
+
+func assertStringSliceEqual(t *testing.T, got []string, want []string) {
+	t.Helper()
+
+	if !slices.Equal(got, want) {
+		t.Fatalf("unexpected torrent files:\nwant %#v\ngot  %#v", want, got)
 	}
 }
 

--- a/internal/torrent/service_test.go
+++ b/internal/torrent/service_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/merkle"
 	"github.com/anacrolix/torrent/metainfo"
 	mkbrr "github.com/autobrr/mkbrr/torrent"
 
@@ -195,6 +197,44 @@ func TestCreateFolderPackUsesWantedFileList(t *testing.T) {
 	assertStringSliceEqual(t, files, []string{"Show.S01E01.mkv", "Show.S01E02.mkv"})
 }
 
+func TestCreateFolderPackRejectsMissingWantedFile(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := filepath.Join(t.TempDir(), "Show.S01.1080p.WEB-DL-GRP")
+	episode1 := filepath.Join(sourceDir, "Show.S01E01.mkv")
+	missing := filepath.Join(sourceDir, "Show.S01E02.mkv")
+	writeTestFile(t, episode1, "episode 1")
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	_, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath: sourceDir,
+		VideoPath:  episode1,
+		FileList:   []string{missing},
+	})
+	if !errors.Is(err, internalerrors.ErrNotFound) {
+		t.Fatalf("expected missing wanted file to fail with not found, got %v", err)
+	}
+}
+
+func TestCreateFolderPackRejectsPartialMissingWantedFile(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := filepath.Join(t.TempDir(), "Show.S01.1080p.WEB-DL-GRP")
+	episode1 := filepath.Join(sourceDir, "Show.S01E01.mkv")
+	missing := filepath.Join(sourceDir, "Show.S01E02.mkv")
+	writeTestFile(t, episode1, "episode 1")
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	_, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath: sourceDir,
+		VideoPath:  episode1,
+		FileList:   []string{episode1, missing},
+	})
+	if !errors.Is(err, internalerrors.ErrNotFound) {
+		t.Fatalf("expected partial missing wanted file to fail with not found, got %v", err)
+	}
+}
+
 func TestCreateFolderPackEscapesWantedFilePatterns(t *testing.T) {
 	t.Parallel()
 
@@ -249,6 +289,76 @@ func TestCreateDiscFolderIgnoresWantedFileList(t *testing.T) {
 		"BDMV/STREAM/00001.m2ts",
 		"CERTIFICATE/id.bdmv",
 	})
+}
+
+func TestCreateDiscMarkerFolderUsesSelectedRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		discType string
+		files    []string
+	}{
+		{
+			name:     "BDMV",
+			discType: "BDMV",
+			files: []string{
+				filepath.Join("PLAYLIST", "00001.mpls"),
+				filepath.Join("STREAM", "00001.m2ts"),
+			},
+		},
+		{
+			name:     "VIDEO_TS",
+			discType: "VIDEO_TS",
+			files: []string{
+				"VIDEO_TS.IFO",
+				"VTS_01_1.VOB",
+			},
+		},
+		{
+			name:     "HVDVD_TS",
+			discType: "HVDVD_TS",
+			files: []string{
+				"HVA00001.EVO",
+				"HVDVD_TS.IFO",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			parent := filepath.Join(t.TempDir(), "Movie.2026.COMPLETE.DISC-GRP")
+			sourceDir := filepath.Join(parent, tt.name)
+			for _, rel := range tt.files {
+				writeTestFile(t, filepath.Join(sourceDir, rel), "disc data")
+			}
+			writeTestFile(t, filepath.Join(parent, "SIBLING", "extra.bin"), "sibling")
+			writeTestFile(t, filepath.Join(parent, "outside.txt"), "outside")
+
+			service := NewService(api.NopLogger{}, t.TempDir())
+			result, err := service.Create(context.Background(), api.PreparedMetadata{
+				SourcePath: sourceDir,
+				DiscType:   tt.discType,
+				VideoPath:  filepath.Join(sourceDir, tt.files[0]),
+				FileList:   []string{filepath.Join(sourceDir, tt.files[0])},
+			})
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			name, files := loadTorrentShape(t, result.Path)
+			if name != tt.name {
+				t.Fatalf("expected torrent root name %q, got %q", tt.name, name)
+			}
+			expected := make([]string, 0, len(tt.files))
+			for _, rel := range tt.files {
+				expected = append(expected, filepath.ToSlash(rel))
+			}
+			assertStringSliceEqual(t, files, expected)
+		})
+	}
 }
 
 func TestCreateFolderSkipsMkbrrIgnoredFilesInValidation(t *testing.T) {
@@ -307,6 +417,181 @@ func TestCreateNoHashRequiresReusableTorrent(t *testing.T) {
 	})
 	if !errors.Is(err, internalerrors.ErrNotFound) {
 		t.Fatalf("expected nohash to fail without reusable torrent, got %v", err)
+	}
+}
+
+func TestCreateNoHashReusesExactCaseClientTorrent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "Video.mkv")
+	writeTestFile(t, source, "source-data")
+
+	clientTorrentPath := filepath.Join(dir, "client.torrent")
+	createTestTorrentFromExisting(t, source, clientTorrentPath)
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	reuseOnly := true
+	result, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath:        source,
+		ClientTorrentPath: clientTorrentPath,
+		TorrentOverrides: api.TorrentOverrides{
+			NoHash: &reuseOnly,
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Path != clientTorrentPath {
+		t.Fatalf("expected exact-case client torrent path %s, got %s", clientTorrentPath, result.Path)
+	}
+}
+
+func TestCreateNoHashRejectsCaseOnlySingleFileClientTorrent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "Video.mkv")
+	writeTestFile(t, source, "source-data")
+
+	clientDir := filepath.Join(dir, "client")
+	clientSource := filepath.Join(clientDir, "video.mkv")
+	writeTestFile(t, clientSource, "source-data")
+	clientTorrentPath := filepath.Join(dir, "client.torrent")
+	createTestTorrentFromExisting(t, clientSource, clientTorrentPath)
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	reuseOnly := true
+	_, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath:        source,
+		ClientTorrentPath: clientTorrentPath,
+		TorrentOverrides: api.TorrentOverrides{
+			NoHash: &reuseOnly,
+		},
+	})
+	if !errors.Is(err, internalerrors.ErrNotFound) {
+		t.Fatalf("expected nohash to reject case-only single-file mismatch, got %v", err)
+	}
+}
+
+func TestCreateNoHashRejectsCaseOnlyMultiFileClientTorrent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sourceDir := filepath.Join(dir, "Show.S01.1080p.WEB-DL-GRP")
+	episode1 := filepath.Join(sourceDir, "Show.S01E01.mkv")
+	episode2 := filepath.Join(sourceDir, "Show.S01E02.mkv")
+	writeTestFile(t, episode1, "episode 1")
+	writeTestFile(t, episode2, "episode 2")
+	if caseSensitiveFilesystem(t, dir) {
+		writeTestFile(t, filepath.Join(sourceDir, "show.s01e01.mkv"), "episode 1")
+		writeTestFile(t, filepath.Join(sourceDir, "show.s01e02.mkv"), "episode 2")
+	}
+
+	clientDir := filepath.Join(dir, "client", filepath.Base(sourceDir))
+	writeTestFile(t, filepath.Join(clientDir, "show.s01e01.mkv"), "episode 1")
+	writeTestFile(t, filepath.Join(clientDir, "show.s01e02.mkv"), "episode 2")
+	clientTorrentPath := filepath.Join(dir, "client.torrent")
+	createTestTorrentFromExisting(t, clientDir, clientTorrentPath)
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	reuseOnly := true
+	_, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath:        sourceDir,
+		VideoPath:         episode1,
+		FileList:          []string{episode1, episode2},
+		ClientTorrentPath: clientTorrentPath,
+		TorrentOverrides: api.TorrentOverrides{
+			NoHash: &reuseOnly,
+		},
+	})
+	if !errors.Is(err, internalerrors.ErrNotFound) {
+		t.Fatalf("expected nohash to reject case-only multi-file mismatch, got %v", err)
+	}
+}
+
+func TestCreateNoHashReusesPureV2ClientTorrent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "video.mkv")
+	content := []byte("source-data")
+	if err := os.WriteFile(source, content, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	clientTorrentPath := filepath.Join(dir, "client.torrent")
+	createPureV2TestTorrent(t, source, content, clientTorrentPath)
+	if err := validateTorrentContent(clientTorrentPath, api.PreparedMetadata{SourcePath: source}); err != nil {
+		t.Fatalf("expected pure v2 torrent to validate, got %v", err)
+	}
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	reuseOnly := true
+	result, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath:        source,
+		ClientTorrentPath: clientTorrentPath,
+		TorrentOverrides: api.TorrentOverrides{
+			NoHash: &reuseOnly,
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Path != clientTorrentPath {
+		t.Fatalf("expected pure v2 client torrent path %s, got %s", clientTorrentPath, result.Path)
+	}
+}
+
+func TestCreateNoHashRejectsPureV2SameNameSameSizeDifferentContent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "video.mkv")
+	sourceContent := []byte("source-data")
+	if err := os.WriteFile(source, sourceContent, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	clientTorrentPath := filepath.Join(dir, "client.torrent")
+	createPureV2TestTorrent(t, source, []byte("source-evil"), clientTorrentPath)
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	reuseOnly := true
+	_, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath:        source,
+		ClientTorrentPath: clientTorrentPath,
+		TorrentOverrides: api.TorrentOverrides{
+			NoHash: &reuseOnly,
+		},
+	})
+	if !errors.Is(err, internalerrors.ErrNotFound) {
+		t.Fatalf("expected nohash to reject mismatched pure v2 torrent, got %v", err)
+	}
+}
+
+func TestCreateNoHashRejectsMismatchedReusableTorrent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "video.mkv")
+	writeTestFile(t, source, "source-data")
+
+	clientDir := filepath.Join(dir, "client")
+	clientSource := filepath.Join(clientDir, "video.mkv")
+	writeTestFile(t, clientSource, "source-evil")
+	clientTorrentPath := filepath.Join(dir, "client.torrent")
+	createTestTorrentFromExisting(t, clientSource, clientTorrentPath)
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	reuseOnly := true
+	_, err := service.Create(context.Background(), api.PreparedMetadata{
+		SourcePath:        source,
+		ClientTorrentPath: clientTorrentPath,
+		TorrentOverrides: api.TorrentOverrides{
+			NoHash: &reuseOnly,
+		},
+	})
+	if !errors.Is(err, internalerrors.ErrNotFound) {
+		t.Fatalf("expected nohash to reject mismatched reusable torrent, got %v", err)
 	}
 }
 
@@ -798,6 +1083,44 @@ func createTestTorrentFromExisting(t *testing.T, sourcePath, torrentPath string)
 	}
 }
 
+func createPureV2TestTorrent(t *testing.T, sourcePath string, content []byte, torrentPath string) {
+	t.Helper()
+
+	hash := merkle.NewHash()
+	if _, err := hash.Write(content); err != nil {
+		t.Fatalf("hash v2 content: %v", err)
+	}
+	piecesRoot := string(hash.Sum(nil))
+	info := metainfo.Info{
+		PieceLength: 1 << 14,
+		Name:        filepath.Base(sourcePath),
+		MetaVersion: 2,
+		FileTree: metainfo.FileTree{
+			File: metainfo.FileTreeFile{
+				Length:     int64(len(content)),
+				PiecesRoot: piecesRoot,
+			},
+		},
+	}
+	infoBytes, err := bencode.Marshal(&info)
+	if err != nil {
+		t.Fatalf("marshal v2 info: %v", err)
+	}
+	meta := metainfo.MetaInfo{InfoBytes: infoBytes}
+	meta.SetDefaults()
+	file, err := os.Create(torrentPath)
+	if err != nil {
+		t.Fatalf("create v2 torrent: %v", err)
+	}
+	if err := meta.Write(file); err != nil {
+		_ = file.Close()
+		t.Fatalf("write v2 torrent: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close v2 torrent: %v", err)
+	}
+}
+
 func writeTestFile(t *testing.T, path string, content string) {
 	t.Helper()
 
@@ -807,6 +1130,30 @@ func writeTestFile(t *testing.T, path string, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write file: %v", err)
 	}
+}
+
+func caseSensitiveFilesystem(t *testing.T, dir string) bool {
+	t.Helper()
+
+	probe := filepath.Join(dir, "CaseProbe")
+	if err := os.WriteFile(probe, []byte("probe"), 0o600); err != nil {
+		t.Fatalf("write case probe: %v", err)
+	}
+	defer func() {
+		if err := os.Remove(probe); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("remove case probe: %v", err)
+		}
+	}()
+
+	_, err := os.Stat(filepath.Join(dir, "caseprobe"))
+	if err == nil {
+		return false
+	}
+	if os.IsNotExist(err) {
+		return true
+	}
+	t.Fatalf("stat case probe: %v", err)
+	return false
 }
 
 func loadTorrentShape(t *testing.T, torrentPath string) (string, []string) {

--- a/internal/trackers/impl/ptp/definition_test.go
+++ b/internal/trackers/impl/ptp/definition_test.go
@@ -4,8 +4,10 @@
 package ptp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
@@ -14,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/anacrolix/torrent/metainfo"
 	mkbrr "github.com/autobrr/mkbrr/torrent"
 
 	"github.com/autobrr/upbrr/internal/config"
@@ -135,6 +138,7 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 	dbPath := filepath.Join(tmp, "ua.db")
 	torrentPath := filepath.Join(tmp, "release.torrent")
 	createTestTorrent(t, filepath.Join(tmp, "source.bin"), torrentPath)
+	markTorrentWithPrivateMetadata(t, torrentPath)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.RequestURI() {
@@ -155,6 +159,29 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 			case ptpUploadPath:
 				if err := r.ParseMultipartForm(5 << 20); err != nil {
 					t.Fatalf("parse multipart: %v", err)
+				}
+				files := r.MultipartForm.File["file_input"]
+				if len(files) != 1 {
+					t.Fatalf("expected one torrent file, got %d", len(files))
+				}
+				uploaded, err := files[0].Open()
+				if err != nil {
+					t.Fatalf("open uploaded torrent: %v", err)
+				}
+				defer uploaded.Close()
+				payload, err := io.ReadAll(uploaded)
+				if err != nil {
+					t.Fatalf("read uploaded torrent: %v", err)
+				}
+				uploadedMeta, err := metainfo.Load(bytes.NewReader(payload))
+				if err != nil {
+					t.Fatalf("load uploaded torrent: %v", err)
+				}
+				if uploadedMeta.Comment != "upbrr" {
+					t.Fatalf("expected cleaned upload torrent comment, got %q", uploadedMeta.Comment)
+				}
+				if uploadedMeta.Announce != "" {
+					t.Fatalf("expected upload torrent announce stripped, got %q", uploadedMeta.Announce)
 				}
 				if r.FormValue("AntiCsrfToken") != "csrf-token" {
 					t.Fatalf("expected csrf token, got %q", r.FormValue("AntiCsrfToken"))
@@ -372,5 +399,24 @@ func createTestTorrent(t *testing.T, sourcePath string, torrentPath string) {
 	})
 	if err != nil {
 		t.Fatalf("create torrent: %v", err)
+	}
+}
+
+func markTorrentWithPrivateMetadata(t *testing.T, torrentPath string) {
+	t.Helper()
+
+	torrentMeta, err := metainfo.LoadFromFile(torrentPath)
+	if err != nil {
+		t.Fatalf("load torrent: %v", err)
+	}
+	torrentMeta.Announce = "https://private.example/passkey/announce"
+	torrentMeta.Comment = "Created by Upload Assistant https://private.example/download/1"
+	file, err := os.Create(torrentPath)
+	if err != nil {
+		t.Fatalf("rewrite torrent: %v", err)
+	}
+	defer file.Close()
+	if err := torrentMeta.Write(file); err != nil {
+		t.Fatalf("write torrent: %v", err)
 	}
 }

--- a/internal/trackers/impl/ptp/upload.go
+++ b/internal/trackers/impl/ptp/upload.go
@@ -29,9 +29,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/anacrolix/torrent/bencode"
-	"github.com/anacrolix/torrent/metainfo"
-
 	"github.com/autobrr/upbrr/internal/config"
 	cookiepkg "github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
@@ -120,8 +117,8 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		if err != nil {
 			return api.UploadSummary{}, err
 		}
-		if err := writeTrackerTorrent(state.torrentPath, trackerTorrentPath, state.announceURL, torrentURL, "PTP"); err != nil {
-			return api.UploadSummary{}, err
+		if err := trackers.WritePersonalizedTorrent(state.torrentPath, trackerTorrentPath, state.announceURL, torrentURL, "PTP"); err != nil {
+			return api.UploadSummary{}, fmt.Errorf("trackers: PTP write torrent artifact: %w", err)
 		}
 		return api.UploadSummary{
 			Uploaded: 1,
@@ -188,9 +185,9 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest, dryRun 
 		baseURL = ptpBaseURL
 	}
 	announceURL := normalizedAnnounceURL(req.TrackerConfig.AnnounceURL)
-	torrentPath, err := resolveTorrentPath(req.Meta, req.AppConfig.MainSettings.DBPath)
+	torrentPath, err := trackers.ResolveUploadTorrentPath(req.Meta, req.AppConfig.MainSettings.DBPath)
 	if err != nil {
-		return uploadState{}, err
+		return uploadState{}, fmt.Errorf("trackers: PTP resolve upload torrent: %w", err)
 	}
 	assets, err := trackers.ResolveDescriptionAssets(ctx, req.Tracker, req.Meta, req.Repo, req.Logger)
 	if err != nil {
@@ -858,30 +855,6 @@ func buildMultipartPayload(fields map[string]string, torrentPath string, fileFie
 	return body.Bytes(), writer.FormDataContentType(), nil
 }
 
-func resolveTorrentPath(meta api.PreparedMetadata, dbPath string) (string, error) {
-	for _, candidate := range []string{strings.TrimSpace(meta.TorrentPath), strings.TrimSpace(meta.ClientTorrentPath)} {
-		if candidate == "" || !strings.EqualFold(filepath.Ext(candidate), ".torrent") {
-			continue
-		}
-		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
-			return candidate, nil
-		}
-	}
-	if strings.TrimSpace(dbPath) != "" && strings.TrimSpace(meta.SourcePath) != "" {
-		tmpRoot, err := db.Subdir(dbPath, "tmp")
-		if err == nil {
-			tmpDir, base, err := paths.ReleaseTempDir(tmpRoot, meta, meta.SourcePath)
-			if err == nil {
-				guessed := filepath.Join(tmpDir, base+".torrent")
-				if info, err := os.Stat(guessed); err == nil && !info.IsDir() {
-					return guessed, nil
-				}
-			}
-		}
-	}
-	return "", errors.New("trackers: PTP torrent file not found")
-}
-
 func resolveTrackerTorrentPath(meta api.PreparedMetadata, dbPath string, tracker string) (string, error) {
 	if strings.TrimSpace(dbPath) == "" || strings.TrimSpace(meta.SourcePath) == "" {
 		return "", errors.New("trackers: PTP tracker torrent path requires db path and source path")
@@ -910,40 +883,6 @@ func resolveFailurePath(meta api.PreparedMetadata, dbPath string) (string, error
 		return "", fmt.Errorf("trackers: %w", err)
 	}
 	return filepath.Join(tmpDir, "[PTP]upload_failure.html"), nil
-}
-
-func writeTrackerTorrent(sourcePath string, outputPath string, announceURL string, comment string, source string) error {
-	torrentMeta, err := metainfo.LoadFromFile(sourcePath)
-	if err != nil {
-		return fmt.Errorf("trackers: PTP load torrent: %w", err)
-	}
-	info, err := torrentMeta.UnmarshalInfo()
-	if err != nil {
-		return fmt.Errorf("trackers: PTP unmarshal torrent info: %w", err)
-	}
-	info.Source = source
-	infoBytes, err := bencode.Marshal(info)
-	if err != nil {
-		return fmt.Errorf("trackers: PTP marshal torrent info: %w", err)
-	}
-	torrentMeta.InfoBytes = infoBytes
-	if strings.TrimSpace(announceURL) != "" {
-		torrentMeta.Announce = announceURL
-		torrentMeta.AnnounceList = metainfo.AnnounceList{{announceURL}}
-	}
-	torrentMeta.Comment = strings.TrimSpace(comment)
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0o700); err != nil {
-		return fmt.Errorf("trackers: PTP create torrent output dir: %w", err)
-	}
-	file, err := os.Create(outputPath)
-	if err != nil {
-		return fmt.Errorf("trackers: PTP create torrent output: %w", err)
-	}
-	defer file.Close()
-	if err := torrentMeta.Write(file); err != nil {
-		return fmt.Errorf("trackers: PTP write torrent: %w", err)
-	}
-	return nil
 }
 
 func loadCookies(ctx context.Context, dbPath string) (map[string]string, error) {

--- a/internal/trackers/upload_artifact.go
+++ b/internal/trackers/upload_artifact.go
@@ -111,6 +111,9 @@ func WriteUploadTorrent(sourcePath string, outputPath string) error {
 		return fmt.Errorf("trackers: load upload torrent: %w: %w", errInvalidUploadTorrent, err)
 	}
 	cleanTorrentMeta(torrentMeta)
+	if err := rewriteTorrentInfoSource(torrentMeta, "", "upload torrent"); err != nil {
+		return err
+	}
 	return writeTorrentMeta(*torrentMeta, outputPath, "upload torrent")
 }
 
@@ -121,16 +124,9 @@ func WritePersonalizedTorrent(sourcePath string, outputPath string, announceURL 
 	}
 	cleanTorrentMeta(torrentMeta)
 
-	info, err := torrentMeta.UnmarshalInfo()
-	if err != nil {
-		return fmt.Errorf("trackers: unmarshal torrent artifact info: %w", err)
+	if err := rewriteTorrentInfoSource(torrentMeta, source, "torrent artifact"); err != nil {
+		return err
 	}
-	info.Source = source
-	infoBytes, err := bencode.Marshal(info)
-	if err != nil {
-		return fmt.Errorf("trackers: marshal torrent artifact info: %w", err)
-	}
-	torrentMeta.InfoBytes = infoBytes
 
 	if trimmedAnnounce := strings.TrimSpace(announceURL); trimmedAnnounce != "" {
 		torrentMeta.Announce = trimmedAnnounce
@@ -144,11 +140,24 @@ func WritePersonalizedTorrent(sourcePath string, outputPath string, announceURL 
 	return writeTorrentMeta(*torrentMeta, outputPath, "torrent artifact")
 }
 
+func rewriteTorrentInfoSource(torrentMeta *metainfo.MetaInfo, source string, context string) error {
+	info, err := torrentMeta.UnmarshalInfo()
+	if err != nil {
+		return fmt.Errorf("trackers: unmarshal %s info: %w", context, err)
+	}
+	info.Source = strings.TrimSpace(source)
+	infoBytes, err := bencode.Marshal(info)
+	if err != nil {
+		return fmt.Errorf("trackers: marshal %s info: %w", context, err)
+	}
+	torrentMeta.InfoBytes = infoBytes
+	return nil
+}
+
 func cleanTorrentMeta(torrentMeta *metainfo.MetaInfo) {
 	torrentMeta.Announce = ""
 	torrentMeta.AnnounceList = nil
 	torrentMeta.Nodes = nil
-	torrentMeta.PieceLayers = nil
 	torrentMeta.UrlList = nil
 	torrentMeta.Comment = "upbrr"
 	if strings.Contains(strings.ToLower(torrentMeta.CreatedBy), "upload assistant") {
@@ -157,17 +166,86 @@ func cleanTorrentMeta(torrentMeta *metainfo.MetaInfo) {
 }
 
 func writeTorrentMeta(torrentMeta metainfo.MetaInfo, outputPath string, context string) error {
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0o700); err != nil {
+	dir := filepath.Dir(outputPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("trackers: create %s dir: %w", context, err)
 	}
-	file, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	file, err := os.CreateTemp(dir, filepath.Base(outputPath)+".tmp-*")
 	if err != nil {
-		return fmt.Errorf("trackers: create %s: %w", context, err)
+		return fmt.Errorf("trackers: create temp %s: %w", context, err)
 	}
-	defer file.Close()
+	tmpPath := file.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
 
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("trackers: chmod temp %s: %w", context, err)
+	}
 	if err := torrentMeta.Write(file); err != nil {
+		_ = file.Close()
 		return fmt.Errorf("trackers: write %s: %w", context, err)
 	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("trackers: close temp %s: %w", context, err)
+	}
+	if err := replaceStagedTorrent(tmpPath, outputPath); err != nil {
+		return fmt.Errorf("trackers: replace %s: %w", context, err)
+	}
+	removeTemp = false
 	return nil
+}
+
+func replaceStagedTorrent(tmpPath string, outputPath string) error {
+	info, err := os.Stat(outputPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if renameErr := os.Rename(tmpPath, outputPath); renameErr != nil {
+				return fmt.Errorf("rename staged torrent into place: %w", renameErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("stat output torrent: %w", err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s is a directory", outputPath)
+	}
+
+	backupPath, err := reserveTorrentBackupPath(filepath.Dir(outputPath), filepath.Base(outputPath)+".backup-*")
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(outputPath, backupPath); err != nil {
+		_ = os.Remove(backupPath)
+		return fmt.Errorf("backup existing torrent: %w", err)
+	}
+	if err := os.Rename(tmpPath, outputPath); err != nil {
+		restoreErr := os.Rename(backupPath, outputPath)
+		if restoreErr != nil {
+			return errors.Join(err, fmt.Errorf("restore original torrent: %w", restoreErr))
+		}
+		return fmt.Errorf("replace existing torrent: %w", err)
+	}
+	if err := os.Remove(backupPath); err != nil {
+		return fmt.Errorf("remove replaced torrent backup: %w", err)
+	}
+	return nil
+}
+
+func reserveTorrentBackupPath(dir string, pattern string) (string, error) {
+	file, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", fmt.Errorf("create temp torrent backup marker: %w", err)
+	}
+	path := file.Name()
+	closeErr := file.Close()
+	removeErr := os.Remove(path)
+	if closeErr != nil || removeErr != nil {
+		return "", errors.Join(closeErr, removeErr)
+	}
+	return path, nil
 }

--- a/internal/trackers/upload_artifact.go
+++ b/internal/trackers/upload_artifact.go
@@ -41,6 +41,7 @@ func ResolveTrackerTorrentArtifactPath(meta api.PreparedMetadata, dbPath string,
 }
 
 func ResolveUploadTorrentPath(meta api.PreparedMetadata, dbPath string) (string, error) {
+	cleanPath, cleanPathOK := uploadTorrentCleanPath(meta, dbPath)
 	candidates := []string{
 		strings.TrimSpace(meta.TorrentPath),
 		strings.TrimSpace(meta.ClientTorrentPath),
@@ -51,6 +52,15 @@ func ResolveUploadTorrentPath(meta api.PreparedMetadata, dbPath string) (string,
 			continue
 		}
 		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			if cleanPathOK {
+				err := WriteUploadTorrent(candidate, cleanPath)
+				if err == nil {
+					return cleanPath, nil
+				}
+				if !isUploadTorrentLoadError(err) {
+					return "", err
+				}
+			}
 			return candidate, nil
 		}
 	}
@@ -62,6 +72,9 @@ func ResolveUploadTorrentPath(meta api.PreparedMetadata, dbPath string) (string,
 			if err == nil {
 				guessed := filepath.Join(tmpDir, base+".torrent")
 				if info, err := os.Stat(guessed); err == nil && !info.IsDir() {
+					if err := WriteUploadTorrent(guessed, guessed); err != nil && !isUploadTorrentLoadError(err) {
+						return "", err
+					}
 					return guessed, nil
 				}
 			}
@@ -71,11 +84,42 @@ func ResolveUploadTorrentPath(meta api.PreparedMetadata, dbPath string) (string,
 	return "", errors.New("trackers: torrent file not found")
 }
 
+func uploadTorrentCleanPath(meta api.PreparedMetadata, dbPath string) (string, bool) {
+	if strings.TrimSpace(dbPath) == "" || strings.TrimSpace(meta.SourcePath) == "" {
+		return "", false
+	}
+	tmpRoot, err := db.Subdir(dbPath, "tmp")
+	if err != nil {
+		return "", false
+	}
+	tmpDir, base, err := paths.ReleaseTempDir(tmpRoot, meta, meta.SourcePath)
+	if err != nil {
+		return "", false
+	}
+	return filepath.Join(tmpDir, base+".torrent"), true
+}
+
+func isUploadTorrentLoadError(err error) bool {
+	return errors.Is(err, errInvalidUploadTorrent)
+}
+
+var errInvalidUploadTorrent = errors.New("invalid upload torrent")
+
+func WriteUploadTorrent(sourcePath string, outputPath string) error {
+	torrentMeta, err := metainfo.LoadFromFile(sourcePath)
+	if err != nil {
+		return fmt.Errorf("trackers: load upload torrent: %w: %w", errInvalidUploadTorrent, err)
+	}
+	cleanTorrentMeta(torrentMeta)
+	return writeTorrentMeta(*torrentMeta, outputPath, "upload torrent")
+}
+
 func WritePersonalizedTorrent(sourcePath string, outputPath string, announceURL string, comment string, source string) error {
 	torrentMeta, err := metainfo.LoadFromFile(sourcePath)
 	if err != nil {
 		return fmt.Errorf("trackers: load torrent artifact: %w", err)
 	}
+	cleanTorrentMeta(torrentMeta)
 
 	info, err := torrentMeta.UnmarshalInfo()
 	if err != nil {
@@ -92,19 +136,38 @@ func WritePersonalizedTorrent(sourcePath string, outputPath string, announceURL 
 		torrentMeta.Announce = trimmedAnnounce
 		torrentMeta.AnnounceList = metainfo.AnnounceList{{trimmedAnnounce}}
 	}
-	torrentMeta.Comment = strings.TrimSpace(comment)
-
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0o700); err != nil {
-		return fmt.Errorf("trackers: create torrent artifact dir: %w", err)
+	torrentMeta.Comment = "upbrr"
+	if trimmedComment := strings.TrimSpace(comment); trimmedComment != "" {
+		torrentMeta.Comment = trimmedComment
 	}
-	file, err := os.Create(outputPath)
+
+	return writeTorrentMeta(*torrentMeta, outputPath, "torrent artifact")
+}
+
+func cleanTorrentMeta(torrentMeta *metainfo.MetaInfo) {
+	torrentMeta.Announce = ""
+	torrentMeta.AnnounceList = nil
+	torrentMeta.Nodes = nil
+	torrentMeta.PieceLayers = nil
+	torrentMeta.UrlList = nil
+	torrentMeta.Comment = "upbrr"
+	if strings.Contains(strings.ToLower(torrentMeta.CreatedBy), "upload assistant") {
+		torrentMeta.CreatedBy = "upbrr"
+	}
+}
+
+func writeTorrentMeta(torrentMeta metainfo.MetaInfo, outputPath string, context string) error {
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o700); err != nil {
+		return fmt.Errorf("trackers: create %s dir: %w", context, err)
+	}
+	file, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
-		return fmt.Errorf("trackers: create torrent artifact: %w", err)
+		return fmt.Errorf("trackers: create %s: %w", context, err)
 	}
 	defer file.Close()
 
 	if err := torrentMeta.Write(file); err != nil {
-		return fmt.Errorf("trackers: write torrent artifact: %w", err)
+		return fmt.Errorf("trackers: write %s: %w", context, err)
 	}
 	return nil
 }

--- a/internal/trackers/upload_artifact_test.go
+++ b/internal/trackers/upload_artifact_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/metainfo"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestResolveUploadTorrentPathWritesCleanBaseCopy(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "Release.mkv")
+	if err := os.WriteFile(sourcePath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	dirtyTorrentPath := filepath.Join(tmp, "dirty.torrent")
+	writeTestMetaInfo(t, dirtyTorrentPath, metainfo.MetaInfo{
+		Announce:     "https://tracker.example/announce",
+		AnnounceList: metainfo.AnnounceList{{"https://tracker.example/announce"}},
+		Nodes:        []metainfo.Node{"127.0.0.1:6881"},
+		Comment:      "Created by Upload Assistant",
+		CreatedBy:    "mkbrr using Upload Assistant",
+		Encoding:     "UTF-8",
+		UrlList:      metainfo.UrlList{"https://webseed.example/file"},
+		PieceLayers:  map[string]string{"root": "layer"},
+		InfoBytes:    testInfoBytes(t, ""),
+	})
+
+	got, err := ResolveUploadTorrentPath(api.PreparedMetadata{
+		SourcePath:  sourcePath,
+		TorrentPath: dirtyTorrentPath,
+	}, filepath.Join(tmp, "state", "upbrr.db"))
+	if err != nil {
+		t.Fatalf("resolve upload torrent: %v", err)
+	}
+	if got == dirtyTorrentPath {
+		t.Fatal("expected clean temp copy, got original path")
+	}
+
+	cleaned := readTestMetaInfo(t, got)
+	if cleaned.Announce != "" {
+		t.Fatalf("expected announce cleared, got %q", cleaned.Announce)
+	}
+	if len(cleaned.AnnounceList) != 0 {
+		t.Fatalf("expected announce-list cleared, got %#v", cleaned.AnnounceList)
+	}
+	if len(cleaned.Nodes) != 0 {
+		t.Fatalf("expected nodes cleared, got %#v", cleaned.Nodes)
+	}
+	if len(cleaned.UrlList) != 0 {
+		t.Fatalf("expected url-list cleared, got %#v", cleaned.UrlList)
+	}
+	if len(cleaned.PieceLayers) != 0 {
+		t.Fatalf("expected piece layers cleared, got %#v", cleaned.PieceLayers)
+	}
+	if cleaned.Comment != "upbrr" {
+		t.Fatalf("expected upbrr comment, got %q", cleaned.Comment)
+	}
+	if cleaned.CreatedBy != "upbrr" {
+		t.Fatalf("expected created-by scrubbed, got %q", cleaned.CreatedBy)
+	}
+
+	original := readTestMetaInfo(t, dirtyTorrentPath)
+	if original.Comment != "Created by Upload Assistant" {
+		t.Fatalf("expected original unchanged, got %q", original.Comment)
+	}
+}
+
+func TestResolveUploadTorrentPathWithoutCleanTargetLeavesOriginalUnchanged(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	torrentPath := filepath.Join(tmp, "original.torrent")
+	writeTestMetaInfo(t, torrentPath, metainfo.MetaInfo{
+		Announce:  "https://tracker.example/announce",
+		Comment:   "private tracker comment",
+		InfoBytes: testInfoBytes(t, ""),
+	})
+
+	got, err := ResolveUploadTorrentPath(api.PreparedMetadata{TorrentPath: torrentPath}, "")
+	if err != nil {
+		t.Fatalf("resolve upload torrent: %v", err)
+	}
+	if got != torrentPath {
+		t.Fatalf("expected original path, got %q", got)
+	}
+
+	original := readTestMetaInfo(t, torrentPath)
+	if original.Announce != "https://tracker.example/announce" {
+		t.Fatalf("expected original announce unchanged, got %q", original.Announce)
+	}
+	if original.Comment != "private tracker comment" {
+		t.Fatalf("expected original comment unchanged, got %q", original.Comment)
+	}
+}
+
+func TestWritePersonalizedTorrentSetsTrackerFields(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "base.torrent")
+	outputPath := filepath.Join(tmp, "out", "release.ptp.torrent")
+	writeTestMetaInfo(t, sourcePath, metainfo.MetaInfo{
+		Announce:     "https://old.example/announce",
+		AnnounceList: metainfo.AnnounceList{{"https://old.example/announce"}},
+		Comment:      "Created by Upload Assistant",
+		UrlList:      metainfo.UrlList{"https://webseed.example/file"},
+		InfoBytes:    testInfoBytes(t, ""),
+	})
+
+	if err := WritePersonalizedTorrent(sourcePath, outputPath, "https://new.example/announce", "https://tracker.example/torrents/123", "PTP"); err != nil {
+		t.Fatalf("write personalized torrent: %v", err)
+	}
+
+	updated := readTestMetaInfo(t, outputPath)
+	if updated.Announce != "https://new.example/announce" {
+		t.Fatalf("expected announce set, got %q", updated.Announce)
+	}
+	if len(updated.AnnounceList) != 1 || len(updated.AnnounceList[0]) != 1 || updated.AnnounceList[0][0] != "https://new.example/announce" {
+		t.Fatalf("expected announce-list set, got %#v", updated.AnnounceList)
+	}
+	if updated.Comment != "https://tracker.example/torrents/123" {
+		t.Fatalf("expected tracker comment, got %q", updated.Comment)
+	}
+	if len(updated.UrlList) != 0 {
+		t.Fatalf("expected url-list cleared, got %#v", updated.UrlList)
+	}
+	info, err := updated.UnmarshalInfo()
+	if err != nil {
+		t.Fatalf("unmarshal info: %v", err)
+	}
+	if info.Source != "PTP" {
+		t.Fatalf("expected source flag, got %q", info.Source)
+	}
+}
+
+func writeTestMetaInfo(t *testing.T, path string, meta metainfo.MetaInfo) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("create torrent dir: %v", err)
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("create torrent: %v", err)
+	}
+	defer file.Close()
+	if err := meta.Write(file); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+}
+
+func readTestMetaInfo(t *testing.T, path string) metainfo.MetaInfo {
+	t.Helper()
+
+	meta, err := metainfo.LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("load torrent %s: %v", path, err)
+	}
+	return *meta
+}
+
+func testInfoBytes(t *testing.T, source string) []byte {
+	t.Helper()
+
+	private := true
+	info := metainfo.Info{
+		PieceLength: 16 * 1024,
+		Pieces:      make([]byte, 20),
+		Name:        "Release.mkv",
+		Length:      4,
+		Private:     &private,
+		Source:      source,
+	}
+	infoBytes, err := bencode.Marshal(info)
+	if err != nil {
+		t.Fatalf("marshal info: %v", err)
+	}
+	return infoBytes
+}

--- a/internal/trackers/upload_artifact_test.go
+++ b/internal/trackers/upload_artifact_test.go
@@ -4,8 +4,10 @@
 package trackers
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/anacrolix/torrent/bencode"
@@ -32,7 +34,7 @@ func TestResolveUploadTorrentPathWritesCleanBaseCopy(t *testing.T) {
 		Encoding:     "UTF-8",
 		UrlList:      metainfo.UrlList{"https://webseed.example/file"},
 		PieceLayers:  map[string]string{"root": "layer"},
-		InfoBytes:    testInfoBytes(t, ""),
+		InfoBytes:    testInfoBytes(t, "BHD"),
 	})
 
 	got, err := ResolveUploadTorrentPath(api.PreparedMetadata{
@@ -59,9 +61,12 @@ func TestResolveUploadTorrentPathWritesCleanBaseCopy(t *testing.T) {
 	if len(cleaned.UrlList) != 0 {
 		t.Fatalf("expected url-list cleared, got %#v", cleaned.UrlList)
 	}
-	if len(cleaned.PieceLayers) != 0 {
-		t.Fatalf("expected piece layers cleared, got %#v", cleaned.PieceLayers)
+	expectedPieceLayers := map[string]string{"root": "layer"}
+	if !reflect.DeepEqual(cleaned.PieceLayers, expectedPieceLayers) {
+		t.Fatalf("expected piece layers preserved, got %#v", cleaned.PieceLayers)
 	}
+	assertInfoSource(t, cleaned, "")
+	assertInfoSourceKeyAbsent(t, cleaned)
 	if cleaned.Comment != "upbrr" {
 		t.Fatalf("expected upbrr comment, got %q", cleaned.Comment)
 	}
@@ -73,6 +78,131 @@ func TestResolveUploadTorrentPathWritesCleanBaseCopy(t *testing.T) {
 	if original.Comment != "Created by Upload Assistant" {
 		t.Fatalf("expected original unchanged, got %q", original.Comment)
 	}
+	if !reflect.DeepEqual(original.PieceLayers, expectedPieceLayers) {
+		t.Fatalf("expected original piece layers unchanged, got %#v", original.PieceLayers)
+	}
+	assertInfoSource(t, original, "BHD")
+}
+
+func TestResolveUploadTorrentPathSamePathRewriteFailurePreservesGuessedTorrent(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "Release.mkv")
+	if err := os.WriteFile(sourcePath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	dbPath := filepath.Join(tmp, "state", "upbrr.db")
+	meta := api.PreparedMetadata{SourcePath: sourcePath}
+	guessed, ok := uploadTorrentCleanPath(meta, dbPath)
+	if !ok {
+		t.Fatal("expected clean upload torrent path")
+	}
+	writeTestMetaInfo(t, guessed, metainfo.MetaInfo{
+		Announce:  "https://tracker.example/announce",
+		Comment:   "original",
+		InfoBytes: testInvalidInfoBytes(t),
+	})
+	before, err := os.ReadFile(guessed)
+	if err != nil {
+		t.Fatalf("read guessed torrent: %v", err)
+	}
+
+	got, err := ResolveUploadTorrentPath(meta, dbPath)
+	if err == nil {
+		t.Fatalf("expected rewrite error, got path %q", got)
+	}
+	if got != "" {
+		t.Fatalf("expected no resolved path on rewrite failure, got %q", got)
+	}
+	after, err := os.ReadFile(guessed)
+	if err != nil {
+		t.Fatalf("read guessed torrent after failure: %v", err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatal("expected guessed torrent bytes preserved after rewrite failure")
+	}
+}
+
+func TestResolveUploadTorrentPathFallsBackToExplicitCandidateWhenCleanCopyInvalid(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "Release.mkv")
+	if err := os.WriteFile(sourcePath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	invalidTorrentPath := filepath.Join(tmp, "invalid.torrent")
+	if err := os.WriteFile(invalidTorrentPath, []byte("not a torrent"), 0o600); err != nil {
+		t.Fatalf("write invalid torrent: %v", err)
+	}
+
+	got, err := ResolveUploadTorrentPath(api.PreparedMetadata{
+		SourcePath:  sourcePath,
+		TorrentPath: invalidTorrentPath,
+	}, filepath.Join(tmp, "state", "upbrr.db"))
+	if err != nil {
+		t.Fatalf("resolve upload torrent: %v", err)
+	}
+	if got != invalidTorrentPath {
+		t.Fatalf("expected explicit invalid torrent fallback, got %q", got)
+	}
+}
+
+func TestWriteUploadTorrentPreservesPieceLayers(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	sourcePath := filepath.Join(tmp, "source.torrent")
+	outputPath := filepath.Join(tmp, "out", "clean.torrent")
+	expectedPieceLayers := map[string]string{
+		"root-a": "layer-a",
+		"root-b": "layer-b",
+	}
+	writeTestMetaInfo(t, sourcePath, metainfo.MetaInfo{
+		Announce:     "https://tracker.example/announce",
+		AnnounceList: metainfo.AnnounceList{{"https://tracker.example/announce"}},
+		Nodes:        []metainfo.Node{"127.0.0.1:6881"},
+		Comment:      "Created by Upload Assistant",
+		UrlList:      metainfo.UrlList{"https://webseed.example/file"},
+		PieceLayers:  expectedPieceLayers,
+		InfoBytes:    testInfoBytes(t, "BHD"),
+	})
+
+	if err := WriteUploadTorrent(sourcePath, outputPath); err != nil {
+		t.Fatalf("write upload torrent: %v", err)
+	}
+
+	cleaned := readTestMetaInfo(t, outputPath)
+	if !reflect.DeepEqual(cleaned.PieceLayers, expectedPieceLayers) {
+		t.Fatalf("expected piece layers preserved, got %#v", cleaned.PieceLayers)
+	}
+	if cleaned.Announce != "" {
+		t.Fatalf("expected announce cleared, got %q", cleaned.Announce)
+	}
+	if len(cleaned.AnnounceList) != 0 {
+		t.Fatalf("expected announce-list cleared, got %#v", cleaned.AnnounceList)
+	}
+	if len(cleaned.Nodes) != 0 {
+		t.Fatalf("expected nodes cleared, got %#v", cleaned.Nodes)
+	}
+	if len(cleaned.UrlList) != 0 {
+		t.Fatalf("expected url-list cleared, got %#v", cleaned.UrlList)
+	}
+	if cleaned.Comment != "upbrr" {
+		t.Fatalf("expected upbrr comment, got %q", cleaned.Comment)
+	}
+	assertInfoSource(t, cleaned, "")
+	assertInfoSourceKeyAbsent(t, cleaned)
+
+	original := readTestMetaInfo(t, sourcePath)
+	if original.Comment != "Created by Upload Assistant" {
+		t.Fatalf("expected original comment unchanged, got %q", original.Comment)
+	}
+	if !reflect.DeepEqual(original.PieceLayers, expectedPieceLayers) {
+		t.Fatalf("expected original piece layers unchanged, got %#v", original.PieceLayers)
+	}
+	assertInfoSource(t, original, "BHD")
 }
 
 func TestResolveUploadTorrentPathWithoutCleanTargetLeavesOriginalUnchanged(t *testing.T) {
@@ -114,7 +244,8 @@ func TestWritePersonalizedTorrentSetsTrackerFields(t *testing.T) {
 		AnnounceList: metainfo.AnnounceList{{"https://old.example/announce"}},
 		Comment:      "Created by Upload Assistant",
 		UrlList:      metainfo.UrlList{"https://webseed.example/file"},
-		InfoBytes:    testInfoBytes(t, ""),
+		PieceLayers:  map[string]string{"root": "layer"},
+		InfoBytes:    testInfoBytes(t, "BHD"),
 	})
 
 	if err := WritePersonalizedTorrent(sourcePath, outputPath, "https://new.example/announce", "https://tracker.example/torrents/123", "PTP"); err != nil {
@@ -134,13 +265,11 @@ func TestWritePersonalizedTorrentSetsTrackerFields(t *testing.T) {
 	if len(updated.UrlList) != 0 {
 		t.Fatalf("expected url-list cleared, got %#v", updated.UrlList)
 	}
-	info, err := updated.UnmarshalInfo()
-	if err != nil {
-		t.Fatalf("unmarshal info: %v", err)
+	expectedPieceLayers := map[string]string{"root": "layer"}
+	if !reflect.DeepEqual(updated.PieceLayers, expectedPieceLayers) {
+		t.Fatalf("expected piece layers preserved, got %#v", updated.PieceLayers)
 	}
-	if info.Source != "PTP" {
-		t.Fatalf("expected source flag, got %q", info.Source)
-	}
+	assertInfoSource(t, updated, "PTP")
 }
 
 func writeTestMetaInfo(t *testing.T, path string, meta metainfo.MetaInfo) {
@@ -186,4 +315,34 @@ func testInfoBytes(t *testing.T, source string) []byte {
 		t.Fatalf("marshal info: %v", err)
 	}
 	return infoBytes
+}
+
+func testInvalidInfoBytes(t *testing.T) []byte {
+	t.Helper()
+
+	infoBytes, err := bencode.Marshal("not-info")
+	if err != nil {
+		t.Fatalf("marshal invalid info: %v", err)
+	}
+	return infoBytes
+}
+
+func assertInfoSource(t *testing.T, meta metainfo.MetaInfo, expected string) {
+	t.Helper()
+
+	info, err := meta.UnmarshalInfo()
+	if err != nil {
+		t.Fatalf("unmarshal info: %v", err)
+	}
+	if info.Source != expected {
+		t.Fatalf("expected info source %q, got %q", expected, info.Source)
+	}
+}
+
+func assertInfoSourceKeyAbsent(t *testing.T, meta metainfo.MetaInfo) {
+	t.Helper()
+
+	if bytes.Contains(meta.InfoBytes, []byte("6:source")) {
+		t.Fatalf("expected raw info source key absent, got %q", string(meta.InfoBytes))
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Torrent uploads now sanitize tracker-facing metadata (announce, announce-list, URL lists, comment) before submission.

* **New Features / Improvements**
  * Upload artifacts are produced via a unified, more reliable generation flow with safer staging, deterministic metadata normalization, and preserved piece data.
  * Improved torrent creation/validation with stricter path handling and content-based reuse checks.

* **Tests**
  * Broadly expanded tests covering upload cleaning, personalization, path resolution, creation/validation, and client-torrent reuse.

* **Documentation**
  * Expanded contributor guidance on workflow, linting, frontend rules, portability, and a cross-area validation matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->