### PR TITLE
feat(webserver): allow remote first-run setup (trust-on-first-use)

### DIFF
--- a/internal/webserver/routes.go
+++ b/internal/webserver/routes.go
@@ -163,10 +163,10 @@ func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request, _ sessi
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 		return
 	}
-	if !s.isLocalWebUIRequest(r) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "bootstrap is only available from localhost web sessions"})
-		return
-	}
+	// First-run setup uses trust-on-first-use: it is reachable from any host so
+	// containerized/LAN deployments can complete setup remotely. The
+	// "user already exists" guard in auth.Bootstrap closes this window once the
+	// admin account is created.
 	if !s.allowAuthRequest(r) {
 		writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
 		return

--- a/internal/webserver/routes_auth_test.go
+++ b/internal/webserver/routes_auth_test.go
@@ -88,7 +88,7 @@ func TestBootstrapRetainedSessionSetsPersistentCookie(t *testing.T) {
 	}
 }
 
-func TestBootstrapRejectsRemoteFirstRunRequest(t *testing.T) {
+func TestBootstrapAllowsRemoteFirstRunRequest(t *testing.T) {
 	server := newAuthTestServer(t, filepath.Join(t.TempDir(), "state", "db.sqlite"))
 
 	body := `{"username":"admin","password":"very-secure-password","retainLogin":true}`
@@ -100,11 +100,40 @@ func TestBootstrapRejectsRemoteFirstRunRequest(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	server.handleBootstrap(recorder, req, session{})
 
-	if recorder.Code != http.StatusForbidden {
-		t.Fatalf("expected remote bootstrap to return 403, got %d: %s", recorder.Code, recorder.Body.String())
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected remote first-run bootstrap to return 200, got %d: %s", recorder.Code, recorder.Body.String())
 	}
-	if !strings.Contains(recorder.Body.String(), "bootstrap is only available from localhost") {
-		t.Fatalf("unexpected bootstrap rejection: %s", recorder.Body.String())
+}
+
+func TestBootstrapRejectsRemoteRequestWhenUserExists(t *testing.T) {
+	server := newAuthTestServer(t, filepath.Join(t.TempDir(), "state", "db.sqlite"))
+
+	body := `{"username":"admin","password":"very-secure-password","retainLogin":true}`
+
+	first := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/auth/bootstrap", strings.NewReader(body))
+	first.Header.Set("Content-Type", "application/json")
+	first.Host = "192.168.1.20:7480"
+	first.RemoteAddr = "192.168.1.25:5000"
+
+	firstRecorder := httptest.NewRecorder()
+	server.handleBootstrap(firstRecorder, first, session{})
+	if firstRecorder.Code != http.StatusOK {
+		t.Fatalf("expected initial bootstrap to return 200, got %d: %s", firstRecorder.Code, firstRecorder.Body.String())
+	}
+
+	second := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/auth/bootstrap", strings.NewReader(body))
+	second.Header.Set("Content-Type", "application/json")
+	second.Host = "192.168.1.20:7480"
+	second.RemoteAddr = "192.168.1.25:5000"
+
+	secondRecorder := httptest.NewRecorder()
+	server.handleBootstrap(secondRecorder, second, session{})
+
+	if secondRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected bootstrap after user exists to return 400, got %d: %s", secondRecorder.Code, secondRecorder.Body.String())
+	}
+	if !strings.Contains(secondRecorder.Body.String(), "user already exists") {
+		t.Fatalf("unexpected bootstrap rejection: %s", secondRecorder.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

First-run admin setup (`POST /api/auth/bootstrap`) was gated to loopback web sessions via `isLocalWebUIRequest`. That blocks the common self-hosted case: running upbrr in Docker on a server (e.g. TrueNAS) and completing setup from a browser on another LAN machine — you'd hit `bootstrap is only available from localhost web sessions`.

This drops the loopback gate and adopts the **trust-on-first-use (TOFU)** model.

## Behavior change

- `/api/auth/bootstrap` is now reachable from any host.
- The existing `auth.Bootstrap` guard (`internal/authmaterial/store.go` — `"web auth: user already exists"`) closes the window **permanently** once the admin account is created.
- Login was never gated, so post-setup remote access is unchanged.
- **Native browse stays loopback-only** — only bootstrap is opened. `isLocalWebUIRequest` is still used there.

## Security tradeoff (deliberate)

On a fresh, account-less instance, anyone who can reach the web port can create the admin account — a first-boot-hijack window that closes the moment setup completes. This was flagged HIGH by automated review and **accepted intentionally**: it's the standard homelab model for a trusted LAN. Operators who may expose the port to untrusted networks before setup should complete setup promptly (or front it with a reverse proxy / auth). A one-time setup-token approach was considered and deferred.

## Tests

- `TestBootstrapAllowsRemoteFirstRunRequest` — remote first-run → `200`
- `TestBootstrapRejectsRemoteRequestWhenUserExists` — remote bootstrap after an account exists → `400 "user already exists"`
- (replaces `TestBootstrapRejectsRemoteFirstRunRequest`, which asserted the old `403`)

## Validation

`go build ./...` clean · `go test ./internal/webserver/...` passes · `golangci-lint run ./internal/webserver/...` → 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote access is now permitted for first-run setup during initial configuration.

* **Bug Fixes**
  * Improved security model by restricting remote access to setup only before the admin account is created; further remote setup attempts are rejected once a user account exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->