### PR TITLE
fix(docker): embed web UI and slim image to CLI + web

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -364,6 +364,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "id=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "go_version=$(awk '/^go /{print $2; exit}' go.mod)" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
@@ -418,6 +419,7 @@ jobs:
           build-args: |
             VERSION=${{ inputs.release_tag || (github.ref_type == 'tag' && github.ref_name) || 'dev' }}
             BUILD_ID=${{ steps.build.outputs.id }}
+            GO_VERSION=${{ steps.build.outputs.go_version }}
           cache-from: type=gha,scope=build-docker-amd64
           cache-to: type=gha,scope=build-docker-amd64,mode=min
 
@@ -444,6 +446,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "id=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "go_version=$(awk '/^go /{print $2; exit}' go.mod)" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
@@ -498,6 +501,7 @@ jobs:
           build-args: |
             VERSION=${{ inputs.release_tag || (github.ref_type == 'tag' && github.ref_name) || 'dev' }}
             BUILD_ID=${{ steps.build.outputs.id }}
+            GO_VERSION=${{ steps.build.outputs.go_version }}
           cache-from: type=gha,scope=build-docker-arm64
           cache-to: type=gha,scope=build-docker-arm64,mode=min
 
@@ -527,6 +531,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "id=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+          echo "go_version=$(awk '/^go /{print $2; exit}' go.mod)" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-## syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1
 
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
@@ -7,6 +7,7 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 ARG VERSION=dev
 ARG BUILD_ID=
+ARG GO_VERSION=1.26.4
 
 FROM --platform=$BUILDPLATFORM node:20-bookworm AS frontend
 
@@ -16,9 +17,9 @@ COPY gui/frontend/package.json gui/frontend/pnpm-lock.yaml ./
 RUN corepack enable && pnpm install --frozen-lockfile
 
 COPY gui/frontend/ ./
-RUN pnpm run build
+RUN pnpm run build:bundle
 
-FROM --platform=$BUILDPLATFORM golang:1.26.4-bookworm AS cli-builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bookworm AS cli-builder
 
 WORKDIR /src
 
@@ -27,6 +28,10 @@ RUN --mount=type=cache,target=/go/pkg/mod \
         go mod download
 
 COPY . .
+
+# Embed the built web UI so `upbrr serve` can serve it. Mirrors
+# scripts/sync-frontend-assets.ps1 used by the binary release workflow.
+COPY --from=frontend /src/gui/frontend/dist/ ./internal/guiapp/assets/
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -43,55 +48,13 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         CGO_ENABLED=0 GOOS="$TARGETOS" GOARCH="$TARGETARCH" GOARM="$goarm" \
             go build -trimpath -ldflags="-s -w -X main.version=${VERSION} -X main.buildIdentifier=${BUILD_ID}" -o /out/upbrr ./cmd/upbrr
 
-FROM golang:1.26.4-bookworm AS gui-builder
-
-WORKDIR /src
-
-ARG VERSION=dev
-ARG BUILD_ID=
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    libgtk-3-dev \
-    libwebkit2gtk-4.1-dev \
-    libglib2.0-dev \
-    libx11-dev \
-    libxkbcommon-dev \
-    libxrandr-dev \
-    libxinerama-dev \
-    libxcursor-dev \
-    libxi-dev \
-    pkg-config \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY go.mod go.sum ./
-RUN --mount=type=cache,target=/go/pkg/mod \
-    go mod download
-
-COPY . .
-COPY --from=frontend /src/gui/frontend/dist ./gui/frontend/dist
-
-RUN --mount=type=cache,target=/root/.cache/go-build \
-        go build -tags webkit2_41 -trimpath -ldflags="-s -w -X main.version=${VERSION} -X main.buildIdentifier=${BUILD_ID}" -o /out/upbrr-gui ./gui
-
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
-    libgtk-3-0 \
-    libwebkit2gtk-4.1-0 \
-    libglib2.0-0 \
-    libx11-6 \
-    libxkbcommon0 \
-    libxrandr2 \
-    libxinerama1 \
-    libxcursor1 \
-    libxi6 \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=cli-builder /out/upbrr /usr/local/bin/upbrr
-COPY --from=gui-builder /out/upbrr-gui /usr/local/bin/upbrr-gui
 
 ENTRYPOINT ["/usr/local/bin/upbrr"]


### PR DESCRIPTION
## Summary

The published Docker image shipped binaries with an **empty web UI**, so `upbrr serve` could not serve the frontend. This PR fixes the root cause, aligns the image build with the binary release workflow, and slims the image down to what's actually useful in a container (CLI + embedded web UI).

## The problems

### 1. Web UI was never embedded (the bug)
- `internal/guiapp/assets_embed.go` embeds `internal/guiapp/assets/` at **compile time** via `//go:embed all:assets`. Both the CLI's `upbrr serve` (`webserver.resolveWebAssets` → `guiapp.ResolveAssets`) and the GUI depend on it.
- In a clean checkout that directory holds only `.keep` — the real build output `gui/frontend/dist` is **gitignored and dockerignored**.
- The binary release workflow handles this with `scripts/sync-frontend-assets.ps1` (copies `dist/*` into `internal/guiapp/assets/` before `go build`). **The Dockerfile never did the equivalent.** The `frontend` stage built `dist`, but `cli-builder` did `COPY . .` → `go build` without it, so the binary embedded only `.keep`.
- Result at runtime: `web assets not found` / blank web UI (the `debian-slim` final image also has no `gui/frontend/dist` disk fallback).

### 2. Broken parser directive
`## syntax=docker/dockerfile:1.7` used a double `#`, so Docker treated it as a normal comment and the syntax pin was silently ignored.

### 3. Build drift vs. the binary workflow
- Dockerfile ran `pnpm run build` (`tsc -b && vite build`); CI uses `build:bundle` (`vite build`), with typecheck as a separate CI concern.
- Dockerfile hardcoded `golang:1.26.4-bookworm` while CI sources the Go version from `go.mod` — guaranteed to drift on a `go.mod` bump.

### 4. Desktop GUI inside a headless image
The image built the Wails desktop GUI (`upbrr-gui`) and installed GTK/webkit2gtk/X11 + ffmpeg into `debian-slim`, yet `ENTRYPOINT` is the CLI. A desktop GUI binary is unusable in a headless container and added significant weight.

## The fixes

- **Embed the web UI**: `cli-builder` now copies the built frontend from the `frontend` stage into `internal/guiapp/assets/` before `go build`, mirroring `sync-frontend-assets.ps1`.
- **Fix the directive**: `# syntax=docker/dockerfile:1`.
- **Align with the binary build**: use `pnpm run build:bundle`; introduce `ARG GO_VERSION` (default `1.26.4`) and have CI inject it from `go.mod` (`awk '/^go /{print $2; exit}'`) for both docker build jobs, so `go.mod` is the single source of truth.
- **Slim the image to CLI + web UI**: remove the `gui-builder` stage, the GTK/webkit2gtk/X11 build + runtime deps, and the `upbrr-gui` binary. **Keep ffmpeg**, which the screenshot service (`internal/services/screenshots`) requires at runtime via `PATH` lookup (without it, upload screenshot generation fails with `screenshots: ffmpeg not found`).

The desktop GUI is still built and released for desktop platforms by the `build-gui` job; it's only dropped from the container image.

## Validation

- `docker build` succeeds with the new `GO_VERSION` build-arg.
- Container `upbrr serve` starts cleanly — no `web assets not found` (only an unrelated TMDB-config warning).
- Binary conclusively embeds the web UI: `index.html` present plus hashed vite bundles (`/assets/index-*.css`, `/assets/index-*.js`).
- Workflow diff reviewed; `awk '/^go /{print $2; exit}' go.mod` → `1.26.4`.

## Notes

- Resulting image is ~520 MB, dominated by ffmpeg's dependencies (SDL2, libgl, etc.) — expected, since ffmpeg is retained intentionally.
- The `go_version` step output was added to all three docker jobs for consistency; only the two build jobs consume it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified binary distribution with embedded web UI assets
  * Streamlined runtime environment with reduced dependencies for faster, lighter deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->