### PR TITLE
Fix: torrent path mapping

### DIFF
--- a/internal/clients/linking.go
+++ b/internal/clients/linking.go
@@ -590,29 +590,79 @@ func symlink(source string, dest string, _ bool) error {
 	return nil
 }
 
+// mapLocalPathToRemote maps a local filesystem path through the first matching,
+// positionally paired local_path/remote_path entry, or returns the trimmed input
+// when no usable pair matches.
 func mapLocalPathToRemote[S ~[]string](value string, localPaths S, remotePaths S) string {
+	if mapped, ok := mappedRemotePath(value, localPaths, remotePaths); ok {
+		return mapped
+	}
+	return strings.TrimSpace(value)
+}
+
+// mappedRemotePath reports whether value is under a usable configured local
+// root and, when it is, returns the paired remote root plus relative suffix.
+// Blank local or remote entries are ignored without shifting later pairs.
+func mappedRemotePath[S ~[]string](value string, localPaths S, remotePaths S) (string, bool) {
 	savePath := strings.TrimSpace(value)
 	if savePath == "" {
-		return ""
+		return "", false
 	}
-	locals := nonEmptyClientPaths(localPaths)
-	remotes := nonEmptyClientPaths(remotePaths)
-	for idx, localPath := range locals {
-		if idx >= len(remotes) {
-			break
-		}
-		remotePath := remotes[idx]
-		rel, ok := relativePathUnderRoot(localPath, savePath)
+	for _, pair := range pathMappingPairs(localPaths, remotePaths) {
+		rel, ok := relativePathUnderRoot(pair.local, savePath)
 		if !ok {
 			continue
 		}
 		if rel == "." {
-			return remotePath
+			return pair.remote, true
 		}
-		//pathpolicy:allow Joins configured qBittorrent remote save path with staged relative suffix before API slash normalization.
-		return filepath.Join(remotePath, rel)
+		return filepath.Join(pair.remote, rel), true
 	}
-	return savePath
+	return "", false
+}
+
+// mappedQbitSavePathForSource maps the prepared source path to the qBittorrent
+// save path parent that can contain the torrent's top-level content. It returns
+// mapped=false without touching source metadata when no usable path pairs exist.
+func mappedQbitSavePathForSource[S ~[]string](meta api.PreparedMetadata, localPaths S, remotePaths S) (string, bool, error) {
+	if len(pathMappingPairs(localPaths, remotePaths)) == 0 {
+		return "", false, nil
+	}
+	source, err := sourcePathForLinking(meta)
+	if err != nil {
+		return "", false, err
+	}
+	mappedSource, ok := mappedRemotePath(source, localPaths, remotePaths)
+	if !ok {
+		return "", false, nil
+	}
+	return qbitSavePath(filepath.Dir(mappedSource)), true, nil
+}
+
+// pathMappingPair is one trimmed local_path/remote_path mapping that kept its
+// original positional relationship from the client configuration.
+type pathMappingPair struct {
+	local  string
+	remote string
+}
+
+// pathMappingPairs trims configured path entries while preserving positional
+// local_path/remote_path pairing; entries with either side blank are ignored.
+func pathMappingPairs[S ~[]string](localPaths S, remotePaths S) []pathMappingPair {
+	limit := len(localPaths)
+	if len(remotePaths) < limit {
+		limit = len(remotePaths)
+	}
+	pairs := make([]pathMappingPair, 0, limit)
+	for idx := 0; idx < limit; idx++ {
+		localPath := strings.TrimSpace(localPaths[idx])
+		remotePath := strings.TrimSpace(remotePaths[idx])
+		if localPath == "" || remotePath == "" {
+			continue
+		}
+		pairs = append(pairs, pathMappingPair{local: localPath, remote: remotePath})
+	}
+	return pairs
 }
 
 func relativePathUnderRoot(root string, target string) (string, bool) {

--- a/internal/clients/linking.go
+++ b/internal/clients/linking.go
@@ -179,6 +179,9 @@ func (s *Service) trackerLinkDirName(tracker string) string {
 	return trimmed
 }
 
+// sourcePathForLinking returns an existing local source path suitable for link
+// creation. It stats candidate paths because link staging must copy or link real
+// filesystem content.
 func sourcePathForLinking(meta api.PreparedMetadata) (string, error) {
 	if len(meta.FileList) == 1 {
 		if candidate := strings.TrimSpace(meta.FileList[0]); candidate != "" {
@@ -203,6 +206,22 @@ func sourcePathForLinking(meta api.PreparedMetadata) (string, error) {
 		return absLocalPath("linking source", source)
 	}
 	return absLocalPath("linking source", source)
+}
+
+// sourcePathForQbitSavePath returns the prepared source path used for qbit
+// savepath mapping. It is intentionally lexical and does not stat the source,
+// because qbit injection can still be valid when source metadata is unavailable.
+func sourcePathForQbitSavePath(meta api.PreparedMetadata) (string, error) {
+	if len(meta.FileList) == 1 {
+		if candidate := strings.TrimSpace(meta.FileList[0]); candidate != "" {
+			return absLocalPath("qbit mapping source", candidate)
+		}
+	}
+	source := strings.TrimSpace(meta.SourcePath)
+	if source == "" {
+		return "", internalerrors.ErrInvalidInput
+	}
+	return absLocalPath("qbit mapping source", source)
 }
 
 func linkedFolderCandidates[S ~[]string](source string, folders S, mode string) ([]string, error) {
@@ -623,12 +642,13 @@ func mappedRemotePath[S ~[]string](value string, localPaths S, remotePaths S) (s
 
 // mappedQbitSavePathForSource maps the prepared source path to the qBittorrent
 // save path parent that can contain the torrent's top-level content. It returns
-// mapped=false without touching source metadata when no usable path pairs exist.
+// mapped=false without touching source metadata when no usable path pairs exist
+// or no configured pair matches the lexical source path.
 func mappedQbitSavePathForSource[S ~[]string](meta api.PreparedMetadata, localPaths S, remotePaths S) (string, bool, error) {
 	if len(pathMappingPairs(localPaths, remotePaths)) == 0 {
 		return "", false, nil
 	}
-	source, err := sourcePathForLinking(meta)
+	source, err := sourcePathForQbitSavePath(meta)
 	if err != nil {
 		return "", false, err
 	}

--- a/internal/clients/service.go
+++ b/internal/clients/service.go
@@ -258,6 +258,17 @@ func (s *Service) injectQbit(ctx context.Context, name string, client config.Tor
 	if staging.Linked {
 		options.SavePath = staging.SavePath
 		s.logger.Debugf("clients: qbit link staging ready client=%s tracker=%s save_path=%s", name, strings.TrimSpace(torrent.Tracker), staging.SavePath)
+	} else {
+		// Without link staging, local_path/remote_path still controls where
+		// qBittorrent should save the injected torrent on the client host.
+		savePath, mapped, err := mappedQbitSavePathForSource(meta, client.LocalPath, client.RemotePath)
+		if err != nil {
+			return fmt.Errorf("clients: %s qbit path mapping: %w", name, err)
+		}
+		if mapped {
+			options.SavePath = savePath
+			s.logger.Debugf("clients: qbit path mapping ready client=%s save_path=%s", name, savePath)
+		}
 	}
 	if category := strings.TrimSpace(client.QbitCrossCategory); torrent.CrossSeed && category != "" {
 		options.Category = category

--- a/internal/clients/service_test.go
+++ b/internal/clients/service_test.go
@@ -207,6 +207,98 @@ func TestInjectQbitClient(t *testing.T) {
 	}
 }
 
+func TestInjectQbitClientUsesPathMappingSavePath(t *testing.T) {
+	t.Parallel()
+
+	server, capture := newQbitAddCaptureServer(t)
+
+	root := t.TempDir()
+	localRoot := filepath.Join(root, "local")
+	releaseDir := filepath.Join(localRoot, "Movies", "Fixture.Title.2024")
+	if err := os.MkdirAll(releaseDir, 0o700); err != nil {
+		t.Fatalf("mkdir release: %v", err)
+	}
+	source := filepath.Join(releaseDir, "video.mkv")
+	if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	torrentPath := filepath.Join(root, "sample.torrent")
+	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+
+	remoteRoot := "/remote/media"
+	svc := NewService(config.Config{
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:       "qbit",
+				URL:        server.URL,
+				Username:   "user",
+				Password:   "pass",
+				LocalPath:  config.StringList{"", localRoot},
+				RemotePath: config.StringList{"/wrong/root", remoteRoot},
+			},
+		},
+	}, nil)
+
+	meta := api.PreparedMetadata{SourcePath: source, FileList: []string{source}}
+	if err := svc.Inject(context.Background(), meta, api.TorrentResult{Path: torrentPath}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	select {
+	case err := <-capture.errCh:
+		t.Fatalf("handler: %v", err)
+	default:
+	}
+
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	wantSavePath := "/remote/media/Movies/Fixture.Title.2024/"
+	if capture.savePath != wantSavePath {
+		t.Fatalf("expected mapped savepath %q, got %q", wantSavePath, capture.savePath)
+	}
+}
+
+func TestMappedRemotePathPreservesBlankPathPairAlignment(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	localRoot := filepath.Join(root, "local")
+	otherRoot := filepath.Join(root, "other")
+	source := filepath.Join(localRoot, "Movies", "Fixture.Title.2024", "video.mkv")
+
+	tests := []struct {
+		name    string
+		locals  config.StringList
+		remotes config.StringList
+	}{
+		{
+			name:    "blank local path",
+			locals:  config.StringList{"", localRoot},
+			remotes: config.StringList{"/wrong/root", "/remote/media"},
+		},
+		{
+			name:    "blank remote path",
+			locals:  config.StringList{otherRoot, localRoot},
+			remotes: config.StringList{"", "/remote/media"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := mappedRemotePath(source, tt.locals, tt.remotes)
+			if !ok {
+				t.Fatal("expected mapped path")
+			}
+			want := filepath.Join("/remote/media", "Movies", "Fixture.Title.2024", "video.mkv")
+			if got != want {
+				t.Fatalf("expected mapped path %q, got %q", want, got)
+			}
+		})
+	}
+}
+
 func TestInjectQbitClientUsesRequestOverrides(t *testing.T) {
 	t.Parallel()
 

--- a/internal/clients/service_test.go
+++ b/internal/clients/service_test.go
@@ -260,6 +260,52 @@ func TestInjectQbitClientUsesPathMappingSavePath(t *testing.T) {
 	}
 }
 
+func TestInjectQbitClientUsesPathMappingSavePathWithoutSourceStat(t *testing.T) {
+	t.Parallel()
+
+	server, capture := newQbitAddCaptureServer(t)
+
+	root := t.TempDir()
+	localRoot := filepath.Join(root, "local")
+	source := filepath.Join(localRoot, "Movies", "Fixture.Title.2024", "video.mkv")
+	torrentPath := filepath.Join(root, "sample.torrent")
+	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+
+	remoteRoot := "/remote/media"
+	svc := NewService(config.Config{
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:       "qbit",
+				URL:        server.URL,
+				Username:   "user",
+				Password:   "pass",
+				LocalPath:  config.StringList{localRoot},
+				RemotePath: config.StringList{remoteRoot},
+			},
+		},
+	}, nil)
+
+	meta := api.PreparedMetadata{SourcePath: source, FileList: []string{source}}
+	if err := svc.Inject(context.Background(), meta, api.TorrentResult{Path: torrentPath}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	select {
+	case err := <-capture.errCh:
+		t.Fatalf("handler: %v", err)
+	default:
+	}
+
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	wantSavePath := "/remote/media/Movies/Fixture.Title.2024/"
+	if capture.savePath != wantSavePath {
+		t.Fatalf("expected mapped savepath %q, got %q", wantSavePath, capture.savePath)
+	}
+}
+
 func TestMappedRemotePathPreservesBlankPathPairAlignment(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced qBittorrent save path mapping to correctly apply configured local/remote path mappings when link staging is disabled, with improved positional path-pair alignment handling.

* **Tests**
  * Added comprehensive test coverage for qBittorrent save path mapping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->