### PR TITLE
fix: no tvdb when movie

### DIFF
--- a/internal/dupechecking/hdb.go
+++ b/internal/dupechecking/hdb.go
@@ -44,7 +44,7 @@ func (h hdbHandler) Search(ctx context.Context, meta api.PreparedMetadata, _ str
 	payload["medium"] = mediumID
 	if meta.ExternalIDs.IMDBID != 0 {
 		payload["imdb"] = map[string]any{"id": formatHDBIMDbID(meta.ExternalIDs.IMDBID)}
-	} else if meta.ExternalIDs.TVDBID != 0 {
+	} else if isHDBTVCategory(meta) && meta.ExternalIDs.TVDBID != 0 {
 		payload["tvdb"] = map[string]any{"id": meta.ExternalIDs.TVDBID}
 	}
 	if _, hasIMDB := payload["imdb"]; !hasIMDB {
@@ -111,6 +111,35 @@ func (h hdbHandler) Search(ctx context.Context, meta api.PreparedMetadata, _ str
 	}
 	logger.Debugf("dupechecking: HDB returned %d entries for %s method=%s", len(entries), meta.SourcePath, searchMethod)
 	return entries, nil, nil
+}
+
+// isHDBTVCategory reports whether HDB dupe searches may use TVDB-specific filters.
+// Explicit movie categories suppress TVDB even when MediaInfo or overrides classify the release as TV.
+func isHDBTVCategory(meta api.PreparedMetadata) bool {
+	if isHDBMovieCategory(meta) {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "TV") ||
+		strings.EqualFold(strings.TrimSpace(meta.MediaInfoCategory), "TV") ||
+		strings.EqualFold(strings.TrimSpace(meta.Release.Category), "TV") {
+		return true
+	}
+	if meta.ReleaseNameOverrides.Category != nil {
+		return strings.EqualFold(strings.TrimSpace(*meta.ReleaseNameOverrides.Category), "TV")
+	}
+	return false
+}
+
+func isHDBMovieCategory(meta api.PreparedMetadata) bool {
+	if strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "MOVIE") ||
+		strings.EqualFold(strings.TrimSpace(meta.MediaInfoCategory), "MOVIE") ||
+		strings.EqualFold(strings.TrimSpace(meta.Release.Category), "MOVIE") {
+		return true
+	}
+	if meta.ReleaseNameOverrides.Category != nil {
+		return strings.EqualFold(strings.TrimSpace(*meta.ReleaseNameOverrides.Category), "MOVIE")
+	}
+	return false
 }
 
 func formatHDBIMDbID(imdbID int) string {

--- a/internal/dupechecking/hdb_test.go
+++ b/internal/dupechecking/hdb_test.go
@@ -235,7 +235,72 @@ func TestHDBHandlerSearchUsesTVDBWhenIMDbMissing(t *testing.T) {
 	}
 
 	meta := api.PreparedMetadata{
-		SourcePath: "C:/media/movie",
+		SourcePath: "C:/media/show",
+		ExternalIDs: api.ExternalIDs{
+			TVDBID:   765432,
+			Category: "TV",
+		},
+	}
+
+	entries, notes, err := handler.Search(context.Background(), meta, "HDB")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(notes) != 0 {
+		t.Fatalf("expected no notes, got %#v", notes)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no entries, got %d", len(entries))
+	}
+}
+
+func TestHDBHandlerSearchSkipsTVDBForMovie(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			var payload map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode request payload: %v", err)
+			}
+			if _, hasTVDB := payload["tvdb"]; hasTVDB {
+				t.Fatalf("did not expect tvdb in movie payload")
+			}
+			if got := stringFromAny(payload["search"]); got != "Movie.Release.2024.1080p.WEB-DL" {
+				t.Fatalf("unexpected fallback search %q", got)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"status":0,"data":[]}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	handler := hdbHandler{
+		cfg: config.Config{
+			MainSettings: config.MainSettingsConfig{
+				DBPath: filepath.Join(tmpDir, "ua.db"),
+			},
+			Trackers: config.TrackersConfig{
+				Trackers: map[string]config.TrackerConfig{
+					"HDB": {
+						Username: "user",
+						Passkey:  "pk",
+					},
+				},
+			},
+		},
+		http:   client,
+		logger: api.NopLogger{},
+	}
+
+	meta := api.PreparedMetadata{
+		SourcePath:        "C:/media/movie",
+		ReleaseName:       "Movie.Release.2024.1080p.WEB-DL",
+		MediaInfoCategory: "TV",
 		ExternalIDs: api.ExternalIDs{
 			TVDBID:   765432,
 			Category: "MOVIE",

--- a/internal/dupechecking/mtv.go
+++ b/internal/dupechecking/mtv.go
@@ -39,7 +39,7 @@ func (h mtvHandler) Search(ctx context.Context, meta api.PreparedMetadata, _ str
 		params.Set("imdbid", "tt"+strconv.Itoa(meta.ExternalIDs.IMDBID))
 	case meta.ExternalIDs.TMDBID != 0:
 		params.Set("tmdbid", strconv.Itoa(meta.ExternalIDs.TMDBID))
-	case meta.ExternalIDs.TVDBID != 0:
+	case isMTVTVCategory(meta) && meta.ExternalIDs.TVDBID != 0:
 		params.Set("tvdbid", strconv.Itoa(meta.ExternalIDs.TVDBID))
 	default:
 		query := cleanMTVSearchTitle(meta)
@@ -111,6 +111,23 @@ func (h mtvHandler) Search(ctx context.Context, meta api.PreparedMetadata, _ str
 	}
 
 	return entries, nil, nil
+}
+
+// isMTVTVCategory reports whether MTV torznab searches may use a TVDB ID query.
+// Explicit movie categories suppress TVDB even when MediaInfo classifies the release as TV.
+func isMTVTVCategory(meta api.PreparedMetadata) bool {
+	if isMTVMovieCategory(meta) {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "TV") ||
+		strings.EqualFold(strings.TrimSpace(meta.MediaInfoCategory), "TV") ||
+		strings.EqualFold(strings.TrimSpace(meta.Release.Category), "TV")
+}
+
+func isMTVMovieCategory(meta api.PreparedMetadata) bool {
+	return strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "MOVIE") ||
+		strings.EqualFold(strings.TrimSpace(meta.MediaInfoCategory), "MOVIE") ||
+		strings.EqualFold(strings.TrimSpace(meta.Release.Category), "MOVIE")
 }
 
 func cleanMTVSearchTitle(meta api.PreparedMetadata) string {

--- a/internal/dupechecking/mtv_test.go
+++ b/internal/dupechecking/mtv_test.go
@@ -178,6 +178,100 @@ func TestMTVHandlerFallsBackToCleanedTitleQuery(t *testing.T) {
 	}
 }
 
+func TestMTVHandlerSkipsTVDBForMovie(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			query := req.URL.Query()
+			assertQueryParam(t, query, "q", "Movie Title")
+			if got := query.Get("tvdbid"); got != "" {
+				t.Fatalf("tvdbid should be empty for movie category, got %q", got)
+			}
+			body := `<rss><channel></channel></rss>`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	handler := mtvHandler{
+		cfg: config.Config{
+			Trackers: config.TrackersConfig{
+				Trackers: map[string]config.TrackerConfig{
+					"MTV": {APIKey: "token"},
+				},
+			},
+		},
+		http: client,
+	}
+	meta := api.PreparedMetadata{
+		MediaInfoCategory: "TV",
+		ExternalIDs:       api.ExternalIDs{Category: "MOVIE", TVDBID: 888},
+		Release:           api.ReleaseInfo{Title: "Movie Title"},
+	}
+
+	entries, notes, err := handler.Search(context.Background(), meta, "MTV")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(notes) != 0 {
+		t.Fatalf("expected no notes, got %#v", notes)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no entries, got %d", len(entries))
+	}
+}
+
+func TestMTVHandlerUsesTVDBForTV(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			query := req.URL.Query()
+			assertQueryParam(t, query, "tvdbid", "888")
+			if got := query.Get("q"); got != "" {
+				t.Fatalf("q should be empty when tvdbid is present, got %q", got)
+			}
+			body := `<rss><channel></channel></rss>`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	handler := mtvHandler{
+		cfg: config.Config{
+			Trackers: config.TrackersConfig{
+				Trackers: map[string]config.TrackerConfig{
+					"MTV": {APIKey: "token"},
+				},
+			},
+		},
+		http: client,
+	}
+	meta := api.PreparedMetadata{
+		MediaInfoCategory: "TV",
+		ExternalIDs:       api.ExternalIDs{TVDBID: 888},
+		Release:           api.ReleaseInfo{Title: "Show Title"},
+	}
+
+	entries, notes, err := handler.Search(context.Background(), meta, "MTV")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(notes) != 0 {
+		t.Fatalf("expected no notes, got %#v", notes)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no entries, got %d", len(entries))
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -366,13 +366,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 	tvdbName := ""
 
 	isTVForTVmaze := func() bool {
-		if strings.EqualFold(ids.Category, "TV") {
-			return true
-		}
-		if strings.TrimSpace(ids.Category) == "" {
-			return isLikelyTV(meta)
-		}
-		return false
+		return shouldUseTVDBForCategory(meta, ids)
 	}
 
 	tmdbLogoFetchAttempted := false
@@ -393,7 +387,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 		if ids.IMDBID != 0 && metadata.IMDB == nil {
 			return true
 		}
-		if !overrideTVDB && ids.TVDBID == 0 && (ids.IMDBID != 0 || ids.TMDBID != 0) {
+		if shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && ids.TVDBID == 0 && (ids.IMDBID != 0 || ids.TMDBID != 0) {
 			return true
 		}
 		if metadata.TVmaze == nil && isTVForTVmaze() && (ids.TVmazeID != 0 || (!overrideTVmaze && ids.TVmazeID == 0 && (ids.IMDBID != 0 || ids.TVDBID != 0))) {
@@ -408,7 +402,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 			tmdbLogoFetchAttempted = true
 		}
 		fetchIMDB := ids.IMDBID != 0 && metadata.IMDB == nil
-		lookupTVDB := !overrideTVDB && ids.TVDBID == 0 && (ids.IMDBID != 0 || ids.TMDBID != 0)
+		lookupTVDB := shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && ids.TVDBID == 0 && (ids.IMDBID != 0 || ids.TMDBID != 0)
 		lookupTVmaze := metadata.TVmaze == nil && isTVForTVmaze() && (ids.TVmazeID != 0 || (!overrideTVmaze && ids.TVmazeID == 0 && (ids.IMDBID != 0 || ids.TVDBID != 0)))
 
 		if s.logger != nil {
@@ -550,11 +544,11 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 			if !overrideIMDB && ids.IMDBID == 0 && tmdbResult.IMDbID != 0 {
 				applyResolvedID(&ids.IMDBID, &ids.SourceIMDB, tmdbResult.IMDbID, "tmdb")
 			}
-			if !overrideTVDB && ids.TVDBID == 0 && tmdbResult.TVDBID != 0 {
-				applyResolvedID(&ids.TVDBID, &ids.SourceTVDB, tmdbResult.TVDBID, "tmdb")
-			}
 			if ids.Category == "" && tmdbResult.TMDBType != "" {
 				ids.Category = normalizeCategory(tmdbResult.TMDBType)
+			}
+			if shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && ids.TVDBID == 0 && tmdbResult.TVDBID != 0 {
+				applyResolvedID(&ids.TVDBID, &ids.SourceTVDB, tmdbResult.TVDBID, "tmdb")
 			}
 		}
 
@@ -574,7 +568,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 			}
 		}
 
-		if ids.TVDBID != 0 {
+		if shouldUseTVDBForCategory(meta, ids) && ids.TVDBID != 0 {
 			tvdbSeries, err := tvdbClient.GetSeriesMetadataWithLanguage(ctx, ids.TVDBID, "")
 			if err != nil {
 				tvdbSeries, err = tvdbClient.GetSeriesMetadata(ctx, ids.TVDBID)
@@ -606,13 +600,13 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 			if !overrideIMDB && ids.IMDBID == 0 && tvmazeResult.IMDBID != 0 {
 				applyResolvedID(&ids.IMDBID, &ids.SourceIMDB, tvmazeResult.IMDBID, "tvmaze")
 			}
-			if !overrideTVDB && ids.TVDBID == 0 && tvmazeResult.TVDBID != 0 {
+			if shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && ids.TVDBID == 0 && tvmazeResult.TVDBID != 0 {
 				applyResolvedID(&ids.TVDBID, &ids.SourceTVDB, tvmazeResult.TVDBID, "tvmaze")
 			}
 			metadata.TVmaze = mapTVmazeMetadata(*tvmazeResult)
 		}
 
-		if metadata.TVDB == nil && ids.TVDBID != 0 {
+		if shouldUseTVDBForCategory(meta, ids) && metadata.TVDB == nil && ids.TVDBID != 0 {
 			metadata.TVDB = &api.TVDBMetadata{TVDBID: ids.TVDBID, Name: tvdbName}
 		}
 		if metadata.TVmaze == nil && ids.TVmazeID != 0 {
@@ -641,6 +635,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 		runFetchPass(true)
 	}
 
+	clearTVDBForNonTVCategory(meta, &ids, &metadata)
 	meta = s.applyTVEpisodeMetadata(ctx, meta, &ids, &metadata, tmdbClient, tvdbClient, tvmazeClient)
 
 	if tmdbErr != nil && s.logger != nil {
@@ -720,6 +715,41 @@ func clearTrackerSourcedExternalIDs(ids *api.ExternalIDs) {
 	if strings.EqualFold(strings.TrimSpace(ids.SourceTVmaze), "tracker") {
 		ids.TVmazeID = 0
 		ids.SourceTVmaze = ""
+	}
+}
+
+// shouldUseTVDBForCategory reports whether TVDB data may be used for the resolved media category.
+// Any explicit MOVIE category is authoritative over TV hints from MediaInfo, stored IDs, release data, or the filename.
+func shouldUseTVDBForCategory(meta api.PreparedMetadata, ids api.ExternalIDs) bool {
+	candidates := []string{ids.Category, meta.ExternalIDs.Category, meta.MediaInfoCategory, meta.Release.Category}
+	if meta.ReleaseNameOverrides.Category != nil {
+		candidates = append(candidates, *meta.ReleaseNameOverrides.Category)
+	}
+	for _, candidate := range candidates {
+		if normalizeCategory(candidate) == "MOVIE" {
+			return false
+		}
+	}
+	for _, candidate := range candidates {
+		if normalizeCategory(candidate) == "TV" {
+			return true
+		}
+	}
+	return isLikelyTV(meta)
+}
+
+// clearTVDBForNonTVCategory removes TVDB IDs and metadata when the resolved category no longer permits TVDB data.
+func clearTVDBForNonTVCategory(meta api.PreparedMetadata, ids *api.ExternalIDs, metadata *api.ExternalMetadata) {
+	if ids == nil {
+		return
+	}
+	if shouldUseTVDBForCategory(meta, *ids) {
+		return
+	}
+	ids.TVDBID = 0
+	ids.SourceTVDB = ""
+	if metadata != nil {
+		metadata.TVDB = nil
 	}
 }
 
@@ -976,10 +1006,19 @@ func resolveCategoryPreference(meta api.PreparedMetadata) string {
 			return category
 		}
 	}
+	// A known movie category wins before tracker or MediaInfo TV candidates can make the resolver keep TVDB state.
+	for _, candidate := range []string{meta.ExternalIDs.Category, meta.Release.Category, meta.MediaInfoCategory} {
+		if normalizeCategory(candidate) == "MOVIE" {
+			return "MOVIE"
+		}
+	}
 	for _, record := range meta.TrackerData {
 		if normalized := normalizeCategory(string(record.Category)); normalized != "" {
 			return normalized
 		}
+	}
+	if normalized := normalizeCategory(meta.ExternalIDs.Category); normalized != "" {
+		return normalized
 	}
 	category := normalizeCategory(meta.MediaInfoCategory)
 	if category != "" {

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -391,7 +391,7 @@ func TestResolveExternalIDsPrecedence(t *testing.T) {
 		MediaInfoTVDBID:   777,
 		SceneIMDB:         666,
 		TrackerData:       []api.TrackerMetadata{{TMDBID: 1, IMDBID: 2, TVDBID: 3}},
-		MediaInfoCategory: "movie",
+		MediaInfoCategory: "TV",
 	}
 
 	result, err := svc.ResolveExternalIDs(context.Background(), meta)
@@ -441,9 +441,10 @@ func TestResolveExternalIDsSkipAutoTorrentIgnoresTrackerSourcedIDs(t *testing.T)
 			SourceTVDB: "tracker",
 			Category:   "MOVIE",
 		},
-		MediaInfoTMDBID: 999,
-		MediaInfoIMDBID: 888,
-		MediaInfoTVDBID: 777,
+		MediaInfoTMDBID:   999,
+		MediaInfoIMDBID:   888,
+		MediaInfoTVDBID:   777,
+		MediaInfoCategory: "movie",
 		TrackerData: []api.TrackerMetadata{{
 			TMDBID: 4,
 			IMDBID: 5,
@@ -460,8 +461,8 @@ func TestResolveExternalIDsSkipAutoTorrentIgnoresTrackerSourcedIDs(t *testing.T)
 	if result.ExternalIDs.IMDBID != 888 || result.ExternalIDs.SourceIMDB != "mediainfo" {
 		t.Fatalf("expected imdb from mediainfo, got %#v", result.ExternalIDs)
 	}
-	if result.ExternalIDs.TVDBID != 777 || result.ExternalIDs.SourceTVDB != "mediainfo" {
-		t.Fatalf("expected tvdb from mediainfo, got %#v", result.ExternalIDs)
+	if result.ExternalIDs.TVDBID != 0 || result.ExternalIDs.SourceTVDB != "" {
+		t.Fatalf("expected tvdb cleared for movie category, got %#v", result.ExternalIDs)
 	}
 	if tmdbClient.findCalls != 0 || tmdbClient.searchCalls != 0 || tmdbClient.metaCalls != 1 {
 		t.Fatalf("expected one tmdb metadata fetch only, got find=%d search=%d metadata=%d", tmdbClient.findCalls, tmdbClient.searchCalls, tmdbClient.metaCalls)
@@ -472,8 +473,8 @@ func TestResolveExternalIDsSkipAutoTorrentIgnoresTrackerSourcedIDs(t *testing.T)
 	if tvdbClient.calls != 0 {
 		t.Fatalf("expected tvdb external lookup skipped, got %d", tvdbClient.calls)
 	}
-	if len(tvdbClient.seriesLangCalls) != 1 {
-		t.Fatalf("expected one tvdb metadata fetch, got %d", len(tvdbClient.seriesLangCalls))
+	if len(tvdbClient.seriesLangCalls) != 0 {
+		t.Fatalf("expected tvdb metadata fetch skipped for movie category, got %d", len(tvdbClient.seriesLangCalls))
 	}
 	if tvmazeClient.calls != 0 {
 		t.Fatalf("expected tvmaze lookup skipped, got %d", tvmazeClient.calls)
@@ -510,9 +511,10 @@ func TestResolveExternalIDsSkipAutoTorrentIgnoresTrackerSourcedIDs(t *testing.T)
 			IMDB:       &api.IMDBMetadata{IMDBID: 888, Title: "Stored IMDb"},
 			TVDB:       &api.TVDBMetadata{TVDBID: 777, Name: "Stored TVDB"},
 		},
-		MediaInfoTMDBID: 999,
-		MediaInfoIMDBID: 888,
-		MediaInfoTVDBID: 777,
+		MediaInfoTMDBID:   999,
+		MediaInfoIMDBID:   888,
+		MediaInfoTVDBID:   777,
+		MediaInfoCategory: "movie",
 		TrackerData: []api.TrackerMetadata{{
 			TMDBID: 4,
 			IMDBID: 5,
@@ -528,8 +530,8 @@ func TestResolveExternalIDsSkipAutoTorrentIgnoresTrackerSourcedIDs(t *testing.T)
 	if reused.ExternalMetadata.IMDB == nil || reused.ExternalMetadata.IMDB.Title != "Stored IMDb" {
 		t.Fatalf("expected stored imdb metadata reused, got %#v", reused.ExternalMetadata.IMDB)
 	}
-	if reused.ExternalMetadata.TVDB == nil || reused.ExternalMetadata.TVDB.Name != "Stored TVDB" {
-		t.Fatalf("expected stored tvdb metadata reused, got %#v", reused.ExternalMetadata.TVDB)
+	if reused.ExternalMetadata.TVDB != nil {
+		t.Fatalf("expected stored tvdb metadata cleared for movie category, got %#v", reused.ExternalMetadata.TVDB)
 	}
 	if reuseTMDBClient.findCalls != 0 || reuseTMDBClient.searchCalls != 0 || reuseTMDBClient.metaCalls != 0 {
 		t.Fatalf("expected tmdb calls skipped for stored metadata, got find=%d search=%d metadata=%d", reuseTMDBClient.findCalls, reuseTMDBClient.searchCalls, reuseTMDBClient.metaCalls)
@@ -545,7 +547,7 @@ func TestResolveExternalIDsSkipAutoTorrentIgnoresTrackerSourcedIDs(t *testing.T)
 	}
 }
 
-func TestResolveExternalIDsPropagatesAuthoritativeMovieTVCategoryToRelease(t *testing.T) {
+func TestResolveExternalIDsMovieCategoryVetoesEarlierTVCandidate(t *testing.T) {
 	repo := &fakeRepo{
 		fileMetadata: api.FileMetadata{
 			Path:     "/media/file.mkv",
@@ -569,26 +571,29 @@ func TestResolveExternalIDsPropagatesAuthoritativeMovieTVCategoryToRelease(t *te
 	result, err := svc.ResolveExternalIDs(context.Background(), api.PreparedMetadata{
 		SourcePath:  "/media/file.mkv",
 		Release:     api.ReleaseInfo{Category: "MOVIE", Title: "Example", Year: 2024},
-		TrackerData: []api.TrackerMetadata{{Category: "TV"}},
+		TrackerData: []api.TrackerMetadata{{Category: "TV", TVDBID: 12345}},
 	})
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
 
-	if result.ExternalIDs.Category != "TV" {
-		t.Fatalf("expected external IDs category TV, got %q", result.ExternalIDs.Category)
+	if result.ExternalIDs.Category != "MOVIE" {
+		t.Fatalf("expected external IDs category MOVIE, got %q", result.ExternalIDs.Category)
 	}
-	if result.Release.Category != "TV" {
-		t.Fatalf("expected release category TV, got %q", result.Release.Category)
+	if result.ExternalIDs.TVDBID != 0 {
+		t.Fatalf("expected tvdb cleared for movie category, got %d", result.ExternalIDs.TVDBID)
 	}
-	if repo.fileMetadata.Category != "TV" {
-		t.Fatalf("expected persisted release category TV, got %q", repo.fileMetadata.Category)
+	if result.Release.Category != "MOVIE" {
+		t.Fatalf("expected release category MOVIE, got %q", result.Release.Category)
 	}
-	if repo.ids.Category != "TV" {
-		t.Fatalf("expected persisted external IDs category TV, got %q", repo.ids.Category)
+	if repo.fileMetadata.Category != "MOVIE" {
+		t.Fatalf("expected persisted release category MOVIE, got %q", repo.fileMetadata.Category)
 	}
-	if len(tmdbClient.searchInputs) == 0 || tmdbClient.searchInputs[0].Category != "TV" {
-		t.Fatalf("expected TV to be passed as TMDB preference, got %#v", tmdbClient.searchInputs)
+	if repo.ids.Category != "MOVIE" {
+		t.Fatalf("expected persisted external IDs category MOVIE, got %q", repo.ids.Category)
+	}
+	if len(tmdbClient.searchInputs) == 0 || tmdbClient.searchInputs[0].Category != "MOVIE" {
+		t.Fatalf("expected MOVIE to be passed as TMDB preference, got %#v", tmdbClient.searchInputs)
 	}
 }
 
@@ -1213,21 +1218,16 @@ func TestResolveExternalIDsDoesNotTreatTMDBMovieWithoutIMDbAsTVMovie(t *testing.
 	if result.ExternalIDs.TVDBID != 0 {
 		t.Fatalf("expected no tvdb id without imdb tv movie metadata, got %d", result.ExternalIDs.TVDBID)
 	}
-	if len(tvdbClient.tvMovieCalls) == 0 {
-		t.Fatalf("expected tvdb lookup")
-	}
-	for _, tvMovie := range tvdbClient.tvMovieCalls {
-		if tvMovie {
-			t.Fatalf("expected tvdb lookup not to use tv movie fallback without imdb metadata, got calls %#v", tvdbClient.tvMovieCalls)
-		}
+	if len(tvdbClient.tvMovieCalls) != 0 {
+		t.Fatalf("expected no tvdb lookup for movie category, got calls %#v", tvdbClient.tvMovieCalls)
 	}
 }
 
-func TestResolveExternalIDsTreatsIMDbTVMovieTypeAsTVMovie(t *testing.T) {
+func TestResolveExternalIDsDoesNotApplyTVDBForMovieCategory(t *testing.T) {
 	repo := &fakeRepo{}
 	tmdbClient := &stubTMDB{
 		searchOutcome: tmdb.SearchOutcome{TMDBID: 1234, Category: "Movie"},
-		metadata:      tmdb.MetadataResult{Title: "Example TV Movie", TMDBType: "Movie"},
+		metadata:      tmdb.MetadataResult{Title: "Example TV Movie", TMDBType: "Movie", TVDBID: 55},
 	}
 	imdbClient := &stubIMDB{
 		searchResult: imdb.SearchResult{IMDbID: 9876},
@@ -1254,14 +1254,14 @@ func TestResolveExternalIDsTreatsIMDbTVMovieTypeAsTVMovie(t *testing.T) {
 		t.Fatalf("resolve: %v", err)
 	}
 
-	if result.ExternalIDs.TVDBID != 55 {
-		t.Fatalf("expected tvdb id from tv movie fallback, got %d", result.ExternalIDs.TVDBID)
+	if result.ExternalIDs.TVDBID != 0 {
+		t.Fatalf("expected no tvdb id for movie category, got %d", result.ExternalIDs.TVDBID)
 	}
-	if len(tvdbClient.tvMovieCalls) != 2 {
-		t.Fatalf("expected initial non-tv-movie lookup and metadata-backed retry, got %#v", tvdbClient.tvMovieCalls)
+	if result.ExternalMetadata.TVDB != nil {
+		t.Fatalf("expected no tvdb metadata for movie category, got %#v", result.ExternalMetadata.TVDB)
 	}
-	if tvdbClient.tvMovieCalls[0] || !tvdbClient.tvMovieCalls[1] {
-		t.Fatalf("expected tv movie fallback only after imdb metadata, got %#v", tvdbClient.tvMovieCalls)
+	if len(tvdbClient.tvMovieCalls) != 0 {
+		t.Fatalf("expected no tvdb lookup for movie category, got %#v", tvdbClient.tvMovieCalls)
 	}
 }
 

--- a/internal/trackers/impl/ar/upload.go
+++ b/internal/trackers/impl/ar/upload.go
@@ -268,7 +268,8 @@ func buildDatabaseLinks(meta api.PreparedMetadata) string {
 	if id := meta.ExternalIDs.TMDBID; id > 0 {
 		links = append(links, fmt.Sprintf("https://www.themoviedb.org/%s/%d", category, id))
 	}
-	if id := meta.ExternalIDs.TVDBID; id > 0 {
+	if isTVDBCategory(meta) && meta.ExternalIDs.TVDBID > 0 {
+		id := meta.ExternalIDs.TVDBID
 		links = append(links, fmt.Sprintf("https://www.thetvdb.com/?id=%d&tab=series", id))
 	}
 	if id := meta.ExternalIDs.TVmazeID; id > 0 {
@@ -278,6 +279,20 @@ func buildDatabaseLinks(meta api.PreparedMetadata) string {
 		links = append(links, fmt.Sprintf("https://myanimelist.net/anime/%d", meta.MALID))
 	}
 	return strings.Join(links, "\n")
+}
+
+// isTVDBCategory reports whether AR descriptions may include a TVDB series link.
+// Explicit movie categories suppress TVDB links even when MediaInfo or episode hints classify the release as TV.
+func isTVDBCategory(meta api.PreparedMetadata) bool {
+	if strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "MOVIE") ||
+		strings.EqualFold(strings.TrimSpace(meta.MediaInfoCategory), "MOVIE") ||
+		strings.EqualFold(strings.TrimSpace(meta.Release.Category), "MOVIE") {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "TV") ||
+		strings.EqualFold(strings.TrimSpace(meta.MediaInfoCategory), "TV") ||
+		strings.EqualFold(strings.TrimSpace(meta.Release.Category), "TV") ||
+		meta.TVPack || meta.SeasonInt > 0 || meta.EpisodeInt > 0
 }
 
 func buildScreenshotSection(images []api.ScreenshotImage) string {

--- a/internal/trackers/impl/ar/upload_test.go
+++ b/internal/trackers/impl/ar/upload_test.go
@@ -64,3 +64,38 @@ func TestPersistLoginCookiesAllowsPlaintextFallbackWhenAuthHelperUnavailable(t *
 		t.Fatalf("expected plaintext fallback warning, got %q", logger.warnings[0])
 	}
 }
+
+func TestBuildDatabaseLinksSkipsTVDBForMovie(t *testing.T) {
+	t.Parallel()
+
+	got := buildDatabaseLinks(api.PreparedMetadata{
+		MediaInfoCategory: "TV",
+		ExternalIDs:       api.ExternalIDs{Category: "MOVIE", TVDBID: 456},
+	})
+	if strings.Contains(got, "thetvdb.com") {
+		t.Fatalf("did not expect tvdb link for movie description, got %q", got)
+	}
+}
+
+func TestBuildDatabaseLinksIncludesTVDBForMediaInfoTV(t *testing.T) {
+	t.Parallel()
+
+	got := buildDatabaseLinks(api.PreparedMetadata{
+		MediaInfoCategory: "TV",
+		ExternalIDs:       api.ExternalIDs{TVDBID: 456},
+	})
+	if !strings.Contains(got, "thetvdb.com/?id=456") {
+		t.Fatalf("expected tvdb link for MediaInfo TV description, got %q", got)
+	}
+}
+
+func TestBuildDatabaseLinksIncludesTVDBForTV(t *testing.T) {
+	t.Parallel()
+
+	got := buildDatabaseLinks(api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "TV", TVDBID: 456},
+	})
+	if !strings.Contains(got, "thetvdb.com/?id=456") {
+		t.Fatalf("expected tvdb link for TV description, got %q", got)
+	}
+}

--- a/internal/trackers/impl/hdb/definition_test.go
+++ b/internal/trackers/impl/hdb/definition_test.go
@@ -233,3 +233,38 @@ func TestDefinitionBuildUploadDryRunUsesProvidedAssets(t *testing.T) {
 		t.Fatalf("expected provided screenshot in dry-run description, got %q", entry.Description)
 	}
 }
+
+func TestBuildUploadFieldsSkipsTVDBForMovie(t *testing.T) {
+	fields := buildUploadFields(api.PreparedMetadata{
+		MediaInfoCategory: "TV",
+		ExternalIDs:       api.ExternalIDs{Category: "MOVIE", TVDBID: 765432},
+	}, config.Config{}, 1, 5, 6, "description")
+
+	if _, ok := fields["tvdb"]; ok {
+		t.Fatalf("did not expect tvdb for movie payload")
+	}
+	if _, ok := fields["tvdb_season"]; ok {
+		t.Fatalf("did not expect tvdb_season for movie payload")
+	}
+	if _, ok := fields["tvdb_episode"]; ok {
+		t.Fatalf("did not expect tvdb_episode for movie payload")
+	}
+}
+
+func TestBuildUploadFieldsIncludesTVDBForTV(t *testing.T) {
+	fields := buildUploadFields(api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "TV", TVDBID: 765432},
+		SeasonInt:   2,
+		EpisodeInt:  3,
+	}, config.Config{}, 2, 5, 6, "description")
+
+	if got := fields["tvdb"]; got != "765432" {
+		t.Fatalf("expected tvdb=765432, got %q", got)
+	}
+	if got := fields["tvdb_season"]; got != "2" {
+		t.Fatalf("expected tvdb_season=2, got %q", got)
+	}
+	if got := fields["tvdb_episode"]; got != "3" {
+		t.Fatalf("expected tvdb_episode=3, got %q", got)
+	}
+}

--- a/internal/trackers/impl/hdb/upload.go
+++ b/internal/trackers/impl/hdb/upload.go
@@ -236,7 +236,7 @@ func buildUploadFields(meta api.PreparedMetadata, appConfig config.Config, categ
 		}
 	}
 
-	if meta.ExternalIDs.TVDBID != 0 {
+	if isHDBTVCategory(meta) && meta.ExternalIDs.TVDBID != 0 {
 		fields["tvdb"] = strconv.Itoa(meta.ExternalIDs.TVDBID)
 	}
 	if imdb := resolveIMDbURL(meta); imdb != "" {
@@ -244,7 +244,7 @@ func buildUploadFields(meta api.PreparedMetadata, appConfig config.Config, categ
 	} else {
 		fields["imdb"] = "0"
 	}
-	if strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "TV") || strings.EqualFold(strings.TrimSpace(meta.MediaInfoCategory), "TV") {
+	if isHDBTVCategory(meta) {
 		season := meta.SeasonInt
 		episode := meta.EpisodeInt
 		if season <= 0 {
@@ -258,6 +258,35 @@ func buildUploadFields(meta api.PreparedMetadata, appConfig config.Config, categ
 	}
 
 	return fields
+}
+
+// isHDBTVCategory reports whether HDB upload payloads may include TVDB fields.
+// Explicit movie categories suppress TVDB fields even when MediaInfo or overrides classify the release as TV.
+func isHDBTVCategory(meta api.PreparedMetadata) bool {
+	if isHDBMovieCategory(meta) {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "TV") ||
+		strings.EqualFold(strings.TrimSpace(meta.MediaInfoCategory), "TV") ||
+		strings.EqualFold(strings.TrimSpace(meta.Release.Category), "TV") {
+		return true
+	}
+	if meta.ReleaseNameOverrides.Category != nil {
+		return strings.EqualFold(strings.TrimSpace(*meta.ReleaseNameOverrides.Category), "TV")
+	}
+	return false
+}
+
+func isHDBMovieCategory(meta api.PreparedMetadata) bool {
+	if strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "MOVIE") ||
+		strings.EqualFold(strings.TrimSpace(meta.MediaInfoCategory), "MOVIE") ||
+		strings.EqualFold(strings.TrimSpace(meta.Release.Category), "MOVIE") {
+		return true
+	}
+	if meta.ReleaseNameOverrides.Category != nil {
+		return strings.EqualFold(strings.TrimSpace(*meta.ReleaseNameOverrides.Category), "MOVIE")
+	}
+	return false
 }
 
 func resolveDescriptionAssets(

--- a/internal/trackers/impl/mtv/upload.go
+++ b/internal/trackers/impl/mtv/upload.go
@@ -692,7 +692,7 @@ func resolveGroupDescription(meta api.PreparedMetadata) string {
 		}
 		parts = append(parts, "https://www.themoviedb.org/"+category+"/"+strconv.Itoa(meta.ExternalIDs.TMDBID))
 	}
-	if meta.ExternalIDs.TVDBID != 0 {
+	if strings.EqualFold(resolveCategory(meta), "TV") && meta.ExternalIDs.TVDBID != 0 {
 		parts = append(parts, "https://www.thetvdb.com/?id="+strconv.Itoa(meta.ExternalIDs.TVDBID))
 	}
 	if meta.ExternalIDs.TVmazeID != 0 {

--- a/internal/trackers/impl/mtv/upload_test.go
+++ b/internal/trackers/impl/mtv/upload_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package mtv
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestResolveGroupDescriptionSkipsTVDBForMovie(t *testing.T) {
+	got := resolveGroupDescription(api.PreparedMetadata{
+		MediaInfoCategory: "TV",
+		ExternalIDs:       api.ExternalIDs{Category: "MOVIE", TVDBID: 456},
+	})
+	if strings.Contains(got, "thetvdb.com") {
+		t.Fatalf("did not expect tvdb link for movie description, got %q", got)
+	}
+}
+
+func TestResolveGroupDescriptionIncludesTVDBForTV(t *testing.T) {
+	got := resolveGroupDescription(api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "TV", TVDBID: 456},
+	})
+	if !strings.Contains(got, "thetvdb.com/?id=456") {
+		t.Fatalf("expected tvdb link for TV description, got %q", got)
+	}
+}

--- a/internal/trackers/impl/tvc/upload.go
+++ b/internal/trackers/impl/tvc/upload.go
@@ -160,7 +160,6 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest) (upload
 		"type":             resolveResolution(req.Meta),
 		"tmdb":             strconv.Itoa(req.Meta.ExternalIDs.TMDBID),
 		"imdb":             strconv.Itoa(req.Meta.ExternalIDs.IMDBID),
-		"tvdb":             strconv.Itoa(req.Meta.ExternalIDs.TVDBID),
 		"mal":              strconv.Itoa(req.Meta.MALID),
 		"igdb":             "0",
 		"anonymous":        boolNum(req.TrackerConfig.Anon),
@@ -175,6 +174,9 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest) (upload
 		"sticky":           "0",
 	}
 	if isTV(req.Meta) {
+		if isTVCategory(req.Meta) {
+			fields["tvdb"] = strconv.Itoa(req.Meta.ExternalIDs.TVDBID)
+		}
 		fields["season_number"] = strconv.Itoa(maxInt(req.Meta.SeasonInt, 0))
 		fields["episode_number"] = strconv.Itoa(maxInt(req.Meta.EpisodeInt, 0))
 	}
@@ -315,7 +317,7 @@ func externalLinks(meta api.PreparedMetadata) string {
 	if meta.ExternalIDs.IMDBID > 0 {
 		parts = append(parts, fmt.Sprintf("[url=https://www.imdb.com/title/tt%07d]IMDb[/url]", meta.ExternalIDs.IMDBID))
 	}
-	if meta.ExternalIDs.TVDBID > 0 {
+	if isTVCategory(meta) && meta.ExternalIDs.TVDBID > 0 {
 		parts = append(parts, fmt.Sprintf("[url=https://www.thetvdb.com/?id=%d&tab=series]TVDB[/url]", meta.ExternalIDs.TVDBID))
 	}
 	return strings.Join(parts, " | ")
@@ -379,7 +381,25 @@ func cloneFields(input map[string]string) map[string]string {
 }
 
 func isTV(meta api.PreparedMetadata) bool {
-	return meta.TVPack || meta.SeasonInt > 0 || meta.EpisodeInt > 0 || strings.EqualFold(meta.ExternalIDs.Category, "TV")
+	return isTVCategory(meta)
+}
+
+// isTVCategory reports whether TVC payloads may include TVDB-specific fields.
+// Explicit movie categories suppress TVDB fields; otherwise TVPack, episode data, and MediaInfo TV are enough.
+func isTVCategory(meta api.PreparedMetadata) bool {
+	if isMovieCategory(meta) {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "TV") ||
+		strings.EqualFold(strings.TrimSpace(meta.MediaInfoCategory), "TV") ||
+		strings.EqualFold(strings.TrimSpace(meta.Release.Category), "TV") ||
+		meta.TVPack || meta.SeasonInt > 0 || meta.EpisodeInt > 0
+}
+
+func isMovieCategory(meta api.PreparedMetadata) bool {
+	return strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "MOVIE") ||
+		strings.EqualFold(strings.TrimSpace(meta.MediaInfoCategory), "MOVIE") ||
+		strings.EqualFold(strings.TrimSpace(meta.Release.Category), "MOVIE")
 }
 
 func categoryName(meta api.PreparedMetadata) string {

--- a/internal/trackers/impl/tvc/upload_test.go
+++ b/internal/trackers/impl/tvc/upload_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package tvc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackers"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestPrepareUploadStateSkipsTVDBForMovie(t *testing.T) {
+	tmp := t.TempDir()
+	torrentPath := filepath.Join(tmp, "movie.torrent")
+	if err := os.WriteFile(torrentPath, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+
+	state, err := prepareUploadState(context.Background(), trackers.UploadRequest{
+		Tracker: "TVC",
+		Meta: api.PreparedMetadata{
+			SourcePath:        filepath.Join(tmp, "Movie.mkv"),
+			TorrentPath:       torrentPath,
+			MediaInfoCategory: "TV",
+			ExternalIDs: api.ExternalIDs{
+				Category: "MOVIE",
+				TMDBID:   123,
+				TVDBID:   456,
+			},
+			ExternalMetadata: api.ExternalMetadata{
+				TMDB: &api.TMDBMetadata{Title: "Movie", Year: 2025},
+			},
+			Release: api.ReleaseInfo{Title: "Movie", Year: 2025, Resolution: "1080p"},
+			Type:    "WEBDL",
+		},
+		TrackerConfig: config.TrackerConfig{APIKey: "token"},
+	})
+	if err != nil {
+		t.Fatalf("prepare upload state: %v", err)
+	}
+	if _, ok := state.fields["tvdb"]; ok {
+		t.Fatalf("did not expect tvdb for movie payload")
+	}
+}
+
+func TestPrepareUploadStateIncludesTVDBForTV(t *testing.T) {
+	tmp := t.TempDir()
+	torrentPath := filepath.Join(tmp, "show.torrent")
+	if err := os.WriteFile(torrentPath, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+
+	state, err := prepareUploadState(context.Background(), trackers.UploadRequest{
+		Tracker: "TVC",
+		Meta: api.PreparedMetadata{
+			SourcePath:  filepath.Join(tmp, "Show.S02E03.mkv"),
+			TorrentPath: torrentPath,
+			ExternalIDs: api.ExternalIDs{
+				Category: "TV",
+				TMDBID:   123,
+				TVDBID:   456,
+			},
+			ExternalMetadata: api.ExternalMetadata{
+				TMDB: &api.TMDBMetadata{Title: "Show", Year: 2025},
+			},
+			Release:    api.ReleaseInfo{Title: "Show", Year: 2025, Resolution: "1080p"},
+			Type:       "WEBDL",
+			SeasonInt:  2,
+			EpisodeInt: 3,
+		},
+		TrackerConfig: config.TrackerConfig{APIKey: "token"},
+	})
+	if err != nil {
+		t.Fatalf("prepare upload state: %v", err)
+	}
+	if got := state.fields["tvdb"]; got != "456" {
+		t.Fatalf("expected tvdb=456, got %q", got)
+	}
+}
+
+func TestPrepareUploadStateIncludesTVDBForMediaInfoTV(t *testing.T) {
+	tmp := t.TempDir()
+	torrentPath := filepath.Join(tmp, "show.torrent")
+	if err := os.WriteFile(torrentPath, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+
+	state, err := prepareUploadState(context.Background(), trackers.UploadRequest{
+		Tracker: "TVC",
+		Meta: api.PreparedMetadata{
+			SourcePath:        filepath.Join(tmp, "Show.mkv"),
+			TorrentPath:       torrentPath,
+			MediaInfoCategory: "TV",
+			ExternalIDs:       api.ExternalIDs{TMDBID: 123, TVDBID: 456},
+			ExternalMetadata: api.ExternalMetadata{
+				TMDB: &api.TMDBMetadata{Title: "Show", Year: 2025},
+			},
+			Release: api.ReleaseInfo{Title: "Show", Year: 2025, Resolution: "1080p"},
+			Type:    "WEBDL",
+		},
+		TrackerConfig: config.TrackerConfig{APIKey: "token"},
+	})
+	if err != nil {
+		t.Fatalf("prepare upload state: %v", err)
+	}
+	if got := state.fields["tvdb"]; got != "456" {
+		t.Fatalf("expected tvdb=456, got %q", got)
+	}
+}
+
+func TestPrepareUploadStateIncludesTVDBForSeasonPackWithoutCategory(t *testing.T) {
+	tmp := t.TempDir()
+	torrentPath := filepath.Join(tmp, "season.torrent")
+	if err := os.WriteFile(torrentPath, []byte("dummy"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+
+	state, err := prepareUploadState(context.Background(), trackers.UploadRequest{
+		Tracker: "TVC",
+		Meta: api.PreparedMetadata{
+			SourcePath:  filepath.Join(tmp, "Show.S02.mkv"),
+			TorrentPath: torrentPath,
+			ExternalIDs: api.ExternalIDs{
+				TMDBID: 123,
+				TVDBID: 456,
+			},
+			ExternalMetadata: api.ExternalMetadata{
+				TMDB: &api.TMDBMetadata{Title: "Show", Year: 2025},
+			},
+			Release:   api.ReleaseInfo{Title: "Show", Year: 2025, Resolution: "1080p"},
+			Type:      "WEBDL",
+			TVPack:    true,
+			SeasonInt: 2,
+		},
+		TrackerConfig: config.TrackerConfig{APIKey: "token"},
+	})
+	if err != nil {
+		t.Fatalf("prepare upload state: %v", err)
+	}
+	if got := state.fields["tvdb"]; got != "456" {
+		t.Fatalf("expected tvdb=456, got %q", got)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect inclusion of TheTVDB database information for content categorized as movies. Movie content no longer receives TV database lookups and associations across duplicate checking and tracker uploads.

* **Tests**
  * Added comprehensive test coverage validating that movies are properly excluded from TV database usage while TV content retains appropriate database associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->