### PR TITLE
feat: new image hosts

### DIFF
--- a/gui/frontend/src/hooks/useSettingsState.test.ts
+++ b/gui/frontend/src/hooks/useSettingsState.test.ts
@@ -169,6 +169,17 @@ function TrackerSettingsHarness() {
   );
 }
 
+function ImageHostingHarness() {
+  const state = useSettingsState({ activeTab: "settings" });
+
+  return createElement(
+    "div",
+    null,
+    state.renderImageHostingSection(),
+    createElement("pre", { "data-testid": "payload" }, state.buildSavePayload() ?? ""),
+  );
+}
+
 describe("renderTorrentClientsSection", () => {
   it("renders watch client fields and preserves qbit clients on update", async () => {
     (globalThis as typeof globalThis & { go?: any }).go = {
@@ -421,5 +432,101 @@ describe("Tracker client selectors", () => {
       Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
     };
     expect(payload.Trackers?.Trackers?.AITHER?.TorrentClient).toBe("watcher");
+  });
+
+  it("shows Lostimg as an LST image host only when configured in image hosting", async () => {
+    (globalThis as typeof globalThis & { go?: any }).go = {
+      guiapp: {
+        App: {
+          GetConfig: async () =>
+            JSON.stringify({
+              ImageHosting: {
+                LostimgEnabled: true,
+                LostimgAPI: "secret",
+              },
+              Trackers: {
+                DefaultTrackers: [],
+                PreferredTracker: "",
+                Trackers: {
+                  LST: {
+                    LinkDirName: "",
+                    APIKey: "",
+                    ImageHost: "",
+                    Anon: false,
+                  },
+                },
+              },
+            }),
+          GetDefaultConfig: async () => JSON.stringify({}),
+          ListKnownTrackers: async () => ["LST"],
+          GetImageHostPolicyMetadata: async () => ({
+            TrackerUploadHosts: { LST: ["lostimg"] },
+            OwnedHosts: { lostimg: "LST" },
+          }),
+        },
+      },
+    };
+
+    render(createElement(TrackerSettingsHarness));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("LST", { selector: ".settings-card__summary-name" }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByText("LST", { selector: ".settings-card__summary-name" }));
+
+    const imageHostSelect = screen.getByLabelText("Image host") as HTMLSelectElement;
+    expect(Array.from(imageHostSelect.options).map((option) => option.value)).toContain("lostimg");
+  });
+});
+
+describe("Image hosting settings", () => {
+  it("renders Lostimg as tracker-specific and keeps it out of global host priority", async () => {
+    (globalThis as typeof globalThis & { go?: any }).go = {
+      guiapp: {
+        App: {
+          GetConfig: async () =>
+            JSON.stringify({
+              ImageHosting: {
+                Host1: "",
+                Host2: "",
+                Host3: "",
+                Host4: "",
+                Host5: "",
+                Host6: "",
+                LostimgEnabled: false,
+                LostimgAPI: "",
+              },
+            }),
+          GetDefaultConfig: async () => JSON.stringify({}),
+          ListKnownTrackers: async () => [],
+          GetImageHostPolicyMetadata: async () => ({}),
+        },
+      },
+    };
+
+    render(createElement(ImageHostingHarness));
+
+    await waitFor(() => expect(screen.getByLabelText("LST Lostimg")).toBeInTheDocument());
+
+    const hostOne = screen.getByLabelText("Host 1") as HTMLSelectElement;
+    expect(Array.from(hostOne.options).map((option) => option.value)).not.toContain("lostimg");
+
+    fireEvent.click(screen.getByLabelText("LST Lostimg"));
+    fireEvent.change(screen.getByLabelText("API key"), {
+      target: { value: "secret" },
+    });
+
+    await waitFor(() => expect(screen.getByLabelText("LST Lostimg")).toBeChecked());
+
+    const payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+      ImageHosting?: {
+        LostimgEnabled?: boolean;
+        LostimgAPI?: string;
+      };
+    };
+    expect(payload.ImageHosting?.LostimgEnabled).toBe(true);
+    expect(payload.ImageHosting?.LostimgAPI).toBe("secret");
   });
 });

--- a/gui/frontend/src/hooks/useSettingsState.test.ts
+++ b/gui/frontend/src/hooks/useSettingsState.test.ts
@@ -169,6 +169,17 @@ function TrackerSettingsHarness() {
   );
 }
 
+function TrackerSettingsAdvancedHarness() {
+  const state = useSettingsState({ activeTab: "settings" });
+
+  return createElement(
+    "div",
+    null,
+    state.renderTrackerSection(true),
+    createElement("pre", { "data-testid": "payload" }, state.buildSavePayload() ?? ""),
+  );
+}
+
 function ImageHostingHarness() {
   const state = useSettingsState({ activeTab: "settings" });
 
@@ -479,6 +490,160 @@ describe("Tracker client selectors", () => {
     const imageHostSelect = screen.getByLabelText("Image host") as HTMLSelectElement;
     expect(Array.from(imageHostSelect.options).map((option) => option.value)).toContain("lostimg");
   });
+
+  it("shows configured global hosts for LST when Lostimg is disabled", async () => {
+    (globalThis as typeof globalThis & { go?: any }).go = {
+      guiapp: {
+        App: {
+          GetConfig: async () =>
+            JSON.stringify({
+              ImageHosting: {
+                Host1: "imgbb",
+                LostimgEnabled: false,
+                LostimgAPI: "",
+              },
+              Trackers: {
+                DefaultTrackers: [],
+                PreferredTracker: "",
+                Trackers: {
+                  LST: {
+                    LinkDirName: "",
+                    APIKey: "",
+                    ImageHost: "",
+                    Anon: false,
+                  },
+                },
+              },
+            }),
+          GetDefaultConfig: async () => JSON.stringify({}),
+          ListKnownTrackers: async () => ["LST"],
+          GetImageHostPolicyMetadata: async () => ({
+            TrackerUploadHosts: { LST: ["lostimg"] },
+            OwnedHosts: { lostimg: "LST" },
+          }),
+        },
+      },
+    };
+
+    render(createElement(TrackerSettingsHarness));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("LST", { selector: ".settings-card__summary-name" }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByText("LST", { selector: ".settings-card__summary-name" }));
+
+    const values = Array.from(
+      (screen.getByLabelText("Image host") as HTMLSelectElement).options,
+    ).map((option) => option.value);
+    expect(values).toContain("imgbb");
+    expect(values).not.toContain("lostimg");
+  });
+
+  it("shows Reelflix as an RF image host and exposes RF image API", async () => {
+    (globalThis as typeof globalThis & { go?: any }).go = {
+      guiapp: {
+        App: {
+          GetConfig: async () =>
+            JSON.stringify({
+              ImageHosting: {},
+              Trackers: {
+                DefaultTrackers: [],
+                PreferredTracker: "",
+                Trackers: {
+                  RF: {
+                    LinkDirName: "",
+                    APIKey: "",
+                    ImgAPI: "",
+                    ImageHost: "reelflix",
+                    Anon: false,
+                  },
+                },
+              },
+            }),
+          GetDefaultConfig: async () => JSON.stringify({}),
+          ListKnownTrackers: async () => ["RF"],
+          GetImageHostPolicyMetadata: async () => ({
+            TrackerUploadHosts: { RF: ["reelflix"] },
+            OwnedHosts: { reelflix: "RF" },
+          }),
+        },
+      },
+    };
+
+    render(createElement(TrackerSettingsAdvancedHarness));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("RF", { selector: ".settings-card__summary-name" }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByText("RF", { selector: ".settings-card__summary-name" }));
+
+    const imageHostSelect = screen.getByLabelText("Image host") as HTMLSelectElement;
+    expect(Array.from(imageHostSelect.options).map((option) => option.value)).toContain("reelflix");
+
+    fireEvent.change(screen.getByLabelText("Image API"), {
+      target: { value: "secret" },
+    });
+
+    await waitFor(() => expect(screen.getByLabelText("Image API")).toHaveValue("secret"));
+
+    const payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+      Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
+    };
+    expect(payload.Trackers?.Trackers?.RF?.ImgAPI).toBe("secret");
+  });
+
+  it("shows configured global hosts for RF when Reelflix is disabled", async () => {
+    (globalThis as typeof globalThis & { go?: any }).go = {
+      guiapp: {
+        App: {
+          GetConfig: async () =>
+            JSON.stringify({
+              ImageHosting: {
+                Host1: "imgbb",
+              },
+              Trackers: {
+                DefaultTrackers: [],
+                PreferredTracker: "",
+                Trackers: {
+                  RF: {
+                    LinkDirName: "",
+                    APIKey: "",
+                    ImgAPI: "",
+                    ImageHost: "",
+                    Anon: false,
+                  },
+                },
+              },
+            }),
+          GetDefaultConfig: async () => JSON.stringify({}),
+          ListKnownTrackers: async () => ["RF"],
+          GetImageHostPolicyMetadata: async () => ({
+            TrackerUploadHosts: { RF: ["reelflix"] },
+            OwnedHosts: { reelflix: "RF" },
+          }),
+        },
+      },
+    };
+
+    render(createElement(TrackerSettingsHarness));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("RF", { selector: ".settings-card__summary-name" }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByText("RF", { selector: ".settings-card__summary-name" }));
+
+    const values = Array.from(
+      (screen.getByLabelText("Image host") as HTMLSelectElement).options,
+    ).map((option) => option.value);
+    expect(values).toContain("imgbb");
+    expect(values).not.toContain("reelflix");
+  });
 });
 
 describe("Image hosting settings", () => {
@@ -528,5 +693,56 @@ describe("Image hosting settings", () => {
     };
     expect(payload.ImageHosting?.LostimgEnabled).toBe(true);
     expect(payload.ImageHosting?.LostimgAPI).toBe("secret");
+  });
+
+  it("renders Reelflix as an RF image host in image hosting settings", async () => {
+    (globalThis as typeof globalThis & { go?: any }).go = {
+      guiapp: {
+        App: {
+          GetConfig: async () =>
+            JSON.stringify({
+              ImageHosting: {
+                Host1: "",
+                Host2: "",
+                Host3: "",
+                Host4: "",
+                Host5: "",
+                Host6: "",
+              },
+              Trackers: {
+                Trackers: {
+                  RF: {
+                    ImageHost: "",
+                    ImgAPI: "",
+                  },
+                },
+              },
+            }),
+          GetDefaultConfig: async () => JSON.stringify({}),
+          ListKnownTrackers: async () => [],
+          GetImageHostPolicyMetadata: async () => ({}),
+        },
+      },
+    };
+
+    render(createElement(ImageHostingHarness));
+
+    await waitFor(() => expect(screen.getByLabelText("RF Reelflix")).toBeInTheDocument());
+
+    const hostOne = screen.getByLabelText("Host 1") as HTMLSelectElement;
+    expect(Array.from(hostOne.options).map((option) => option.value)).not.toContain("reelflix");
+
+    fireEvent.click(screen.getByLabelText("RF Reelflix"));
+    fireEvent.change(screen.getByLabelText("Image API"), {
+      target: { value: "secret" },
+    });
+
+    await waitFor(() => expect(screen.getByLabelText("RF Reelflix")).toBeChecked());
+
+    const payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+      Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
+    };
+    expect(payload.Trackers?.Trackers?.RF?.ImageHost).toBe("reelflix");
+    expect(payload.Trackers?.Trackers?.RF?.ImgAPI).toBe("secret");
   });
 });

--- a/gui/frontend/src/hooks/useSettingsState.tsx
+++ b/gui/frontend/src/hooks/useSettingsState.tsx
@@ -94,7 +94,11 @@ const imageHostOptions = [
   { value: "utppm", label: "UTPPM" },
 ];
 
-const trackerImageHostOptions = [...imageHostOptions, { value: "hdb", label: "HDB" }];
+const trackerImageHostOptions = [
+  ...imageHostOptions,
+  { value: "hdb", label: "HDB" },
+  { value: "lostimg", label: "Lostimg" },
+];
 const torrentClientTypeOptions = [
   { value: "qbit", label: "qBit" },
   { value: "watch", label: "Watch" },
@@ -108,7 +112,7 @@ const torrentClientLinkingOptions = [
 const imageHostOptionLabels = new Map(
   trackerImageHostOptions.map((option) => [option.value, option.label]),
 );
-const defaultOwnedImageHosts: Record<string, string> = { hdb: "HDB" };
+const defaultOwnedImageHosts: Record<string, string> = { hdb: "HDB", lostimg: "LST" };
 const normalizeImageHostValue = (value: string) => value.trim().toLowerCase();
 const imageHostOptionFor = (host: string) => {
   const value = normalizeImageHostValue(host);
@@ -520,6 +524,9 @@ const sensitiveKeyHints = [
 ];
 
 const sectionFieldMeta: Record<string, Record<string, FieldMeta>> = {
+  ImageHosting: {
+    LostimgAPI: stringField("LostimgAPI", { label: "API key", sensitive: true }),
+  },
   MainSettings: {
     TrackerPassChecks: { key: "TrackerPassChecks", advanced: true },
     InputHistoryLimit: { key: "InputHistoryLimit", label: "Input history limit", type: "number" },
@@ -963,12 +970,21 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
       const hosts = (policyHosts ?? fallbackHosts).filter((host) => {
         const normalizedHost = normalizeImageHostValue(host);
         const owner = ownerByHost[normalizedHost];
+        if (normalizedHost === "lostimg") {
+          const imageCfg =
+            configData?.ImageHosting &&
+            typeof configData.ImageHosting === "object" &&
+            !Array.isArray(configData.ImageHosting)
+              ? (configData.ImageHosting as ConfigMap)
+              : null;
+          return trackerKey === "LST" && Boolean(imageCfg?.LostimgEnabled);
+        }
         return !owner || owner.trim().toUpperCase() === trackerKey;
       });
 
       return buildImageHostOptions(hosts);
     },
-    [buildImageHostOptions, imageHostPolicyMetadata],
+    [buildImageHostOptions, configData, imageHostPolicyMetadata],
   );
 
   const updateConfigValue = (path: string[], value: ConfigValue) => {
@@ -2103,7 +2119,6 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
     const imageCfg = configData.ImageHosting as ConfigMap;
     const hostFields = ["Host1", "Host2", "Host3", "Host4", "Host5", "Host6"];
     const requiredKeys = new Set<string>();
-
     hostFields.forEach((field) => {
       const selected = String(imageCfg[field] ?? "").trim();
       if (!selected) return;
@@ -2150,6 +2165,28 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
               )}
             </div>
           )}
+        </div>
+
+        <div className="settings-subgroup">
+          <div className="settings-subgroup__title">Tracker Image Hosts</div>
+          <div className="settings-grid">
+            <div className="settings-switch-row">
+              <span>LST Lostimg</span>
+              <Switch
+                aria-label="LST Lostimg"
+                checked={Boolean(imageCfg.LostimgEnabled)}
+                onChange={(event) =>
+                  updateConfigValue(["ImageHosting", "LostimgEnabled"], event.target.checked)
+                }
+              />
+            </div>
+            {renderField(
+              "LostimgAPI",
+              (imageCfg.LostimgAPI as ConfigValue) ?? "",
+              ["ImageHosting", "LostimgAPI"],
+              sectionFieldMeta.ImageHosting.LostimgAPI,
+            )}
+          </div>
         </div>
       </div>
     );

--- a/gui/frontend/src/hooks/useSettingsState.tsx
+++ b/gui/frontend/src/hooks/useSettingsState.tsx
@@ -98,6 +98,7 @@ const trackerImageHostOptions = [
   ...imageHostOptions,
   { value: "hdb", label: "HDB" },
   { value: "lostimg", label: "Lostimg" },
+  { value: "reelflix", label: "Reelflix" },
 ];
 const torrentClientTypeOptions = [
   { value: "qbit", label: "qBit" },
@@ -112,7 +113,11 @@ const torrentClientLinkingOptions = [
 const imageHostOptionLabels = new Map(
   trackerImageHostOptions.map((option) => [option.value, option.label]),
 );
-const defaultOwnedImageHosts: Record<string, string> = { hdb: "HDB", lostimg: "LST" };
+const defaultOwnedImageHosts: Record<string, string> = {
+  hdb: "HDB",
+  lostimg: "LST",
+  reelflix: "RF",
+};
 const normalizeImageHostValue = (value: string) => value.trim().toLowerCase();
 const imageHostOptionFor = (host: string) => {
   const value = normalizeImageHostValue(host);
@@ -428,7 +433,12 @@ const trackerSchemas: Record<string, FieldMeta[]> = {
     trackerFieldMeta.Anon,
   ],
   RAS: [trackerFieldMeta.LinkDirName, trackerFieldMeta.APIKey, trackerFieldMeta.Anon],
-  RF: [trackerFieldMeta.LinkDirName, trackerFieldMeta.APIKey, trackerFieldMeta.Anon],
+  RF: [
+    trackerFieldMeta.LinkDirName,
+    trackerFieldMeta.APIKey,
+    trackerFieldMeta.ImgAPI,
+    trackerFieldMeta.Anon,
+  ],
   RTF: [
     trackerFieldMeta.LinkDirName,
     trackerFieldMeta.Username,
@@ -936,8 +946,7 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
   };
 
   const resolveImageHostLabel = (value: string) => {
-    const option = imageHostOptions.find((entry) => entry.value === value);
-    return option ? option.label : value;
+    return imageHostOptionLabels.get(value) ?? value;
   };
 
   const buildImageHostOptions = useCallback((hosts: string[]) => {
@@ -967,24 +976,68 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
         imageHostPolicyMetadata.UploadHosts?.map((host) => normalizeImageHostValue(host)) ??
         imageHostOptions.filter((option) => option.value).map((option) => option.value);
       const ownerByHost = imageHostPolicyMetadata.OwnedHosts ?? defaultOwnedImageHosts;
-      const hosts = (policyHosts ?? fallbackHosts).filter((host) => {
+      const imageCfg =
+        configData?.ImageHosting &&
+        typeof configData.ImageHosting === "object" &&
+        !Array.isArray(configData.ImageHosting)
+          ? (configData.ImageHosting as ConfigMap)
+          : null;
+      const trackerRoot =
+        configData?.Trackers &&
+        typeof configData.Trackers === "object" &&
+        !Array.isArray(configData.Trackers)
+          ? (configData.Trackers as ConfigMap)
+          : null;
+      const trackerEntries =
+        trackerRoot?.Trackers &&
+        typeof trackerRoot.Trackers === "object" &&
+        !Array.isArray(trackerRoot.Trackers)
+          ? (trackerRoot.Trackers as ConfigMap)
+          : null;
+      const trackerCfg =
+        trackerEntries?.[trackerKey] &&
+        typeof trackerEntries[trackerKey] === "object" &&
+        !Array.isArray(trackerEntries[trackerKey])
+          ? (trackerEntries[trackerKey] as ConfigMap)
+          : null;
+      const globalFallbackHosts = fallbackHosts.filter((host) => !ownerByHost[host]);
+      const globalHosts = (configuredImageHosts.length ? configuredImageHosts : globalFallbackHosts)
+        .map((host) => normalizeImageHostValue(host))
+        .filter((host) => host.length > 0 && !ownerByHost[host]);
+      const policyHostSet = new Set(
+        (policyHosts ?? []).map((host) => normalizeImageHostValue(host)).filter(Boolean),
+      );
+      const policyHasGlobalHosts = Array.from(policyHostSet).some((host) => !ownerByHost[host]);
+      const policyAllowsGlobalFallback =
+        policyHostSet.size === 0 ||
+        Array.from(policyHostSet).every((host) => host === "lostimg" || host === "reelflix");
+      const hosts = globalHosts.filter(
+        (host) => policyAllowsGlobalFallback || (policyHasGlobalHosts && policyHostSet.has(host)),
+      );
+
+      (policyHosts ?? []).forEach((host) => {
         const normalizedHost = normalizeImageHostValue(host);
         const owner = ownerByHost[normalizedHost];
-        if (normalizedHost === "lostimg") {
-          const imageCfg =
-            configData?.ImageHosting &&
-            typeof configData.ImageHosting === "object" &&
-            !Array.isArray(configData.ImageHosting)
-              ? (configData.ImageHosting as ConfigMap)
-              : null;
-          return trackerKey === "LST" && Boolean(imageCfg?.LostimgEnabled);
+        if (!owner || owner.trim().toUpperCase() !== trackerKey) {
+          return;
         }
-        return !owner || owner.trim().toUpperCase() === trackerKey;
+        if (normalizedHost === "lostimg" && !Boolean(imageCfg?.LostimgEnabled)) {
+          return;
+        }
+        if (
+          normalizedHost === "reelflix" &&
+          normalizeImageHostValue(String(trackerCfg?.ImageHost ?? "")) !== "reelflix"
+        ) {
+          return;
+        }
+        if (!hosts.includes(normalizedHost)) {
+          hosts.push(normalizedHost);
+        }
       });
 
       return buildImageHostOptions(hosts);
     },
-    [buildImageHostOptions, configData, imageHostPolicyMetadata],
+    [buildImageHostOptions, configData, configuredImageHosts, imageHostPolicyMetadata],
   );
 
   const updateConfigValue = (path: string[], value: ConfigValue) => {
@@ -2117,6 +2170,24 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
     }
 
     const imageCfg = configData.ImageHosting as ConfigMap;
+    const trackersRoot =
+      configData.Trackers &&
+      typeof configData.Trackers === "object" &&
+      !Array.isArray(configData.Trackers)
+        ? (configData.Trackers as ConfigMap)
+        : null;
+    const trackerEntries =
+      trackersRoot?.Trackers &&
+      typeof trackersRoot.Trackers === "object" &&
+      !Array.isArray(trackersRoot.Trackers)
+        ? (trackersRoot.Trackers as ConfigMap)
+        : null;
+    const rfTrackerCfg =
+      trackerEntries?.RF &&
+      typeof trackerEntries.RF === "object" &&
+      !Array.isArray(trackerEntries.RF)
+        ? (trackerEntries.RF as ConfigMap)
+        : null;
     const hostFields = ["Host1", "Host2", "Host3", "Host4", "Host5", "Host6"];
     const requiredKeys = new Set<string>();
     hostFields.forEach((field) => {
@@ -2185,6 +2256,27 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
               (imageCfg.LostimgAPI as ConfigValue) ?? "",
               ["ImageHosting", "LostimgAPI"],
               sectionFieldMeta.ImageHosting.LostimgAPI,
+            )}
+            <div className="settings-switch-row">
+              <span>RF Reelflix</span>
+              <Switch
+                aria-label="RF Reelflix"
+                checked={
+                  normalizeImageHostValue(String(rfTrackerCfg?.ImageHost ?? "")) === "reelflix"
+                }
+                onChange={(event) =>
+                  updateConfigValue(
+                    ["Trackers", "Trackers", "RF", "ImageHost"],
+                    event.target.checked ? "reelflix" : "",
+                  )
+                }
+              />
+            </div>
+            {renderField(
+              "ImgAPI",
+              (rfTrackerCfg?.ImgAPI as ConfigValue) ?? "",
+              ["Trackers", "Trackers", "RF", "ImgAPI"],
+              trackerFieldMeta.ImgAPI,
             )}
           </div>
         </div>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,6 +87,8 @@ type ImageHostingConfig struct {
 	ShareXURL       string `yaml:"sharex_url"`
 	ShareXAPIKey    string `yaml:"sharex_api_key"`
 	UTPPMAPI        string `yaml:"utppm_api"`
+	LostimgEnabled  bool   `yaml:"lostimg_enabled"`
+	LostimgAPI      string `yaml:"lostimg_api"`
 }
 
 type MetadataConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -223,6 +223,19 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "valid owned RF tracker image host",
+			cfg: Config{
+				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},
+				ScreenshotHandling: ScreenshotHandlingConfig{Screens: 1},
+				Trackers: TrackersConfig{
+					Trackers: map[string]TrackerConfig{
+						"RF": {ImageHost: "reelflix"},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/config/defaults/example.yaml
+++ b/internal/config/defaults/example.yaml
@@ -360,6 +360,7 @@ trackers:
   RF:
     link_dir_name: ""
     api_key: ""
+    img_api: ""
     anon: false
   RTF:
     link_dir_name: ""

--- a/internal/config/defaults/example.yaml
+++ b/internal/config/defaults/example.yaml
@@ -25,6 +25,8 @@ image_hosting:
   sharex_url: ""
   sharex_api_key: ""
   utppm_api: ""
+  lostimg_enabled: false
+  lostimg_api: ""
 
 metadata:
   btn_api: ""

--- a/internal/config/legacy/converter.go
+++ b/internal/config/legacy/converter.go
@@ -42,6 +42,8 @@ var legacyDefaultSectionByKey = map[string]string{
 	"sharex_url":                     "image_hosting",
 	"sharex_api_key":                 "image_hosting",
 	"utppm_api":                      "image_hosting",
+	"lostimg_enabled":                "image_hosting",
+	"lostimg_api":                    "image_hosting",
 	"btn_api":                        "metadata",
 	"skip_auto_torrent":              "metadata",
 	"skip_tracker_filename_lookup":   "metadata",

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -349,6 +349,7 @@ func walkSecretFields(cfg *Config, visit func(path string, value *string) error)
 		&cfg.ImageHosting.SeedpoolCDNAPI,
 		&cfg.ImageHosting.ShareXAPIKey,
 		&cfg.ImageHosting.UTPPMAPI,
+		&cfg.ImageHosting.LostimgAPI,
 	}
 	for idx, field := range imageSecrets {
 		if err := visit(fmt.Sprintf("ImageHosting[%d]", idx), field); err != nil {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -1170,7 +1170,7 @@ func (c *Core) resolveImageUploadTargets(req api.Request, meta api.PreparedMetad
 	trackerCfg.Trackers.DefaultTrackers = nil
 	resolvedTrackers := trackers.ResolveTrackers(trackerCfg, req.Trackers, req.TrackersRemove, c.logger)
 	resolvedTrackers = c.filterImageUploadTrackers(resolvedTrackers, meta)
-	targets, err := trackers.NeededImageUploadTargets(c.cfg, resolvedTrackers, normalizedHost)
+	targets, err := trackers.NeededImageUploadTargetsForMetadata(c.cfg, resolvedTrackers, normalizedHost, meta)
 	if err != nil {
 		return nil, fmt.Errorf("core: %w", err)
 	}
@@ -1262,12 +1262,12 @@ func ruleFailuresForTracker(failures map[string][]api.RuleFailure, tracker strin
 	return nil
 }
 
-func (c *Core) resolveFallbackImageUploadTargets(host string, trackerNames []string, excludedHosts []string) ([]trackers.ImageUploadTarget, error) {
+func (c *Core) resolveFallbackImageUploadTargets(host string, trackerNames []string, excludedHosts []string, meta api.PreparedMetadata) ([]trackers.ImageUploadTarget, error) {
 	normalizedHost := strings.ToLower(strings.TrimSpace(host))
 	if normalizedHost == "" || len(trackerNames) == 0 {
 		return nil, nil
 	}
-	targets, err := trackers.NeededImageUploadTargetsExcluding(c.cfg, trackerNames, normalizedHost, excludedHosts)
+	targets, err := trackers.NeededImageUploadTargetsForMetadataExcluding(c.cfg, trackerNames, normalizedHost, excludedHosts, meta)
 	if err != nil {
 		return nil, fmt.Errorf("core: %w", err)
 	}
@@ -1304,7 +1304,7 @@ func (c *Core) uploadImagesToTargetsWithFallback(ctx context.Context, meta api.P
 		}
 
 		blockedTrackers := uploadFailureTrackers(failures)
-		fallbackTargets, err := c.resolveFallbackImageUploadTargets(host, blockedTrackers, sortedMapKeys(failedHosts))
+		fallbackTargets, err := c.resolveFallbackImageUploadTargets(host, blockedTrackers, sortedMapKeys(failedHosts), meta)
 		if err != nil {
 			return api.UploadImagesResult{}, err
 		}

--- a/internal/core/upload_images_test.go
+++ b/internal/core/upload_images_test.go
@@ -589,6 +589,59 @@ func TestUploadImagesFallsBackWhenSelectedHostFails(t *testing.T) {
 	}
 }
 
+func TestUploadImagesFallsBackFromTrackerConfiguredHostForUnrestrictedTracker(t *testing.T) {
+	t.Parallel()
+
+	images := []api.ScreenshotImage{{Path: "/tmp/img1.png"}}
+	var calls []string
+	imageService := &stubImageHosting{
+		uploadFn: func(_ context.Context, meta api.PreparedMetadata, host string, usageScope string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+			calls = append(calls, host)
+			if host == "pixhost" {
+				return nil, errors.New("pixhost unavailable")
+			}
+			return uploadedImageLinksForHost(meta, host, usageScope, images), nil
+		},
+	}
+	core := &Core{
+		logger: api.NopLogger{},
+		cfg: config.Config{
+			ImageHosting: config.ImageHostingConfig{
+				Host1: "pixhost",
+				Host2: "imgbb",
+			},
+			Trackers: config.TrackersConfig{
+				Trackers: map[string]config.TrackerConfig{
+					"HHD": {ImageHost: "pixhost"},
+				},
+			},
+		},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{"/tmp/source"}},
+			Images:     imageService,
+		},
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+
+	result, err := core.UploadImages(context.Background(), api.Request{
+		Paths:    []string{"/tmp/source"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"HHD"},
+	}, "pixhost", images)
+	if err != nil {
+		t.Fatalf("expected fallback upload to succeed, got %v", err)
+	}
+	if len(result.Failures) != 0 {
+		t.Fatalf("expected configured host failure to be recovered by fallback, got %#v", result.Failures)
+	}
+	if len(result.Links) != 1 || result.Links[0].Host != "imgbb" {
+		t.Fatalf("expected fallback imgbb link, got %#v", result)
+	}
+	if !slices.Equal(calls, []string{"pixhost", "imgbb"}) {
+		t.Fatalf("expected configured host then fallback host, got %v", calls)
+	}
+}
+
 func uploadedImageLinksForHost(meta api.PreparedMetadata, host string, usageScope string, images []api.ScreenshotImage) []api.UploadedImageLink {
 	result := make([]api.UploadedImageLink, 0, len(images))
 	for _, image := range images {

--- a/internal/imagehostpolicy/policy.go
+++ b/internal/imagehostpolicy/policy.go
@@ -41,6 +41,7 @@ var uploadHosts = map[string]struct{}{
 	"imgbb":        {},
 	"imgbox":       {},
 	"lensdump":     {},
+	"lostimg":      {},
 	"onlyimage":    {},
 	"passtheimage": {},
 	"pixhost":      {},
@@ -53,8 +54,13 @@ var uploadHosts = map[string]struct{}{
 }
 
 var ownedHosts = map[string]string{
-	"hdb": "HDB",
-	"thr": "THR",
+	"hdb":     "HDB",
+	"lostimg": "LST",
+	"thr":     "THR",
+}
+
+var trackerOptionalUploadHosts = map[string][]string{
+	"LST": {"lostimg"},
 }
 
 func ForTracker(tracker string, imgRehost bool, imgAPI string) Policy {
@@ -107,6 +113,10 @@ func KnownTrackerUploadPolicies() map[string][]string {
 	out := make(map[string][]string, len(trackerAllowedHosts))
 	for tracker, hosts := range trackerAllowedHosts {
 		out[tracker] = filterUploadHosts(normalizeUnique(hosts...))
+	}
+	for tracker, hosts := range trackerOptionalUploadHosts {
+		existing := out[tracker]
+		out[tracker] = filterUploadHosts(normalizeUnique(append(existing, hosts...)...))
 	}
 	return out
 }

--- a/internal/imagehostpolicy/policy.go
+++ b/internal/imagehostpolicy/policy.go
@@ -4,6 +4,7 @@
 package imagehostpolicy
 
 import (
+	"maps"
 	"slices"
 	"strings"
 )
@@ -46,6 +47,7 @@ var uploadHosts = map[string]struct{}{
 	"passtheimage": {},
 	"pixhost":      {},
 	"ptscreens":    {},
+	"reelflix":     {},
 	"seedpool_cdn": {},
 	"sharex":       {},
 	"thr":          {},
@@ -54,13 +56,15 @@ var uploadHosts = map[string]struct{}{
 }
 
 var ownedHosts = map[string]string{
-	"hdb":     "HDB",
-	"lostimg": "LST",
-	"thr":     "THR",
+	"hdb":      "HDB",
+	"lostimg":  "LST",
+	"reelflix": "RF",
+	"thr":      "THR",
 }
 
 var trackerOptionalUploadHosts = map[string][]string{
 	"LST": {"lostimg"},
+	"RF":  {"reelflix"},
 }
 
 func ForTracker(tracker string, imgRehost bool, imgAPI string) Policy {
@@ -123,9 +127,7 @@ func KnownTrackerUploadPolicies() map[string][]string {
 
 func KnownOwnedHosts() map[string]string {
 	out := make(map[string]string, len(ownedHosts))
-	for host, tracker := range ownedHosts {
-		out[host] = tracker
-	}
+	maps.Copy(out, ownedHosts)
 	return out
 }
 

--- a/internal/imagehostpolicy/policy_test.go
+++ b/internal/imagehostpolicy/policy_test.go
@@ -37,3 +37,17 @@ func TestPolicyMetadataDefensivelyCopiesOwnedHosts(t *testing.T) {
 		t.Fatalf("OwnerForHost(hdb) = %q, want HDB", got)
 	}
 }
+
+func TestPolicyMetadataExposesLostimgAsLSTOwnedUploadHost(t *testing.T) {
+	t.Parallel()
+
+	metadata := PolicyMetadata()
+	lstHosts := metadata.TrackerUploadHosts["LST"]
+
+	if !HostAllowed("lostimg", lstHosts) {
+		t.Fatalf("LST upload hosts should include lostimg: %v", lstHosts)
+	}
+	if got := metadata.OwnedHosts["lostimg"]; got != "LST" {
+		t.Fatalf("lostimg owner = %q, want LST", got)
+	}
+}

--- a/internal/imagehostpolicy/policy_test.go
+++ b/internal/imagehostpolicy/policy_test.go
@@ -51,3 +51,17 @@ func TestPolicyMetadataExposesLostimgAsLSTOwnedUploadHost(t *testing.T) {
 		t.Fatalf("lostimg owner = %q, want LST", got)
 	}
 }
+
+func TestPolicyMetadataExposesReelflixAsRFOwnedUploadHost(t *testing.T) {
+	t.Parallel()
+
+	metadata := PolicyMetadata()
+	rfHosts := metadata.TrackerUploadHosts["RF"]
+
+	if !HostAllowed("reelflix", rfHosts) {
+		t.Fatalf("RF upload hosts should include reelflix: %v", rfHosts)
+	}
+	if got := metadata.OwnedHosts["reelflix"]; got != "RF" {
+		t.Fatalf("reelflix owner = %q, want RF", got)
+	}
+}

--- a/internal/services/imagehosting/service.go
+++ b/internal/services/imagehosting/service.go
@@ -336,9 +336,7 @@ dispatchLoop:
 			<-sem
 			break
 		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			defer func() { <-sem }()
 			if err := ctx.Err(); err != nil {
 				mu.Lock()
@@ -410,7 +408,7 @@ dispatchLoop:
 			})
 			mu.Unlock()
 			s.logger.Debugf("image hosting: successfully uploaded %s in %v", fileName, uploadDuration)
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/services/imagehosting/uploaders.go
+++ b/internal/services/imagehosting/uploaders.go
@@ -51,6 +51,7 @@ func newUploaderRegistry(cfg config.Config, client *http.Client) map[string]uplo
 		"hdb":          &hdbUploader{username: cfg.Trackers.Trackers["HDB"].Username, passkey: cfg.Trackers.Trackers["HDB"].Passkey, client: client},
 		"pixhost":      &pixhostUploader{client: client},
 		"lensdump":     &lensdumpUploader{apiKey: cfg.ImageHosting.LensdumpAPI, client: client},
+		"lostimg":      &lostimgUploader{apiKey: cfg.ImageHosting.LostimgAPI, client: client},
 		"ptscreens":    &ptScreensUploader{apiKey: cfg.ImageHosting.PTScreensAPI, client: client},
 		"onlyimage":    &onlyImageUploader{apiKey: cfg.ImageHosting.OnlyImageAPI, client: client},
 		"dalexni":      &dalexniUploader{apiKey: cfg.ImageHosting.DalexniAPI, client: client},
@@ -775,6 +776,83 @@ func (u *thrUploader) Upload(ctx context.Context, imagePath string) (uploadResul
 	return uploadResult{ImgURL: imageURL, RawURL: imageURL, WebURL: imageURL}, nil
 }
 
+type lostimgUploader struct {
+	apiKey string
+	client *http.Client
+}
+
+const lostimgMaxBatchUploadImages = 50
+
+func (u *lostimgUploader) Upload(ctx context.Context, imagePath string) (uploadResult, error) {
+	results, err := u.UploadBatch(ctx, []string{imagePath})
+	if err != nil {
+		return uploadResult{}, err
+	}
+	return results[0], nil
+}
+
+func (u *lostimgUploader) UploadBatch(ctx context.Context, imagePaths []string) ([]uploadResult, error) {
+	if strings.TrimSpace(u.apiKey) == "" {
+		return nil, errors.New("image hosting: lostimg api key missing")
+	}
+	if len(imagePaths) == 0 {
+		return nil, errors.New("image hosting: no Lostimg images to upload")
+	}
+	results := make([]uploadResult, 0, len(imagePaths))
+	for start := 0; start < len(imagePaths); start += lostimgMaxBatchUploadImages {
+		end := start + lostimgMaxBatchUploadImages
+		if end > len(imagePaths) {
+			end = len(imagePaths)
+		}
+		chunkResults, err := u.uploadBatch(ctx, imagePaths[start:end])
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, chunkResults...)
+	}
+	return results, nil
+}
+
+func (u *lostimgUploader) uploadBatch(ctx context.Context, imagePaths []string) ([]uploadResult, error) {
+	headers := map[string]string{"Authorization": "Bearer " + strings.TrimSpace(u.apiKey)}
+	body, status, err := postMultipartRepeatedFileField(ctx, u.client, "https://lostimg.cc/api/v1/images", "file[]", imagePaths, headers)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("lostimg upload failed with status %d", status)
+	}
+
+	var response struct {
+		URL   string   `json:"url"`
+		URLs  []string `json:"urls"`
+		Error string   `json:"error"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("lostimg invalid response: %w", err)
+	}
+	if strings.TrimSpace(response.Error) != "" {
+		return nil, fmt.Errorf("lostimg upload failed: %s", strings.TrimSpace(response.Error))
+	}
+
+	urls := response.URLs
+	if len(urls) == 0 && strings.TrimSpace(response.URL) != "" {
+		urls = []string{response.URL}
+	}
+	if len(urls) != len(imagePaths) {
+		return nil, fmt.Errorf("lostimg upload returned %d images for %d uploads", len(urls), len(imagePaths))
+	}
+	results := make([]uploadResult, 0, len(urls))
+	for _, raw := range urls {
+		imageURL := strings.TrimSpace(raw)
+		if imageURL == "" {
+			return nil, errors.New("lostimg upload returned empty image URL")
+		}
+		results = append(results, uploadResult{ImgURL: imageURL, RawURL: imageURL, WebURL: imageURL})
+	}
+	return results, nil
+}
+
 type pixhostUploader struct {
 	client *http.Client
 }
@@ -1051,6 +1129,52 @@ func postMultipartWithFields(ctx context.Context, client *http.Client, target st
 	sort.Strings(fileFieldKeys)
 	for _, fileField := range fileFieldKeys {
 		filePath := fileFields[fileField]
+		file, err := os.Open(filePath)
+		if err != nil {
+			return nil, 0, fmt.Errorf("image hosting: open multipart file: %w", err)
+		}
+		part, err := writer.CreateFormFile(fileField, filepath.Base(filePath))
+		if err != nil {
+			_ = file.Close()
+			return nil, 0, fmt.Errorf("image hosting: create multipart file %q: %w", fileField, err)
+		}
+		if _, err := io.Copy(part, file); err != nil {
+			_ = file.Close()
+			return nil, 0, fmt.Errorf("image hosting: copy multipart file: %w", err)
+		}
+		if err := file.Close(); err != nil {
+			return nil, 0, fmt.Errorf("image hosting: close multipart file: %w", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, 0, fmt.Errorf("image hosting: close multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target, body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("image hosting: create multipart request for %s: %w", target, err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		closeResponseBody(resp)
+		return nil, 0, fmt.Errorf("image hosting: send multipart request to %s: %w", target, err)
+	}
+	bodyBytes, err := readAndCloseResponseBody(resp)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return bodyBytes, resp.StatusCode, nil
+}
+
+func postMultipartRepeatedFileField(ctx context.Context, client *http.Client, target string, fileField string, filePaths []string, headers map[string]string) ([]byte, int, error) {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	for _, filePath := range filePaths {
 		file, err := os.Open(filePath)
 		if err != nil {
 			return nil, 0, fmt.Errorf("image hosting: open multipart file: %w", err)

--- a/internal/services/imagehosting/uploaders.go
+++ b/internal/services/imagehosting/uploaders.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -57,6 +58,7 @@ func newUploaderRegistry(cfg config.Config, client *http.Client) map[string]uplo
 		"dalexni":      &dalexniUploader{apiKey: cfg.ImageHosting.DalexniAPI, client: client},
 		"zipline":      &ziplineUploader{apiKey: cfg.ImageHosting.ZiplineAPIKey, url: cfg.ImageHosting.ZiplineURL, client: client},
 		"passtheimage": &passTheImageUploader{apiKey: cfg.ImageHosting.PassTheImageAPI, client: client},
+		"reelflix":     &reelflixUploader{apiKey: cfg.Trackers.Trackers["RF"].ImgAPI, client: client},
 		"seedpool_cdn": &seedpoolUploader{apiKey: cfg.ImageHosting.SeedpoolCDNAPI, client: client},
 		"sharex":       &shareXUploader{apiKey: cfg.ImageHosting.ShareXAPIKey, url: cfg.ImageHosting.ShareXURL, client: client},
 		"thr":          &thrUploader{apiKey: cfg.Trackers.Trackers["THR"].ImgAPI, client: client},
@@ -254,10 +256,7 @@ func (u *hdbUploader) UploadBatchWithName(ctx context.Context, imagePaths []stri
 	}
 	results := make([]uploadResult, 0, len(imagePaths))
 	for start := 0; start < len(imagePaths); start += hdbMaxBatchUploadImages {
-		end := start + hdbMaxBatchUploadImages
-		if end > len(imagePaths) {
-			end = len(imagePaths)
-		}
+		end := min(start+hdbMaxBatchUploadImages, len(imagePaths))
 		chunk, err := u.uploadBatchWithGalleryName(ctx, imagePaths[start:end], galleryName)
 		if err != nil {
 			return nil, err
@@ -393,7 +392,7 @@ func imgboxGetUploadToken(ctx context.Context, client *http.Client, csrfToken st
 		}
 		return imgboxUploadToken{}, fmt.Errorf("imgbox token request failed with status %d, response: %s", resp.StatusCode, bodyStr)
 	}
-	var tokenResp map[string]interface{}
+	var tokenResp map[string]any
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
 		bodyStr := string(body)
 		if len(bodyStr) > 200 {
@@ -425,9 +424,7 @@ func imgboxHeaders(cookie string, extra map[string]string) map[string]string {
 	if strings.TrimSpace(cookie) != "" {
 		headers["Cookie"] = cookie
 	}
-	for key, value := range extra {
-		headers[key] = value
-	}
+	maps.Copy(headers, extra)
 	return headers
 }
 
@@ -464,7 +461,7 @@ func imgboxPickCookie(resp *http.Response) string {
 	return strings.Join(parts, "; ")
 }
 
-func imgboxJSONValue(value interface{}) string {
+func imgboxJSONValue(value any) string {
 	switch typed := value.(type) {
 	case nil:
 		return "null"
@@ -800,10 +797,7 @@ func (u *lostimgUploader) UploadBatch(ctx context.Context, imagePaths []string) 
 	}
 	results := make([]uploadResult, 0, len(imagePaths))
 	for start := 0; start < len(imagePaths); start += lostimgMaxBatchUploadImages {
-		end := start + lostimgMaxBatchUploadImages
-		if end > len(imagePaths) {
-			end = len(imagePaths)
-		}
+		end := min(start+lostimgMaxBatchUploadImages, len(imagePaths))
 		chunkResults, err := u.uploadBatch(ctx, imagePaths[start:end])
 		if err != nil {
 			return nil, err
@@ -975,6 +969,62 @@ func (u *passTheImageUploader) Upload(ctx context.Context, imagePath string) (up
 
 	return uploadResult{
 		ImgURL: response.Image.URL,
+		RawURL: response.Image.URL,
+		WebURL: response.Image.URLViewer,
+	}, nil
+}
+
+type reelflixUploader struct {
+	apiKey string
+	client *http.Client
+}
+
+func (u *reelflixUploader) Upload(ctx context.Context, imagePath string) (uploadResult, error) {
+	if strings.TrimSpace(u.apiKey) == "" {
+		return uploadResult{}, errors.New("image hosting: reelflix api key missing")
+	}
+	headers := map[string]string{"X-API-Key": strings.TrimSpace(u.apiKey)}
+	body, status, err := postMultipart(ctx, u.client, "https://img.reelflix.cc/api/1/upload", nil, "source", imagePath, headers)
+	if err != nil {
+		return uploadResult{}, err
+	}
+	if status != http.StatusOK {
+		return uploadResult{}, fmt.Errorf("reelflix upload failed with status %d", status)
+	}
+
+	var response struct {
+		StatusCode int `json:"status_code"`
+		Image      struct {
+			Medium struct {
+				URL string `json:"url"`
+			} `json:"medium"`
+			URL       string `json:"url"`
+			URLViewer string `json:"url_viewer"`
+		} `json:"image"`
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return uploadResult{}, fmt.Errorf("reelflix invalid response: %w", err)
+	}
+	if response.StatusCode != 0 && response.StatusCode != http.StatusOK {
+		message := strings.TrimSpace(response.Error.Message)
+		if message == "" {
+			message = "reelflix upload failed"
+		}
+		return uploadResult{}, fmt.Errorf("reelflix upload failed: %s", message)
+	}
+	if response.Image.URL == "" {
+		return uploadResult{}, errors.New("reelflix upload failed")
+	}
+	imgURL := response.Image.Medium.URL
+	if strings.TrimSpace(imgURL) == "" {
+		imgURL = response.Image.URL
+	}
+
+	return uploadResult{
+		ImgURL: imgURL,
 		RawURL: response.Image.URL,
 		WebURL: response.Image.URLViewer,
 	}, nil

--- a/internal/services/imagehosting/uploaders_test.go
+++ b/internal/services/imagehosting/uploaders_test.go
@@ -140,7 +140,7 @@ func TestHDBUploadBatchUsesSingleGalleryRequest(t *testing.T) {
 func TestHDBUploadBatchChunksLargeUploads(t *testing.T) {
 	tmpDir := t.TempDir()
 	paths := make([]string, 0, hdbMaxBatchUploadImages+1)
-	for idx := 0; idx < hdbMaxBatchUploadImages+1; idx++ {
+	for idx := range hdbMaxBatchUploadImages + 1 {
 		path := filepath.Join(tmpDir, fmt.Sprintf("shot-%02d.png", idx+1))
 		if err := os.WriteFile(path, []byte("testdata"), 0o644); err != nil {
 			t.Fatalf("write temp file: %v", err)
@@ -393,6 +393,76 @@ func TestLostimgUploaderAcceptsSingleURLResponse(t *testing.T) {
 	}
 	if result.RawURL != "https://lostimg.cc/shot.png" {
 		t.Fatalf("unexpected raw URL: %q", result.RawURL)
+	}
+}
+
+func TestReelflixUploaderPostsSourceWithAPIKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	imagePath := filepath.Join(tmpDir, "shot.png")
+	if err := os.WriteFile(imagePath, []byte("testdata"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() != "https://img.reelflix.cc/api/1/upload" {
+				t.Fatalf("unexpected request URL: %s", req.URL.String())
+			}
+			if got := req.Header.Get("X-Api-Key"); got != "secret" {
+				t.Fatalf("expected X-API-Key, got %q", got)
+			}
+			mediaType, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+			if err != nil {
+				t.Fatalf("parse media type: %v", err)
+			}
+			if mediaType != "multipart/form-data" {
+				t.Fatalf("unexpected media type: %s", mediaType)
+			}
+			reader := multipartReader(t, req, params["boundary"])
+			fileFields := []string{}
+			for {
+				part, err := reader.NextPart()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					t.Fatalf("read multipart part: %v", err)
+				}
+				_, _ = io.Copy(io.Discard, part)
+				if part.FileName() != "" {
+					fileFields = append(fileFields, part.FormName())
+				}
+			}
+			if len(fileFields) != 1 || fileFields[0] != "source" {
+				t.Fatalf("expected source file field, got %v", fileFields)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+					"status_code": 200,
+					"image": {
+						"url": "https://img.reelflix.cc/images/shot.png",
+						"url_viewer": "https://img.reelflix.cc/image/shot",
+						"medium": {"url": "https://img.reelflix.cc/images/medium/shot.png"}
+					}
+				}`)),
+			}, nil
+		}),
+	}
+
+	result, err := (&reelflixUploader{apiKey: "secret", client: client}).Upload(context.Background(), imagePath)
+	if err != nil {
+		t.Fatalf("Upload returned error: %v", err)
+	}
+	if result.ImgURL != "https://img.reelflix.cc/images/medium/shot.png" {
+		t.Fatalf("unexpected img URL: %q", result.ImgURL)
+	}
+	if result.RawURL != "https://img.reelflix.cc/images/shot.png" {
+		t.Fatalf("unexpected raw URL: %q", result.RawURL)
+	}
+	if result.WebURL != "https://img.reelflix.cc/image/shot" {
+		t.Fatalf("unexpected web URL: %q", result.WebURL)
 	}
 }
 

--- a/internal/services/imagehosting/uploaders_test.go
+++ b/internal/services/imagehosting/uploaders_test.go
@@ -310,6 +310,92 @@ func TestTHRUploaderRequiresImageURL(t *testing.T) {
 	}
 }
 
+func TestLostimgUploaderPostsRepeatedFileFields(t *testing.T) {
+	tmpDir := t.TempDir()
+	firstPath := filepath.Join(tmpDir, "shot-01.png")
+	secondPath := filepath.Join(tmpDir, "shot-02.png")
+	for _, path := range []string{firstPath, secondPath} {
+		if err := os.WriteFile(path, []byte("testdata"), 0o644); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+	}
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() != "https://lostimg.cc/api/v1/images" {
+				t.Fatalf("unexpected request URL: %s", req.URL.String())
+			}
+			if got := req.Header.Get("Authorization"); got != "Bearer secret" {
+				t.Fatalf("expected bearer auth, got %q", got)
+			}
+			mediaType, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+			if err != nil {
+				t.Fatalf("parse media type: %v", err)
+			}
+			if mediaType != "multipart/form-data" {
+				t.Fatalf("unexpected media type: %s", mediaType)
+			}
+			reader := multipartReader(t, req, params["boundary"])
+			fileFields := []string{}
+			for {
+				part, err := reader.NextPart()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					t.Fatalf("read multipart part: %v", err)
+				}
+				_, _ = io.Copy(io.Discard, part)
+				if part.FileName() != "" {
+					fileFields = append(fileFields, part.FormName())
+				}
+			}
+			if len(fileFields) != 2 || fileFields[0] != "file[]" || fileFields[1] != "file[]" {
+				t.Fatalf("expected repeated file[] fields, got %v", fileFields)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"urls":["https://lostimg.cc/a.png","https://lostimg.cc/b.png"]}`)),
+			}, nil
+		}),
+	}
+
+	results, err := (&lostimgUploader{apiKey: "secret", client: client}).UploadBatch(context.Background(), []string{firstPath, secondPath})
+	if err != nil {
+		t.Fatalf("UploadBatch returned error: %v", err)
+	}
+	if len(results) != 2 || results[0].RawURL != "https://lostimg.cc/a.png" || results[1].RawURL != "https://lostimg.cc/b.png" {
+		t.Fatalf("unexpected lostimg results: %#v", results)
+	}
+}
+
+func TestLostimgUploaderAcceptsSingleURLResponse(t *testing.T) {
+	tmpDir := t.TempDir()
+	imagePath := filepath.Join(tmpDir, "shot.png")
+	if err := os.WriteFile(imagePath, []byte("testdata"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"url":"https://lostimg.cc/shot.png"}`)),
+			}, nil
+		}),
+	}
+
+	result, err := (&lostimgUploader{apiKey: "secret", client: client}).Upload(context.Background(), imagePath)
+	if err != nil {
+		t.Fatalf("Upload returned error: %v", err)
+	}
+	if result.RawURL != "https://lostimg.cc/shot.png" {
+		t.Fatalf("unexpected raw URL: %q", result.RawURL)
+	}
+}
+
 func TestReadAndCloseResponseBodyClosesBody(t *testing.T) {
 	body := &trackingReadCloser{reader: strings.NewReader("partial response")}
 	resp := &http.Response{

--- a/internal/trackers/description_assets_test.go
+++ b/internal/trackers/description_assets_test.go
@@ -1742,6 +1742,48 @@ func TestEnsureDescriptionImageHostFallsBackAfterConfiguredHostFailure(t *testin
 	}
 }
 
+func TestEnsureDescriptionImageHostFallsBackFromConfiguredHostForUnrestrictedTracker(t *testing.T) {
+	repo := &stubRepo{
+		selections: []api.ScreenshotFinalSelection{
+			{SourcePath: "/tmp/source", ImagePath: "/tmp/a.png", Order: 0},
+			{SourcePath: "/tmp/source", ImagePath: "/tmp/b.png", Order: 1},
+		},
+	}
+	meta := api.PreparedMetadata{SourcePath: "/tmp/source"}
+	images := &stubImageService{
+		errs: map[string]error{"pixhost": errors.New("pixhost unavailable")},
+	}
+
+	resolution, err := ensureDescriptionImageHost(
+		context.Background(),
+		"HHD",
+		meta,
+		config.Config{ImageHosting: config.ImageHostingConfig{Host1: "pixhost", Host2: "imgbb"}},
+		config.TrackerConfig{ImageHost: "pixhost"},
+		repo,
+		images,
+		api.NopLogger{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolution.blocking {
+		t.Fatalf("expected fallback success not to block")
+	}
+	if resolution.feedback.SelectedHost != "imgbb" {
+		t.Fatalf("expected imgbb fallback, got %#v", resolution.feedback)
+	}
+	if len(resolution.feedback.AllowedHosts) != 0 {
+		t.Fatalf("expected unrestricted tracker policy, got %#v", resolution.feedback.AllowedHosts)
+	}
+	if len(resolution.feedback.Warnings) != 1 || resolution.feedback.Warnings[0].Host != "pixhost" {
+		t.Fatalf("expected pixhost warning, got %#v", resolution.feedback.Warnings)
+	}
+	if len(images.calls) != 2 || images.calls[0] != "pixhost" || images.calls[1] != "imgbb" {
+		t.Fatalf("expected pixhost then imgbb calls, got %#v", images.calls)
+	}
+}
+
 func TestEnsureDescriptionImageHostBlocksWhenAllUploadHostsFail(t *testing.T) {
 	repo := &stubRepo{
 		selections: []api.ScreenshotFinalSelection{

--- a/internal/trackers/image_host_policy.go
+++ b/internal/trackers/image_host_policy.go
@@ -62,7 +62,7 @@ func applyImageHostOverrides(tracker string, policy imageHostPolicy, overrides a
 		return imageHostPolicy{}, fmt.Errorf("trackers: %s image host override %q is unsupported", strings.TrimSpace(tracker), host)
 	}
 	if len(policy.allowed) == 0 {
-		return newImageHostPolicy(host), nil
+		return newPreferredImageHostPolicy(host), nil
 	}
 	if !hostAllowed(host, policy.allowed) {
 		return imageHostPolicy{}, fmt.Errorf("trackers: %s image host override %q is not allowed (allowed: %s)", strings.TrimSpace(tracker), host, strings.Join(policy.allowed, ", "))
@@ -88,7 +88,7 @@ func resolveImageHostPolicy(tracker string, trackerCfg config.TrackerConfig, ove
 		return imageHostPolicy{}, fmt.Errorf("trackers: %s configured image_host %q is not allowed", strings.TrimSpace(tracker), trackerCfg.ImageHost)
 	}
 	if len(policy.allowed) == 0 {
-		return newImageHostPolicy(host), nil
+		return newPreferredImageHostPolicy(host), nil
 	}
 	policy.preferred = prependHost(host, policy.preferred)
 	policy.fallbackOK = true
@@ -104,10 +104,18 @@ func resolveImageHostPolicyForMetadata(tracker string, appCfg config.Config, tra
 		trackerCfg.ImageHost = ""
 	}
 	if strings.TrimSpace(trackerCfg.ImageHost) != "" || overrides.PreferredHost != nil {
-		return resolveImageHostPolicy(tracker, trackerCfg, overrides)
+		policy, err := resolveImageHostPolicy(tracker, trackerCfg, overrides)
+		if err != nil {
+			return imageHostPolicy{}, err
+		}
+		return withUnrestrictedImageHostFallbacks(tracker, policy, appCfg), nil
 	}
 	policy := policyForTrackerWithConfig(tracker, appCfg, trackerCfg)
-	return applyImageHostOverrides(tracker, policy, overrides)
+	policy, err := applyImageHostOverrides(tracker, policy, overrides)
+	if err != nil {
+		return imageHostPolicy{}, err
+	}
+	return withUnrestrictedImageHostFallbacks(tracker, policy, appCfg), nil
 }
 
 func PreferredImageUploadHost(tracker string, trackerCfg config.TrackerConfig, overrides api.ImageHostOverrides) (string, error) {
@@ -422,7 +430,11 @@ func candidateImageUploadTargetHosts(tracker string, policy imageHostPolicy, can
 
 func resolveImageHostPolicyForTarget(tracker string, appCfg config.Config, trackerCfg config.TrackerConfig, meta *api.PreparedMetadata) (imageHostPolicy, error) {
 	if meta == nil {
-		return resolveImageHostPolicy(tracker, trackerCfg, api.ImageHostOverrides{})
+		policy, err := resolveImageHostPolicy(tracker, trackerCfg, api.ImageHostOverrides{})
+		if err != nil {
+			return imageHostPolicy{}, err
+		}
+		return withUnrestrictedImageHostFallbacks(tracker, policy, appCfg), nil
 	}
 	return resolveImageHostPolicyForMetadata(tracker, appCfg, trackerCfg, *meta, api.ImageHostOverrides{})
 }
@@ -527,6 +539,38 @@ func newImageHostPolicy(hosts ...string) imageHostPolicy {
 		preferred:   uploadHostsFor(normalized),
 		required:    true,
 	}
+}
+
+func newPreferredImageHostPolicy(host string, fallbackHosts ...string) imageHostPolicy {
+	hosts := make([]string, 0, len(fallbackHosts)+1)
+	if supportedUploadImageHost(host) {
+		hosts = appendUniqueHost(hosts, host)
+	}
+	for _, fallbackHost := range fallbackHosts {
+		if supportedUploadImageHost(fallbackHost) {
+			hosts = appendUniqueHost(hosts, fallbackHost)
+		}
+	}
+	return imageHostPolicy{
+		uploadHosts: hosts,
+		preferred:   hosts,
+		required:    len(hosts) > 0,
+		fallbackOK:  len(hosts) > 0,
+	}
+}
+
+func withUnrestrictedImageHostFallbacks(tracker string, policy imageHostPolicy, appCfg config.Config) imageHostPolicy {
+	if !policy.required || len(policy.allowed) > 0 || !policy.fallbackOK {
+		return policy
+	}
+	for _, host := range imageUploadCandidatesForTracker(appCfg, tracker, configuredImageUploadHosts(appCfg)) {
+		if !imageHostUsableForPolicy(tracker, host, policy) {
+			continue
+		}
+		policy.uploadHosts = appendUniqueHost(policy.uploadHosts, host)
+		policy.preferred = appendUniqueHost(policy.preferred, host)
+	}
+	return policy
 }
 
 func policyFromShared(policy imagehostpolicy.Policy) imageHostPolicy {

--- a/internal/trackers/image_host_policy.go
+++ b/internal/trackers/image_host_policy.go
@@ -39,7 +39,10 @@ func policyForTracker(tracker string, trackerCfg config.TrackerConfig) imageHost
 
 func policyForTrackerWithConfig(tracker string, appCfg config.Config, trackerCfg config.TrackerConfig) imageHostPolicy {
 	if lostimgEnabledForTracker(appCfg, tracker) {
-		return newImageHostPolicy(true, "lostimg")
+		return newImageHostPolicy("lostimg")
+	}
+	if reelflixEnabledForTracker(tracker, trackerCfg) {
+		return newImageHostPolicy("reelflix")
 	}
 	return policyForTracker(tracker, trackerCfg)
 }
@@ -59,7 +62,7 @@ func applyImageHostOverrides(tracker string, policy imageHostPolicy, overrides a
 		return imageHostPolicy{}, fmt.Errorf("trackers: %s image host override %q is unsupported", strings.TrimSpace(tracker), host)
 	}
 	if len(policy.allowed) == 0 {
-		return newImageHostPolicy(true, host), nil
+		return newImageHostPolicy(host), nil
 	}
 	if !hostAllowed(host, policy.allowed) {
 		return imageHostPolicy{}, fmt.Errorf("trackers: %s image host override %q is not allowed (allowed: %s)", strings.TrimSpace(tracker), host, strings.Join(policy.allowed, ", "))
@@ -85,7 +88,7 @@ func resolveImageHostPolicy(tracker string, trackerCfg config.TrackerConfig, ove
 		return imageHostPolicy{}, fmt.Errorf("trackers: %s configured image_host %q is not allowed", strings.TrimSpace(tracker), trackerCfg.ImageHost)
 	}
 	if len(policy.allowed) == 0 {
-		return newImageHostPolicy(true, host), nil
+		return newImageHostPolicy(host), nil
 	}
 	policy.preferred = prependHost(host, policy.preferred)
 	policy.fallbackOK = true
@@ -95,6 +98,9 @@ func resolveImageHostPolicy(tracker string, trackerCfg config.TrackerConfig, ove
 func resolveImageHostPolicyForMetadata(tracker string, appCfg config.Config, trackerCfg config.TrackerConfig, _ api.PreparedMetadata, overrides api.ImageHostOverrides) (imageHostPolicy, error) {
 	host := strings.ToLower(strings.TrimSpace(trackerCfg.ImageHost))
 	if host == "lostimg" && !lostimgEnabledForTracker(appCfg, tracker) {
+		trackerCfg.ImageHost = ""
+	}
+	if host == "reelflix" && !reelflixEnabledForTracker(tracker, trackerCfg) {
 		trackerCfg.ImageHost = ""
 	}
 	if strings.TrimSpace(trackerCfg.ImageHost) != "" || overrides.PreferredHost != nil {
@@ -430,6 +436,9 @@ func imageUploadCandidatesForTracker(appCfg config.Config, tracker string, userH
 	if lostimgEnabledForTracker(appCfg, tracker) {
 		candidates = appendUniqueHost(candidates, "lostimg")
 	}
+	if reelflixEnabledForTracker(tracker, trackerConfigForImageHostPolicy(appCfg, tracker)) {
+		candidates = appendUniqueHost(candidates, "reelflix")
+	}
 	return candidates
 }
 
@@ -444,6 +453,13 @@ func lostimgEnabledForTracker(appCfg config.Config, tracker string) bool {
 	}
 	cfg := appCfg.ImageHosting
 	return cfg.LostimgEnabled
+}
+
+func reelflixEnabledForTracker(tracker string, trackerCfg config.TrackerConfig) bool {
+	if !strings.EqualFold(strings.TrimSpace(tracker), "RF") {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(trackerCfg.ImageHost), "reelflix")
 }
 
 func normalizeConfiguredImageUploadHosts(hosts ...string) []string {
@@ -491,7 +507,7 @@ func supportedUploadImageHost(host string) bool {
 	return imagehostpolicy.IsUploadHost(host)
 }
 
-func newImageHostPolicy(required bool, hosts ...string) imageHostPolicy {
+func newImageHostPolicy(hosts ...string) imageHostPolicy {
 	normalized := make([]string, 0, len(hosts))
 	seen := make(map[string]struct{}, len(hosts))
 	for _, host := range hosts {
@@ -509,7 +525,7 @@ func newImageHostPolicy(required bool, hosts ...string) imageHostPolicy {
 		allowed:     normalized,
 		uploadHosts: uploadHostsFor(normalized),
 		preferred:   uploadHostsFor(normalized),
-		required:    required,
+		required:    true,
 	}
 }
 

--- a/internal/trackers/image_host_policy.go
+++ b/internal/trackers/image_host_policy.go
@@ -37,6 +37,13 @@ func policyForTracker(tracker string, trackerCfg config.TrackerConfig) imageHost
 	return policyFromShared(imagehostpolicy.ForTracker(tracker, trackerCfg.ImgRehost, trackerCfg.ImgAPI))
 }
 
+func policyForTrackerWithConfig(tracker string, appCfg config.Config, trackerCfg config.TrackerConfig) imageHostPolicy {
+	if lostimgEnabledForTracker(appCfg, tracker) {
+		return newImageHostPolicy(true, "lostimg")
+	}
+	return policyForTracker(tracker, trackerCfg)
+}
+
 func applyImageHostOverrides(tracker string, policy imageHostPolicy, overrides api.ImageHostOverrides) (imageHostPolicy, error) {
 	if overrides.PreferredHost == nil {
 		return policy, nil
@@ -83,6 +90,18 @@ func resolveImageHostPolicy(tracker string, trackerCfg config.TrackerConfig, ove
 	policy.preferred = prependHost(host, policy.preferred)
 	policy.fallbackOK = true
 	return policy, nil
+}
+
+func resolveImageHostPolicyForMetadata(tracker string, appCfg config.Config, trackerCfg config.TrackerConfig, _ api.PreparedMetadata, overrides api.ImageHostOverrides) (imageHostPolicy, error) {
+	host := strings.ToLower(strings.TrimSpace(trackerCfg.ImageHost))
+	if host == "lostimg" && !lostimgEnabledForTracker(appCfg, tracker) {
+		trackerCfg.ImageHost = ""
+	}
+	if strings.TrimSpace(trackerCfg.ImageHost) != "" || overrides.PreferredHost != nil {
+		return resolveImageHostPolicy(tracker, trackerCfg, overrides)
+	}
+	policy := policyForTrackerWithConfig(tracker, appCfg, trackerCfg)
+	return applyImageHostOverrides(tracker, policy, overrides)
 }
 
 func PreferredImageUploadHost(tracker string, trackerCfg config.TrackerConfig, overrides api.ImageHostOverrides) (string, error) {
@@ -167,7 +186,11 @@ func ConfiguredImageUploadTargets(appCfg config.Config, trackerNames []string) (
 }
 
 func NeededImageUploadTargets(appCfg config.Config, trackerNames []string, selectedHost string) ([]ImageUploadTarget, error) {
-	return neededImageUploadTargets(appCfg, trackerNames, selectedHost, nil)
+	return neededImageUploadTargets(appCfg, trackerNames, selectedHost, nil, nil)
+}
+
+func NeededImageUploadTargetsForMetadata(appCfg config.Config, trackerNames []string, selectedHost string, meta api.PreparedMetadata) ([]ImageUploadTarget, error) {
+	return neededImageUploadTargets(appCfg, trackerNames, selectedHost, nil, &meta)
 }
 
 func NeededImageUploadTargetsExcluding(appCfg config.Config, trackerNames []string, selectedHost string, excludedHosts []string) ([]ImageUploadTarget, error) {
@@ -178,10 +201,21 @@ func NeededImageUploadTargetsExcluding(appCfg config.Config, trackerNames []stri
 			excluded[normalized] = struct{}{}
 		}
 	}
-	return neededImageUploadTargets(appCfg, trackerNames, selectedHost, excluded)
+	return neededImageUploadTargets(appCfg, trackerNames, selectedHost, excluded, nil)
 }
 
-func neededImageUploadTargets(appCfg config.Config, trackerNames []string, selectedHost string, excludedHosts map[string]struct{}) ([]ImageUploadTarget, error) {
+func NeededImageUploadTargetsForMetadataExcluding(appCfg config.Config, trackerNames []string, selectedHost string, excludedHosts []string, meta api.PreparedMetadata) ([]ImageUploadTarget, error) {
+	excluded := make(map[string]struct{}, len(excludedHosts))
+	for _, host := range excludedHosts {
+		normalized := strings.ToLower(strings.TrimSpace(host))
+		if normalized != "" {
+			excluded[normalized] = struct{}{}
+		}
+	}
+	return neededImageUploadTargets(appCfg, trackerNames, selectedHost, excluded, &meta)
+}
+
+func neededImageUploadTargets(appCfg config.Config, trackerNames []string, selectedHost string, excludedHosts map[string]struct{}, meta *api.PreparedMetadata) ([]ImageUploadTarget, error) {
 	selectedHost = strings.ToLower(strings.TrimSpace(selectedHost))
 	userHosts := configuredImageUploadHosts(appCfg)
 	targets := make([]ImageUploadTarget, 0, len(trackerNames)+1)
@@ -218,7 +252,7 @@ func neededImageUploadTargets(appCfg config.Config, trackerNames []string, selec
 		}
 		trackerCfg := trackerConfigForImageHostPolicy(appCfg, name)
 		if strings.TrimSpace(trackerCfg.ImageHost) != "" {
-			policy, err := resolveImageHostPolicy(name, trackerCfg, api.ImageHostOverrides{})
+			policy, err := resolveImageHostPolicyForTarget(name, appCfg, trackerCfg, meta)
 			if err != nil {
 				return nil, err
 			}
@@ -232,8 +266,9 @@ func neededImageUploadTargets(appCfg config.Config, trackerNames []string, selec
 			continue
 		}
 
-		policy := policyForTracker(name, trackerCfg)
-		flexibleTargets = append(flexibleTargets, imageUploadPolicyTarget{tracker: name, policy: policy, candidates: userHosts})
+		policy := policyForTrackerForTarget(name, appCfg, trackerCfg)
+		candidates := imageUploadCandidatesForTracker(appCfg, name, userHosts)
+		flexibleTargets = append(flexibleTargets, imageUploadPolicyTarget{tracker: name, policy: policy, candidates: candidates})
 	}
 
 	if selectedHost != "" && trackerForOwnedHost(selectedHost) == "" && hostInList(selectedHost, userHosts) {
@@ -379,9 +414,36 @@ func candidateImageUploadTargetHosts(tracker string, policy imageHostPolicy, can
 	return hosts
 }
 
+func resolveImageHostPolicyForTarget(tracker string, appCfg config.Config, trackerCfg config.TrackerConfig, meta *api.PreparedMetadata) (imageHostPolicy, error) {
+	if meta == nil {
+		return resolveImageHostPolicy(tracker, trackerCfg, api.ImageHostOverrides{})
+	}
+	return resolveImageHostPolicyForMetadata(tracker, appCfg, trackerCfg, *meta, api.ImageHostOverrides{})
+}
+
+func policyForTrackerForTarget(tracker string, appCfg config.Config, trackerCfg config.TrackerConfig) imageHostPolicy {
+	return policyForTrackerWithConfig(tracker, appCfg, trackerCfg)
+}
+
+func imageUploadCandidatesForTracker(appCfg config.Config, tracker string, userHosts []string) []string {
+	candidates := append([]string(nil), userHosts...)
+	if lostimgEnabledForTracker(appCfg, tracker) {
+		candidates = appendUniqueHost(candidates, "lostimg")
+	}
+	return candidates
+}
+
 func configuredImageUploadHosts(appCfg config.Config) []string {
 	cfg := appCfg.ImageHosting
 	return normalizeConfiguredImageUploadHosts(cfg.Host1, cfg.Host2, cfg.Host3, cfg.Host4, cfg.Host5, cfg.Host6)
+}
+
+func lostimgEnabledForTracker(appCfg config.Config, tracker string) bool {
+	if !strings.EqualFold(strings.TrimSpace(tracker), "LST") {
+		return false
+	}
+	cfg := appCfg.ImageHosting
+	return cfg.LostimgEnabled
 }
 
 func normalizeConfiguredImageUploadHosts(hosts ...string) []string {

--- a/internal/trackers/image_host_policy_test.go
+++ b/internal/trackers/image_host_policy_test.go
@@ -251,3 +251,40 @@ func TestNeededImageUploadTargetsDoesNotShareTrackerConfiguredHostUnlessGlobally
 		t.Fatalf("expected imgbb only for STC, got %#v", targets[1])
 	}
 }
+
+func TestNeededImageUploadTargetsUsesConfiguredLostimgForLST(t *testing.T) {
+	t.Parallel()
+
+	targets, err := NeededImageUploadTargets(config.Config{
+		ImageHosting: config.ImageHostingConfig{
+			Host1:          "imgbb",
+			LostimgEnabled: true,
+			LostimgAPI:     "secret",
+		},
+	}, []string{"LST"}, "imgbb")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected one target, got %#v", targets)
+	}
+	if targets[0].Host != "lostimg" || targets[0].UsageScope != "tracker:LST" {
+		t.Fatalf("expected LST scoped lostimg target, got %#v", targets[0])
+	}
+}
+
+func TestNeededImageUploadTargetsSkipsLostimgWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	targets, err := NeededImageUploadTargets(config.Config{
+		ImageHosting: config.ImageHostingConfig{
+			Host1: "imgbb",
+		},
+	}, []string{"LST"}, "imgbb")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(targets) != 1 || targets[0].Host != "imgbb" {
+		t.Fatalf("expected global imgbb fallback, got %#v", targets)
+	}
+}

--- a/internal/trackers/image_host_policy_test.go
+++ b/internal/trackers/image_host_policy_test.go
@@ -50,7 +50,7 @@ func TestResolveImageHostPolicy(t *testing.T) {
 			cfg:              config.TrackerConfig{ImageHost: "imgbox"},
 			overrides:        api.ImageHostOverrides{},
 			wantPreferred:    "imgbox",
-			wantAllowedCount: 1,
+			wantAllowedCount: 0,
 		},
 		{
 			name:             "rejects owned cli host for other tracker",
@@ -118,12 +118,56 @@ func TestResolveImageHostPolicy(t *testing.T) {
 				}
 			default:
 				if tc.wantAllowedCount >= 0 {
-					if len(policy.allowed) != tc.wantAllowedCount || (tc.wantAllowedCount == 1 && policy.allowed[0] != "imgbox") {
-						t.Fatalf("expected configured no-policy tracker host to be required, got %#v", policy)
+					if len(policy.allowed) != tc.wantAllowedCount {
+						t.Fatalf("expected allowed host count %d, got %#v", tc.wantAllowedCount, policy)
 					}
 				}
 			}
 		})
+	}
+}
+
+func TestNeededImageUploadTargetsFallsBackFromTrackerConfiguredHostForUnrestrictedTracker(t *testing.T) {
+	t.Parallel()
+
+	targets, err := NeededImageUploadTargetsExcluding(config.Config{
+		ImageHosting: config.ImageHostingConfig{
+			Host1: "pixhost",
+			Host2: "imgbb",
+		},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"HHD": {ImageHost: "pixhost"},
+			},
+		},
+	}, []string{"HHD"}, "pixhost", []string{"pixhost"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(targets) != 1 || targets[0].Host != "imgbb" {
+		t.Fatalf("expected unrestricted tracker to fall back to global imgbb, got %#v", targets)
+	}
+}
+
+func TestNeededImageUploadTargetsDoesNotFallbackToUnsupportedHostForRestrictedTracker(t *testing.T) {
+	t.Parallel()
+
+	targets, err := NeededImageUploadTargetsExcluding(config.Config{
+		ImageHosting: config.ImageHostingConfig{
+			Host1: "pixhost",
+			Host2: "imgbox",
+		},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"PTP": {ImageHost: "pixhost"},
+			},
+		},
+	}, []string{"PTP"}, "pixhost", []string{"pixhost"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(targets) != 0 {
+		t.Fatalf("expected restricted tracker to reject unsupported imgbox fallback, got %#v", targets)
 	}
 }
 

--- a/internal/trackers/image_host_policy_test.go
+++ b/internal/trackers/image_host_policy_test.go
@@ -288,3 +288,48 @@ func TestNeededImageUploadTargetsSkipsLostimgWhenDisabled(t *testing.T) {
 		t.Fatalf("expected global imgbb fallback, got %#v", targets)
 	}
 }
+
+func TestNeededImageUploadTargetsUsesConfiguredReelflixForRF(t *testing.T) {
+	t.Parallel()
+
+	targets, err := NeededImageUploadTargets(config.Config{
+		ImageHosting: config.ImageHostingConfig{
+			Host1: "imgbb",
+		},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"RF": {ImageHost: "reelflix", ImgAPI: "secret"},
+			},
+		},
+	}, []string{"RF"}, "imgbb")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected one target, got %#v", targets)
+	}
+	if targets[0].Host != "reelflix" || targets[0].UsageScope != "tracker:RF" {
+		t.Fatalf("expected RF scoped reelflix target, got %#v", targets[0])
+	}
+}
+
+func TestNeededImageUploadTargetsSkipsReelflixWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	targets, err := NeededImageUploadTargets(config.Config{
+		ImageHosting: config.ImageHostingConfig{
+			Host1: "imgbb",
+		},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"RF": {ImgAPI: "secret"},
+			},
+		},
+	}, []string{"RF"}, "imgbb")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(targets) != 1 || targets[0].Host != "imgbb" {
+		t.Fatalf("expected global imgbb fallback, got %#v", targets)
+	}
+}

--- a/internal/trackers/image_host_resolution.go
+++ b/internal/trackers/image_host_resolution.go
@@ -108,7 +108,7 @@ func ensureDescriptionImageHostWithData(
 		}
 	}
 
-	if len(policy.allowed) == 0 {
+	if !policy.required {
 		selectionPolicy := imageHostPolicy{}
 		if host := firstPreferredDescriptionImageHost(preferredHosts); host != "" {
 			selectionPolicy.preferred = []string{host}
@@ -141,7 +141,7 @@ func ensureDescriptionImageHostWithData(
 
 	if skipUpload {
 		feedback.Status = "warning"
-		feedback.Message = fmt.Sprintf("%s requires screenshots from %s, but automatic image-host uploads are disabled.", tracker, strings.Join(policy.allowed, ", "))
+		feedback.Message = fmt.Sprintf("%s requires screenshots from %s, but automatic image-host uploads are disabled.", tracker, imageHostRequirementLabel(policy))
 		return descriptionImageHostResolution{feedback: feedback}, nil
 	}
 
@@ -179,7 +179,7 @@ func ensureDescriptionImageHostWithData(
 			return descriptionImageHostResolution{screenshots: screenshots, feedback: feedback, usageScope: globalImageUsageScope}, nil
 		}
 		feedback.Status = "warning"
-		feedback.Message = fmt.Sprintf("%s requires screenshots from %s, but no local screenshots are available to rehost.", tracker, strings.Join(policy.allowed, ", "))
+		feedback.Message = fmt.Sprintf("%s requires screenshots from %s, but no local screenshots are available to rehost.", tracker, imageHostRequirementLabel(policy))
 		return descriptionImageHostResolution{feedback: feedback}, nil
 	}
 
@@ -216,7 +216,7 @@ func ensureDescriptionImageHostWithData(
 			}
 		}
 		feedback.Status = "warning"
-		feedback.Message = fmt.Sprintf("%s requires screenshots from %s, but image hosting is unavailable.", tracker, strings.Join(policy.allowed, ", "))
+		feedback.Message = fmt.Sprintf("%s requires screenshots from %s, but image hosting is unavailable.", tracker, imageHostRequirementLabel(policy))
 		return descriptionImageHostResolution{feedback: feedback}, nil
 	}
 
@@ -298,6 +298,16 @@ func firstPreferredDescriptionImageHost(hosts []string) string {
 		}
 	}
 	return ""
+}
+
+func imageHostRequirementLabel(policy imageHostPolicy) string {
+	if len(policy.allowed) > 0 {
+		return strings.Join(policy.allowed, ", ")
+	}
+	if len(policy.preferred) > 0 {
+		return strings.Join(policy.preferred, ", ")
+	}
+	return "a configured image host"
 }
 
 func imageHostUploadSkipped(meta api.PreparedMetadata) bool {

--- a/internal/trackers/image_host_resolution.go
+++ b/internal/trackers/image_host_resolution.go
@@ -76,7 +76,7 @@ func ensureDescriptionImageHostWithData(
 	preloaded *preloadedDescriptionAssetData,
 	preferredHosts ...string,
 ) (descriptionImageHostResolution, error) {
-	policy, err := resolveImageHostPolicy(tracker, trackerCfg, meta.ImageHostOverrides)
+	policy, err := resolveImageHostPolicyForMetadata(tracker, appCfg, trackerCfg, meta, meta.ImageHostOverrides)
 	if err != nil {
 		return descriptionImageHostResolution{}, err
 	}

--- a/internal/trackers/service.go
+++ b/internal/trackers/service.go
@@ -474,7 +474,7 @@ func (s *Service) preflightDescriptionImageHostsWithPreferences(
 		trackerCfg := trackerConfigFor(s.cfg, tracker)
 		trackerCfg = applyTrackerConfigOverrides(trackerCfg, meta.TrackerConfigOverrides)
 		targetKey := ""
-		policy, err := resolveImageHostPolicy(tracker, trackerCfg, meta.ImageHostOverrides)
+		policy, err := resolveImageHostPolicyForMetadata(tracker, s.cfg, trackerCfg, meta, meta.ImageHostOverrides)
 		if err != nil {
 			s.logger.Warnf("trackers: image host preflight failed for %s: %v", tracker, err)
 			continue
@@ -782,7 +782,7 @@ func preparationImageHostPreferences(appCfg config.Config, meta api.PreparedMeta
 	if meta.ImageHostOverrides.PreferredHost != nil {
 		return nil
 	}
-	targets, err := NeededImageUploadTargets(appCfg, trackers, "")
+	targets, err := NeededImageUploadTargetsForMetadata(appCfg, trackers, "", meta)
 	if err != nil {
 		if logger != nil {
 			logger.Warnf("trackers: preparation image host target resolution failed: %v", err)

--- a/internal/trackers/service_test.go
+++ b/internal/trackers/service_test.go
@@ -667,8 +667,8 @@ func TestBuildPreparationGroupsUnit3DWhenImageHostMessageOnlyDiffers(t *testing.
 	if preview.Descriptions[0].ImageHost.Status != "warning" {
 		t.Fatalf("expected image host warning status, got %q", preview.Descriptions[0].ImageHost.Status)
 	}
-	if len(preview.Descriptions[0].ImageHost.AllowedHosts) != 1 || preview.Descriptions[0].ImageHost.AllowedHosts[0] != "imgbox" {
-		t.Fatalf("expected allowed host imgbox policy to be preserved, got %#v", preview.Descriptions[0].ImageHost.AllowedHosts)
+	if len(preview.Descriptions[0].ImageHost.AllowedHosts) != 0 {
+		t.Fatalf("expected unrestricted configured-host policy, got %#v", preview.Descriptions[0].ImageHost.AllowedHosts)
 	}
 }
 

--- a/scripts/convert_ua_config.py
+++ b/scripts/convert_ua_config.py
@@ -61,6 +61,8 @@ LEGACY_DEFAULT_SECTION_BY_KEY = {
     "sharex_url": "image_hosting",
     "sharex_api_key": "image_hosting",
     "utppm_api": "image_hosting",
+    "lostimg_enabled": "image_hosting",
+    "lostimg_api": "image_hosting",
     "btn_api": "metadata",
     "skip_auto_torrent": "metadata",
     "use_largest_playlist": "metadata",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Lostimg and Reelflix as selectable image hosts with tracker-level enable toggles and API key fields in settings; dedicated “Tracker Image Hosts” controls added.

* **Bug Fixes**
  * Image upload selection and fallback now consider per-upload metadata and tracker-specific host availability.

* **Tests**
  * Expanded UI and unit tests for Lostimg/Reelflix, image-host selection, payloads, and fallback behavior.

* **Chores**
  * Updated default config, legacy import mappings, and secret handling for new image-host fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->