### PR TITLE
Fix: respect selected tracker handling

### DIFF
--- a/gui/frontend/src/app.test.ts
+++ b/gui/frontend/src/app.test.ts
@@ -1,0 +1,645 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { createElement } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import App, { hasExplicitEmptyReleaseTrackerSelection } from "./app";
+import type {
+  DescriptionBuilderPreview,
+  DupeCheckResult,
+  DupeEntry,
+  DupeMatch,
+  MetadataPreview,
+  ScreenshotPlan,
+  TrackerUploadSnapshot,
+} from "./types";
+import { hasFilteredEmptyUploadTrackerSelection } from "./utils/trackerSelection";
+
+vi.mock("../wailsjs/runtime/runtime", () => ({
+  EventsOn: vi.fn(() => () => undefined),
+  OnFileDrop: vi.fn(),
+  OnFileDropOff: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  delete (globalThis as typeof globalThis & { go?: any }).go;
+});
+
+type FetchMetadata = (
+  sourcePath: string,
+  sourceLookupURL: string,
+  overrides: unknown,
+  nameOverrides: unknown,
+  trackers: string[],
+) => Promise<MetadataPreview>;
+
+type ResetMetadata = FetchMetadata;
+type SaveConfig = (config: string) => Promise<void>;
+type FetchScreenshotPlan = (sourcePath: string) => Promise<ScreenshotPlan>;
+type FetchDescriptionBuilder = (
+  sourcePath: string,
+  overrides: unknown,
+  nameOverrides: unknown,
+  trackers: string[],
+  ignoreDupesFor: string[],
+) => Promise<DescriptionBuilderPreview>;
+type FetchPreparation = (
+  sourcePath: string,
+  overrides: unknown,
+  nameOverrides: unknown,
+  trackers: string[],
+  ignoreDupesFor: string[],
+) => Promise<unknown>;
+type StartTrackerUpload = (...args: unknown[]) => Promise<string>;
+type RetryFailedTrackerUpload = (jobID: string) => Promise<string>;
+type CancelTrackerUpload = (jobID: string) => Promise<void>;
+type GetTrackerUploadSnapshot = (jobID: string) => Promise<TrackerUploadSnapshot>;
+
+const metadataPreview = (sourcePath: string): MetadataPreview => ({
+  SourcePath: sourcePath,
+  TrackerName: "AITHER",
+  ReleaseName: "Example.Release.2026.1080p",
+  Warnings: [],
+  ReleaseNameOverrides: {},
+  ExternalIDs: {
+    TMDBID: 1,
+    IMDBID: 0,
+    TVDBID: 0,
+    TVmazeID: 0,
+    Category: "movie",
+    SourceTMDB: "",
+    SourceIMDB: "",
+    SourceTVDB: "",
+    SourceTVmaze: "",
+  },
+  ExternalIDCandidates: {
+    TMDB: [],
+    IMDB: [],
+    TMDBAutoSelected: false,
+    IMDBAutoSelected: false,
+  },
+  ExternalIDInfo: [],
+  ExternalPreview: [],
+  TrackerData: [],
+});
+
+const screenshotPlan = (sourcePath: string): ScreenshotPlan => ({
+  SourcePath: sourcePath,
+  DiscType: "",
+  DurationSeconds: 60,
+  FrameRate: 24,
+  SuggestedSelections: [],
+  ExistingScreenshots: [],
+  ExistingTrackerScreenshots: [],
+  FinalSelections: [],
+  TrackerImageLinks: [],
+  PreviewImages: [],
+  MetadataTimestamp: "",
+  RequiresManualFrames: false,
+});
+
+const descriptionBuilderPreview = (sourcePath: string): DescriptionBuilderPreview => ({
+  SourcePath: sourcePath,
+  Groups: [],
+});
+
+const trackerUploadSnapshot = (
+  jobID: string,
+  status: string,
+  overrides: Partial<TrackerUploadSnapshot> = {},
+): TrackerUploadSnapshot => ({
+  jobID,
+  sourcePath: "C:\\media\\Example",
+  status,
+  currentTask: "",
+  currentTaskStatus: status,
+  currentMessage: "",
+  currentCompletedPieces: 0,
+  currentTotalPieces: 0,
+  currentPercent: 0,
+  currentHashRateMiB: 0,
+  trackers: [],
+  failedTrackers: [],
+  uploadedCount: status === "completed" ? 1 : 0,
+  error: "",
+  startedAt: "2026-06-17T00:00:00Z",
+  finishedAt: "",
+  ...overrides,
+});
+
+const emptyDupeMatch: DupeMatch = {
+  FilenameMatch: "",
+  FileCountMatch: 0,
+  SizeMatch: "",
+  TrumpableID: "",
+  MatchedID: "",
+  MatchedName: "",
+  MatchedLink: "",
+  MatchedDownload: "",
+  MatchedReason: "",
+  SeasonPackExists: false,
+  SeasonPackName: "",
+  SeasonPackLink: "",
+  SeasonPackID: "",
+  SeasonPackContainsEpisode: false,
+  MatchedEpisodeIDs: [],
+};
+
+const dupeEntry = (tracker: string): DupeEntry => ({
+  Name: `${tracker} duplicate`,
+  SizeBytes: 0,
+  SizeKnown: false,
+  SizeText: "",
+  Files: [],
+  FileCount: 0,
+  Trumpable: false,
+  Link: "",
+  Download: "",
+  Flags: [],
+  ID: "",
+  Type: "",
+  Res: "",
+  Internal: false,
+  BDInfo: "",
+  Description: "",
+});
+
+const dupeResult = (tracker: string, hasDupes: boolean): DupeCheckResult => ({
+  Tracker: tracker,
+  Raw: [],
+  Filtered: hasDupes ? [dupeEntry(tracker)] : [],
+  HasDupes: hasDupes,
+  ContentFail: false,
+  Match: emptyDupeMatch,
+  Notes: [],
+  Skipped: false,
+  SkipReason: "",
+  Status: "completed",
+  Error: "",
+  CheckedAt: "2026-06-17T00:00:00Z",
+});
+
+const installAppBridge = (
+  fetchMetadata: FetchMetadata,
+  options: {
+    resetMetadata?: ResetMetadata;
+    saveConfig?: SaveConfig;
+    fetchScreenshotPlan?: FetchScreenshotPlan;
+    fetchDescriptionBuilder?: FetchDescriptionBuilder;
+    fetchPreparation?: FetchPreparation;
+    startTrackerUpload?: StartTrackerUpload;
+    retryFailedTrackerUpload?: RetryFailedTrackerUpload;
+    cancelTrackerUpload?: CancelTrackerUpload;
+    getTrackerUploadSnapshot?: GetTrackerUploadSnapshot;
+  } = {},
+) => {
+  const storage = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+  });
+  vi.stubGlobal("matchMedia", () => ({ matches: true }));
+  (globalThis as typeof globalThis & { go?: any }).go = {
+    guiapp: {
+      App: {
+        GetConfig: async () =>
+          JSON.stringify({
+            MainSettings: {
+              UseFavicons: false,
+            },
+            Trackers: {
+              DefaultTrackers: ["AITHER", "BLU"],
+              Trackers: {
+                AITHER: { APIKey: "configured" },
+                BLU: { APIKey: "configured" },
+              },
+            },
+            ScreenshotHandling: {
+              ProcessLimit: 1,
+            },
+          }),
+        BrowseFolder: async () => "C:\\media\\Example\\BDMV",
+        GetDefaultConfig: async () => JSON.stringify({ Trackers: { Trackers: {} } }),
+        FetchMetadata: fetchMetadata,
+        ResetMetadata:
+          options.resetMetadata ?? (async (sourcePath: string) => metadataPreview(sourcePath)),
+        SaveConfig: options.saveConfig ?? (async () => undefined),
+        FetchScreenshotPlan:
+          options.fetchScreenshotPlan ?? (async (sourcePath: string) => screenshotPlan(sourcePath)),
+        FetchDescriptionBuilder:
+          options.fetchDescriptionBuilder ??
+          (async (sourcePath: string) => descriptionBuilderPreview(sourcePath)),
+        FetchPreparation: options.fetchPreparation ?? (async () => ({})),
+        ListUploadedImages: async () => [],
+        DiscoverPlaylists: async () => [
+          {
+            file: "00001.mpls",
+            duration: 7200,
+            size: 0,
+            score: 1,
+            items: [{ path: "00001.m2ts", size: 1024 }],
+          },
+        ],
+        SavePlaylistSelection: async () => undefined,
+        StartDupeCheck: async () => "dupe-job-1",
+        GetDupeCheckSnapshot: async () => ({
+          jobID: "dupe-job-1",
+          sourcePath: "C:\\media\\Example",
+          status: "completed",
+          trackers: [],
+          completedCount: 2,
+          totalCount: 2,
+          summary: {
+            SourcePath: "C:\\media\\Example",
+            Results: [dupeResult("AITHER", false), dupeResult("BLU", true)],
+            Notes: [],
+          },
+          error: "",
+          startedAt: "2026-06-17T00:00:00Z",
+          finishedAt: "2026-06-17T00:00:01Z",
+        }),
+        StartTrackerUpload: options.startTrackerUpload ?? (async () => "upload-job-1"),
+        RetryFailedTrackerUpload: options.retryFailedTrackerUpload ?? (async () => "upload-job-2"),
+        CancelTrackerUpload: options.cancelTrackerUpload ?? (async () => undefined),
+        GetTrackerUploadSnapshot:
+          options.getTrackerUploadSnapshot ??
+          (async (jobID: string) => trackerUploadSnapshot(jobID, "completed")),
+      },
+    },
+  };
+};
+
+const openTrackerUploadPage = async (
+  fetchMetadata: FetchMetadata,
+  options: Parameters<typeof installAppBridge>[1] = {},
+) => {
+  installAppBridge(fetchMetadata, options);
+
+  render(createElement(App));
+
+  fireEvent.change(screen.getByLabelText("Source path"), {
+    target: { value: "C:\\media\\Example" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+  await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+  await screen.findByText("2/2");
+
+  fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+  fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+  await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+  fireEvent.click(screen.getByRole("button", { name: "Description Builder" }));
+  await screen.findByRole("button", { name: "Tracker Upload" });
+  fireEvent.click(screen.getByRole("button", { name: "Tracker Upload" }));
+  await screen.findByRole("heading", { name: "Upload Targets" });
+};
+
+describe("hasExplicitEmptyReleaseTrackerSelection", () => {
+  it("does not treat pre-selection state as deselect-all", () => {
+    expect(hasExplicitEmptyReleaseTrackerSelection([], {})).toBe(false);
+    expect(hasExplicitEmptyReleaseTrackerSelection([{ name: "AITHER" }], {})).toBe(false);
+  });
+
+  it("treats initialized all-false tracker state as explicit empty selection", () => {
+    expect(
+      hasExplicitEmptyReleaseTrackerSelection([{ name: "AITHER" }, { name: "BLU" }], {
+        AITHER: false,
+        BLU: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps nonempty tracker selections available", () => {
+    expect(
+      hasExplicitEmptyReleaseTrackerSelection([{ name: "AITHER" }, { name: "BLU" }], {
+        AITHER: true,
+        BLU: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("hasFilteredEmptyUploadTrackerSelection", () => {
+  const trackerUploadItems = [
+    { name: "AITHER", config: {} },
+    { name: "BLU", config: {} },
+  ];
+
+  it("detects selected input trackers filtered out of upload eligibility", () => {
+    expect(
+      hasFilteredEmptyUploadTrackerSelection({
+        trackerUploadItems,
+        releasePageTrackerSelection: {
+          AITHER: false,
+          BLU: true,
+        },
+        uploadToggles: { AITHER: true, BLU: true },
+        dupedTrackerSet: new Set(["blu"]),
+        ruleSkippedTrackerSet: new Set(),
+        failedDupeTrackerSet: new Set(),
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves missing-key startup and nonempty eligible selections", () => {
+    expect(
+      hasFilteredEmptyUploadTrackerSelection({
+        trackerUploadItems,
+        releasePageTrackerSelection: {},
+        uploadToggles: { AITHER: true, BLU: true },
+        dupedTrackerSet: new Set(),
+        ruleSkippedTrackerSet: new Set(),
+        failedDupeTrackerSet: new Set(),
+      }),
+    ).toBe(false);
+    expect(
+      hasFilteredEmptyUploadTrackerSelection({
+        trackerUploadItems,
+        releasePageTrackerSelection: {
+          AITHER: true,
+        },
+        uploadToggles: { AITHER: true, BLU: true },
+        dupedTrackerSet: new Set(),
+        ruleSkippedTrackerSet: new Set(),
+        failedDupeTrackerSet: new Set(),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat disabled upload toggles as missing startup state", () => {
+    expect(
+      hasFilteredEmptyUploadTrackerSelection({
+        trackerUploadItems,
+        releasePageTrackerSelection: {
+          AITHER: true,
+          BLU: false,
+        },
+        uploadToggles: { AITHER: false, BLU: true },
+        dupedTrackerSet: new Set(),
+        ruleSkippedTrackerSet: new Set(),
+        failedDupeTrackerSet: new Set(),
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("metadata tracker payloads", () => {
+  it("excludes dupe-blocked upload targets from metadata fetches", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    installAppBridge(fetchMetadata);
+
+    render(createElement(App));
+
+    const sourcePath = screen.getByLabelText("Source path");
+    fireEvent.change(sourcePath, { target: { value: "C:\\media\\Example" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+    await screen.findByText("2/2");
+
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(2));
+    expect(fetchMetadata.mock.calls[1][4]).toEqual(["AITHER", "BLU"]);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(3));
+    expect(fetchMetadata.mock.calls[2][4]).toEqual(["AITHER"]);
+  });
+
+  it("blocks metadata fetch when all selected trackers are filtered out", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    installAppBridge(fetchMetadata);
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+    await screen.findByText("2/2");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "AITHER" }));
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Select at least one tracker before fetching metadata."),
+      ).toBeInTheDocument(),
+    );
+    expect(fetchMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks metadata reset when all selected trackers are filtered out", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const resetMetadata = vi.fn<ResetMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const confirm = vi.fn(() => true);
+    installAppBridge(fetchMetadata, { resetMetadata });
+    vi.stubGlobal("confirm", confirm);
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+    await screen.findByText("2/2");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "AITHER" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reset data + refresh" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Select at least one tracker before resetting metadata."),
+      ).toBeInTheDocument(),
+    );
+    expect(confirm).not.toHaveBeenCalled();
+    expect(resetMetadata).not.toHaveBeenCalled();
+  });
+
+  it("skips warm metadata fetch when all selected trackers are filtered out", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const saveConfig = vi.fn<SaveConfig>(async () => undefined);
+    installAppBridge(fetchMetadata, { saveConfig });
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+    await screen.findByText("2/2");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "AITHER" }));
+    fireEvent.click(screen.getByRole("button", { name: "Screenshots" }));
+    fireEvent.click(screen.getByText("Screenshot settings"));
+    fireEvent.change(screen.getByLabelText("FFmpeg concurrency"), { target: { value: "2" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply settings" }));
+
+    await waitFor(() => expect(saveConfig).toHaveBeenCalledTimes(1));
+    expect(fetchMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses upload-eligible trackers when preparing selected playlists", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const fetchPreparation = vi.fn<FetchPreparation>(async () => ({}));
+    installAppBridge(fetchMetadata, { fetchPreparation });
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+    await screen.findByText("2/2");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.click(screen.getByRole("button", { name: "Browse folder" }));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Confirm Selection" }));
+
+    await waitFor(() => expect(fetchPreparation).toHaveBeenCalledTimes(1));
+    expect(fetchPreparation.mock.calls[0][3]).toEqual(["AITHER"]);
+    expect(fetchPreparation.mock.calls[0][4]).toEqual([]);
+  });
+});
+
+describe("tracker upload job tracking", () => {
+  it("keeps start upload tracking alive when bootstrap snapshot loading fails", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const startTrackerUpload = vi.fn<StartTrackerUpload>(async () => "upload-job-1");
+    const getTrackerUploadSnapshot = vi
+      .fn<GetTrackerUploadSnapshot>()
+      .mockRejectedValueOnce(new Error("bootstrap failed"))
+      .mockResolvedValueOnce(trackerUploadSnapshot("upload-job-1", "running"));
+    await openTrackerUploadPage(fetchMetadata, { startTrackerUpload, getTrackerUploadSnapshot });
+
+    fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
+
+    await waitFor(() => expect(startTrackerUpload).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(getTrackerUploadSnapshot).toHaveBeenCalledWith("upload-job-1"));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled());
+    await waitFor(() => expect(getTrackerUploadSnapshot).toHaveBeenCalledTimes(2), {
+      timeout: 1500,
+    });
+    expect(getTrackerUploadSnapshot.mock.calls[1][0]).toBe("upload-job-1");
+  });
+
+  it("preserves start upload creation failures", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const startTrackerUpload = vi.fn<StartTrackerUpload>(async () => {
+      throw new Error("start failed");
+    });
+    const getTrackerUploadSnapshot = vi.fn<GetTrackerUploadSnapshot>();
+    await openTrackerUploadPage(fetchMetadata, { startTrackerUpload, getTrackerUploadSnapshot });
+
+    fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
+
+    await waitFor(() => expect(screen.getByText("Error: start failed")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(getTrackerUploadSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("keeps retry upload tracking alive when replacement bootstrap snapshot loading fails", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const startTrackerUpload = vi.fn<StartTrackerUpload>(async () => "upload-job-1");
+    const retryFailedTrackerUpload = vi.fn<RetryFailedTrackerUpload>(async () => "upload-job-2");
+    const getTrackerUploadSnapshot = vi
+      .fn<GetTrackerUploadSnapshot>()
+      .mockResolvedValueOnce(
+        trackerUploadSnapshot("upload-job-1", "failed", {
+          failedTrackers: ["AITHER"],
+          error: "upload failed",
+          finishedAt: "2026-06-17T00:00:01Z",
+        }),
+      )
+      .mockRejectedValueOnce(new Error("retry bootstrap failed"))
+      .mockResolvedValueOnce(trackerUploadSnapshot("upload-job-2", "running"));
+    await openTrackerUploadPage(fetchMetadata, {
+      startTrackerUpload,
+      retryFailedTrackerUpload,
+      getTrackerUploadSnapshot,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Retry Failed" })).toBeEnabled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry Failed" }));
+
+    await waitFor(() => expect(retryFailedTrackerUpload).toHaveBeenCalledWith("upload-job-1"));
+    await waitFor(() => expect(getTrackerUploadSnapshot).toHaveBeenCalledWith("upload-job-2"));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled());
+    await waitFor(() => expect(getTrackerUploadSnapshot).toHaveBeenCalledTimes(3), {
+      timeout: 1500,
+    });
+    expect(getTrackerUploadSnapshot.mock.calls[2][0]).toBe("upload-job-2");
+  });
+
+  it("preserves retry creation failures", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const startTrackerUpload = vi.fn<StartTrackerUpload>(async () => "upload-job-1");
+    const retryFailedTrackerUpload = vi.fn<RetryFailedTrackerUpload>(async () => {
+      throw new Error("retry failed");
+    });
+    const getTrackerUploadSnapshot = vi.fn<GetTrackerUploadSnapshot>().mockResolvedValueOnce(
+      trackerUploadSnapshot("upload-job-1", "failed", {
+        failedTrackers: ["AITHER"],
+        error: "upload failed",
+        finishedAt: "2026-06-17T00:00:01Z",
+      }),
+    );
+    await openTrackerUploadPage(fetchMetadata, {
+      startTrackerUpload,
+      retryFailedTrackerUpload,
+      getTrackerUploadSnapshot,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Retry Failed" })).toBeEnabled());
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry Failed" }));
+
+    await waitFor(() => expect(screen.getByText("Error: retry failed")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(getTrackerUploadSnapshot).toHaveBeenCalledTimes(1);
+  });
+});

--- a/gui/frontend/src/app.test.ts
+++ b/gui/frontend/src/app.test.ts
@@ -9,12 +9,14 @@ import App, { hasExplicitEmptyReleaseTrackerSelection } from "./app";
 import type {
   DescriptionBuilderPreview,
   DupeCheckResult,
+  DupeCheckSnapshot,
   DupeEntry,
   DupeMatch,
   MetadataPreview,
   ScreenshotPlan,
   TrackerUploadSnapshot,
 } from "./types";
+import { isRuntimePathCaseInsensitive, updateBrowserCSRFToken } from "./utils/runtime";
 import { hasFilteredEmptyUploadTrackerSelection } from "./utils/trackerSelection";
 
 vi.mock("../wailsjs/runtime/runtime", () => ({
@@ -23,10 +25,13 @@ vi.mock("../wailsjs/runtime/runtime", () => ({
   OnFileDropOff: vi.fn(),
 }));
 
+const defaultPathCaseInsensitive = isRuntimePathCaseInsensitive();
+
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
   vi.unstubAllGlobals();
+  updateBrowserCSRFToken("", defaultPathCaseInsensitive);
   delete (globalThis as typeof globalThis & { go?: any }).go;
 });
 
@@ -55,6 +60,7 @@ type FetchPreparation = (
   trackers: string[],
   ignoreDupesFor: string[],
 ) => Promise<unknown>;
+type DetectDiscType = (sourcePath: string) => Promise<string>;
 type StartTrackerUpload = (...args: unknown[]) => Promise<string>;
 type RetryFailedTrackerUpload = (jobID: string) => Promise<string>;
 type CancelTrackerUpload = (jobID: string) => Promise<void>;
@@ -184,6 +190,23 @@ const dupeResult = (tracker: string, hasDupes: boolean): DupeCheckResult => ({
   CheckedAt: "2026-06-17T00:00:00Z",
 });
 
+const dupeCheckSnapshot = (sourcePath = "C:\\media\\Example"): DupeCheckSnapshot => ({
+  jobID: "dupe-job-1",
+  sourcePath,
+  status: "completed",
+  trackers: [],
+  completedCount: 2,
+  totalCount: 2,
+  summary: {
+    SourcePath: sourcePath,
+    Results: [dupeResult("AITHER", false), dupeResult("BLU", true)],
+    Notes: [],
+  },
+  error: "",
+  startedAt: "2026-06-17T00:00:00Z",
+  finishedAt: "2026-06-17T00:00:01Z",
+});
+
 const installAppBridge = (
   fetchMetadata: FetchMetadata,
   options: {
@@ -192,6 +215,9 @@ const installAppBridge = (
     fetchScreenshotPlan?: FetchScreenshotPlan;
     fetchDescriptionBuilder?: FetchDescriptionBuilder;
     fetchPreparation?: FetchPreparation;
+    browseFolder?: () => Promise<string>;
+    getDupeCheckSnapshot?: () => Promise<DupeCheckSnapshot>;
+    detectDiscType?: DetectDiscType;
     startTrackerUpload?: StartTrackerUpload;
     retryFailedTrackerUpload?: RetryFailedTrackerUpload;
     cancelTrackerUpload?: CancelTrackerUpload;
@@ -228,9 +254,10 @@ const installAppBridge = (
               ProcessLimit: 1,
             },
           }),
-        BrowseFolder: async () => "C:\\media\\Example\\BDMV",
+        BrowseFolder: options.browseFolder ?? (async () => "C:\\media\\Example\\BDMV"),
         GetDefaultConfig: async () => JSON.stringify({ Trackers: { Trackers: {} } }),
         FetchMetadata: fetchMetadata,
+        DetectDiscType: options.detectDiscType,
         ResetMetadata:
           options.resetMetadata ?? (async (sourcePath: string) => metadataPreview(sourcePath)),
         SaveConfig: options.saveConfig ?? (async () => undefined),
@@ -252,22 +279,7 @@ const installAppBridge = (
         ],
         SavePlaylistSelection: async () => undefined,
         StartDupeCheck: async () => "dupe-job-1",
-        GetDupeCheckSnapshot: async () => ({
-          jobID: "dupe-job-1",
-          sourcePath: "C:\\media\\Example",
-          status: "completed",
-          trackers: [],
-          completedCount: 2,
-          totalCount: 2,
-          summary: {
-            SourcePath: "C:\\media\\Example",
-            Results: [dupeResult("AITHER", false), dupeResult("BLU", true)],
-            Notes: [],
-          },
-          error: "",
-          startedAt: "2026-06-17T00:00:00Z",
-          finishedAt: "2026-06-17T00:00:01Z",
-        }),
+        GetDupeCheckSnapshot: options.getDupeCheckSnapshot ?? (async () => dupeCheckSnapshot()),
         StartTrackerUpload: options.startTrackerUpload ?? (async () => "upload-job-1"),
         RetryFailedTrackerUpload: options.retryFailedTrackerUpload ?? (async () => "upload-job-2"),
         CancelTrackerUpload: options.cancelTrackerUpload ?? (async () => undefined),
@@ -425,6 +437,82 @@ describe("metadata tracker payloads", () => {
     expect(fetchMetadata.mock.calls[2][4]).toEqual(["AITHER"]);
   });
 
+  it("does not apply dupe blocks from a previous path to metadata fetches", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    installAppBridge(fetchMetadata);
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+    await screen.findByText("2/2");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Other" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(2));
+    expect(fetchMetadata.mock.calls[1][0]).toBe("C:\\media\\Other");
+    expect(fetchMetadata.mock.calls[1][4]).toEqual(["AITHER", "BLU"]);
+  });
+
+  it("keeps current upload disables when stale dupe state came from another path", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    installAppBridge(fetchMetadata);
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+    await screen.findByText("2/2");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Other" },
+    });
+    await waitFor(() =>
+      expect(screen.getByLabelText("Source path")).toHaveValue("C:\\media\\Other"),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(2));
+    expect(fetchMetadata.mock.calls[1][4]).toEqual(["AITHER", "BLU"]);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(await screen.findByRole("button", { name: "Description Builder" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Tracker Upload" }));
+    await screen.findByRole("heading", { name: "Upload Targets" });
+    const aitherUploadSwitch = screen.getByRole("switch", { name: "Enable upload for AITHER" });
+    expect(aitherUploadSwitch).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(aitherUploadSwitch);
+    await waitFor(() => expect(aitherUploadSwitch).toHaveAttribute("aria-checked", "false"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(3));
+    expect(fetchMetadata.mock.calls[2][0]).toBe("C:\\media\\Other");
+    expect(fetchMetadata.mock.calls[2][4]).toEqual(["BLU"]);
+  });
+
   it("blocks metadata fetch when all selected trackers are filtered out", async () => {
     const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
     installAppBridge(fetchMetadata);
@@ -537,6 +625,86 @@ describe("metadata tracker payloads", () => {
     fireEvent.click(screen.getByRole("button", { name: "Input" }));
     fireEvent.click(screen.getByRole("button", { name: "Browse folder" }));
 
+    fireEvent.click(await screen.findByRole("button", { name: "Confirm Selection" }));
+
+    await waitFor(() => expect(fetchPreparation).toHaveBeenCalledTimes(1));
+    expect(fetchPreparation.mock.calls[0][3]).toEqual(["AITHER"]);
+    expect(fetchPreparation.mock.calls[0][4]).toEqual([]);
+  });
+
+  it("does not apply previous path dupe blocks when preparing selected playlists", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const fetchPreparation = vi.fn<FetchPreparation>(async () => ({}));
+    installAppBridge(fetchMetadata, {
+      browseFolder: async () => "C:\\media\\Other\\BDMV",
+      fetchPreparation,
+    });
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+    await screen.findByText("2/2");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.click(screen.getByRole("button", { name: "Browse folder" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Confirm Selection" }));
+
+    await waitFor(() => expect(fetchPreparation).toHaveBeenCalledTimes(1));
+    expect(fetchPreparation.mock.calls[0][3]).toEqual(["AITHER", "BLU"]);
+    expect(fetchPreparation.mock.calls[0][4]).toEqual([]);
+  });
+
+  it.each([
+    {
+      name: "root to lowercase child",
+      dupeSourcePath: "C:\\media\\Example",
+      browsePath: "C:\\media\\Example\\bdmv",
+    },
+    {
+      name: "lowercase child to root",
+      dupeSourcePath: "C:\\media\\Example\\bdmv",
+      browsePath: "C:\\media\\Example",
+      detectDiscType: async () => "BDMV",
+    },
+    {
+      name: "trailing slash root to lowercase child",
+      dupeSourcePath: "C:\\media\\Example\\",
+      browsePath: "C:\\media\\Example\\bdmv\\",
+    },
+  ])("matches lowercase BDMV context for playlist preparation: $name", async (testCase) => {
+    updateBrowserCSRFToken("", false);
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const fetchPreparation = vi.fn<FetchPreparation>(async () => ({}));
+    installAppBridge(fetchMetadata, {
+      browseFolder: async () => testCase.browsePath,
+      getDupeCheckSnapshot: async () => dupeCheckSnapshot(testCase.dupeSourcePath),
+      detectDiscType: testCase.detectDiscType,
+      fetchPreparation,
+    });
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: testCase.dupeSourcePath },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+    await screen.findByText("2/2");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.click(screen.getByRole("button", { name: "Browse folder" }));
     fireEvent.click(await screen.findByRole("button", { name: "Confirm Selection" }));
 
     await waitFor(() => expect(fetchPreparation).toHaveBeenCalledTimes(1));

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -214,6 +214,46 @@ export const hasExplicitEmptyReleaseTrackerSelection = (
   );
 };
 
+const hasOwnSelection = (value: Record<string, boolean>, key: string) =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+/**
+ * Normalizes source paths for lightweight context comparisons.
+ *
+ * This keeps host path identity checks independent of slash direction and
+ * trailing separators without replacing the runtime-aware same-path helper.
+ */
+const normalizePathContext = (value: string, caseInsensitive: boolean) => {
+  let normalized = value.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+  if (caseInsensitive) {
+    normalized = normalized.toLowerCase();
+  }
+  return normalized;
+};
+
+const normalizeBdmvPathContext = (value: string, caseInsensitive: boolean) =>
+  normalizePathContext(value, caseInsensitive).replace(/(^|\/)bdmv(?=\/|$)/gi, "$1BDMV");
+
+/**
+ * Returns true when two source paths refer to the same eligibility context.
+ *
+ * A selected Blu-ray folder may be represented by either the release root or
+ * its BDMV child folder; both must share dupe/rule tracker eligibility.
+ */
+const isSourcePathContextMatch = (left: string, right: string, caseInsensitive: boolean) => {
+  if (sameSourcePath(left, right, caseInsensitive)) {
+    return true;
+  }
+  const normalizedLeft = normalizeBdmvPathContext(left, caseInsensitive);
+  const normalizedRight = normalizeBdmvPathContext(right, caseInsensitive);
+  if (!normalizedLeft || !normalizedRight) {
+    return false;
+  }
+  return (
+    normalizedLeft === `${normalizedRight}/BDMV` || normalizedRight === `${normalizedLeft}/BDMV`
+  );
+};
+
 const upsertBuilderGroup = (
   preview: DescriptionBuilderPreview,
   nextGroup: DescriptionBuilderPreview["Groups"][number],
@@ -1295,23 +1335,108 @@ export default function App() {
     handleDeleteTrackerImageURL,
   } = screenshots;
 
-  const selectedUploadImageTrackers = useMemo(() => {
-    return resolveSelectedUploadTrackers({
-      trackerUploadItems,
-      releasePageTrackerSelection,
-      uploadToggles,
+  /**
+   * Resolves upload-eligible trackers for the requested source path.
+   *
+   * Dupe and rule-failure filters apply only when their snapshot source path
+   * matches the requested path context, preventing stale blocks from a previous
+   * source path from changing metadata fetch or playlist preparation payloads.
+   */
+  const resolveUploadTrackerEligibilityForPath = useCallback(
+    (sourcePath: string) => {
+      const targetPath = sourcePath.trim();
+      const currentPath = path.trim();
+      const dupeSourcePath = String(
+        dupeSummary.SourcePath || dupeCheckSnapshot?.sourcePath || "",
+      ).trim();
+      const pathCaseInsensitive = isRuntimePathCaseInsensitive();
+      const dupeSourceMatchesTarget =
+        targetPath !== "" &&
+        dupeSourcePath !== "" &&
+        isSourcePathContextMatch(dupeSourcePath, targetPath, pathCaseInsensitive);
+      const uploadTogglesMatchTarget =
+        targetPath === "" ||
+        currentPath === "" ||
+        isSourcePathContextMatch(currentPath, targetPath, pathCaseInsensitive);
+      const effectiveUploadToggles: Record<string, boolean> = {};
+
+      trackerUploadItems.forEach((item) => {
+        const normalized = item.name.toLowerCase().trim();
+        if (uploadTogglesMatchTarget && hasOwnSelection(uploadToggles, item.name)) {
+          effectiveUploadToggles[item.name] = uploadToggles[item.name];
+          return;
+        }
+        if (hasOwnSelection(releasePageTrackerSelection, item.name)) {
+          effectiveUploadToggles[item.name] = releasePageTrackerSelection[item.name];
+          return;
+        }
+        effectiveUploadToggles[item.name] = defaultTrackerSet.has(normalized);
+      });
+
+      const emptyTrackerSet = new Set<string>();
+      const scopedDupedTrackerSet = dupeSourceMatchesTarget ? dupedTrackerSet : emptyTrackerSet;
+      const scopedRuleSkippedTrackerSet = dupeSourceMatchesTarget
+        ? ruleSkippedTrackerSet
+        : emptyTrackerSet;
+      const scopedFailedDupeTrackerSet = dupeSourceMatchesTarget
+        ? failedDupeTrackerSet
+        : emptyTrackerSet;
+      const selectedTrackers = resolveSelectedUploadTrackers({
+        trackerUploadItems,
+        releasePageTrackerSelection,
+        uploadToggles: effectiveUploadToggles,
+        dupedTrackerSet: scopedDupedTrackerSet,
+        ruleSkippedTrackerSet: scopedRuleSkippedTrackerSet,
+        failedDupeTrackerSet: scopedFailedDupeTrackerSet,
+      });
+
+      return {
+        selectedTrackers,
+        emptySelection:
+          hasExplicitEmptyReleaseTrackerSelection(
+            trackerUploadItems,
+            releasePageTrackerSelection,
+          ) ||
+          hasFilteredEmptyUploadTrackerSelectionState({
+            trackerUploadItems,
+            releasePageTrackerSelection,
+            uploadToggles: effectiveUploadToggles,
+            dupedTrackerSet: scopedDupedTrackerSet,
+            ruleSkippedTrackerSet: scopedRuleSkippedTrackerSet,
+            failedDupeTrackerSet: scopedFailedDupeTrackerSet,
+          }),
+      };
+    },
+    [
+      defaultTrackerSet,
+      dupeCheckSnapshot?.sourcePath,
+      dupeSummary.SourcePath,
       dupedTrackerSet,
-      ruleSkippedTrackerSet,
       failedDupeTrackerSet,
-    });
-  }, [
-    releasePageTrackerSelection,
-    uploadToggles,
-    trackerUploadItems,
-    dupedTrackerSet,
-    ruleSkippedTrackerSet,
-    failedDupeTrackerSet,
-  ]);
+      path,
+      releasePageTrackerSelection,
+      ruleSkippedTrackerSet,
+      trackerUploadItems,
+      uploadToggles,
+    ],
+  );
+
+  const selectedUploadTrackerEligibility = useMemo(
+    () => resolveUploadTrackerEligibilityForPath(path),
+    [path, resolveUploadTrackerEligibilityForPath],
+  );
+  const selectedUploadImageTrackers = selectedUploadTrackerEligibility.selectedTrackers;
+  const dupeFiltersMatchCurrentPath = useMemo(() => {
+    const currentPath = path.trim();
+    const dupeSourcePath = String(
+      dupeSummary.SourcePath || dupeCheckSnapshot?.sourcePath || "",
+    ).trim();
+    return (
+      currentPath !== "" &&
+      dupeSourcePath !== "" &&
+      isSourcePathContextMatch(dupeSourcePath, currentPath, isRuntimePathCaseInsensitive())
+    );
+  }, [dupeCheckSnapshot?.sourcePath, dupeSummary.SourcePath, path]);
 
   // Upload images workflow hook
   const uploadImages = useUploadImages({
@@ -1978,20 +2103,13 @@ export default function App() {
       bdmvPath = `${trimmedPath}/BDMV`;
     }
 
+    const playlistTrackerEligibility = resolveUploadTrackerEligibilityForPath(trimmedPath);
+
     // Set the path for playlist discovery (component will discover the playlists)
     setPlaylistSelectionPath(bdmvPath);
     setPlaylistPreparationTrackerSnapshot({
-      selectedTrackers: selectedUploadImageTrackers,
-      emptySelection:
-        hasExplicitEmptyReleaseTrackerSelection(trackerUploadItems, releasePageTrackerSelection) ||
-        hasFilteredEmptyUploadTrackerSelectionState({
-          trackerUploadItems,
-          releasePageTrackerSelection,
-          uploadToggles,
-          dupedTrackerSet,
-          ruleSkippedTrackerSet,
-          failedDupeTrackerSet,
-        }),
+      selectedTrackers: playlistTrackerEligibility.selectedTrackers,
+      emptySelection: playlistTrackerEligibility.emptySelection,
     });
     setShowPlaylistSelection(true);
     return { path: trimmedPath, mode: selectedMode, waitsForPlaylistSelection: true };
@@ -2014,18 +2132,11 @@ export default function App() {
       return false;
     }
     const selectedTrackers =
-      playlistPreparationTrackerSnapshot?.selectedTrackers ?? selectedUploadImageTrackers;
+      playlistPreparationTrackerSnapshot?.selectedTrackers ??
+      selectedUploadTrackerEligibility.selectedTrackers;
     const emptySelection =
       playlistPreparationTrackerSnapshot?.emptySelection ??
-      (hasExplicitEmptyReleaseTrackerSelection(trackerUploadItems, releasePageTrackerSelection) ||
-        hasFilteredEmptyUploadTrackerSelectionState({
-          trackerUploadItems,
-          releasePageTrackerSelection,
-          uploadToggles,
-          dupedTrackerSet,
-          ruleSkippedTrackerSet,
-          failedDupeTrackerSet,
-        }));
+      selectedUploadTrackerEligibility.emptySelection;
     if (selectedTrackers.length === 0 && emptySelection) {
       setPlaylistPreparationError("Select at least one tracker before preparing playlists.");
       return false;
@@ -2080,19 +2191,9 @@ export default function App() {
       setError("Please select a file or folder.");
       return;
     }
-    const selectedTrackers = selectedUploadImageTrackers;
-    if (
-      selectedTrackers.length === 0 &&
-      (hasExplicitEmptyReleaseTrackerSelection(trackerUploadItems, releasePageTrackerSelection) ||
-        hasFilteredEmptyUploadTrackerSelectionState({
-          trackerUploadItems,
-          releasePageTrackerSelection,
-          uploadToggles,
-          dupedTrackerSet,
-          ruleSkippedTrackerSet,
-          failedDupeTrackerSet,
-        }))
-    ) {
+    const trackerEligibility = resolveUploadTrackerEligibilityForPath(targetPath);
+    const selectedTrackers = trackerEligibility.selectedTrackers;
+    if (selectedTrackers.length === 0 && trackerEligibility.emptySelection) {
       setError("Select at least one tracker before fetching metadata.");
       return;
     }
@@ -2201,18 +2302,7 @@ export default function App() {
       return;
     }
     const selectedTrackers = selectedUploadImageTrackers;
-    if (
-      selectedTrackers.length === 0 &&
-      (hasExplicitEmptyReleaseTrackerSelection(trackerUploadItems, releasePageTrackerSelection) ||
-        hasFilteredEmptyUploadTrackerSelectionState({
-          trackerUploadItems,
-          releasePageTrackerSelection,
-          uploadToggles,
-          dupedTrackerSet,
-          ruleSkippedTrackerSet,
-          failedDupeTrackerSet,
-        }))
-    ) {
+    if (selectedTrackers.length === 0 && selectedUploadTrackerEligibility.emptySelection) {
       setError("Select at least one tracker before resetting metadata.");
       return;
     }
@@ -2551,18 +2641,7 @@ export default function App() {
       return;
     }
     const selectedTrackers = selectedUploadImageTrackers;
-    if (
-      selectedTrackers.length === 0 &&
-      (hasExplicitEmptyReleaseTrackerSelection(trackerUploadItems, releasePageTrackerSelection) ||
-        hasFilteredEmptyUploadTrackerSelectionState({
-          trackerUploadItems,
-          releasePageTrackerSelection,
-          uploadToggles,
-          dupedTrackerSet,
-          ruleSkippedTrackerSet,
-          failedDupeTrackerSet,
-        }))
-    ) {
+    if (selectedTrackers.length === 0 && selectedUploadTrackerEligibility.emptySelection) {
       return;
     }
     await fetcher(
@@ -3140,11 +3219,14 @@ export default function App() {
           delete next[item.name];
           return;
         }
-        if (failedDupeTrackerSet.has(normalized)) {
+        if (dupeFiltersMatchCurrentPath && failedDupeTrackerSet.has(normalized)) {
           next[item.name] = false;
           return;
         }
-        if (dupedTrackerSet.has(normalized) || ruleSkippedTrackerSet.has(normalized)) {
+        if (
+          dupeFiltersMatchCurrentPath &&
+          (dupedTrackerSet.has(normalized) || ruleSkippedTrackerSet.has(normalized))
+        ) {
           next[item.name] = false;
           return;
         }
@@ -3175,6 +3257,7 @@ export default function App() {
   }, [
     trackerUploadItems,
     defaultTrackerSet,
+    dupeFiltersMatchCurrentPath,
     dupedTrackerSet,
     ruleSkippedTrackerSet,
     failedDupeTrackerSet,

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -83,6 +83,10 @@ import {
 import { handleExternalLinkClick } from "./utils/externalLinks";
 import { normalizeJobStatus } from "./utils/jobStatus";
 import { isMetadataProgressPathMatch } from "./utils/metadataProgress";
+import {
+  hasFilteredEmptyUploadTrackerSelection as hasFilteredEmptyUploadTrackerSelectionState,
+  resolveSelectedUploadTrackers,
+} from "./utils/trackerSelection";
 
 const appLayoutClass =
   "relative z-[1] block min-h-screen ml-[204px] max-[960px]:ml-0 max-[960px]:pb-[78px]";
@@ -189,6 +193,25 @@ const splitTrackerLabel = (value: string) =>
 const emptyDescriptionBuilder: DescriptionBuilderPreview = {
   SourcePath: "",
   Groups: [],
+};
+
+/**
+ * Returns true when every available release tracker has an explicit false selection.
+ *
+ * Missing tracker keys are treated as uninitialized state, not user deselection.
+ */
+export const hasExplicitEmptyReleaseTrackerSelection = (
+  trackerUploadItems: Array<{ name: string }>,
+  releasePageTrackerSelection: Record<string, boolean>,
+) => {
+  if (trackerUploadItems.length === 0) {
+    return false;
+  }
+  return trackerUploadItems.every(
+    (item) =>
+      Object.prototype.hasOwnProperty.call(releasePageTrackerSelection, item.name) &&
+      !releasePageTrackerSelection[item.name],
+  );
 };
 
 const upsertBuilderGroup = (
@@ -614,6 +637,10 @@ export default function App() {
   const [playlistSelectionPath, setPlaylistSelectionPath] = useState("");
   const [playlistAutoPreparing, setPlaylistAutoPreparing] = useState(false);
   const [playlistPreparationError, setPlaylistPreparationError] = useState("");
+  const [playlistPreparationTrackerSnapshot, setPlaylistPreparationTrackerSnapshot] = useState<{
+    selectedTrackers: string[];
+    emptySelection: boolean;
+  } | null>(null);
   const [bdinfoProgressLines, setBdinfoProgressLines] = useState<string[]>([]);
   const bdinfoProgressActiveRef = useRef(false);
   const [metadataProgressActive, setMetadataProgressActive] = useState(false);
@@ -1269,20 +1296,16 @@ export default function App() {
   } = screenshots;
 
   const selectedUploadImageTrackers = useMemo(() => {
-    const validTrackers = new Set(trackerUploadItems.map((item) => item.name));
-    return Object.entries(uploadToggles)
-      .filter(([name, enabled]) => {
-        if (!enabled) return false;
-        if (!validTrackers.has(name)) return false;
-        const normalized = name.toLowerCase().trim();
-        if (!normalized) return false;
-        if (dupedTrackerSet.has(normalized)) return false;
-        if (ruleSkippedTrackerSet.has(normalized)) return false;
-        if (failedDupeTrackerSet.has(normalized)) return false;
-        return true;
-      })
-      .map(([name]) => name);
+    return resolveSelectedUploadTrackers({
+      trackerUploadItems,
+      releasePageTrackerSelection,
+      uploadToggles,
+      dupedTrackerSet,
+      ruleSkippedTrackerSet,
+      failedDupeTrackerSet,
+    });
   }, [
+    releasePageTrackerSelection,
     uploadToggles,
     trackerUploadItems,
     dupedTrackerSet,
@@ -1935,6 +1958,7 @@ export default function App() {
     if (selectedMode === "file") {
       setShowPlaylistSelection(false);
       setPlaylistSelectionPath("");
+      setPlaylistPreparationTrackerSnapshot(null);
       setActiveTab("input");
       return { path: trimmedPath, mode: selectedMode, waitsForPlaylistSelection: false };
     }
@@ -1942,6 +1966,7 @@ export default function App() {
     if (discType !== "BDMV") {
       setShowPlaylistSelection(false);
       setPlaylistSelectionPath("");
+      setPlaylistPreparationTrackerSnapshot(null);
       setActiveTab("input");
       return { path: trimmedPath, mode: selectedMode, waitsForPlaylistSelection: false };
     }
@@ -1955,6 +1980,19 @@ export default function App() {
 
     // Set the path for playlist discovery (component will discover the playlists)
     setPlaylistSelectionPath(bdmvPath);
+    setPlaylistPreparationTrackerSnapshot({
+      selectedTrackers: selectedUploadImageTrackers,
+      emptySelection:
+        hasExplicitEmptyReleaseTrackerSelection(trackerUploadItems, releasePageTrackerSelection) ||
+        hasFilteredEmptyUploadTrackerSelectionState({
+          trackerUploadItems,
+          releasePageTrackerSelection,
+          uploadToggles,
+          dupedTrackerSet,
+          ruleSkippedTrackerSet,
+          failedDupeTrackerSet,
+        }),
+    });
     setShowPlaylistSelection(true);
     return { path: trimmedPath, mode: selectedMode, waitsForPlaylistSelection: true };
   };
@@ -1975,8 +2013,25 @@ export default function App() {
       setPlaylistPreparationError("Please select a file or folder.");
       return false;
     }
+    const selectedTrackers =
+      playlistPreparationTrackerSnapshot?.selectedTrackers ?? selectedUploadImageTrackers;
+    const emptySelection =
+      playlistPreparationTrackerSnapshot?.emptySelection ??
+      (hasExplicitEmptyReleaseTrackerSelection(trackerUploadItems, releasePageTrackerSelection) ||
+        hasFilteredEmptyUploadTrackerSelectionState({
+          trackerUploadItems,
+          releasePageTrackerSelection,
+          uploadToggles,
+          dupedTrackerSet,
+          ruleSkippedTrackerSet,
+          failedDupeTrackerSet,
+        }));
+    if (selectedTrackers.length === 0 && emptySelection) {
+      setPlaylistPreparationError("Select at least one tracker before preparing playlists.");
+      return false;
+    }
     try {
-      await fetcher(path.trim(), {}, {}, getSelectedTrackers(), []);
+      await fetcher(path.trim(), {}, {}, selectedTrackers, []);
       return true;
     } catch (err) {
       setPlaylistPreparationError(String(err));
@@ -1995,6 +2050,7 @@ export default function App() {
     if (completed) {
       setShowPlaylistSelection(false);
       setPlaylistSelectionPath("");
+      setPlaylistPreparationTrackerSnapshot(null);
       setActiveTab("input");
     }
   };
@@ -2024,6 +2080,22 @@ export default function App() {
       setError("Please select a file or folder.");
       return;
     }
+    const selectedTrackers = selectedUploadImageTrackers;
+    if (
+      selectedTrackers.length === 0 &&
+      (hasExplicitEmptyReleaseTrackerSelection(trackerUploadItems, releasePageTrackerSelection) ||
+        hasFilteredEmptyUploadTrackerSelectionState({
+          trackerUploadItems,
+          releasePageTrackerSelection,
+          uploadToggles,
+          dupedTrackerSet,
+          ruleSkippedTrackerSet,
+          failedDupeTrackerSet,
+        }))
+    ) {
+      setError("Select at least one tracker before fetching metadata.");
+      return;
+    }
     metadataProgressTargetRef.current = targetPath;
     metadataProgressActiveRef.current = true;
     setMetadataProgressUpdates([]);
@@ -2035,7 +2107,7 @@ export default function App() {
         sourceLookupURL.trim(),
         normalizeOverrides(overrides),
         normalizeReleaseOverrides(nameOverrides),
-        getSelectedTrackers(),
+        selectedTrackers,
       );
       applyPreviewResult(result, { switchToInput: options.switchToInput });
       rememberSourcePath(
@@ -2128,6 +2200,22 @@ export default function App() {
       setError("Please select a file or folder.");
       return;
     }
+    const selectedTrackers = selectedUploadImageTrackers;
+    if (
+      selectedTrackers.length === 0 &&
+      (hasExplicitEmptyReleaseTrackerSelection(trackerUploadItems, releasePageTrackerSelection) ||
+        hasFilteredEmptyUploadTrackerSelectionState({
+          trackerUploadItems,
+          releasePageTrackerSelection,
+          uploadToggles,
+          dupedTrackerSet,
+          ruleSkippedTrackerSet,
+          failedDupeTrackerSet,
+        }))
+    ) {
+      setError("Select at least one tracker before resetting metadata.");
+      return;
+    }
     if (
       !globalThis.confirm(
         "Remove cached metadata and temporary files for this content, then refetch metadata?",
@@ -2144,13 +2232,7 @@ export default function App() {
     setLoading(true);
     setMetadataResetting(true);
     try {
-      const result = await resetter(
-        targetPath,
-        sourceLookupURL.trim(),
-        {},
-        {},
-        getSelectedTrackers(),
-      );
+      const result = await resetter(targetPath, sourceLookupURL.trim(), {}, {}, selectedTrackers);
       applyPreviewResult(result);
       setShowExternalIDInputUI(true);
     } catch (err) {
@@ -2158,8 +2240,8 @@ export default function App() {
     } finally {
       metadataProgressActiveRef.current = false;
       setMetadataProgressActive(false);
-      setMetadataResetting(false);
       setLoading(false);
+      setMetadataResetting(false);
     }
   };
 
@@ -2205,6 +2287,18 @@ export default function App() {
         setBuilderError("Please select a file or folder.");
         return;
       }
+      const selectedTrackers = selectedUploadImageTrackers;
+      if (
+        selectedTrackers.length === 0 &&
+        hasExplicitEmptyReleaseTrackerSelection(trackerUploadItems, releasePageTrackerSelection)
+      ) {
+        setBuilderError("Select at least one tracker before building descriptions.");
+        return;
+      }
+      if (selectedTrackers.length === 0) {
+        setBuilderError("Enable at least one tracker in Upload Targets.");
+        return;
+      }
       setBuilderLoading(true);
       setBuilderProgressMessage("Preparing metadata and tracker selection...");
       builderProgressTimers.current = [
@@ -2235,9 +2329,7 @@ export default function App() {
           path.trim(),
           normalizeOverrides(overrides),
           normalizeReleaseOverrides(nameOverrides),
-          Object.entries(releasePageTrackerSelection)
-            .filter(([, selected]) => selected)
-            .map(([name]) => name),
+          selectedTrackers,
           ignoredDupeTrackers,
         );
         setBuilderPreview(result);
@@ -2270,7 +2362,14 @@ export default function App() {
         setBuilderLoading(false);
       }
     },
-    [path, releasePageTrackerSelection, ignoredDupeTrackers, refreshUploadedImages],
+    [
+      path,
+      releasePageTrackerSelection,
+      trackerUploadItems,
+      selectedUploadImageTrackers,
+      ignoredDupeTrackers,
+      refreshUploadedImages,
+    ],
   );
 
   const refreshDescriptionBuilder = useCallback(async () => {
@@ -2451,12 +2550,27 @@ export default function App() {
     if (!path.trim()) {
       return;
     }
+    const selectedTrackers = selectedUploadImageTrackers;
+    if (
+      selectedTrackers.length === 0 &&
+      (hasExplicitEmptyReleaseTrackerSelection(trackerUploadItems, releasePageTrackerSelection) ||
+        hasFilteredEmptyUploadTrackerSelectionState({
+          trackerUploadItems,
+          releasePageTrackerSelection,
+          uploadToggles,
+          dupedTrackerSet,
+          ruleSkippedTrackerSet,
+          failedDupeTrackerSet,
+        }))
+    ) {
+      return;
+    }
     await fetcher(
       path.trim(),
       sourceLookupURL.trim(),
       normalizeOverrides(idOverrideState?.overrides || {}),
       normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-      getSelectedTrackers(),
+      selectedTrackers,
     );
   };
 
@@ -3018,6 +3132,14 @@ export default function App() {
       const next = { ...prev };
       trackerUploadItems.forEach((item) => {
         const normalized = item.name.toLowerCase();
+        const hasReleaseSelection = Object.prototype.hasOwnProperty.call(
+          releasePageTrackerSelection,
+          item.name,
+        );
+        if (hasReleaseSelection && !releasePageTrackerSelection[item.name]) {
+          delete next[item.name];
+          return;
+        }
         if (failedDupeTrackerSet.has(normalized)) {
           next[item.name] = false;
           return;
@@ -3028,11 +3150,24 @@ export default function App() {
         }
         if (next[item.name] === undefined) {
           // Prioritize release page selection, then fall back to defaults
-          if (releasePageTrackerSelection[item.name] !== undefined) {
+          if (hasReleaseSelection) {
             next[item.name] = releasePageTrackerSelection[item.name];
           } else {
             next[item.name] = defaultTrackerSet.has(normalized);
           }
+        }
+      });
+      const trackerNames = new Set(trackerUploadItems.map((item) => item.name));
+      Object.keys(next).forEach((name) => {
+        if (!trackerNames.has(name)) {
+          delete next[name];
+          return;
+        }
+        if (
+          Object.prototype.hasOwnProperty.call(releasePageTrackerSelection, name) &&
+          !releasePageTrackerSelection[name]
+        ) {
+          delete next[name];
         }
       });
       return next;
@@ -3107,12 +3242,8 @@ export default function App() {
     setTrackerDryRunProgress(null);
   }, [path]);
 
-  // NOTE: releasePageTrackerSelection is memory-only state tracking which trackers
-  // the user has selected for the current release on the input page.
-  // During final upload handling, use the trackers selected here combined with
-  // dupe-check filtering and any special rules (e.g., banned groups).
-
-  // Helper to get selected tracker names
+  // releasePageTrackerSelection is raw input-page state. Workflows that must
+  // honor upload eligibility use selectedUploadImageTrackers instead.
   const getSelectedTrackers = () => {
     return Object.entries(releasePageTrackerSelection)
       .filter(([, selected]) => selected)
@@ -3208,8 +3339,9 @@ export default function App() {
     }
     setTrackerUploadRunning(true);
     setTrackerUploadSnapshot(null);
+    let jobID = "";
     try {
-      const jobID = await starter(
+      jobID = await starter(
         path.trim(),
         normalizeOverrides(idOverrideState?.overrides || {}),
         normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
@@ -3221,14 +3353,19 @@ export default function App() {
         uploadSkipClientInjection,
         runLogLevel,
       );
-      setTrackerUploadJobID(jobID);
-      if (snapshotLoader) {
-        const snapshot = await snapshotLoader(jobID);
-        applyTrackerUploadSnapshot(snapshot);
-      }
     } catch (err) {
       setTrackerUploadRunning(false);
       setTrackerUploadError(String(err));
+      return;
+    }
+    setTrackerUploadJobID(jobID);
+    if (snapshotLoader) {
+      try {
+        const snapshot = await snapshotLoader(jobID);
+        applyTrackerUploadSnapshot(snapshot);
+      } catch {
+        // Events and polling continue tracking the started job when bootstrap refresh fails.
+      }
     }
   }, [
     path,
@@ -3402,16 +3539,23 @@ export default function App() {
       return;
     }
     setTrackerUploadRunning(true);
+    let nextJobID = "";
     try {
-      const nextJobID = await retry(trackerUploadJobID);
-      setTrackerUploadJobID(nextJobID);
-      if (snapshotLoader) {
-        const snapshot = await snapshotLoader(nextJobID);
-        applyTrackerUploadSnapshot(snapshot);
-      }
+      nextJobID = await retry(trackerUploadJobID);
     } catch (err) {
       setTrackerUploadRunning(false);
       setTrackerUploadError(String(err));
+      return;
+    }
+    setTrackerUploadJobID(nextJobID);
+    setTrackerUploadSnapshot(null);
+    if (snapshotLoader) {
+      try {
+        const snapshot = await snapshotLoader(nextJobID);
+        applyTrackerUploadSnapshot(snapshot);
+      } catch {
+        // Events and polling continue tracking the replacement job when bootstrap refresh fails.
+      }
     }
   }, [applyTrackerUploadSnapshot, trackerUploadJobID]);
 
@@ -3819,7 +3963,10 @@ export default function App() {
           {showPlaylistSelection ? (
             <PlaylistSelectionPage
               path={playlistSelectionPath}
-              onBack={() => setShowPlaylistSelection(false)}
+              onBack={() => {
+                setShowPlaylistSelection(false);
+                setPlaylistPreparationTrackerSnapshot(null);
+              }}
               onConfirm={handlePlaylistSelectionComplete}
               preparing={playlistAutoPreparing}
               progressLines={bdinfoProgressLines}

--- a/gui/frontend/src/utils/trackerSelection.test.ts
+++ b/gui/frontend/src/utils/trackerSelection.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, expect, it } from "vitest";
+import {
+  hasFilteredEmptyUploadTrackerSelection,
+  resolveSelectedUploadTrackers,
+} from "./trackerSelection";
+import type { TrackerUploadItem } from "../types";
+
+describe("resolveSelectedUploadTrackers", () => {
+  const trackerUploadItems: TrackerUploadItem[] = [
+    { name: "AITHER", config: {} },
+    { name: "BLU", config: {} },
+  ];
+
+  it("excludes stale upload toggles for trackers deselected on the input page", () => {
+    expect(
+      resolveSelectedUploadTrackers({
+        trackerUploadItems,
+        releasePageTrackerSelection: { AITHER: true, BLU: false },
+        uploadToggles: { AITHER: true, BLU: true },
+        dupedTrackerSet: new Set(),
+        ruleSkippedTrackerSet: new Set(),
+        failedDupeTrackerSet: new Set(),
+      }),
+    ).toEqual(["AITHER"]);
+  });
+
+  it("excludes blocked selected trackers", () => {
+    expect(
+      resolveSelectedUploadTrackers({
+        trackerUploadItems,
+        releasePageTrackerSelection: { AITHER: true, BLU: true },
+        uploadToggles: { AITHER: true, BLU: true },
+        dupedTrackerSet: new Set(["blu"]),
+        ruleSkippedTrackerSet: new Set(),
+        failedDupeTrackerSet: new Set(),
+      }),
+    ).toEqual(["AITHER"]);
+  });
+
+  it("detects explicit release selections filtered to no upload trackers", () => {
+    expect(
+      hasFilteredEmptyUploadTrackerSelection({
+        trackerUploadItems,
+        releasePageTrackerSelection: { AITHER: true, BLU: true },
+        uploadToggles: { AITHER: false, BLU: true },
+        dupedTrackerSet: new Set(["blu"]),
+        ruleSkippedTrackerSet: new Set(),
+        failedDupeTrackerSet: new Set(),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat uninitialized toggles or eligible trackers as filtered empty", () => {
+    expect(
+      hasFilteredEmptyUploadTrackerSelection({
+        trackerUploadItems,
+        releasePageTrackerSelection: { AITHER: true },
+        uploadToggles: {},
+        dupedTrackerSet: new Set(),
+        ruleSkippedTrackerSet: new Set(),
+        failedDupeTrackerSet: new Set(),
+      }),
+    ).toBe(false);
+
+    expect(
+      hasFilteredEmptyUploadTrackerSelection({
+        trackerUploadItems,
+        releasePageTrackerSelection: { AITHER: true, BLU: true },
+        uploadToggles: { AITHER: true, BLU: false },
+        dupedTrackerSet: new Set(),
+        ruleSkippedTrackerSet: new Set(),
+        failedDupeTrackerSet: new Set(),
+      }),
+    ).toBe(false);
+  });
+});

--- a/gui/frontend/src/utils/trackerSelection.ts
+++ b/gui/frontend/src/utils/trackerSelection.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import type { TrackerUploadItem } from "../types";
+
+type ResolveSelectedUploadTrackersInput = {
+  trackerUploadItems: TrackerUploadItem[];
+  releasePageTrackerSelection: Record<string, boolean>;
+  uploadToggles: Record<string, boolean>;
+  dupedTrackerSet: Set<string>;
+  ruleSkippedTrackerSet: Set<string>;
+  failedDupeTrackerSet: Set<string>;
+};
+
+const hasOwn = (value: Record<string, boolean>, key: string) =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+/**
+ * resolveSelectedUploadTrackers returns the trackers that may be sent to
+ * metadata, upload, dry-run, and image-upload requests.
+ *
+ * A tracker must still be selected on the input page, enabled on the upload page,
+ * configured in the current tracker list, and not blocked by dupe/rule failures.
+ * Blocked-tracker sets use lower-case trimmed tracker names; returned names keep
+ * the upload toggle keys used by the caller. Callers that pass the result to
+ * backend APIs where an empty tracker list means defaults must guard filtered-empty
+ * selections separately.
+ */
+export const resolveSelectedUploadTrackers = ({
+  trackerUploadItems,
+  releasePageTrackerSelection,
+  uploadToggles,
+  dupedTrackerSet,
+  ruleSkippedTrackerSet,
+  failedDupeTrackerSet,
+}: ResolveSelectedUploadTrackersInput) => {
+  const validTrackers = new Set(trackerUploadItems.map((item) => item.name));
+  return Object.entries(uploadToggles)
+    .filter(([name, enabled]) => {
+      if (!enabled) return false;
+      if (!validTrackers.has(name)) return false;
+      if (!releasePageTrackerSelection[name]) return false;
+      const normalized = name.toLowerCase().trim();
+      if (!normalized) return false;
+      if (dupedTrackerSet.has(normalized)) return false;
+      if (ruleSkippedTrackerSet.has(normalized)) return false;
+      if (failedDupeTrackerSet.has(normalized)) return false;
+      return true;
+    })
+    .map(([name]) => name);
+};
+
+/**
+ * hasFilteredEmptyUploadTrackerSelection returns true when the release page has
+ * at least one explicit selected tracker, but upload eligibility filters remove
+ * every selected tracker before the backend call.
+ *
+ * Missing upload toggle keys are treated as startup/uninitialized state, while
+ * disabled toggles and dupe/rule-failure blocks count as upload filters.
+ */
+export const hasFilteredEmptyUploadTrackerSelection = ({
+  trackerUploadItems,
+  releasePageTrackerSelection,
+  uploadToggles,
+  dupedTrackerSet,
+  ruleSkippedTrackerSet,
+  failedDupeTrackerSet,
+}: ResolveSelectedUploadTrackersInput) => {
+  const selectedReleaseTrackers = trackerUploadItems.filter(
+    (item) => releasePageTrackerSelection[item.name] === true,
+  );
+  if (selectedReleaseTrackers.length === 0) {
+    return false;
+  }
+  return selectedReleaseTrackers.every((item) => {
+    const normalized = item.name.toLowerCase().trim();
+    if (!normalized) return true;
+    if (!hasOwn(uploadToggles, item.name)) return false;
+    if (!uploadToggles[item.name]) return true;
+    if (dupedTrackerSet.has(normalized)) return true;
+    if (ruleSkippedTrackerSet.has(normalized)) return true;
+    if (failedDupeTrackerSet.has(normalized)) return true;
+    return false;
+  });
+};

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -300,7 +300,7 @@ func (c *Core) executePreparedUpload(ctx context.Context, req api.Request, meta 
 			return 0, fmt.Errorf("context canceled: %w", ctx.Err())
 		default:
 		}
-		if err := c.repo.Save(ctx, db.FileMetadata{Path: meta.SourcePath, InfoHash: torrent.InfoHash, UpdatedAt: time.Now().UTC()}); err != nil {
+		if err := c.persistPreparedInfoHash(ctx, meta.SourcePath, torrent.InfoHash); err != nil {
 			return 0, fmt.Errorf("metadata: persist info hash: %w", err)
 		}
 	}
@@ -363,6 +363,33 @@ func (c *Core) executePreparedUpload(ctx context.Context, req api.Request, meta 
 	}
 
 	return summary.Uploaded, nil
+}
+
+func (c *Core) persistPreparedInfoHash(ctx context.Context, sourcePath string, infoHash string) error {
+	if c == nil || c.repo == nil {
+		return nil
+	}
+	trimmedPath := strings.TrimSpace(sourcePath)
+	trimmedHash := strings.TrimSpace(infoHash)
+	if trimmedPath == "" || trimmedHash == "" {
+		return nil
+	}
+
+	metadata, err := c.repo.GetByPath(ctx, trimmedPath)
+	if err != nil {
+		if !errors.Is(err, internalerrors.ErrNotFound) {
+			return fmt.Errorf("lookup existing metadata: %w", err)
+		}
+		metadata = db.FileMetadata{Path: trimmedPath}
+	} else if strings.TrimSpace(metadata.Path) == "" {
+		metadata.Path = trimmedPath
+	}
+	metadata.InfoHash = trimmedHash
+	metadata.UpdatedAt = time.Now().UTC()
+	if err := c.repo.Save(ctx, metadata); err != nil {
+		return fmt.Errorf("save metadata: %w", err)
+	}
+	return nil
 }
 
 func (c *Core) injectCrossSeedTorrents(ctx context.Context, req api.Request, meta api.PreparedMetadata) error {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -193,6 +193,9 @@ func (c *Core) RunUpload(ctx context.Context, req api.Request) (api.Result, erro
 	return c.RunUploadPrepared(ctx, req)
 }
 
+// RunUploadPrepared uploads from cached prepared metadata for each requested path.
+// Explicit tracker selections that resolve empty return without tracker upload
+// side effects, while omitted tracker selections retain configured default behavior.
 func (c *Core) RunUploadPrepared(ctx context.Context, req api.Request) (api.Result, error) {
 	req = normalizeExecutionRequest(req)
 	resolvedReq, err := c.resolveDescriptionOverrideRequest(ctx, req)
@@ -272,6 +275,11 @@ func (c *Core) executePreparedUpload(ctx context.Context, req api.Request, meta 
 	if err != nil {
 		return 0, err
 	}
+	if _, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, meta.TrackersRemove, c.logger, false, false); explicitEmpty {
+		c.logger.Debugf("core: upload prepared explicit trackers resolved empty source=%s", meta.SourcePath)
+		return 0, nil
+	}
+
 	descriptionGroups, err := c.resolveCanonicalDescriptionGroups(ctx, meta, req)
 	if err != nil {
 		return 0, err
@@ -467,9 +475,6 @@ func (c *Core) CheckDupes(ctx context.Context, req api.Request) (api.DupeCheckSu
 			matchedTrackers := mergeTrackerRemovals(nil, cached.MatchedTrackers)
 			removeTrackers := mergeTrackerRemovals(req.TrackersRemove, matchedTrackers)
 			resolvedTrackers := trackers.ResolveTrackers(c.cfg, req.Trackers, removeTrackers, c.logger)
-			if req.Mode == api.ModeGUI {
-				resolvedTrackers = trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, removeTrackers, c.logger)
-			}
 			summary, err := c.services.Dupes.Check(ctx, cached, resolvedTrackers)
 			if err != nil {
 				return api.DupeCheckSummary{}, fmt.Errorf("core: %w", err)
@@ -1191,6 +1196,8 @@ func (c *Core) resolveImageUploadTargets(req api.Request, meta api.PreparedMetad
 	return normalized, nil
 }
 
+// filterImageUploadTrackers returns canonical tracker names that can receive
+// tracker-scoped image uploads, excluding blocked, rule-failed, or already matched trackers.
 func (c *Core) filterImageUploadTrackers(trackerNames []string, meta api.PreparedMetadata) []string {
 	filtered := make([]string, 0, len(trackerNames))
 	for _, tracker := range trackerNames {
@@ -1653,6 +1660,10 @@ func (c *Core) DeleteUploadedImage(ctx context.Context, req api.Request, imagePa
 	return wrapCoreError(c.repo.DeleteUploadedImage(ctx, uniquePaths[0], imagePath, host))
 }
 
+// FetchMetadataPreview prepares and enriches metadata for one validated source path,
+// emits metadata progress, and stores the refreshed prepared metadata cache entry.
+// An empty tracker request is not an explicit "no trackers" request; downstream
+// tracker resolution can still use configured defaults.
 func (c *Core) FetchMetadataPreview(ctx context.Context, req api.Request) (api.MetadataPreview, error) {
 	req = normalizeExecutionRequest(req)
 	if len(req.Paths) == 0 {
@@ -1861,6 +1872,9 @@ func (c *Core) FetchMetadataPreview(ctx context.Context, req api.Request) (api.M
 	return buildMetadataPreview(meta, c.cfg), nil
 }
 
+// FetchPreparationPreview builds the tracker preparation preview for one validated
+// source path. Explicit tracker selections include configured defaults unless all
+// selected trackers resolve as removed, which returns an empty preview.
 func (c *Core) FetchPreparationPreview(ctx context.Context, req api.Request) (api.PreparationPreview, error) {
 	resolvedReq, err := c.resolveDescriptionOverrideRequest(ctx, req)
 	if err != nil {
@@ -1901,7 +1915,11 @@ func (c *Core) FetchPreparationPreview(ctx context.Context, req api.Request) (ap
 		if cached, ok, err := c.resolveGUICachedPreparedMeta(ctx, req, uniquePaths[0]); err != nil {
 			return api.PreparationPreview{}, err
 		} else if ok {
-			resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, cached.TrackersRemove, c.logger)
+			resolvedTrackers, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, requestPreparedMetaTrackersRemove(cached, req), c.logger, true, false)
+			if explicitEmpty {
+				c.logger.Debugf("core: preparation explicit trackers resolved empty source=%s", cached.SourcePath)
+				return api.PreparationPreview{SourcePath: cached.SourcePath}, nil
+			}
 			c.logger.Debugf("core: preparation resolved trackers %v", resolvedTrackers)
 			return wrapCoreResult(c.services.Trackers.BuildPreparation(ctx, cached, resolvedTrackers))
 		}
@@ -1923,15 +1941,21 @@ func (c *Core) FetchPreparationPreview(ctx context.Context, req api.Request) (ap
 		return api.PreparationPreview{}, fmt.Errorf("core: %w", err)
 	}
 	meta = applyRequestToPreparedMeta(meta, singleReq, c.cfg, c.logger)
+
+	resolvedTrackers, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, meta.TrackersRemove, c.logger, true, false)
+	if explicitEmpty {
+		c.logger.Debugf("core: preparation explicit trackers resolved empty after prepare source=%s", meta.SourcePath)
+		return api.PreparationPreview{SourcePath: meta.SourcePath}, nil
+	}
 	if req.Mode == api.ModeGUI {
 		c.storeDupeCache(meta.SourcePath, overrideSignature(meta.ExternalIDOverrides, meta.ReleaseNameOverrides, meta.MetadataOverrides, meta.TrackerConfigOverrides, meta.TrackerSiteOverrides, meta.ClientOverrides, meta.TorrentOverrides, meta.ImageHostOverrides, meta.ScreenshotOverrides), meta)
 	}
-
-	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, meta.TrackersRemove, c.logger)
 	c.logger.Debugf("core: preparation resolved trackers %v", resolvedTrackers)
 	return wrapCoreResult(c.services.Trackers.BuildPreparation(ctx, meta, resolvedTrackers))
 }
 
+// FetchTrackerDryRunPreview builds per-tracker dry-run upload entries from cached
+// prepared metadata, creating torrents and cache state only after selected trackers resolve.
 func (c *Core) FetchTrackerDryRunPreview(ctx context.Context, req api.Request) (api.TrackerDryRunPreview, error) {
 	req = normalizeExecutionRequest(req)
 	resolvedReq, err := c.resolveDescriptionOverrideRequest(ctx, req)
@@ -1991,13 +2015,29 @@ func (c *Core) FetchTrackerDryRunPreview(ctx context.Context, req api.Request) (
 	signature := overrideSignature(singleReq.ExternalIDOverrides, singleReq.ReleaseNameOverrides, singleReq.MetadataOverrides, singleReq.TrackerConfigOverrides, singleReq.TrackerSiteOverrides, singleReq.ClientOverrides, singleReq.TorrentOverrides, singleReq.ImageHostOverrides, singleReq.ScreenshotOverrides)
 	meta, ok := c.getDupeCache(uniquePaths[0], signature)
 	if req.Mode == api.ModeGUI {
-		meta, ok, err = c.resolveGUICachedPreparedMeta(ctx, singleReq, uniquePaths[0])
-		if err != nil {
-			return api.TrackerDryRunPreview{}, err
+		entry, _, found := c.lookupGUICachedMetaEntry(singleReq, uniquePaths[0])
+		if found {
+			ok = true
+			if _, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, requestPreparedMetaTrackersRemove(entry.meta, singleReq), c.logger, false, false); explicitEmpty {
+				c.logger.Debugf("core: tracker dry-run explicit trackers resolved empty source=%s", entry.meta.SourcePath)
+				return api.TrackerDryRunPreview{SourcePath: entry.meta.SourcePath, Trackers: []api.TrackerDryRunEntry{}}, nil
+			}
+			if entry.requestRefreshed && cachedPreparedMetaMatchesRequest(entry.meta, singleReq, uniquePaths[0]) {
+				meta = deepCopyPreparedMetadata(entry.meta)
+			} else {
+				meta, err = c.applyRequestToCachedPreparedMeta(ctx, entry.meta, singleReq)
+				if err != nil {
+					return api.TrackerDryRunPreview{}, err
+				}
+			}
 		}
 	} else {
 		if !ok {
 			return api.TrackerDryRunPreview{}, fmt.Errorf("core: tracker dry-run requires prepared metadata for %s", uniquePaths[0])
+		}
+		if _, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, requestPreparedMetaTrackersRemove(meta, singleReq), c.logger, false, false); explicitEmpty {
+			c.logger.Debugf("core: tracker dry-run explicit trackers resolved empty source=%s", meta.SourcePath)
+			return api.TrackerDryRunPreview{SourcePath: meta.SourcePath, Trackers: []api.TrackerDryRunEntry{}}, nil
 		}
 		meta, err = c.applyRequestToCachedPreparedMeta(ctx, meta, singleReq)
 		if err != nil {
@@ -2008,6 +2048,11 @@ func (c *Core) FetchTrackerDryRunPreview(ctx context.Context, req api.Request) (
 		return api.TrackerDryRunPreview{}, fmt.Errorf("core: tracker dry-run requires prepared metadata for %s", uniquePaths[0])
 	}
 	c.logger.Debugf("core: tracker dry-run using cached prepared metadata for %s meta_no_seed=%t req_no_seed=%t", uniquePaths[0], meta.Options.NoSeed, singleReq.Options.NoSeed)
+	resolvedTrackers, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, meta.TrackersRemove, c.logger, false, false)
+	if explicitEmpty {
+		c.logger.Debugf("core: tracker dry-run explicit trackers resolved empty source=%s", meta.SourcePath)
+		return api.TrackerDryRunPreview{SourcePath: meta.SourcePath, Trackers: []api.TrackerDryRunEntry{}}, nil
+	}
 	descriptionGroups, err := c.resolveCanonicalDescriptionGroups(ctx, meta, singleReq)
 	if err != nil {
 		return api.TrackerDryRunPreview{}, err
@@ -2020,7 +2065,6 @@ func (c *Core) FetchTrackerDryRunPreview(ctx context.Context, req api.Request) (
 	}
 	meta.TorrentPath = torrent.Path
 
-	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, meta.TrackersRemove, c.logger)
 	entries, err := c.services.Trackers.BuildUploadDryRun(ctx, meta, resolvedTrackers)
 	if err != nil {
 		return api.TrackerDryRunPreview{}, fmt.Errorf("core: %w", err)
@@ -2131,6 +2175,9 @@ func annotateDryRunReleaseNames(meta api.PreparedMetadata, entries []api.Tracker
 	}
 }
 
+// FetchDescriptionBuilderPreview builds editable description groups from cached
+// or freshly prepared metadata. Explicit tracker selections that resolve empty
+// return an empty preview instead of falling back to configured defaults.
 func (c *Core) FetchDescriptionBuilderPreview(ctx context.Context, req api.Request) (api.DescriptionBuilderPreview, error) {
 	resolvedReq, err := c.resolveDescriptionOverrideRequest(ctx, req)
 	if err != nil {
@@ -2183,6 +2230,7 @@ func (c *Core) FetchDescriptionBuilderPreview(ctx context.Context, req api.Reque
 	}
 
 	var meta api.PreparedMetadata
+	storePreparedCache := false
 	if req.Mode == api.ModeGUI {
 		if cached, ok, err := c.resolveGUICachedPreparedMeta(ctx, req, uniquePaths[0]); err != nil {
 			return api.DescriptionBuilderPreview{}, err
@@ -2232,16 +2280,21 @@ func (c *Core) FetchDescriptionBuilderPreview(ctx context.Context, req api.Reque
 			return api.DescriptionBuilderPreview{}, fmt.Errorf("core: %w", err)
 		}
 		meta = applyRequestToPreparedMeta(meta, singleReq, c.cfg, c.logger)
-		if req.Mode == api.ModeGUI {
-			c.storeDupeCache(meta.SourcePath, overrideSignature(meta.ExternalIDOverrides, meta.ReleaseNameOverrides, meta.MetadataOverrides, meta.TrackerConfigOverrides, meta.TrackerSiteOverrides, meta.ClientOverrides, meta.TorrentOverrides, meta.ImageHostOverrides, meta.ScreenshotOverrides), meta)
-		}
+		storePreparedCache = req.Mode == api.ModeGUI
+	}
+	resolvedTrackers, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, meta.TrackersRemove, c.logger, true, false)
+	if explicitEmpty {
+		c.logger.Debugf("core: description builder explicit trackers resolved empty source=%s", meta.SourcePath)
+		return api.DescriptionBuilderPreview{SourcePath: meta.SourcePath}, nil
+	}
+	if storePreparedCache {
+		c.storeDupeCache(meta.SourcePath, overrideSignature(meta.ExternalIDOverrides, meta.ReleaseNameOverrides, meta.MetadataOverrides, meta.TrackerConfigOverrides, meta.TrackerSiteOverrides, meta.ClientOverrides, meta.TorrentOverrides, meta.ImageHostOverrides, meta.ScreenshotOverrides), meta)
 	}
 	meta, err = c.ensureDescriptionBuilderMetadata(ctx, req, uniquePaths[0], meta)
 	if err != nil {
 		return api.DescriptionBuilderPreview{}, err
 	}
 
-	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, meta.TrackersRemove, c.logger)
 	prep, err := c.services.Trackers.BuildPreparation(ctx, meta, resolvedTrackers)
 	if err != nil {
 		c.logger.Errorf("core: description builder preparation failed source=%s: %v", meta.SourcePath, err)
@@ -2350,6 +2403,8 @@ func normalizeDescriptionBuilderGroupKey(groupKey string, trackersList []string)
 	return normalized
 }
 
+// FetchDescriptionBuilderGroupPreview rebuilds one description group from cached
+// or freshly prepared metadata while honoring tracker removals from the request.
 func (c *Core) FetchDescriptionBuilderGroupPreview(ctx context.Context, req api.Request) (api.DescriptionBuilderGroup, error) {
 	targetGroup := strings.TrimSpace(req.DescriptionOverrideGroup)
 	if targetGroup == "" && len(req.Trackers) > 0 {
@@ -2409,6 +2464,7 @@ func (c *Core) FetchDescriptionBuilderGroupPreview(ctx context.Context, req api.
 	}
 
 	var meta api.PreparedMetadata
+	storePreparedCache := false
 	if req.Mode == api.ModeGUI {
 		if cached, ok, err := c.resolveGUICachedPreparedMeta(ctx, req, uniquePaths[0]); err != nil {
 			return api.DescriptionBuilderGroup{}, err
@@ -2442,19 +2498,20 @@ func (c *Core) FetchDescriptionBuilderGroupPreview(ctx context.Context, req api.
 			return api.DescriptionBuilderGroup{}, fmt.Errorf("core: %w", err)
 		}
 		meta = applyRequestToPreparedMeta(meta, singleReq, c.cfg, c.logger)
-		if req.Mode == api.ModeGUI {
-			c.storeDupeCache(meta.SourcePath, overrideSignature(meta.ExternalIDOverrides, meta.ReleaseNameOverrides, meta.MetadataOverrides, meta.TrackerConfigOverrides, meta.TrackerSiteOverrides, meta.ClientOverrides, meta.TorrentOverrides, meta.ImageHostOverrides, meta.ScreenshotOverrides), meta)
-		}
+		storePreparedCache = req.Mode == api.ModeGUI
+	}
+	resolvedTrackers, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, meta.TrackersRemove, c.logger, false, false)
+	if explicitEmpty {
+		return api.DescriptionBuilderGroup{}, nil
+	}
+	if storePreparedCache {
+		c.storeDupeCache(meta.SourcePath, overrideSignature(meta.ExternalIDOverrides, meta.ReleaseNameOverrides, meta.MetadataOverrides, meta.TrackerConfigOverrides, meta.TrackerSiteOverrides, meta.ClientOverrides, meta.TorrentOverrides, meta.ImageHostOverrides, meta.ScreenshotOverrides), meta)
 	}
 	meta, err = c.ensureDescriptionBuilderMetadata(ctx, req, uniquePaths[0], meta)
 	if err != nil {
 		return api.DescriptionBuilderGroup{}, err
 	}
 
-	resolvedTrackers := req.Trackers
-	if len(resolvedTrackers) == 0 {
-		resolvedTrackers = trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, meta.TrackersRemove, c.logger)
-	}
 	prep, err := c.services.Trackers.BuildPreparation(ctx, meta, resolvedTrackers)
 	if err != nil {
 		return api.DescriptionBuilderGroup{}, fmt.Errorf("core: %w", err)
@@ -2463,8 +2520,8 @@ func (c *Core) FetchDescriptionBuilderGroupPreview(ctx context.Context, req api.
 		normalizedGroupKey := normalizeDescriptionBuilderGroupKey(entry.GroupKey, entry.Trackers)
 		if strings.EqualFold(normalizedGroupKey, targetGroup) {
 			group := buildDescriptionBuilderGroup(entry, overrideByGroup, meta, c.logger)
-			if len(group.Trackers) == 0 && len(req.Trackers) > 0 {
-				group.Trackers = append([]string{}, req.Trackers...)
+			if len(group.Trackers) == 0 && len(resolvedTrackers) > 0 {
+				group.Trackers = append([]string{}, resolvedTrackers...)
 			}
 			return group, nil
 		}
@@ -2869,6 +2926,7 @@ func cachedPreparedMetaMatchesRequest(meta api.PreparedMetadata, req api.Request
 		reflect.DeepEqual(meta.ScreenshotOverrides, req.ScreenshotOverrides) &&
 		reflect.DeepEqual(meta.TorrentOverrides, req.TorrentOverrides) &&
 		meta.IgnoreTrackerRuleFailures == req.IgnoreTrackerRuleFailures &&
+		len(req.IgnoreDupesFor) == 0 &&
 		reflect.DeepEqual(meta.ExternalIDOverrides, mergedOverrides) &&
 		reflect.DeepEqual(meta.ReleaseNameOverrides, req.ReleaseNameOverrides) &&
 		sameQuestionnaireAnswers(meta.TrackerQuestionnaireAnswers, req.TrackerQuestionnaireAnswers) &&
@@ -2879,15 +2937,75 @@ func requestedTrackersApplied(metaTrackers []string, requested []string) bool {
 	if len(requested) == 0 {
 		return true
 	}
-	if len(metaTrackers) != len(requested) {
+	return sameTrackerSet(metaTrackers, requested)
+}
+
+func sameTrackerSet(left []string, right []string) bool {
+	leftCounts, leftTotal := trackerNameCounts(left)
+	rightCounts, rightTotal := trackerNameCounts(right)
+	if leftTotal != rightTotal {
 		return false
 	}
-	for idx, tracker := range requested {
-		if !strings.EqualFold(strings.TrimSpace(metaTrackers[idx]), strings.TrimSpace(tracker)) {
+	if len(leftCounts) != len(rightCounts) {
+		return false
+	}
+	for name, count := range leftCounts {
+		if rightCounts[name] != count {
 			return false
 		}
 	}
 	return true
+}
+
+func trackerNameCounts(trackers []string) (map[string]int, int) {
+	counts := make(map[string]int, len(trackers))
+	total := 0
+	for _, tracker := range trackers {
+		name := strings.ToUpper(strings.TrimSpace(tracker))
+		if name == "" {
+			continue
+		}
+		counts[name]++
+		total++
+	}
+	return counts, total
+}
+
+// explicitTrackerSelectionResolvedEmpty reports whether a non-empty requested
+// tracker set was fully removed by tracker resolution.
+func explicitTrackerSelectionResolvedEmpty(requested []string, resolved []string) bool {
+	return len(requested) > 0 && len(resolved) == 0
+}
+
+// resolveTrackersPreservingExplicitEmpty resolves requested trackers while
+// preserving the difference between an omitted selection and an explicit
+// selection that was fully removed.
+//
+// includeDefaults adds configured defaults to non-empty explicit selections.
+// fallbackDefaultsWhenExplicitEmpty controls whether a removed explicit
+// selection may fall back to defaults instead of returning explicitEmpty.
+func resolveTrackersPreservingExplicitEmpty(
+	cfg config.Config,
+	requested []string,
+	remove []string,
+	logger api.Logger,
+	includeDefaults bool,
+	fallbackDefaultsWhenExplicitEmpty bool,
+) ([]string, bool) {
+	resolved := trackers.ResolveTrackers(cfg, requested, remove, logger)
+	if explicitTrackerSelectionResolvedEmpty(requested, resolved) {
+		if includeDefaults && fallbackDefaultsWhenExplicitEmpty {
+			defaults := trackers.ResolveTrackers(cfg, nil, remove, logger)
+			if len(defaults) > 0 {
+				return defaults, false
+			}
+		}
+		return nil, true
+	}
+	if includeDefaults && len(requested) > 0 {
+		return trackers.ResolveTrackersWithDefaults(cfg, requested, remove, logger), false
+	}
+	return resolved, false
 }
 
 func requestedTrackersRemoveApplied(metaTrackersRemove []string, requested []string) bool {
@@ -4369,6 +4487,15 @@ func mergeTrackerRemovals(existing []string, additions []string) []string {
 	return merged
 }
 
+// requestPreparedMetaTrackersRemove returns the removal set that should be used
+// for pre-application explicit-empty checks. Request dupe bypasses are applied
+// first so ignored or skipped matched trackers can still resolve when selected.
+func requestPreparedMetaTrackersRemove(meta api.PreparedMetadata, req api.Request) []string {
+	metaRemove, matched := duplicateTrackerStateForRequest(meta, req)
+	remove := mergeTrackerRemovals(req.TrackersRemove, metaRemove)
+	return mergeTrackerRemovals(remove, matched)
+}
+
 func normalizeExecutionRequest(req api.Request) api.Request {
 	if req.Execution.SiteCheck {
 		req.Options.DryRun = true
@@ -4379,6 +4506,9 @@ func normalizeExecutionRequest(req api.Request) api.Request {
 	return req
 }
 
+// resolveCanonicalDescriptionGroups returns request or cached description groups
+// before rebuilding groups from tracker preparation for the resolved tracker set.
+// Explicit tracker selections that resolve empty do not fall back to defaults.
 func (c *Core) resolveCanonicalDescriptionGroups(ctx context.Context, meta api.PreparedMetadata, req api.Request) ([]api.DescriptionBuilderGroup, error) {
 	if len(req.DescriptionGroups) > 0 {
 		return api.CloneDescriptionBuilderGroups(req.DescriptionGroups), nil
@@ -4390,7 +4520,10 @@ func (c *Core) resolveCanonicalDescriptionGroups(ctx context.Context, meta api.P
 		return nil, errors.New("core: tracker service not configured")
 	}
 
-	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, req.Trackers, meta.TrackersRemove, c.logger)
+	resolvedTrackers, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, meta.TrackersRemove, c.logger, false, false)
+	if explicitEmpty {
+		return nil, nil
+	}
 	prep, err := c.services.Trackers.BuildPreparation(ctx, meta, resolvedTrackers)
 	if err != nil {
 		return nil, fmt.Errorf("core: %w", err)

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -365,6 +365,8 @@ func (c *Core) executePreparedUpload(ctx context.Context, req api.Request, meta 
 	return summary.Uploaded, nil
 }
 
+// persistPreparedInfoHash stores the prepared torrent hash without replacing
+// existing release metadata used by history views.
 func (c *Core) persistPreparedInfoHash(ctx context.Context, sourcePath string, infoHash string) error {
 	if c == nil || c.repo == nil {
 		return nil

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -1873,8 +1873,8 @@ func (c *Core) FetchMetadataPreview(ctx context.Context, req api.Request) (api.M
 }
 
 // FetchPreparationPreview builds the tracker preparation preview for one validated
-// source path. Explicit tracker selections include configured defaults unless all
-// selected trackers resolve as removed, which returns an empty preview.
+// source path. Explicit tracker selections limit preparation to those trackers;
+// selections that resolve empty return an empty preview.
 func (c *Core) FetchPreparationPreview(ctx context.Context, req api.Request) (api.PreparationPreview, error) {
 	resolvedReq, err := c.resolveDescriptionOverrideRequest(ctx, req)
 	if err != nil {
@@ -1915,7 +1915,7 @@ func (c *Core) FetchPreparationPreview(ctx context.Context, req api.Request) (ap
 		if cached, ok, err := c.resolveGUICachedPreparedMeta(ctx, req, uniquePaths[0]); err != nil {
 			return api.PreparationPreview{}, err
 		} else if ok {
-			resolvedTrackers, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, requestPreparedMetaTrackersRemove(cached, req), c.logger, true, false)
+			resolvedTrackers, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, requestPreparedMetaTrackersRemove(cached, req), c.logger, false, false)
 			if explicitEmpty {
 				c.logger.Debugf("core: preparation explicit trackers resolved empty source=%s", cached.SourcePath)
 				return api.PreparationPreview{SourcePath: cached.SourcePath}, nil
@@ -1942,7 +1942,7 @@ func (c *Core) FetchPreparationPreview(ctx context.Context, req api.Request) (ap
 	}
 	meta = applyRequestToPreparedMeta(meta, singleReq, c.cfg, c.logger)
 
-	resolvedTrackers, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, meta.TrackersRemove, c.logger, true, false)
+	resolvedTrackers, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, meta.TrackersRemove, c.logger, false, false)
 	if explicitEmpty {
 		c.logger.Debugf("core: preparation explicit trackers resolved empty after prepare source=%s", meta.SourcePath)
 		return api.PreparationPreview{SourcePath: meta.SourcePath}, nil
@@ -2176,8 +2176,9 @@ func annotateDryRunReleaseNames(meta api.PreparedMetadata, entries []api.Tracker
 }
 
 // FetchDescriptionBuilderPreview builds editable description groups from cached
-// or freshly prepared metadata. Explicit tracker selections that resolve empty
-// return an empty preview instead of falling back to configured defaults.
+// or freshly prepared metadata. When request trackers are provided, only that
+// selected set contributes groups; selections that resolve empty return an empty
+// preview instead of falling back to configured defaults.
 func (c *Core) FetchDescriptionBuilderPreview(ctx context.Context, req api.Request) (api.DescriptionBuilderPreview, error) {
 	resolvedReq, err := c.resolveDescriptionOverrideRequest(ctx, req)
 	if err != nil {
@@ -2282,7 +2283,7 @@ func (c *Core) FetchDescriptionBuilderPreview(ctx context.Context, req api.Reque
 		meta = applyRequestToPreparedMeta(meta, singleReq, c.cfg, c.logger)
 		storePreparedCache = req.Mode == api.ModeGUI
 	}
-	resolvedTrackers, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, meta.TrackersRemove, c.logger, true, false)
+	resolvedTrackers, explicitEmpty := resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, meta.TrackersRemove, c.logger, false, false)
 	if explicitEmpty {
 		c.logger.Debugf("core: description builder explicit trackers resolved empty source=%s", meta.SourcePath)
 		return api.DescriptionBuilderPreview{SourcePath: meta.SourcePath}, nil
@@ -2404,7 +2405,8 @@ func normalizeDescriptionBuilderGroupKey(groupKey string, trackersList []string)
 }
 
 // FetchDescriptionBuilderGroupPreview rebuilds one description group from cached
-// or freshly prepared metadata while honoring tracker removals from the request.
+// or freshly prepared metadata. Request trackers limit the rebuild to the
+// selected set while tracker removals still suppress removed selections.
 func (c *Core) FetchDescriptionBuilderGroupPreview(ctx context.Context, req api.Request) (api.DescriptionBuilderGroup, error) {
 	targetGroup := strings.TrimSpace(req.DescriptionOverrideGroup)
 	if targetGroup == "" && len(req.Trackers) > 0 {
@@ -4507,8 +4509,9 @@ func normalizeExecutionRequest(req api.Request) api.Request {
 }
 
 // resolveCanonicalDescriptionGroups returns request or cached description groups
-// before rebuilding groups from tracker preparation for the resolved tracker set.
-// Explicit tracker selections that resolve empty do not fall back to defaults.
+// before rebuilding groups from tracker preparation for the selected tracker set.
+// Explicit tracker selections constrain the rebuild and do not fall back to
+// configured defaults when they resolve empty.
 func (c *Core) resolveCanonicalDescriptionGroups(ctx context.Context, meta api.PreparedMetadata, req api.Request) ([]api.DescriptionBuilderGroup, error) {
 	if len(req.DescriptionGroups) > 0 {
 		return api.CloneDescriptionBuilderGroups(req.DescriptionGroups), nil

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -2536,6 +2536,46 @@ func TestRunUploadPreparedUsesCachedMetadata(t *testing.T) {
 	}
 }
 
+func TestRunUploadPreparedUsesOnlySelectedTrackers(t *testing.T) {
+	t.Parallel()
+
+	tracker := &stubTrackers{}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{
+			MainSettings:       config.MainSettingsConfig{TMDBAPI: "x"},
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+			Trackers:           config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+		},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   tracker,
+		},
+		Repository: dryRunPreviewRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	core.storeDupeCache("/tmp/a", "", api.PreparedMetadata{SourcePath: "/tmp/a", Trackers: []string{"BLU", "AITHER"}})
+
+	result, err := core.RunUploadPrepared(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("run upload prepared: %v", err)
+	}
+	if result.UploadedCount != 1 {
+		t.Fatalf("expected 1 upload, got %d", result.UploadedCount)
+	}
+	if !reflect.DeepEqual(tracker.lastMeta.Trackers, []string{"AITHER"}) {
+		t.Fatalf("expected only selected tracker in upload metadata, got %v", tracker.lastMeta.Trackers)
+	}
+}
+
 func TestRunUploadPreparedInjectsEachUploadedTrackerURL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -1851,6 +1851,58 @@ func TestRunUploadPersistsInfoHash(t *testing.T) {
 	}
 }
 
+func TestRunUploadPersistsInfoHashWithoutClearingHistoryMetadata(t *testing.T) {
+	t.Parallel()
+
+	repo := &recordingRepo{
+		existing: db.FileMetadata{
+			Path:       "/tmp/a",
+			Title:      "Fixture Title",
+			Source:     "BluRay",
+			Resolution: "1080p",
+			Year:       2026,
+		},
+	}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Torrents:   &stubTorrentWithHash{hash: "hash123"},
+			Clients:    &stubClient{},
+			Trackers:   &stubTrackers{},
+		},
+		Repository: repo,
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	core.storeDupeCache("/tmp/a", "", api.PreparedMetadata{SourcePath: "/tmp/a"})
+
+	_, err = core.RunUpload(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeCLI,
+	})
+	if err != nil {
+		t.Fatalf("run upload: %v", err)
+	}
+	if len(repo.saved) != 1 {
+		t.Fatalf("expected 1 metadata save, got %d", len(repo.saved))
+	}
+	if repo.saved[0].InfoHash != "hash123" {
+		t.Fatalf("expected info hash saved, got %q", repo.saved[0].InfoHash)
+	}
+	if repo.saved[0].Title != "Fixture Title" {
+		t.Fatalf("expected release title preserved, got %q", repo.saved[0].Title)
+	}
+	if repo.saved[0].Source != "BluRay" {
+		t.Fatalf("expected release source preserved, got %q", repo.saved[0].Source)
+	}
+	if repo.saved[0].Resolution != "1080p" {
+		t.Fatalf("expected release resolution preserved, got %q", repo.saved[0].Resolution)
+	}
+}
+
 func TestExportGUICachedPreparedMetaExactSignature(t *testing.T) {
 	t.Parallel()
 
@@ -3502,12 +3554,20 @@ func (trackerRepo) ListTrackerMetadataByPath(context.Context, string) ([]db.Trac
 
 type recordingRepo struct {
 	saved       []db.FileMetadata
+	existing    db.FileMetadata
+	getErr      error
 	purgeCalls  int
 	purgedPaths []string
 }
 
 func (r *recordingRepo) GetByPath(context.Context, string) (db.FileMetadata, error) {
-	return db.FileMetadata{}, internalerrors.ErrNotImplemented
+	if r.getErr != nil {
+		return db.FileMetadata{}, r.getErr
+	}
+	if strings.TrimSpace(r.existing.Path) != "" {
+		return r.existing, nil
+	}
+	return db.FileMetadata{}, internalerrors.ErrNotFound
 }
 
 func (r *recordingRepo) Save(_ context.Context, metadata db.FileMetadata) error {

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -395,6 +396,80 @@ func TestResolveGUICachedPreparedMetaTreatsResolvedTrackerDataAsCacheMatch(t *te
 	}
 }
 
+func TestResolveGUICachedPreparedMetaMatchesTrackerSetIgnoringOrderAndCase(t *testing.T) {
+	t.Parallel()
+
+	metaSvc := &stubMeta{}
+	core := &Core{
+		cfg:    config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}},
+		logger: api.NopLogger{},
+		services: api.ServiceSet{
+			Metadata: metaSvc,
+		},
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+
+	sourcePath := "/tmp/a"
+	core.storeRefreshedDupeCache(sourcePath, "", api.PreparedMetadata{
+		SourcePath: sourcePath,
+		Paths:      []string{sourcePath},
+		Mode:       api.ModeGUI,
+		Trackers:   []string{"BLU", "AITHER"},
+	})
+
+	if _, ok, err := core.resolveGUICachedPreparedMeta(context.Background(), api.Request{
+		Paths:    []string{sourcePath},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"aither", "blu"},
+	}, sourcePath); err != nil {
+		t.Fatalf("resolve reordered cached prepared metadata: %v", err)
+	} else if !ok {
+		t.Fatal("expected cached metadata")
+	}
+	if metaSvc.refreshCalls != 0 {
+		t.Fatalf("expected reordered tracker set to reuse cache, got %d refreshes", metaSvc.refreshCalls)
+	}
+}
+
+func TestResolveGUICachedPreparedMetaRefreshesWhenIgnoringDupes(t *testing.T) {
+	t.Parallel()
+
+	metaSvc := &stubMeta{}
+	core := &Core{
+		cfg:    config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}},
+		logger: api.NopLogger{},
+		services: api.ServiceSet{
+			Metadata: metaSvc,
+		},
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+
+	sourcePath := "/tmp/a"
+	core.storeRefreshedDupeCache(sourcePath, "", api.PreparedMetadata{
+		SourcePath: sourcePath,
+		Paths:      []string{sourcePath},
+		Mode:       api.ModeGUI,
+		Trackers:   []string{"AITHER"},
+		BlockedTrackers: map[string][]api.TrackerBlockReason{
+			"AITHER": {api.TrackerBlockReasonDupe},
+		},
+	})
+
+	if _, ok, err := core.resolveGUICachedPreparedMeta(context.Background(), api.Request{
+		Paths:          []string{sourcePath},
+		Mode:           api.ModeGUI,
+		Trackers:       []string{"AITHER"},
+		IgnoreDupesFor: []string{"AITHER"},
+	}, sourcePath); err != nil {
+		t.Fatalf("resolve ignored-dupe cached prepared metadata: %v", err)
+	} else if !ok {
+		t.Fatal("expected cached metadata")
+	}
+	if metaSvc.refreshCalls != 1 {
+		t.Fatalf("expected ignored-dupe request to refresh cache once, got %d", metaSvc.refreshCalls)
+	}
+}
+
 func TestResolveGUICachedPreparedMetaAllowsTrackerlessFollowUp(t *testing.T) {
 	t.Parallel()
 
@@ -693,6 +768,116 @@ func TestRunUploadPreparedSiteUploadTrackerOverridesTrackers(t *testing.T) {
 	}
 	if len(tracker.lastMeta.Trackers) != 1 || tracker.lastMeta.Trackers[0] != "BLU" {
 		t.Fatalf("expected site upload tracker override, got %#v", tracker.lastMeta.Trackers)
+	}
+}
+
+func TestRunUploadPreparedReturnsEmptyWithoutSideEffectsWhenSelectedTrackersResolveEmpty(t *testing.T) {
+	t.Parallel()
+
+	repo := &recordingRepo{}
+	torrent := &recordingTorrent{}
+	tracker := &stubTrackers{}
+	client := &stubClient{}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Torrents:   torrent,
+			Clients:    client,
+			Trackers:   tracker,
+		},
+		Repository: repo,
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	prepared := api.PreparedMetadata{
+		SourcePath:     "/tmp/a",
+		TrackersRemove: []string{"AITHER"},
+	}
+	core.storeDupeCache("/tmp/a", "", prepared)
+
+	result, err := core.RunUploadPrepared(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("run upload prepared: %v", err)
+	}
+	if result.UploadedCount != 0 {
+		t.Fatalf("expected 0 uploads, got %d", result.UploadedCount)
+	}
+	if torrent.calls != 0 {
+		t.Fatalf("expected torrent creation skipped, got %d calls", torrent.calls)
+	}
+	if tracker.calls != 0 {
+		t.Fatalf("expected tracker upload skipped, got %d calls", tracker.calls)
+	}
+	if client.calls != 0 {
+		t.Fatalf("expected client injection skipped, got %d calls", client.calls)
+	}
+	if len(repo.saved) != 0 {
+		t.Fatalf("expected no metadata save, got %d", len(repo.saved))
+	}
+	cached, ok := core.getDupeCache("/tmp/a", "")
+	if !ok {
+		t.Fatal("expected prepared metadata to remain cached")
+	}
+	if !reflect.DeepEqual(cached, prepared) {
+		t.Fatalf("expected cache unchanged, got %#v", cached)
+	}
+}
+
+func TestRunUploadPreparedUploadsIgnoredMatchedTracker(t *testing.T) {
+	t.Parallel()
+
+	torrent := &recordingTorrent{}
+	tracker := &stubTrackers{}
+	client := &stubClient{}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Torrents:   torrent,
+			Clients:    client,
+			Trackers:   tracker,
+		},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	core.storeDupeCache("/tmp/a", "", api.PreparedMetadata{
+		SourcePath:      "/tmp/a",
+		TrackersRemove:  []string{"AITHER"},
+		MatchedTrackers: []string{"AITHER"},
+	})
+
+	result, err := core.RunUploadPrepared(context.Background(), api.Request{
+		Paths:          []string{"/tmp/a"},
+		Mode:           api.ModeGUI,
+		Trackers:       []string{"AITHER"},
+		IgnoreDupesFor: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("run upload prepared: %v", err)
+	}
+	if result.UploadedCount != 1 {
+		t.Fatalf("expected one upload, got %d", result.UploadedCount)
+	}
+	if torrent.calls != 1 {
+		t.Fatalf("expected torrent creation, got %d calls", torrent.calls)
+	}
+	if tracker.calls != 1 {
+		t.Fatalf("expected tracker upload, got %d calls", tracker.calls)
+	}
+	if containsCoreString(tracker.lastMeta.TrackersRemove, "AITHER") {
+		t.Fatalf("expected ignored duplicate removal cleared before upload, got %v", tracker.lastMeta.TrackersRemove)
+	}
+	if containsCoreString(tracker.lastMeta.MatchedTrackers, "AITHER") {
+		t.Fatalf("expected ignored duplicate match cleared before upload, got %v", tracker.lastMeta.MatchedTrackers)
 	}
 }
 
@@ -1802,6 +1987,51 @@ func TestCheckDupesGUIFallbackReappliesReleaseOverrides(t *testing.T) {
 	}
 }
 
+func TestCheckDupesGUIExplicitTrackersDoNotMergeDefaults(t *testing.T) {
+	t.Parallel()
+
+	dupes := &stubDupes{}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{
+			MainSettings: config.MainSettingsConfig{TMDBAPI: "x"},
+			ScreenshotHandling: config.ScreenshotHandlingConfig{
+				Screens: 1,
+			},
+			Trackers: config.TrackersConfig{
+				DefaultTrackers: config.CSVList{"BLU", "BHD"},
+			},
+		},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Dupes:      dupes,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	if err := core.ImportPreparedMetadataForGUI(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	}, api.PreparedMetadata{SourcePath: "/tmp/a"}); err != nil {
+		t.Fatalf("import prepared metadata for gui: %v", err)
+	}
+
+	if _, err := core.CheckDupes(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	}); err != nil {
+		t.Fatalf("check dupes: %v", err)
+	}
+
+	if got, want := dupes.lastTrackers, []string{"AITHER"}; !slices.Equal(got, want) {
+		t.Fatalf("expected selected tracker only, got %v want %v", got, want)
+	}
+}
+
 func TestExportGUICachedPreparedMetaRequiresExactMatchForExternalOverrides(t *testing.T) {
 	t.Parallel()
 
@@ -2846,6 +3076,120 @@ func TestFetchTrackerDryRunPreviewRequiresCachedMetadata(t *testing.T) {
 	}
 }
 
+func TestFetchTrackerDryRunPreviewReturnsEmptyWithoutSideEffectsWhenSelectedTrackersResolveEmpty(t *testing.T) {
+	t.Parallel()
+
+	client := &stubClient{}
+	metaSvc := &stubMeta{}
+	tracker := &stubTrackers{dryRunEntries: []api.TrackerDryRunEntry{{Tracker: "BLU", Status: "ready"}}}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{
+			MainSettings:       config.MainSettingsConfig{TMDBAPI: "x"},
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+			Trackers:           config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+		},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   metaSvc,
+			Torrents:   &stubTorrent{},
+			Clients:    client,
+			Trackers:   tracker,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	prepared := api.PreparedMetadata{
+		SourcePath:     "/tmp/a",
+		TrackersRemove: []string{"AITHER"},
+	}
+	core.storeDupeCache("/tmp/a", "", prepared)
+
+	preview, err := core.FetchTrackerDryRunPreview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("fetch tracker dry-run preview: %v", err)
+	}
+	if preview.SourcePath != "/tmp/a" {
+		t.Fatalf("expected source path /tmp/a, got %q", preview.SourcePath)
+	}
+	if len(preview.Trackers) != 0 {
+		t.Fatalf("expected no dry-run entries, got %#v", preview.Trackers)
+	}
+	if tracker.dryRunCalls != 0 {
+		t.Fatalf("expected no dry-run build call, got %d", tracker.dryRunCalls)
+	}
+	if client.calls != 0 {
+		t.Fatalf("expected no client injection, got %d", client.calls)
+	}
+	if metaSvc.refreshCalls != 0 {
+		t.Fatalf("expected no metadata refresh, got %d", metaSvc.refreshCalls)
+	}
+	cached, ok := core.getDupeCache("/tmp/a", "")
+	if !ok {
+		t.Fatal("expected cached prepared metadata")
+	}
+	if !reflect.DeepEqual(cached, prepared) {
+		t.Fatalf("expected cache to remain unchanged, got %#v", cached)
+	}
+}
+
+func TestFetchTrackerDryRunPreviewUsesIgnoredMatchedTracker(t *testing.T) {
+	t.Parallel()
+
+	tracker := &stubTrackers{dryRunEntries: []api.TrackerDryRunEntry{{Tracker: "AITHER", Status: "ready"}}}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{
+			MainSettings:       config.MainSettingsConfig{TMDBAPI: "x"},
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+			Trackers:           config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+		},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   tracker,
+		},
+		Repository: dryRunPreviewRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	core.storeDupeCache("/tmp/a", "", api.PreparedMetadata{
+		SourcePath:      "/tmp/a",
+		TrackersRemove:  []string{"AITHER", "BLU"},
+		MatchedTrackers: []string{"AITHER", "BLU"},
+	})
+
+	preview, err := core.FetchTrackerDryRunPreview(context.Background(), api.Request{
+		Paths:          []string{"/tmp/a"},
+		Mode:           api.ModeGUI,
+		Trackers:       []string{"AITHER"},
+		IgnoreDupesFor: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("fetch tracker dry-run preview: %v", err)
+	}
+	if len(preview.Trackers) != 1 || preview.Trackers[0].Tracker != "AITHER" {
+		t.Fatalf("expected AITHER dry-run preview, got %#v", preview.Trackers)
+	}
+	if !reflect.DeepEqual(tracker.lastTrackers, []string{"AITHER"}) {
+		t.Fatalf("expected ignored matched tracker without default fallback, got %v", tracker.lastTrackers)
+	}
+	if containsCoreString(tracker.lastMeta.TrackersRemove, "AITHER") || !containsCoreString(tracker.lastMeta.TrackersRemove, "BLU") {
+		t.Fatalf("expected only unignored duplicate removal to remain, got %v", tracker.lastMeta.TrackersRemove)
+	}
+	if containsCoreString(tracker.lastMeta.MatchedTrackers, "AITHER") || !containsCoreString(tracker.lastMeta.MatchedTrackers, "BLU") {
+		t.Fatalf("expected only unignored matched tracker to remain, got %v", tracker.lastMeta.MatchedTrackers)
+	}
+}
+
 func TestRunUploadPreparedPassesRuleFailureOverride(t *testing.T) {
 	t.Parallel()
 
@@ -2927,6 +3271,14 @@ func TestRunUploadPreparedFiltersRuleFailuresPerTracker(t *testing.T) {
 }
 
 type stubRepo struct{}
+
+type dryRunPreviewRepo struct {
+	stubRepo
+}
+
+func (dryRunPreviewRepo) SaveTrackerRuleFailures(context.Context, string, string, []db.TrackerRuleFailure) error {
+	return nil
+}
 
 func (stubRepo) GetByPath(context.Context, string) (db.FileMetadata, error) {
 	return db.FileMetadata{}, internalerrors.ErrNotImplemented
@@ -3409,6 +3761,15 @@ type stubTorrentWithHash struct {
 
 func (s *stubTorrentWithHash) Create(context.Context, api.PreparedMetadata) (api.TorrentResult, error) {
 	return api.TorrentResult{Path: "/tmp/file.torrent", InfoHash: s.hash}, nil
+}
+
+type recordingTorrent struct {
+	calls int
+}
+
+func (r *recordingTorrent) Create(context.Context, api.PreparedMetadata) (api.TorrentResult, error) {
+	r.calls++
+	return api.TorrentResult{Path: "/tmp/file.torrent", InfoHash: "hash123"}, nil
 }
 
 type stubClient struct {

--- a/internal/core/description_builder_test.go
+++ b/internal/core/description_builder_test.go
@@ -209,7 +209,7 @@ func TestFetchDescriptionBuilderPreviewFallsBackToPrepareInGUI(t *testing.T) {
 	}
 }
 
-func TestFetchDescriptionBuilderPreviewAddsDefaultsForExplicitTrackers(t *testing.T) {
+func TestFetchDescriptionBuilderPreviewUsesOnlyExplicitTrackers(t *testing.T) {
 	t.Parallel()
 
 	repo := &stubDescriptionRepo{}
@@ -243,8 +243,8 @@ func TestFetchDescriptionBuilderPreviewAddsDefaultsForExplicitTrackers(t *testin
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if !reflect.DeepEqual(trackerSvc.prepareTrackers, []string{"BLU", "AITHER"}) {
-		t.Fatalf("expected default plus explicit trackers, got %v", trackerSvc.prepareTrackers)
+	if !reflect.DeepEqual(trackerSvc.prepareTrackers, []string{"AITHER"}) {
+		t.Fatalf("expected explicit tracker only, got %v", trackerSvc.prepareTrackers)
 	}
 }
 

--- a/internal/core/description_builder_test.go
+++ b/internal/core/description_builder_test.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -15,12 +16,13 @@ import (
 )
 
 type stubDescriptionBuilderTrackers struct {
-	called      bool
-	prepareMeta api.PreparedMetadata
-	preview     api.PreparationPreview
-	dryRunMeta  api.PreparedMetadata
-	uploadMeta  api.PreparedMetadata
-	dryRunItems []api.TrackerDryRunEntry
+	called          bool
+	prepareMeta     api.PreparedMetadata
+	prepareTrackers []string
+	preview         api.PreparationPreview
+	dryRunMeta      api.PreparedMetadata
+	uploadMeta      api.PreparedMetadata
+	dryRunItems     []api.TrackerDryRunEntry
 }
 
 func (s *stubDescriptionBuilderTrackers) Upload(_ context.Context, meta api.PreparedMetadata) (api.UploadSummary, error) {
@@ -31,6 +33,7 @@ func (s *stubDescriptionBuilderTrackers) Upload(_ context.Context, meta api.Prep
 func (s *stubDescriptionBuilderTrackers) BuildPreparation(_ context.Context, meta api.PreparedMetadata, trackers []string) (api.PreparationPreview, error) {
 	s.called = true
 	s.prepareMeta = meta
+	s.prepareTrackers = append([]string{}, trackers...)
 	if strings.TrimSpace(s.preview.SourcePath) == "" {
 		s.preview.SourcePath = meta.SourcePath
 	}
@@ -203,6 +206,141 @@ func TestFetchDescriptionBuilderPreviewFallsBackToPrepareInGUI(t *testing.T) {
 	}
 	if preview.SourcePath != "/tmp/source" {
 		t.Fatalf("expected source path to be set, got %q", preview.SourcePath)
+	}
+}
+
+func TestFetchDescriptionBuilderPreviewAddsDefaultsForExplicitTrackers(t *testing.T) {
+	t.Parallel()
+
+	repo := &stubDescriptionRepo{}
+	trackerSvc := &stubDescriptionBuilderTrackers{}
+	metaSvc := &stubMeta{prepared: api.PreparedMetadata{
+		SourcePath: "/tmp/source",
+		Trackers:   []string{"BLU"},
+	}}
+	core := &Core{
+		cfg: config.Config{
+			Description:        config.DescriptionSettingsConfig{AddLogo: true},
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+			Trackers:           config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+		},
+		logger: api.NopLogger{},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{"/tmp/source"}},
+			Trackers:   trackerSvc,
+			Metadata:   metaSvc,
+		},
+		repo:      repo,
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+
+	_, err := core.FetchDescriptionBuilderPreview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/source"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+		Options:  api.UploadOptions{Screens: 1},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(trackerSvc.prepareTrackers, []string{"BLU", "AITHER"}) {
+		t.Fatalf("expected default plus explicit trackers, got %v", trackerSvc.prepareTrackers)
+	}
+}
+
+func TestFetchDescriptionBuilderPreviewReturnsEmptyWhenSelectedTrackersResolveEmpty(t *testing.T) {
+	t.Parallel()
+
+	repo := &stubDescriptionRepo{}
+	trackerSvc := &stubDescriptionBuilderTrackers{}
+	metaSvc := &stubMeta{prepared: api.PreparedMetadata{
+		SourcePath:     "/tmp/source",
+		TrackersRemove: []string{"AITHER"},
+	}}
+	core := &Core{
+		cfg:    config.Config{ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		logger: api.NopLogger{},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{"/tmp/source"}},
+			Trackers:   trackerSvc,
+			Metadata:   metaSvc,
+		},
+		repo:      repo,
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+
+	preview, err := core.FetchDescriptionBuilderPreview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/source"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+		Options:  api.UploadOptions{Screens: 1},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if trackerSvc.called {
+		t.Fatal("expected tracker preparation to be skipped when selected trackers resolve empty")
+	}
+	if metaSvc.resolveCalls != 0 {
+		t.Fatalf("expected external metadata refresh to be skipped when selected trackers resolve empty, got %d", metaSvc.resolveCalls)
+	}
+	if preview.SourcePath != "/tmp/source" {
+		t.Fatalf("expected source path to be preserved, got %q", preview.SourcePath)
+	}
+	if len(preview.Groups) != 0 {
+		t.Fatalf("expected no description groups, got %d", len(preview.Groups))
+	}
+	if _, ok := core.getDupeCache("/tmp/source", ""); ok {
+		t.Fatal("expected explicit-empty preview not to seed GUI cache")
+	}
+}
+
+func TestFetchDescriptionBuilderGroupPreviewReturnsEmptyWhenSelectedTrackersResolveEmpty(t *testing.T) {
+	t.Parallel()
+
+	repo := &stubDescriptionRepo{}
+	trackerSvc := &stubDescriptionBuilderTrackers{}
+	metaSvc := &stubMeta{prepared: api.PreparedMetadata{
+		SourcePath:     "/tmp/source",
+		TrackersRemove: []string{"AITHER"},
+	}}
+	core := &Core{
+		cfg: config.Config{
+			Description:        config.DescriptionSettingsConfig{AddLogo: true},
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+			Trackers:           config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+		},
+		logger: api.NopLogger{},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{"/tmp/source"}},
+			Trackers:   trackerSvc,
+			Metadata:   metaSvc,
+		},
+		repo:      repo,
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+
+	group, err := core.FetchDescriptionBuilderGroupPreview(context.Background(), api.Request{
+		Paths:                    []string{"/tmp/source"},
+		Mode:                     api.ModeGUI,
+		Trackers:                 []string{"AITHER"},
+		DescriptionOverrideGroup: "AITHER",
+		Options:                  api.UploadOptions{Screens: 1},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if trackerSvc.called {
+		t.Fatal("expected tracker preparation to be skipped when selected trackers resolve empty")
+	}
+	if metaSvc.resolveCalls != 0 {
+		t.Fatalf("expected external metadata refresh to be skipped when selected trackers resolve empty, got %d", metaSvc.resolveCalls)
+	}
+	if !reflect.DeepEqual(group, api.DescriptionBuilderGroup{}) {
+		t.Fatalf("expected empty group, got %#v", group)
+	}
+	if _, ok := core.getDupeCache("/tmp/source", ""); ok {
+		t.Fatal("expected explicit-empty group preview not to seed GUI cache")
 	}
 }
 
@@ -509,6 +647,61 @@ func TestFetchDescriptionBuilderPreviewAppliesIgnoredDupesToCachedMeta(t *testin
 	}
 }
 
+func TestFetchDescriptionBuilderPreviewUsesIgnoredMatchedTracker(t *testing.T) {
+	t.Parallel()
+
+	repo := &stubDescriptionRepo{}
+	trackerSvc := &stubDescriptionBuilderTrackers{
+		preview: api.PreparationPreview{
+			SourcePath: "/tmp/source",
+			Descriptions: []api.PreparationDescription{
+				{GroupKey: "aither", Trackers: []string{"AITHER"}, Description: "aither body"},
+			},
+		},
+	}
+	core := &Core{
+		cfg: config.Config{
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+			Trackers:           config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+		},
+		logger: api.NopLogger{},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{"/tmp/source"}},
+			Trackers:   trackerSvc,
+		},
+		repo:      repo,
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+	core.storeRefreshedDupeCache("/tmp/source", "", api.PreparedMetadata{
+		SourcePath:      "/tmp/source",
+		TrackersRemove:  []string{"AITHER", "BLU"},
+		MatchedTrackers: []string{"AITHER", "BLU"},
+	})
+
+	preview, err := core.FetchDescriptionBuilderPreview(context.Background(), api.Request{
+		Paths:          []string{"/tmp/source"},
+		Mode:           api.ModeGUI,
+		Trackers:       []string{"AITHER"},
+		IgnoreDupesFor: []string{"AITHER"},
+		Options:        api.UploadOptions{Screens: 1},
+	})
+	if err != nil {
+		t.Fatalf("fetch description builder preview: %v", err)
+	}
+	if len(preview.Groups) != 1 {
+		t.Fatalf("expected one description group, got %d", len(preview.Groups))
+	}
+	if !reflect.DeepEqual(trackerSvc.prepareTrackers, []string{"AITHER"}) {
+		t.Fatalf("expected ignored matched tracker without default fallback, got %v", trackerSvc.prepareTrackers)
+	}
+	if containsTrackerName(trackerSvc.prepareMeta.TrackersRemove, "AITHER") || !containsTrackerName(trackerSvc.prepareMeta.TrackersRemove, "BLU") {
+		t.Fatalf("expected only unignored duplicate removal to remain, got %v", trackerSvc.prepareMeta.TrackersRemove)
+	}
+	if containsTrackerName(trackerSvc.prepareMeta.MatchedTrackers, "AITHER") || !containsTrackerName(trackerSvc.prepareMeta.MatchedTrackers, "BLU") {
+		t.Fatalf("expected only unignored matched tracker to remain, got %v", trackerSvc.prepareMeta.MatchedTrackers)
+	}
+}
+
 func TestFetchDescriptionBuilderGroupPreviewAppliesIgnoredFailuresToRefreshedCache(t *testing.T) {
 	t.Parallel()
 
@@ -776,6 +969,38 @@ func TestFetchTrackerDryRunPreviewUsesCanonicalDescriptionGroups(t *testing.T) {
 	}
 	if trackerSvc.dryRunMeta.DescriptionGroups[0].RawDescription != "saved canonical body" {
 		t.Fatalf("expected dry-run to use canonical description group, got %q", trackerSvc.dryRunMeta.DescriptionGroups[0].RawDescription)
+	}
+}
+
+func TestResolveCanonicalDescriptionGroupsSkipsDefaultsWhenExplicitSelectionResolvesEmpty(t *testing.T) {
+	t.Parallel()
+
+	trackerSvc := &stubDescriptionBuilderTrackers{}
+	core := &Core{
+		cfg: config.Config{
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+			Trackers:           config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+		},
+		logger: api.NopLogger{},
+		services: api.ServiceSet{
+			Trackers: trackerSvc,
+		},
+	}
+
+	groups, err := core.resolveCanonicalDescriptionGroups(context.Background(), api.PreparedMetadata{
+		SourcePath:     "/tmp/source",
+		TrackersRemove: []string{"AITHER"},
+	}, api.Request{
+		Trackers: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if trackerSvc.called {
+		t.Fatal("expected tracker preparation to be skipped when selected trackers resolve empty")
+	}
+	if len(groups) != 0 {
+		t.Fatalf("expected no canonical groups, got %#v", groups)
 	}
 }
 

--- a/internal/core/preparation_test.go
+++ b/internal/core/preparation_test.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/config"
@@ -74,6 +75,116 @@ func TestFetchPreparationPreviewFromCache(t *testing.T) {
 	}
 	if preview.SourcePath != meta.SourcePath {
 		t.Fatalf("expected source path %q, got %q", meta.SourcePath, preview.SourcePath)
+	}
+}
+
+func TestFetchPreparationPreviewReturnsEmptyWhenCachedSelectedTrackersResolveEmpty(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{
+		SourcePath:     "/tmp/source",
+		TrackersRemove: []string{"AITHER"},
+	}
+	trackerSvc := &stubPreparationTrackers{}
+	core := &Core{
+		logger: api.NopLogger{},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{meta.SourcePath}},
+			Trackers:   trackerSvc,
+		},
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+	core.storeDupeCache(meta.SourcePath, "", meta)
+
+	preview, err := core.FetchPreparationPreview(context.Background(), api.Request{
+		Paths:    []string{meta.SourcePath},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if trackerSvc.called {
+		t.Fatal("expected tracker preparation to be skipped when selected trackers resolve empty")
+	}
+	if preview.SourcePath != meta.SourcePath {
+		t.Fatalf("expected source path %q, got %q", meta.SourcePath, preview.SourcePath)
+	}
+}
+
+func TestFetchPreparationPreviewUsesIgnoredMatchedTrackerFromCache(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{
+		SourcePath:      "/tmp/source",
+		TrackersRemove:  []string{"AITHER", "BLU"},
+		MatchedTrackers: []string{"AITHER", "BLU"},
+	}
+	trackerSvc := &stubPreparationTrackers{}
+	core := &Core{
+		cfg: config.Config{
+			Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+		},
+		logger: api.NopLogger{},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{meta.SourcePath}},
+			Trackers:   trackerSvc,
+		},
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+	core.storeDupeCache(meta.SourcePath, "", meta)
+
+	preview, err := core.FetchPreparationPreview(context.Background(), api.Request{
+		Paths:          []string{meta.SourcePath},
+		Mode:           api.ModeGUI,
+		Trackers:       []string{"AITHER"},
+		IgnoreDupesFor: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if preview.SourcePath != meta.SourcePath {
+		t.Fatalf("expected source path %q, got %q", meta.SourcePath, preview.SourcePath)
+	}
+	if !slices.Equal(trackerSvc.trackers, []string{"AITHER"}) {
+		t.Fatalf("expected ignored matched tracker without default fallback, got %v", trackerSvc.trackers)
+	}
+	if slices.Contains(trackerSvc.meta.TrackersRemove, "AITHER") || !slices.Contains(trackerSvc.meta.TrackersRemove, "BLU") {
+		t.Fatalf("expected only unignored duplicate removal to remain, got %v", trackerSvc.meta.TrackersRemove)
+	}
+	if slices.Contains(trackerSvc.meta.MatchedTrackers, "AITHER") || !slices.Contains(trackerSvc.meta.MatchedTrackers, "BLU") {
+		t.Fatalf("expected only unignored matched tracker to remain, got %v", trackerSvc.meta.MatchedTrackers)
+	}
+}
+
+func TestFetchPreparationPreviewAddsDefaultsForExplicitTrackers(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{SourcePath: "/tmp/source"}
+	trackerSvc := &stubPreparationTrackers{}
+	core := &Core{
+		cfg: config.Config{
+			Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+		},
+		logger: api.NopLogger{},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{meta.SourcePath}},
+			Trackers:   trackerSvc,
+		},
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+	core.storeDupeCache(meta.SourcePath, "", meta)
+
+	_, err := core.FetchPreparationPreview(context.Background(), api.Request{
+		Paths:    []string{meta.SourcePath},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !slices.Equal(trackerSvc.trackers, []string{"BLU", "AITHER"}) {
+		t.Fatalf("expected default plus explicit trackers, got %v", trackerSvc.trackers)
 	}
 }
 
@@ -182,5 +293,45 @@ func TestFetchPreparationPreviewCachesMergedExternalIDSelections(t *testing.T) {
 	}
 	if exported.ExternalIDOverrides.TMDBID == nil || *exported.ExternalIDOverrides.TMDBID != tmdbID {
 		t.Fatalf("expected exported cached metadata to preserve merged TMDB selection, got %#v", exported.ExternalIDOverrides)
+	}
+}
+
+func TestFetchPreparationPreviewReturnsEmptyWhenPreparedSelectedTrackersResolveEmpty(t *testing.T) {
+	t.Parallel()
+
+	trackerSvc := &stubPreparationTrackers{}
+	core := &Core{
+		cfg: config.Config{
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+			Trackers:           config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+		},
+		logger: api.NopLogger{},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{"/tmp/source"}},
+			Metadata: &stubMeta{prepared: api.PreparedMetadata{
+				SourcePath:     "/tmp/source",
+				TrackersRemove: []string{"AITHER"},
+			}},
+			Trackers: trackerSvc,
+		},
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+
+	preview, err := core.FetchPreparationPreview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/source"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if trackerSvc.called {
+		t.Fatal("expected tracker preparation to be skipped when prepared selected trackers resolve empty")
+	}
+	if preview.SourcePath != "/tmp/source" {
+		t.Fatalf("expected source path to be preserved, got %q", preview.SourcePath)
+	}
+	if _, ok := core.getDupeCache("/tmp/source", ""); ok {
+		t.Fatal("expected explicit-empty preparation not to seed GUI cache")
 	}
 }

--- a/internal/core/preparation_test.go
+++ b/internal/core/preparation_test.go
@@ -157,7 +157,7 @@ func TestFetchPreparationPreviewUsesIgnoredMatchedTrackerFromCache(t *testing.T)
 	}
 }
 
-func TestFetchPreparationPreviewAddsDefaultsForExplicitTrackers(t *testing.T) {
+func TestFetchPreparationPreviewUsesOnlyExplicitTrackers(t *testing.T) {
 	t.Parallel()
 
 	meta := api.PreparedMetadata{SourcePath: "/tmp/source"}
@@ -183,8 +183,8 @@ func TestFetchPreparationPreviewAddsDefaultsForExplicitTrackers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if !slices.Equal(trackerSvc.trackers, []string{"BLU", "AITHER"}) {
-		t.Fatalf("expected default plus explicit trackers, got %v", trackerSvc.trackers)
+	if !slices.Equal(trackerSvc.trackers, []string{"AITHER"}) {
+		t.Fatalf("expected explicit tracker only, got %v", trackerSvc.trackers)
 	}
 }
 

--- a/internal/core/upload_review.go
+++ b/internal/core/upload_review.go
@@ -18,6 +18,10 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+// BuildUploadReview returns dupe, rule, dry-run, and banned-group review data
+// for one prepared source path, committing GUI cache updates only after review work succeeds.
+// Partial GUI reviews preserve unreviewed tracker cache state and can commit from
+// a request-refreshed cache entry only when that entry matches the current request.
 func (c *Core) BuildUploadReview(ctx context.Context, req api.Request) (api.UploadReview, error) {
 	req = normalizeExecutionRequest(req)
 	resolvedReq, err := c.resolveDescriptionOverrideRequest(ctx, req)
@@ -71,13 +75,28 @@ func (c *Core) BuildUploadReview(ctx context.Context, req api.Request) (api.Uplo
 
 	signature := overrideSignature(singleReq.ExternalIDOverrides, singleReq.ReleaseNameOverrides, singleReq.MetadataOverrides, singleReq.TrackerConfigOverrides, singleReq.TrackerSiteOverrides, singleReq.ClientOverrides, singleReq.TorrentOverrides, singleReq.ImageHostOverrides, singleReq.ScreenshotOverrides)
 	var (
-		meta api.PreparedMetadata
-		ok   bool
+		baseMeta   api.PreparedMetadata
+		baseMetaOK bool
+		meta       api.PreparedMetadata
+		ok         bool
 	)
 	if req.Mode == api.ModeGUI {
-		meta, ok, err = c.resolveGUICachedPreparedMeta(ctx, singleReq, uniquePaths[0])
-		if err != nil {
-			return api.UploadReview{}, err
+		entry, _, found := c.lookupGUICachedMetaEntry(singleReq, uniquePaths[0])
+		if found {
+			ok = true
+			entryMatchesRequest := entry.requestRefreshed && cachedPreparedMetaMatchesRequest(entry.meta, singleReq, uniquePaths[0])
+			baseMetaOK = !entry.requestRefreshed || entryMatchesRequest
+			if baseMetaOK {
+				baseMeta = deepCopyPreparedMetadata(entry.meta)
+			}
+			if entryMatchesRequest {
+				meta = deepCopyPreparedMetadata(entry.meta)
+			} else {
+				meta, err = c.applyRequestToCachedPreparedMeta(ctx, entry.meta, singleReq)
+				if err != nil {
+					return api.UploadReview{}, err
+				}
+			}
 		}
 	} else {
 		meta, ok = c.getDupeCache(uniquePaths[0], signature)
@@ -92,7 +111,13 @@ func (c *Core) BuildUploadReview(ctx context.Context, req api.Request) (api.Uplo
 		return api.UploadReview{}, fmt.Errorf("core: upload review requires prepared metadata for %s", uniquePaths[0])
 	}
 
-	resolvedTrackers := trackers.ResolveTrackersWithDefaults(c.cfg, singleReq.Trackers, meta.TrackersRemove, c.logger)
+	resolvedTrackers, explicitEmpty := c.resolveUploadReviewTrackers(singleReq, meta)
+	if explicitEmpty {
+		return api.UploadReview{
+			SourcePath: meta.SourcePath,
+			Trackers:   []api.TrackerReview{},
+		}, nil
+	}
 
 	dupeResults := make(map[string]api.DupeCheckResult)
 	if singleReq.SkipDupeCheck {
@@ -121,8 +146,21 @@ func (c *Core) BuildUploadReview(ctx context.Context, req api.Request) (api.Uplo
 		meta.CrossSeedTorrents = removeCrossSeedTorrentsForTrackers(meta.CrossSeedTorrents, singleReq.IgnoreDupesFor)
 		dupeResults = mapDupeResults(summary.Results)
 	}
+	var cacheCommit func()
 	if req.Mode == api.ModeGUI && cacheableGUIPreparedMetaRequest(singleReq) {
-		c.storeRefreshedDupeCache(uniquePaths[0], signature, meta)
+		if len(singleReq.Trackers) > 0 {
+			if baseMetaOK {
+				cacheMeta := mergeUploadReviewCacheMeta(baseMeta, meta, resolvedTrackers)
+				cacheCommit = func() {
+					c.storeDupeCache(uniquePaths[0], signature, cacheMeta)
+				}
+			}
+		} else {
+			cacheMeta := deepCopyPreparedMetadata(meta)
+			cacheCommit = func() {
+				c.storeRefreshedDupeCache(uniquePaths[0], signature, cacheMeta)
+			}
+		}
 	}
 
 	dryRunMeta := meta
@@ -189,10 +227,33 @@ func (c *Core) BuildUploadReview(ctx context.Context, req api.Request) (api.Uplo
 		reviews = append(reviews, review)
 	}
 
+	if cacheCommit != nil {
+		cacheCommit()
+	}
+
 	return api.UploadReview{
 		SourcePath: meta.SourcePath,
 		Trackers:   reviews,
 	}, nil
+}
+
+// resolveUploadReviewTrackers applies GUI replacement semantics while allowing
+// non-GUI review flows to include or fall back to configured defaults unless
+// site upload pins one tracker.
+func (c *Core) resolveUploadReviewTrackers(req api.Request, meta api.PreparedMetadata) ([]string, bool) {
+	includeDefaults := req.Mode != api.ModeGUI && strings.TrimSpace(req.Execution.SiteUploadTracker) == ""
+	remove := meta.TrackersRemove
+	if req.Mode == api.ModeGUI && len(req.Trackers) > 0 && len(meta.MatchedTrackers) > 0 {
+		reviewedMatchedTrackers := make([]string, 0, len(req.Trackers))
+		for _, tracker := range req.Trackers {
+			if containsTrackerName(meta.MatchedTrackers, tracker) {
+				reviewedMatchedTrackers = append(reviewedMatchedTrackers, tracker)
+			}
+		}
+		remove = removeReviewedTrackerNames(remove, reviewedMatchedTrackers)
+		remove = mergeTrackerRemovals(remove, req.TrackersRemove)
+	}
+	return resolveTrackersPreservingExplicitEmpty(c.cfg, req.Trackers, remove, c.logger, includeDefaults, includeDefaults)
 }
 
 func formatBlockedReasons(reasons []api.TrackerBlockReason) string {
@@ -229,8 +290,7 @@ func applyRequestToPreparedMetaBeforeRefresh(meta api.PreparedMetadata, req api.
 func applyRequestToPreparedMetaWithDerivedFields(meta api.PreparedMetadata, req api.Request, cfg config.Config, logger api.Logger, rebuildDerivedFields bool) api.PreparedMetadata {
 	meta = deepCopyPreparedMetadata(meta)
 	existingTrackerIDs := cloneStringMap(meta.TrackerIDs)
-	existingTrackersRemove := append([]string{}, meta.TrackersRemove...)
-	existingMatchedTrackers := append([]string{}, meta.MatchedTrackers...)
+	existingTrackersRemove, existingMatchedTrackers := duplicateTrackerStateForRequest(meta, req)
 	meta.Mode = req.Mode
 	meta.Options = req.Options
 	meta.Paths = append([]string{}, req.Paths...)
@@ -238,6 +298,7 @@ func applyRequestToPreparedMetaWithDerivedFields(meta api.PreparedMetadata, req 
 		meta.DescriptionGroups = api.CloneDescriptionBuilderGroups(req.DescriptionGroups)
 	}
 	meta.Trackers = append([]string{}, req.Trackers...)
+	meta.MatchedTrackers = existingMatchedTrackers
 	meta.TrackersRemove = mergeTrackerRemovals(req.TrackersRemove, existingTrackersRemove)
 	meta.TrackersRemove = mergeTrackerRemovals(meta.TrackersRemove, existingMatchedTrackers)
 	meta.TrackerIDs = mergeTrackerIDOverrides(existingTrackerIDs, req.TrackerIDOverrides)
@@ -269,6 +330,21 @@ func applyRequestToPreparedMetaWithDerivedFields(meta api.PreparedMetadata, req 
 		meta.CrossSeedTorrents = removeCrossSeedTorrentsForTrackers(meta.CrossSeedTorrents, req.IgnoreDupesFor)
 	}
 	return meta
+}
+
+// duplicateTrackerStateForRequest returns cached duplicate removal state after
+// applying the request's dupe bypass semantics. Ignored or skipped matched
+// trackers are removed from suppression state before later tracker resolution.
+func duplicateTrackerStateForRequest(meta api.PreparedMetadata, req api.Request) ([]string, []string) {
+	remove := append([]string(nil), meta.TrackersRemove...)
+	matched := append([]string(nil), meta.MatchedTrackers...)
+	if req.SkipDupeCheck {
+		return removeReviewedTrackerNames(remove, matched), nil
+	}
+	if len(req.IgnoreDupesFor) > 0 {
+		return removeReviewedTrackerNames(remove, req.IgnoreDupesFor), removeReviewedTrackerNames(matched, req.IgnoreDupesFor)
+	}
+	return remove, matched
 }
 
 func mergeTrackerIDOverrides(existing map[string]string, overrides map[string]string) map[string]string {
@@ -651,4 +727,181 @@ func removeCrossSeedTorrentsForTrackers(torrents []api.UploadedTorrent, trackers
 		filtered = append(filtered, torrent)
 	}
 	return filtered
+}
+
+// mergeUploadReviewCacheMeta preserves unreviewed GUI cache state while
+// replacing refreshed tracker-scoped review state for the trackers reviewed by
+// this request, including matched-tracker and removal state.
+func mergeUploadReviewCacheMeta(base api.PreparedMetadata, updated api.PreparedMetadata, reviewedTrackers []string) api.PreparedMetadata {
+	merged := deepCopyPreparedMetadata(base)
+	merged.BlockedTrackers = mergeReviewedTrackerBlocks(base.BlockedTrackers, updated.BlockedTrackers, reviewedTrackers)
+	merged.CrossSeedTorrents = mergeReviewedTrackerCrossSeeds(base.CrossSeedTorrents, updated.CrossSeedTorrents, reviewedTrackers)
+	merged.TrackerRuleFailures = mergeReviewedTrackerRuleFailures(base.TrackerRuleFailures, updated.TrackerRuleFailures, reviewedTrackers)
+	merged.TrackersRemove = mergeReviewedTrackerNames(base.TrackersRemove, updated.TrackersRemove, reviewedTrackers)
+	merged.MatchedTrackers = mergeReviewedTrackerNames(base.MatchedTrackers, updated.MatchedTrackers, reviewedTrackers)
+	return merged
+}
+
+// mergeReviewedTrackerBlocks keeps base tracker blocks for unreviewed trackers
+// and replaces only reviewed trackers with refreshed block results.
+func mergeReviewedTrackerBlocks(
+	base map[string][]api.TrackerBlockReason,
+	updated map[string][]api.TrackerBlockReason,
+	reviewedTrackers []string,
+) map[string][]api.TrackerBlockReason {
+	merged := removeReviewedTrackerMapEntries(cloneBlockedTrackers(base), reviewedTrackers)
+	for _, tracker := range reviewedTrackers {
+		name := strings.ToUpper(strings.TrimSpace(tracker))
+		if name == "" {
+			continue
+		}
+		reasons := append([]api.TrackerBlockReason(nil), lookupTrackerMapValue(updated, name)...)
+		if len(reasons) == 0 {
+			continue
+		}
+		if merged == nil {
+			merged = make(map[string][]api.TrackerBlockReason)
+		}
+		merged[name] = reasons
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+// mergeReviewedTrackerCrossSeeds keeps base cross-seed torrents for unreviewed
+// trackers and replaces only reviewed trackers with updated cross-seed results.
+func mergeReviewedTrackerCrossSeeds(
+	base []api.UploadedTorrent,
+	updated []api.UploadedTorrent,
+	reviewedTrackers []string,
+) []api.UploadedTorrent {
+	merged := removeCrossSeedTorrentsForTrackers(base, reviewedTrackers)
+	for _, torrent := range updated {
+		name := strings.ToUpper(strings.TrimSpace(torrent.Tracker))
+		if name == "" || !containsTrackerName(reviewedTrackers, name) {
+			continue
+		}
+		merged = append(merged, torrent)
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+// mergeReviewedTrackerRuleFailures keeps base rule failures for unreviewed
+// trackers and replaces only reviewed trackers with refreshed failures.
+func mergeReviewedTrackerRuleFailures(
+	base map[string][]api.RuleFailure,
+	updated map[string][]api.RuleFailure,
+	reviewedTrackers []string,
+) map[string][]api.RuleFailure {
+	merged := removeReviewedTrackerMapEntries(deepCopyTrackerRuleFailures(base), reviewedTrackers)
+	for _, tracker := range reviewedTrackers {
+		name := strings.ToUpper(strings.TrimSpace(tracker))
+		if name == "" {
+			continue
+		}
+		failures := cloneRuleFailures(lookupTrackerMapValue(updated, name))
+		if len(failures) == 0 {
+			continue
+		}
+		if merged == nil {
+			merged = make(map[string][]api.RuleFailure)
+		}
+		merged[name] = failures
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+func mergeReviewedTrackerNames(base []string, updated []string, reviewedTrackers []string) []string {
+	merged := removeReviewedTrackerNames(base, reviewedTrackers)
+	for _, tracker := range updated {
+		name := strings.ToUpper(strings.TrimSpace(tracker))
+		if name == "" || !containsTrackerName(reviewedTrackers, name) || containsTrackerName(merged, name) {
+			continue
+		}
+		merged = append(merged, name)
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
+func removeReviewedTrackerNames(trackers []string, reviewedTrackers []string) []string {
+	if len(trackers) == 0 {
+		return nil
+	}
+	if len(reviewedTrackers) == 0 {
+		return append([]string(nil), trackers...)
+	}
+	filtered := make([]string, 0, len(trackers))
+	for _, tracker := range trackers {
+		if strings.TrimSpace(tracker) == "" || containsTrackerName(reviewedTrackers, tracker) {
+			continue
+		}
+		filtered = append(filtered, tracker)
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
+}
+
+// removeReviewedTrackerMapEntries deletes reviewed tracker entries using
+// case-insensitive tracker names so stale mixed-case cache keys cannot survive.
+func removeReviewedTrackerMapEntries[T any](input map[string]T, reviewedTrackers []string) map[string]T {
+	if len(input) == 0 {
+		return nil
+	}
+	reviewed := make(map[string]struct{}, len(reviewedTrackers))
+	for _, tracker := range reviewedTrackers {
+		name := strings.ToUpper(strings.TrimSpace(tracker))
+		if name == "" {
+			continue
+		}
+		reviewed[name] = struct{}{}
+	}
+	if len(reviewed) == 0 {
+		return input
+	}
+	for key := range input {
+		name := strings.ToUpper(strings.TrimSpace(key))
+		if _, ok := reviewed[name]; ok {
+			delete(input, key)
+		}
+	}
+	if len(input) == 0 {
+		return nil
+	}
+	return input
+}
+
+func containsTrackerName(trackers []string, target string) bool {
+	for _, tracker := range trackers {
+		if strings.EqualFold(strings.TrimSpace(tracker), strings.TrimSpace(target)) {
+			return true
+		}
+	}
+	return false
+}
+
+func lookupTrackerMapValue[T any](input map[string]T, tracker string) T {
+	var zero T
+	name := strings.ToUpper(strings.TrimSpace(tracker))
+	if name == "" {
+		return zero
+	}
+	for key, value := range input {
+		if strings.EqualFold(strings.TrimSpace(key), name) {
+			return value
+		}
+	}
+	return zero
 }

--- a/internal/core/upload_review_test.go
+++ b/internal/core/upload_review_test.go
@@ -5,6 +5,9 @@ package core
 
 import (
 	"context"
+	"errors"
+	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -35,6 +38,46 @@ func (reviewTrackers) BuildUploadDryRun(context.Context, api.PreparedMetadata, [
 		{Tracker: "AITHER", Status: "ready", ReleaseName: "AITHER.NAME"},
 		{Tracker: "BLU", Status: "ready", ReleaseName: "BLU.NAME"},
 	}, nil
+}
+
+type recordingReviewTrackers struct {
+	calls        int
+	lastTrackers []string
+	entries      []api.TrackerDryRunEntry
+	err          error
+}
+
+func (*recordingReviewTrackers) Upload(context.Context, api.PreparedMetadata) (api.UploadSummary, error) {
+	return api.UploadSummary{}, nil
+}
+
+func (*recordingReviewTrackers) BuildPreparation(context.Context, api.PreparedMetadata, []string) (api.PreparationPreview, error) {
+	return api.PreparationPreview{}, nil
+}
+
+func (r *recordingReviewTrackers) BuildUploadDryRun(_ context.Context, _ api.PreparedMetadata, trackers []string) ([]api.TrackerDryRunEntry, error) {
+	r.calls++
+	r.lastTrackers = append([]string{}, trackers...)
+	if r.err != nil {
+		return nil, r.err
+	}
+	if len(r.entries) == 0 {
+		return []api.TrackerDryRunEntry{}, nil
+	}
+	return append([]api.TrackerDryRunEntry(nil), r.entries...), nil
+}
+
+type recordingReviewTorrent struct {
+	calls int
+	err   error
+}
+
+func (r *recordingReviewTorrent) Create(context.Context, api.PreparedMetadata) (api.TorrentResult, error) {
+	r.calls++
+	if r.err != nil {
+		return api.TorrentResult{}, r.err
+	}
+	return api.TorrentResult{Path: "/tmp/file.torrent"}, nil
 }
 
 func TestBuildUploadReviewIncludesRuleFailuresDupesAndDryRun(t *testing.T) {
@@ -117,6 +160,43 @@ func TestApplyRequestToPreparedMetaClearsDupeBlocksForIgnoredTrackers(t *testing
 	}
 	if got := meta.BlockedTrackers["BHD"]; len(got) != 1 || got[0] != api.TrackerBlockReasonDupe {
 		t.Fatalf("expected BHD dupe block to remain, got %#v", meta.BlockedTrackers)
+	}
+}
+
+func TestApplyRequestToPreparedMetaClearsIgnoredDupeRemovalState(t *testing.T) {
+	t.Parallel()
+
+	meta := applyRequestToPreparedMeta(api.PreparedMetadata{
+		TrackersRemove:  []string{"AiThEr", "BLU"},
+		MatchedTrackers: []string{"aither", "BLU"},
+	}, api.Request{
+		IgnoreDupesFor: []string{"AITHER"},
+	}, config.Config{}, api.NopLogger{})
+
+	if !reflect.DeepEqual(meta.TrackersRemove, []string{"BLU"}) {
+		t.Fatalf("expected ignored duplicate removal cleared and unignored removal preserved, got %#v", meta.TrackersRemove)
+	}
+	if !reflect.DeepEqual(meta.MatchedTrackers, []string{"BLU"}) {
+		t.Fatalf("expected ignored duplicate match cleared and unignored match preserved, got %#v", meta.MatchedTrackers)
+	}
+}
+
+func TestApplyRequestToPreparedMetaPreservesRequestedRemovalForIgnoredDupe(t *testing.T) {
+	t.Parallel()
+
+	meta := applyRequestToPreparedMeta(api.PreparedMetadata{
+		TrackersRemove:  []string{"AITHER"},
+		MatchedTrackers: []string{"AITHER"},
+	}, api.Request{
+		TrackersRemove: []string{"AITHER"},
+		IgnoreDupesFor: []string{"AITHER"},
+	}, config.Config{}, api.NopLogger{})
+
+	if !reflect.DeepEqual(meta.TrackersRemove, []string{"AITHER"}) {
+		t.Fatalf("expected requested removal to remain authoritative, got %#v", meta.TrackersRemove)
+	}
+	if len(meta.MatchedTrackers) != 0 {
+		t.Fatalf("expected ignored duplicate match cleared, got %#v", meta.MatchedTrackers)
 	}
 }
 
@@ -335,6 +415,591 @@ func TestBuildUploadReviewMarksBlockedTrackersInDryRun(t *testing.T) {
 	}
 	if !strings.Contains(review.Trackers[0].DryRun.Message, "claim") {
 		t.Fatalf("expected blocked dry-run message to mention claim, got %#v", review.Trackers[0].DryRun)
+	}
+}
+
+func TestBuildUploadReviewReturnsEmptyWhenSelectedTrackersResolveEmpty(t *testing.T) {
+	t.Parallel()
+
+	trackersSvc := &recordingReviewTrackers{
+		entries: []api.TrackerDryRunEntry{{Tracker: "BLU", Status: "ready"}},
+	}
+	coreSvc, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Dupes:      &reviewDupes{},
+			Torrents:   &stubTorrent{},
+			Trackers:   trackersSvc,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	coreSvc.storeDupeCache("/tmp/a", "", api.PreparedMetadata{
+		SourcePath:     "/tmp/a",
+		TrackersRemove: []string{"AITHER"},
+	})
+
+	review, err := coreSvc.BuildUploadReview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeCLI,
+		Trackers: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("build upload review: %v", err)
+	}
+	if trackersSvc.calls != 0 {
+		t.Fatalf("expected dry-run to be skipped, got %d calls", trackersSvc.calls)
+	}
+	if len(review.Trackers) != 0 {
+		t.Fatalf("expected no tracker reviews, got %#v", review.Trackers)
+	}
+}
+
+func TestBuildUploadReviewAddsDefaultsForExplicitTrackersOutsideGUI(t *testing.T) {
+	t.Parallel()
+
+	trackersSvc := &recordingReviewTrackers{
+		entries: []api.TrackerDryRunEntry{
+			{Tracker: "BLU", Status: "ready"},
+			{Tracker: "AITHER", Status: "ready"},
+		},
+	}
+	coreSvc, err := New(api.CoreDependencies{
+		Config: config.Config{
+			MainSettings:       config.MainSettingsConfig{TMDBAPI: "x"},
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+			Trackers:           config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+		},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Dupes:      &reviewDupes{},
+			Torrents:   &stubTorrent{},
+			Trackers:   trackersSvc,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	coreSvc.storeDupeCache("/tmp/a", "", api.PreparedMetadata{SourcePath: "/tmp/a"})
+
+	review, err := coreSvc.BuildUploadReview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeCLI,
+		Trackers: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("build upload review: %v", err)
+	}
+	if !slices.Equal(trackersSvc.lastTrackers, []string{"BLU", "AITHER"}) {
+		t.Fatalf("expected default plus explicit trackers, got %v", trackersSvc.lastTrackers)
+	}
+	if got := []string{review.Trackers[0].Tracker, review.Trackers[1].Tracker}; !slices.Equal(got, []string{"BLU", "AITHER"}) {
+		t.Fatalf("expected review rows for default plus explicit trackers, got %v", got)
+	}
+}
+
+func TestBuildUploadReviewFallsBackToDefaultsWhenExplicitTrackersRemovedOutsideGUI(t *testing.T) {
+	t.Parallel()
+
+	trackersSvc := &recordingReviewTrackers{
+		entries: []api.TrackerDryRunEntry{{Tracker: "BLU", Status: "ready"}},
+	}
+	coreSvc, err := New(api.CoreDependencies{
+		Config: config.Config{
+			MainSettings:       config.MainSettingsConfig{TMDBAPI: "x"},
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+			Trackers:           config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+		},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Dupes:      &reviewDupes{},
+			Torrents:   &stubTorrent{},
+			Trackers:   trackersSvc,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	coreSvc.storeDupeCache("/tmp/a", "", api.PreparedMetadata{
+		SourcePath:     "/tmp/a",
+		TrackersRemove: []string{"AITHER"},
+	})
+
+	review, err := coreSvc.BuildUploadReview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeCLI,
+		Trackers: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("build upload review: %v", err)
+	}
+	if !slices.Equal(trackersSvc.lastTrackers, []string{"BLU"}) {
+		t.Fatalf("expected default tracker after explicit tracker removal, got %v", trackersSvc.lastTrackers)
+	}
+	if len(review.Trackers) != 1 || review.Trackers[0].Tracker != "BLU" {
+		t.Fatalf("expected one BLU review row, got %#v", review.Trackers)
+	}
+}
+
+func TestBuildUploadReviewPreservesSiteUploadSingleton(t *testing.T) {
+	t.Parallel()
+
+	trackersSvc := &recordingReviewTrackers{
+		entries: []api.TrackerDryRunEntry{{Tracker: "AITHER", Status: "ready"}},
+	}
+	coreSvc, err := New(api.CoreDependencies{
+		Config: config.Config{
+			MainSettings:       config.MainSettingsConfig{TMDBAPI: "x"},
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+			Trackers:           config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+		},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Dupes:      &reviewDupes{},
+			Torrents:   &stubTorrent{},
+			Trackers:   trackersSvc,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	coreSvc.storeDupeCache("/tmp/a", "", api.PreparedMetadata{SourcePath: "/tmp/a"})
+
+	review, err := coreSvc.BuildUploadReview(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeCLI,
+		Execution: api.ExecutionOptions{
+			SiteUploadTracker: "AITHER",
+		},
+	})
+	if err != nil {
+		t.Fatalf("build upload review: %v", err)
+	}
+	if !slices.Equal(trackersSvc.lastTrackers, []string{"AITHER"}) {
+		t.Fatalf("expected singleton site-upload tracker, got %v", trackersSvc.lastTrackers)
+	}
+	if len(review.Trackers) != 1 || review.Trackers[0].Tracker != "AITHER" {
+		t.Fatalf("expected one AITHER review row, got %#v", review.Trackers)
+	}
+}
+
+func TestBuildUploadReviewPartialGUIReviewPreservesOmittedCacheState(t *testing.T) {
+	t.Parallel()
+
+	trackersSvc := &recordingReviewTrackers{
+		entries: []api.TrackerDryRunEntry{{Tracker: "AITHER", Status: "ready", ReleaseName: "AITHER.NAME"}},
+	}
+	coreSvc, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Dupes: &reviewDupes{summary: api.DupeCheckSummary{
+				SourcePath: "/tmp/a",
+				Results: []api.DupeCheckResult{{
+					Tracker:  "AITHER",
+					HasDupes: true,
+					Status:   "completed",
+					Match: api.DupeMatch{
+						MatchedID:       "200",
+						MatchedLink:     "https://aither.cc/torrents/200",
+						MatchedDownload: "https://aither.cc/download/200.torrent",
+					},
+				}},
+			}},
+			Torrents: &stubTorrent{},
+			Trackers: trackersSvc,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	coreSvc.storeDupeCache("/tmp/a", "", api.PreparedMetadata{
+		SourcePath: "/tmp/a",
+		Trackers:   []string{"AITHER", "BLU"},
+		TrackersRemove: []string{
+			"BLU",
+		},
+		MatchedTrackers: []string{
+			"BLU",
+		},
+		BlockedTrackers: map[string][]api.TrackerBlockReason{
+			"BLU": {api.TrackerBlockReasonDupe},
+		},
+		CrossSeedTorrents: []api.UploadedTorrent{{
+			Tracker:     "BLU",
+			TorrentID:   "100",
+			DownloadURL: "https://blu/download/100.torrent",
+			TorrentURL:  "https://blu/torrents/100",
+		}},
+	})
+
+	review, err := coreSvc.BuildUploadReview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("build upload review: %v", err)
+	}
+	if len(review.Trackers) != 1 || review.Trackers[0].Tracker != "AITHER" {
+		t.Fatalf("expected one AITHER review row, got %#v", review.Trackers)
+	}
+
+	exported, ok, err := coreSvc.ExportGUICachedPreparedMeta(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	})
+	if err != nil {
+		t.Fatalf("export gui cached prepared meta: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected exported cached metadata after partial review")
+	}
+	if got := exported.BlockedTrackers["BLU"]; len(got) != 1 || got[0] != api.TrackerBlockReasonDupe {
+		t.Fatalf("expected BLU dupe block to survive, got %#v", exported.BlockedTrackers)
+	}
+	if got := exported.BlockedTrackers["AITHER"]; len(got) != 1 || got[0] != api.TrackerBlockReasonDupe {
+		t.Fatalf("expected AITHER dupe block to update, got %#v", exported.BlockedTrackers)
+	}
+	if !reflect.DeepEqual(exported.TrackersRemove, []string{"BLU"}) {
+		t.Fatalf("expected reviewed tracker removals cleared and unreviewed removals preserved, got %#v", exported.TrackersRemove)
+	}
+	if !reflect.DeepEqual(exported.MatchedTrackers, []string{"BLU"}) {
+		t.Fatalf("expected reviewed tracker matches cleared and unreviewed matches preserved, got %#v", exported.MatchedTrackers)
+	}
+	if len(exported.CrossSeedTorrents) != 2 {
+		t.Fatalf("expected both cross-seed torrents to survive, got %#v", exported.CrossSeedTorrents)
+	}
+
+	runCore, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new run core: %v", err)
+	}
+	if err := runCore.ImportPreparedMetadataForGUI(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	}, exported); err != nil {
+		t.Fatalf("import prepared metadata for gui: %v", err)
+	}
+	imported, ok := runCore.lookupGUICachedMeta(api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	}, "/tmp/a")
+	if !ok {
+		t.Fatal("expected imported cached metadata")
+	}
+	if got := imported.BlockedTrackers["BLU"]; len(got) != 1 || got[0] != api.TrackerBlockReasonDupe {
+		t.Fatalf("expected imported BLU dupe block to survive, got %#v", imported.BlockedTrackers)
+	}
+	if len(imported.CrossSeedTorrents) != 2 {
+		t.Fatalf("expected imported cross-seed torrents to survive, got %#v", imported.CrossSeedTorrents)
+	}
+}
+
+func TestMergeUploadReviewCacheMetaRefreshesReviewedTrackerStateWithMixedCaseBaseKeys(t *testing.T) {
+	t.Parallel()
+
+	base := api.PreparedMetadata{
+		BlockedTrackers: map[string][]api.TrackerBlockReason{
+			"AiThEr": {api.TrackerBlockReasonDupe},
+			"BLU":    {api.TrackerBlockReasonClaim},
+		},
+		TrackerRuleFailures: map[string][]api.RuleFailure{
+			"AiThEr": {{Rule: "old_aither", Reason: "stale"}},
+			"aither": {{Rule: "older_aither", Reason: "staler"}},
+			"BLU":    {{Rule: "old_blu", Reason: "keep"}},
+		},
+		TrackersRemove:  []string{"AiThEr", "BLU"},
+		MatchedTrackers: []string{"AiThEr", "BLU"},
+		CrossSeedTorrents: []api.UploadedTorrent{
+			{Tracker: "AiThEr", TorrentID: "1"},
+			{Tracker: "BLU", TorrentID: "2"},
+		},
+	}
+	updated := api.PreparedMetadata{
+		BlockedTrackers: map[string][]api.TrackerBlockReason{
+			"aItHeR": {api.TrackerBlockReasonAudio, api.TrackerBlockReasonDupe},
+		},
+		TrackerRuleFailures: map[string][]api.RuleFailure{
+			"aither": {{Rule: "new_aither", Reason: "fresh"}},
+		},
+		TrackersRemove: []string{"aither"},
+		CrossSeedTorrents: []api.UploadedTorrent{
+			{Tracker: "AITHER", TorrentID: "3"},
+		},
+	}
+
+	merged := mergeUploadReviewCacheMeta(base, updated, []string{"AITHER"})
+
+	if got := merged.BlockedTrackers["AITHER"]; !reflect.DeepEqual(got, []api.TrackerBlockReason{api.TrackerBlockReasonAudio, api.TrackerBlockReasonDupe}) {
+		t.Fatalf("expected reviewed tracker blocks to refresh, got %#v", got)
+	}
+	if _, ok := merged.BlockedTrackers["AiThEr"]; ok {
+		t.Fatalf("expected mixed-case reviewed tracker block key removed, got %#v", merged.BlockedTrackers)
+	}
+	if got := merged.BlockedTrackers["BLU"]; !reflect.DeepEqual(got, []api.TrackerBlockReason{api.TrackerBlockReasonClaim}) {
+		t.Fatalf("expected unreviewed tracker blocks to remain, got %#v", got)
+	}
+	if got := merged.TrackerRuleFailures["AITHER"]; !reflect.DeepEqual(got, []api.RuleFailure{{Rule: "new_aither", Reason: "fresh"}}) {
+		t.Fatalf("expected reviewed tracker rule failures to refresh, got %#v", got)
+	}
+	if _, ok := merged.TrackerRuleFailures["AiThEr"]; ok {
+		t.Fatalf("expected mixed-case reviewed tracker rule failure key removed, got %#v", merged.TrackerRuleFailures)
+	}
+	if _, ok := merged.TrackerRuleFailures["aither"]; ok {
+		t.Fatalf("expected duplicate reviewed tracker rule failure key removed, got %#v", merged.TrackerRuleFailures)
+	}
+	if got := merged.TrackerRuleFailures["BLU"]; !reflect.DeepEqual(got, []api.RuleFailure{{Rule: "old_blu", Reason: "keep"}}) {
+		t.Fatalf("expected unreviewed tracker rule failures to remain, got %#v", got)
+	}
+	if !reflect.DeepEqual(merged.TrackersRemove, []string{"BLU", "AITHER"}) {
+		t.Fatalf("expected reviewed tracker removals to refresh and unreviewed removals to remain, got %#v", merged.TrackersRemove)
+	}
+	if !reflect.DeepEqual(merged.MatchedTrackers, []string{"BLU"}) {
+		t.Fatalf("expected reviewed matched tracker cleared and unreviewed match preserved, got %#v", merged.MatchedTrackers)
+	}
+	if len(merged.CrossSeedTorrents) != 2 {
+		t.Fatalf("expected merged cross-seed torrents, got %#v", merged.CrossSeedTorrents)
+	}
+	if len(base.CrossSeedTorrents) != 2 || len(updated.CrossSeedTorrents) != 1 {
+		t.Fatalf("expected merge to avoid aliasing, base=%#v updated=%#v", base.CrossSeedTorrents, updated.CrossSeedTorrents)
+	}
+	coreSvc := &Core{logger: api.NopLogger{}}
+	eligible := mergeUploadReviewCacheMeta(base, api.PreparedMetadata{}, []string{"AITHER"})
+	if got := coreSvc.filterImageUploadTrackers([]string{"AITHER", "BLU"}, eligible); !reflect.DeepEqual(got, []string{"AITHER"}) {
+		t.Fatalf("expected reviewed tracker image upload eligibility restored after merge, got %#v", got)
+	}
+}
+
+func TestBuildUploadReviewCommitsReviewedTrackerUpdateFromMatchingRefreshedCache(t *testing.T) {
+	t.Parallel()
+
+	trackersSvc := &recordingReviewTrackers{
+		entries: []api.TrackerDryRunEntry{
+			{Tracker: "AITHER", Status: "ready"},
+			{Tracker: "BLU", Status: "ready"},
+		},
+	}
+	coreSvc, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Dupes:      &reviewDupes{},
+			Torrents:   &stubTorrent{},
+			Trackers:   trackersSvc,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	initial := api.PreparedMetadata{
+		SourcePath: "/tmp/a",
+		Mode:       api.ModeGUI,
+		Options: api.UploadOptions{
+			InteractionMode: api.InteractionModeInteractive,
+			Screens:         1,
+		},
+		Trackers: []string{"BLU", "AITHER"},
+		BlockedTrackers: map[string][]api.TrackerBlockReason{
+			"AITHER": {api.TrackerBlockReasonDupe},
+			"BLU":    {api.TrackerBlockReasonDupe},
+		},
+		TrackerRuleFailures: map[string][]api.RuleFailure{
+			"BLU": {{Rule: "old_blu", Reason: "keep"}},
+		},
+		CrossSeedTorrents: []api.UploadedTorrent{
+			{Tracker: "AITHER", TorrentID: "1", DownloadURL: "https://dupes/aither"},
+			{Tracker: "BLU", TorrentID: "2", DownloadURL: "https://dupes/blu"},
+		},
+	}
+	coreSvc.storeRefreshedDupeCache("/tmp/a", "", initial)
+
+	_, err = coreSvc.BuildUploadReview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"aither", "blu"},
+	})
+	if err != nil {
+		t.Fatalf("build upload review: %v", err)
+	}
+	entry, _, ok := coreSvc.lookupGUICachedMetaEntry(api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"aither", "blu"},
+	}, "/tmp/a")
+	if !ok {
+		t.Fatal("expected gui cache entry")
+	}
+	if entry.requestRefreshed {
+		t.Fatal("expected matching refreshed cache entry to commit as stable cache")
+	}
+	if got := entry.meta.BlockedTrackers["AITHER"]; len(got) != 0 {
+		t.Fatalf("expected reviewed tracker dupe block cleared, got %#v", entry.meta.BlockedTrackers)
+	}
+}
+
+func TestBuildUploadReviewSkipsCacheCommitWhenRefreshedBaseDoesNotMatchRequest(t *testing.T) {
+	t.Parallel()
+
+	trackersSvc := &recordingReviewTrackers{
+		entries: []api.TrackerDryRunEntry{{Tracker: "BLU", Status: "ready"}},
+	}
+	coreSvc, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Dupes:      &reviewDupes{},
+			Torrents:   &stubTorrent{},
+			Trackers:   trackersSvc,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	initial := api.PreparedMetadata{
+		SourcePath: "/tmp/a",
+		Mode:       api.ModeGUI,
+		Options: api.UploadOptions{
+			InteractionMode: api.InteractionModeInteractive,
+			Screens:         1,
+		},
+		Trackers: []string{"AITHER"},
+		BlockedTrackers: map[string][]api.TrackerBlockReason{
+			"BLU": {api.TrackerBlockReasonDupe},
+		},
+	}
+	coreSvc.storeRefreshedDupeCache("/tmp/a", "", initial)
+
+	_, err = coreSvc.BuildUploadReview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"BLU"},
+	})
+	if err != nil {
+		t.Fatalf("build upload review: %v", err)
+	}
+	entry, _, ok := coreSvc.lookupGUICachedMetaEntry(api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"BLU"},
+	}, "/tmp/a")
+	if !ok {
+		t.Fatal("expected gui cache entry")
+	}
+	if !entry.requestRefreshed {
+		t.Fatal("expected mismatched refreshed cache entry to remain request-refreshed")
+	}
+	if !reflect.DeepEqual(entry.meta, initial) {
+		t.Fatalf("expected mismatched refreshed cache entry unchanged, got %#v", entry.meta)
+	}
+}
+
+func TestBuildUploadReviewDoesNotCorruptCacheWhenTorrentCreateFails(t *testing.T) {
+	t.Parallel()
+
+	torrentSvc := &recordingReviewTorrent{err: errors.New("torrent create failed")}
+	trackersSvc := &recordingReviewTrackers{
+		entries: []api.TrackerDryRunEntry{{Tracker: "AITHER", Status: "ready"}},
+	}
+	coreSvc, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Dupes:      &reviewDupes{},
+			Torrents:   torrentSvc,
+			Trackers:   trackersSvc,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	initial := api.PreparedMetadata{SourcePath: "/tmp/a", Trackers: []string{"AITHER"}}
+	coreSvc.storeRefreshedDupeCache("/tmp/a", "", initial)
+
+	_, err = coreSvc.BuildUploadReview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "torrent create failed") {
+		t.Fatalf("expected torrent create failure, got %v", err)
+	}
+	entry, _, ok := coreSvc.lookupGUICachedMetaEntry(api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	}, "/tmp/a")
+	if !ok {
+		t.Fatal("expected gui cache entry")
+	}
+	if !reflect.DeepEqual(entry.meta, initial) {
+		t.Fatalf("expected cache entry unchanged after torrent failure, got %#v", entry.meta)
+	}
+}
+
+func TestBuildUploadReviewDoesNotCorruptCacheWhenDryRunFails(t *testing.T) {
+	t.Parallel()
+
+	trackersSvc := &recordingReviewTrackers{err: errors.New("dry-run failed")}
+	coreSvc, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Dupes:      &reviewDupes{},
+			Torrents:   &stubTorrent{},
+			Trackers:   trackersSvc,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+	initial := api.PreparedMetadata{SourcePath: "/tmp/a", Trackers: []string{"AITHER"}}
+	coreSvc.storeRefreshedDupeCache("/tmp/a", "", initial)
+
+	_, err = coreSvc.BuildUploadReview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "dry-run failed") {
+		t.Fatalf("expected dry-run failure, got %v", err)
+	}
+	entry, _, ok := coreSvc.lookupGUICachedMetaEntry(api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	}, "/tmp/a")
+	if !ok {
+		t.Fatal("expected gui cache entry")
+	}
+	if !reflect.DeepEqual(entry.meta, initial) {
+		t.Fatalf("expected cache entry unchanged after dry-run failure, got %#v", entry.meta)
 	}
 }
 

--- a/internal/trackers/resolve.go
+++ b/internal/trackers/resolve.go
@@ -10,6 +10,9 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+// ResolveTrackers returns known trackers from explicit overrides when provided,
+// otherwise configured defaults, after applying removals. Returned names are
+// trimmed and uppercased.
 func ResolveTrackers(cfg config.Config, override []string, remove []string, logger api.Logger) []string {
 	resolved := resolveTrackers(cfg, override, remove)
 	resolved = filterKnownTrackers(resolved, logger)
@@ -19,6 +22,10 @@ func ResolveTrackers(cfg config.Config, override []string, remove []string, logg
 	return resolved
 }
 
+// ResolveTrackersWithDefaults returns known configured default trackers plus
+// explicit overrides, after applying removals. Use it for flows where explicit
+// tracker selections augment defaults instead of replacing them. Returned names
+// are trimmed and uppercased.
 func ResolveTrackersWithDefaults(cfg config.Config, override []string, remove []string, logger api.Logger) []string {
 	resolved := resolveTrackersWithDefaults(cfg, override, remove)
 	resolved = filterKnownTrackers(resolved, logger)

--- a/internal/trackers/service_test.go
+++ b/internal/trackers/service_test.go
@@ -61,6 +61,48 @@ func TestUploadOverrideTrackers(t *testing.T) {
 	}
 }
 
+func TestUploadOverrideTrackersReplaceDefaults(t *testing.T) {
+	t.Parallel()
+
+	requests := make(chan UploadRequest, 2)
+	registry := NewRegistry()
+	for _, definition := range []Definition{
+		trackingUploadDefinition{name: "BLU", requests: requests},
+		trackingUploadDefinition{name: "AITHER", requests: requests},
+	} {
+		if err := registry.Register(definition); err != nil {
+			t.Fatalf("register stub: %v", err)
+		}
+	}
+
+	cfg := config.Config{Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}}}
+	svc := NewServiceWithRegistry(cfg, nil, nil, registry)
+	summary, err := svc.Upload(context.Background(), api.PreparedMetadata{
+		SourcePath: "/tmp/file",
+		Trackers:   []string{"aither"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary.Uploaded != 1 {
+		t.Fatalf("expected 1 upload, got %d", summary.Uploaded)
+	}
+
+	select {
+	case req := <-requests:
+		if req.Tracker != "AITHER" {
+			t.Fatalf("expected AITHER upload, got %q", req.Tracker)
+		}
+	default:
+		t.Fatal("expected upload request")
+	}
+	select {
+	case req := <-requests:
+		t.Fatalf("expected defaults excluded from override upload, got extra %q", req.Tracker)
+	default:
+	}
+}
+
 func TestUploadRemovesTrackers(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -102,8 +102,14 @@ type Core interface {
 	RunUpload(ctx context.Context, req Request) (Result, error)
 	RunUploadPrepared(ctx context.Context, req Request) (Result, error)
 	FetchMetadataPreview(ctx context.Context, req Request) (MetadataPreview, error)
+	// FetchDescriptionBuilderPreview returns editable description groups for one
+	// source path. Non-empty request trackers limit group generation to that set.
 	FetchDescriptionBuilderPreview(ctx context.Context, req Request) (DescriptionBuilderPreview, error)
+	// FetchDescriptionBuilderGroupPreview rebuilds one editable description group
+	// for the requested source path and selected tracker set.
 	FetchDescriptionBuilderGroupPreview(ctx context.Context, req Request) (DescriptionBuilderGroup, error)
+	// FetchPreparationPreview returns tracker preparation details for one source
+	// path. Non-empty request trackers limit preparation to that set.
 	FetchPreparationPreview(ctx context.Context, req Request) (PreparationPreview, error)
 	FetchTrackerDryRunPreview(ctx context.Context, req Request) (TrackerDryRunPreview, error)
 	CheckDupes(ctx context.Context, req Request) (DupeCheckSummary, error)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved tracker selection handling to distinguish “explicitly empty” from “not set”, ensuring consistent empty-selection behavior across fetch, reset, playlist preparation, previews, and uploads.
  * Centralized upload eligibility filtering so only eligible trackers drive backend operations.

* **Bug Fixes**
  * Prevented metadata/preview and upload-prepared actions from running when the resolved selection is empty (including warm and cached flows).
  * Improved tracker upload start/retry/cancel state handling when bootstrapping fails, and tightened cached-preparation matching/refresh behavior.

* **Tests**
  * Added extensive frontend and core test coverage for eligibility, cached matching/refresh, and empty-resolution short-circuiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->