### PR TITLE
restrict Docker latest tag to tag releases

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -386,7 +386,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}},value=${{ inputs.release_tag || github.ref_name }},enable=${{ inputs.release_tag != '' || github.ref_type == 'tag' }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.release_tag || github.ref_name }},enable=${{ inputs.release_tag != '' || github.ref_type == 'tag' }}
-            type=raw,value=latest,enable=${{ inputs.release_tag != '' || github.ref_type == 'tag' || github.ref_name == github.event.repository.default_branch }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref_type == 'tag' }}
 
       - name: Derive amd64 image tags
         id: amd64_tags
@@ -468,7 +468,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}},value=${{ inputs.release_tag || github.ref_name }},enable=${{ inputs.release_tag != '' || github.ref_type == 'tag' }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.release_tag || github.ref_name }},enable=${{ inputs.release_tag != '' || github.ref_type == 'tag' }}
-            type=raw,value=latest,enable=${{ inputs.release_tag != '' || github.ref_type == 'tag' || github.ref_name == github.event.repository.default_branch }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref_type == 'tag' }}
 
       - name: Derive arm64 image tags
         id: arm64_tags
@@ -553,7 +553,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}},value=${{ inputs.release_tag || github.ref_name }},enable=${{ inputs.release_tag != '' || github.ref_type == 'tag' }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.release_tag || github.ref_name }},enable=${{ inputs.release_tag != '' || github.ref_type == 'tag' }}
-            type=raw,value=latest,enable=${{ inputs.release_tag != '' || github.ref_type == 'tag' || github.ref_name == github.event.repository.default_branch }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref_type == 'tag' }}
 
       - name: Create and push multi-arch manifests
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary

Restricts Docker image `latest` tagging in `build-binaries.yml` to actual tag-push release events.

## Why

The reusable build workflow currently emits `latest` for workflow calls with `release_tag` and for default-branch builds. That lets non-tag build paths update `latest`, while release publishing should be the only path that moves it.

## Impact

Docker arch images and the multi-arch manifest now publish `latest` only when the event is a pushed Git tag. Branch builds, PR builds, direct build workflow dispatches, and manual release workflow calls with an existing tag no longer emit `latest`.

## Validation

- `git diff --check -- .github\workflows\build-binaries.yml`
- `actionlint .github\workflows\build-binaries.yml .github\workflows\release.yml`
- `pnpm --dir gui/frontend run typecheck`
- pre-push hook: `go-lint`, `frontend-typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified Docker image tag generation behavior in automated build workflows across multiple platforms (AMD64, ARM64). The "latest" image tag is now restricted to container builds triggered by tagged version releases, improving version consistency compared to the previous behavior of tagging builds from default branch updates and other release sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->