### PR TITLE
fix: dupe checking season/episode behavior

### DIFF
--- a/internal/dupechecking/filter.go
+++ b/internal/dupechecking/filter.go
@@ -507,29 +507,37 @@ func isSeasonEpisodeMatch(filename string, targetSeason string, targetEpisode st
 		}
 	}
 
-	seasonPatternValue := ""
+	var seasonRegex *regexp.Regexp
 	if targetSeasonValue > 0 {
-		seasonPatternValue = "S" + strconv.FormatInt(int64(targetSeasonValue), 10)
+		seasonRegex = seasonTokenRegex("S", targetSeasonValue)
 	}
-	isSeasonPack := !regexp.MustCompile(`(?i)e\d{2}`).MatchString(filename)
+	isSeasonPack := !regexp.MustCompile(`(?i)e\d{1,3}`).MatchString(filename)
 
 	if len(targetEpisodes) == 0 {
-		seasonMatches := seasonPatternValue != "" && regexp.MustCompile(`(?i)`+seasonPatternValue).MatchString(filename)
+		seasonMatches := seasonRegex != nil && seasonRegex.MatchString(filename)
 		return seasonMatches && isSeasonPack, seasonMatches
 	}
 
-	if seasonPatternValue != "" {
+	if seasonRegex != nil {
 		if isSeasonPack {
-			return regexp.MustCompile(`(?i)` + seasonPatternValue).MatchString(filename), true
+			return seasonRegex.MatchString(filename), true
 		}
 		for _, ep := range targetEpisodes {
-			pattern := regexp.MustCompile(`(?i)E` + leftPad(ep, 2))
-			if regexp.MustCompile(`(?i)`+seasonPatternValue).MatchString(filename) && pattern.MatchString(filename) {
+			pattern := episodeTokenRegex(ep)
+			if seasonRegex.MatchString(filename) && pattern.MatchString(filename) {
 				return true, false
 			}
 		}
 	}
 	return false, false
+}
+
+func seasonTokenRegex(prefix string, value int) *regexp.Regexp {
+	return regexp.MustCompile(`(?i)(?:^|[^a-z0-9])` + regexp.QuoteMeta(prefix) + `0*` + strconv.Itoa(value) + `(?:[^0-9]|$)`)
+}
+
+func episodeTokenRegex(value int) *regexp.Regexp {
+	return regexp.MustCompile(`(?i)E0*` + strconv.Itoa(value) + `(?:[^0-9]|$)`)
 }
 
 func isOTWSameSeasonEpisodeResolutionMismatch(meta api.PreparedMetadata, tracker string, name string, targetSeason string, targetEpisode string, targetResolution string) bool {

--- a/internal/dupechecking/filter_test.go
+++ b/internal/dupechecking/filter_test.go
@@ -60,6 +60,42 @@ func TestIsSeasonEpisodeMatchDailyEpisodeNonMatch(t *testing.T) {
 	}
 }
 
+func TestIsSeasonEpisodeMatchDoesNotCrossMatchUnpaddedSeason(t *testing.T) {
+	t.Parallel()
+
+	matched, isSeasonPack := isSeasonEpisodeMatch("Show.S10E02.1080p.WEB-DL.x264-GRP", "S1", "E02")
+	if matched {
+		t.Fatalf("did not expect S1 target to match S10 episode")
+	}
+	if isSeasonPack {
+		t.Fatalf("did not expect S10E02 to be treated as season pack")
+	}
+}
+
+func TestIsSeasonEpisodeMatchKeepsUnpaddedEpisodeAsEpisode(t *testing.T) {
+	t.Parallel()
+
+	matched, isSeasonPack := isSeasonEpisodeMatch("Show.S01E1.1080p.WEB-DL.x264-GRP", "S01", "E01")
+	if !matched {
+		t.Fatalf("expected unpadded episode to match padded target")
+	}
+	if isSeasonPack {
+		t.Fatalf("did not expect unpadded episode to be treated as season pack")
+	}
+}
+
+func TestIsSeasonEpisodeMatchAllowsUnpaddedSeasonEpisode(t *testing.T) {
+	t.Parallel()
+
+	matched, isSeasonPack := isSeasonEpisodeMatch("Show.S1E2.1080p.WEB-DL.x264-GRP", "S01", "E02")
+	if !matched {
+		t.Fatalf("expected unpadded season and episode to match padded target")
+	}
+	if isSeasonPack {
+		t.Fatalf("did not expect unpadded season episode to be treated as season pack")
+	}
+}
+
 func TestFilterDupesKeepsMatchingDailyEpisode(t *testing.T) {
 	t.Parallel()
 
@@ -82,6 +118,78 @@ func TestFilterDupesKeepsMatchingDailyEpisode(t *testing.T) {
 	}
 	if got := filtered[0].Name; got != "Show.2026.03.27.1080p.WEB-DL.x264-OTHER" {
 		t.Fatalf("unexpected surviving dupe %q", got)
+	}
+}
+
+func TestFilterDupesSingleEpisodeKeepsMatchingSeasonPack(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{
+		ReleaseName: "Show.S01E02.1080p.WEB-DL.x264-GRP",
+		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		SeasonStr:   "S01",
+		EpisodeStr:  "E02",
+		Release:     api.ReleaseInfo{Resolution: "1080p"},
+		Type:        "WEBDL",
+		SourcePath:  "x",
+	}
+	dupes := []api.DupeEntry{{Name: "Show.S01.1080p.WEB-DL.x264-OTHER", Link: "https://example.invalid/pack", ID: "pack-1"}}
+
+	filtered, match := FilterDupes(dupes, meta, "AITHER", config.Config{}, api.NopLogger{})
+	if len(filtered) != 1 {
+		t.Fatalf("expected matching season pack to remain as dupe, got %d", len(filtered))
+	}
+	if !match.SeasonPackExists || !match.SeasonPackContainsEpisode {
+		t.Fatalf("expected season pack match details, got %#v", match)
+	}
+	if match.SeasonPackID != "pack-1" || match.SeasonPackLink != "https://example.invalid/pack" {
+		t.Fatalf("unexpected season pack match metadata: %#v", match)
+	}
+}
+
+func TestFilterDupesTVPackExcludesSingleEpisodes(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{
+		ReleaseName: "Show.S01.1080p.WEB-DL.x264-GRP",
+		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		SeasonStr:   "S01",
+		TVPack:      true,
+		Release:     api.ReleaseInfo{Resolution: "1080p"},
+		Type:        "WEBDL",
+		SourcePath:  "x",
+	}
+	dupes := []api.DupeEntry{
+		{Name: "Show.S01E02.1080p.WEB-DL.x264-OTHER"},
+		{Name: "Show.S01.1080p.WEB-DL.x264-OTHER"},
+	}
+
+	filtered, _ := FilterDupes(dupes, meta, "AITHER", config.Config{}, api.NopLogger{})
+	if len(filtered) != 1 {
+		t.Fatalf("expected only season pack dupe to remain, got %d", len(filtered))
+	}
+	if got := filtered[0].Name; got != "Show.S01.1080p.WEB-DL.x264-OTHER" {
+		t.Fatalf("unexpected surviving dupe %q", got)
+	}
+}
+
+func TestFilterDupesTVPackDoesNotCrossMatchSeason(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{
+		ReleaseName: "Show.S01.1080p.WEB-DL.x264-GRP",
+		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		SeasonStr:   "S1",
+		TVPack:      true,
+		Release:     api.ReleaseInfo{Resolution: "1080p"},
+		Type:        "WEBDL",
+		SourcePath:  "x",
+	}
+	dupes := []api.DupeEntry{{Name: "Show.S10.1080p.WEB-DL.x264-OTHER"}}
+
+	filtered, _ := FilterDupes(dupes, meta, "AITHER", config.Config{}, api.NopLogger{})
+	if len(filtered) != 0 {
+		t.Fatalf("did not expect S1 pack to match S10 pack, got %#v", filtered)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate filtering for TV content by enhancing season/episode pattern matching to better handle various formatting variations and increase season pack detection accuracy.

* **Tests**
  * Added comprehensive unit tests for season/episode matching behavior and TV/season-pack handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->