### PR TITLE
fix(clients): correct torrent injection selection

### DIFF
--- a/internal/clients/linking.go
+++ b/internal/clients/linking.go
@@ -669,12 +669,9 @@ type pathMappingPair struct {
 // pathMappingPairs trims configured path entries while preserving positional
 // local_path/remote_path pairing; entries with either side blank are ignored.
 func pathMappingPairs[S ~[]string](localPaths S, remotePaths S) []pathMappingPair {
-	limit := len(localPaths)
-	if len(remotePaths) < limit {
-		limit = len(remotePaths)
-	}
+	limit := min(len(remotePaths), len(localPaths))
 	pairs := make([]pathMappingPair, 0, limit)
-	for idx := 0; idx < limit; idx++ {
+	for idx := range limit {
 		localPath := strings.TrimSpace(localPaths[idx])
 		remotePath := strings.TrimSpace(remotePaths[idx])
 		if localPath == "" || remotePath == "" {

--- a/internal/clients/search_test.go
+++ b/internal/clients/search_test.go
@@ -1091,7 +1091,7 @@ func padTorrentData(t *testing.T, data []byte, minSize int, expectedHash string)
 	}
 
 	padding := bytes.Repeat([]byte("p"), minSize-len(data)+32)
-	entry := []byte(fmt.Sprintf("7:padding%d:", len(padding)))
+	entry := fmt.Appendf(nil, "7:padding%d:", len(padding))
 	padded := make([]byte, 0, len(data)+len(entry)+len(padding))
 	padded = append(padded, data[:len(data)-1]...)
 	padded = append(padded, entry...)

--- a/internal/clients/service.go
+++ b/internal/clients/service.go
@@ -34,6 +34,11 @@ func NewService(cfg config.Config, logger api.Logger) *Service {
 	return &Service{cfg: cfg, logger: logger}
 }
 
+// Inject dispatches a prepared torrent to the configured injection clients.
+// URL-only torrents require a URL-capable client unless global/default fallback
+// can select one; explicit tracker or caller selections that resolve only to
+// watch-folder clients return [internalerrors.ErrInvalidInput] instead of a
+// successful no-op.
 func (s *Service) Inject(ctx context.Context, meta api.PreparedMetadata, torrent api.TorrentResult) error {
 	select {
 	case <-ctx.Done():
@@ -76,6 +81,8 @@ func (s *Service) Inject(ctx context.Context, meta api.PreparedMetadata, torrent
 	}
 	sort.Strings(clientNames)
 
+	injected := false
+	skippedURLOnlyClients := 0
 	for _, name := range clientNames {
 		client := applyClientOverrides(clients[name], clientOverrides)
 		clientType := strings.ToLower(strings.TrimSpace(client.ClientType()))
@@ -85,6 +92,7 @@ func (s *Service) Inject(ctx context.Context, meta api.PreparedMetadata, torrent
 		// a skipped client cannot fail a successful URL add.
 		if clientType == "watch" && torrentPath == "" && torrentURL != "" {
 			s.logger.Debugf("clients: skipping watch folder client %s for URL injection", name)
+			skippedURLOnlyClients++
 			continue
 		}
 		if err := s.waitInjectDelay(ctx, torrent.Tracker); err != nil {
@@ -98,15 +106,21 @@ func (s *Service) Inject(ctx context.Context, meta api.PreparedMetadata, torrent
 			if err := s.injectWatchFolder(ctx, name, client.WatchFolder, torrent.Path); err != nil {
 				return err
 			}
+			injected = true
 		case "qbit", "qbittorrent", "qui":
 			if err := s.injectQbit(ctx, name, client, meta, torrent); err != nil {
 				return err
 			}
+			injected = true
 		case "":
 			return fmt.Errorf("clients: %s type is required", name)
 		default:
 			return fmt.Errorf("clients: type %q not yet supported: %w", client.ClientType(), internalerrors.ErrNotImplemented)
 		}
+	}
+
+	if effectiveClientOverride && torrentPath == "" && torrentURL != "" && skippedURLOnlyClients > 0 && !injected {
+		return fmt.Errorf("clients: no selected torrent client supports URL injection: %w", internalerrors.ErrInvalidInput)
 	}
 
 	s.logger.Debugf("clients: injection dispatch complete for %s", meta.SourcePath)
@@ -375,31 +389,32 @@ func hasNonBlankSelector(selected []string) bool {
 	return false
 }
 
-// selectTorrentClients returns configured clients selected by name. Blank,
-// unknown, normalized duplicate, and ambiguous selectors are ignored rather than
-// allowing map iteration order to choose a target. Failed lookups do not consume
-// the normalized selector, so a later exact selector remains eligible.
+// selectTorrentClients returns configured clients selected by name. Blank and
+// unknown selectors are ignored; ambiguous case-insensitive selectors are
+// ignored rather than letting map iteration order choose a target. Duplicate
+// selectors are collapsed only after they resolve to the same configured client,
+// so exact case-variant client names can both be selected.
 func selectTorrentClients(clients map[string]config.TorrentClientConfig, selected []string) map[string]config.TorrentClientConfig {
 	if len(clients) == 0 || len(selected) == 0 {
 		return nil
 	}
 
 	matches := make(map[string]config.TorrentClientConfig)
-	seenSelectors := make(map[string]struct{}, len(selected))
+	seenClients := make(map[string]struct{}, len(selected))
 	for _, value := range selected {
 		trimmed := strings.TrimSpace(value)
 		if trimmed == "" {
 			continue
 		}
-		normalized := strings.ToLower(trimmed)
-		if _, ok := seenSelectors[normalized]; ok {
+		name, client, ok := lookupTorrentClientConfig(clients, trimmed)
+		if !ok {
 			continue
 		}
-		name, client, ok := lookupTorrentClientConfig(clients, trimmed)
-		if ok {
-			seenSelectors[normalized] = struct{}{}
-			matches[name] = client
+		if _, ok := seenClients[name]; ok {
+			continue
 		}
+		seenClients[name] = struct{}{}
+		matches[name] = client
 	}
 	if len(matches) == 0 {
 		return nil
@@ -445,9 +460,11 @@ func lookupTorrentClientConfig(clients map[string]config.TorrentClientConfig, se
 	return "", config.TorrentClientConfig{}, false
 }
 
-// withURLCapableInjectFallback adds configured qbit/qui clients for URL-only
-// injection when a global/default selection exists but cannot consume URLs.
-// Selected none/disabled clients are authoritative and suppress fallback fanout.
+// withURLCapableInjectFallback replaces URL-incompatible global/default
+// selections with configured qbit/qui clients for URL-only injection. The
+// original selection is not merged into the fallback set, so unsupported client
+// types cannot fail an otherwise valid URL fallback. Selected none/disabled
+// clients are authoritative and suppress fallback fanout.
 func withURLCapableInjectFallback(selected, configured map[string]config.TorrentClientConfig) map[string]config.TorrentClientConfig {
 	if len(selected) == 0 {
 		return selected
@@ -464,10 +481,7 @@ func withURLCapableInjectFallback(selected, configured map[string]config.Torrent
 		return selected
 	}
 
-	merged := make(map[string]config.TorrentClientConfig, len(selected)+len(fallback))
-	maps.Copy(merged, selected)
-	maps.Copy(merged, fallback)
-	return merged
+	return maps.Clone(fallback)
 }
 
 // hasDisabledTorrentClient reports whether the selected set explicitly disables

--- a/internal/clients/service.go
+++ b/internal/clients/service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -464,12 +465,8 @@ func withURLCapableInjectFallback(selected, configured map[string]config.Torrent
 	}
 
 	merged := make(map[string]config.TorrentClientConfig, len(selected)+len(fallback))
-	for name, client := range selected {
-		merged[name] = client
-	}
-	for name, client := range fallback {
-		merged[name] = client
-	}
+	maps.Copy(merged, selected)
+	maps.Copy(merged, fallback)
 	return merged
 }
 
@@ -497,11 +494,11 @@ func hasURLCapableTorrentClient(clients map[string]config.TorrentClientConfig) b
 }
 
 // urlCapableTorrentClients returns every configured client that can add a
-// torrent by URL.
+// torrent by URL and permits fallback fanout.
 func urlCapableTorrentClients(clients map[string]config.TorrentClientConfig) map[string]config.TorrentClientConfig {
 	matches := make(map[string]config.TorrentClientConfig)
 	for name, client := range clients {
-		if isURLCapableTorrentClient(client) {
+		if client.FallbackAllowed() && isURLCapableTorrentClient(client) {
 			matches[name] = client
 		}
 	}

--- a/internal/clients/service.go
+++ b/internal/clients/service.go
@@ -56,7 +56,13 @@ func (s *Service) Inject(ctx context.Context, meta api.PreparedMetadata, torrent
 	}
 
 	clientOverrides := s.resolveInjectClientOverrides(meta.ClientOverrides, torrent.Tracker)
-	clients := selectedTorrentClients(s.cfg.TorrentClients, clientOverrides)
+	clients := resolveInjectClients(s.cfg, clientOverrides)
+	// Tracker-scoped torrent_client is an effective client override; URL
+	// fallback is only for global/default selections that cannot consume URLs.
+	effectiveClientOverride := clientOverrides.Client != nil && strings.TrimSpace(*clientOverrides.Client) != ""
+	if torrentPath == "" && torrentURL != "" && !effectiveClientOverride {
+		clients = withURLCapableInjectFallback(clients, s.cfg.TorrentClients)
+	}
 	if len(clients) == 0 {
 		s.logger.Debugf("clients: no matching torrent clients selected, skipping injection")
 		return nil
@@ -73,6 +79,13 @@ func (s *Service) Inject(ctx context.Context, meta api.PreparedMetadata, torrent
 		client := applyClientOverrides(clients[name], clientOverrides)
 		clientType := strings.ToLower(strings.TrimSpace(client.ClientType()))
 		s.logger.Debugf("clients: processing client %s (%s)", name, clientType)
+		// Watch folders can still consume a local torrent file when URL metadata
+		// is also present. Skip only URL-only input before any injection delay so
+		// a skipped client cannot fail a successful URL add.
+		if clientType == "watch" && torrentPath == "" && torrentURL != "" {
+			s.logger.Debugf("clients: skipping watch folder client %s for URL injection", name)
+			continue
+		}
 		if err := s.waitInjectDelay(ctx, torrent.Tracker); err != nil {
 			return err
 		}
@@ -81,10 +94,6 @@ func (s *Service) Inject(ctx context.Context, meta api.PreparedMetadata, torrent
 			s.logger.Debugf("clients: skipping disabled client %s", name)
 			continue
 		case "watch":
-			if torrentURL != "" {
-				s.logger.Debugf("clients: skipping watch folder client %s for URL injection", name)
-				continue
-			}
 			if err := s.injectWatchFolder(ctx, name, client.WatchFolder, torrent.Path); err != nil {
 				return err
 			}
@@ -318,22 +327,198 @@ func (s *Service) cleanupFailedLinkStaging(clientName string, tracker string, st
 	s.logger.Debugf("clients: %s cleaned staged links after qbit add error tracker=%s", clientName, strings.TrimSpace(tracker))
 }
 
-func selectedTorrentClients(clients map[string]config.TorrentClientConfig, overrides api.ClientOverrides) map[string]config.TorrentClientConfig {
+// resolveInjectClients selects the configured torrent clients that should receive
+// an injected torrent. Explicit client overrides take precedence, then a
+// non-empty injecting_client_list, then default_torrent_client. Unknown config
+// selectors fall through to lower-priority defaults, while unknown explicit
+// overrides stay authoritative and select no clients.
+func resolveInjectClients(cfg config.Config, overrides api.ClientOverrides) map[string]config.TorrentClientConfig {
+	clients := cfg.TorrentClients
 	if len(clients) == 0 {
 		return nil
 	}
 
-	if overrides.Client == nil || strings.TrimSpace(*overrides.Client) == "" {
-		return clients
+	if overrides.Client != nil && strings.TrimSpace(*overrides.Client) != "" {
+		return selectTorrentClients(clients, []string{*overrides.Client})
 	}
 
-	selected := strings.TrimSpace(*overrides.Client)
-	for name, client := range clients {
-		if strings.EqualFold(strings.TrimSpace(name), selected) {
+	if hasNonBlankSelector(cfg.ClientSetup.InjectClients) {
+		if selected := selectTorrentClients(clients, cfg.ClientSetup.InjectClients); len(selected) > 0 {
+			return selected
+		}
+	}
+
+	if strings.TrimSpace(cfg.ClientSetup.DefaultClient) != "" {
+		if selected := selectTorrentClients(clients, []string{cfg.ClientSetup.DefaultClient}); len(selected) > 0 {
+			return selected
+		}
+	}
+
+	if len(clients) == 1 {
+		for name, client := range clients {
 			return map[string]config.TorrentClientConfig{name: client}
 		}
 	}
+
 	return nil
+}
+
+// hasNonBlankSelector reports whether a selector list should participate in
+// client resolution after whitespace-only entries are ignored.
+func hasNonBlankSelector(selected []string) bool {
+	for _, value := range selected {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// selectTorrentClients returns configured clients selected by name. Blank,
+// unknown, normalized duplicate, and ambiguous selectors are ignored rather than
+// allowing map iteration order to choose a target. Failed lookups do not consume
+// the normalized selector, so a later exact selector remains eligible.
+func selectTorrentClients(clients map[string]config.TorrentClientConfig, selected []string) map[string]config.TorrentClientConfig {
+	if len(clients) == 0 || len(selected) == 0 {
+		return nil
+	}
+
+	matches := make(map[string]config.TorrentClientConfig)
+	seenSelectors := make(map[string]struct{}, len(selected))
+	for _, value := range selected {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		normalized := strings.ToLower(trimmed)
+		if _, ok := seenSelectors[normalized]; ok {
+			continue
+		}
+		name, client, ok := lookupTorrentClientConfig(clients, trimmed)
+		if ok {
+			seenSelectors[normalized] = struct{}{}
+			matches[name] = client
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	return matches
+}
+
+// lookupTorrentClientConfig returns the configured client using the original map
+// key casing when selected matches exactly or has exactly one case-insensitive
+// match. Ambiguous exact or folded matches are rejected.
+func lookupTorrentClientConfig(clients map[string]config.TorrentClientConfig, selected string) (string, config.TorrentClientConfig, bool) {
+	trimmed := strings.TrimSpace(selected)
+	if trimmed == "" {
+		return "", config.TorrentClientConfig{}, false
+	}
+
+	exactMatches := make([]string, 0, 1)
+	foldMatches := make([]string, 0, 1)
+	for name := range clients {
+		nameTrimmed := strings.TrimSpace(name)
+		if nameTrimmed == trimmed {
+			exactMatches = append(exactMatches, name)
+			continue
+		}
+		if strings.EqualFold(nameTrimmed, trimmed) {
+			foldMatches = append(foldMatches, name)
+		}
+	}
+
+	switch len(exactMatches) {
+	case 1:
+		name := exactMatches[0]
+		return name, clients[name], true
+	case 0:
+	default:
+		return "", config.TorrentClientConfig{}, false
+	}
+
+	if len(foldMatches) == 1 {
+		name := foldMatches[0]
+		return name, clients[name], true
+	}
+	return "", config.TorrentClientConfig{}, false
+}
+
+// withURLCapableInjectFallback adds configured qbit/qui clients for URL-only
+// injection when a global/default selection exists but cannot consume URLs.
+// Selected none/disabled clients are authoritative and suppress fallback fanout.
+func withURLCapableInjectFallback(selected, configured map[string]config.TorrentClientConfig) map[string]config.TorrentClientConfig {
+	if len(selected) == 0 {
+		return selected
+	}
+	if hasDisabledTorrentClient(selected) {
+		return selected
+	}
+	if hasURLCapableTorrentClient(selected) {
+		return selected
+	}
+
+	fallback := urlCapableTorrentClients(configured)
+	if len(fallback) == 0 {
+		return selected
+	}
+
+	merged := make(map[string]config.TorrentClientConfig, len(selected)+len(fallback))
+	for name, client := range selected {
+		merged[name] = client
+	}
+	for name, client := range fallback {
+		merged[name] = client
+	}
+	return merged
+}
+
+// hasDisabledTorrentClient reports whether the selected set explicitly disables
+// injection, which must not fan out into fallback clients.
+func hasDisabledTorrentClient(clients map[string]config.TorrentClientConfig) bool {
+	for _, client := range clients {
+		switch strings.ToLower(strings.TrimSpace(client.ClientType())) {
+		case "none", "disabled":
+			return true
+		}
+	}
+	return false
+}
+
+// hasURLCapableTorrentClient reports whether any selected client type can add a
+// torrent by URL.
+func hasURLCapableTorrentClient(clients map[string]config.TorrentClientConfig) bool {
+	for _, client := range clients {
+		if isURLCapableTorrentClient(client) {
+			return true
+		}
+	}
+	return false
+}
+
+// urlCapableTorrentClients returns every configured client that can add a
+// torrent by URL.
+func urlCapableTorrentClients(clients map[string]config.TorrentClientConfig) map[string]config.TorrentClientConfig {
+	matches := make(map[string]config.TorrentClientConfig)
+	for name, client := range clients {
+		if isURLCapableTorrentClient(client) {
+			matches[name] = client
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	return matches
+}
+
+// isURLCapableTorrentClient reports whether a client type supports URL adds.
+func isURLCapableTorrentClient(client config.TorrentClientConfig) bool {
+	switch strings.ToLower(strings.TrimSpace(client.ClientType())) {
+	case "qbit", "qbittorrent", "qui":
+		return true
+	default:
+		return false
+	}
 }
 
 func applyClientOverrides(client config.TorrentClientConfig, overrides api.ClientOverrides) config.TorrentClientConfig {

--- a/internal/clients/service_test.go
+++ b/internal/clients/service_test.go
@@ -1469,7 +1469,7 @@ func TestInjectClientOverrideWinsOverTrackerTorrentClient(t *testing.T) {
 	}
 }
 
-func TestInjectTrackerTorrentClientDoesNotURLFallbackToQbit(t *testing.T) {
+func TestInjectTrackerTorrentClientURLOnlyWatchReturnsErrorWithoutFallback(t *testing.T) {
 	t.Parallel()
 
 	watchRoot := t.TempDir()
@@ -1522,8 +1522,8 @@ func TestInjectTrackerTorrentClientDoesNotURLFallbackToQbit(t *testing.T) {
 		URL:     "https://aither.cc/torrent/download/374352.382",
 		Tracker: "aither",
 	})
-	if err != nil {
-		t.Fatalf("inject: %v", err)
+	if !errors.Is(err, internalerrors.ErrInvalidInput) {
+		t.Fatalf("expected invalid input error, got %v", err)
 	}
 
 	entries, err := os.ReadDir(watch)
@@ -1626,6 +1626,26 @@ func TestSelectTorrentClientsDeduplicatesNormalizedSelectors(t *testing.T) {
 	}
 	if _, ok := matches["qbit"]; !ok {
 		t.Fatalf("expected qbit match, got %v", matches)
+	}
+}
+
+func TestSelectTorrentClientsKeepsExactCaseVariantClients(t *testing.T) {
+	t.Parallel()
+
+	clients := map[string]config.TorrentClientConfig{
+		"Qbit": {Type: "watch"},
+		"qbit": {Type: "qbit"},
+	}
+
+	matches := selectTorrentClients(clients, []string{"Qbit", "qbit"})
+	if len(matches) != 2 {
+		t.Fatalf("expected both exact case-variant clients, got %v", matches)
+	}
+	if _, ok := matches["Qbit"]; !ok {
+		t.Fatalf("expected exact upper-case client match, got %v", matches)
+	}
+	if _, ok := matches["qbit"]; !ok {
+		t.Fatalf("expected exact lower-case client match, got %v", matches)
 	}
 }
 
@@ -2060,6 +2080,58 @@ func TestInjectURLFallsBackToQbitWhenDefaultWatchCannotHandleURL(t *testing.T) {
 	if len(entries) != 0 {
 		t.Fatalf("expected watch folder untouched for URL injection, got %d entries", len(entries))
 	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !addCalled {
+		t.Fatalf("expected qbit URL add call")
+	}
+}
+
+func TestInjectURLFallbackIgnoresUnsupportedSelectedClient(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	addCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		case "/api/v2/torrents/add":
+			mu.Lock()
+			addCalled = true
+			mu.Unlock()
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "rtorrent",
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"rtorrent": {Type: "rtorrent"},
+			"qbit": {
+				Type:     "qbit",
+				URL:      server.URL,
+				Username: "user",
+				Password: "pass",
+			},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{URL: "https://aither.cc/torrent/download/374352.382"}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
 	mu.Lock()
 	defer mu.Unlock()
 	if !addCalled {

--- a/internal/clients/service_test.go
+++ b/internal/clients/service_test.go
@@ -1150,6 +1150,233 @@ func TestInjectUsesSelectedClientOverride(t *testing.T) {
 	}
 }
 
+func TestInjectUsesDefaultClientWhenNoInjectionListOrTrackerClient(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	defaultWatch := filepath.Join(watchRoot, "default")
+	otherWatch := filepath.Join(watchRoot, "other")
+	if err := os.MkdirAll(defaultWatch, 0o700); err != nil {
+		t.Fatalf("mkdir default: %v", err)
+	}
+	if err := os.MkdirAll(otherWatch, 0o700); err != nil {
+		t.Fatalf("mkdir other: %v", err)
+	}
+
+	torrentPath := filepath.Join(watchRoot, "sample.torrent")
+	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "default",
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"default": {Type: "watch", WatchFolder: defaultWatch},
+			"other":   {Type: "watch", WatchFolder: otherWatch},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{Path: torrentPath}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(defaultWatch, filepath.Base(torrentPath))); err != nil {
+		t.Fatalf("expected default client copy, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(otherWatch, filepath.Base(torrentPath))); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected other client untouched, got %v", err)
+	}
+}
+
+func TestInjectUsesMultipleInjectionClients(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	firstWatch := filepath.Join(watchRoot, "first")
+	secondWatch := filepath.Join(watchRoot, "second")
+	thirdWatch := filepath.Join(watchRoot, "third")
+	for _, dir := range []string{firstWatch, secondWatch, thirdWatch} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	torrentPath := filepath.Join(watchRoot, "sample.torrent")
+	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "first",
+			InjectClients: config.CSVList{"second", "third"},
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"first":  {Type: "watch", WatchFolder: firstWatch},
+			"second": {Type: "watch", WatchFolder: secondWatch},
+			"third":  {Type: "watch", WatchFolder: thirdWatch},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{Path: torrentPath}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(firstWatch, filepath.Base(torrentPath))); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected default client untouched, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(secondWatch, filepath.Base(torrentPath))); err != nil {
+		t.Fatalf("expected second client copy, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(thirdWatch, filepath.Base(torrentPath))); err != nil {
+		t.Fatalf("expected third client copy, got %v", err)
+	}
+}
+
+func TestInjectUsesSingleInjectionClientBeforeDefaultClient(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	defaultWatch := filepath.Join(watchRoot, "default")
+	otherWatch := filepath.Join(watchRoot, "other")
+	if err := os.MkdirAll(defaultWatch, 0o700); err != nil {
+		t.Fatalf("mkdir default: %v", err)
+	}
+	if err := os.MkdirAll(otherWatch, 0o700); err != nil {
+		t.Fatalf("mkdir other: %v", err)
+	}
+
+	torrentPath := filepath.Join(watchRoot, "sample.torrent")
+	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "default",
+			InjectClients: config.CSVList{"other"},
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"default": {Type: "watch", WatchFolder: defaultWatch},
+			"other":   {Type: "watch", WatchFolder: otherWatch},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{Path: torrentPath}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(defaultWatch, filepath.Base(torrentPath))); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected default client untouched, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(otherWatch, filepath.Base(torrentPath))); err != nil {
+		t.Fatalf("expected single injection client copy, got %v", err)
+	}
+}
+
+func TestInjectFallsBackToDefaultClientWhenInjectionClientUnknown(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	defaultWatch := filepath.Join(watchRoot, "default")
+	if err := os.MkdirAll(defaultWatch, 0o700); err != nil {
+		t.Fatalf("mkdir default: %v", err)
+	}
+
+	torrentPath := filepath.Join(watchRoot, "sample.torrent")
+	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "default",
+			InjectClients: config.CSVList{"missing"},
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"default": {Type: "watch", WatchFolder: defaultWatch},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{Path: torrentPath}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(defaultWatch, filepath.Base(torrentPath))); err != nil {
+		t.Fatalf("expected default client copy, got %v", err)
+	}
+}
+
+func TestInjectFallsBackToImplicitSingleClientWhenDefaultClientUnknown(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	watch := filepath.Join(watchRoot, "watch")
+	if err := os.MkdirAll(watch, 0o700); err != nil {
+		t.Fatalf("mkdir watch: %v", err)
+	}
+
+	torrentPath := filepath.Join(watchRoot, "sample.torrent")
+	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "missing",
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"watch": {Type: "watch", WatchFolder: watch},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{Path: torrentPath}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(watch, filepath.Base(torrentPath))); err != nil {
+		t.Fatalf("expected implicit single client copy, got %v", err)
+	}
+}
+
+func TestInjectUnknownExplicitClientOverrideSkipsImplicitFallback(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	watch := filepath.Join(watchRoot, "watch")
+	if err := os.MkdirAll(watch, 0o700); err != nil {
+		t.Fatalf("mkdir watch: %v", err)
+	}
+
+	torrentPath := filepath.Join(watchRoot, "sample.torrent")
+	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	missing := "missing"
+	svc := NewService(config.Config{
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"watch": {Type: "watch", WatchFolder: watch},
+		},
+	}, nil)
+
+	meta := api.PreparedMetadata{
+		SourcePath: "video.mkv",
+		ClientOverrides: api.ClientOverrides{
+			Client: &missing,
+		},
+	}
+	if err := svc.Inject(context.Background(), meta, api.TorrentResult{Path: torrentPath}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(watch, filepath.Base(torrentPath))); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected explicit unknown override to skip fallback, got %v", err)
+	}
+}
+
 func TestInjectUsesTrackerTorrentClient(t *testing.T) {
 	t.Parallel()
 
@@ -1242,6 +1469,77 @@ func TestInjectClientOverrideWinsOverTrackerTorrentClient(t *testing.T) {
 	}
 }
 
+func TestInjectTrackerTorrentClientDoesNotURLFallbackToQbit(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	watch := filepath.Join(watchRoot, "watch")
+	if err := os.MkdirAll(watch, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	var mu sync.Mutex
+	addCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		case "/api/v2/torrents/add":
+			mu.Lock()
+			addCalled = true
+			mu.Unlock()
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"AITHER": {TorrentClient: "watch"},
+			},
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"watch": {Type: "watch", WatchFolder: watch},
+			"qbit": {
+				Type:     "qbit",
+				URL:      server.URL,
+				Username: "user",
+				Password: "pass",
+			},
+		},
+	}, nil)
+
+	err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{
+		URL:     "https://aither.cc/torrent/download/374352.382",
+		Tracker: "aither",
+	})
+	if err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	entries, err := os.ReadDir(watch)
+	if err != nil {
+		t.Fatalf("read watch folder: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected watch folder untouched for URL injection, got %d entries", len(entries))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if addCalled {
+		t.Fatalf("did not expect tracker-selected watch client to fall back to qbit")
+	}
+}
+
 func TestInjectTrackerTorrentClientCanSelectClientNamedNone(t *testing.T) {
 	t.Parallel()
 
@@ -1282,6 +1580,52 @@ func TestInjectTrackerTorrentClientCanSelectClientNamedNone(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(otherWatch, filepath.Base(torrentPath))); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected other client untouched, got %v", err)
+	}
+}
+
+func TestSelectTorrentClientsRejectsAmbiguousCaseInsensitiveNames(t *testing.T) {
+	t.Parallel()
+
+	clients := map[string]config.TorrentClientConfig{
+		"Qbit": {Type: "watch"},
+		"qbit": {Type: "qbit"},
+	}
+
+	matches := selectTorrentClients(clients, []string{"QBIT"})
+	if len(matches) != 0 {
+		t.Fatalf("expected ambiguous case-insensitive selector to be ignored, got %v", matches)
+	}
+
+	matches = selectTorrentClients(clients, []string{"qbit"})
+	if len(matches) != 1 {
+		t.Fatalf("expected exact selector match, got %v", matches)
+	}
+	if _, ok := matches["qbit"]; !ok {
+		t.Fatalf("expected exact lower-case client match, got %v", matches)
+	}
+
+	matches = selectTorrentClients(clients, []string{"QBIT", "qbit"})
+	if len(matches) != 1 {
+		t.Fatalf("expected later exact selector after ambiguous selector, got %v", matches)
+	}
+	if _, ok := matches["qbit"]; !ok {
+		t.Fatalf("expected exact lower-case client match after ambiguous selector, got %v", matches)
+	}
+}
+
+func TestSelectTorrentClientsDeduplicatesNormalizedSelectors(t *testing.T) {
+	t.Parallel()
+
+	clients := map[string]config.TorrentClientConfig{
+		"qbit": {Type: "qbit"},
+	}
+
+	matches := selectTorrentClients(clients, []string{"qbit", " QBIT ", "qbit"})
+	if len(matches) != 1 {
+		t.Fatalf("expected duplicate selector variants to select one client, got %v", matches)
+	}
+	if _, ok := matches["qbit"]; !ok {
+		t.Fatalf("expected qbit match, got %v", matches)
 	}
 }
 
@@ -1602,6 +1946,7 @@ func TestInjectURLSkipsWatchFolderClient(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 
+	var mu sync.Mutex
 	addCalled := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -1610,7 +1955,9 @@ func TestInjectURLSkipsWatchFolderClient(t *testing.T) {
 			_, _ = w.Write([]byte("Ok."))
 			return
 		case "/api/v2/torrents/add":
+			mu.Lock()
 			addCalled = true
+			mu.Unlock()
 			w.Header().Set("Content-Type", "text/plain")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("Ok."))
@@ -1623,6 +1970,9 @@ func TestInjectURLSkipsWatchFolderClient(t *testing.T) {
 	defer server.Close()
 
 	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "qbit",
+		},
 		TorrentClients: map[string]config.TorrentClientConfig{
 			"watch": {Type: "watch", WatchFolder: watch},
 			"qbit": {
@@ -1645,8 +1995,367 @@ func TestInjectURLSkipsWatchFolderClient(t *testing.T) {
 	if len(entries) != 0 {
 		t.Fatalf("expected watch folder untouched for URL injection, got %d entries", len(entries))
 	}
+	mu.Lock()
+	defer mu.Unlock()
 	if !addCalled {
 		t.Fatalf("expected qbit URL add call")
+	}
+}
+
+func TestInjectURLFallsBackToQbitWhenDefaultWatchCannotHandleURL(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	watch := filepath.Join(watchRoot, "watch")
+	if err := os.MkdirAll(watch, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	var mu sync.Mutex
+	addCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		case "/api/v2/torrents/add":
+			mu.Lock()
+			addCalled = true
+			mu.Unlock()
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "watch",
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"watch": {Type: "watch", WatchFolder: watch},
+			"qbit": {
+				Type:     "qbit",
+				URL:      server.URL,
+				Username: "user",
+				Password: "pass",
+			},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{URL: "https://aither.cc/torrent/download/374352.382"}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	entries, err := os.ReadDir(watch)
+	if err != nil {
+		t.Fatalf("read watch folder: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected watch folder untouched for URL injection, got %d entries", len(entries))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !addCalled {
+		t.Fatalf("expected qbit URL add call")
+	}
+}
+
+func TestInjectURLDefaultDisabledDoesNotFallbackToQbit(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	addCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		case "/api/v2/torrents/add":
+			mu.Lock()
+			addCalled = true
+			mu.Unlock()
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "disabled",
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"disabled": {Type: "disabled"},
+			"qbit": {
+				Type:     "qbit",
+				URL:      server.URL,
+				Username: "user",
+				Password: "pass",
+			},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{URL: "https://aither.cc/torrent/download/374352.382"}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if addCalled {
+		t.Fatalf("did not expect disabled default client to fall back to qbit")
+	}
+}
+
+func TestInjectURLInjectionListDisabledDoesNotFallbackToQbit(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	addCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		case "/api/v2/torrents/add":
+			mu.Lock()
+			addCalled = true
+			mu.Unlock()
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "qbit",
+			InjectClients: config.CSVList{
+				"disabled",
+			},
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"disabled": {Type: "none"},
+			"qbit": {
+				Type:     "qbit",
+				URL:      server.URL,
+				Username: "user",
+				Password: "pass",
+			},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{URL: "https://aither.cc/torrent/download/374352.382"}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if addCalled {
+		t.Fatalf("did not expect disabled injection client to fall back to qbit")
+	}
+}
+
+func TestInjectWatchFolderCopiesFileWhenURLAlsoPresent(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	watch := filepath.Join(watchRoot, "watch")
+	if err := os.MkdirAll(watch, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	torrentPath := filepath.Join(watchRoot, "sample.torrent")
+	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "watch",
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"watch": {Type: "watch", WatchFolder: watch},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{
+		Path: torrentPath,
+		URL:  "https://aither.cc/torrent/download/374352.382",
+	}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(watch, filepath.Base(torrentPath))); err != nil {
+		t.Fatalf("expected watch client copy with file and URL, got %v", err)
+	}
+}
+
+func TestInjectURLFallbackSkipsWatchBeforeDelay(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	watch := filepath.Join(watchRoot, "watch")
+	if err := os.MkdirAll(watch, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	var mu sync.Mutex
+	addCalled := false
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		case "/api/v2/torrents/add":
+			mu.Lock()
+			addCalled = true
+			mu.Unlock()
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			go func() {
+				time.Sleep(100 * time.Millisecond)
+				cancel()
+			}()
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(config.Config{
+		PostUpload: config.PostUploadConfig{InjectDelay: 1},
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "watch",
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"watch": {Type: "watch", WatchFolder: watch},
+			"qbit": {
+				Type:     "qbit",
+				URL:      server.URL,
+				Username: "user",
+				Password: "pass",
+			},
+		},
+	}, nil)
+
+	err := svc.Inject(ctx, api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{URL: "https://aither.cc/torrent/download/374352.382"})
+	if err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !addCalled {
+		t.Fatalf("expected qbit URL add call")
+	}
+}
+
+func TestInjectCrossSeedURLFallbackPreservesQbitMetadata(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	watch := filepath.Join(watchRoot, "watch")
+	if err := os.MkdirAll(watch, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	var mu sync.Mutex
+	addCategory := ""
+	addTags := ""
+	errCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		case "/api/v2/torrents/add":
+			if err := r.ParseForm(); err != nil {
+				errCh <- err
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			addCategory = r.FormValue("category")
+			addTags = r.FormValue("tags")
+			mu.Unlock()
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "watch",
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"watch": {Type: "watch", WatchFolder: watch},
+			"qbit": {
+				Type:              "qbit",
+				URL:               server.URL,
+				Username:          "user",
+				Password:          "pass",
+				QbitCrossCategory: "cross-cat",
+				QbitCrossTag:      "cross-tag",
+			},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{
+		URL:       "https://aither.cc/torrent/download/374352.382",
+		Tracker:   "AITHER",
+		CrossSeed: true,
+	}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("handler: %v", err)
+	default:
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if addCategory != "cross-cat" {
+		t.Fatalf("expected cross category, got %q", addCategory)
+	}
+	if addTags != "cross-tag" {
+		t.Fatalf("expected cross tag, got %q", addTags)
 	}
 }
 

--- a/internal/clients/service_test.go
+++ b/internal/clients/service_test.go
@@ -2174,6 +2174,66 @@ func TestInjectURLInjectionListDisabledDoesNotFallbackToQbit(t *testing.T) {
 	}
 }
 
+func TestInjectURLFallbackSkipsQbitWhenFallbackDisallowed(t *testing.T) {
+	t.Parallel()
+
+	watchRoot := t.TempDir()
+	watch := filepath.Join(watchRoot, "watch")
+	if err := os.MkdirAll(watch, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	var mu sync.Mutex
+	addCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		case "/api/v2/torrents/add":
+			mu.Lock()
+			addCalled = true
+			mu.Unlock()
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	allowFallback := false
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "watch",
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"watch": {Type: "watch", WatchFolder: watch},
+			"qbit": {
+				Type:          "qbit",
+				URL:           server.URL,
+				Username:      "user",
+				Password:      "pass",
+				AllowFallback: &allowFallback,
+			},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{URL: "https://aither.cc/torrent/download/374352.382"}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if addCalled {
+		t.Fatalf("did not expect qbit client with fallback disabled to receive URL fallback")
+	}
+}
+
 func TestInjectWatchFolderCopiesFileWhenURLAlsoPresent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -906,15 +906,38 @@ func (c Config) Validate() error {
 	return nil
 }
 
+// lookupTorrentClient resolves tracker torrent_client selectors using the same
+// exact-or-unique-folded name rule as runtime injection. Ambiguous folded names
+// are rejected so config validation cannot accept a selector runtime skips.
 func lookupTorrentClient(clients map[string]TorrentClientConfig, selected string) (string, bool) {
 	trimmed := strings.TrimSpace(selected)
 	if trimmed == "" {
 		return "", false
 	}
+
+	exactMatches := make([]string, 0, 1)
+	foldMatches := make([]string, 0, 1)
 	for name := range clients {
-		if strings.EqualFold(strings.TrimSpace(name), trimmed) {
-			return name, true
+		nameTrimmed := strings.TrimSpace(name)
+		if nameTrimmed == trimmed {
+			exactMatches = append(exactMatches, name)
+			continue
 		}
+		if strings.EqualFold(nameTrimmed, trimmed) {
+			foldMatches = append(foldMatches, name)
+		}
+	}
+
+	switch len(exactMatches) {
+	case 1:
+		return exactMatches[0], true
+	case 0:
+	default:
+		return "", false
+	}
+
+	if len(foldMatches) == 1 {
+		return foldMatches[0], true
 	}
 	return "", false
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,6 +75,40 @@ func TestValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid tracker torrent client exact match with folded duplicate",
+			cfg: Config{
+				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},
+				ScreenshotHandling: ScreenshotHandlingConfig{Screens: 1},
+				TorrentClients: map[string]TorrentClientConfig{
+					"Qbit": {Type: "watch", WatchFolder: "/tmp/watch1"},
+					"qbit": {Type: "watch", WatchFolder: "/tmp/watch2"},
+				},
+				Trackers: TrackersConfig{
+					Trackers: map[string]TrackerConfig{
+						"AITHER": {TorrentClient: "qbit"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid tracker torrent client ambiguous folded duplicate",
+			cfg: Config{
+				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},
+				ScreenshotHandling: ScreenshotHandlingConfig{Screens: 1},
+				TorrentClients: map[string]TorrentClientConfig{
+					"Qbit": {Type: "watch", WatchFolder: "/tmp/watch1"},
+					"qbit": {Type: "watch", WatchFolder: "/tmp/watch2"},
+				},
+				Trackers: TrackersConfig{
+					Trackers: map[string]TrackerConfig{
+						"AITHER": {TorrentClient: "QBIT"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "invalid tracker torrent client",
 			cfg: Config{
 				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved torrent client selection with stricter precedence/override rules for injection targets (including safer handling of unknown and blank selectors).
  * Refined URL-only injection behavior, routing to URL-capable clients when appropriate and suppressing fallback when explicitly disabled.
  * Watch-folder clients now skip URL-only injections earlier, and URL/file handling respects inject delay more reliably.
  * Stricter client name matching: prefers exact matches and rejects ambiguous case-variant selections.
* **Tests**
  * Expanded coverage for injection routing, fallback conditions, and selector hardening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->