### PR TITLE
fix(clients): validate torrent client selectors

### DIFF
--- a/internal/clients/search.go
+++ b/internal/clients/search.go
@@ -348,42 +348,38 @@ func resolvePieceConstraints(cfg config.Config) pieceConstraints {
 	return pieceConstraints{}
 }
 
+// resolveSearchClients returns configured qbit/qui client names for pathed
+// search. Explicit overrides, searching_client_list, and default_torrent_client
+// are authoritative after normalization. Blank search list entries do not block
+// default_torrent_client, while "none" disables implicit fallback. The boolean
+// reports only whether the implicit all qbit/qui fallback was used.
 func resolveSearchClients(cfg config.Config, overrides api.ClientOverrides) ([]string, bool) {
 	if overrides.Client != nil {
 		requested := strings.TrimSpace(*overrides.Client)
 		if requested == "" || strings.EqualFold(requested, "none") {
 			return nil, false
 		}
-		for name := range cfg.TorrentClients {
-			if strings.EqualFold(name, requested) {
-				return []string{name}, false
-			}
+		if name, _, ok := lookupTorrentClientConfig(cfg.TorrentClients, requested); ok {
+			return []string{name}, false
 		}
 		return nil, false
 	}
 
 	values := make([]string, 0)
-	if len(cfg.ClientSetup.SearchClients) > 0 {
+	if hasSearchDisableSelector(cfg.ClientSetup.SearchClients) {
+		return selectSearchClientNames(cfg.TorrentClients, cfg.ClientSetup.SearchClients), false
+	}
+	if hasNonBlankSearchSelector(cfg.ClientSetup.SearchClients) {
 		values = append(values, cfg.ClientSetup.SearchClients...)
 	} else if strings.TrimSpace(cfg.ClientSetup.DefaultClient) != "" {
 		values = append(values, cfg.ClientSetup.DefaultClient)
 	}
 
-	seen := make(map[string]struct{}, len(values))
-	result := make([]string, 0, len(values))
-	for _, value := range values {
-		trimmed := strings.TrimSpace(value)
-		if trimmed == "" || strings.EqualFold(trimmed, "none") {
-			continue
-		}
-		if _, ok := seen[trimmed]; ok {
-			continue
-		}
-		seen[trimmed] = struct{}{}
-		result = append(result, trimmed)
+	if hasSearchDisableSelector(values) {
+		return selectSearchClientNames(cfg.TorrentClients, values), false
 	}
-	if len(result) > 0 {
-		return result, false
+	if hasNonBlankSearchSelector(values) {
+		return selectSearchClientNames(cfg.TorrentClients, values), false
 	}
 
 	clientNames := make([]string, 0, len(cfg.TorrentClients))
@@ -391,6 +387,7 @@ func resolveSearchClients(cfg config.Config, overrides api.ClientOverrides) ([]s
 		clientNames = append(clientNames, name)
 	}
 	sort.Strings(clientNames)
+	result := make([]string, 0, len(clientNames))
 	for _, name := range clientNames {
 		clientType := strings.ToLower(strings.TrimSpace(cfg.TorrentClients[name].ClientType()))
 		if clientType != "qbit" && clientType != "qbittorrent" && clientType != "qui" {
@@ -400,6 +397,63 @@ func resolveSearchClients(cfg config.Config, overrides api.ClientOverrides) ([]s
 	}
 
 	return result, len(result) > 0
+}
+
+// hasNonBlankSearchSelector reports whether configured search selectors should
+// suppress lower-priority selectors after blank and "none" entries are ignored.
+func hasNonBlankSearchSelector(selected []string) bool {
+	for _, value := range selected {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" && !strings.EqualFold(trimmed, "none") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasSearchDisableSelector reports whether a selector list explicitly disables
+// search. "none" is authoritative when no usable client selector accompanies it.
+func hasSearchDisableSelector(selected []string) bool {
+	hasNone := false
+	for _, value := range selected {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if !strings.EqualFold(trimmed, "none") {
+			return false
+		}
+		hasNone = true
+	}
+	return hasNone
+}
+
+// selectSearchClientNames resolves configured search selectors to canonical map
+// keys. Unknown and ambiguous selectors are ignored rather than returned as raw
+// names for callers to skip later.
+func selectSearchClientNames(clients map[string]config.TorrentClientConfig, selected []string) []string {
+	if len(clients) == 0 || len(selected) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(selected))
+	result := make([]string, 0, len(selected))
+	for _, value := range selected {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" || strings.EqualFold(trimmed, "none") {
+			continue
+		}
+		name, _, ok := lookupTorrentClientConfig(clients, trimmed)
+		if !ok {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		result = append(result, name)
+	}
+	return result
 }
 
 func (s *Service) searchQbitClient(ctx context.Context, name string, clientCfg config.TorrentClientConfig, meta api.PreparedMetadata, constraints pieceConstraints) (api.ClientSearchResult, []api.TorrentMatch, error) {

--- a/internal/clients/search_test.go
+++ b/internal/clients/search_test.go
@@ -939,6 +939,137 @@ func TestResolveSearchClientsUsesClientOverride(t *testing.T) {
 	}
 }
 
+func TestResolveSearchClientsSkipsFallbackWhenDefaultClientUnknown(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "missing",
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {Type: "qbit"},
+		},
+	}
+
+	clients, usedFallback := resolveSearchClients(cfg, api.ClientOverrides{})
+	if usedFallback {
+		t.Fatalf("expected unknown default selector to suppress fallback")
+	}
+	if len(clients) != 0 {
+		t.Fatalf("expected no search clients, got %v", clients)
+	}
+}
+
+func TestResolveSearchClientsSkipsFallbackWhenSearchClientUnknown(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "qbit",
+			SearchClients: config.CSVList{"missing"},
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {Type: "qbit"},
+		},
+	}
+
+	clients, usedFallback := resolveSearchClients(cfg, api.ClientOverrides{})
+	if usedFallback {
+		t.Fatalf("expected unknown search selector to suppress fallback")
+	}
+	if len(clients) != 0 {
+		t.Fatalf("expected no search clients, got %v", clients)
+	}
+}
+
+func TestResolveSearchClientsNoneSearchListDisablesFallback(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "qbit",
+			SearchClients: config.CSVList{" none "},
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {Type: "qbit"},
+		},
+	}
+
+	clients, usedFallback := resolveSearchClients(cfg, api.ClientOverrides{})
+	if usedFallback {
+		t.Fatalf("expected none search selector to suppress fallback")
+	}
+	if len(clients) != 0 {
+		t.Fatalf("expected no search clients, got %v", clients)
+	}
+}
+
+func TestResolveSearchClientsBlankSearchListUsesDefaultClient(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "qbit",
+			SearchClients: config.CSVList{" ", ""},
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit":  {Type: "qbit"},
+			"other": {Type: "qbit"},
+		},
+	}
+
+	clients, usedFallback := resolveSearchClients(cfg, api.ClientOverrides{})
+	if usedFallback {
+		t.Fatalf("expected blank search list to use default without fallback")
+	}
+	if len(clients) != 1 || clients[0] != "qbit" {
+		t.Fatalf("expected default qbit selector, got %v", clients)
+	}
+}
+
+func TestResolveSearchClientsBlankSearchListWithoutDefaultUsesFallback(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			SearchClients: config.CSVList{" "},
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit":  {Type: "qbit"},
+			"watch": {Type: "watch"},
+		},
+	}
+
+	clients, usedFallback := resolveSearchClients(cfg, api.ClientOverrides{})
+	if !usedFallback {
+		t.Fatalf("expected blank search list without default to use implicit fallback")
+	}
+	if len(clients) != 1 || clients[0] != "qbit" {
+		t.Fatalf("expected qbit fallback only, got %v", clients)
+	}
+}
+
+func TestResolveSearchClientsNormalizesSelectorCase(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			SearchClients: config.CSVList{" QBIT ", "qbit"},
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {Type: "qbit"},
+		},
+	}
+
+	clients, usedFallback := resolveSearchClients(cfg, api.ClientOverrides{})
+	if usedFallback {
+		t.Fatalf("expected configured selector to avoid fallback")
+	}
+	if len(clients) != 1 || clients[0] != "qbit" {
+		t.Fatalf("expected normalized qbit selector, got %v", clients)
+	}
+}
+
 func TestBuildTrackerIDPatternsIncludesUnit3DBaseURLs(t *testing.T) {
 	for _, tracker := range trackers.Unit3DTrackers() {
 		baseURL, ok := unit3dmeta.BaseURL(tracker)

--- a/internal/clients/service.go
+++ b/internal/clients/service.go
@@ -344,9 +344,9 @@ func (s *Service) cleanupFailedLinkStaging(clientName string, tracker string, st
 
 // resolveInjectClients selects the configured torrent clients that should receive
 // an injected torrent. Explicit client overrides take precedence, then a
-// non-empty injecting_client_list, then default_torrent_client. Unknown config
-// selectors fall through to lower-priority defaults, while unknown explicit
-// overrides stay authoritative and select no clients.
+// non-empty injecting_client_list, then default_torrent_client. Configured
+// selectors are authoritative: if a non-empty selector set resolves to no
+// clients, lower-priority fallbacks are skipped.
 func resolveInjectClients(cfg config.Config, overrides api.ClientOverrides) map[string]config.TorrentClientConfig {
 	clients := cfg.TorrentClients
 	if len(clients) == 0 {
@@ -354,19 +354,27 @@ func resolveInjectClients(cfg config.Config, overrides api.ClientOverrides) map[
 	}
 
 	if overrides.Client != nil && strings.TrimSpace(*overrides.Client) != "" {
+		if isDisableSelector(*overrides.Client) {
+			if selected := selectTorrentClients(clients, []string{*overrides.Client}); len(selected) > 0 {
+				return selected
+			}
+			return disabledTorrentClientSelection()
+		}
 		return selectTorrentClients(clients, []string{*overrides.Client})
 	}
 
+	if hasDisableOnlySelector(cfg.ClientSetup.InjectClients) {
+		return disabledTorrentClientSelection()
+	}
 	if hasNonBlankSelector(cfg.ClientSetup.InjectClients) {
-		if selected := selectTorrentClients(clients, cfg.ClientSetup.InjectClients); len(selected) > 0 {
-			return selected
-		}
+		return selectTorrentClients(clients, cfg.ClientSetup.InjectClients)
 	}
 
 	if strings.TrimSpace(cfg.ClientSetup.DefaultClient) != "" {
-		if selected := selectTorrentClients(clients, []string{cfg.ClientSetup.DefaultClient}); len(selected) > 0 {
-			return selected
+		if isDisableSelector(cfg.ClientSetup.DefaultClient) {
+			return disabledTorrentClientSelection()
 		}
+		return selectTorrentClients(clients, []string{cfg.ClientSetup.DefaultClient})
 	}
 
 	if len(clients) == 1 {
@@ -378,15 +386,48 @@ func resolveInjectClients(cfg config.Config, overrides api.ClientOverrides) map[
 	return nil
 }
 
-// hasNonBlankSelector reports whether a selector list should participate in
-// client resolution after whitespace-only entries are ignored.
+// hasNonBlankSelector reports whether a selector list contains at least one
+// real client name. A lone "none" selector is handled separately as an
+// explicit disable sentinel.
 func hasNonBlankSelector(selected []string) bool {
 	for _, value := range selected {
-		if strings.TrimSpace(value) != "" {
+		if strings.TrimSpace(value) != "" && !isDisableSelector(value) {
 			return true
 		}
 	}
 	return false
+}
+
+// hasDisableOnlySelector reports whether the selector list contains only blank
+// values and "none", with at least one "none" entry.
+func hasDisableOnlySelector(selected []string) bool {
+	hasDisable := false
+	for _, value := range selected {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		if !isDisableSelector(trimmed) {
+			return false
+		}
+		hasDisable = true
+	}
+	return hasDisable
+}
+
+// isDisableSelector recognizes the literal selector used in config to disable
+// torrent injection or search fallback. Client configs with Type "disabled" are
+// detected later after a real client has been selected.
+func isDisableSelector(selected string) bool {
+	return strings.EqualFold(strings.TrimSpace(selected), "none")
+}
+
+// disabledTorrentClientSelection returns a synthetic selected client set that
+// carries the same no-op behavior as a configured client with Type "none".
+func disabledTorrentClientSelection() map[string]config.TorrentClientConfig {
+	return map[string]config.TorrentClientConfig{
+		"none": {Type: "none"},
+	}
 }
 
 // selectTorrentClients returns configured clients selected by name. Blank and
@@ -460,15 +501,12 @@ func lookupTorrentClientConfig(clients map[string]config.TorrentClientConfig, se
 	return "", config.TorrentClientConfig{}, false
 }
 
-// withURLCapableInjectFallback replaces URL-incompatible global/default
+// withURLCapableInjectFallback replaces empty or URL-incompatible global/default
 // selections with configured qbit/qui clients for URL-only injection. The
 // original selection is not merged into the fallback set, so unsupported client
 // types cannot fail an otherwise valid URL fallback. Selected none/disabled
 // clients are authoritative and suppress fallback fanout.
 func withURLCapableInjectFallback(selected, configured map[string]config.TorrentClientConfig) map[string]config.TorrentClientConfig {
-	if len(selected) == 0 {
-		return selected
-	}
 	if hasDisabledTorrentClient(selected) {
 		return selected
 	}

--- a/internal/clients/service_test.go
+++ b/internal/clients/service_test.go
@@ -1276,7 +1276,7 @@ func TestInjectUsesSingleInjectionClientBeforeDefaultClient(t *testing.T) {
 	}
 }
 
-func TestInjectFallsBackToDefaultClientWhenInjectionClientUnknown(t *testing.T) {
+func TestInjectSkipsDefaultClientWhenInjectionClientUnknown(t *testing.T) {
 	t.Parallel()
 
 	watchRoot := t.TempDir()
@@ -1304,12 +1304,12 @@ func TestInjectFallsBackToDefaultClientWhenInjectionClientUnknown(t *testing.T) 
 		t.Fatalf("inject: %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(defaultWatch, filepath.Base(torrentPath))); err != nil {
-		t.Fatalf("expected default client copy, got %v", err)
+	if _, err := os.Stat(filepath.Join(defaultWatch, filepath.Base(torrentPath))); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected unknown injection selector to skip default fallback, got %v", err)
 	}
 }
 
-func TestInjectFallsBackToImplicitSingleClientWhenDefaultClientUnknown(t *testing.T) {
+func TestInjectSkipsImplicitSingleClientWhenDefaultClientUnknown(t *testing.T) {
 	t.Parallel()
 
 	watchRoot := t.TempDir()
@@ -1336,8 +1336,8 @@ func TestInjectFallsBackToImplicitSingleClientWhenDefaultClientUnknown(t *testin
 		t.Fatalf("inject: %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(watch, filepath.Base(torrentPath))); err != nil {
-		t.Fatalf("expected implicit single client copy, got %v", err)
+	if _, err := os.Stat(filepath.Join(watch, filepath.Base(torrentPath))); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected unknown default selector to skip implicit fallback, got %v", err)
 	}
 }
 
@@ -2188,6 +2188,111 @@ func TestInjectURLDefaultDisabledDoesNotFallbackToQbit(t *testing.T) {
 	defer mu.Unlock()
 	if addCalled {
 		t.Fatalf("did not expect disabled default client to fall back to qbit")
+	}
+}
+
+func TestInjectURLUnknownDefaultFallsBackToQbit(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	addCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		case "/api/v2/torrents/add":
+			mu.Lock()
+			addCalled = true
+			mu.Unlock()
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "missing",
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:     "qbit",
+				URL:      server.URL,
+				Username: "user",
+				Password: "pass",
+			},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{URL: "https://aither.cc/torrent/download/374352.382"}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !addCalled {
+		t.Fatalf("expected qbit URL add call")
+	}
+}
+
+func TestInjectURLUnknownInjectionListFallsBackToQbit(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	addCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		case "/api/v2/torrents/add":
+			mu.Lock()
+			addCalled = true
+			mu.Unlock()
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	svc := NewService(config.Config{
+		ClientSetup: config.ClientSetupConfig{
+			DefaultClient: "missing-default",
+			InjectClients: config.CSVList{
+				"missing-inject",
+			},
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:     "qbit",
+				URL:      server.URL,
+				Username: "user",
+				Password: "pass",
+			},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "video.mkv"}, api.TorrentResult{URL: "https://aither.cc/torrent/download/374352.382"}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !addCalled {
+		t.Fatalf("expected qbit URL add call")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -873,10 +873,14 @@ func (c Config) Validate() error {
 		}
 	}
 
+	if err := validateGlobalTorrentClientSelectors(c); err != nil {
+		return err
+	}
+
 	for trackerName, trackerCfg := range c.Trackers.Trackers {
 		torrentClient := strings.TrimSpace(trackerCfg.TorrentClient)
 		if torrentClient != "" {
-			if _, ok := lookupTorrentClient(c.TorrentClients, torrentClient); !ok {
+			if !lookupTorrentClient(c.TorrentClients, torrentClient) {
 				return fmt.Errorf("config: trackers.%s.torrent_client references unknown torrent client %q", trackerName, trackerCfg.TorrentClient)
 			}
 		}
@@ -906,13 +910,46 @@ func (c Config) Validate() error {
 	return nil
 }
 
+// validateGlobalTorrentClientSelectors checks the global client selectors that
+// are resolved at search and injection time. This keeps stale global refs from
+// becoming silent runtime skips while preserving blank and "none" sentinels.
+func validateGlobalTorrentClientSelectors(c Config) error {
+	if err := validateGlobalTorrentClientSelector(c.TorrentClients, "client_setup.default_torrent_client", c.ClientSetup.DefaultClient); err != nil {
+		return err
+	}
+	for _, selected := range c.ClientSetup.InjectClients {
+		if err := validateGlobalTorrentClientSelector(c.TorrentClients, "client_setup.injecting_client_list", selected); err != nil {
+			return err
+		}
+	}
+	for _, selected := range c.ClientSetup.SearchClients {
+		if err := validateGlobalTorrentClientSelector(c.TorrentClients, "client_setup.searching_client_list", selected); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateGlobalTorrentClientSelector applies the same exact-or-unique-folded
+// lookup rule used by runtime client resolution.
+func validateGlobalTorrentClientSelector(clients map[string]TorrentClientConfig, field string, selected string) error {
+	trimmed := strings.TrimSpace(selected)
+	if trimmed == "" || strings.EqualFold(trimmed, "none") {
+		return nil
+	}
+	if !lookupTorrentClient(clients, trimmed) {
+		return fmt.Errorf("config: %s references unknown torrent client %q", field, selected)
+	}
+	return nil
+}
+
 // lookupTorrentClient resolves tracker torrent_client selectors using the same
 // exact-or-unique-folded name rule as runtime injection. Ambiguous folded names
 // are rejected so config validation cannot accept a selector runtime skips.
-func lookupTorrentClient(clients map[string]TorrentClientConfig, selected string) (string, bool) {
+func lookupTorrentClient(clients map[string]TorrentClientConfig, selected string) bool {
 	trimmed := strings.TrimSpace(selected)
 	if trimmed == "" {
-		return "", false
+		return false
 	}
 
 	exactMatches := make([]string, 0, 1)
@@ -930,16 +967,13 @@ func lookupTorrentClient(clients map[string]TorrentClientConfig, selected string
 
 	switch len(exactMatches) {
 	case 1:
-		return exactMatches[0], true
+		return true
 	case 0:
 	default:
-		return "", false
+		return false
 	}
 
-	if len(foldMatches) == 1 {
-		return foldMatches[0], true
-	}
-	return "", false
+	return len(foldMatches) == 1
 }
 
 func DisableUnsupportedTrackerImageRehosts(cfg *Config) []string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -59,6 +59,84 @@ func TestValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid global torrent client refs",
+			cfg: Config{
+				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},
+				ScreenshotHandling: ScreenshotHandlingConfig{Screens: 1},
+				ClientSetup: ClientSetupConfig{
+					DefaultClient: "qbit",
+					InjectClients: CSVList{"qbit"},
+					SearchClients: CSVList{"QBIT"},
+				},
+				TorrentClients: map[string]TorrentClientConfig{
+					"qbit": {Type: "qbit", URL: "http://localhost", Username: "user", Password: "pass"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "global torrent client none selectors allowed",
+			cfg: Config{
+				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},
+				ScreenshotHandling: ScreenshotHandlingConfig{Screens: 1},
+				ClientSetup: ClientSetupConfig{
+					DefaultClient: "none",
+					InjectClients: CSVList{"none"},
+					SearchClients: CSVList{"none"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid default torrent client ref",
+			cfg: Config{
+				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},
+				ScreenshotHandling: ScreenshotHandlingConfig{Screens: 1},
+				ClientSetup:        ClientSetupConfig{DefaultClient: "missing"},
+				TorrentClients: map[string]TorrentClientConfig{
+					"qbit": {Type: "qbit", URL: "http://localhost", Username: "user", Password: "pass"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid searching torrent client ref",
+			cfg: Config{
+				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},
+				ScreenshotHandling: ScreenshotHandlingConfig{Screens: 1},
+				ClientSetup:        ClientSetupConfig{SearchClients: CSVList{"missing"}},
+				TorrentClients: map[string]TorrentClientConfig{
+					"qbit": {Type: "qbit", URL: "http://localhost", Username: "user", Password: "pass"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid injecting torrent client ref",
+			cfg: Config{
+				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},
+				ScreenshotHandling: ScreenshotHandlingConfig{Screens: 1},
+				ClientSetup:        ClientSetupConfig{InjectClients: CSVList{"missing"}},
+				TorrentClients: map[string]TorrentClientConfig{
+					"qbit": {Type: "qbit", URL: "http://localhost", Username: "user", Password: "pass"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid global torrent client ambiguous folded duplicate",
+			cfg: Config{
+				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},
+				ScreenshotHandling: ScreenshotHandlingConfig{Screens: 1},
+				ClientSetup:        ClientSetupConfig{DefaultClient: "QBIT"},
+				TorrentClients: map[string]TorrentClientConfig{
+					"Qbit": {Type: "watch", WatchFolder: "/tmp/watch1"},
+					"qbit": {Type: "watch", WatchFolder: "/tmp/watch2"},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "valid tracker torrent client",
 			cfg: Config{
 				MainSettings:       MainSettingsConfig{TMDBAPI: "x"},

--- a/internal/config/importer/importer.go
+++ b/internal/config/importer/importer.go
@@ -83,12 +83,16 @@ func finalize(cfg *config.Config, warnings []string, err error) (*config.Config,
 // parseNative handles .yaml/.yml/.json exports by overlaying the user's data
 // onto the embedded default config. This mirrors the legacy conversion flow
 // and guarantees that fields absent from the import keep sensible defaults,
-// including any new settings added since the file was written.
+// including any new settings added since the file was written. Template torrent
+// clients are stripped, but an omitted or null torrent_clients section is
+// normalized to an empty map so exports and UI consumers see {} instead of null.
 func parseNative(filename string, data []byte) (*config.Config, error) {
 	cfg, err := config.LoadEmbeddedDefaultConfig()
 	if err != nil {
 		return nil, fmt.Errorf("import config: load defaults: %w", err)
 	}
+	// Template clients are examples, not imported user configuration.
+	cfg.TorrentClients = make(map[string]config.TorrentClientConfig)
 
 	ext := strings.ToLower(filepath.Ext(filename))
 	switch ext {
@@ -108,6 +112,9 @@ func parseNative(filename string, data []byte) (*config.Config, error) {
 		}
 	default:
 		return nil, fmt.Errorf("import config: unsupported file extension %q (supported: .py, .yaml, .yml, .json)", ext)
+	}
+	if cfg.TorrentClients == nil {
+		cfg.TorrentClients = make(map[string]config.TorrentClientConfig)
 	}
 
 	if err := config.MergeMissingTrackerDefaults(cfg); err != nil {

--- a/internal/config/importer/importer_test.go
+++ b/internal/config/importer/importer_test.go
@@ -4,10 +4,13 @@
 package importer
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
 )
 
 func TestImportFromContentYAMLOverlaysDefaults(t *testing.T) {
@@ -46,6 +49,159 @@ func TestImportFromContentJSONOverlaysDefaults(t *testing.T) {
 	}
 	if len(cfg.Trackers.Trackers) == 0 {
 		t.Fatal("expected tracker defaults to be merged in")
+	}
+}
+
+func TestImportFromContentYAMLDoesNotKeepTemplateQbit(t *testing.T) {
+	yaml := []byte(`
+main_settings:
+  tmdb_api: test-key
+torrent_clients:
+  watch-client:
+    type: watch
+    watch_folder: C:/Watch
+`)
+
+	cfg, _, err := ImportFromContent("config.yaml", yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := cfg.TorrentClients["qbittorrent"]; ok {
+		t.Fatal("did not expect template qbittorrent client to be retained")
+	}
+	if _, ok := cfg.TorrentClients["watch-client"]; !ok {
+		t.Fatal("watch-client not found")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("imported config should validate: %v", err)
+	}
+}
+
+func TestImportFromContentJSONDoesNotKeepTemplateQbit(t *testing.T) {
+	json := []byte(`{
+  "MainSettings": {"TMDBAPI": "test-key"},
+  "TorrentClients": {
+    "watch-client": {
+      "Type": "watch",
+      "WatchFolder": "C:/Watch"
+    }
+  }
+}`)
+
+	cfg, _, err := ImportFromContent("config.json", json)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := cfg.TorrentClients["qbittorrent"]; ok {
+		t.Fatal("did not expect template qbittorrent client to be retained")
+	}
+	if _, ok := cfg.TorrentClients["watch-client"]; !ok {
+		t.Fatal("watch-client not found")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("imported config should validate: %v", err)
+	}
+}
+
+func TestImportFromContentYAMLOmittedTorrentClientsExportsEmptyMap(t *testing.T) {
+	cfg, _, err := ImportFromContent("config.yaml", []byte("main_settings:\n  tmdb_api: test-key\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TorrentClients == nil {
+		t.Fatal("expected omitted torrent_clients to import as an empty map")
+	}
+	if len(cfg.TorrentClients) != 0 {
+		t.Fatalf("expected no imported torrent clients, got %d", len(cfg.TorrentClients))
+	}
+
+	payload, err := config.ExportToPlaintextJSON(cfg)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	var exported struct {
+		TorrentClients map[string]config.TorrentClientConfig
+	}
+	if err := json.Unmarshal([]byte(payload), &exported); err != nil {
+		t.Fatalf("unmarshal export: %v", err)
+	}
+	if exported.TorrentClients == nil {
+		t.Fatal("expected exported TorrentClients to be {}, got null")
+	}
+	if len(exported.TorrentClients) != 0 {
+		t.Fatalf("expected exported TorrentClients to be empty, got %d", len(exported.TorrentClients))
+	}
+}
+
+func TestImportFromContentYAMLNullTorrentClientsExportsEmptyMap(t *testing.T) {
+	cfg, _, err := ImportFromContent("config.yaml", []byte("main_settings:\n  tmdb_api: test-key\ntorrent_clients: null\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TorrentClients == nil {
+		t.Fatal("expected null torrent_clients to import as an empty map")
+	}
+	if len(cfg.TorrentClients) != 0 {
+		t.Fatalf("expected no imported torrent clients, got %d", len(cfg.TorrentClients))
+	}
+
+	payload, err := config.ExportToPlaintextJSON(cfg)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	var exported map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(payload), &exported); err != nil {
+		t.Fatalf("unmarshal export: %v", err)
+	}
+	if string(exported["TorrentClients"]) != "{}" {
+		t.Fatalf("expected exported TorrentClients {}, got %s", exported["TorrentClients"])
+	}
+}
+
+func TestImportFromContentJSONOmittedTorrentClientsExportsEmptyMap(t *testing.T) {
+	cfg, _, err := ImportFromContent("config.json", []byte(`{"MainSettings":{"TMDBAPI":"json-key"}}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TorrentClients == nil {
+		t.Fatal("expected omitted TorrentClients to import as an empty map")
+	}
+
+	payload, err := config.ExportToPlaintextJSON(cfg)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	var exported map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(payload), &exported); err != nil {
+		t.Fatalf("unmarshal export: %v", err)
+	}
+	if string(exported["TorrentClients"]) != "{}" {
+		t.Fatalf("expected exported TorrentClients {}, got %s", exported["TorrentClients"])
+	}
+}
+
+func TestImportFromContentJSONNullTorrentClientsExportsEmptyMap(t *testing.T) {
+	cfg, _, err := ImportFromContent("config.json", []byte(`{"TorrentClients":null}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TorrentClients == nil {
+		t.Fatal("expected null TorrentClients to normalize to an empty map")
+	}
+	if len(cfg.TorrentClients) != 0 {
+		t.Fatalf("expected no imported torrent clients, got %d", len(cfg.TorrentClients))
+	}
+
+	payload, err := config.ExportToPlaintextJSON(cfg)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	var exported map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(payload), &exported); err != nil {
+		t.Fatalf("unmarshal export: %v", err)
+	}
+	if string(exported["TorrentClients"]) != "{}" {
+		t.Fatalf("expected exported TorrentClients {}, got %s", exported["TorrentClients"])
 	}
 }
 

--- a/internal/config/legacy/converter.go
+++ b/internal/config/legacy/converter.go
@@ -153,6 +153,8 @@ func Convert(legacy *Config, template *config.Config) (*config.Config, []string,
 	if err != nil {
 		return nil, nil, fmt.Errorf("copy template: %w", err)
 	}
+	// Template clients are examples, not imported user configuration.
+	out.TorrentClients = make(map[string]config.TorrentClientConfig)
 	outMap, err := configToSectionMaps(out)
 	if err != nil {
 		return nil, nil, fmt.Errorf("build output map: %w", err)

--- a/internal/config/legacy/converter_test.go
+++ b/internal/config/legacy/converter_test.go
@@ -208,6 +208,39 @@ func TestConvertClientKeyAliases(t *testing.T) {
 	}
 }
 
+func TestConvertTorrentClientsDoesNotKeepTemplateQbit(t *testing.T) {
+	input := []byte(`
+config = {
+    'DEFAULT': {'tmdb_api': 'test', 'screens': 6},
+    'TRACKERS': {},
+    'TORRENT_CLIENTS': {
+        'watch-client': {
+            'torrent_client': 'watch',
+            'watch_folder': 'C:/Watch',
+        },
+    },
+}
+`)
+
+	cfg, _, err := ImportFromContent(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := cfg.TorrentClients["qbittorrent"]; ok {
+		t.Fatal("did not expect template qbittorrent client to be retained")
+	}
+	watch, ok := cfg.TorrentClients["watch-client"]
+	if !ok {
+		t.Fatal("watch-client not found")
+	}
+	if watch.ClientType() != "watch" {
+		t.Fatalf("ClientType: got %q, want watch", watch.ClientType())
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("converted config should validate: %v", err)
+	}
+}
+
 func TestConvertTrackers(t *testing.T) {
 	legacy := &Config{
 		Default: map[string]any{

--- a/scripts/convert_ua_config.py
+++ b/scripts/convert_ua_config.py
@@ -466,6 +466,8 @@ def build_output(template: dict[str, Any]) -> dict[str, Any]:
     for key in SECTION_ORDER:
         if key in template:
             out[key] = copy.deepcopy(template[key])
+    # Template clients are examples, not imported user configuration.
+    out["torrent_clients"] = {}
     return out
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed client selection fallback behavior when configured clients are unknown or unavailable
  * Improved handling of blank and disabled client configurations to prevent unintended fallbacks

* **New Features**
  * Client selector names are now case-insensitive and whitespace-tolerant
  * Added "none" option to explicitly disable client selection
  * Enhanced client selection precedence and validation rules

* **Tests**
  * Added comprehensive test coverage for client selection edge cases, including unknown clients, disabled selections, and configuration normalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->