### PR TITLE
feat: handle serve listen options

### DIFF
--- a/cmd/upbrr/cli_options.go
+++ b/cmd/upbrr/cli_options.go
@@ -118,8 +118,12 @@ type cliOptions struct {
 }
 
 type serveOptions struct {
-	ConfigPath string
-	DevNoAuth  bool
+	ConfigPath    string
+	Addr          string
+	Host          string
+	Port          int
+	PersistListen bool
+	DevNoAuth     bool
 }
 
 type cliHelpError struct {
@@ -494,12 +498,18 @@ func cliFlagAliases() map[string]string {
 	}
 }
 
+// parseServeOptions parses serve-only flags and returns the set of flags the
+// caller supplied so config defaults are not overwritten by zero values.
 func parseServeOptions(args []string) (serveOptions, map[string]bool, error) {
 	var opts serveOptions
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 
 	fs.StringVar(&opts.ConfigPath, "config", "", "Path to config file")
+	fs.StringVar(&opts.Addr, "addr", "", "Web UI listen address (host:port)")
+	fs.StringVar(&opts.Host, "host", "", "Web UI host to bind")
+	fs.Var(&decimalPortValue{target: &opts.Port}, "port", "Web UI port to bind")
+	fs.BoolVar(&opts.PersistListen, "persist-listen", false, "Persist Web UI listen host and port to web-config.json")
 	fs.BoolVar(&opts.DevNoAuth, "dev-no-auth", false, "Development only: serve web UI without web authentication on loopback hosts")
 
 	if err := fs.Parse(args); err != nil {
@@ -522,8 +532,9 @@ func formatFlagUsage(fs *flag.FlagSet, usage string) string {
 	fmt.Fprintf(&builder, "Usage: %s\n", usage)
 	if fs.Name() == "upbrr" {
 		fmt.Fprint(&builder, "\nCommands:\n")
-		fmt.Fprint(&builder, "  serve\n")
+		fmt.Fprint(&builder, "  serve [options]\n")
 		fmt.Fprint(&builder, "      Start the embedded web UI server\n")
+		fmt.Fprint(&builder, "      Options: --addr, --host, --port, --persist-listen, --dev-no-auth\n")
 	}
 	fmt.Fprint(&builder, "\nOptions:\n")
 	sections := cliHelpSections(fs.Name())
@@ -575,6 +586,7 @@ func cliHelpSections(name string) []helpSection {
 	if name == "serve" {
 		return []helpSection{
 			{title: "Config", names: []string{"config"}},
+			{title: "Server", names: []string{"addr", "host", "port", "persist-listen"}},
 			{title: "Development", names: []string{"dev-no-auth"}},
 		}
 	}
@@ -621,6 +633,9 @@ func cliAliasesByCanonical() map[string][]string {
 
 func formatHelpFlag(builder *strings.Builder, f *flag.Flag, aliases []string) {
 	valueName, usage := flag.UnquoteUsage(f)
+	if _, ok := f.Value.(*decimalPortValue); ok {
+		valueName = "int"
+	}
 	names := make([]string, 0, 2+len(aliases))
 	names = append(names, "-"+f.Name, "--"+f.Name)
 	for _, alias := range aliases {
@@ -636,6 +651,28 @@ func formatHelpFlag(builder *strings.Builder, f *flag.Flag, aliases []string) {
 
 type boolFlag interface {
 	IsBoolFlag() bool
+}
+
+// decimalPortValue parses --port from raw flag text so leading-zero values use
+// decimal syntax instead of the integer-literal rules used by flag.IntVar.
+type decimalPortValue struct {
+	target *int
+}
+
+func (v *decimalPortValue) Set(value string) error {
+	port, err := parseServePortValue(value)
+	if err != nil {
+		return err
+	}
+	*v.target = port
+	return nil
+}
+
+func (v *decimalPortValue) String() string {
+	if v == nil || v.target == nil {
+		return "0"
+	}
+	return strconv.Itoa(*v.target)
 }
 
 func isBoolFlag(f *flag.Flag) bool {

--- a/cmd/upbrr/cli_options_test.go
+++ b/cmd/upbrr/cli_options_test.go
@@ -5,11 +5,14 @@ package main
 
 import (
 	"bytes"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/autobrr/upbrr/internal/webserver"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -85,6 +88,238 @@ func TestParseServeOptionsDevNoAuth(t *testing.T) {
 	}
 	if !visited["dev-no-auth"] {
 		t.Fatalf("expected dev-no-auth visited flag, got %#v", visited)
+	}
+}
+
+func TestParseServeOptionsAddressHostPort(t *testing.T) {
+	opts, visited, err := parseServeOptions([]string{"--addr", "0.0.0.0:9090", "--host", "localhost", "--port", "7481", "--persist-listen"})
+	if err != nil {
+		t.Fatalf("parse serve options: %v", err)
+	}
+	if opts.Addr != "0.0.0.0:9090" || opts.Host != "localhost" || opts.Port != 7481 || !opts.PersistListen {
+		t.Fatalf("unexpected serve options: %#v", opts)
+	}
+	for _, name := range []string{"addr", "host", "port", "persist-listen"} {
+		if !visited[name] {
+			t.Fatalf("expected %s visited flag, got %#v", name, visited)
+		}
+	}
+}
+
+func TestParseServeOptionsPortUsesDecimalSyntax(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{name: "separate value", args: []string{"--port", "080"}, want: 80},
+		{name: "equals value", args: []string{"--port=010"}, want: 10},
+		{name: "leading zero nine", args: []string{"--port", "009"}, want: 9},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, visited, err := parseServeOptions(tc.args)
+			if err != nil {
+				t.Fatalf("parse serve options: %v", err)
+			}
+			if opts.Port != tc.want {
+				t.Fatalf("port = %d, want %d", opts.Port, tc.want)
+			}
+			if !visited["port"] {
+				t.Fatalf("expected port visited flag, got %#v", visited)
+			}
+		})
+	}
+}
+
+func TestParseServeOptionsRejectsNonDecimalPort(t *testing.T) {
+	_, _, err := parseServeOptions([]string{"--port", "0x50"})
+	if err == nil || !strings.Contains(err.Error(), "invalid port") {
+		t.Fatalf("expected invalid port error, got %v", err)
+	}
+}
+
+func TestApplyServeOptionOverridesAddress(t *testing.T) {
+	cfg, err := applyServeOptionOverrides(webserver.DefaultCLIConfig(), serveOptions{Addr: "0.0.0.0:9090"}, map[string]bool{"addr": true})
+	if err != nil {
+		t.Fatalf("apply serve overrides: %v", err)
+	}
+	if cfg.Host != "0.0.0.0" || cfg.Port != 9090 {
+		t.Fatalf("unexpected web config: %#v", cfg)
+	}
+}
+
+func TestApplyServeOptionOverridesAddressMatrix(t *testing.T) {
+	cases := []struct {
+		name string
+		addr string
+		host string
+		port int
+	}{
+		{name: "host port", addr: "localhost:9090", host: "localhost", port: 9090},
+		{name: "colon port shorthand", addr: ":9091", host: "0.0.0.0", port: 9091},
+		{name: "bracketed ipv6", addr: "[::1]:9092", host: "::1", port: 9092},
+		{name: "scoped ipv6", addr: "[fe80::1%zone]:9093", host: "fe80::1%zone", port: 9093},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := applyServeOptionOverrides(webserver.DefaultCLIConfig(), serveOptions{Addr: tc.addr}, map[string]bool{"addr": true})
+			if err != nil {
+				t.Fatalf("apply serve overrides: %v", err)
+			}
+			if cfg.Host != tc.host || cfg.Port != tc.port {
+				t.Fatalf("unexpected web config: %#v", cfg)
+			}
+		})
+	}
+}
+
+func TestApplyServeOptionOverridesHostPort(t *testing.T) {
+	cfg, err := applyServeOptionOverrides(webserver.DefaultCLIConfig(), serveOptions{Host: "[::1]", Port: 9091}, map[string]bool{"host": true, "port": true})
+	if err != nil {
+		t.Fatalf("apply serve overrides: %v", err)
+	}
+	if cfg.Host != "::1" || cfg.Port != 9091 {
+		t.Fatalf("unexpected web config: %#v", cfg)
+	}
+}
+
+func TestApplyServeOptionOverridesHostPortScopedIPv6(t *testing.T) {
+	cfg, err := applyServeOptionOverrides(webserver.DefaultCLIConfig(), serveOptions{Host: "[fe80::1%zone]", Port: 9091}, map[string]bool{"host": true, "port": true})
+	if err != nil {
+		t.Fatalf("apply serve overrides: %v", err)
+	}
+	if cfg.Host != "fe80::1%zone" || cfg.Port != 9091 {
+		t.Fatalf("unexpected web config: %#v", cfg)
+	}
+	if got := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port)); got != "[fe80::1%zone]:9091" {
+		t.Fatalf("unexpected bind address: %q", got)
+	}
+}
+
+func TestApplyServeOptionOverridesHostPortIPv4MappedIPv6(t *testing.T) {
+	cfg, err := applyServeOptionOverrides(webserver.DefaultCLIConfig(), serveOptions{Host: "[::ffff:127.0.0.1]", Port: 9091}, map[string]bool{"host": true, "port": true})
+	if err != nil {
+		t.Fatalf("apply serve overrides: %v", err)
+	}
+	if cfg.Host != "::ffff:127.0.0.1" || cfg.Port != 9091 {
+		t.Fatalf("unexpected web config: %#v", cfg)
+	}
+	if got := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port)); got != "[::ffff:127.0.0.1]:9091" {
+		t.Fatalf("unexpected bind address: %q", got)
+	}
+}
+
+func TestApplyServeOptionOverridesAddressScopedIPv6ProducesValidBindAddress(t *testing.T) {
+	cfg, err := applyServeOptionOverrides(webserver.DefaultCLIConfig(), serveOptions{Addr: "[fe80::1%zone]:9093"}, map[string]bool{"addr": true})
+	if err != nil {
+		t.Fatalf("apply serve overrides: %v", err)
+	}
+	if cfg.Host != "fe80::1%zone" || cfg.Port != 9093 {
+		t.Fatalf("unexpected web config: %#v", cfg)
+	}
+	if got := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port)); got != "[fe80::1%zone]:9093" {
+		t.Fatalf("unexpected bind address: %q", got)
+	}
+}
+
+func TestApplyServeOptionOverridesRejectsInvalidValues(t *testing.T) {
+	cases := []struct {
+		name    string
+		opts    serveOptions
+		visited map[string]bool
+		want    string
+	}{
+		{name: "addr with host", opts: serveOptions{Addr: "localhost:7480", Host: "localhost"}, visited: map[string]bool{"addr": true, "host": true}, want: "--addr cannot be used"},
+		{name: "empty host", opts: serveOptions{Host: " "}, visited: map[string]bool{"host": true}, want: "--host cannot be empty"},
+		{name: "host includes port", opts: serveOptions{Host: "localhost:7480"}, visited: map[string]bool{"host": true}, want: "--host cannot include a port"},
+		{name: "scoped ipv6 hostport", opts: serveOptions{Host: "fe80::1%zone:9090"}, visited: map[string]bool{"host": true}, want: "--host cannot include a port"},
+		{name: "invalid port", opts: serveOptions{Port: 70000}, visited: map[string]bool{"port": true}, want: "invalid port"},
+		{name: "invalid addr", opts: serveOptions{Addr: "localhost"}, visited: map[string]bool{"addr": true}, want: "--addr must be host:port"},
+		{name: "unbracketed ipv6 addr", opts: serveOptions{Addr: "::1:9090"}, visited: map[string]bool{"addr": true}, want: "--addr must be host:port"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := applyServeOptionOverrides(webserver.DefaultCLIConfig(), tc.opts, tc.visited)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestParseServeHostRejectsMalformedBrackets(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		host string
+		want string
+	}{
+		{name: "leading bracket only", host: "[::1", want: "invalid bracket syntax"},
+		{name: "trailing bracket only", host: "::1]", want: "invalid bracket syntax"},
+		{name: "nested brackets", host: "[[::1]]", want: "invalid bracket syntax"},
+		{name: "empty brackets", host: "[]", want: "invalid bracket syntax"},
+		{name: "bracketed hostname", host: "[localhost]", want: "IPv6 literals"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseServeHost(tc.host)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("parseServeHost(%q) error = %v, want substring %q", tc.host, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseServeHostRejectsInvalidColonHosts(t *testing.T) {
+	t.Parallel()
+
+	for _, host := range []string{"foo:bar:baz", "::1:http", "fe80::1%zone:9090", "::ffff:127.0.0.1:9090", "::ffff:127.0.0.999", "localhost:"} {
+		t.Run(host, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseServeHost(host)
+			if err == nil || !strings.Contains(err.Error(), "cannot include a port") {
+				t.Fatalf("parseServeHost(%q) error = %v, want port rejection", host, err)
+			}
+		})
+	}
+}
+
+func TestParseServeHostPreservesValidIPv6(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		host string
+		want string
+	}{
+		{host: "::1", want: "::1"},
+		{host: "::1:9090", want: "::1:9090"},
+		{host: "2001:db8::1234", want: "2001:db8::1234"},
+		{host: "[2001:db8::1234]", want: "2001:db8::1234"},
+		{host: "[::1]", want: "::1"},
+		{host: "::ffff:127.0.0.1", want: "::ffff:127.0.0.1"},
+		{host: "[::ffff:127.0.0.1]", want: "::ffff:127.0.0.1"},
+		{host: "fe80::1%zone", want: "fe80::1%zone"},
+		{host: "[fe80::1%zone]", want: "fe80::1%zone"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseServeHost(tc.host)
+			if err != nil {
+				t.Fatalf("parseServeHost(%q): %v", tc.host, err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseServeHost(%q) = %q, want %q", tc.host, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -377,6 +379,9 @@ func runServe(args []string) error {
 	if err != nil {
 		return err
 	}
+	if visitedFlags["persist-listen"] && !hasServeListenOverrides(visitedFlags) {
+		return errors.New("--persist-listen requires --addr, --host, or --port")
+	}
 
 	configFlagProvided := visitedFlags["config"]
 	resolvedConfigPath, err := configstore.ResolveYAMLPath(opts.ConfigPath, configFlagProvided)
@@ -393,9 +398,11 @@ func runServe(args []string) error {
 	if err != nil {
 		return fmt.Errorf("upbrr: %w", err)
 	}
-	if err := webserver.SaveCLIConfig(dbPath, webCfg); err != nil {
-		return fmt.Errorf("upbrr: %w", err)
+	webCfg, err = applyServeOptionOverrides(webCfg, opts, visitedFlags)
+	if err != nil {
+		return err
 	}
+	persistWebCfg := webCfg
 	if opts.DevNoAuth {
 		webCfg.OpenBrowser = false
 	}
@@ -410,7 +417,185 @@ func runServe(args []string) error {
 	}
 	defer server.Close()
 
+	if visitedFlags["persist-listen"] {
+		return wrapUpbrrError(server.RunAfterListen(context.Background(), func() error {
+			if err := webserver.SaveCLIConfig(dbPath, persistWebCfg); err != nil {
+				return fmt.Errorf("save web config: %w", err)
+			}
+			return nil
+		}))
+	}
+
 	return wrapUpbrrError(server.Run(context.Background()))
+}
+
+// hasServeListenOverrides reports whether serve bind flags were provided.
+// These flags affect the current process, and --persist-listen makes them durable.
+func hasServeListenOverrides(visited map[string]bool) bool {
+	return visited["addr"] || visited["host"] || visited["port"]
+}
+
+// applyServeOptionOverrides returns webCfg with explicitly supplied serve listen
+// flags applied. --addr replaces both host and port; --host and --port may
+// update either field independently.
+func applyServeOptionOverrides(webCfg webserver.CLIConfig, opts serveOptions, visited map[string]bool) (webserver.CLIConfig, error) {
+	if visited["addr"] && (visited["host"] || visited["port"]) {
+		return webserver.CLIConfig{}, errors.New("--addr cannot be used with --host or --port")
+	}
+
+	if visited["addr"] {
+		host, port, err := parseServeAddress(opts.Addr)
+		if err != nil {
+			return webserver.CLIConfig{}, err
+		}
+		webCfg.Host = host
+		webCfg.Port = port
+		return webCfg, nil
+	}
+
+	if visited["host"] {
+		host, err := parseServeHost(opts.Host)
+		if err != nil {
+			return webserver.CLIConfig{}, err
+		}
+		webCfg.Host = host
+	}
+	if visited["port"] {
+		port, err := parseServePort(strconv.Itoa(opts.Port))
+		if err != nil {
+			return webserver.CLIConfig{}, err
+		}
+		webCfg.Port = port
+	}
+
+	return webCfg, nil
+}
+
+// parseServeAddress splits a serve listen address into normalized host and
+// validated TCP port parts.
+func parseServeAddress(value string) (string, int, error) {
+	host, portValue, err := net.SplitHostPort(strings.TrimSpace(value))
+	if err != nil {
+		return "", 0, fmt.Errorf("parse serve options: --addr must be host:port: %w", err)
+	}
+	parsedHost, err := parseServeAddressHost(host)
+	if err != nil {
+		return "", 0, err
+	}
+	parsedPort, err := parseServePort(portValue)
+	if err != nil {
+		return "", 0, err
+	}
+	return parsedHost, parsedPort, nil
+}
+
+// parseServeAddressHost normalizes the host part of --addr. An empty host is
+// the supported :port shorthand and maps to the TCP wildcard bind host.
+func parseServeAddressHost(value string) (string, error) {
+	host := strings.TrimSpace(value)
+	if host == "" {
+		return "0.0.0.0", nil
+	}
+	return parseServeHost(host)
+}
+
+// parseServeHost normalizes a serve bind host. Bracketed IPv6 literals are
+// unwrapped, valid IPv6 literals stay valid, and host:port values are rejected
+// so port ownership stays explicit.
+func parseServeHost(value string) (string, error) {
+	host := strings.TrimSpace(value)
+	if host == "" {
+		return "", errors.New("parse serve options: --host cannot be empty")
+	}
+	host, err := normalizeServeHostBrackets(host)
+	if err != nil {
+		return "", err
+	}
+	if _, _, err := net.SplitHostPort(host); err == nil {
+		return "", errors.New("parse serve options: --host cannot include a port; use --addr or --port")
+	}
+	if looksLikeUnbracketedIPv6HostPort(host) {
+		return "", errors.New("parse serve options: --host cannot include a port; use bracketed IPv6 with --addr")
+	}
+	if strings.Contains(host, ":") && !isValidServeIPv6Host(host) {
+		return "", errors.New("parse serve options: --host cannot include a port; use bracketed IPv6 with --addr")
+	}
+	return host, nil
+}
+
+// normalizeServeHostBrackets unwraps bracketed IPv6 literals and rejects any
+// other bracket syntax before the host is persisted or passed to JoinHostPort.
+func normalizeServeHostBrackets(host string) (string, error) {
+	if !strings.ContainsAny(host, "[]") {
+		return host, nil
+	}
+	if !strings.HasPrefix(host, "[") || !strings.HasSuffix(host, "]") {
+		return "", errors.New("parse serve options: --host has invalid bracket syntax")
+	}
+	inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(host, "["), "]"))
+	if inner == "" || strings.ContainsAny(inner, "[]") {
+		return "", errors.New("parse serve options: --host has invalid bracket syntax")
+	}
+	if !isValidServeIPv6Host(inner) {
+		return "", errors.New("parse serve options: --host brackets are only valid for IPv6 literals")
+	}
+	return inner, nil
+}
+
+func isValidServeIPv6Host(host string) bool {
+	addr, err := netip.ParseAddr(host)
+	return err == nil && addr.Is6()
+}
+
+// looksLikeUnbracketedIPv6HostPort detects ambiguous IPv6-ish host text whose
+// final colon-separated segment looks like a port suffix, including scoped
+// literals where netip.ParseAddr would otherwise treat the suffix as part of
+// the zone. IPv4-mapped IPv6 literals stay valid because their trailing dotted
+// IPv4 text is address data, not a port suffix.
+func looksLikeUnbracketedIPv6HostPort(host string) bool {
+	if strings.ContainsAny(host, "[]") || strings.Count(host, ":") < 2 {
+		return false
+	}
+	if addr, err := netip.ParseAddr(host); err == nil {
+		if addr.Is4In6() {
+			return false
+		}
+		if addr.Is6() && !strings.Contains(addr.Zone(), ":") {
+			return false
+		}
+	}
+	idx := strings.LastIndex(host, ":")
+	if idx <= 0 || idx == len(host)-1 {
+		return false
+	}
+	suffix := host[idx+1:]
+	if suffix == "" {
+		return false
+	}
+	for _, r := range suffix {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return isValidServeIPv6Host(host[:idx])
+}
+
+// parseServePort validates a serve TCP port in the user-assignable range.
+func parseServePort(value string) (int, error) {
+	port, err := parseServePortValue(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse serve options: %w", err)
+	}
+	return port, nil
+}
+
+// parseServePortValue accepts decimal TCP ports in the user-assignable range.
+func parseServePortValue(value string) (int, error) {
+	port, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || port < 1 || port > 65535 {
+		return 0, fmt.Errorf("invalid port %q", value)
+	}
+	return port, nil
 }
 
 func loadCLIConfig(configPath string, configProvided bool) (config.Config, string, error) {

--- a/cmd/upbrr/main_test.go
+++ b/cmd/upbrr/main_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -183,8 +184,9 @@ func TestRunHelpFlagsPrintUsageAndSucceed(t *testing.T) {
 			}
 			for _, expected := range []string{
 				"Commands:",
-				"  serve",
+				"  serve [options]",
 				"Start the embedded web UI server",
+				"Options: --addr, --host, --port, --persist-listen, --dev-no-auth",
 				"Config:",
 				"Execution:",
 				"Tracker Selection:",
@@ -220,10 +222,78 @@ func TestRunServeHelpPrintsUsageAndSucceeds(t *testing.T) {
 	if !strings.Contains(output, "Usage: upbrr serve [options]") {
 		t.Fatalf("expected serve usage in output, got %q", output)
 	}
-	for _, expected := range []string{"Config:", "Development:", "-config, --config string", "-dev-no-auth, --dev-no-auth"} {
+	for _, expected := range []string{"Config:", "Server:", "Development:", "-config, --config string", "-addr, --addr string", "-host, --host string", "-port, --port int", "-persist-listen, --persist-listen", "-dev-no-auth, --dev-no-auth"} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("expected output to contain %q, got %q", expected, output)
 		}
+	}
+}
+
+func TestRunServePersistListenRequiresListenOverride(t *testing.T) {
+	err := runServe([]string{"--persist-listen"})
+	if err == nil || !strings.Contains(err.Error(), "--persist-listen requires --addr, --host, or --port") {
+		t.Fatalf("expected persist-listen requirement error, got %v", err)
+	}
+}
+
+func TestRunServeRejectedDevelopmentNoAuthHostDoesNotPersistListenOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	dbPath := filepath.Join(tmpDir, "state", "upbrr.db")
+	body := "main_settings:\n  db_path: " + filepath.ToSlash(dbPath) + "\nscreenshot_handling:\n  screens: 1\n"
+	if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	err := runServe([]string{"--config", configPath, "--dev-no-auth", "--host", "0.0.0.0", "--persist-listen"})
+	if err == nil || !strings.Contains(err.Error(), "--dev-no-auth requires a loopback host") {
+		t.Fatalf("expected dev-no-auth loopback error, got %v", err)
+	}
+
+	cfg, err := webserver.LoadCLIConfig(dbPath)
+	if err != nil {
+		t.Fatalf("load web config: %v", err)
+	}
+	if cfg.Host != "localhost" || cfg.Port != 7480 {
+		t.Fatalf("rejected listen override persisted: %#v", cfg)
+	}
+}
+
+func TestRunServePersistListenBindFailureDoesNotWriteWebConfig(t *testing.T) {
+	listenConfig := net.ListenConfig{}
+	listener, err := listenConfig.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen fixture: %v", err)
+	}
+	defer listener.Close()
+
+	tmpDir := t.TempDir()
+	distPath := filepath.Join(tmpDir, "gui", "frontend", "dist")
+	if err := os.MkdirAll(distPath, 0o755); err != nil {
+		t.Fatalf("create web assets fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(distPath, "index.html"), []byte("<!doctype html><title>upbrr</title>"), 0o600); err != nil {
+		t.Fatalf("write web assets fixture: %v", err)
+	}
+	t.Chdir(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	dbPath := filepath.Join(tmpDir, "state", "upbrr.db")
+	body := "main_settings:\n  db_path: " + filepath.ToSlash(dbPath) + "\nscreenshot_handling:\n  screens: 1\n"
+	if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split listener addr: %v", err)
+	}
+	err = runServe([]string{"--config", configPath, "--dev-no-auth", "--host", "127.0.0.1", "--port", port, "--persist-listen"})
+	if err == nil || !strings.Contains(err.Error(), "webserver: listen") {
+		t.Fatalf("expected listen error, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(dbPath), "web-config.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected no persisted web config after bind failure, stat error: %v", err)
 	}
 }
 

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -11,6 +11,8 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"net/netip"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -23,14 +25,22 @@ import (
 
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/guiapp"
+	"github.com/autobrr/upbrr/internal/redaction"
 )
 
+var openBrowserURL = browser.OpenURL
+
+// Options configures the embedded web UI server.
 type Options struct {
-	Config            config.Config
-	CLIConfig         CLIConfig
+	// Config supplies the application configuration used by the backend.
+	Config config.Config
+	// CLIConfig supplies persisted or command-line web server settings.
+	CLIConfig CLIConfig
+	// DevelopmentNoAuth enables the development-only auth bypass for loopback hosts.
 	DevelopmentNoAuth bool
 }
 
+// Server owns the embedded web UI HTTP server, backend services, auth stores, and event hub.
 type Server struct {
 	cfg                config.Config
 	cliCfg             CLIConfig
@@ -48,6 +58,8 @@ type Server struct {
 	developmentSession session
 }
 
+// New constructs a server from application and web CLI configuration.
+// It rejects development no-auth mode for non-loopback hosts.
 func New(opts Options) (*Server, error) {
 	cfg := opts.Config
 	cliCfg := normalizeCLIConfig(opts.CLIConfig)
@@ -116,6 +128,7 @@ func isDevelopmentNoAuthHost(host string) bool {
 	return isLoopbackHostPort(host)
 }
 
+// Close releases session and backend resources owned by the server.
 func (s *Server) Close() error {
 	if s.sessions != nil {
 		s.sessions.Close()
@@ -126,7 +139,22 @@ func (s *Server) Close() error {
 	return nil
 }
 
+// Run binds the configured TCP address and serves until ctx is cancelled or a shutdown signal arrives.
 func (s *Server) Run(ctx context.Context) error {
+	return s.run(ctx, nil)
+}
+
+// RunAfterListen runs the server and calls afterListen once the TCP listener
+// has bound successfully, before HTTP serving starts. If afterListen fails,
+// the listener is closed and the server does not start accepting requests.
+func (s *Server) RunAfterListen(ctx context.Context, afterListen func() error) error {
+	if afterListen == nil {
+		return s.Run(ctx)
+	}
+	return s.run(ctx, afterListen)
+}
+
+func (s *Server) run(ctx context.Context, afterListen func() error) error {
 	if ctx == nil {
 		return errors.New("webserver: context is required")
 	}
@@ -138,17 +166,27 @@ func (s *Server) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("webserver: listen %s: %w", s.server.Addr, err)
 	}
+	if afterListen != nil {
+		if err := afterListen(); err != nil {
+			_ = listener.Close()
+			return err
+		}
+	}
 	return s.serve(ctx, listener)
 }
 
 func (s *Server) serve(ctx context.Context, listener net.Listener) error {
 	errCh := make(chan error, 1)
+	browserCtx, cancelBrowser := context.WithCancel(ctx)
+	defer cancelBrowser()
 	s.server.BaseContext = func(net.Listener) context.Context {
 		return ctx
 	}
 	go func() {
 		errCh <- s.server.Serve(listener)
 	}()
+	browserURL := s.baseURL(listener.Addr())
+	s.logServeAddress(listener.Addr(), browserURL)
 
 	if s.cliCfg.OpenBrowser {
 		go func() {
@@ -156,15 +194,15 @@ func (s *Server) serve(ctx context.Context, listener net.Listener) error {
 			defer timer.Stop()
 
 			select {
-			case <-ctx.Done():
+			case <-browserCtx.Done():
 				return
 			case <-timer.C:
 			}
 
-			if ctx.Err() != nil {
+			if browserCtx.Err() != nil {
 				return
 			}
-			_ = browser.OpenURL(s.baseURL())
+			_ = openBrowserURL(browserURL)
 		}()
 	}
 
@@ -184,11 +222,125 @@ func (s *Server) serve(ctx context.Context, listener net.Listener) error {
 	}
 }
 
-func (s *Server) baseURL() string {
-	if strings.TrimSpace(s.cliCfg.BaseURL) != "" {
-		return strings.TrimRight(strings.TrimSpace(s.cliCfg.BaseURL), "/")
+// logServeAddress records the effective listener address after a successful
+// bind, along with a redacted browser URL when one is available.
+func (s *Server) logServeAddress(addr net.Addr, browserURL string) {
+	if s == nil || s.backend == nil || s.backend.logger == nil || addr == nil {
+		return
 	}
-	return "http://" + net.JoinHostPort(s.cliCfg.Host, strconv.Itoa(s.cliCfg.Port))
+	loggedBrowserURL := redactLoggedBrowserURL(browserURL)
+	if loggedBrowserURL == "" {
+		s.backend.logger.Infof("web: serving web UI on %s", addr.String())
+		return
+	}
+	s.backend.logger.Infof("web: serving web UI on %s (browser URL %s)", addr.String(), loggedBrowserURL)
+}
+
+// redactLoggedBrowserURL returns a log-safe browser URL, removing userinfo and
+// query values while keeping the scheme, host, path, and query keys visible.
+func redactLoggedBrowserURL(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return redaction.RedactValue(trimmed, nil)
+	}
+
+	safe := *parsed
+	safe.User = nil
+	if safe.RawQuery != "" {
+		safe.RawQuery = redactLoggedBrowserURLQuery(safe.Query()).Encode()
+	}
+
+	return redaction.RedactValue(safe.String(), nil)
+}
+
+// redactLoggedBrowserURLQuery preserves query keys and value counts while
+// replacing every query value with a redaction marker.
+func redactLoggedBrowserURLQuery(values url.Values) url.Values {
+	redacted := make(url.Values, len(values))
+	for key, items := range values {
+		if len(items) == 0 {
+			redacted[key] = nil
+			continue
+		}
+		redactedItems := make([]string, len(items))
+		for i := range items {
+			redactedItems[i] = "[REDACTED]"
+		}
+		redacted[key] = redactedItems
+	}
+	return redacted
+}
+
+// baseURL returns the URL opened in a browser. Explicit BaseURL wins; otherwise
+// the URL uses the effective listener port and a navigable host for wildcard binds.
+func (s *Server) baseURL(addr net.Addr) string {
+	if strings.TrimSpace(s.cliCfg.BaseURL) != "" {
+		return strings.TrimSpace(s.cliCfg.BaseURL)
+	}
+	port := s.cliCfg.Port
+	if tcpAddr, ok := addr.(*net.TCPAddr); ok && tcpAddr.Port > 0 {
+		port = tcpAddr.Port
+	}
+	host := browserHost(s.cliCfg.Host)
+	hostPort := net.JoinHostPort(host, strconv.Itoa(port))
+	if needsBrowserURLHostEscaping(host) {
+		return (&url.URL{
+			Scheme: "http",
+			Host:   hostPort,
+		}).String()
+	}
+	return "http://" + hostPort
+}
+
+// browserHost maps unspecified bind addresses to localhost because wildcard
+// addresses are valid listen targets but not useful browser destinations.
+func browserHost(host string) string {
+	trimmed := strings.TrimSpace(host)
+	if trimmed == "" {
+		return "localhost"
+	}
+
+	normalized, ok := unwrapBrowserIPv6Host(trimmed)
+	if ok {
+		trimmed = normalized
+	}
+
+	if ip, err := netip.ParseAddr(trimmed); err == nil && ip.IsUnspecified() {
+		return "localhost"
+	}
+	return trimmed
+}
+
+// needsBrowserURLHostEscaping reports whether URL construction must
+// percent-encode an IPv6 zone before the host is embedded in a browser URL.
+func needsBrowserURLHostEscaping(host string) bool {
+	addr, err := netip.ParseAddr(host)
+	return err == nil && addr.Is6() && addr.Zone() != ""
+}
+
+// unwrapBrowserIPv6Host removes balanced brackets only for valid IPv6
+// literals, leaving malformed host text unchanged for the browser URL builder.
+func unwrapBrowserIPv6Host(host string) (string, bool) {
+	if !strings.ContainsAny(host, "[]") {
+		return host, true
+	}
+	if !strings.HasPrefix(host, "[") || !strings.HasSuffix(host, "]") {
+		return host, false
+	}
+	inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(host, "["), "]"))
+	if inner == "" || strings.ContainsAny(inner, "[]") {
+		return host, false
+	}
+	addr, err := netip.ParseAddr(inner)
+	if err != nil || !addr.Is6() {
+		return host, false
+	}
+	return inner, true
 }
 
 func resolveWebAssets() (fs.FS, error) {

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -4,8 +4,18 @@
 package webserver
 
 import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/logging"
 )
 
 func TestNewRejectsDevelopmentNoAuthOnNonLoopbackHost(t *testing.T) {
@@ -73,4 +83,385 @@ func TestIsLoopbackHostPort(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLogServeAddressUsesInfo(t *testing.T) {
+	t.Parallel()
+
+	logger, err := logging.NewWithLevel(config.LoggingConfig{Level: "info"}, filepath.Join(t.TempDir(), "upbrr.db"), "")
+	if err != nil {
+		t.Fatalf("new logger: %v", err)
+	}
+	defer logger.Close()
+
+	server := &Server{
+		backend: &Backend{
+			logger: logger,
+		},
+	}
+	server.logServeAddress(&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7480}, "http://127.0.0.1:7480")
+
+	entries := logger.Recent(1)
+	if len(entries) != 1 {
+		t.Fatalf("expected one log entry, got %d", len(entries))
+	}
+	if entries[0].Level != "info" {
+		t.Fatalf("expected info log, got %q", entries[0].Level)
+	}
+	if !strings.Contains(entries[0].Message, "127.0.0.1:7480") {
+		t.Fatalf("expected address in log, got %q", entries[0].Message)
+	}
+	if !strings.Contains(entries[0].Message, "http://127.0.0.1:7480") {
+		t.Fatalf("expected browser URL in log, got %q", entries[0].Message)
+	}
+}
+
+func TestLogServeAddressRedactsBrowserURLSecrets(t *testing.T) {
+	t.Parallel()
+
+	logger, err := logging.NewWithLevel(config.LoggingConfig{Level: "info"}, filepath.Join(t.TempDir(), "upbrr.db"), "")
+	if err != nil {
+		t.Fatalf("new logger: %v", err)
+	}
+	defer logger.Close()
+
+	server := &Server{
+		backend: &Backend{
+			logger: logger,
+		},
+	}
+	server.logServeAddress(
+		&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7480},
+		"https://user:pass@example.test/upbrr/?next=dashboard&token=abc123",
+	)
+
+	entries := logger.Recent(1)
+	if len(entries) != 1 {
+		t.Fatalf("expected one log entry, got %d", len(entries))
+	}
+	message := entries[0].Message
+	if strings.Contains(message, "user") || strings.Contains(message, "pass") || strings.Contains(message, "abc123") || strings.Contains(message, "dashboard") {
+		t.Fatalf("expected browser URL secrets redacted, got %q", message)
+	}
+	if !strings.Contains(message, "https://example.test/upbrr/") {
+		t.Fatalf("expected safe browser URL host/path retained, got %q", message)
+	}
+}
+
+func TestBaseURLUsesLoopbackForWildcardBindHost(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{
+		cliCfg: CLIConfig{
+			Host: "0.0.0.0",
+			Port: 7480,
+		},
+	}
+	got := server.baseURL(&net.TCPAddr{IP: net.ParseIP("0.0.0.0"), Port: 49152})
+	if got != "http://localhost:49152" {
+		t.Fatalf("baseURL() = %q, want loopback URL with listener port", got)
+	}
+}
+
+func TestBaseURLPreservesExplicitBaseURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{name: "path trailing slash", baseURL: " https://example.test/upbrr/ ", want: "https://example.test/upbrr/"},
+		{name: "root slash", baseURL: "https://example.test/", want: "https://example.test/"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := &Server{
+				cliCfg: CLIConfig{
+					Host:    "0.0.0.0",
+					Port:    7480,
+					BaseURL: tc.baseURL,
+				},
+			}
+			got := server.baseURL(&net.TCPAddr{IP: net.ParseIP("0.0.0.0"), Port: 49152})
+			if got != tc.want {
+				t.Fatalf("baseURL() = %q, want explicit BaseURL %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBrowserHostNormalization(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		host string
+		want string
+	}{
+		{host: "", want: "localhost"},
+		{host: "0.0.0.0", want: "localhost"},
+		{host: "::", want: "localhost"},
+		{host: "[::]", want: "localhost"},
+		{host: "[fe80::1%zone]", want: "fe80::1%zone"},
+		{host: "[::", want: "[::"},
+		{host: "::]", want: "::]"},
+		{host: "[[::]]", want: "[[::]]"},
+		{host: "[]", want: "[]"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			t.Parallel()
+			if got := browserHost(tc.host); got != tc.want {
+				t.Fatalf("browserHost(%q) = %q, want %q", tc.host, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBaseURLEscapesScopedIPv6Zone(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		host string
+		want string
+	}{
+		{host: "fe80::1%zone", want: "http://[fe80::1%25zone]:49152"},
+		{host: "[fe80::1%zone]", want: "http://[fe80::1%25zone]:49152"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			t.Parallel()
+			server := &Server{
+				cliCfg: CLIConfig{
+					Host: tc.host,
+					Port: 7480,
+				},
+			}
+			got := server.baseURL(&net.TCPAddr{IP: net.ParseIP("fe80::1"), Port: 49152, Zone: "zone"})
+			if got != tc.want {
+				t.Fatalf("baseURL() = %q, want %q", got, tc.want)
+			}
+			parsed, err := url.Parse(got)
+			if err != nil {
+				t.Fatalf("url.Parse(%q): %v", got, err)
+			}
+			if parsed.Hostname() != "fe80::1%zone" {
+				t.Fatalf("parsed hostname = %q, want scoped IPv6 host", parsed.Hostname())
+			}
+		})
+	}
+}
+
+func TestBaseURLPreservesMalformedBracketHost(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		host string
+		want string
+	}{
+		{host: "[::", want: "http://[[::]:49152"},
+		{host: "[[::]]", want: "http://[[[::]]]:49152"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			t.Parallel()
+			server := &Server{
+				cliCfg: CLIConfig{
+					Host: tc.host,
+					Port: 7480,
+				},
+			}
+			got := server.baseURL(&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 49152})
+			if got != tc.want {
+				t.Fatalf("baseURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunAfterListenSkipsCallbackWhenBindFails(t *testing.T) {
+	listenConfig := net.ListenConfig{}
+	listener, err := listenConfig.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen fixture: %v", err)
+	}
+	defer listener.Close()
+
+	server := &Server{
+		server: &http.Server{
+			Addr: listener.Addr().String(),
+		},
+	}
+	called := false
+	err = server.RunAfterListen(context.Background(), func() error {
+		called = true
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "webserver: listen") {
+		t.Fatalf("expected listen error, got %v", err)
+	}
+	if called {
+		t.Fatal("afterListen callback ran despite bind failure")
+	}
+}
+
+func TestRunAfterListenRunsCallbackAfterBind(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	server := &Server{
+		server: &http.Server{
+			Addr:    "127.0.0.1:0",
+			Handler: http.NewServeMux(),
+		},
+	}
+	afterListenCalled := make(chan struct{})
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- server.RunAfterListen(ctx, func() error {
+			close(afterListenCalled)
+			cancel()
+			return nil
+		})
+	}()
+
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("run after listen: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		cancel()
+		select {
+		case err := <-runErr:
+			if err != nil {
+				t.Fatalf("run after listen after timeout cancellation: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for RunAfterListen to return")
+		}
+	}
+	select {
+	case <-afterListenCalled:
+	default:
+		t.Fatal("afterListen callback was not called")
+	}
+}
+
+func TestServeDoesNotOpenBrowserAfterServeError(t *testing.T) {
+	originalOpenBrowserURL := openBrowserURL
+	defer func() {
+		openBrowserURL = originalOpenBrowserURL
+	}()
+
+	opened := make(chan string, 1)
+	openBrowserURL = func(url string) error {
+		opened <- url
+		return nil
+	}
+
+	server := &Server{
+		cliCfg: CLIConfig{
+			Host:        "127.0.0.1",
+			Port:        7480,
+			OpenBrowser: true,
+		},
+		server: &http.Server{
+			Handler: http.NewServeMux(),
+		},
+	}
+
+	err := server.serve(context.Background(), failingListener{
+		addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 49152},
+		err:  errors.New("accept boom"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "accept boom") {
+		t.Fatalf("serve error = %v, want accept failure", err)
+	}
+
+	select {
+	case url := <-opened:
+		t.Fatalf("unexpected browser open for %q", url)
+	case <-time.After(400 * time.Millisecond):
+	}
+}
+
+func TestServeOpensBrowserAfterSuccessfulListen(t *testing.T) {
+	originalOpenBrowserURL := openBrowserURL
+	defer func() {
+		openBrowserURL = originalOpenBrowserURL
+	}()
+
+	opened := make(chan string, 1)
+	openBrowserURL = func(url string) error {
+		opened <- url
+		return nil
+	}
+
+	listenConfig := net.ListenConfig{}
+	listener, err := listenConfig.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen fixture: %v", err)
+	}
+	defer listener.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server := &Server{
+		cliCfg: CLIConfig{
+			Host:        "127.0.0.1",
+			Port:        7480,
+			OpenBrowser: true,
+		},
+		server: &http.Server{
+			Handler: http.NewServeMux(),
+		},
+	}
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- server.serve(ctx, listener)
+	}()
+
+	select {
+	case url := <-opened:
+		want := "http://" + listener.Addr().String()
+		if url != want {
+			t.Fatalf("browser URL = %q, want %q", url, want)
+		}
+		cancel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for browser open")
+	}
+
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("serve returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for serve shutdown")
+	}
+}
+
+type failingListener struct {
+	addr net.Addr
+	err  error
+}
+
+func (l failingListener) Accept() (net.Conn, error) {
+	return nil, l.err
+}
+
+func (l failingListener) Close() error {
+	return nil
+}
+
+func (l failingListener) Addr() net.Addr {
+	return l.addr
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--addr`, `--host`, and `--port` flags to configure server binding
  * Added `--persist-listen` flag to save server bind configuration across restarts
  * Enhanced IPv6 address support in server configuration

* **Improvements**
  * Improved address and port validation with better error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->