### PR TITLE
fix: dry-run handling

### DIFF
--- a/gui/frontend/src/pages/tracker_upload/index.test.tsx
+++ b/gui/frontend/src/pages/tracker_upload/index.test.tsx
@@ -1,0 +1,178 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import TrackerUploadPage from "./index";
+import type { MetadataPreview, TrackerDryRunPreview } from "../../types";
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+const preview = {
+  SourcePath: "C:\\Media\\Watcher.mkv",
+  TrackerName: "",
+  ReleaseName: "Watcher 2160p WEB-DL DD+ 5.1-FLUX",
+  Warnings: [],
+  ReleaseNameOverrides: {},
+  ExternalIDs: {
+    TMDBID: 0,
+    IMDBID: 0,
+    TVDBID: 0,
+    TVmazeID: 0,
+    Category: "",
+    SourceTMDB: "",
+    SourceIMDB: "",
+    SourceTVDB: "",
+    SourceTVmaze: "",
+  },
+  ExternalIDCandidates: {
+    TMDB: [],
+    IMDB: [],
+    TMDBAutoSelected: false,
+    IMDBAutoSelected: false,
+  },
+  ExternalIDInfo: [],
+  ExternalPreview: [],
+  TrackerData: [],
+} satisfies MetadataPreview;
+
+const dryRunPreview: TrackerDryRunPreview = {
+  SourcePath: "C:\\Media\\Watcher.mkv",
+  Trackers: [
+    {
+      Tracker: "AITHER",
+      Status: "ready",
+      Message: "",
+      ReleaseName: "Watcher.2160p.WEB-DL.DDP5.1-FLUX",
+      OriginalReleaseName: "Watcher 2160p WEB-DL DD+ 5.1-FLUX",
+      UploadReleaseName: "Watcher.2160p.WEB-DL.DDP5.1-FLUX",
+      ReleaseNameChanged: true,
+      ReleaseNameChangeReason: "tracker naming rules",
+      DescriptionGroup: "",
+      Description: "",
+      Endpoint: "",
+      Payload: {},
+      Files: [],
+      ImageHost: {
+        Status: "",
+        SelectedHost: "",
+        AllowedHosts: [],
+        Warnings: [],
+        Reuploaded: false,
+        Message: "",
+      },
+    },
+  ],
+};
+
+describe("TrackerUploadPage", () => {
+  const baseProps = {
+    trackerUploadItems: [{ name: "AITHER", config: {} }],
+    releasePageTrackerSelection: { AITHER: true },
+    dupedTrackerSet: new Set<string>(),
+    ruleSkipReasons: {},
+    ruleSkippedTrackerSet: new Set<string>(),
+    failedDupeTrackerSet: new Set<string>(),
+    uploadToggles: { AITHER: true },
+    setUploadToggles: vi.fn(),
+    namingOverrides: [],
+    preview,
+    formatLabel: (value: string) => value,
+    uploadRunning: false,
+    uploadError: "",
+    uploadSnapshot: null,
+    dryRunLoading: false,
+    dryRunError: "",
+    dryRunProgress: null,
+    dryRunPreview,
+    trackerQuestionnaireAnswers: {},
+    onQuestionnaireAnswerChange: vi.fn(),
+    onRunDryRun: vi.fn(),
+    onStartUpload: vi.fn(),
+    onCancelUpload: vi.fn(),
+    onRetryFailed: vi.fn(),
+  };
+
+  it("shows tracker-specific dry-run naming changes on the tracker tile", () => {
+    render(<TrackerUploadPage {...baseProps} />);
+
+    expect(screen.getByText("Name changed")).toBeTruthy();
+    expect(screen.getByText(/Original:/).textContent).toContain(
+      "Watcher 2160p WEB-DL DD+ 5.1-FLUX",
+    );
+    expect(screen.getByText(/Upload:/).textContent).toContain("Watcher.2160p.WEB-DL.DDP5.1-FLUX");
+  });
+
+  it("does not show stale dry-run naming changes for disabled trackers", () => {
+    render(<TrackerUploadPage {...baseProps} uploadToggles={{ AITHER: false }} />);
+
+    expect(screen.queryByText("Name changed")).toBeNull();
+    expect(screen.queryByText(/Upload:/)).toBeNull();
+  });
+
+  it("does not lose a pending live dry-run refresh when the timer is cleaned up", () => {
+    vi.useFakeTimers();
+    const firstRun = vi.fn();
+    const secondRun = vi.fn();
+    const { rerender } = render(<TrackerUploadPage {...baseProps} onRunDryRun={firstRun} />);
+
+    rerender(
+      <TrackerUploadPage
+        {...baseProps}
+        namingOverrides={[["AITHER", "Watcher custom"]]}
+        onRunDryRun={firstRun}
+      />,
+    );
+    rerender(
+      <TrackerUploadPage
+        {...baseProps}
+        namingOverrides={[["AITHER", "Watcher custom"]]}
+        onRunDryRun={secondRun}
+      />,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    expect(firstRun).not.toHaveBeenCalled();
+    expect(secondRun).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it("defers live dry-run refresh while dry-run or upload work is running", () => {
+    vi.useFakeTimers();
+    const onRunDryRun = vi.fn();
+    const { rerender } = render(<TrackerUploadPage {...baseProps} onRunDryRun={onRunDryRun} />);
+
+    rerender(
+      <TrackerUploadPage
+        {...baseProps}
+        dryRunLoading={true}
+        namingOverrides={[["AITHER", "Watcher custom"]]}
+        onRunDryRun={onRunDryRun}
+      />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(onRunDryRun).not.toHaveBeenCalled();
+
+    rerender(
+      <TrackerUploadPage
+        {...baseProps}
+        namingOverrides={[["AITHER", "Watcher custom"]]}
+        onRunDryRun={onRunDryRun}
+      />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    expect(onRunDryRun).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});

--- a/gui/frontend/src/pages/tracker_upload/index.tsx
+++ b/gui/frontend/src/pages/tracker_upload/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026, Audionut and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { Button } from "../../components/ui/button";
 import { Checkbox } from "../../components/ui/checkbox";
@@ -60,6 +60,7 @@ const subtleBox = "rounded-md border border-white/10 bg-white/5 px-2 py-1.5";
 const blockReasonClass =
   "inline-flex h-5 items-center rounded border border-red-400/30 bg-red-500/10 px-1.5 text-[11px] font-semibold leading-none text-red-700 dark:text-red-100";
 const formatStatusText = (value: string) => value.replaceAll("_", " ");
+const trimName = (value: unknown) => String(value || "").trim();
 
 export default function TrackerUploadPage(props: Readonly<Props>) {
   const {
@@ -204,6 +205,7 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
   const currentPercent = activeProgress.percent;
   const currentTotalPieces = activeProgress.totalPieces;
   const canRetry = !uploadRunning && (uploadSnapshot?.failedTrackers?.length || 0) > 0;
+  const lastDryRunSelectionKey = useRef("");
   const dryRunMap = useMemo(() => {
     const next: Record<string, (typeof dryRunPreview.Trackers)[number]> = {};
     (dryRunPreview?.Trackers || []).forEach((entry) => {
@@ -215,6 +217,44 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
     });
     return next;
   }, [dryRunPreview]);
+  const selectedTrackerKey = useMemo(
+    () =>
+      availableTrackers
+        .filter((tracker) => Boolean(uploadToggles[tracker.name]))
+        .map((tracker) => tracker.name.toLowerCase().trim())
+        .sort()
+        .join("|"),
+    [availableTrackers, uploadToggles],
+  );
+  const namingOverrideKey = useMemo(() => JSON.stringify(namingOverrides), [namingOverrides]);
+
+  useEffect(() => {
+    const refreshKey = `${selectedTrackerKey}:${namingOverrideKey}`;
+    if (!dryRunPreview?.Trackers?.length || !selectedTrackerKey) {
+      lastDryRunSelectionKey.current = refreshKey;
+      return;
+    }
+    if (!lastDryRunSelectionKey.current) {
+      lastDryRunSelectionKey.current = refreshKey;
+      return;
+    }
+    if (lastDryRunSelectionKey.current === refreshKey) return;
+
+    if (dryRunLoading || uploadRunning) return;
+
+    const timeout = window.setTimeout(() => {
+      lastDryRunSelectionKey.current = refreshKey;
+      onRunDryRun();
+    }, 250);
+    return () => window.clearTimeout(timeout);
+  }, [
+    dryRunLoading,
+    dryRunPreview,
+    namingOverrideKey,
+    onRunDryRun,
+    selectedTrackerKey,
+    uploadRunning,
+  ]);
 
   const renderQuestionnaireField = (
     trackerName: string,
@@ -400,13 +440,22 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
             const selected = Boolean(uploadToggles[tracker.name]);
             const enabled = selected;
             const trackerStatus = trackerStatusMap[tracker.name];
-            const dryRun = dryRunMap[normalizedTrackerName];
+            const dryRun = selected ? dryRunMap[normalizedTrackerName] : undefined;
             const imageHost = dryRun?.ImageHost;
             const imageHostWarnings = imageHost?.Warnings || [];
             const imageHostStatus = String(imageHost?.Status || "").toLowerCase();
             const questionnaire = dryRun?.Questionnaire;
             const questionnaireAnswers =
               trackerQuestionnaireAnswers[tracker.name.toUpperCase().trim()] || {};
+            const originalReleaseName = trimName(
+              dryRun?.OriginalReleaseName || preview.ReleaseName,
+            );
+            const uploadReleaseName = trimName(dryRun?.UploadReleaseName || dryRun?.ReleaseName);
+            const releaseNameChanged =
+              Boolean(dryRun?.ReleaseNameChanged) ||
+              (Boolean(originalReleaseName) &&
+                Boolean(uploadReleaseName) &&
+                originalReleaseName !== uploadReleaseName);
             let statusLabel = trackerStatus?.status || "";
             if (!statusLabel) {
               statusLabel = enabled ? "ready" : "disabled";
@@ -490,6 +539,30 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
                     </p>
                   );
                 })}
+
+                {releaseNameChanged ? (
+                  <div className="grid gap-1 rounded-md border border-amber-300/55 bg-amber-300/12 px-2.5 py-2">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className="inline-flex items-center rounded border border-amber-300/50 px-1.5 py-0.5 text-[11px] font-semibold uppercase leading-none text-amber-100">
+                        Name changed
+                      </span>
+                      {dryRun?.ReleaseNameChangeReason ? (
+                        <span className="text-xs text-amber-100/80">
+                          {dryRun.ReleaseNameChangeReason}
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="grid gap-1 text-xs">
+                      <p className="m-0 text-[var(--muted)] [overflow-wrap:anywhere]">
+                        Original:{" "}
+                        <span className="mono text-[var(--text)]">{originalReleaseName}</span>
+                      </p>
+                      <p className="m-0 text-amber-100 [overflow-wrap:anywhere]">
+                        Upload: <span className="mono font-semibold">{uploadReleaseName}</span>
+                      </p>
+                    </div>
+                  </div>
+                ) : null}
 
                 <details>
                   <summary className="cursor-pointer list-none text-sm font-semibold marker:content-[''] [&::-webkit-details-marker]:hidden">

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -797,6 +797,10 @@ export type TrackerDryRunEntry = {
   Status: string;
   Message: string;
   ReleaseName: string;
+  OriginalReleaseName: string;
+  UploadReleaseName: string;
+  ReleaseNameChanged: boolean;
+  ReleaseNameChangeReason: string;
   DescriptionGroup: string;
   Description: string;
   Endpoint: string;

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -1948,10 +1948,33 @@ func (c *Core) FetchTrackerDryRunPreview(ctx context.Context, req api.Request) (
 	if err != nil {
 		return api.TrackerDryRunPreview{}, fmt.Errorf("core: %w", err)
 	}
+	annotateDryRunReleaseNames(meta, entries)
 
 	c.storeDupeCache(meta.SourcePath, overrideSignature(meta.ExternalIDOverrides, meta.ReleaseNameOverrides, meta.MetadataOverrides, meta.TrackerConfigOverrides, meta.TrackerSiteOverrides, meta.ClientOverrides, meta.TorrentOverrides, meta.ImageHostOverrides, meta.ScreenshotOverrides), meta)
 
 	return api.TrackerDryRunPreview{SourcePath: meta.SourcePath, Trackers: entries}, nil
+}
+
+func annotateDryRunReleaseNames(meta api.PreparedMetadata, entries []api.TrackerDryRunEntry) {
+	original := strings.TrimSpace(meta.ReleaseName)
+	if original == "" {
+		original = strings.TrimSpace(meta.ReleaseNameNoTag)
+	}
+	if original == "" {
+		original = strings.TrimSpace(meta.Filename)
+	}
+	for idx := range entries {
+		uploadName := strings.TrimSpace(entries[idx].ReleaseName)
+		if uploadName == "" {
+			uploadName = original
+		}
+		entries[idx].OriginalReleaseName = original
+		entries[idx].UploadReleaseName = uploadName
+		entries[idx].ReleaseNameChanged = original != "" && uploadName != "" && uploadName != original
+		if entries[idx].ReleaseNameChanged && strings.TrimSpace(entries[idx].ReleaseNameChangeReason) == "" {
+			entries[idx].ReleaseNameChangeReason = "tracker naming rules"
+		}
+	}
 }
 
 func (c *Core) FetchDescriptionBuilderPreview(ctx context.Context, req api.Request) (api.DescriptionBuilderPreview, error) {

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -2299,6 +2299,60 @@ func TestFetchTrackerDryRunPreviewUsesCachedMetadata(t *testing.T) {
 	}
 }
 
+func TestFetchTrackerDryRunPreviewAnnotatesReleaseNameChange(t *testing.T) {
+	t.Parallel()
+
+	tracker := &stubTrackers{dryRunEntries: []api.TrackerDryRunEntry{{
+		Tracker:     "AITHER",
+		ReleaseName: "Watcher.2160p.WEB-DL.DDP5.1-FLUX",
+	}}}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   tracker,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	core.storeDupeCache("/tmp/a", "", api.PreparedMetadata{
+		SourcePath:  "/tmp/a",
+		ReleaseName: "Watcher 2160p WEB-DL DD+ 5.1-FLUX",
+		Trackers:    []string{"AITHER", "BLU"},
+	})
+
+	preview, err := core.FetchTrackerDryRunPreview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("fetch tracker dry-run preview: %v", err)
+	}
+	if len(tracker.lastTrackers) != 1 || tracker.lastTrackers[0] != "AITHER" {
+		t.Fatalf("expected dry run for selected tracker only, got %#v", tracker.lastTrackers)
+	}
+	if len(preview.Trackers) != 1 {
+		t.Fatalf("expected one dry-run entry, got %d", len(preview.Trackers))
+	}
+	entry := preview.Trackers[0]
+	if !entry.ReleaseNameChanged {
+		t.Fatalf("expected release name change annotation, got %#v", entry)
+	}
+	if entry.OriginalReleaseName != "Watcher 2160p WEB-DL DD+ 5.1-FLUX" {
+		t.Fatalf("expected original release name, got %q", entry.OriginalReleaseName)
+	}
+	if entry.UploadReleaseName != "Watcher.2160p.WEB-DL.DDP5.1-FLUX" {
+		t.Fatalf("expected upload release name, got %q", entry.UploadReleaseName)
+	}
+}
+
 func TestFetchTrackerDryRunPreviewPassesRuleFailureOverride(t *testing.T) {
 	t.Parallel()
 
@@ -2963,12 +3017,13 @@ func (s *stubDupes) Check(_ context.Context, meta api.PreparedMetadata, trackers
 }
 
 type stubTrackers struct {
-	calls        int
-	prepCalls    int
-	dryRunCalls  int
-	lastMeta     api.PreparedMetadata
-	lastTrackers []string
-	summary      api.UploadSummary
+	calls         int
+	prepCalls     int
+	dryRunCalls   int
+	lastMeta      api.PreparedMetadata
+	lastTrackers  []string
+	dryRunEntries []api.TrackerDryRunEntry
+	summary       api.UploadSummary
 }
 
 func (s *stubTrackers) Upload(_ context.Context, meta api.PreparedMetadata) (api.UploadSummary, error) {
@@ -3001,5 +3056,5 @@ func (s *stubTrackers) BuildUploadDryRun(_ context.Context, meta api.PreparedMet
 	s.dryRunCalls++
 	s.lastMeta = meta
 	s.lastTrackers = append([]string{}, trackers...)
-	return []api.TrackerDryRunEntry{}, nil
+	return append([]api.TrackerDryRunEntry{}, s.dryRunEntries...), nil
 }

--- a/internal/core/upload_review.go
+++ b/internal/core/upload_review.go
@@ -131,6 +131,7 @@ func (c *Core) BuildUploadReview(ctx context.Context, req api.Request) (api.Uplo
 	if err != nil {
 		return api.UploadReview{}, fmt.Errorf("core: %w", err)
 	}
+	annotateDryRunReleaseNames(dryRunMeta, dryRunEntries)
 	dryRunByTracker := make(map[string]api.TrackerDryRunEntry, len(dryRunEntries))
 	for _, entry := range dryRunEntries {
 		name := strings.ToUpper(strings.TrimSpace(entry.Tracker))

--- a/pkg/api/preview.go
+++ b/pkg/api/preview.go
@@ -65,17 +65,21 @@ type TrackerReview struct {
 }
 
 type TrackerDryRunEntry struct {
-	Tracker          string
-	Status           string
-	Message          string
-	ReleaseName      string
-	DescriptionGroup string
-	Description      string
-	Endpoint         string
-	Payload          map[string]string
-	Files            []TrackerDryRunFile
-	Questionnaire    *TrackerQuestionnaire
-	ImageHost        ImageHostFeedback
+	Tracker                 string
+	Status                  string
+	Message                 string
+	ReleaseName             string
+	OriginalReleaseName     string
+	UploadReleaseName       string
+	ReleaseNameChanged      bool
+	ReleaseNameChangeReason string
+	DescriptionGroup        string
+	Description             string
+	Endpoint                string
+	Payload                 map[string]string
+	Files                   []TrackerDryRunFile
+	Questionnaire           *TrackerQuestionnaire
+	ImageHost               ImageHostFeedback
 }
 
 type TrackerDryRunFile struct {

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -207,7 +207,7 @@ type PreparedMetadata struct {
 	BlockedTrackers             map[string][]TrackerBlockReason
 	IgnoreTrackerRuleFailures   bool
 	TrackerRuleFailures         map[string][]RuleFailure
-	BDInfo                      map[string]interface{}
+	BDInfo                      map[string]any
 }
 
 type MetadataOverrides struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tracker upload now displays release name changes with the original name, updated name, and reason for the change.

* **Tests**
  * Added comprehensive test suite for tracker upload covering release name change rendering, naming overrides, and dry-run refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->