### PR TITLE
feat(docker): switch build and runtime to alpine + apk ffmpeg for libplacebo Dolby Vision tonemapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,14 +48,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         CGO_ENABLED=0 GOOS="$TARGETOS" GOARCH="$TARGETARCH" GOARM="$goarm" \
             go build -trimpath -ldflags="-s -w -X main.version=${VERSION} -X main.buildIdentifier=${BUILD_ID}" -o /out/upbrr ./cmd/upbrr
 
-FROM debian:bookworm-slim
+FROM alpine:3.21
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY --from=mwader/static-ffmpeg:8.1.1 /ffmpeg /bin/
-COPY --from=mwader/static-ffmpeg:8.1.1 /ffprobe /bin/
+RUN apk add --no-cache ca-certificates ffmpeg mesa-vulkan-swrast vulkan-loader
 
 COPY --from=cli-builder /out/upbrr /usr/local/bin/upbrr
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,11 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ffmpeg \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=mwader/static-ffmpeg:8.1.1 /ffmpeg /bin/
+COPY --from=mwader/static-ffmpeg:8.1.1 /ffprobe /bin/
 
 COPY --from=cli-builder /out/upbrr /usr/local/bin/upbrr
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         CGO_ENABLED=0 GOOS="$TARGETOS" GOARCH="$TARGETARCH" GOARM="$goarm" \
             go build -trimpath -ldflags="-s -w -X main.version=${VERSION} -X main.buildIdentifier=${BUILD_ID}" -o /out/upbrr ./cmd/upbrr
 
-FROM alpine:3.21
+FROM alpine:3.23
 
 RUN apk add --no-cache ca-certificates ffmpeg mesa-vulkan-swrast vulkan-loader
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG VERSION=dev
 ARG BUILD_ID=
 ARG GO_VERSION=1.26.4
 
-FROM --platform=$BUILDPLATFORM node:20-bookworm AS frontend
+FROM --platform=$BUILDPLATFORM node:20-alpine AS frontend
 
 WORKDIR /src/gui/frontend
 
@@ -19,7 +19,7 @@ RUN corepack enable && pnpm install --frozen-lockfile
 COPY gui/frontend/ ./
 RUN pnpm run build:bundle
 
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bookworm AS cli-builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS cli-builder
 
 WORKDIR /src
 


### PR DESCRIPTION
## Summary

Swaps the apt-installed `ffmpeg` package in the final image stage for
statically linked `ffmpeg` and `ffprobe` binaries copied from
`mwader/static-ffmpeg:8.1.1`.
This saves approximately 230MiB

## Motivation

The Debian `ffmpeg` package drags in a large tree of shared-library
dependencies. Copying the standalone static binaries instead removes
those transitive deps and significantly reduces the final image size.

## Changes

- Remove `ffmpeg` from the `apt-get install` step (keep `ca-certificates`).
- `COPY` `/ffmpeg` and `/ffprobe` from `mwader/static-ffmpeg:8.1.1` into `/bin/`.
- Version pinned to `8.1.1` for reproducible builds.

## Notes

- The linked version of ffmpeg **does not include** `libplacebo` - a feature request to the upstream project has been submitted.
- The `static-ffmpeg` image is a multi-platform manifest; the `COPY --from`
  resolves to the final stage's target platform, so arm64/amd64 builds
  pick the correct binaries automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container images to use Alpine-based stages instead of Debian-based ones across the build and runtime process.
  * Ensured the runtime image still includes required media support and certificates, and added Vulkan/Mesa graphics components for broader graphics-related compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->