### PR TITLE
fix: pixhost domain change

### DIFF
--- a/internal/services/bbcode/bbcode_test.go
+++ b/internal/services/bbcode/bbcode_test.go
@@ -275,6 +275,11 @@ func TestNormalizeImageRawURLConvertsPixhostThumbURL(t *testing.T) {
 			want: "https://img1.pixhost.cc/images/11645/685417513_file-upload-0.png",
 		},
 		{
+			name: "mixed case current domain",
+			in:   "https://T1.PixHost.Cc/thumbs/11645/685417513_file-upload-0.png",
+			want: "https://img1.pixhost.cc/images/11645/685417513_file-upload-0.png",
+		},
+		{
 			name: "legacy domain",
 			in:   "https://t1.pixhost.to/thumbs/11645/685417513_file-upload-0.png",
 			want: "https://img1.pixhost.to/images/11645/685417513_file-upload-0.png",

--- a/internal/services/bbcode/bbcode_test.go
+++ b/internal/services/bbcode/bbcode_test.go
@@ -264,9 +264,44 @@ func TestCleanPTPDescriptionRemovesWidthStyledImageBlocks(t *testing.T) {
 }
 
 func TestNormalizeImageRawURLConvertsPixhostThumbURL(t *testing.T) {
-	value := normalizeImageRawURL("https://t1.pixhost.to/thumbs/11645/685417513_file-upload-0.png")
-	if value != "https://img1.pixhost.to/images/11645/685417513_file-upload-0.png" {
-		t.Fatalf("unexpected normalized value %q", value)
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "current domain",
+			in:   "https://t1.pixhost.cc/thumbs/11645/685417513_file-upload-0.png",
+			want: "https://img1.pixhost.cc/images/11645/685417513_file-upload-0.png",
+		},
+		{
+			name: "legacy domain",
+			in:   "https://t1.pixhost.to/thumbs/11645/685417513_file-upload-0.png",
+			want: "https://img1.pixhost.to/images/11645/685417513_file-upload-0.png",
+		},
+		{
+			name: "exact current host",
+			in:   "https://pixhost.cc/thumbs/11645/685417513_file-upload-0.png",
+			want: "https://pixhost.cc/images/11645/685417513_file-upload-0.png",
+		},
+		{
+			name: "foreign suffix current domain",
+			in:   "https://t1.evilpixhost.cc/thumbs/11645/685417513_file-upload-0.png",
+			want: "https://t1.evilpixhost.cc/thumbs/11645/685417513_file-upload-0.png",
+		},
+		{
+			name: "foreign suffix legacy domain",
+			in:   "https://t1.evilpixhost.to/thumbs/11645/685417513_file-upload-0.png",
+			want: "https://t1.evilpixhost.to/thumbs/11645/685417513_file-upload-0.png",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value := normalizeImageRawURL(tt.in)
+			if value != tt.want {
+				t.Fatalf("unexpected normalized value %q", value)
+			}
+		})
 	}
 }
 

--- a/internal/services/bbcode/common.go
+++ b/internal/services/bbcode/common.go
@@ -290,14 +290,26 @@ func convertPixhostThumbURL(value string) string {
 	if !isPixhostHost(host) || !strings.HasPrefix(pathValue, "/thumbs/") {
 		return value
 	}
-	if strings.HasPrefix(host, "t") {
-		number := strings.TrimPrefix(strings.SplitN(host, ".", 2)[0], "t")
-		if number != "" {
-			parsed.Host = strings.Replace(parsed.Host, "t"+number+".", "img"+number+".", 1)
-		}
-	}
+	replacePixhostThumbHost(parsed, host)
 	parsed.Path = strings.Replace(pathValue, "/thumbs/", "/images/", 1)
 	return parsed.String()
+}
+
+func replacePixhostThumbHost(parsed *url.URL, host string) {
+	hostParts := strings.SplitN(host, ".", 2)
+	if len(hostParts) != 2 {
+		return
+	}
+	first := hostParts[0]
+	if !strings.HasPrefix(first, "t") || len(first) == 1 {
+		return
+	}
+
+	port := parsed.Port()
+	parsed.Host = "img" + strings.TrimPrefix(first, "t") + "." + hostParts[1]
+	if port != "" {
+		parsed.Host += ":" + port
+	}
 }
 
 func isPixhostHost(host string) bool {

--- a/internal/services/bbcode/common.go
+++ b/internal/services/bbcode/common.go
@@ -287,7 +287,7 @@ func convertPixhostThumbURL(value string) string {
 	}
 	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
 	pathValue := strings.TrimSpace(parsed.Path)
-	if !strings.HasSuffix(host, "pixhost.to") || !strings.HasPrefix(pathValue, "/thumbs/") {
+	if !isPixhostHost(host) || !strings.HasPrefix(pathValue, "/thumbs/") {
 		return value
 	}
 	if strings.HasPrefix(host, "t") {
@@ -298,4 +298,11 @@ func convertPixhostThumbURL(value string) string {
 	}
 	parsed.Path = strings.Replace(pathValue, "/thumbs/", "/images/", 1)
 	return parsed.String()
+}
+
+func isPixhostHost(host string) bool {
+	return host == "pixhost.cc" ||
+		host == "pixhost.to" ||
+		strings.HasSuffix(host, ".pixhost.cc") ||
+		strings.HasSuffix(host, ".pixhost.to")
 }

--- a/internal/services/description/unit3d/clean.go
+++ b/internal/services/description/unit3d/clean.go
@@ -440,19 +440,29 @@ func normalizeRawImageURL(value string) string {
 	}
 
 	if isPixhostHost(host) && strings.HasPrefix(pathValue, "/thumbs/") {
-		hostParts := strings.SplitN(host, ".", 2)
-		if len(hostParts) == 2 {
-			first := hostParts[0]
-			if strings.HasPrefix(first, "t") && len(first) > 1 {
-				number := strings.TrimPrefix(first, "t")
-				parsed.Host = strings.Replace(parsed.Host, "t"+number+".", "img"+number+".", 1)
-			}
-		}
+		replacePixhostThumbHost(parsed, host)
 		parsed.Path = strings.Replace(pathValue, "/thumbs/", "/images/", 1)
 		return parsed.String()
 	}
 
 	return trimmed
+}
+
+func replacePixhostThumbHost(parsed *url.URL, host string) {
+	hostParts := strings.SplitN(host, ".", 2)
+	if len(hostParts) != 2 {
+		return
+	}
+	first := hostParts[0]
+	if !strings.HasPrefix(first, "t") || len(first) == 1 {
+		return
+	}
+
+	port := parsed.Port()
+	parsed.Host = "img" + strings.TrimPrefix(first, "t") + "." + hostParts[1]
+	if port != "" {
+		parsed.Host += ":" + port
+	}
 }
 
 func normalizeLinkedRawImageURL(value string) (string, bool) {

--- a/internal/services/description/unit3d/clean.go
+++ b/internal/services/description/unit3d/clean.go
@@ -377,6 +377,7 @@ func filterUnit3DImages(images []Image) []Image {
 		"https://blutopia.xyz/favicon.ico":       {},
 		"https://i.ibb.co/2NVWb0c/uploadrr.webp": {},
 		"https://blutopia/favicon.ico":           {},
+		"https://pixhost.cc/606tk4.png":          {},
 		"https://pixhost.to/606tk4.png":          {},
 	}
 
@@ -438,7 +439,7 @@ func normalizeRawImageURL(value string) string {
 		return parsed.String()
 	}
 
-	if strings.HasSuffix(host, "pixhost.to") && strings.HasPrefix(pathValue, "/thumbs/") {
+	if isPixhostHost(host) && strings.HasPrefix(pathValue, "/thumbs/") {
 		hostParts := strings.SplitN(host, ".", 2)
 		if len(hostParts) == 2 {
 			first := hostParts[0]
@@ -466,11 +467,18 @@ func normalizeLinkedRawImageURL(value string) (string, bool) {
 
 	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
 	pathValue := strings.ToLower(strings.TrimSpace(parsed.Path))
-	if strings.HasSuffix(host, "pixhost.to") && strings.HasPrefix(pathValue, "/show/") {
+	if isPixhostHost(host) && strings.HasPrefix(pathValue, "/show/") {
 		return "", false
 	}
 
 	return normalizeRawImageURL(trimmed), true
+}
+
+func isPixhostHost(host string) bool {
+	return host == "pixhost.cc" ||
+		host == "pixhost.to" ||
+		strings.HasSuffix(host, ".pixhost.cc") ||
+		strings.HasSuffix(host, ".pixhost.to")
 }
 
 func isLikelyImageURL(value string) bool {

--- a/internal/services/description/unit3d/clean_test.go
+++ b/internal/services/description/unit3d/clean_test.go
@@ -42,6 +42,68 @@ func TestCleanDescriptionUsesLinkedImageURLAsRawSource(t *testing.T) {
 	}
 }
 
+func TestCleanDescriptionConvertsPixhostCurrentDomainThumbURL(t *testing.T) {
+	report := CleanDescription(
+		`[center][url=https://pixhost.cc/show/11645/shot.png][img]https://t1.pixhost.cc/thumbs/11645/shot.png[/img][/url][/center]`,
+		"https://example.com",
+	)
+
+	if len(report.Images) != 1 {
+		t.Fatalf("expected one image, got %d: %+v", len(report.Images), report.Images)
+	}
+	if report.Images[0].RawURL != "https://img1.pixhost.cc/images/11645/shot.png" {
+		t.Fatalf("expected pixhost raw URL conversion, got %q", report.Images[0].RawURL)
+	}
+}
+
+func TestNormalizeRawImageURLRejectsPixhostSuffixHosts(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "current suffix host",
+			in:   "https://t1.evilpixhost.cc/thumbs/11645/shot.png",
+			want: "https://t1.evilpixhost.cc/thumbs/11645/shot.png",
+		},
+		{
+			name: "legacy suffix host",
+			in:   "https://t1.evilpixhost.to/thumbs/11645/shot.png",
+			want: "https://t1.evilpixhost.to/thumbs/11645/shot.png",
+		},
+		{
+			name: "current exact host",
+			in:   "https://pixhost.cc/thumbs/11645/shot.png",
+			want: "https://pixhost.cc/images/11645/shot.png",
+		},
+		{
+			name: "current subdomain",
+			in:   "https://t1.pixhost.cc/thumbs/11645/shot.png",
+			want: "https://img1.pixhost.cc/images/11645/shot.png",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeRawImageURL(tt.in)
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestNormalizeLinkedRawImageURLPreservesPixhostSuffixShowURL(t *testing.T) {
+	got, ok := normalizeLinkedRawImageURL("https://evilpixhost.cc/show/11645/shot.png")
+	if !ok {
+		t.Fatal("expected foreign suffix host to remain usable")
+	}
+	if got != "https://evilpixhost.cc/show/11645/shot.png" {
+		t.Fatalf("expected foreign suffix host preserved, got %q", got)
+	}
+}
+
 func TestReplaceSiteHostSkipsURLs(t *testing.T) {
 	result := replaceSiteHost(
 		"Visit www.example.com or https://www.example.com/path or HTTPS://www.example.com/full.png for details",

--- a/internal/services/description/unit3d/clean_test.go
+++ b/internal/services/description/unit3d/clean_test.go
@@ -56,6 +56,20 @@ func TestCleanDescriptionConvertsPixhostCurrentDomainThumbURL(t *testing.T) {
 	}
 }
 
+func TestCleanDescriptionConvertsMixedCasePixhostThumbURL(t *testing.T) {
+	report := CleanDescription(
+		`[center][url=https://pixhost.cc/show/11645/shot.png][img]https://T1.PixHost.Cc/thumbs/11645/shot.png[/img][/url][/center]`,
+		"https://example.com",
+	)
+
+	if len(report.Images) != 1 {
+		t.Fatalf("expected one image, got %d: %+v", len(report.Images), report.Images)
+	}
+	if report.Images[0].RawURL != "https://img1.pixhost.cc/images/11645/shot.png" {
+		t.Fatalf("expected pixhost raw URL conversion, got %q", report.Images[0].RawURL)
+	}
+}
+
 func TestNormalizeRawImageURLRejectsPixhostSuffixHosts(t *testing.T) {
 	tests := []struct {
 		name string
@@ -80,6 +94,11 @@ func TestNormalizeRawImageURLRejectsPixhostSuffixHosts(t *testing.T) {
 		{
 			name: "current subdomain",
 			in:   "https://t1.pixhost.cc/thumbs/11645/shot.png",
+			want: "https://img1.pixhost.cc/images/11645/shot.png",
+		},
+		{
+			name: "mixed case current subdomain",
+			in:   "https://T1.PixHost.Cc/thumbs/11645/shot.png",
 			want: "https://img1.pixhost.cc/images/11645/shot.png",
 		},
 	}

--- a/internal/services/imagehost/imagehost.go
+++ b/internal/services/imagehost/imagehost.go
@@ -11,6 +11,7 @@ import (
 // HostMapping maps URL domain patterns to normalized host names
 var HostMapping = map[string]string{
 	"ibb.co":               "imgbb",
+	"pixhost.cc":           "pixhost",
 	"pixhost.to":           "pixhost",
 	"imgbox.com":           "imgbox",
 	"beyondhd.co":          "bhd",

--- a/internal/services/imagehost/imagehost_test.go
+++ b/internal/services/imagehost/imagehost_test.go
@@ -13,8 +13,9 @@ func TestExtractHost(t *testing.T) {
 	}{
 		{"imgbb standard", "https://ibb.co/abc123", "imgbb"},
 		{"imgbb with i subdomain", "https://i.ibb.co/image.png", "imgbb"},
-		{"pixhost standard", "https://pixhost.to/abc123.png", "pixhost"},
-		{"pixhost", "https://pixhost.to/show/123/456.png", "pixhost"},
+		{"pixhost standard", "https://pixhost.cc/abc123.png", "pixhost"},
+		{"pixhost show", "https://pixhost.cc/show/123/456.png", "pixhost"},
+		{"pixhost legacy", "https://pixhost.to/abc123.png", "pixhost"},
 		{"imgbox", "https://imgbox.com/g/abc", "imgbox"},
 		{"imgbox cdn", "https://cdn.imgbox.com/image.png", "imgbox"},
 		{"beyondhd", "https://beyondhd.co/image/123", "bhd"},

--- a/internal/services/imagehosting/uploaders.go
+++ b/internal/services/imagehosting/uploaders.go
@@ -851,12 +851,14 @@ type pixhostUploader struct {
 	client *http.Client
 }
 
+const pixhostUploadURL = "https://api.pixhost.cc/images"
+
 func (u *pixhostUploader) Upload(ctx context.Context, imagePath string) (uploadResult, error) {
 	fields := map[string]string{
 		"content_type": "0",
 		"max_th_size":  "350",
 	}
-	body, status, err := postMultipart(ctx, u.client, "https://api.pixhost.to/images", fields, "img", imagePath, nil)
+	body, status, err := postMultipart(ctx, u.client, pixhostUploadURL, fields, "img", imagePath, nil)
 	if err != nil {
 		return uploadResult{}, err
 	}

--- a/internal/services/imagehosting/uploaders_test.go
+++ b/internal/services/imagehosting/uploaders_test.go
@@ -396,6 +396,75 @@ func TestLostimgUploaderAcceptsSingleURLResponse(t *testing.T) {
 	}
 }
 
+func TestPixhostUploaderPostsCurrentDomain(t *testing.T) {
+	tmpDir := t.TempDir()
+	imagePath := filepath.Join(tmpDir, "shot.png")
+	if err := os.WriteFile(imagePath, []byte("testdata"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() != pixhostUploadURL {
+				t.Fatalf("unexpected request URL: %s", req.URL.String())
+			}
+			mediaType, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+			if err != nil {
+				t.Fatalf("parse media type: %v", err)
+			}
+			if mediaType != "multipart/form-data" {
+				t.Fatalf("unexpected media type: %s", mediaType)
+			}
+			reader := multipartReader(t, req, params["boundary"])
+			fields := map[string]string{}
+			fileFields := []string{}
+			for {
+				part, err := reader.NextPart()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if err != nil {
+					t.Fatalf("read multipart part: %v", err)
+				}
+				body, err := io.ReadAll(part)
+				if err != nil {
+					t.Fatalf("read part body: %v", err)
+				}
+				if part.FileName() == "" {
+					fields[part.FormName()] = string(body)
+					continue
+				}
+				fileFields = append(fileFields, part.FormName())
+			}
+			if fields["content_type"] != "0" || fields["max_th_size"] != "350" {
+				t.Fatalf("unexpected pixhost fields: %v", fields)
+			}
+			if len(fileFields) != 1 || fileFields[0] != "img" {
+				t.Fatalf("expected img file field, got %v", fileFields)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"th_url":"https://t1.pixhost.cc/thumbs/11645/shot.png","show_url":"https://pixhost.cc/show/11645/shot.png"}`)),
+			}, nil
+		}),
+	}
+
+	result, err := (&pixhostUploader{client: client}).Upload(context.Background(), imagePath)
+	if err != nil {
+		t.Fatalf("Upload returned error: %v", err)
+	}
+	if result.ImgURL != "https://t1.pixhost.cc/thumbs/11645/shot.png" {
+		t.Fatalf("unexpected img URL: %q", result.ImgURL)
+	}
+	if result.RawURL != "https://img1.pixhost.cc/images/11645/shot.png" {
+		t.Fatalf("unexpected raw URL: %q", result.RawURL)
+	}
+	if result.WebURL != "https://pixhost.cc/show/11645/shot.png" {
+		t.Fatalf("unexpected web URL: %q", result.WebURL)
+	}
+}
+
 func TestReelflixUploaderPostsSourceWithAPIKey(t *testing.T) {
 	tmpDir := t.TempDir()
 	imagePath := filepath.Join(tmpDir, "shot.png")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extended Pixhost support to recognize current and legacy domains (including mixed-case/subdomain variants)
  * Improved normalization of Pixhost thumbnail/show URLs to produce correct full-size image links
  * Updated Pixhost upload target to the current domain endpoint

* **Tests**
  * Added and expanded tests covering Pixhost domain variants, thumb→image conversions, and uploader behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->