### PR TITLE
fix: config handling

### DIFF
--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -598,6 +598,8 @@ func parseServePortValue(value string) (int, error) {
 	return port, nil
 }
 
+// loadCLIConfig bootstraps CLI config and validates both the env-applied
+// pre-persist candidate and the returned runtime config.
 func loadCLIConfig(configPath string, configProvided bool) (config.Config, string, error) {
 	cfg, dbPath, err := configstore.BootstrapWithValidator(context.Background(), configPath, configProvided, true, func(cfg *config.Config) error {
 		return cfg.Validate()
@@ -613,7 +615,9 @@ func loadCLIConfig(configPath string, configProvided bool) (config.Config, strin
 
 // loadServeConfig loads config for the web server without requiring a fully
 // valid config (e.g. tmdb_api). The web UI handles initial setup, so the
-// server must be able to start even on a fresh install with no config yet.
+// server must be able to start even on a fresh install with no config yet. A
+// provided --config may seed or merge database config, but invalid env-applied
+// input is not persisted over stored settings.
 func loadServeConfig(configPath string, configProvided bool) (config.Config, string, error) {
 	return wrapUpbrrResult2(configstore.Bootstrap(context.Background(), configPath, configProvided, configProvided))
 }

--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -599,7 +599,9 @@ func parseServePortValue(value string) (int, error) {
 }
 
 func loadCLIConfig(configPath string, configProvided bool) (config.Config, string, error) {
-	cfg, dbPath, err := configstore.Bootstrap(context.Background(), configPath, configProvided, true)
+	cfg, dbPath, err := configstore.BootstrapWithValidator(context.Background(), configPath, configProvided, true, func(cfg *config.Config) error {
+		return cfg.Validate()
+	})
 	if err != nil {
 		return config.Config{}, "", fmt.Errorf("upbrr: %w", err)
 	}
@@ -613,7 +615,7 @@ func loadCLIConfig(configPath string, configProvided bool) (config.Config, strin
 // valid config (e.g. tmdb_api). The web UI handles initial setup, so the
 // server must be able to start even on a fresh install with no config yet.
 func loadServeConfig(configPath string, configProvided bool) (config.Config, string, error) {
-	return wrapUpbrrResult2(configstore.Bootstrap(context.Background(), configPath, configProvided, false))
+	return wrapUpbrrResult2(configstore.Bootstrap(context.Background(), configPath, configProvided, configProvided))
 }
 
 func exportConfigToYAML(ctx context.Context, configPath string, configProvided bool, outputPath string, plaintext bool) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1149,7 +1149,7 @@ func asciiEqualFold(value string, target string) bool {
 	if len(value) != len(target) {
 		return false
 	}
-	for i := range value {
+	for i := 0; i < len(value); i++ {
 		left := value[i]
 		right := target[i]
 		if 'A' <= left && left <= 'Z' {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1015,6 +1015,8 @@ func ResolveBTNAPIToken(cfg Config) string {
 	return token
 }
 
+// trackerAPIKeyByName returns an exact tracker token before considering
+// deterministic ASCII-case aliases for the same canonical tracker name.
 func trackerAPIKeyByName(trackers map[string]TrackerConfig, name string) string {
 	if token := trackerAPIKeyForExactName(trackers, name); token != "" {
 		return token
@@ -1027,6 +1029,8 @@ func trackerAPIKeyByName(trackers map[string]TrackerConfig, name string) string 
 	return ""
 }
 
+// trackerAPIKeyForExactName returns the trimmed API key for name without any
+// case folding or alias lookup.
 func trackerAPIKeyForExactName(trackers map[string]TrackerConfig, name string) string {
 	if trackerCfg, ok := trackers[name]; ok {
 		return strings.TrimSpace(trackerCfg.APIKey)
@@ -1099,6 +1103,8 @@ func MergeMissingTrackerDefaults(cfg *Config) error {
 	return nil
 }
 
+// trackerDefaultMergeEntry returns the exact tracker entry when present, then
+// the first ASCII-case alias in sorted order.
 func trackerDefaultMergeEntry(trackers map[string]TrackerConfig, name string) (string, TrackerConfig, bool) {
 	if trackerCfg, ok := trackers[name]; ok {
 		return name, trackerCfg, true
@@ -1111,6 +1117,8 @@ func trackerDefaultMergeEntry(trackers map[string]TrackerConfig, name string) (s
 	return "", TrackerConfig{}, false
 }
 
+// trackerBTNMergeName selects the tracker map key that should receive a legacy
+// metadata BTN token during default backfill.
 func trackerBTNMergeName(trackers map[string]TrackerConfig) string {
 	if _, ok := trackers["BTN"]; ok {
 		return "BTN"
@@ -1122,6 +1130,8 @@ func trackerBTNMergeName(trackers map[string]TrackerConfig) string {
 	return "BTN"
 }
 
+// sortedASCIITrackerAliases returns non-exact tracker keys that match name
+// under ASCII-only case folding.
 func sortedASCIITrackerAliases(trackers map[string]TrackerConfig, name string) []string {
 	aliases := make([]string, 0, len(trackers))
 	for trackerName := range trackers {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/url"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,6 +34,8 @@ type Config struct {
 	Logging            LoggingConfig                  `yaml:"logging"`
 	Trackers           TrackersConfig                 `yaml:"trackers"`
 	TorrentClients     map[string]TorrentClientConfig `yaml:"torrent_clients"`
+
+	secretReencryptionRequired bool
 }
 
 const DefaultInputHistoryLimit = 20
@@ -814,6 +817,8 @@ func torrentClientConfigYAMLMap(c TorrentClientConfig) map[string]any {
 	return out
 }
 
+// Validate checks the loaded configuration values needed before runtime
+// services can safely start or save settings.
 func (c Config) Validate() error {
 	if c.MainSettings.TMDBAPI == "" {
 		return errors.New("config: main_settings.tmdb_api is required")
@@ -976,6 +981,8 @@ func lookupTorrentClient(clients map[string]TorrentClientConfig, selected string
 	return len(foldMatches) == 1
 }
 
+// DisableUnsupportedTrackerImageRehosts turns off img_rehost for trackers that
+// have no image-host policy and returns the tracker names that changed.
 func DisableUnsupportedTrackerImageRehosts(cfg *Config) []string {
 	if cfg == nil || len(cfg.Trackers.Trackers) == 0 {
 		return nil
@@ -997,19 +1004,41 @@ func DisableUnsupportedTrackerImageRehosts(cfg *Config) []string {
 	return disabled
 }
 
+// ResolveBTNAPIToken returns the BTN tracker API key from ASCII case variants
+// of "BTN" before falling back to the legacy metadata-level token. Fuzzy or
+// Unicode-equivalent tracker names are not treated as aliases.
 func ResolveBTNAPIToken(cfg Config) string {
-	if trackerCfg, ok := cfg.Trackers.Trackers["BTN"]; ok {
-		token := strings.TrimSpace(trackerCfg.APIKey)
-		if token != "" {
-			return token
-		}
+	if token := trackerAPIKeyByName(cfg.Trackers.Trackers, "BTN"); token != "" {
+		return token
 	}
 	token := strings.TrimSpace(cfg.Metadata.BTNAPI)
 	return token
 }
 
+func trackerAPIKeyByName(trackers map[string]TrackerConfig, name string) string {
+	if token := trackerAPIKeyForExactName(trackers, name); token != "" {
+		return token
+	}
+	for _, trackerName := range sortedASCIITrackerAliases(trackers, name) {
+		if token := strings.TrimSpace(trackers[trackerName].APIKey); token != "" {
+			return token
+		}
+	}
+	return ""
+}
+
+func trackerAPIKeyForExactName(trackers map[string]TrackerConfig, name string) string {
+	if trackerCfg, ok := trackers[name]; ok {
+		return strings.TrimSpace(trackerCfg.APIKey)
+	}
+	return ""
+}
+
 // MergeMissingTrackerDefaults backfills tracker stubs from the embedded example
 // config so older saved configs can discover newly added trackers in the GUI.
+// Existing exact tracker names are preserved; ASCII case variants of "BTN" are
+// treated as the BTN entry so default backfill and legacy metadata tokens do not
+// create a duplicate canonical "BTN" entry.
 // CZT keeps user credentials in Passkey only, so stale URL, APIKey, and
 // AnnounceURL values are removed while preserving the passkey.
 func MergeMissingTrackerDefaults(cfg *Config) error {
@@ -1030,32 +1059,33 @@ func MergeMissingTrackerDefaults(cfg *Config) error {
 		return errors.New("load embedded tracker defaults: embedded default trackers missing")
 	}
 	for trackerName, trackerCfg := range defaults.Trackers.Trackers {
-		existing, ok := cfg.Trackers.Trackers[trackerName]
+		existingName, existing, ok := trackerDefaultMergeEntry(cfg.Trackers.Trackers, trackerName)
 		if !ok {
 			cfg.Trackers.Trackers[trackerName] = trackerCfg
 			continue
 		}
-		if strings.EqualFold(strings.TrimSpace(trackerName), "CZT") {
+		if asciiEqualFold(trackerName, "CZT") {
 			existing.URL = ""
 			existing.APIKey = ""
 			existing.AnnounceURL = ""
-			cfg.Trackers.Trackers[trackerName] = existing
+			cfg.Trackers.Trackers[existingName] = existing
 			continue
 		}
 		if strings.TrimSpace(existing.URL) == "" && strings.TrimSpace(trackerCfg.URL) != "" {
 			existing.URL = trackerCfg.URL
-			cfg.Trackers.Trackers[trackerName] = existing
+			cfg.Trackers.Trackers[existingName] = existing
 		}
 	}
-	if token := strings.TrimSpace(cfg.Metadata.BTNAPI); token != "" {
-		btnCfg := cfg.Trackers.Trackers["BTN"]
+	if token := strings.TrimSpace(cfg.Metadata.BTNAPI); token != "" && trackerAPIKeyByName(cfg.Trackers.Trackers, "BTN") == "" {
+		btnName := trackerBTNMergeName(cfg.Trackers.Trackers)
+		btnCfg := cfg.Trackers.Trackers[btnName]
 		if strings.TrimSpace(btnCfg.APIKey) == "" {
 			btnCfg.APIKey = token
-			cfg.Trackers.Trackers["BTN"] = btnCfg
+			cfg.Trackers.Trackers[btnName] = btnCfg
 		}
 	}
 	for trackerName, trackerCfg := range cfg.Trackers.Trackers {
-		if !strings.EqualFold(strings.TrimSpace(trackerName), "CZT") {
+		if !asciiEqualFold(trackerName, "CZT") {
 			continue
 		}
 		if strings.TrimSpace(trackerCfg.APIKey) == "" && strings.TrimSpace(trackerCfg.URL) == "" && strings.TrimSpace(trackerCfg.AnnounceURL) == "" {
@@ -1067,6 +1097,62 @@ func MergeMissingTrackerDefaults(cfg *Config) error {
 		cfg.Trackers.Trackers[trackerName] = trackerCfg
 	}
 	return nil
+}
+
+func trackerDefaultMergeEntry(trackers map[string]TrackerConfig, name string) (string, TrackerConfig, bool) {
+	if trackerCfg, ok := trackers[name]; ok {
+		return name, trackerCfg, true
+	}
+	aliases := sortedASCIITrackerAliases(trackers, name)
+	if len(aliases) > 0 {
+		trackerName := aliases[0]
+		return trackerName, trackers[trackerName], true
+	}
+	return "", TrackerConfig{}, false
+}
+
+func trackerBTNMergeName(trackers map[string]TrackerConfig) string {
+	if _, ok := trackers["BTN"]; ok {
+		return "BTN"
+	}
+	aliases := sortedASCIITrackerAliases(trackers, "BTN")
+	if len(aliases) > 0 {
+		return aliases[0]
+	}
+	return "BTN"
+}
+
+func sortedASCIITrackerAliases(trackers map[string]TrackerConfig, name string) []string {
+	aliases := make([]string, 0, len(trackers))
+	for trackerName := range trackers {
+		if trackerName != name && asciiEqualFold(trackerName, name) {
+			aliases = append(aliases, trackerName)
+		}
+	}
+	sort.Strings(aliases)
+	return aliases
+}
+
+// asciiEqualFold compares fixed tracker names using ASCII-only case folding so
+// Unicode-equivalent names are not treated as tracker aliases.
+func asciiEqualFold(value string, target string) bool {
+	if len(value) != len(target) {
+		return false
+	}
+	for i := range value {
+		left := value[i]
+		right := target[i]
+		if 'A' <= left && left <= 'Z' {
+			left += 'a' - 'A'
+		}
+		if 'A' <= right && right <= 'Z' {
+			right += 'a' - 'A'
+		}
+		if left != right {
+			return false
+		}
+	}
+	return true
 }
 
 func (c TorrentClientConfig) QbitHost() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestValidate(t *testing.T) {
@@ -754,6 +756,166 @@ func TestResolveBTNAPITokenPrefersTrackerConfig(t *testing.T) {
 	}
 }
 
+func TestResolveBTNAPITokenUsesLowercaseTrackerConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Metadata: MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: TrackersConfig{
+			Trackers: map[string]TrackerConfig{
+				"btn": {APIKey: " lowercase-token "},
+			},
+		},
+	}
+
+	if got := ResolveBTNAPIToken(cfg); got != "lowercase-token" {
+		t.Fatalf("expected lowercase tracker token, got %q", got)
+	}
+}
+
+func TestResolveBTNAPITokenPrefersExactBTNOverFoldedTrackerConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Trackers: TrackersConfig{
+			Trackers: map[string]TrackerConfig{
+				"BTN": {APIKey: "canonical-token"},
+				"btn": {APIKey: "lowercase-token"},
+			},
+		},
+	}
+
+	if got := ResolveBTNAPIToken(cfg); got != "canonical-token" {
+		t.Fatalf("expected canonical tracker token, got %q", got)
+	}
+}
+
+func TestResolveBTNAPITokenUsesLowercaseTrackerWhenExactBTNEmpty(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Metadata: MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: TrackersConfig{
+			Trackers: map[string]TrackerConfig{
+				"BTN": {APIKey: " "},
+				"btn": {APIKey: "lowercase-token"},
+			},
+		},
+	}
+
+	if got := ResolveBTNAPIToken(cfg); got != "lowercase-token" {
+		t.Fatalf("expected lowercase tracker token, got %q", got)
+	}
+}
+
+func TestResolveBTNAPITokenUsesDeterministicASCIICaseAliasPrecedence(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Metadata: MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: TrackersConfig{
+			Trackers: map[string]TrackerConfig{
+				"BTN": {APIKey: " "},
+				"bTN": {APIKey: "third-token"},
+				"btn": {APIKey: "second-token"},
+				"BtN": {APIKey: "first-token"},
+			},
+		},
+	}
+
+	for range 25 {
+		if got := ResolveBTNAPIToken(cfg); got != "first-token" {
+			t.Fatalf("expected deterministic folded tracker token, got %q", got)
+		}
+	}
+}
+
+func TestResolveBTNAPITokenMatchesASCIICaseTrackerNames(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Metadata: MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: TrackersConfig{
+			Trackers: map[string]TrackerConfig{
+				"BTN": {APIKey: " "},
+				"BtN": {APIKey: "mixed-token"},
+			},
+		},
+	}
+
+	if got := ResolveBTNAPIToken(cfg); got != "mixed-token" {
+		t.Fatalf("expected mixed-case tracker token, got %q", got)
+	}
+}
+
+func TestResolveBTNAPITokenDoesNotMatchUnicodeEquivalentTrackerNames(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Metadata: MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: TrackersConfig{
+			Trackers: map[string]TrackerConfig{
+				"\uFF22\uFF34\uFF2E": {APIKey: "fullwidth-token"},
+			},
+		},
+	}
+
+	if got := ResolveBTNAPIToken(cfg); got != "legacy-token" {
+		t.Fatalf("expected legacy token fallback, got %q", got)
+	}
+}
+
+func TestResolveBTNAPITokenDoesNotMatchFuzzyTrackerNames(t *testing.T) {
+	t.Parallel()
+
+	spacedBTNTrackerName := " BTN "
+	cfg := Config{
+		Metadata: MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: TrackersConfig{
+			Trackers: map[string]TrackerConfig{
+				spacedBTNTrackerName: {APIKey: "spaced-token"},
+				"BTNx":               {APIKey: "suffix-token"},
+				"b-t-n":              {APIKey: "separator-token"},
+				"xBTN":               {APIKey: "prefix-token"},
+			},
+		},
+	}
+
+	if got := ResolveBTNAPIToken(cfg); got != "legacy-token" {
+		t.Fatalf("expected legacy token fallback, got %q", got)
+	}
+}
+
+func TestResolveBTNAPITokenUsesLowercaseTrackerConfigFromJSONAndYAML(t *testing.T) {
+	t.Parallel()
+
+	var jsonCfg Config
+	if err := json.Unmarshal([]byte(`{
+		"metadata": {"btn_api": "legacy-token"},
+		"trackers": {"Trackers": {"btn": {"APIKey": "json-token"}}}
+	}`), &jsonCfg); err != nil {
+		t.Fatalf("unmarshal json config: %v", err)
+	}
+	if got := ResolveBTNAPIToken(jsonCfg); got != "json-token" {
+		t.Fatalf("expected json tracker token, got %q", got)
+	}
+
+	var yamlCfg Config
+	if err := yaml.Unmarshal([]byte(`
+metadata:
+  btn_api: legacy-token
+trackers:
+  trackers:
+    btn:
+      api_key: yaml-token
+`), &yamlCfg); err != nil {
+		t.Fatalf("unmarshal yaml config: %v", err)
+	}
+	if got := ResolveBTNAPIToken(yamlCfg); got != "yaml-token" {
+		t.Fatalf("expected yaml tracker token, got %q", got)
+	}
+}
+
 func TestMergeMissingTrackerDefaultsBackfillsLegacyBTNAPIIntoTrackerConfig(t *testing.T) {
 	t.Parallel()
 
@@ -773,14 +935,103 @@ func TestMergeMissingTrackerDefaultsBackfillsLegacyBTNAPIIntoTrackerConfig(t *te
 	}
 }
 
+func TestMergeMissingTrackerDefaultsDoesNotBackfillLegacyBTNAPIOverLowercaseTrackerConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Metadata: MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: TrackersConfig{
+			Trackers: map[string]TrackerConfig{
+				"btn": {APIKey: "lowercase-token"},
+			},
+		},
+	}
+
+	if err := MergeMissingTrackerDefaults(cfg); err != nil {
+		t.Fatalf("merge missing tracker defaults: %v", err)
+	}
+
+	if got := ResolveBTNAPIToken(*cfg); got != "lowercase-token" {
+		t.Fatalf("expected lowercase tracker token after merge, got %q", got)
+	}
+	if _, ok := cfg.Trackers.Trackers["BTN"]; ok {
+		t.Fatalf("expected canonical BTN default not to duplicate lowercase btn tracker")
+	}
+	if got := cfg.Trackers.Trackers["btn"].URL; got != "https://backup.landof.tv" {
+		t.Fatalf("expected lowercase btn URL to be backfilled, got %q", got)
+	}
+}
+
+func TestMergeMissingTrackerDefaultsReconcilesLowercaseBTNWithoutToken(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Metadata: MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: TrackersConfig{
+			Trackers: map[string]TrackerConfig{
+				"btn": {Username: "user", Password: "pass"},
+			},
+		},
+	}
+
+	if err := MergeMissingTrackerDefaults(cfg); err != nil {
+		t.Fatalf("merge missing tracker defaults: %v", err)
+	}
+
+	if _, ok := cfg.Trackers.Trackers["BTN"]; ok {
+		t.Fatalf("expected canonical BTN default not to duplicate lowercase btn tracker")
+	}
+	btn := cfg.Trackers.Trackers["btn"]
+	if got := btn.APIKey; got != "legacy-token" {
+		t.Fatalf("expected legacy BTN api token to backfill lowercase tracker config, got %q", got)
+	}
+	if got := ResolveBTNAPIToken(*cfg); got != "legacy-token" {
+		t.Fatalf("expected legacy tracker token after merge, got %q", got)
+	}
+	if btn.Username != "user" || btn.Password != "pass" {
+		t.Fatalf("expected lowercase btn non-token fields to be preserved, got username=%q password=%q", btn.Username, btn.Password)
+	}
+	if got := btn.URL; got != "https://backup.landof.tv" {
+		t.Fatalf("expected lowercase btn URL to be backfilled, got %q", got)
+	}
+}
+
+func TestMergeMissingTrackerDefaultsUsesASCIICaseBTNTrackerConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Metadata: MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: TrackersConfig{
+			Trackers: map[string]TrackerConfig{
+				"BtN": {Username: "user"},
+			},
+		},
+	}
+
+	if err := MergeMissingTrackerDefaults(cfg); err != nil {
+		t.Fatalf("merge missing tracker defaults: %v", err)
+	}
+
+	if got := ResolveBTNAPIToken(*cfg); got != "legacy-token" {
+		t.Fatalf("expected legacy token on mixed-case tracker after merge, got %q", got)
+	}
+	if _, ok := cfg.Trackers.Trackers["BTN"]; ok {
+		t.Fatalf("expected canonical BTN default not to duplicate mixed-case BTN tracker")
+	}
+	if got := cfg.Trackers.Trackers["BtN"].APIKey; got != "legacy-token" {
+		t.Fatalf("expected mixed-case BTN token to receive legacy token, got %q", got)
+	}
+}
+
 func TestMergeMissingTrackerDefaultsClearsCZTSensitiveFields(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Config{
 		Trackers: TrackersConfig{
 			Trackers: map[string]TrackerConfig{
-				"CZT": {APIKey: "stale-token", URL: "https://stale.example", AnnounceURL: "https://czteam.me/announce.php?passkey=stale", Passkey: "passkey"},
-				"czt": {AnnounceURL: "https://czteam.me/announce.php?passkey=lowercase"},
+				"CZT":                {APIKey: "stale-token", URL: "https://stale.example", AnnounceURL: "https://czteam.me/announce.php?passkey=stale", Passkey: "passkey"},
+				"czt":                {AnnounceURL: "https://czteam.me/announce.php?passkey=lowercase"},
+				"\uFF23\uFF3A\uFF34": {AnnounceURL: "https://czteam.me/announce.php?passkey=fullwidth"},
 			},
 		},
 	}
@@ -803,6 +1054,9 @@ func TestMergeMissingTrackerDefaultsClearsCZTSensitiveFields(t *testing.T) {
 	}
 	if lower := cfg.Trackers.Trackers["czt"]; lower.AnnounceURL != "" {
 		t.Fatalf("expected lowercase CZT AnnounceURL to be cleared, got %q", lower.AnnounceURL)
+	}
+	if folded := cfg.Trackers.Trackers["\uFF23\uFF3A\uFF34"]; folded.AnnounceURL == "" {
+		t.Fatalf("expected non-ASCII CZT equivalent AnnounceURL to be preserved")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -865,6 +865,14 @@ func TestResolveBTNAPITokenDoesNotMatchUnicodeEquivalentTrackerNames(t *testing.
 	}
 }
 
+func TestASCIIEqualFoldComparesEveryByte(t *testing.T) {
+	t.Parallel()
+
+	if asciiEqualFold("é", "è") {
+		t.Fatal("expected non-ASCII strings with different continuation bytes not to match")
+	}
+}
+
 func TestResolveBTNAPITokenDoesNotMatchFuzzyTrackerNames(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/importer/importer.go
+++ b/internal/config/importer/importer.go
@@ -211,6 +211,8 @@ func mergeConfigMap(base map[string]any, overlay map[string]any) error {
 	return mergeConfigMapAt(base, overlay, "")
 }
 
+// mergeConfigMapAt applies one overlay level and tracks a dotted schema path
+// so dynamic tracker and torrent-client entries can be validated by context.
 func mergeConfigMapAt(base map[string]any, overlay map[string]any, path string) error {
 	for key, overlayValue := range overlay {
 		field := key
@@ -276,18 +278,26 @@ func mergeConfigMapAt(base map[string]any, overlay map[string]any, path string) 
 	return nil
 }
 
+// isTrackerCollectionPath reports whether path points at the map of dynamic
+// tracker configs for YAML or native JSON imports.
 func isTrackerCollectionPath(path string) bool {
 	return path == "trackers" || path == "Trackers.Trackers"
 }
 
+// isTrackerEntryPath reports whether path points inside one dynamic tracker
+// config, where tracker-specific extension fields are allowed.
 func isTrackerEntryPath(path string) bool {
 	return strings.HasPrefix(path, "trackers.") || strings.HasPrefix(path, "Trackers.Trackers.")
 }
 
+// isTorrentClientCollectionPath reports whether path points at the map of
+// dynamic torrent-client configs for YAML or native JSON imports.
 func isTorrentClientCollectionPath(path string) bool {
 	return path == "torrent_clients" || path == "TorrentClients"
 }
 
+// torrentClientSchemaMap builds the allowed key set for a dynamic torrent
+// client entry using YAML tag names or exported JSON field names.
 func torrentClientSchemaMap(path string) map[string]any {
 	t := reflect.TypeFor[config.TorrentClientConfig]()
 	schema := make(map[string]any, t.NumField())

--- a/internal/config/importer/importer.go
+++ b/internal/config/importer/importer.go
@@ -97,9 +97,7 @@ func parseNative(filename string, data []byte) (*config.Config, error) {
 	ext := strings.ToLower(filepath.Ext(filename))
 	switch ext {
 	case ".yaml", ".yml":
-		if err := yaml.Unmarshal(data, cfg); err != nil {
-			return nil, fmt.Errorf("import config: unmarshal yaml: %w", err)
-		}
+		cfg, err = parseNativeYAML(data, cfg)
 	case ".json":
 		// The export path (ExportToJSON) uses json.MarshalIndent, which
 		// uses Go field names because the config structs have no json
@@ -107,11 +105,12 @@ func parseNative(filename string, data []byte) (*config.Config, error) {
 		// symmetric — yaml.Unmarshal would look for yaml tag names
 		// (e.g. "tmdb_api") which do not match the exported keys
 		// (e.g. "TMDBAPI").
-		if err := json.Unmarshal(data, cfg); err != nil {
-			return nil, fmt.Errorf("import config: unmarshal json: %w", err)
-		}
+		cfg, err = parseNativeJSON(data, cfg)
 	default:
 		return nil, fmt.Errorf("import config: unsupported file extension %q (supported: .py, .yaml, .yml, .json)", ext)
+	}
+	if err != nil {
+		return nil, err
 	}
 	if cfg.TorrentClients == nil {
 		cfg.TorrentClients = make(map[string]config.TorrentClientConfig)
@@ -122,6 +121,84 @@ func parseNative(filename string, data []byte) (*config.Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func parseNativeYAML(data []byte, defaults *config.Config) (*config.Config, error) {
+	defaultRaw := map[string]any{}
+	defaultData, err := yaml.Marshal(defaults)
+	if err != nil {
+		return nil, fmt.Errorf("import config: marshal yaml defaults: %w", err)
+	}
+	if err := yaml.Unmarshal(defaultData, &defaultRaw); err != nil {
+		return nil, fmt.Errorf("import config: unmarshal yaml defaults: %w", err)
+	}
+	defaultRaw["torrent_clients"] = map[string]any{}
+
+	overlay := map[string]any{}
+	if err := yaml.Unmarshal(data, &overlay); err != nil {
+		return nil, fmt.Errorf("import config: unmarshal yaml: %w", err)
+	}
+	mergeConfigMap(defaultRaw, overlay)
+
+	merged, err := yaml.Marshal(defaultRaw)
+	if err != nil {
+		return nil, fmt.Errorf("import config: marshal merged yaml: %w", err)
+	}
+
+	var cfg config.Config
+	if err := yaml.Unmarshal(merged, &cfg); err != nil {
+		return nil, fmt.Errorf("import config: unmarshal merged yaml: %w", err)
+	}
+	decrypted, err := config.DecryptConfigSecrets(&cfg)
+	if err != nil {
+		return nil, fmt.Errorf("import config: decrypt secrets: %w", err)
+	}
+	return decrypted, nil
+}
+
+func parseNativeJSON(data []byte, defaults *config.Config) (*config.Config, error) {
+	defaultRaw := map[string]any{}
+	defaultData, err := json.Marshal(defaults)
+	if err != nil {
+		return nil, fmt.Errorf("import config: marshal json defaults: %w", err)
+	}
+	if err := json.Unmarshal(defaultData, &defaultRaw); err != nil {
+		return nil, fmt.Errorf("import config: unmarshal json defaults: %w", err)
+	}
+	defaultRaw["TorrentClients"] = map[string]any{}
+
+	overlay := map[string]any{}
+	if err := json.Unmarshal(data, &overlay); err != nil {
+		return nil, fmt.Errorf("import config: unmarshal json: %w", err)
+	}
+	mergeConfigMap(defaultRaw, overlay)
+
+	merged, err := json.Marshal(defaultRaw)
+	if err != nil {
+		return nil, fmt.Errorf("import config: marshal merged json: %w", err)
+	}
+
+	var cfg config.Config
+	if err := json.Unmarshal(merged, &cfg); err != nil {
+		return nil, fmt.Errorf("import config: unmarshal merged json: %w", err)
+	}
+	decrypted, err := config.DecryptConfigSecrets(&cfg)
+	if err != nil {
+		return nil, fmt.Errorf("import config: decrypt secrets: %w", err)
+	}
+	return decrypted, nil
+}
+
+func mergeConfigMap(base map[string]any, overlay map[string]any) {
+	for key, overlayValue := range overlay {
+		overlayMap, overlayOK := overlayValue.(map[string]any)
+		baseMap, baseOK := base[key].(map[string]any)
+		if overlayOK && baseOK {
+			mergeConfigMap(baseMap, overlayMap)
+			continue
+		}
+		base[key] = overlayValue
+	}
 }
 
 func isPythonFile(filename string) bool {

--- a/internal/config/importer/importer.go
+++ b/internal/config/importer/importer.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -50,7 +51,9 @@ func ImportFromFile(path string) (*config.Config, []string, error) {
 }
 
 // ImportFromContent parses raw file content. The filename is used only to
-// decide which parser to invoke; its directory (if any) is ignored.
+// decide which parser to invoke; its directory (if any) is ignored. Native
+// YAML/JSON imports with encrypted secret envelopes are decrypted and marked so
+// later database saves require helper-backed re-encryption.
 func ImportFromContent(filename string, data []byte) (*config.Config, []string, error) {
 	if len(data) > MaxFileBytes {
 		return nil, nil, fmt.Errorf("import config: file is too large (%d bytes, limit %d)", len(data), MaxFileBytes)
@@ -124,7 +127,8 @@ func parseNative(filename string, data []byte) (*config.Config, error) {
 }
 
 // parseNativeYAML merges YAML input into defaults using YAML tag names, then
-// decrypts any encrypted secret fields before returning the runtime config.
+// decrypts imported encrypted secret fields and preserves the later persistence
+// guard for helper-backed re-encryption.
 func parseNativeYAML(data []byte, defaults *config.Config) (*config.Config, error) {
 	defaultRaw := map[string]any{}
 	defaultData, err := yaml.Marshal(defaults)
@@ -140,7 +144,9 @@ func parseNativeYAML(data []byte, defaults *config.Config) (*config.Config, erro
 	if err := yaml.Unmarshal(data, &overlay); err != nil {
 		return nil, fmt.Errorf("import config: unmarshal yaml: %w", err)
 	}
-	mergeConfigMap(defaultRaw, overlay)
+	if err := mergeConfigMap(defaultRaw, overlay); err != nil {
+		return nil, fmt.Errorf("import config: merge yaml: %w", err)
+	}
 
 	merged, err := yaml.Marshal(defaultRaw)
 	if err != nil {
@@ -151,7 +157,7 @@ func parseNativeYAML(data []byte, defaults *config.Config) (*config.Config, erro
 	if err := yaml.Unmarshal(merged, &cfg); err != nil {
 		return nil, fmt.Errorf("import config: unmarshal merged yaml: %w", err)
 	}
-	decrypted, err := config.DecryptConfigSecrets(&cfg)
+	decrypted, err := config.DecryptImportedConfigSecrets(&cfg)
 	if err != nil {
 		return nil, fmt.Errorf("import config: decrypt secrets: %w", err)
 	}
@@ -159,7 +165,8 @@ func parseNativeYAML(data []byte, defaults *config.Config) (*config.Config, erro
 }
 
 // parseNativeJSON merges JSON input into defaults using exported Go field
-// names, matching the shape produced by config.ExportToJSON.
+// names, matching the shape produced by config.ExportToJSON. Encrypted secret
+// envelopes are decrypted with the same persistence guard used for YAML.
 func parseNativeJSON(data []byte, defaults *config.Config) (*config.Config, error) {
 	defaultRaw := map[string]any{}
 	defaultData, err := json.Marshal(defaults)
@@ -175,7 +182,9 @@ func parseNativeJSON(data []byte, defaults *config.Config) (*config.Config, erro
 	if err := json.Unmarshal(data, &overlay); err != nil {
 		return nil, fmt.Errorf("import config: unmarshal json: %w", err)
 	}
-	mergeConfigMap(defaultRaw, overlay)
+	if err := mergeConfigMap(defaultRaw, overlay); err != nil {
+		return nil, fmt.Errorf("import config: merge json: %w", err)
+	}
 
 	merged, err := json.Marshal(defaultRaw)
 	if err != nil {
@@ -186,7 +195,7 @@ func parseNativeJSON(data []byte, defaults *config.Config) (*config.Config, erro
 	if err := json.Unmarshal(merged, &cfg); err != nil {
 		return nil, fmt.Errorf("import config: unmarshal merged json: %w", err)
 	}
-	decrypted, err := config.DecryptConfigSecrets(&cfg)
+	decrypted, err := config.DecryptImportedConfigSecrets(&cfg)
 	if err != nil {
 		return nil, fmt.Errorf("import config: decrypt secrets: %w", err)
 	}
@@ -194,17 +203,105 @@ func parseNativeJSON(data []byte, defaults *config.Config) (*config.Config, erro
 }
 
 // mergeConfigMap recursively overlays user-supplied maps onto default maps.
-// Non-map values, including nil, replace the default at the same key.
-func mergeConfigMap(base map[string]any, overlay map[string]any) {
+// Unknown sections and fields are rejected except tracker extension fields, and
+// dynamically named torrent clients are validated against the client schema.
+// Null or empty object overlays leave default objects intact; scalar or array
+// overlays cannot replace an object section.
+func mergeConfigMap(base map[string]any, overlay map[string]any) error {
+	return mergeConfigMapAt(base, overlay, "")
+}
+
+func mergeConfigMapAt(base map[string]any, overlay map[string]any, path string) error {
 	for key, overlayValue := range overlay {
-		overlayMap, overlayOK := overlayValue.(map[string]any)
-		baseMap, baseOK := base[key].(map[string]any)
-		if overlayOK && baseOK {
-			mergeConfigMap(baseMap, overlayMap)
+		field := key
+		if path != "" {
+			field = path + "." + key
+		}
+		baseValue, exists := base[key]
+		baseMap, baseOK := baseValue.(map[string]any)
+		if baseOK {
+			if overlayValue == nil {
+				continue
+			}
+			overlayMap, overlayOK := overlayValue.(map[string]any)
+			if !overlayOK {
+				return fmt.Errorf("cannot replace config object %q with %T", field, overlayValue)
+			}
+			if err := mergeConfigMapAt(baseMap, overlayMap, field); err != nil {
+				return err
+			}
 			continue
+		}
+		if !exists {
+			switch {
+			case isTrackerEntryPath(path):
+				base[key] = overlayValue
+				continue
+			case isTrackerCollectionPath(path):
+				entry, ok := overlayValue.(map[string]any)
+				if overlayValue == nil {
+					continue
+				}
+				if !ok {
+					return fmt.Errorf("cannot replace config object %q with %T", field, overlayValue)
+				}
+				target := map[string]any{}
+				base[key] = target
+				if err := mergeConfigMapAt(target, entry, field); err != nil {
+					return err
+				}
+				continue
+			case isTorrentClientCollectionPath(path):
+				entry, ok := overlayValue.(map[string]any)
+				if overlayValue == nil {
+					continue
+				}
+				if !ok {
+					return fmt.Errorf("cannot replace config object %q with %T", field, overlayValue)
+				}
+				target := torrentClientSchemaMap(path)
+				base[key] = target
+				if err := mergeConfigMapAt(target, entry, field); err != nil {
+					return err
+				}
+				continue
+			case path == "":
+				return fmt.Errorf("unknown config section %q", key)
+			default:
+				return fmt.Errorf("unknown config key %q", field)
+			}
 		}
 		base[key] = overlayValue
 	}
+	return nil
+}
+
+func isTrackerCollectionPath(path string) bool {
+	return path == "trackers" || path == "Trackers.Trackers"
+}
+
+func isTrackerEntryPath(path string) bool {
+	return strings.HasPrefix(path, "trackers.") || strings.HasPrefix(path, "Trackers.Trackers.")
+}
+
+func isTorrentClientCollectionPath(path string) bool {
+	return path == "torrent_clients" || path == "TorrentClients"
+}
+
+func torrentClientSchemaMap(path string) map[string]any {
+	t := reflect.TypeFor[config.TorrentClientConfig]()
+	schema := make(map[string]any, t.NumField())
+	for field := range t.Fields() {
+		key := field.Name
+		if path == "torrent_clients" {
+			key = strings.TrimSpace(strings.Split(field.Tag.Get("yaml"), ",")[0])
+		}
+		if key == "" || key == "-" {
+			continue
+		}
+		schema[key] = nil
+	}
+	return schema
 }
 
 func isPythonFile(filename string) bool {

--- a/internal/config/importer/importer.go
+++ b/internal/config/importer/importer.go
@@ -123,6 +123,8 @@ func parseNative(filename string, data []byte) (*config.Config, error) {
 	return cfg, nil
 }
 
+// parseNativeYAML merges YAML input into defaults using YAML tag names, then
+// decrypts any encrypted secret fields before returning the runtime config.
 func parseNativeYAML(data []byte, defaults *config.Config) (*config.Config, error) {
 	defaultRaw := map[string]any{}
 	defaultData, err := yaml.Marshal(defaults)
@@ -156,6 +158,8 @@ func parseNativeYAML(data []byte, defaults *config.Config) (*config.Config, erro
 	return decrypted, nil
 }
 
+// parseNativeJSON merges JSON input into defaults using exported Go field
+// names, matching the shape produced by config.ExportToJSON.
 func parseNativeJSON(data []byte, defaults *config.Config) (*config.Config, error) {
 	defaultRaw := map[string]any{}
 	defaultData, err := json.Marshal(defaults)
@@ -189,6 +193,8 @@ func parseNativeJSON(data []byte, defaults *config.Config) (*config.Config, erro
 	return decrypted, nil
 }
 
+// mergeConfigMap recursively overlays user-supplied maps onto default maps.
+// Non-map values, including nil, replace the default at the same key.
 func mergeConfigMap(base map[string]any, overlay map[string]any) {
 	for key, overlayValue := range overlay {
 		overlayMap, overlayOK := overlayValue.(map[string]any)

--- a/internal/config/importer/importer_penetration_test.go
+++ b/internal/config/importer/importer_penetration_test.go
@@ -39,10 +39,8 @@ func TestImportFromContentMalformedYAML(t *testing.T) {
 func TestImportFromContentMalformedJSON(t *testing.T) {
 	t.Parallel()
 
-	// JSON imports are dispatched through yaml.v3, which is stricter than
-	// encoding/json on structure but more permissive on trailing commas in
-	// flow maps (YAML flow style allows them). So we only assert on cases
-	// that are malformed in both JSON and YAML flow style.
+	// Keep cases structurally malformed for encoding/json rather than relying
+	// on semantic config validation.
 	cases := map[string]string{
 		"unterminated":     `{"MainSettings":{"TMDBAPI":"x"`,
 		"mapping in array": `[{"MainSettings":{"TMDBAPI":"x"}}]`,

--- a/internal/config/importer/importer_test.go
+++ b/internal/config/importer/importer_test.go
@@ -29,6 +29,9 @@ func TestImportFromContentYAMLOverlaysDefaults(t *testing.T) {
 	if cfg.MainSettings.TMDBAPI != "test-key" {
 		t.Fatalf("expected tmdb_api to be overwritten, got %q", cfg.MainSettings.TMDBAPI)
 	}
+	if cfg.MainSettings.TrackerPassChecks != 1 {
+		t.Fatalf("expected tracker_pass_checks default to be preserved, got %d", cfg.MainSettings.TrackerPassChecks)
+	}
 	if len(cfg.Trackers.Trackers) == 0 {
 		t.Fatal("expected tracker defaults to be merged in")
 	}
@@ -46,6 +49,9 @@ func TestImportFromContentJSONOverlaysDefaults(t *testing.T) {
 	}
 	if cfg.MainSettings.TMDBAPI != "json-key" {
 		t.Fatalf("expected TMDBAPI to be overwritten, got %q", cfg.MainSettings.TMDBAPI)
+	}
+	if cfg.MainSettings.TrackerPassChecks != 1 {
+		t.Fatalf("expected TrackerPassChecks default to be preserved, got %d", cfg.MainSettings.TrackerPassChecks)
 	}
 	if len(cfg.Trackers.Trackers) == 0 {
 		t.Fatal("expected tracker defaults to be merged in")

--- a/internal/config/importer/importer_test.go
+++ b/internal/config/importer/importer_test.go
@@ -4,14 +4,42 @@
 package importer
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/autobrr/upbrr/internal/authmaterial"
 	"github.com/autobrr/upbrr/internal/config"
 )
+
+type importSecretRepo struct {
+	saved *config.Config
+}
+
+func (r *importSecretRepo) SaveFullConfig(_ context.Context, cfg any) error {
+	typed, ok := cfg.(*config.Config)
+	if !ok {
+		return errors.New("unexpected config payload type")
+	}
+	r.saved = typed
+	return nil
+}
+
+func (r *importSecretRepo) LoadFullConfig(_ context.Context, dest any) error {
+	if r.saved == nil {
+		return errors.New("no saved config")
+	}
+	out, ok := dest.(*config.Config)
+	if !ok {
+		return errors.New("unexpected destination type")
+	}
+	*out = *r.saved
+	return nil
+}
 
 func TestImportFromContentYAMLOverlaysDefaults(t *testing.T) {
 	yaml := []byte("main_settings:\n  tmdb_api: test-key\n")
@@ -55,6 +83,237 @@ func TestImportFromContentJSONOverlaysDefaults(t *testing.T) {
 	}
 	if len(cfg.Trackers.Trackers) == 0 {
 		t.Fatal("expected tracker defaults to be merged in")
+	}
+}
+
+func TestImportFromContentRejectsDestructiveObjectOverlays(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		payload []byte
+		wantErr bool
+	}{
+		{name: "yaml-null", file: "config.yaml", payload: []byte("main_settings: null\n")},
+		{name: "yaml-empty-map", file: "config.yaml", payload: []byte("main_settings: {}\n")},
+		{name: "yaml-empty-array", file: "config.yaml", payload: []byte("main_settings: []\n"), wantErr: true},
+		{name: "yaml-scalar", file: "config.yaml", payload: []byte("main_settings: nope\n"), wantErr: true},
+		{name: "json-null", file: "config.json", payload: []byte(`{"MainSettings":null}`)},
+		{name: "json-empty-map", file: "config.json", payload: []byte(`{"MainSettings":{}}`)},
+		{name: "json-empty-array", file: "config.json", payload: []byte(`{"MainSettings":[]}`), wantErr: true},
+		{name: "json-scalar", file: "config.json", payload: []byte(`{"MainSettings":"nope"}`), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, _, err := ImportFromContent(tt.file, tt.payload)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected destructive object replacement to fail")
+				}
+				if !strings.Contains(err.Error(), "cannot replace config object") {
+					t.Fatalf("expected object replacement error, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.MainSettings.TrackerPassChecks != 1 {
+				t.Fatalf("expected main settings defaults to survive, got tracker_pass_checks=%d", cfg.MainSettings.TrackerPassChecks)
+			}
+		})
+	}
+}
+
+func TestImportFromContentRejectsUnknownTopLevelSections(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		payload []byte
+	}{
+		{name: "yaml-scalar", file: "config.yaml", payload: []byte("unknown_section: nope\n")},
+		{name: "yaml-array", file: "config.yaml", payload: []byte("unknown_section: []\n")},
+		{name: "yaml-object", file: "config.yaml", payload: []byte("unknown_section:\n  nested: true\n")},
+		{name: "yaml-null", file: "config.yaml", payload: []byte("unknown_section: null\n")},
+		{name: "yaml-case-twin", file: "config.yaml", payload: []byte("MainSettings:\n  TMDBAPI: wrong\n")},
+		{name: "json-scalar", file: "config.json", payload: []byte(`{"UnknownSection":"nope"}`)},
+		{name: "json-array", file: "config.json", payload: []byte(`{"UnknownSection":[]}`)},
+		{name: "json-object", file: "config.json", payload: []byte(`{"UnknownSection":{"nested":true}}`)},
+		{name: "json-null", file: "config.json", payload: []byte(`{"UnknownSection":null}`)},
+		{name: "json-case-twin", file: "config.json", payload: []byte(`{"main_settings":{"tmdb_api":"wrong"}}`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, _, err := ImportFromContent(tt.file, tt.payload)
+			if err == nil {
+				t.Fatal("expected unknown top-level section to fail")
+			}
+			if cfg != nil {
+				t.Fatalf("expected nil config on merge error, got %#v", cfg)
+			}
+			if !strings.Contains(err.Error(), "unknown config section") {
+				t.Fatalf("expected unknown section error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestImportFromContentRejectsNestedUnknownKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		payload []byte
+		wantKey string
+	}{
+		{
+			name:    "yaml-main-settings-typo",
+			file:    "config.yaml",
+			payload: []byte("main_settings:\n  tmdb_api_typo: test-key\n"),
+			wantKey: "main_settings.tmdb_api_typo",
+		},
+		{
+			name:    "json-main-settings-typo",
+			file:    "config.json",
+			payload: []byte(`{"MainSettings":{"TMDBAPITypo":"test-key"}}`),
+			wantKey: "MainSettings.TMDBAPITypo",
+		},
+		{
+			name:    "json-main-settings-case-twin",
+			file:    "config.json",
+			payload: []byte(`{"MainSettings":{"tmdbapi":"test-key"}}`),
+			wantKey: "MainSettings.tmdbapi",
+		},
+		{
+			name:    "yaml-torrent-client-typo",
+			file:    "config.yaml",
+			payload: []byte("torrent_clients:\n  watch-client:\n    type: watch\n    watch_folder_typo: C:/Watch\n"),
+			wantKey: "torrent_clients.watch-client.watch_folder_typo",
+		},
+		{
+			name:    "json-torrent-client-typo",
+			file:    "config.json",
+			payload: []byte(`{"TorrentClients":{"watch-client":{"Type":"watch","WatchFolderTypo":"C:/Watch"}}}`),
+			wantKey: "TorrentClients.watch-client.WatchFolderTypo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, _, err := ImportFromContent(tt.file, tt.payload)
+			if err == nil {
+				t.Fatal("expected nested unknown key to fail")
+			}
+			if cfg != nil {
+				t.Fatalf("expected nil config on merge error, got %#v", cfg)
+			}
+			if !strings.Contains(err.Error(), "unknown config key") || !strings.Contains(err.Error(), tt.wantKey) {
+				t.Fatalf("expected unknown key %q error, got %v", tt.wantKey, err)
+			}
+		})
+	}
+}
+
+func TestImportFromContentPreservesTrackerCustomUnknownKeys(t *testing.T) {
+	payloads := map[string][]byte{
+		"yaml": []byte("trackers:\n  A4K:\n    api_key: tracker-key\n    custom_yaml: keep\n"),
+		"json": []byte(`{
+			"Trackers": {
+				"Trackers": {
+					"A4K": {
+						"APIKey": "tracker-key",
+						"custom_json": "keep"
+					}
+				}
+			}
+		}`),
+	}
+
+	for name, payload := range payloads {
+		t.Run(name, func(t *testing.T) {
+			cfg, _, err := ImportFromContent("config."+name, payload)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tracker := cfg.Trackers.Trackers["A4K"]
+			if tracker.APIKey != "tracker-key" {
+				t.Fatalf("expected A4K api key overlay, got %q", tracker.APIKey)
+			}
+			if got := tracker.Unknown["custom_"+name]; got != "keep" {
+				t.Fatalf("expected tracker custom key to survive, got %#v", got)
+			}
+		})
+	}
+}
+
+func TestImportFromContentEncryptedNativeSecretsRejectPlaintextFallback(t *testing.T) {
+	formats := map[string]string{
+		"yaml": "config.yaml",
+		"json": "config.json",
+	}
+	for name, filename := range formats {
+		t.Run(name, func(t *testing.T) {
+			sourceDB := filepath.Join(t.TempDir(), "source.db")
+			writeImportWebAuthFixture(t, sourceDB)
+			payload := encryptedNativePayload(t, filename, importSecretConfig(sourceDB))
+
+			cfg, _, err := ImportFromContent(filename, payload)
+			if err != nil {
+				t.Fatalf("import encrypted native config: %v", err)
+			}
+			assertImportedSecretValues(t, cfg)
+
+			cfg.MainSettings.DBPath = filepath.Join(t.TempDir(), "dest.db")
+			repo := &importSecretRepo{}
+			err = config.SaveToDatabase(context.Background(), cfg, repo)
+			if err == nil {
+				t.Fatal("expected helper-unavailable save error")
+			}
+			if !errors.Is(err, config.ErrSecretEncryptionHelperUnavailable) {
+				t.Fatalf("expected ErrSecretEncryptionHelperUnavailable, got %v", err)
+			}
+			if repo.saved != nil {
+				t.Fatalf("repository received config despite save error: %+v", repo.saved)
+			}
+		})
+	}
+}
+
+func TestImportFromContentEncryptedNativeSecretsReencryptsWithDestinationHelper(t *testing.T) {
+	formats := map[string]string{
+		"yaml": "config.yaml",
+		"json": "config.json",
+	}
+	for name, filename := range formats {
+		t.Run(name, func(t *testing.T) {
+			sourceDB := filepath.Join(t.TempDir(), "source.db")
+			writeImportWebAuthFixture(t, sourceDB)
+			payload := encryptedNativePayload(t, filename, importSecretConfig(sourceDB))
+
+			cfg, _, err := ImportFromContent(filename, payload)
+			if err != nil {
+				t.Fatalf("import encrypted native config: %v", err)
+			}
+			assertImportedSecretValues(t, cfg)
+
+			destDB := filepath.Join(t.TempDir(), "dest.db")
+			writeImportWebAuthFixture(t, destDB)
+			cfg.MainSettings.DBPath = destDB
+			repo := &importSecretRepo{}
+			if err := config.SaveToDatabase(context.Background(), cfg, repo); err != nil {
+				t.Fatalf("save imported config: %v", err)
+			}
+			if repo.saved == nil {
+				t.Fatal("expected repository to receive saved config")
+			}
+			assertNoPlaintextSecretValues(t, repo.saved)
+
+			loaded, err := config.LoadFromDatabase(context.Background(), repo)
+			if err != nil {
+				t.Fatalf("load saved config: %v", err)
+			}
+			assertImportedSecretValues(t, loaded)
+		})
 	}
 }
 
@@ -308,6 +567,105 @@ func TestImportFromContentDisablesUnsupportedImageRehost(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected warning about TL img_rehost, got %v", warnings)
+	}
+}
+
+func writeImportWebAuthFixture(t *testing.T, dbPath string) {
+	t.Helper()
+	authPath := filepath.Join(filepath.Dir(dbPath), authmaterial.WebAuthFileName)
+	payload := `{"username":"tester","password_hash":"very-secret-password-hash","encryption_key_seed":"stable-seed-for-import-tests"}`
+	if err := os.WriteFile(authPath, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write web auth fixture: %v", err)
+	}
+}
+
+func importSecretConfig(dbPath string) *config.Config {
+	return &config.Config{
+		MainSettings: config.MainSettingsConfig{
+			DBPath:  dbPath,
+			TMDBAPI: "plain-tmdb-token",
+		},
+		ArrIntegration: config.ArrIntegrationConfig{
+			SonarrAPIKey: "plain-sonarr-token",
+		},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"BTN": {
+					APIKey: "plain-btn-api-key",
+					URL:    "https://secret.btn.example",
+				},
+			},
+		},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:     "qbit",
+				QbitPass: "plain-qbit-pass",
+			},
+		},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+	}
+}
+
+func encryptedNativePayload(t *testing.T, filename string, cfg *config.Config) []byte {
+	t.Helper()
+	switch filepath.Ext(filename) {
+	case ".yaml":
+		path := filepath.Join(t.TempDir(), filename)
+		if err := config.ExportToYAML(cfg, path); err != nil {
+			t.Fatalf("export yaml: %v", err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read exported yaml: %v", err)
+		}
+		return data
+	case ".json":
+		payload, err := config.ExportToJSON(cfg)
+		if err != nil {
+			t.Fatalf("export json: %v", err)
+		}
+		return []byte(payload)
+	default:
+		t.Fatalf("unsupported test filename: %s", filename)
+		return nil
+	}
+}
+
+func assertImportedSecretValues(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	if cfg.MainSettings.TMDBAPI != "plain-tmdb-token" {
+		t.Fatalf("TMDBAPI: got %q", cfg.MainSettings.TMDBAPI)
+	}
+	if cfg.ArrIntegration.SonarrAPIKey != "plain-sonarr-token" {
+		t.Fatalf("SonarrAPIKey: got %q", cfg.ArrIntegration.SonarrAPIKey)
+	}
+	if cfg.Trackers.Trackers["BTN"].APIKey != "plain-btn-api-key" {
+		t.Fatalf("BTN APIKey: got %q", cfg.Trackers.Trackers["BTN"].APIKey)
+	}
+	if cfg.Trackers.Trackers["BTN"].URL != "https://secret.btn.example" {
+		t.Fatalf("BTN URL: got %q", cfg.Trackers.Trackers["BTN"].URL)
+	}
+	if cfg.TorrentClients["qbit"].QbitPass != "plain-qbit-pass" {
+		t.Fatalf("QbitPass: got %q", cfg.TorrentClients["qbit"].QbitPass)
+	}
+}
+
+func assertNoPlaintextSecretValues(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	if cfg.MainSettings.TMDBAPI == "plain-tmdb-token" {
+		t.Fatal("saved config leaked plaintext TMDBAPI")
+	}
+	if cfg.ArrIntegration.SonarrAPIKey == "plain-sonarr-token" {
+		t.Fatal("saved config leaked plaintext SonarrAPIKey")
+	}
+	if cfg.Trackers.Trackers["BTN"].APIKey == "plain-btn-api-key" {
+		t.Fatal("saved config leaked plaintext BTN APIKey")
+	}
+	if cfg.Trackers.Trackers["BTN"].URL == "https://secret.btn.example" {
+		t.Fatal("saved config leaked plaintext BTN URL")
+	}
+	if cfg.TorrentClients["qbit"].QbitPass == "plain-qbit-pass" {
+		t.Fatal("saved config leaked plaintext QbitPass")
 	}
 }
 

--- a/internal/config/importer/importer_test.go
+++ b/internal/config/importer/importer_test.go
@@ -254,7 +254,7 @@ func TestImportFromContentEncryptedNativeSecretsRejectPlaintextFallback(t *testi
 	for name, filename := range formats {
 		t.Run(name, func(t *testing.T) {
 			sourceDB := filepath.Join(t.TempDir(), "source.db")
-			writeImportWebAuthFixture(t, sourceDB)
+			writeImportWebAuthFixture(t, sourceDB, "source")
 			payload := encryptedNativePayload(t, filename, importSecretConfig(sourceDB))
 
 			cfg, _, err := ImportFromContent(filename, payload)
@@ -287,7 +287,7 @@ func TestImportFromContentEncryptedNativeSecretsReencryptsWithDestinationHelper(
 	for name, filename := range formats {
 		t.Run(name, func(t *testing.T) {
 			sourceDB := filepath.Join(t.TempDir(), "source.db")
-			writeImportWebAuthFixture(t, sourceDB)
+			writeImportWebAuthFixture(t, sourceDB, "source")
 			payload := encryptedNativePayload(t, filename, importSecretConfig(sourceDB))
 
 			cfg, _, err := ImportFromContent(filename, payload)
@@ -297,7 +297,7 @@ func TestImportFromContentEncryptedNativeSecretsReencryptsWithDestinationHelper(
 			assertImportedSecretValues(t, cfg)
 
 			destDB := filepath.Join(t.TempDir(), "dest.db")
-			writeImportWebAuthFixture(t, destDB)
+			writeImportWebAuthFixture(t, destDB, "destination")
 			cfg.MainSettings.DBPath = destDB
 			repo := &importSecretRepo{}
 			if err := config.SaveToDatabase(context.Background(), cfg, repo); err != nil {
@@ -570,11 +570,20 @@ func TestImportFromContentDisablesUnsupportedImageRehost(t *testing.T) {
 	}
 }
 
-func writeImportWebAuthFixture(t *testing.T, dbPath string) {
+// writeImportWebAuthFixture writes auth material whose seed can differ between
+// source and destination databases in native encrypted import tests.
+func writeImportWebAuthFixture(t *testing.T, dbPath string, seedID string) {
 	t.Helper()
 	authPath := filepath.Join(filepath.Dir(dbPath), authmaterial.WebAuthFileName)
-	payload := `{"username":"tester","password_hash":"very-secret-password-hash","encryption_key_seed":"stable-seed-for-import-tests"}`
-	if err := os.WriteFile(authPath, []byte(payload), 0o600); err != nil {
+	payload, err := json.Marshal(map[string]string{
+		"username":            "tester",
+		"password_hash":       "very-secret-password-hash",
+		"encryption_key_seed": "stable-seed-for-import-tests-" + seedID,
+	})
+	if err != nil {
+		t.Fatalf("marshal web auth fixture: %v", err)
+	}
+	if err := os.WriteFile(authPath, payload, 0o600); err != nil {
 		t.Fatalf("write web auth fixture: %v", err)
 	}
 }

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -40,6 +40,8 @@ const (
 	secretArgon2KeyLen = 32
 )
 
+// ErrSecretEncryptionHelperUnavailable means encrypted secret operations need
+// web auth helper material that is not available for the config's DB path.
 var ErrSecretEncryptionHelperUnavailable = errors.New("config secret encryption helper unavailable")
 
 type secretEnvelope struct {
@@ -50,7 +52,9 @@ type secretEnvelope struct {
 	T string `json:"t"`
 }
 
-// EncryptConfigSecrets returns a cloned config where known secret fields are encrypted.
+// EncryptConfigSecrets returns a cloned config where known secret fields are
+// encrypted. If helper material is unavailable, configs with imported or
+// existing encrypted envelopes fail instead of falling back to plaintext.
 func EncryptConfigSecrets(cfg *Config) (*Config, error) {
 	if cfg == nil {
 		return nil, errors.New("config secret encryption: nil config")
@@ -59,6 +63,9 @@ func EncryptConfigSecrets(cfg *Config) (*Config, error) {
 	helper, err := resolveSecretHelper(cfg)
 	if err != nil {
 		if errors.Is(err, ErrSecretEncryptionHelperUnavailable) {
+			if cfg.secretReencryptionRequired {
+				return nil, err
+			}
 			hasEncryptedSecrets, scanErr := hasEncryptedSecretEnvelopes(cfg)
 			if scanErr != nil {
 				return nil, scanErr
@@ -74,7 +81,29 @@ func EncryptConfigSecrets(cfg *Config) (*Config, error) {
 	return encryptConfigSecretsWithHelper(cfg, helper)
 }
 
-// DecryptConfigSecrets returns a cloned config where known encrypted secret fields are decrypted.
+// DecryptImportedConfigSecrets decrypts native-import secret envelopes and
+// marks the returned config so later persistence cannot silently fall back to
+// plaintext if destination helper material is unavailable.
+func DecryptImportedConfigSecrets(cfg *Config) (*Config, error) {
+	hasEncryptedSecrets, err := hasEncryptedSecretEnvelopes(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	decrypted, err := DecryptConfigSecrets(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if hasEncryptedSecrets {
+		decrypted.secretReencryptionRequired = true
+	}
+
+	return decrypted, nil
+}
+
+// DecryptConfigSecrets returns a cloned config where known encrypted secret
+// fields are decrypted. Helper material is required only when at least one
+// secret envelope is present.
 func DecryptConfigSecrets(cfg *Config) (*Config, error) {
 	if cfg == nil {
 		return nil, errors.New("config secret decryption: nil config")
@@ -177,6 +206,8 @@ func decryptConfigSecretsWithHelperFrom(cfg *Config, helper string, assumeCloned
 	return cloned, nil
 }
 
+// RewrapSecretsInDatabase decrypts stored config secrets with oldMaterial,
+// re-encrypts them with newMaterial, and saves the updated config.
 func RewrapSecretsInDatabase(ctx context.Context, repo interface {
 	LoadFullConfig(ctx context.Context, dest any) error
 	SaveFullConfig(ctx context.Context, cfg any) error
@@ -184,6 +215,8 @@ func RewrapSecretsInDatabase(ctx context.Context, repo interface {
 	return RewrapSecretsInDatabaseWithFallback(ctx, repo, []authmaterial.Material{oldMaterial}, newMaterial)
 }
 
+// RewrapSecretsInDatabaseWithFallback decrypts stored config secrets using the
+// first matching source material, then re-encrypts them with newMaterial.
 func RewrapSecretsInDatabaseWithFallback(ctx context.Context, repo interface {
 	LoadFullConfig(ctx context.Context, dest any) error
 	SaveFullConfig(ctx context.Context, cfg any) error

--- a/internal/configstore/dbloader.go
+++ b/internal/configstore/dbloader.go
@@ -9,11 +9,16 @@ package configstore
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/config/importer"
@@ -78,6 +83,10 @@ func LoadFromPathOrEmbedded(path string) (*config.Config, error) {
 // Callers decide whether to validate the returned config — the CLI fails fast
 // while the web/GUI start with invalid config so users can fix it via the UI.
 func LoadFromDBPath(ctx context.Context, dbPath string) (*config.Config, error) {
+	return loadFromDBPath(ctx, dbPath, true)
+}
+
+func loadFromDBPath(ctx context.Context, dbPath string, applyEnv bool) (*config.Config, error) {
 	repo, err := db.OpenContext(ctx, dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("config store: %w", err)
@@ -100,12 +109,16 @@ func LoadFromDBPath(ctx context.Context, dbPath string) (*config.Config, error) 
 			return nil, fmt.Errorf("config store: %w", err)
 		}
 	}
-	config.ApplyEnvOverrides(loaded)
+	if applyEnv {
+		config.ApplyEnvOverrides(loaded)
+	}
 	return loaded, nil
 }
 
-// SaveToDBPath opens the sqlite database at dbPath, runs migrations, and
-// persists the provided config.
+// SaveToDBPath opens the sqlite database at dbPath, runs migrations, validates
+// any web auth material, syncs cookie encryption metadata when auth material is
+// usable, and persists the provided config. Malformed auth material and other
+// cookie sync failures are returned before config or cookie metadata is saved.
 func SaveToDBPath(ctx context.Context, cfg *config.Config, dbPath string) error {
 	repo, err := db.OpenContext(ctx, dbPath)
 	if err != nil {
@@ -116,17 +129,48 @@ func SaveToDBPath(ctx context.Context, cfg *config.Config, dbPath string) error 
 	if err := repo.MigrateContext(ctx); err != nil {
 		return fmt.Errorf("config store: %w", err)
 	}
-	if err := config.SaveToDatabase(ctx, cfg, repo); err != nil {
+
+	if err := SaveToRepository(ctx, cfg, repo, dbPath); err != nil {
 		return fmt.Errorf("config store: %w", err)
 	}
 
-	if err := cookies.SyncCookieEncryptionWithAuth(ctx, repo.RawDB(), dbPath); err != nil {
+	return nil
+}
+
+// SaveToRepository persists cfg and cookie encryption auth metadata through one
+// repository transaction.
+func SaveToRepository(ctx context.Context, cfg *config.Config, repo *db.SQLiteRepository, dbPath string) error {
+	if cfg == nil {
+		return internalerrors.ErrInvalidInput
+	}
+	if repo == nil {
+		return errors.New("config save: nil repository")
+	}
+
+	encryptedCfg, err := config.EncryptConfigSecrets(cfg)
+	if err != nil {
+		return fmt.Errorf("config save to database: encrypt secrets: %w", err)
+	}
+
+	if err := repo.SaveFullConfigWithPreSave(ctx, encryptedCfg, func(ctx context.Context, tx *sql.Tx) error {
+		if err := syncCookieEncryptionBeforeConfigSaveTx(ctx, tx, dbPath); err != nil {
+			return fmt.Errorf("cookie encryption sync before config save: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("config save to database: %w", err)
+	}
+
+	return nil
+}
+
+func syncCookieEncryptionBeforeConfigSaveTx(ctx context.Context, tx *sql.Tx, dbPath string) error {
+	if err := cookies.SyncCookieEncryptionWithAuthTx(ctx, tx, dbPath); err != nil {
 		if errors.Is(err, cookies.ErrAuthHelperUnavailable) {
 			return nil
 		}
-		return fmt.Errorf("cookie encryption sync after config save: %w", err)
+		return fmt.Errorf("sync cookie encryption with auth: %w", err)
 	}
-
 	return nil
 }
 
@@ -145,17 +189,22 @@ func Bootstrap(ctx context.Context, configPath string, configProvided, persistYA
 	return BootstrapWithValidator(ctx, configPath, configProvided, persistYAML, nil)
 }
 
-// BootstrapWithValidator is Bootstrap plus an optional validation hook that
-// runs before a provided config is persisted. CLI callers use it so a bad
-// --config file cannot be written to the database before startup validation
-// fails, while GUI/web callers can still start with incomplete setup config.
+// BootstrapWithValidator is Bootstrap plus an optional validation hook for
+// provided configs. The hook validates the exact config that would be persisted
+// so environment-only fixes cannot write a config that fails after env removal.
+// Without a hook, provided YAML/JSON is merged with stored DB config when
+// present and persisted only if the persisted candidate validates.
 func BootstrapWithValidator(ctx context.Context, configPath string, configProvided, persistYAML bool, validateBeforePersist func(*config.Config) error) (config.Config, string, error) {
 	if configProvided {
 		resolved, err := ResolveYAMLPath(configPath, configProvided)
 		if err != nil {
 			return config.Config{}, "", err
 		}
-		loaded, _, err := importer.ImportFromFile(resolved)
+		providedData, err := os.ReadFile(resolved)
+		if err != nil {
+			return config.Config{}, "", fmt.Errorf("config store: read provided config: %w", err)
+		}
+		loaded, _, err := importer.ImportFromContent(resolved, providedData)
 		if err != nil {
 			return config.Config{}, "", fmt.Errorf("config store: %w", err)
 		}
@@ -168,9 +217,22 @@ func BootstrapWithValidator(ctx context.Context, configPath string, configProvid
 
 		if persistYAML {
 			if validateBeforePersist != nil {
-				if err := validateBeforePersist(loaded); err != nil {
+				if err := validatePersistableConfig(loaded, dbPath, validateBeforePersist); err != nil {
 					return config.Config{}, "", fmt.Errorf("config store: validate provided config: %w", err)
 				}
+			} else {
+				persisted, runtime, shouldPersist, err := prepareProvidedConfigForSave(ctx, resolved, providedData, loaded, dbPath)
+				if err != nil {
+					return config.Config{}, "", err
+				}
+				loaded = runtime
+				if !shouldPersist {
+					runtime := *loaded
+					config.ApplyEnvOverrides(&runtime)
+					runtime.MainSettings.DBPath = dbPath
+					return runtime, dbPath, nil
+				}
+				loaded = persisted
 			}
 			if err := SaveToDBPath(ctx, loaded, dbPath); err != nil {
 				return config.Config{}, "", err
@@ -188,7 +250,7 @@ func BootstrapWithValidator(ctx context.Context, configPath string, configProvid
 		return config.Config{}, "", fmt.Errorf("default db path: %w", err)
 	}
 
-	loaded, err := LoadFromDBPath(ctx, defaultDBPath)
+	loaded, err := loadFromDBPath(ctx, defaultDBPath, false)
 	if err == nil {
 		if strings.TrimSpace(loaded.MainSettings.DBPath) == "" || loaded.MainSettings.DBPath != defaultDBPath {
 			loaded.MainSettings.DBPath = defaultDBPath
@@ -196,7 +258,10 @@ func BootstrapWithValidator(ctx context.Context, configPath string, configProvid
 				return config.Config{}, "", err
 			}
 		}
-		return *loaded, defaultDBPath, nil
+		runtime := *loaded
+		config.ApplyEnvOverrides(&runtime)
+		runtime.MainSettings.DBPath = defaultDBPath
+		return runtime, defaultDBPath, nil
 	}
 	if !errors.Is(err, internalerrors.ErrNotFound) {
 		return config.Config{}, "", err
@@ -240,6 +305,282 @@ func BootstrapWithValidator(ctx context.Context, configPath string, configProvid
 	config.ApplyEnvOverrides(&runtime)
 	runtime.MainSettings.DBPath = fallbackDBPath
 	return runtime, fallbackDBPath, nil
+}
+
+func validatePersistableConfig(cfg *config.Config, dbPath string, validate func(*config.Config) error) error {
+	candidate := *cfg
+	candidate.MainSettings.DBPath = dbPath
+	return validate(&candidate)
+}
+
+// prepareProvidedConfigForSave decides whether a provided config should replace
+// or merge with stored DB config. It uses the already-read providedData for
+// native YAML/JSON overlays so validation and persistence share one input.
+func prepareProvidedConfigForSave(ctx context.Context, configPath string, providedData []byte, imported *config.Config, dbPath string) (*config.Config, *config.Config, bool, error) {
+	stored, err := loadStoredConfigForProvidedMerge(ctx, dbPath)
+	storedLoaded := err == nil
+	if err != nil && !errors.Is(err, internalerrors.ErrNotFound) {
+		return nil, nil, false, err
+	}
+
+	persisted := imported
+	runtime := imported
+	if storedLoaded {
+		merged, mergeErr := mergeProvidedConfig(stored, configPath, providedData, imported)
+		if mergeErr != nil {
+			return nil, nil, false, mergeErr
+		}
+		persisted = merged
+		runtime = merged
+	}
+
+	persisted.MainSettings.DBPath = dbPath
+	if err := validatePersistableConfig(persisted, dbPath, func(cfg *config.Config) error {
+		return cfg.Validate()
+	}); err != nil {
+		if storedLoaded {
+			runtime = stored
+		}
+		return persisted, runtime, false, nil
+	}
+
+	return persisted, runtime, true, nil
+}
+
+// loadStoredConfigForProvidedMerge loads stored config for a provided-file merge
+// without persisting sanitizer side effects. Unsupported image rehosts are
+// disabled only in the returned copy so an invalid provided config cannot mutate
+// the database during validation.
+func loadStoredConfigForProvidedMerge(ctx context.Context, dbPath string) (*config.Config, error) {
+	if _, err := os.Stat(dbPath); err != nil { //nolint:gosec // Existence probe for resolved DB path avoids creating SQLite DB before provided config validates.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, internalerrors.ErrNotFound
+		}
+		return nil, fmt.Errorf("config store: stat database: %w", err)
+	}
+
+	repo, err := db.OpenContext(ctx, dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("config store: %w", err)
+	}
+	defer repo.Close()
+
+	if err := repo.MigrateContext(ctx); err != nil {
+		return nil, fmt.Errorf("config store: %w", err)
+	}
+
+	loaded, err := config.LoadFromDatabase(ctx, repo)
+	if err != nil {
+		return nil, fmt.Errorf("config store: %w", err)
+	}
+	if err := config.MergeMissingTrackerDefaults(loaded); err != nil {
+		return nil, fmt.Errorf("config store: %w", err)
+	}
+	config.DisableUnsupportedTrackerImageRehosts(loaded)
+	return loaded, nil
+}
+
+// mergeProvidedConfig merges native YAML/JSON overlays into stored config and
+// returns non-native imports unchanged.
+func mergeProvidedConfig(base *config.Config, configPath string, providedData []byte, imported *config.Config) (*config.Config, error) {
+	switch strings.ToLower(filepath.Ext(configPath)) {
+	case ".yaml", ".yml":
+		return mergeYAMLConfig(base, providedData)
+	case ".json":
+		return mergeJSONConfig(base, providedData)
+	default:
+		return imported, nil
+	}
+}
+
+func mergeYAMLConfig(base *config.Config, overlayData []byte) (*config.Config, error) {
+	baseRaw := map[string]any{}
+	baseData, err := yaml.Marshal(base)
+	if err != nil {
+		return nil, fmt.Errorf("config store: marshal stored config: %w", err)
+	}
+	if err := yaml.Unmarshal(baseData, &baseRaw); err != nil {
+		return nil, fmt.Errorf("config store: unmarshal stored config: %w", err)
+	}
+
+	overlayRaw := map[string]any{}
+	if err := yaml.Unmarshal(overlayData, &overlayRaw); err != nil {
+		return nil, fmt.Errorf("config store: unmarshal provided config: %w", err)
+	}
+	if err := mergeConfigMap(baseRaw, overlayRaw); err != nil {
+		return nil, fmt.Errorf("config store: merge provided config: %w", err)
+	}
+
+	mergedData, err := yaml.Marshal(baseRaw)
+	if err != nil {
+		return nil, fmt.Errorf("config store: marshal merged config: %w", err)
+	}
+	var merged config.Config
+	if err := yaml.Unmarshal(mergedData, &merged); err != nil {
+		return nil, fmt.Errorf("config store: unmarshal merged config: %w", err)
+	}
+	return finalizeMergedConfig(&merged)
+}
+
+func mergeJSONConfig(base *config.Config, overlayData []byte) (*config.Config, error) {
+	baseRaw := map[string]any{}
+	baseData, err := json.Marshal(base)
+	if err != nil {
+		return nil, fmt.Errorf("config store: marshal stored config: %w", err)
+	}
+	if err := json.Unmarshal(baseData, &baseRaw); err != nil {
+		return nil, fmt.Errorf("config store: unmarshal stored config: %w", err)
+	}
+
+	overlayRaw := map[string]any{}
+	if err := json.Unmarshal(overlayData, &overlayRaw); err != nil {
+		return nil, fmt.Errorf("config store: unmarshal provided config: %w", err)
+	}
+	if err := mergeConfigMap(baseRaw, overlayRaw); err != nil {
+		return nil, fmt.Errorf("config store: merge provided config: %w", err)
+	}
+
+	mergedData, err := json.Marshal(baseRaw)
+	if err != nil {
+		return nil, fmt.Errorf("config store: marshal merged config: %w", err)
+	}
+	var merged config.Config
+	if err := json.Unmarshal(mergedData, &merged); err != nil {
+		return nil, fmt.Errorf("config store: unmarshal merged config: %w", err)
+	}
+	return finalizeMergedConfig(&merged)
+}
+
+// mergeConfigMap recursively overlays provided config onto stored config.
+// Unknown sections and fields are rejected except tracker extension fields, and
+// dynamically named torrent clients are validated against the client schema.
+// Null or empty object overlays leave stored objects intact; scalar or array
+// overlays cannot replace an object section.
+func mergeConfigMap(base map[string]any, overlay map[string]any) error {
+	return mergeConfigMapAt(base, overlay, "")
+}
+
+func mergeConfigMapAt(base map[string]any, overlay map[string]any, path string) error {
+	for key, overlayValue := range overlay {
+		field := key
+		if path != "" {
+			field = path + "." + key
+		}
+		baseValue, baseExists := base[key]
+		baseMap, baseOK := baseValue.(map[string]any)
+		if baseOK {
+			if overlayValue == nil {
+				continue
+			}
+			overlayMap, overlayOK := overlayValue.(map[string]any)
+			if !overlayOK {
+				return fmt.Errorf("cannot replace config object %q with %T", field, overlayValue)
+			}
+			if err := mergeConfigMapAt(baseMap, overlayMap, field); err != nil {
+				return err
+			}
+			continue
+		}
+		if !baseExists {
+			if path == "" {
+				return fmt.Errorf("unknown config section %q", key)
+			}
+			if allowsDynamicConfigEntry(path) {
+				if err := mergeDynamicConfigEntry(base, path, key, overlayValue); err != nil {
+					return err
+				}
+				continue
+			}
+			if allowsTrackerExtensionField(path) {
+				base[key] = overlayValue
+				continue
+			}
+			return fmt.Errorf("unknown config field %q", field)
+		}
+		base[key] = overlayValue
+	}
+	return nil
+}
+
+func allowsDynamicConfigEntry(path string) bool {
+	switch path {
+	case "trackers", "Trackers.Trackers", "torrent_clients", "TorrentClients":
+		return true
+	default:
+		return false
+	}
+}
+
+func allowsTrackerExtensionField(path string) bool {
+	return strings.HasPrefix(path, "trackers.") || strings.HasPrefix(path, "Trackers.Trackers.")
+}
+
+func configMapEntrySchema(path string) (map[string]any, bool) {
+	switch path {
+	case "torrent_clients":
+		return torrentClientSchemaMap(path), true
+	case "TorrentClients":
+		return torrentClientSchemaMap(path), true
+	default:
+		return nil, false
+	}
+}
+
+func torrentClientSchemaMap(path string) map[string]any {
+	t := reflect.TypeFor[config.TorrentClientConfig]()
+	schema := make(map[string]any, t.NumField())
+	for field := range t.Fields() {
+		key := field.Name
+		if path == "torrent_clients" {
+			key = strings.TrimSpace(strings.Split(field.Tag.Get("yaml"), ",")[0])
+		}
+		if key == "" || key == "-" {
+			continue
+		}
+		schema[key] = nil
+	}
+	return schema
+}
+
+// mergeDynamicConfigEntry merges a dynamically named tracker or torrent-client
+// entry. Nil overlays are treated as absent so partial provided configs cannot
+// clobber stored dynamic entries, while scalar overlays still fail schema checks.
+func mergeDynamicConfigEntry(base map[string]any, path, key string, overlayValue any) error {
+	field := path + "." + key
+	if overlayValue == nil {
+		return nil
+	}
+	overlayMap, overlayOK := overlayValue.(map[string]any)
+	if !overlayOK {
+		return fmt.Errorf("cannot replace config object %q with %T", field, overlayValue)
+	}
+	if len(overlayMap) == 0 {
+		return nil
+	}
+	schema, hasSchema := configMapEntrySchema(path)
+	if hasSchema {
+		if err := mergeConfigMapAt(schema, overlayMap, field); err != nil {
+			return err
+		}
+		base[key] = schema
+		return nil
+	}
+	base[key] = overlayMap
+	return nil
+}
+
+// finalizeMergedConfig restores imported-secret rewrap requirements and fills
+// tracker defaults before a merged native config is validated or persisted.
+func finalizeMergedConfig(cfg *config.Config) (*config.Config, error) {
+	decrypted, err := config.DecryptImportedConfigSecrets(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("config store: decrypt merged config: %w", err)
+	}
+	if err := config.MergeMissingTrackerDefaults(decrypted); err != nil {
+		return nil, fmt.Errorf("config store: merge tracker defaults: %w", err)
+	}
+	config.DisableUnsupportedTrackerImageRehosts(decrypted)
+	return decrypted, nil
 }
 
 // resolveDBPath returns the database path to use for cfg, honoring any env

--- a/internal/configstore/dbloader.go
+++ b/internal/configstore/dbloader.go
@@ -86,6 +86,8 @@ func LoadFromDBPath(ctx context.Context, dbPath string) (*config.Config, error) 
 	return loadFromDBPath(ctx, dbPath, true)
 }
 
+// loadFromDBPath loads persisted config and optionally applies environment
+// overrides to the returned runtime copy.
 func loadFromDBPath(ctx context.Context, dbPath string, applyEnv bool) (*config.Config, error) {
 	repo, err := db.OpenContext(ctx, dbPath)
 	if err != nil {
@@ -164,6 +166,9 @@ func SaveToRepository(ctx context.Context, cfg *config.Config, repo *db.SQLiteRe
 	return nil
 }
 
+// syncCookieEncryptionBeforeConfigSaveTx updates cookie encryption metadata in
+// the caller's config-save transaction, treating missing auth material as a
+// plaintext-cookie install rather than a save failure.
 func syncCookieEncryptionBeforeConfigSaveTx(ctx context.Context, tx *sql.Tx, dbPath string) error {
 	if err := cookies.SyncCookieEncryptionWithAuthTx(ctx, tx, dbPath); err != nil {
 		if errors.Is(err, cookies.ErrAuthHelperUnavailable) {
@@ -307,6 +312,9 @@ func BootstrapWithValidator(ctx context.Context, configPath string, configProvid
 	return runtime, fallbackDBPath, nil
 }
 
+// validatePersistableConfig validates the exact config shape that would be
+// written to the database, including the resolved DB path and excluding env-only
+// runtime overrides.
 func validatePersistableConfig(cfg *config.Config, dbPath string, validate func(*config.Config) error) error {
 	candidate := *cfg
 	candidate.MainSettings.DBPath = dbPath
@@ -393,6 +401,8 @@ func mergeProvidedConfig(base *config.Config, configPath string, providedData []
 	}
 }
 
+// mergeYAMLConfig overlays provided YAML bytes onto a stored config using YAML
+// field names, then finalizes decrypted secrets and tracker defaults.
 func mergeYAMLConfig(base *config.Config, overlayData []byte) (*config.Config, error) {
 	baseRaw := map[string]any{}
 	baseData, err := yaml.Marshal(base)
@@ -422,6 +432,8 @@ func mergeYAMLConfig(base *config.Config, overlayData []byte) (*config.Config, e
 	return finalizeMergedConfig(&merged)
 }
 
+// mergeJSONConfig overlays provided JSON bytes onto a stored config using the
+// exported field-name shape produced by native JSON export.
 func mergeJSONConfig(base *config.Config, overlayData []byte) (*config.Config, error) {
 	baseRaw := map[string]any{}
 	baseData, err := json.Marshal(base)
@@ -460,6 +472,8 @@ func mergeConfigMap(base map[string]any, overlay map[string]any) error {
 	return mergeConfigMapAt(base, overlay, "")
 }
 
+// mergeConfigMapAt applies one overlay level and tracks a dotted schema path so
+// dynamic tracker and torrent-client entries can be validated by context.
 func mergeConfigMapAt(base map[string]any, overlay map[string]any, path string) error {
 	for key, overlayValue := range overlay {
 		field := key
@@ -502,6 +516,8 @@ func mergeConfigMapAt(base map[string]any, overlay map[string]any, path string) 
 	return nil
 }
 
+// allowsDynamicConfigEntry reports whether path accepts user-named child
+// entries such as tracker names or torrent-client names.
 func allowsDynamicConfigEntry(path string) bool {
 	switch path {
 	case "trackers", "Trackers.Trackers", "torrent_clients", "TorrentClients":
@@ -511,10 +527,14 @@ func allowsDynamicConfigEntry(path string) bool {
 	}
 }
 
+// allowsTrackerExtensionField reports whether path is inside a dynamic tracker
+// config, where tracker-specific extension fields are preserved.
 func allowsTrackerExtensionField(path string) bool {
 	return strings.HasPrefix(path, "trackers.") || strings.HasPrefix(path, "Trackers.Trackers.")
 }
 
+// configMapEntrySchema returns the schema for a dynamically named map entry
+// when the entry requires fixed field validation.
 func configMapEntrySchema(path string) (map[string]any, bool) {
 	switch path {
 	case "torrent_clients":
@@ -526,6 +546,8 @@ func configMapEntrySchema(path string) (map[string]any, bool) {
 	}
 }
 
+// torrentClientSchemaMap builds the allowed key set for a dynamic torrent
+// client entry using YAML tag names or exported JSON field names.
 func torrentClientSchemaMap(path string) map[string]any {
 	t := reflect.TypeFor[config.TorrentClientConfig]()
 	schema := make(map[string]any, t.NumField())

--- a/internal/configstore/dbloader.go
+++ b/internal/configstore/dbloader.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/config/importer"
 	"github.com/autobrr/upbrr/internal/cookies"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/services/db"
@@ -52,7 +53,7 @@ func ResolveYAMLPath(path string, provided bool) (string, error) {
 func LoadFromPathOrEmbedded(path string) (*config.Config, error) {
 	if strings.TrimSpace(path) != "" {
 		if _, err := os.Stat(path); err == nil {
-			loaded, err := config.ImportFromYAML(path)
+			loaded, _, err := importer.ImportFromFile(path)
 			if err != nil {
 				return nil, fmt.Errorf("load config from yaml: %w", err)
 			}
@@ -132,22 +133,29 @@ func SaveToDBPath(ctx context.Context, cfg *config.Config, dbPath string) error 
 // Bootstrap resolves the effective config and database path at process
 // startup. It prefers the sqlite database (with YAML used only as a bootstrap
 // source when the database is empty). The persistYAML flag controls whether a
-// YAML import is written back to the database: CLI/GUI persist so subsequent
-// runs reuse the imported config, while the web server does not, because
-// writing an incomplete YAML back would overwrite previously valid database
-// state with zero-valued fields.
+// YAML import is written back to the database. Callers that accept incomplete
+// setup config can pass false or omit validation; CLI callers validate before
+// saving so bad --config input cannot overwrite valid database state.
 //
 // Environment overrides are applied to the returned runtime config but not to
 // the config written to the database. This keeps the persisted state free of
 // env-specific values so unsetting an env var later does not leave a stale
 // override sitting in the database.
 func Bootstrap(ctx context.Context, configPath string, configProvided, persistYAML bool) (config.Config, string, error) {
+	return BootstrapWithValidator(ctx, configPath, configProvided, persistYAML, nil)
+}
+
+// BootstrapWithValidator is Bootstrap plus an optional validation hook that
+// runs before a provided config is persisted. CLI callers use it so a bad
+// --config file cannot be written to the database before startup validation
+// fails, while GUI/web callers can still start with incomplete setup config.
+func BootstrapWithValidator(ctx context.Context, configPath string, configProvided, persistYAML bool, validateBeforePersist func(*config.Config) error) (config.Config, string, error) {
 	if configProvided {
 		resolved, err := ResolveYAMLPath(configPath, configProvided)
 		if err != nil {
 			return config.Config{}, "", err
 		}
-		loaded, err := config.ImportFromYAML(resolved)
+		loaded, _, err := importer.ImportFromFile(resolved)
 		if err != nil {
 			return config.Config{}, "", fmt.Errorf("config store: %w", err)
 		}
@@ -159,6 +167,11 @@ func Bootstrap(ctx context.Context, configPath string, configProvided, persistYA
 		loaded.MainSettings.DBPath = dbPath
 
 		if persistYAML {
+			if validateBeforePersist != nil {
+				if err := validateBeforePersist(loaded); err != nil {
+					return config.Config{}, "", fmt.Errorf("config store: validate provided config: %w", err)
+				}
+			}
 			if err := SaveToDBPath(ctx, loaded, dbPath); err != nil {
 				return config.Config{}, "", err
 			}

--- a/internal/configstore/dbloader_internal_test.go
+++ b/internal/configstore/dbloader_internal_test.go
@@ -1,0 +1,474 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package configstore
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/config/importer"
+)
+
+func testMergeBaseConfig(t *testing.T) *config.Config {
+	t.Helper()
+
+	cfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("load embedded config: %v", err)
+	}
+	cfg.MainSettings.DBPath = filepath.Join(t.TempDir(), "merge.db")
+	cfg.MainSettings.TMDBAPI = "stored-key"
+	cfg.ScreenshotHandling.Screens = 7
+	return cfg
+}
+
+func TestMergeProvidedConfigUsesProvidedBytes(t *testing.T) {
+	formats := map[string]struct {
+		filename string
+		original []byte
+		mutated  []byte
+	}{
+		"yaml": {
+			filename: "config.yaml",
+			original: []byte("main_settings:\n  tmdb_api: original-key\nscreenshot_handling:\n  screens: 4\n"),
+			mutated:  []byte("main_settings:\n  tmdb_api: mutated-key\nscreenshot_handling:\n  screens: 5\n"),
+		},
+		"json": {
+			filename: "config.json",
+			original: []byte(`{"MainSettings":{"TMDBAPI":"original-key"},"ScreenshotHandling":{"Screens":4}}`),
+			mutated:  []byte(`{"MainSettings":{"TMDBAPI":"mutated-key"},"ScreenshotHandling":{"Screens":5}}`),
+		},
+	}
+
+	for name, tc := range formats {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), tc.filename)
+			if err := os.WriteFile(path, tc.mutated, 0o600); err != nil {
+				t.Fatalf("write mutated config: %v", err)
+			}
+
+			merged, err := mergeProvidedConfig(testMergeBaseConfig(t), path, tc.original, nil)
+			if err != nil {
+				t.Fatalf("merge provided config: %v", err)
+			}
+			if merged.MainSettings.TMDBAPI != "original-key" {
+				t.Fatalf("merge used changed file bytes: got TMDBAPI %q", merged.MainSettings.TMDBAPI)
+			}
+			if merged.ScreenshotHandling.Screens != 4 {
+				t.Fatalf("merge used changed file bytes: got screens %d", merged.ScreenshotHandling.Screens)
+			}
+		})
+	}
+}
+
+func TestMergeNativeConfigObjectOverlayMatrix(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		payload []byte
+		wantErr bool
+	}{
+		{name: "yaml-null", format: "yaml", payload: []byte("main_settings: null\n")},
+		{name: "yaml-empty-map", format: "yaml", payload: []byte("main_settings: {}\n")},
+		{name: "yaml-empty-array", format: "yaml", payload: []byte("main_settings: []\n"), wantErr: true},
+		{name: "yaml-scalar", format: "yaml", payload: []byte("main_settings: nope\n"), wantErr: true},
+		{name: "json-null", format: "json", payload: []byte(`{"MainSettings":null}`)},
+		{name: "json-empty-map", format: "json", payload: []byte(`{"MainSettings":{}}`)},
+		{name: "json-empty-array", format: "json", payload: []byte(`{"MainSettings":[]}`), wantErr: true},
+		{name: "json-scalar", format: "json", payload: []byte(`{"MainSettings":"nope"}`), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				merged *config.Config
+				err    error
+			)
+			switch tt.format {
+			case "yaml":
+				merged, err = mergeYAMLConfig(testMergeBaseConfig(t), tt.payload)
+			case "json":
+				merged, err = mergeJSONConfig(testMergeBaseConfig(t), tt.payload)
+			default:
+				t.Fatalf("unknown format %q", tt.format)
+			}
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected destructive object replacement to fail")
+				}
+				if !strings.Contains(err.Error(), "cannot replace config object") {
+					t.Fatalf("expected object replacement error, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("merge native config: %v", err)
+			}
+			if merged.MainSettings.TMDBAPI != "stored-key" {
+				t.Fatalf("object overlay clobbered TMDBAPI: got %q", merged.MainSettings.TMDBAPI)
+			}
+			if merged.ScreenshotHandling.Screens != 7 {
+				t.Fatalf("object overlay clobbered screens: got %d", merged.ScreenshotHandling.Screens)
+			}
+		})
+	}
+}
+
+func TestMergeNativeConfigNilDynamicTorrentClientEntryMatchesImporterSkip(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   string
+		filename string
+		payload  []byte
+	}{
+		{
+			name:     "yaml",
+			format:   "yaml",
+			filename: "config.yaml",
+			payload:  []byte("torrent_clients:\n  watch-client: null\n"),
+		},
+		{
+			name:     "json",
+			format:   "json",
+			filename: "config.json",
+			payload:  []byte(`{"TorrentClients":{"watch-client":null}}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := testMergeBaseConfig(t)
+			base.TorrentClients = map[string]config.TorrentClientConfig{
+				"watch-client": {
+					Type:        "watch",
+					WatchFolder: "stored-watch",
+				},
+			}
+
+			var (
+				merged *config.Config
+				err    error
+			)
+			switch tt.format {
+			case "yaml":
+				merged, err = mergeYAMLConfig(base, tt.payload)
+			case "json":
+				merged, err = mergeJSONConfig(base, tt.payload)
+			default:
+				t.Fatalf("unknown format %q", tt.format)
+			}
+			if err != nil {
+				t.Fatalf("merge native config: %v", err)
+			}
+			got, ok := merged.TorrentClients["watch-client"]
+			if !ok {
+				t.Fatal("nil dynamic overlay removed stored torrent client")
+			}
+			if got.WatchFolder != "stored-watch" {
+				t.Fatalf("nil dynamic overlay clobbered stored torrent client: got watch_folder %q", got.WatchFolder)
+			}
+
+			imported, _, err := importer.ImportFromContent(tt.filename, tt.payload)
+			if err != nil {
+				t.Fatalf("import native config: %v", err)
+			}
+			if _, ok := imported.TorrentClients["watch-client"]; ok {
+				t.Fatal("importer should skip nil dynamic torrent client entries")
+			}
+		})
+	}
+}
+
+func TestMergeNativeConfigTorrentClientCollectionNullKeepsStoredClients(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		payload []byte
+	}{
+		{name: "yaml", format: "yaml", payload: []byte("torrent_clients: null\n")},
+		{name: "json", format: "json", payload: []byte(`{"TorrentClients":null}`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := testMergeBaseConfig(t)
+			base.TorrentClients = map[string]config.TorrentClientConfig{
+				"watch-client": {
+					Type:        "watch",
+					WatchFolder: "stored-watch",
+				},
+			}
+
+			var (
+				merged *config.Config
+				err    error
+			)
+			switch tt.format {
+			case "yaml":
+				merged, err = mergeYAMLConfig(base, tt.payload)
+			case "json":
+				merged, err = mergeJSONConfig(base, tt.payload)
+			default:
+				t.Fatalf("unknown format %q", tt.format)
+			}
+			if err != nil {
+				t.Fatalf("merge native config: %v", err)
+			}
+			if got := merged.TorrentClients["watch-client"].WatchFolder; got != "stored-watch" {
+				t.Fatalf("top-level null collection clobbered stored torrent client: got watch_folder %q", got)
+			}
+		})
+	}
+}
+
+func TestMergeNativeConfigRejectsInvalidDynamicTorrentClientEntries(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		payload []byte
+	}{
+		{name: "yaml-scalar", format: "yaml", payload: []byte("torrent_clients:\n  watch-client: nope\n")},
+		{name: "yaml-array", format: "yaml", payload: []byte("torrent_clients:\n  watch-client: []\n")},
+		{name: "json-scalar", format: "json", payload: []byte(`{"TorrentClients":{"watch-client":"nope"}}`)},
+		{name: "json-array", format: "json", payload: []byte(`{"TorrentClients":{"watch-client":[]}}`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			switch tt.format {
+			case "yaml":
+				_, err = mergeYAMLConfig(testMergeBaseConfig(t), tt.payload)
+			case "json":
+				_, err = mergeJSONConfig(testMergeBaseConfig(t), tt.payload)
+			default:
+				t.Fatalf("unknown format %q", tt.format)
+			}
+			if err == nil {
+				t.Fatal("expected invalid dynamic torrent client entry to fail")
+			}
+			if !strings.Contains(err.Error(), "cannot replace config object") {
+				t.Fatalf("expected object replacement error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestMergeNativeConfigAcceptsValidAndSkipsEmptyDynamicTorrentClientEntries(t *testing.T) {
+	tests := []struct {
+		name            string
+		format          string
+		payload         []byte
+		wantType        string
+		wantWatchFolder string
+		wantAbsent      string
+	}{
+		{
+			name:            "yaml-valid-watch",
+			format:          "yaml",
+			payload:         []byte("torrent_clients:\n  watch-client:\n    type: watch\n    watch_folder: incoming-watch\n"),
+			wantType:        "watch",
+			wantWatchFolder: "incoming-watch",
+		},
+		{
+			name:       "yaml-empty-object",
+			format:     "yaml",
+			payload:    []byte("torrent_clients:\n  empty-client: {}\n"),
+			wantAbsent: "empty-client",
+		},
+		{
+			name:            "json-valid-watch",
+			format:          "json",
+			payload:         []byte(`{"TorrentClients":{"watch-client":{"Type":"watch","WatchFolder":"incoming-watch"}}}`),
+			wantType:        "watch",
+			wantWatchFolder: "incoming-watch",
+		},
+		{
+			name:       "json-empty-object",
+			format:     "json",
+			payload:    []byte(`{"TorrentClients":{"empty-client":{}}}`),
+			wantAbsent: "empty-client",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				merged *config.Config
+				err    error
+			)
+			switch tt.format {
+			case "yaml":
+				merged, err = mergeYAMLConfig(testMergeBaseConfig(t), tt.payload)
+			case "json":
+				merged, err = mergeJSONConfig(testMergeBaseConfig(t), tt.payload)
+			default:
+				t.Fatalf("unknown format %q", tt.format)
+			}
+			if err != nil {
+				t.Fatalf("merge native config: %v", err)
+			}
+			if tt.wantAbsent != "" {
+				if _, ok := merged.TorrentClients[tt.wantAbsent]; ok {
+					t.Fatalf("empty dynamic torrent client %q should be skipped", tt.wantAbsent)
+				}
+				return
+			}
+			clientName := "watch-client"
+			client, ok := merged.TorrentClients[clientName]
+			if !ok {
+				t.Fatalf("expected dynamic torrent client %q", clientName)
+			}
+			if client.Type != tt.wantType {
+				t.Fatalf("type: got %q want %q", client.Type, tt.wantType)
+			}
+			if client.WatchFolder != tt.wantWatchFolder {
+				t.Fatalf("watch_folder: got %q want %q", client.WatchFolder, tt.wantWatchFolder)
+			}
+		})
+	}
+}
+
+func TestMergeNativeConfigRejectsUnknownTopLevelSections(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		payload []byte
+	}{
+		{name: "yaml-scalar", format: "yaml", payload: []byte("unknown_section: nope\n")},
+		{name: "yaml-array", format: "yaml", payload: []byte("unknown_section: []\n")},
+		{name: "yaml-object", format: "yaml", payload: []byte("unknown_section:\n  nested: true\n")},
+		{name: "yaml-null", format: "yaml", payload: []byte("unknown_section: null\n")},
+		{name: "yaml-case-twin", format: "yaml", payload: []byte("MainSettings:\n  TMDBAPI: wrong\n")},
+		{name: "json-scalar", format: "json", payload: []byte(`{"UnknownSection":"nope"}`)},
+		{name: "json-array", format: "json", payload: []byte(`{"UnknownSection":[]}`)},
+		{name: "json-object", format: "json", payload: []byte(`{"UnknownSection":{"nested":true}}`)},
+		{name: "json-null", format: "json", payload: []byte(`{"UnknownSection":null}`)},
+		{name: "json-case-twin", format: "json", payload: []byte(`{"main_settings":{"tmdb_api":"wrong"}}`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			switch tt.format {
+			case "yaml":
+				_, err = mergeYAMLConfig(testMergeBaseConfig(t), tt.payload)
+			case "json":
+				_, err = mergeJSONConfig(testMergeBaseConfig(t), tt.payload)
+			default:
+				t.Fatalf("unknown format %q", tt.format)
+			}
+			if err == nil {
+				t.Fatal("expected unknown top-level section to fail")
+			}
+			if !strings.Contains(err.Error(), "unknown config section") {
+				t.Fatalf("expected unknown section error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestMergeNativeConfigRejectsUnknownNestedFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		format    string
+		payload   []byte
+		wantField string
+	}{
+		{
+			name:      "yaml-main-settings",
+			format:    "yaml",
+			payload:   []byte("main_settings:\n  tmdb_api_typo: drop\n"),
+			wantField: "main_settings.tmdb_api_typo",
+		},
+		{
+			name:      "json-main-settings",
+			format:    "json",
+			payload:   []byte(`{"MainSettings":{"TMDBAPITypo":"drop"}}`),
+			wantField: "MainSettings.TMDBAPITypo",
+		},
+		{
+			name:      "yaml-torrent-client",
+			format:    "yaml",
+			payload:   []byte("torrent_clients:\n  qbit:\n    unknown_key: drop\n"),
+			wantField: "torrent_clients.qbit.unknown_key",
+		},
+		{
+			name:      "json-torrent-client",
+			format:    "json",
+			payload:   []byte(`{"TorrentClients":{"qbit":{"UnknownKey":"drop"}}}`),
+			wantField: "TorrentClients.qbit.UnknownKey",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			switch tt.format {
+			case "yaml":
+				_, err = mergeYAMLConfig(testMergeBaseConfig(t), tt.payload)
+			case "json":
+				_, err = mergeJSONConfig(testMergeBaseConfig(t), tt.payload)
+			default:
+				t.Fatalf("unknown format %q", tt.format)
+			}
+			if err == nil {
+				t.Fatal("expected unknown nested field to fail")
+			}
+			if !strings.Contains(err.Error(), "unknown config field") || !strings.Contains(err.Error(), tt.wantField) {
+				t.Fatalf("expected unknown nested field %q, got %v", tt.wantField, err)
+			}
+		})
+	}
+}
+
+func TestMergeNativeConfigPreservesTrackerCustomUnknownKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		payload []byte
+		key     string
+	}{
+		{
+			name:    "yaml",
+			format:  "yaml",
+			payload: []byte("trackers:\n  A4K:\n    api_key: tracker-key\n    custom_yaml: keep\n"),
+			key:     "custom_yaml",
+		},
+		{
+			name:    "json",
+			format:  "json",
+			payload: []byte(`{"Trackers":{"Trackers":{"A4K":{"APIKey":"tracker-key","custom_json":"keep"}}}}`),
+			key:     "custom_json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				merged *config.Config
+				err    error
+			)
+			switch tt.format {
+			case "yaml":
+				merged, err = mergeYAMLConfig(testMergeBaseConfig(t), tt.payload)
+			case "json":
+				merged, err = mergeJSONConfig(testMergeBaseConfig(t), tt.payload)
+			default:
+				t.Fatalf("unknown format %q", tt.format)
+			}
+			if err != nil {
+				t.Fatalf("merge native config: %v", err)
+			}
+			tracker := merged.Trackers.Trackers["A4K"]
+			if got := tracker.Unknown[tt.key]; got != "keep" {
+				t.Fatalf("expected tracker custom key %q to survive, got %#v", tt.key, got)
+			}
+		})
+	}
+}

--- a/internal/configstore/dbloader_penetration_test.go
+++ b/internal/configstore/dbloader_penetration_test.go
@@ -246,6 +246,36 @@ func TestBootstrapProvidedYAMLPersistsToDB(t *testing.T) {
 	if stored.ScreenshotHandling.Screens != 2 {
 		t.Fatalf("persisted screens: got %d want 2 (env override leaked into DB)", stored.ScreenshotHandling.Screens)
 	}
+	if stored.MainSettings.TrackerPassChecks != 1 {
+		t.Fatalf("persisted tracker_pass_checks default: got %d want 1", stored.MainSettings.TrackerPassChecks)
+	}
+}
+
+func TestBootstrapWithValidatorRejectsInvalidProvidedYAMLBeforePersist(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "invalid.db")
+	yamlPath := filepath.Join(tmp, "config.yaml")
+
+	body := "main_settings:\n  tmdb_api: provided\n  db_path: " + dbPath + "\nscreenshot_handling:\n  screens: 0\n"
+	if err := os.WriteFile(yamlPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	_, _, err := configstore.BootstrapWithValidator(ctx, yamlPath, true, true, func(cfg *config.Config) error {
+		return cfg.Validate()
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "screenshot_handling.screens") {
+		t.Fatalf("expected screens validation error, got %v", err)
+	}
+	if _, statErr := os.Stat(dbPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("invalid provided config should not create database file, stat err=%v", statErr)
+	}
 }
 
 func TestBootstrapProvidedYAMLPersistsPlaintextSecretsWithoutWebAuth(t *testing.T) {

--- a/internal/configstore/dbloader_penetration_test.go
+++ b/internal/configstore/dbloader_penetration_test.go
@@ -207,6 +207,73 @@ func TestLoadFromDBPathEnvOverrideNotPersisted(t *testing.T) {
 	}
 }
 
+func TestBootstrapDefaultDBPathRepairDoesNotPersistEnvOverrides(t *testing.T) {
+	ctx := context.Background()
+
+	for name, storedDBPath := range map[string]string{
+		"blank":      "",
+		"mismatched": "other.db",
+	} {
+		t.Run(name, func(t *testing.T) {
+			xdgRoot := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", xdgRoot)
+			defaultDBPath, err := db.DefaultPath()
+			if err != nil {
+				t.Fatalf("default db path: %v", err)
+			}
+
+			cfg, err := config.LoadEmbeddedDefaultConfig()
+			if err != nil {
+				t.Fatalf("embed: %v", err)
+			}
+			cfg.MainSettings.DBPath = storedDBPath
+			cfg.MainSettings.TMDBAPI = "persisted"
+			cfg.ScreenshotHandling.Screens = 2
+			if storedDBPath == "other.db" {
+				cfg.MainSettings.DBPath = filepath.Join(t.TempDir(), storedDBPath)
+			}
+			if err := configstore.SaveToDBPath(ctx, cfg, defaultDBPath); err != nil {
+				t.Fatalf("seed default db: %v", err)
+			}
+
+			t.Setenv("UA_DEFAULT_TMDB_API", "from-env")
+			t.Setenv("UA_DEFAULT_SCREENS", "8")
+			runtime, resolvedDB, err := configstore.BootstrapWithValidator(ctx, "", false, false, nil)
+			if err != nil {
+				t.Fatalf("bootstrap: %v", err)
+			}
+			if resolvedDB != defaultDBPath {
+				t.Fatalf("resolved DB path: got %q want %q", resolvedDB, defaultDBPath)
+			}
+			if runtime.MainSettings.DBPath != defaultDBPath {
+				t.Fatalf("runtime DB path: got %q want %q", runtime.MainSettings.DBPath, defaultDBPath)
+			}
+			if runtime.MainSettings.TMDBAPI != "from-env" {
+				t.Fatalf("runtime env TMDBAPI missing: got %q", runtime.MainSettings.TMDBAPI)
+			}
+			if runtime.ScreenshotHandling.Screens != 8 {
+				t.Fatalf("runtime env screens missing: got %d", runtime.ScreenshotHandling.Screens)
+			}
+
+			t.Setenv("UA_DEFAULT_TMDB_API", "")
+			t.Setenv("UA_DEFAULT_SCREENS", "")
+			stored, err := configstore.LoadFromDBPath(ctx, defaultDBPath)
+			if err != nil {
+				t.Fatalf("reload default db: %v", err)
+			}
+			if stored.MainSettings.DBPath != defaultDBPath {
+				t.Fatalf("stored DB path repair missing: got %q want %q", stored.MainSettings.DBPath, defaultDBPath)
+			}
+			if stored.MainSettings.TMDBAPI != "persisted" {
+				t.Fatalf("env TMDBAPI leaked into stored config: got %q", stored.MainSettings.TMDBAPI)
+			}
+			if stored.ScreenshotHandling.Screens != 2 {
+				t.Fatalf("env screens leaked into stored config: got %d", stored.ScreenshotHandling.Screens)
+			}
+		})
+	}
+}
+
 // Bootstrap with a provided config path and persistYAML=true must import the
 // YAML, persist it to the DB, and return a runtime config with env overrides
 // applied.
@@ -278,6 +345,107 @@ func TestBootstrapWithValidatorRejectsInvalidProvidedYAMLBeforePersist(t *testin
 	}
 }
 
+func TestBootstrapWithValidatorRejectsEnvOnlyProvidedYAMLBeforePersist(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "env-rescue.db")
+	yamlPath := filepath.Join(tmp, "config.yaml")
+
+	body := "main_settings:\n  db_path: " + dbPath + "\nscreenshot_handling:\n  screens: 2\n"
+	if err := os.WriteFile(yamlPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	t.Setenv("UA_DEFAULT_TMDB_API", "from-env")
+	_, _, err := configstore.BootstrapWithValidator(ctx, yamlPath, true, true, func(cfg *config.Config) error {
+		return cfg.Validate()
+	})
+	if err == nil {
+		t.Fatal("expected env-only valid config to fail before persistence")
+	}
+	if !strings.Contains(err.Error(), "tmdb_api") {
+		t.Fatalf("expected raw config validation error, got %v", err)
+	}
+	if _, statErr := os.Stat(dbPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("env-rescued provided config should not create database file, stat err=%v", statErr)
+	}
+}
+
+func TestBootstrapStoredEncryptedNativeMergeRejectsPlaintextFallback(t *testing.T) {
+	ctx := context.Background()
+	formats := map[string]string{
+		"yaml": "config.yaml",
+		"json": "config.json",
+	}
+
+	for name, filename := range formats {
+		t.Run(name, func(t *testing.T) {
+			sourceDir := t.TempDir()
+			destDir := t.TempDir()
+			sourceDB := filepath.Join(sourceDir, "source.db")
+			destDB := filepath.Join(destDir, "dest.db")
+			writeWebAuthFixture(t, sourceDB)
+
+			sourceCfg, err := config.LoadEmbeddedDefaultConfig()
+			if err != nil {
+				t.Fatalf("load source config: %v", err)
+			}
+			sourceCfg.MainSettings.DBPath = sourceDB
+			sourceCfg.MainSettings.TMDBAPI = "encrypted-source-token"
+			sourceCfg.ScreenshotHandling.Screens = 4
+			sourceCfg.TorrentClients = map[string]config.TorrentClientConfig{}
+			if err := sourceCfg.Validate(); err != nil {
+				t.Fatalf("source config should validate: %v", err)
+			}
+
+			configPath := filepath.Join(sourceDir, filename)
+			switch filepath.Ext(filename) {
+			case ".yaml":
+				if err := config.ExportToYAML(sourceCfg, configPath); err != nil {
+					t.Fatalf("export yaml: %v", err)
+				}
+			case ".json":
+				payload, err := config.ExportToJSON(sourceCfg)
+				if err != nil {
+					t.Fatalf("export json: %v", err)
+				}
+				if err := os.WriteFile(configPath, []byte(payload), 0o600); err != nil {
+					t.Fatalf("write json: %v", err)
+				}
+			default:
+				t.Fatalf("unsupported test filename %q", filename)
+			}
+			storedCfg, err := config.LoadEmbeddedDefaultConfig()
+			if err != nil {
+				t.Fatalf("load stored config: %v", err)
+			}
+			storedCfg.MainSettings.DBPath = destDB
+			storedCfg.MainSettings.TMDBAPI = "stored-token"
+			storedCfg.TorrentClients = map[string]config.TorrentClientConfig{}
+			if err := configstore.SaveToDBPath(ctx, storedCfg, destDB); err != nil {
+				t.Fatalf("seed destination DB: %v", err)
+			}
+
+			t.Setenv("UA_DEFAULT_DB_PATH", destDB)
+			_, _, err = configstore.Bootstrap(ctx, configPath, true, true)
+			if err == nil {
+				t.Fatal("expected helper-unavailable error for encrypted stored merge")
+			}
+			if !errors.Is(err, config.ErrSecretEncryptionHelperUnavailable) {
+				t.Fatalf("expected ErrSecretEncryptionHelperUnavailable, got %v", err)
+			}
+
+			reloaded, err := configstore.LoadFromDBPath(ctx, destDB)
+			if err != nil {
+				t.Fatalf("reload destination DB: %v", err)
+			}
+			if reloaded.MainSettings.TMDBAPI != "stored-token" {
+				t.Fatalf("stored config changed after failed encrypted merge: got %q", reloaded.MainSettings.TMDBAPI)
+			}
+		})
+	}
+}
+
 func TestBootstrapProvidedYAMLPersistsPlaintextSecretsWithoutWebAuth(t *testing.T) {
 	ctx := context.Background()
 	tmp := t.TempDir()
@@ -339,6 +507,227 @@ func TestBootstrapProvidedYAMLNoPersist(t *testing.T) {
 		if loaded.MainSettings.TMDBAPI == "webserver-overlay" {
 			t.Fatalf("web bootstrap must not persist YAML to DB")
 		}
+	}
+}
+
+func TestBootstrapProvidedYAMLMergePreservesStoredConfig(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "merge.db")
+	yamlPath := filepath.Join(tmp, "config.yaml")
+
+	storedCfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	storedCfg.MainSettings.DBPath = dbPath
+	storedCfg.MainSettings.TMDBAPI = "stored-key"
+	storedCfg.ScreenshotHandling.Screens = 7
+	storedCfg.TorrentClients = map[string]config.TorrentClientConfig{}
+	if err := configstore.SaveToDBPath(ctx, storedCfg, dbPath); err != nil {
+		t.Fatalf("seed db: %v", err)
+	}
+
+	body := "main_settings:\n  db_path: " + dbPath + "\nscreenshot_handling:\n  screens: 4\n"
+	if err := os.WriteFile(yamlPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	runtime, resolvedDB, err := configstore.Bootstrap(ctx, yamlPath, true, true)
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if resolvedDB != dbPath {
+		t.Fatalf("DB path: got %q want %q", resolvedDB, dbPath)
+	}
+	if runtime.MainSettings.TMDBAPI != "stored-key" {
+		t.Fatalf("runtime TMDBAPI clobbered: got %q", runtime.MainSettings.TMDBAPI)
+	}
+	if runtime.ScreenshotHandling.Screens != 4 {
+		t.Fatalf("runtime screens: got %d want 4", runtime.ScreenshotHandling.Screens)
+	}
+
+	reloaded, err := configstore.LoadFromDBPath(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("load stored: %v", err)
+	}
+	if reloaded.MainSettings.TMDBAPI != "stored-key" {
+		t.Fatalf("stored TMDBAPI clobbered: got %q", reloaded.MainSettings.TMDBAPI)
+	}
+	if reloaded.ScreenshotHandling.Screens != 4 {
+		t.Fatalf("stored screens: got %d want 4", reloaded.ScreenshotHandling.Screens)
+	}
+}
+
+func TestBootstrapProvidedYAMLMergeSkipsNilDynamicTorrentClientEntry(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "merge-nil-client.db")
+	yamlPath := filepath.Join(tmp, "config.yaml")
+
+	storedCfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	storedCfg.MainSettings.DBPath = dbPath
+	storedCfg.MainSettings.TMDBAPI = "stored-key"
+	storedCfg.ScreenshotHandling.Screens = 7
+	storedCfg.TorrentClients = map[string]config.TorrentClientConfig{
+		"watch-client": {
+			Type:        "watch",
+			WatchFolder: "stored-watch",
+		},
+	}
+	if err := configstore.SaveToDBPath(ctx, storedCfg, dbPath); err != nil {
+		t.Fatalf("seed db: %v", err)
+	}
+
+	body := "main_settings:\n  db_path: " + dbPath + "\nscreenshot_handling:\n  screens: 4\ntorrent_clients:\n  watch-client: null\n"
+	if err := os.WriteFile(yamlPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	runtime, resolvedDB, err := configstore.Bootstrap(ctx, yamlPath, true, true)
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if resolvedDB != dbPath {
+		t.Fatalf("DB path: got %q want %q", resolvedDB, dbPath)
+	}
+	if got := runtime.TorrentClients["watch-client"].WatchFolder; got != "stored-watch" {
+		t.Fatalf("runtime nil dynamic overlay clobbered stored torrent client: got watch_folder %q", got)
+	}
+	if runtime.ScreenshotHandling.Screens != 4 {
+		t.Fatalf("runtime screens: got %d want 4", runtime.ScreenshotHandling.Screens)
+	}
+
+	reloaded, err := configstore.LoadFromDBPath(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("load stored: %v", err)
+	}
+	if got := reloaded.TorrentClients["watch-client"].WatchFolder; got != "stored-watch" {
+		t.Fatalf("stored nil dynamic overlay clobbered torrent client: got watch_folder %q", got)
+	}
+	if reloaded.ScreenshotHandling.Screens != 4 {
+		t.Fatalf("stored screens: got %d want 4", reloaded.ScreenshotHandling.Screens)
+	}
+}
+
+func TestBootstrapProvidedYAMLInvalidMergeDoesNotOverwriteStoredConfig(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "invalid-merge.db")
+	yamlPath := filepath.Join(tmp, "config.yaml")
+
+	storedCfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	storedCfg.MainSettings.DBPath = dbPath
+	storedCfg.MainSettings.TMDBAPI = "stored-key"
+	storedCfg.ScreenshotHandling.Screens = 7
+	storedCfg.TorrentClients = map[string]config.TorrentClientConfig{}
+	if err := configstore.SaveToDBPath(ctx, storedCfg, dbPath); err != nil {
+		t.Fatalf("seed db: %v", err)
+	}
+
+	body := "main_settings:\n  tmdb_api: \"\"\n  db_path: " + dbPath + "\nscreenshot_handling:\n  screens: 4\n"
+	if err := os.WriteFile(yamlPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	runtime, resolvedDB, err := configstore.Bootstrap(ctx, yamlPath, true, true)
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if resolvedDB != dbPath {
+		t.Fatalf("DB path: got %q want %q", resolvedDB, dbPath)
+	}
+	if runtime.MainSettings.TMDBAPI != "stored-key" || runtime.ScreenshotHandling.Screens != 7 {
+		t.Fatalf("runtime should fall back to stored config, got tmdb=%q screens=%d", runtime.MainSettings.TMDBAPI, runtime.ScreenshotHandling.Screens)
+	}
+
+	reloaded, err := configstore.LoadFromDBPath(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("load stored: %v", err)
+	}
+	if reloaded.MainSettings.TMDBAPI != "stored-key" || reloaded.ScreenshotHandling.Screens != 7 {
+		t.Fatalf("stored config overwritten: tmdb=%q screens=%d", reloaded.MainSettings.TMDBAPI, reloaded.ScreenshotHandling.Screens)
+	}
+}
+
+func TestBootstrapProvidedYAMLInvalidFreshSetupDoesNotCreateDB(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "fresh-invalid.db")
+	yamlPath := filepath.Join(tmp, "config.yaml")
+
+	body := "main_settings:\n  tmdb_api: \"\"\n  db_path: " + dbPath + "\nscreenshot_handling:\n  screens: 4\n"
+	if err := os.WriteFile(yamlPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	runtime, resolvedDB, err := configstore.Bootstrap(ctx, yamlPath, true, true)
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if resolvedDB != dbPath {
+		t.Fatalf("DB path: got %q want %q", resolvedDB, dbPath)
+	}
+	if runtime.MainSettings.TMDBAPI != "" {
+		t.Fatalf("runtime TMDBAPI: got %q want empty setup value", runtime.MainSettings.TMDBAPI)
+	}
+	if _, statErr := os.Stat(dbPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("invalid fresh setup should not create database before validation succeeds, stat err=%v", statErr)
+	}
+}
+
+func TestBootstrapProvidedYAMLInvalidMergeDoesNotPersistStoredSanitization(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "invalid-merge-sanitize.db")
+	yamlPath := filepath.Join(tmp, "config.yaml")
+
+	storedCfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	storedCfg.MainSettings.DBPath = dbPath
+	storedCfg.MainSettings.TMDBAPI = "stored-key"
+	storedCfg.ScreenshotHandling.Screens = 7
+	storedCfg.Trackers.Trackers["TL"] = config.TrackerConfig{ImgRehost: true}
+	if err := configstore.SaveToDBPath(ctx, storedCfg, dbPath); err != nil {
+		t.Fatalf("seed db: %v", err)
+	}
+
+	body := "main_settings:\n  tmdb_api: \"\"\n  db_path: " + dbPath + "\nscreenshot_handling:\n  screens: 4\n"
+	if err := os.WriteFile(yamlPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	runtime, resolvedDB, err := configstore.Bootstrap(ctx, yamlPath, true, true)
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if resolvedDB != dbPath {
+		t.Fatalf("DB path: got %q want %q", resolvedDB, dbPath)
+	}
+	if runtime.MainSettings.TMDBAPI != "stored-key" || runtime.ScreenshotHandling.Screens != 7 {
+		t.Fatalf("runtime should fall back to stored config, got tmdb=%q screens=%d", runtime.MainSettings.TMDBAPI, runtime.ScreenshotHandling.Screens)
+	}
+
+	repo, err := db.OpenContext(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer repo.Close()
+
+	reloaded, err := config.LoadFromDatabase(ctx, repo)
+	if err != nil {
+		t.Fatalf("load raw stored: %v", err)
+	}
+	if !reloaded.Trackers.Trackers["TL"].ImgRehost {
+		t.Fatalf("invalid provided config persisted unsupported TL img_rehost sanitization")
 	}
 }
 

--- a/internal/configstore/dbloader_test.go
+++ b/internal/configstore/dbloader_test.go
@@ -5,7 +5,9 @@ package configstore_test
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -157,5 +159,216 @@ func TestSaveToDBPathSyncsCookieEncryptionStateWhenWebAuthExists(t *testing.T) {
 	authPath := webserver.AuthFilePath(dbPath)
 	if _, err := os.Stat(authPath); err != nil {
 		t.Fatalf("expected auth file to remain present: %v", err)
+	}
+}
+
+func TestSaveToDBPathMalformedWebAuthFailsBeforeConfigSave(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "guiapp.db")
+	if err := os.WriteFile(webserver.AuthFilePath(dbPath), []byte(`{`), 0o600); err != nil {
+		t.Fatalf("write malformed auth file: %v", err)
+	}
+
+	cfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("load embedded config: %v", err)
+	}
+	cfg.MainSettings.DBPath = dbPath
+
+	err = configstore.SaveToDBPath(ctx, cfg, dbPath)
+	if err == nil {
+		t.Fatal("expected SaveToDBPath to fail for malformed web auth")
+	}
+
+	repo, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+
+	for _, section := range []string{
+		"MainSettings",
+		"cookies_encryption_salt",
+		"cookies_encryption_auth_state",
+	} {
+		var data string
+		err = repo.RawDB().QueryRowContext(ctx,
+			`SELECT data FROM config_settings WHERE section = ?`,
+			section,
+		).Scan(&data)
+		if !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("expected section %q to be absent after failed sync, got row=%q err=%v", section, data, err)
+		}
+	}
+}
+
+func TestSaveToDBPathRollsBackCookieSyncWhenConfigSaveFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "guiapp.db")
+	if err := webserver.BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+
+	repo, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	if err := repo.Migrate(); err != nil {
+		_ = repo.Close()
+		t.Fatalf("migrate repo: %v", err)
+	}
+	for _, statement := range []string{
+		`CREATE TRIGGER fail_main_settings_insert BEFORE INSERT ON config_settings WHEN NEW.section = 'MainSettings' BEGIN SELECT RAISE(ABORT, 'forced main settings failure'); END`,
+		`CREATE TRIGGER fail_main_settings_update BEFORE UPDATE ON config_settings WHEN NEW.section = 'MainSettings' BEGIN SELECT RAISE(ABORT, 'forced main settings failure'); END`,
+	} {
+		if _, err := repo.RawDB().ExecContext(ctx, statement); err != nil {
+			_ = repo.Close()
+			t.Fatalf("create failure trigger: %v", err)
+		}
+	}
+	_ = repo.Close()
+
+	cfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("load embedded config: %v", err)
+	}
+	cfg.MainSettings.DBPath = dbPath
+
+	err = configstore.SaveToDBPath(ctx, cfg, dbPath)
+	if err == nil {
+		t.Fatal("expected SaveToDBPath to fail")
+	}
+
+	repo, err = db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+
+	for _, section := range []string{
+		"cookies_encryption_salt",
+		"cookies_encryption_auth_state",
+	} {
+		var data string
+		err = repo.RawDB().QueryRowContext(ctx,
+			`SELECT data FROM config_settings WHERE section = ?`,
+			section,
+		).Scan(&data)
+		if !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("expected section %q to be absent after failed config save, got row=%q err=%v", section, data, err)
+		}
+	}
+}
+
+func TestSaveToDBPathCookieSyncRollsBackWhenConfigSaveFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "guiapp.db")
+	if err := webserver.BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	installFailMainSettingsTrigger(ctx, t, dbPath)
+
+	cfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("load embedded config: %v", err)
+	}
+	cfg.MainSettings.DBPath = dbPath
+
+	err = configstore.SaveToDBPath(ctx, cfg, dbPath)
+	if err == nil {
+		t.Fatal("expected SaveToDBPath to fail")
+	}
+
+	repo, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	assertConfigStoreSectionsAbsent(ctx, t, repo, "MainSettings", "cookies_encryption_salt", "cookies_encryption_auth_state")
+}
+
+func TestSaveToDBPathIncompleteWebAuthStillSavesConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "guiapp.db")
+	if err := os.WriteFile(webserver.AuthFilePath(dbPath), []byte(`{"username":"tester"}`), 0o600); err != nil {
+		t.Fatalf("write incomplete auth file: %v", err)
+	}
+
+	cfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("load embedded config: %v", err)
+	}
+	cfg.MainSettings.DBPath = dbPath
+
+	if err := configstore.SaveToDBPath(ctx, cfg, dbPath); err != nil {
+		t.Fatalf("SaveToDBPath: %v", err)
+	}
+
+	repo, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+
+	var mainSettings string
+	if err := repo.RawDB().QueryRowContext(ctx,
+		`SELECT data FROM config_settings WHERE section = ?`,
+		"MainSettings",
+	).Scan(&mainSettings); err != nil {
+		t.Fatalf("expected main_settings to be saved with unavailable auth helper: %v", err)
+	}
+}
+
+func installFailMainSettingsTrigger(ctx context.Context, t *testing.T, dbPath string) {
+	t.Helper()
+
+	repo, err := db.OpenContext(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	defer repo.Close()
+	if err := repo.MigrateContext(ctx); err != nil {
+		t.Fatalf("migrate repo: %v", err)
+	}
+	if _, err := repo.RawDB().ExecContext(ctx, `
+		CREATE TRIGGER fail_main_settings_save
+		BEFORE INSERT ON config_settings
+		WHEN NEW.section = 'MainSettings'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced main settings failure');
+		END
+	`); err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+}
+
+func assertConfigStoreSectionsAbsent(ctx context.Context, t *testing.T, repo *db.SQLiteRepository, sections ...string) {
+	t.Helper()
+
+	for _, section := range sections {
+		var data string
+		err := repo.RawDB().QueryRowContext(ctx,
+			`SELECT data FROM config_settings WHERE section = ?`,
+			section,
+		).Scan(&data)
+		if !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("expected section %q to be absent, got row=%q err=%v", section, data, err)
+		}
 	}
 }

--- a/internal/cookies/init.go
+++ b/internal/cookies/init.go
@@ -14,8 +14,9 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-// SyncCookieEncryptionWithAuth ensures encrypted cookie state is synchronized with the current
-// web auth helper and performs key rotation when auth details have changed.
+// SyncCookieEncryptionWithAuth synchronizes encrypted cookie state with the
+// current web auth helper and rotates encrypted rows when auth details change.
+// It returns ErrAuthHelperUnavailable when no usable auth material exists.
 func SyncCookieEncryptionWithAuth(ctx context.Context, db *sql.DB, dbPath string) error {
 	if ctx == nil {
 		return errors.New("cookies: context is required")
@@ -23,6 +24,27 @@ func SyncCookieEncryptionWithAuth(ctx context.Context, db *sql.DB, dbPath string
 
 	keyManager := NewKeyManager(db)
 	_, err := keyManager.InitializeEncryptionKey(ctx, dbPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SyncCookieEncryptionWithAuthTx synchronizes encrypted cookie state inside an
+// existing transaction so callers can commit or roll back cookie metadata with
+// the surrounding database write.
+func SyncCookieEncryptionWithAuthTx(ctx context.Context, tx *sql.Tx, dbPath string) error {
+	if ctx == nil {
+		return errors.New("cookies: context is required")
+	}
+	if tx == nil {
+		return errors.New("cookies: transaction is required")
+	}
+
+	_, err := initializeEncryptionKey(ctx, tx, dbPath, func(ctx context.Context, oldKey, newKey []byte) error {
+		return reencryptCookiesTx(ctx, tx, oldKey, newKey)
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/cookies/keymanager.go
+++ b/internal/cookies/keymanager.go
@@ -64,17 +64,39 @@ func NewKeyManager(db *sql.DB) *KeyManager {
 
 // InitializeEncryptionKey derives the current cookie encryption key from web
 // auth details and transparently rotates encrypted cookie rows when the auth
-// fingerprint changes. ctx must be non-nil.
+// fingerprint changes. Salt creation, cookie re-encryption, and auth-state
+// persistence commit atomically. ctx must be non-nil.
 func (km *KeyManager) InitializeEncryptionKey(ctx context.Context, dbPath string) ([]byte, error) {
 	if ctx == nil {
 		return nil, ErrNilContext
 	}
 
-	return initializeEncryptionKey(ctx, km.db, dbPath, km.reencryptCookies)
+	tx, err := km.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin cookie encryption transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	key, err := initializeEncryptionKey(ctx, tx, dbPath, func(ctx context.Context, oldKey, newKey []byte) error {
+		return reencryptCookiesTx(ctx, tx, oldKey, newKey)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("failed to commit cookie encryption transaction: %w", err)
+	}
+
+	return key, nil
 }
 
 // initializeEncryptionKey derives the current key and rotates existing cookie
 // rows when the stored auth fingerprint no longer matches web auth material.
+// Callers that pass a transaction must also supply a reencrypt callback that
+// writes through that same transaction.
 func initializeEncryptionKey(ctx context.Context, db cookieDBExecutor, dbPath string, reencrypt func(context.Context, []byte, []byte) error) ([]byte, error) {
 	helpers, err := loadAuthHelpers(dbPath)
 	if err != nil {
@@ -204,7 +226,8 @@ func loadAuthHelpers(dbPath string) ([]authHelperCandidate, error) {
 }
 
 // RewrapCookiesWithAuthChange re-encrypts stored cookies when web auth
-// material changes and records the new auth fingerprint.
+// material changes and records the new auth fingerprint. Salt creation, cookie
+// re-encryption, and auth-state persistence commit atomically.
 func RewrapCookiesWithAuthChange(ctx context.Context, db *sql.DB, oldMaterial, newMaterial authmaterial.Material) error {
 	if ctx == nil {
 		return ErrNilContext
@@ -222,8 +245,15 @@ func RewrapCookiesWithAuthChange(ctx context.Context, db *sql.DB, oldMaterial, n
 		return fmt.Errorf("cookies: derive new auth helper: %w", err)
 	}
 
-	km := NewKeyManager(db)
-	salt, err := ensureSalt(ctx, db)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("cookies: begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	salt, err := ensureSalt(ctx, tx)
 	if err != nil {
 		return fmt.Errorf("cookies: ensure salt: %w", err)
 	}
@@ -237,38 +267,17 @@ func RewrapCookiesWithAuthChange(ctx context.Context, db *sql.DB, oldMaterial, n
 		if err != nil {
 			return fmt.Errorf("cookies: derive new encryption key: %w", err)
 		}
-		if err := km.reencryptCookies(ctx, oldKey, newKey); err != nil {
+		if err := reencryptCookiesTx(ctx, tx, oldKey, newKey); err != nil {
 			return fmt.Errorf("cookies: re-encrypt cookies after auth update: %w", err)
 		}
 	}
 
-	if err := storeAuthStateInDB(ctx, db, authState{Fingerprint: newFingerprint}); err != nil {
+	if err := storeAuthStateInDB(ctx, tx, authState{Fingerprint: newFingerprint}); err != nil {
 		return fmt.Errorf("cookies: store auth state: %w", err)
 	}
 
-	return nil
-}
-
-func (km *KeyManager) reencryptCookies(ctx context.Context, oldKey, newKey []byte) error {
-	if ctx == nil {
-		return ErrNilContext
-	}
-
-	tx, err := km.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-
-	defer func() {
-		_ = tx.Rollback()
-	}()
-
-	if err := reencryptCookiesTx(ctx, tx, oldKey, newKey); err != nil {
-		return err
-	}
-
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit cookie re-encryption transaction: %w", err)
+		return fmt.Errorf("cookies: commit transaction: %w", err)
 	}
 
 	return nil

--- a/internal/cookies/keymanager.go
+++ b/internal/cookies/keymanager.go
@@ -43,6 +43,8 @@ type KeyManager struct {
 	db *sql.DB
 }
 
+// cookieDBExecutor is the shared DB surface used by both *sql.DB and *sql.Tx
+// cookie-auth operations.
 type cookieDBExecutor interface {
 	ExecContext(context.Context, string, ...any) (sql.Result, error)
 	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
@@ -71,6 +73,8 @@ func (km *KeyManager) InitializeEncryptionKey(ctx context.Context, dbPath string
 	return initializeEncryptionKey(ctx, km.db, dbPath, km.reencryptCookies)
 }
 
+// initializeEncryptionKey derives the current key and rotates existing cookie
+// rows when the stored auth fingerprint no longer matches web auth material.
 func initializeEncryptionKey(ctx context.Context, db cookieDBExecutor, dbPath string, reencrypt func(context.Context, []byte, []byte) error) ([]byte, error) {
 	helpers, err := loadAuthHelpers(dbPath)
 	if err != nil {
@@ -140,6 +144,8 @@ func initializeEncryptionKey(ctx context.Context, db cookieDBExecutor, dbPath st
 	return key, nil
 }
 
+// ensureSalt loads the cookie encryption salt or creates and persists one when
+// this database has no prior cookie encryption state.
 func ensureSalt(ctx context.Context, db cookieDBExecutor) (string, error) {
 	salt, err := getSaltFromDB(ctx, db)
 	if err != nil {
@@ -268,6 +274,8 @@ func (km *KeyManager) reencryptCookies(ctx context.Context, oldKey, newKey []byt
 	return nil
 }
 
+// reencryptCookiesTx rewrites encrypted cookie values inside tx after
+// decrypting with oldKey and encrypting with newKey.
 func reencryptCookiesTx(ctx context.Context, tx *sql.Tx, oldKey, newKey []byte) error {
 	if ctx == nil {
 		return ErrNilContext
@@ -335,6 +343,8 @@ func reencryptCookiesTx(ctx context.Context, tx *sql.Tx, oldKey, newKey []byte) 
 	return nil
 }
 
+// getAuthStateFromDB returns the stored web-auth fingerprint and notes whether
+// a legacy helper value was present in older auth state JSON.
 func getAuthStateFromDB(ctx context.Context, db cookieDBExecutor) (authState, error) {
 	if ctx == nil {
 		return authState{}, ErrNilContext
@@ -363,6 +373,8 @@ func getAuthStateFromDB(ctx context.Context, db cookieDBExecutor) (authState, er
 	}, nil
 }
 
+// storeAuthStateInDB persists the current web-auth fingerprint used for cookie
+// encryption key rotation.
 func storeAuthStateInDB(ctx context.Context, db cookieDBExecutor, state authState) error {
 	if ctx == nil {
 		return ErrNilContext

--- a/internal/cookies/keymanager.go
+++ b/internal/cookies/keymanager.go
@@ -38,12 +38,18 @@ type authHelperCandidate struct {
 	Fingerprint string
 }
 
-// KeyManager manages the encryption key for cookies.
+// KeyManager derives and rotates encrypted-cookie keys from web auth material.
 type KeyManager struct {
 	db *sql.DB
 }
 
-// NewKeyManager creates a new KeyManager instance.
+type cookieDBExecutor interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+// NewKeyManager creates a KeyManager backed by db. It panics when db is nil.
 func NewKeyManager(db *sql.DB) *KeyManager {
 	if db == nil {
 		panic("nil db passed to NewKeyManager")
@@ -54,19 +60,18 @@ func NewKeyManager(db *sql.DB) *KeyManager {
 	}
 }
 
-// InitializeEncryptionKey derives the cookie encryption key from existing web auth details.
-// ctx must be non-nil.
-// and transparently rotates encrypted cookie rows when the source auth changes.
+// InitializeEncryptionKey derives the current cookie encryption key from web
+// auth details and transparently rotates encrypted cookie rows when the auth
+// fingerprint changes. ctx must be non-nil.
 func (km *KeyManager) InitializeEncryptionKey(ctx context.Context, dbPath string) ([]byte, error) {
 	if ctx == nil {
 		return nil, ErrNilContext
 	}
 
-	salt, err := ensureSalt(ctx, km.db)
-	if err != nil {
-		return nil, fmt.Errorf("failed to ensure salt: %w", err)
-	}
+	return initializeEncryptionKey(ctx, km.db, dbPath, km.reencryptCookies)
+}
 
+func initializeEncryptionKey(ctx context.Context, db cookieDBExecutor, dbPath string, reencrypt func(context.Context, []byte, []byte) error) ([]byte, error) {
 	helpers, err := loadAuthHelpers(dbPath)
 	if err != nil {
 		if errors.Is(err, ErrAuthHelperUnavailable) {
@@ -77,7 +82,12 @@ func (km *KeyManager) InitializeEncryptionKey(ctx context.Context, dbPath string
 	currentHelper := helpers[0].Helper
 	currentFingerprint := helpers[0].Fingerprint
 
-	state, err := getAuthStateFromDB(ctx, km.db)
+	salt, err := ensureSalt(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure salt: %w", err)
+	}
+
+	state, err := getAuthStateFromDB(ctx, db)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load auth state: %w", err)
 	}
@@ -86,7 +96,7 @@ func (km *KeyManager) InitializeEncryptionKey(ctx context.Context, dbPath string
 
 	switch {
 	case state.Fingerprint == "":
-		if err := storeAuthStateInDB(ctx, km.db, authState{Fingerprint: currentFingerprint}); err != nil {
+		if err := storeAuthStateInDB(ctx, db, authState{Fingerprint: currentFingerprint}); err != nil {
 			return nil, fmt.Errorf("failed to store initial auth state: %w", err)
 		}
 	case state.Fingerprint != currentFingerprint:
@@ -105,17 +115,17 @@ func (km *KeyManager) InitializeEncryptionKey(ctx context.Context, dbPath string
 			return nil, fmt.Errorf("failed to derive new encryption key: %w", err)
 		}
 
-		if err := km.reencryptCookies(ctx, oldKey, newKey); err != nil {
+		if err := reencrypt(ctx, oldKey, newKey); err != nil {
 			return nil, fmt.Errorf("failed to re-encrypt cookies after auth update: %w", err)
 		}
 
-		if err := storeAuthStateInDB(ctx, km.db, authState{Fingerprint: currentFingerprint}); err != nil {
+		if err := storeAuthStateInDB(ctx, db, authState{Fingerprint: currentFingerprint}); err != nil {
 			return nil, fmt.Errorf("failed to persist updated auth state: %w", err)
 		}
 
 		key = newKey
 	case state.legacyHelperFound:
-		if err := storeAuthStateInDB(ctx, km.db, authState{Fingerprint: currentFingerprint}); err != nil {
+		if err := storeAuthStateInDB(ctx, db, authState{Fingerprint: currentFingerprint}); err != nil {
 			return nil, fmt.Errorf("failed to normalize auth state: %w", err)
 		}
 	}
@@ -130,7 +140,7 @@ func (km *KeyManager) InitializeEncryptionKey(ctx context.Context, dbPath string
 	return key, nil
 }
 
-func ensureSalt(ctx context.Context, db *sql.DB) (string, error) {
+func ensureSalt(ctx context.Context, db cookieDBExecutor) (string, error) {
 	salt, err := getSaltFromDB(ctx, db)
 	if err != nil {
 		return "", err
@@ -187,6 +197,8 @@ func loadAuthHelpers(dbPath string) ([]authHelperCandidate, error) {
 	return candidates, nil
 }
 
+// RewrapCookiesWithAuthChange re-encrypts stored cookies when web auth
+// material changes and records the new auth fingerprint.
 func RewrapCookiesWithAuthChange(ctx context.Context, db *sql.DB, oldMaterial, newMaterial authmaterial.Material) error {
 	if ctx == nil {
 		return ErrNilContext
@@ -245,6 +257,25 @@ func (km *KeyManager) reencryptCookies(ctx context.Context, oldKey, newKey []byt
 		_ = tx.Rollback()
 	}()
 
+	if err := reencryptCookiesTx(ctx, tx, oldKey, newKey); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit cookie re-encryption transaction: %w", err)
+	}
+
+	return nil
+}
+
+func reencryptCookiesTx(ctx context.Context, tx *sql.Tx, oldKey, newKey []byte) error {
+	if ctx == nil {
+		return ErrNilContext
+	}
+	if tx == nil {
+		return errors.New("cookies: transaction is required")
+	}
+
 	rows, err := tx.QueryContext(ctx, `SELECT tracker_id, cookie_name, encrypted_value, nonce, auth_tag FROM tracker_cookies`)
 	if err != nil {
 		return fmt.Errorf("failed to query cookies: %w", err)
@@ -301,14 +332,10 @@ func (km *KeyManager) reencryptCookies(ctx context.Context, oldKey, newKey []byt
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit cookie re-encryption transaction: %w", err)
-	}
-
 	return nil
 }
 
-func getAuthStateFromDB(ctx context.Context, db *sql.DB) (authState, error) {
+func getAuthStateFromDB(ctx context.Context, db cookieDBExecutor) (authState, error) {
 	if ctx == nil {
 		return authState{}, ErrNilContext
 	}
@@ -336,7 +363,7 @@ func getAuthStateFromDB(ctx context.Context, db *sql.DB) (authState, error) {
 	}, nil
 }
 
-func storeAuthStateInDB(ctx context.Context, db *sql.DB, state authState) error {
+func storeAuthStateInDB(ctx context.Context, db cookieDBExecutor, state authState) error {
 	if ctx == nil {
 		return ErrNilContext
 	}
@@ -370,7 +397,7 @@ func findAuthHelperByFingerprint(helpers []authHelperCandidate, fingerprint stri
 }
 
 // getSaltFromDB retrieves the encryption salt from the database.
-func getSaltFromDB(ctx context.Context, db *sql.DB) (string, error) {
+func getSaltFromDB(ctx context.Context, db cookieDBExecutor) (string, error) {
 	if ctx == nil {
 		return "", ErrNilContext
 	}
@@ -400,12 +427,12 @@ func getSaltFromDB(ctx context.Context, db *sql.DB) (string, error) {
 }
 
 // storeSaltInDB stores the encryption salt in the database.
-func storeSaltInDB(ctx context.Context, db *sql.DB, salt string) error {
+func storeSaltInDB(ctx context.Context, db cookieDBExecutor, salt string) error {
 	if ctx == nil {
 		return ErrNilContext
 	}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"salt": salt,
 	}
 

--- a/internal/cookies/keymanager_test.go
+++ b/internal/cookies/keymanager_test.go
@@ -185,7 +185,7 @@ func TestInitializeEncryptionKeyChangedFingerprintWithoutRecoverableHelper(t *te
 		t.Fatalf("save cookie with old key: %v", err)
 	}
 
-	before := readCookieCiphertext(ctx, t, db, "tracker", "session")
+	before := readCookieCiphertext(ctx, t, db)
 
 	km := NewKeyManager(db)
 	_, err = km.InitializeEncryptionKey(ctx, dbPath)
@@ -193,7 +193,7 @@ func TestInitializeEncryptionKeyChangedFingerprintWithoutRecoverableHelper(t *te
 		t.Fatalf("expected ErrAuthHelperUnavailable, got %v", err)
 	}
 
-	after := readCookieCiphertext(ctx, t, db, "tracker", "session")
+	after := readCookieCiphertext(ctx, t, db)
 	if before != after {
 		t.Fatalf("expected encrypted cookie row to remain unchanged")
 	}
@@ -205,6 +205,29 @@ func TestInitializeEncryptionKeyChangedFingerprintWithoutRecoverableHelper(t *te
 
 	if _, err := store.GetCookie(ctx, "tracker", "session", oldKey); err != nil {
 		t.Fatalf("expected old key to continue decrypting cookie: %v", err)
+	}
+}
+
+func TestInitializeEncryptionKeyRollsBackSaltWhenAuthStateStoreFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := newTestCookieDB(t)
+	dbPath := writeWebAuthFile(t, "initial-user", "initial-password-hash")
+	rejectAuthStateWrites(ctx, t, db)
+
+	km := NewKeyManager(db)
+	_, err := km.InitializeEncryptionKey(ctx, dbPath)
+	if err == nil || !strings.Contains(err.Error(), "failed to store initial auth state") {
+		t.Fatalf("expected auth state store error, got %v", err)
+	}
+
+	salt, err := getSaltFromDB(ctx, db)
+	if err != nil {
+		t.Fatalf("get salt: %v", err)
+	}
+	if salt != "" {
+		t.Fatalf("expected salt insert to roll back, got %q", salt)
 	}
 }
 
@@ -269,6 +292,68 @@ func TestInitializeEncryptionKeyErrorCases(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRewrapCookiesWithAuthChangeRollsBackCookiesWhenAuthStateStoreFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := newTestCookieDB(t)
+
+	oldMaterial := authmaterial.Material{
+		Username:     "tester",
+		PasswordHash: "old-password-hash",
+	}
+	newMaterial := authmaterial.Material{
+		Username:          "tester",
+		PasswordHash:      "new-password-hash",
+		EncryptionKeySeed: "stable-seed-value",
+	}
+
+	salt, err := ensureSalt(ctx, db)
+	if err != nil {
+		t.Fatalf("ensure salt: %v", err)
+	}
+	oldHelper, oldFingerprint, err := oldMaterial.PrimaryHelper()
+	if err != nil {
+		t.Fatalf("old helper: %v", err)
+	}
+	oldKey, err := DeriveEncryptionKey(oldHelper, salt)
+	if err != nil {
+		t.Fatalf("derive old key: %v", err)
+	}
+
+	store, err := NewCookieStore(db)
+	if err != nil {
+		t.Fatalf("create cookie store: %v", err)
+	}
+	if err := store.SaveCookie(ctx, "tracker", "session", "cookie-value", oldKey); err != nil {
+		t.Fatalf("save legacy cookie: %v", err)
+	}
+	if err := storeAuthStateInDB(ctx, db, authState{Fingerprint: oldFingerprint}); err != nil {
+		t.Fatalf("store legacy auth state: %v", err)
+	}
+	before := readCookieCiphertext(ctx, t, db)
+	rejectAuthStateWrites(ctx, t, db)
+
+	err = RewrapCookiesWithAuthChange(ctx, db, oldMaterial, newMaterial)
+	if err == nil || !strings.Contains(err.Error(), "cookies: store auth state") {
+		t.Fatalf("expected auth state store error, got %v", err)
+	}
+
+	after := readCookieCiphertext(ctx, t, db)
+	if before != after {
+		t.Fatalf("expected cookie rewrap to roll back")
+	}
+
+	state, _ := readPersistedAuthState(ctx, t, db)
+	if state.Fingerprint != oldFingerprint {
+		t.Fatalf("expected auth state fingerprint to remain %q, got %q", oldFingerprint, state.Fingerprint)
+	}
+
+	if _, err := store.GetCookie(ctx, "tracker", "session", oldKey); err != nil {
+		t.Fatalf("expected old key to continue decrypting cookie: %v", err)
 	}
 }
 
@@ -490,13 +575,13 @@ func readPersistedAuthState(ctx context.Context, t *testing.T, db *sql.DB) (auth
 	return state, rawJSON
 }
 
-func readCookieCiphertext(ctx context.Context, t *testing.T, db *sql.DB, trackerID, cookieName string) string {
+func readCookieCiphertext(ctx context.Context, t *testing.T, db *sql.DB) string {
 	t.Helper()
 
 	var ciphertext, nonce, authTag string
 	if err := db.QueryRowContext(ctx,
 		`SELECT encrypted_value, nonce, auth_tag FROM tracker_cookies WHERE tracker_id = ? AND cookie_name = ?`,
-		trackerID, cookieName,
+		"tracker", "session",
 	).Scan(&ciphertext, &nonce, &authTag); err != nil {
 		t.Fatalf("query encrypted cookie row: %v", err)
 	}
@@ -514,4 +599,26 @@ func helperFingerprint(t *testing.T, helper string) string {
 
 	sum := sha256.Sum256([]byte(rawHelper))
 	return hex.EncodeToString(sum[:])
+}
+
+func rejectAuthStateWrites(ctx context.Context, t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	statements := []string{
+		`CREATE TRIGGER reject_auth_state_insert BEFORE INSERT ON config_settings
+			WHEN NEW.section = '` + cookieAuthStateConfigSection + `'
+			BEGIN
+				SELECT RAISE(ABORT, 'blocked auth state write');
+			END`,
+		`CREATE TRIGGER reject_auth_state_update BEFORE UPDATE ON config_settings
+			WHEN NEW.section = '` + cookieAuthStateConfigSection + `'
+			BEGIN
+				SELECT RAISE(ABORT, 'blocked auth state write');
+			END`,
+	}
+	for _, statement := range statements {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			t.Fatalf("create auth state rejection trigger: %v", err)
+		}
+	}
 }

--- a/internal/cookies/loader.go
+++ b/internal/cookies/loader.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -21,6 +22,9 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+// LoadTrackerCookieMap returns cookies for trackerID from encrypted database
+// storage and legacy cookie files. Legacy file values override database values
+// when both sources contain the same cookie name.
 func LoadTrackerCookieMap(ctx context.Context, dbPath string, trackerID string) (map[string]string, error) {
 	if ctx == nil {
 		return nil, errors.New("cookies: context is required")
@@ -60,6 +64,8 @@ func LoadTrackerCookieMap(ctx context.Context, dbPath string, trackerID string) 
 	return nil, err
 }
 
+// LoadTrackerHTTPCookies returns tracker cookies as HTTP cookies for domain,
+// using the same database-plus-legacy-file merge as LoadTrackerCookieMap.
 func LoadTrackerHTTPCookies(ctx context.Context, dbPath string, trackerID string, domain string) ([]*http.Cookie, error) {
 	if ctx == nil {
 		return nil, errors.New("cookies: context is required")
@@ -99,6 +105,8 @@ func LoadTrackerHTTPCookies(ctx context.Context, dbPath string, trackerID string
 	return nil, err
 }
 
+// SaveTrackerCookieMap replaces trackerID's encrypted database cookies with
+// non-empty entries from values. It requires usable web auth material.
 func SaveTrackerCookieMap(ctx context.Context, dbPath string, trackerID string, values map[string]string) error {
 	if ctx == nil {
 		return errors.New("cookies: context is required")
@@ -140,10 +148,13 @@ func SaveTrackerCookieMap(ctx context.Context, dbPath string, trackerID string, 
 	return nil
 }
 
+// SaveTrackerHTTPCookies stores HTTP cookies by cookie name for trackerID.
 func SaveTrackerHTTPCookies(ctx context.Context, dbPath string, trackerID string, values []*http.Cookie) error {
 	return SaveTrackerCookieMap(ctx, dbPath, trackerID, httpCookiesToMap(values))
 }
 
+// DeleteTrackerCookies removes trackerID cookies from encrypted database
+// storage and deletes matching legacy cookie files when present.
 func DeleteTrackerCookies(ctx context.Context, dbPath string, trackerID string) error {
 	if ctx == nil {
 		return errors.New("cookies: context is required")
@@ -173,6 +184,8 @@ func DeleteTrackerCookies(ctx context.Context, dbPath string, trackerID string) 
 	return deleteErr
 }
 
+// CookieMapToHTTPCookies converts non-empty cookie name/value pairs to HTTP
+// cookies scoped to domain and path "/".
 func CookieMapToHTTPCookies(values map[string]string, domain string) []*http.Cookie {
 	trimmedDomain := strings.TrimSpace(domain)
 	result := make([]*http.Cookie, 0, len(values))
@@ -296,12 +309,8 @@ func mergeCookieMaps(base map[string]string, override map[string]string) map[str
 	}
 
 	merged := make(map[string]string, len(base)+len(override))
-	for name, value := range base {
-		merged[name] = value
-	}
-	for name, value := range override {
-		merged[name] = value
-	}
+	maps.Copy(merged, base)
+	maps.Copy(merged, override)
 
 	return merged
 }

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -115,7 +115,7 @@ func newCore(ctx context.Context, deps api.CoreDependencies) (*Core, error) {
 		repo = sqliteRepo
 		ownsRepo = true
 	}
-	if sqliteRepo, ok := repo.(*db.SQLiteRepository); ok {
+	if sqliteRepo, ok := repo.(*db.SQLiteRepository); ok && !deps.SkipCookieMigration {
 		if err := migrateLegacyCookies(ctx, sqliteRepo.RawDB(), cfg.MainSettings.DBPath, logger); err != nil {
 			logger.Warnf("core: cookie migration failed: %v (continuing)", err)
 		}

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -1275,6 +1275,8 @@ func (a *App) SaveConfig(payload string) error {
 	return a.saveAndApplyConfig(ctx, cfg, runtimeCfg, cfg.MainSettings.DBPath)
 }
 
+// normalizeGUIConfigForExport clones cfg and fills tracker defaults, legacy
+// nils, and a missing DB path without mutating runtime or persisted config.
 func normalizeGUIConfigForExport(cfg *config.Config, dbPath string) (*config.Config, error) {
 	normalized, err := cloneGUIConfigForExport(cfg)
 	if err != nil {
@@ -1295,6 +1297,8 @@ func normalizeGUIConfigForExport(cfg *config.Config, dbPath string) (*config.Con
 	return normalized, nil
 }
 
+// cloneGUIConfigForExport deep-copies config through JSON so export
+// normalization cannot mutate the source snapshot.
 func cloneGUIConfigForExport(cfg *config.Config) (*config.Config, error) {
 	payload, err := json.Marshal(cfg)
 	if err != nil {
@@ -1581,6 +1585,8 @@ func (a *App) ImportConfig() (ImportResult, error) {
 	return a.importConfigFromPath(ctx, path)
 }
 
+// importConfigFromPath imports one selected config file, validates both
+// persisted and env-applied runtime forms, then atomically saves and applies it.
 func (a *App) importConfigFromPath(ctx context.Context, path string) (ImportResult, error) {
 	cfg, warnings, err := importer.ImportFromFile(path)
 	if err != nil {
@@ -1687,6 +1693,8 @@ func (a *App) saveAndApplyConfig(ctx context.Context, storedCfg *config.Config, 
 	return nil
 }
 
+// applyConfig builds and installs a runtime from cfg without writing cfg to the
+// repository; it is used for startup and explicit runtime refresh paths.
 func (a *App) applyConfig(ctx context.Context, cfg config.Config) error {
 	rt, err := guishared.BuildRuntime(ctx, cfg, a.repo)
 	if err != nil {

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -59,6 +59,7 @@ type App struct {
 	dupes       map[string]*dupeCheckJob
 	uploadMu    sync.Mutex
 	uploads     map[string]*trackerUploadJob
+	uploadWG    sync.WaitGroup
 }
 
 type blurayCandidateSelector interface {

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -6,6 +6,7 @@ package guiapp
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -22,7 +23,9 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/config/importer"
 	"github.com/autobrr/upbrr/internal/configstore"
+	"github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/core"
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/filesystem"
 	"github.com/autobrr/upbrr/internal/guishared"
 	"github.com/autobrr/upbrr/internal/imagehostpolicy"
@@ -41,6 +44,7 @@ const previewTimeout = 30 * time.Minute
 const bdinfoProgressEvent = "bdinfo:progress"
 const metadataProgressEvent = "metadata:progress"
 
+// App owns the Wails-bound backend state for the desktop GUI.
 type App struct {
 	runtimeCtx  *appRuntimeContext
 	runtimeMu   sync.RWMutex
@@ -61,10 +65,14 @@ type blurayCandidateSelector interface {
 	SelectBlurayCandidate(ctx context.Context, sourcePath string, releaseID string) (api.MetadataPreview, error)
 }
 
+// NewApp creates a Wails backend using the default background context.
 func NewApp(configPath string, configProvided bool) (*App, error) {
 	return NewAppWithContext(context.Background(), configPath, configProvided)
 }
 
+// NewAppWithContext bootstraps config, logging, repository access, and the core
+// service used by Wails calls. Invalid runtime config leaves upload features
+// disabled until settings are saved, while config/settings calls remain usable.
 func NewAppWithContext(ctx context.Context, configPath string, configProvided bool) (*App, error) {
 	if ctx == nil {
 		return nil, errors.New("guiapp: context is required")
@@ -633,7 +641,8 @@ func (a *App) FetchPreparation(path string, overrides api.ExternalIDOverrides, n
 }
 
 func (a *App) FetchTrackerDryRun(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (api.TrackerDryRunPreview, error) {
-	if err := a.requireCore(); err != nil {
+	rt, err := a.requireRuntime()
+	if err != nil {
 		return api.TrackerDryRunPreview{}, err
 	}
 	if strings.TrimSpace(path) == "" {
@@ -654,7 +663,7 @@ func (a *App) FetchTrackerDryRun(path string, overrides api.ExternalIDOverrides,
 	if logger := a.currentLogger(); logger != nil {
 		logger.Debugf("gui: tracker dry-run request path=%s debug=%t no_seed=%t run_log_level=%s", trimmedPath, debug, noSeed, runOpts.RunLogLevel)
 	}
-	runCore, runLogger, err := a.buildRunCore(runOpts)
+	runCore, runLogger, err := a.buildRunCoreFromSnapshot(rt, runOpts)
 	if err != nil {
 		return api.TrackerDryRunPreview{}, err
 	}
@@ -670,13 +679,13 @@ func (a *App) FetchTrackerDryRun(path string, overrides api.ExternalIDOverrides,
 		Trackers:                    slices.Clone(trackers),
 		IgnoreDupesFor:              normalizeTrackerList(ignoreDupesFor),
 		IgnoreTrackerRuleFailures:   false,
-		Options:                     buildRunUploadOptions(a.currentConfig(), runOpts),
+		Options:                     buildRunUploadOptions(rt.cfg, runOpts),
 		ExternalIDOverrides:         overrides,
 		ReleaseNameOverrides:        nameOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(questionnaireAnswers),
 	}
 	req.Options.DryRun = true
-	if err := guishared.SeedRunCorePreparedMeta(ctx, a.currentCore(), runCore, req); err != nil {
+	if err := guishared.SeedRunCorePreparedMeta(ctx, rt.core, runCore, req); err != nil {
 		return api.TrackerDryRunPreview{}, fmt.Errorf("gui: %w", err)
 	}
 
@@ -850,8 +859,9 @@ func (a *App) DeleteHistoryRelease(sourcePath string) error {
 }
 
 func (a *App) FetchScreenshotPlan(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) (api.ScreenshotPlan, error) {
-	if a == nil || a.currentCore() == nil {
-		return api.ScreenshotPlan{}, errors.New("app not initialized")
+	rt, err := a.requireRuntime()
+	if err != nil {
+		return api.ScreenshotPlan{}, err
 	}
 	if strings.TrimSpace(path) == "" {
 		return api.ScreenshotPlan{}, errors.New("path is required")
@@ -864,18 +874,19 @@ func (a *App) FetchScreenshotPlan(path string, overrides api.ExternalIDOverrides
 	req := api.Request{
 		Paths:   []string{path},
 		Mode:    api.ModeGUI,
-		Options: a.baseUploadOptions(),
+		Options: rt.baseUploadOptions(),
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIResult(a.currentCore().FetchScreenshotPlan(ctx, req))
+	return wrapGUIResult(rt.core.FetchScreenshotPlan(ctx, req))
 }
 
 func (a *App) GenerateScreenshots(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, selections []api.ScreenshotSelection, purpose api.ScreenshotPurpose) (api.ScreenshotResult, error) {
-	if a == nil || a.currentCore() == nil {
-		return api.ScreenshotResult{}, errors.New("app not initialized")
+	rt, err := a.requireRuntime()
+	if err != nil {
+		return api.ScreenshotResult{}, err
 	}
 	if strings.TrimSpace(path) == "" {
 		return api.ScreenshotResult{}, errors.New("path is required")
@@ -888,18 +899,19 @@ func (a *App) GenerateScreenshots(path string, overrides api.ExternalIDOverrides
 	req := api.Request{
 		Paths:   []string{path},
 		Mode:    api.ModeGUI,
-		Options: a.baseUploadOptions(),
+		Options: rt.baseUploadOptions(),
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIResult(a.currentCore().GenerateScreenshots(ctx, req, selections, purpose))
+	return wrapGUIResult(rt.core.GenerateScreenshots(ctx, req, selections, purpose))
 }
 
 func (a *App) ListUploadCandidates(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) ([]api.ScreenshotImage, error) {
-	if a == nil || a.currentCore() == nil {
-		return nil, errors.New("app not initialized")
+	rt, err := a.requireRuntime()
+	if err != nil {
+		return nil, err
 	}
 	if strings.TrimSpace(path) == "" {
 		return nil, errors.New("path is required")
@@ -912,18 +924,19 @@ func (a *App) ListUploadCandidates(path string, overrides api.ExternalIDOverride
 	req := api.Request{
 		Paths:   []string{path},
 		Mode:    api.ModeGUI,
-		Options: a.baseUploadOptions(),
+		Options: rt.baseUploadOptions(),
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIResult(a.currentCore().ListUploadCandidates(ctx, req))
+	return wrapGUIResult(rt.core.ListUploadCandidates(ctx, req))
 }
 
 func (a *App) ListUploadedImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) ([]api.UploadedImageLink, error) {
-	if a == nil || a.currentCore() == nil {
-		return nil, errors.New("app not initialized")
+	rt, err := a.requireRuntime()
+	if err != nil {
+		return nil, err
 	}
 	if strings.TrimSpace(path) == "" {
 		return nil, errors.New("path is required")
@@ -936,18 +949,19 @@ func (a *App) ListUploadedImages(path string, overrides api.ExternalIDOverrides,
 	req := api.Request{
 		Paths:   []string{path},
 		Mode:    api.ModeGUI,
-		Options: a.baseUploadOptions(),
+		Options: rt.baseUploadOptions(),
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
 
-	return wrapGUIResult(a.currentCore().ListUploadedImages(ctx, req))
+	return wrapGUIResult(rt.core.ListUploadedImages(ctx, req))
 }
 
 func (a *App) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, host string, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
-	if a == nil || a.currentCore() == nil {
-		return api.UploadImagesResult{}, errors.New("app not initialized")
+	rt, err := a.requireRuntime()
+	if err != nil {
+		return api.UploadImagesResult{}, err
 	}
 	if strings.TrimSpace(path) == "" {
 		return api.UploadImagesResult{}, errors.New("path is required")
@@ -966,14 +980,14 @@ func (a *App) UploadImages(path string, overrides api.ExternalIDOverrides, nameO
 	req := api.Request{
 		Paths:   []string{path},
 		Mode:    api.ModeGUI,
-		Options: a.baseUploadOptions(),
+		Options: rt.baseUploadOptions(),
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 		Trackers:             slices.Clone(trackers),
 	}
 
-	return wrapGUIResult(a.currentCore().UploadImages(ctx, req, host, images))
+	return wrapGUIResult(rt.core.UploadImages(ctx, req, host, images))
 }
 
 func (a *App) DeleteUploadedImage(path string, imagePath string, host string) error {
@@ -1152,6 +1166,8 @@ func (a *App) ReadScreenshotImage(path string) (string, error) {
 	return "data:image/png;base64," + encoded, nil
 }
 
+// GetConfig returns the GUI settings payload as encrypted JSON. If no config
+// rows exist yet, it exports the current runtime config without persisting it.
 func (a *App) GetConfig() (string, error) {
 	if a == nil {
 		return "", errors.New("app not initialized")
@@ -1161,25 +1177,22 @@ func (a *App) GetConfig() (string, error) {
 	}
 
 	ctx := a.runtimeContext()
+	rt := a.runtimeSnapshot()
 
 	cfg, err := config.LoadFromDatabase(ctx, a.repo)
 	if err != nil {
-		return "", fmt.Errorf("gui: %w", err)
+		if errors.Is(err, internalerrors.ErrNotFound) {
+			cfg = &rt.cfg
+		} else {
+			return "", fmt.Errorf("gui: %w", err)
+		}
 	}
-	if err := config.MergeMissingTrackerDefaults(cfg); err != nil {
-		return "", fmt.Errorf("gui: %w", err)
-	}
-	if strings.TrimSpace(cfg.MainSettings.DBPath) == "" {
-		cfg.MainSettings.DBPath = a.currentConfig().MainSettings.DBPath
-	}
-	if cfg.Trackers.Trackers == nil {
-		cfg.Trackers.Trackers = map[string]config.TrackerConfig{}
-	}
-	if cfg.Trackers.DefaultTrackers == nil {
-		cfg.Trackers.DefaultTrackers = config.CSVList{}
+	normalized, err := normalizeGUIConfigForExport(cfg, rt.cfg.MainSettings.DBPath)
+	if err != nil {
+		return "", err
 	}
 
-	return wrapGUIResult(config.ExportToJSON(cfg))
+	return wrapGUIResult(config.ExportToJSON(normalized))
 }
 
 func (a *App) GetApplicationInfo() (api.ApplicationInfo, error) {
@@ -1218,6 +1231,10 @@ func (a *App) GetImageHostPolicyMetadata() (imagehostpolicy.Metadata, error) {
 	return imagehostpolicy.PolicyMetadata(), nil
 }
 
+// SaveConfig validates encrypted GUI settings, builds the replacement runtime,
+// then syncs cookie encryption metadata and saves the non-env config. Runtime
+// build or save failures leave the persisted config and active runtime unchanged;
+// env overrides apply only to the installed runtime config.
 func (a *App) SaveConfig(payload string) error {
 	if a == nil {
 		return errors.New("app not initialized")
@@ -1240,9 +1257,10 @@ func (a *App) SaveConfig(payload string) error {
 	if strings.TrimSpace(cfg.MainSettings.DBPath) == "" {
 		cfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
 	}
-	if cfg.MainSettings.DBPath != currentCfg.MainSettings.DBPath {
+	if !pathutil.SamePath(cfg.MainSettings.DBPath, currentCfg.MainSettings.DBPath) {
 		return errors.New("changing main_settings.db_path requires restart and is not supported in the GUI")
 	}
+	cfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("gui: %w", err)
 	}
@@ -1254,11 +1272,39 @@ func (a *App) SaveConfig(payload string) error {
 	}
 
 	ctx := a.runtimeContext()
-	if err := config.SaveToDatabase(ctx, cfg, a.repo); err != nil {
-		return fmt.Errorf("gui: %w", err)
-	}
+	return a.saveAndApplyConfig(ctx, cfg, runtimeCfg, cfg.MainSettings.DBPath)
+}
 
-	return a.applyConfig(runtimeCfg)
+func normalizeGUIConfigForExport(cfg *config.Config, dbPath string) (*config.Config, error) {
+	normalized, err := cloneGUIConfigForExport(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := config.MergeMissingTrackerDefaults(normalized); err != nil {
+		return nil, fmt.Errorf("gui: %w", err)
+	}
+	if strings.TrimSpace(normalized.MainSettings.DBPath) == "" {
+		normalized.MainSettings.DBPath = dbPath
+	}
+	if normalized.Trackers.Trackers == nil {
+		normalized.Trackers.Trackers = map[string]config.TrackerConfig{}
+	}
+	if normalized.Trackers.DefaultTrackers == nil {
+		normalized.Trackers.DefaultTrackers = config.CSVList{}
+	}
+	return normalized, nil
+}
+
+func cloneGUIConfigForExport(cfg *config.Config) (*config.Config, error) {
+	payload, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("gui: clone config for export: marshal: %w", err)
+	}
+	var cloned config.Config
+	if err := json.Unmarshal(payload, &cloned); err != nil {
+		return nil, fmt.Errorf("gui: clone config for export: unmarshal: %w", err)
+	}
+	return &cloned, nil
 }
 
 // isDialogCancelledErr reports whether err is the result of the user closing a
@@ -1272,6 +1318,9 @@ func isDialogCancelledErr(err error) bool {
 	return strings.Contains(err.Error(), "shellItem is nil")
 }
 
+// ExportConfig opens a native save dialog and writes the GUI config as YAML.
+// It returns the written host path, or an empty string when the dialog is
+// canceled or yields a blank path.
 func (a *App) ExportConfig() (string, error) {
 	if a == nil {
 		return "", errors.New("app not initialized")
@@ -1306,31 +1355,74 @@ func (a *App) ExportConfig() (string, error) {
 		trimmedPath += ".yaml"
 	}
 
-	allowPlaintext, err := a.allowUnencryptedExport()
+	return a.exportConfigToPath(ctx, trimmedPath)
+}
+
+// exportConfigToPath writes the persisted config to trimmedPath, adding a YAML
+// extension when needed. Fresh installs with no config rows export the current
+// runtime config without persisting it.
+func (a *App) exportConfigToPath(ctx context.Context, trimmedPath string) (string, error) {
+	trimmedPath = strings.TrimSpace(trimmedPath)
+	if trimmedPath == "" {
+		return "", nil
+	}
+	if ext := strings.ToLower(filepath.Ext(trimmedPath)); ext == "" {
+		trimmedPath += ".yaml"
+	}
+
+	cfg, authDBPath, err := a.exportableConfig(ctx)
+	if err != nil {
+		return "", err
+	}
+	allowPlaintext, err := a.allowUnencryptedExport(authDBPath)
 	if err != nil {
 		return "", err
 	}
 
 	if allowPlaintext {
-		if err := config.ExportFromDatabaseToPlaintextYAML(ctx, trimmedPath, a.repo); err != nil {
+		if err := config.ExportToPlaintextYAML(cfg, trimmedPath); err != nil {
 			return "", fmt.Errorf("gui: %w", err)
 		}
 		return trimmedPath, nil
 	}
 
-	if err := config.ExportFromDatabaseToYAML(ctx, trimmedPath, a.repo); err != nil {
+	if err := config.ExportToYAML(cfg, trimmedPath); err != nil {
 		return "", fmt.Errorf("gui: %w", err)
 	}
 
 	return trimmedPath, nil
 }
 
-func (a *App) allowUnencryptedExport() (bool, error) {
+// exportableConfig returns the normalized GUI export snapshot and the DB path
+// embedded in that snapshot. Plaintext export authorization must use that same
+// DB path so runtime config changes cannot authorize a different persisted
+// config boundary.
+func (a *App) exportableConfig(ctx context.Context) (*config.Config, string, error) {
+	rt := a.runtimeSnapshot()
+	cfg, err := config.LoadFromDatabase(ctx, a.repo)
+	if err != nil {
+		if errors.Is(err, internalerrors.ErrNotFound) {
+			cfg = &rt.cfg
+		} else {
+			return nil, "", fmt.Errorf("gui: %w", err)
+		}
+	}
+	normalized, err := normalizeGUIConfigForExport(cfg, rt.cfg.MainSettings.DBPath)
+	if err != nil {
+		return nil, "", err
+	}
+	return normalized, normalized.MainSettings.DBPath, nil
+}
+
+// allowUnencryptedExport reports whether the supplied DB auth material
+// permits plaintext config export. Missing auth material denies plaintext
+// export; malformed material is returned as an error.
+func (a *App) allowUnencryptedExport(dbPath string) (bool, error) {
 	if a == nil {
 		return false, errors.New("app not initialized")
 	}
 
-	dbPath := strings.TrimSpace(a.currentConfig().MainSettings.DBPath)
+	dbPath = strings.TrimSpace(dbPath)
 	if dbPath == "" {
 		return false, nil
 	}
@@ -1345,22 +1437,37 @@ func (a *App) allowUnencryptedExport() (bool, error) {
 	return false, fmt.Errorf("gui: %w", err)
 }
 
+// ImportResult is returned to the GUI after an interactive config import.
 type ImportResult struct {
-	Message  string   `json:"message"`
+	// Message is a user-displayable import summary.
+	Message string `json:"message"`
+	// Warnings contains non-fatal parser/import warnings.
 	Warnings []string `json:"warnings"`
 }
 
+// WebAuthStatus reports whether the current database has usable web auth
+// material for config secret encryption.
 type WebAuthStatus struct {
-	Path                    string `json:"path"`
-	Exists                  bool   `json:"exists"`
-	Usable                  bool   `json:"usable"`
-	CanCreate               bool   `json:"canCreate"`
-	Username                string `json:"username"`
-	AllowUnencryptedExport  bool   `json:"allowUnencryptedExport"`
-	BrowseRoot              string `json:"browseRoot"`
-	AllowUnrestrictedBrowse bool   `json:"allowUnrestrictedBrowse"`
-	EncryptionEnabled       bool   `json:"encryptionEnabled"`
-	Message                 string `json:"message"`
+	// Path is the host filesystem path to the web auth material file.
+	Path string `json:"path"`
+	// Exists reports whether web auth material was found on disk.
+	Exists bool `json:"exists"`
+	// Usable reports whether the auth material can decrypt/encrypt config secrets.
+	Usable bool `json:"usable"`
+	// CanCreate reports whether the GUI may create new auth material at Path.
+	CanCreate bool `json:"canCreate"`
+	// Username is populated only when usable auth material is loaded.
+	Username string `json:"username"`
+	// AllowUnencryptedExport mirrors the loaded auth policy.
+	AllowUnencryptedExport bool `json:"allowUnencryptedExport"`
+	// BrowseRoot is the host filesystem root enforced for browser file browsing.
+	BrowseRoot string `json:"browseRoot"`
+	// AllowUnrestrictedBrowse reports whether browser file browsing may ignore BrowseRoot.
+	AllowUnrestrictedBrowse bool `json:"allowUnrestrictedBrowse"`
+	// EncryptionEnabled reports whether config secret encryption is active.
+	EncryptionEnabled bool `json:"encryptionEnabled"`
+	// Message is a user-displayable status summary.
+	Message string `json:"message"`
 }
 
 func (a *App) GetWebAuthStatus() (WebAuthStatus, error) {
@@ -1438,6 +1545,10 @@ func (a *App) CreateWebAuth(username string, password string) (WebAuthStatus, er
 	return a.GetWebAuthStatus()
 }
 
+// ImportConfig opens a native file picker, imports the selected config, builds
+// the replacement runtime, then syncs cookie encryption metadata and saves the
+// non-env config. Runtime build or save failures leave the persisted config and
+// active runtime unchanged; env overrides apply only to the installed runtime.
 func (a *App) ImportConfig() (ImportResult, error) {
 	if a == nil {
 		return ImportResult{}, errors.New("app not initialized")
@@ -1467,6 +1578,10 @@ func (a *App) ImportConfig() (ImportResult, error) {
 		return ImportResult{}, nil
 	}
 
+	return a.importConfigFromPath(ctx, path)
+}
+
+func (a *App) importConfigFromPath(ctx context.Context, path string) (ImportResult, error) {
 	cfg, warnings, err := importer.ImportFromFile(path)
 	if err != nil {
 		return ImportResult{}, fmt.Errorf("gui: %w", err)
@@ -1485,11 +1600,7 @@ func (a *App) ImportConfig() (ImportResult, error) {
 		return ImportResult{}, fmt.Errorf("validate imported config: %w", err)
 	}
 
-	if err := config.SaveToDatabase(ctx, cfg, a.repo); err != nil {
-		return ImportResult{}, fmt.Errorf("gui: %w", err)
-	}
-
-	if err := a.applyConfig(runtimeCfg); err != nil {
+	if err := a.saveAndApplyConfig(ctx, cfg, runtimeCfg, cfg.MainSettings.DBPath); err != nil {
 		return ImportResult{}, err
 	}
 
@@ -1500,15 +1611,90 @@ func (a *App) ImportConfig() (ImportResult, error) {
 	return ImportResult{Message: message, Warnings: warnings}, nil
 }
 
-func (a *App) applyConfig(cfg config.Config) error {
-	ctx := a.runtimeContext()
+// saveConfigToRepository enforces the shared pre-save cookie encryption sync
+// before persisting GUI config changes through the already-open repository.
+func (a *App) saveConfigToRepository(ctx context.Context, cfg *config.Config, dbPath string) error {
+	if err := configstore.SaveToRepository(ctx, cfg, a.repo, dbPath); err != nil {
+		return fmt.Errorf("gui: %w", err)
+	}
+	return nil
+}
+
+// validateCookieAuthMaterial returns ErrAuthHelperUnavailable only when auth
+// material is absent; malformed material remains an error so callers can abort
+// before cookie encryption metadata is initialized.
+func validateCookieAuthMaterial(dbPath string) error {
+	material, err := authmaterial.LoadFromDBPath(dbPath)
+	if err != nil {
+		if errors.Is(err, authmaterial.ErrUnavailable) {
+			return cookies.ErrAuthHelperUnavailable
+		}
+		return fmt.Errorf("load auth helper: %w", err)
+	}
+	if _, _, err := material.PrimaryHelper(); err != nil {
+		if errors.Is(err, authmaterial.ErrUnavailable) {
+			return cookies.ErrAuthHelperUnavailable
+		}
+		return fmt.Errorf("derive auth helper: %w", err)
+	}
+	return nil
+}
+
+// saveAndApplyConfig builds the replacement runtime before any repository
+// writes, then persists cfg and installs the runtime as one ordered transition.
+// If persistence fails, the built runtime is closed and the active runtime is
+// left untouched.
+func (a *App) saveAndApplyConfig(ctx context.Context, storedCfg *config.Config, runtimeCfg config.Config, dbPath string) error {
+	if err := validateCookieAuthMaterial(dbPath); err != nil {
+		if !errors.Is(err, cookies.ErrAuthHelperUnavailable) {
+			return fmt.Errorf("gui: validate cookie auth before config save: %w", err)
+		}
+	}
+
+	rt, err := guishared.BuildRuntime(ctx, runtimeCfg, a.repo)
+	if err != nil {
+		return fmt.Errorf("gui: %w", err)
+	}
+
+	applied := false
+	defer func() {
+		if applied {
+			return
+		}
+		if rt.Core != nil {
+			_ = rt.Core.Close()
+		}
+		if rt.Logger != nil {
+			_ = rt.Logger.Close()
+		}
+	}()
+
+	if err := a.saveConfigToRepository(ctx, storedCfg, dbPath); err != nil {
+		return err
+	}
+
+	oldCore, oldLogger := a.replaceRuntime(runtimeCfg, rt.Core, rt.Logger)
+	applied = true
+	a.rebindLogStreams(ctx, oldLogger, rt.Logger)
+
+	if oldCore != nil {
+		_ = oldCore.Close()
+	}
+	if oldLogger != nil {
+		_ = oldLogger.Close()
+	}
+
+	return nil
+}
+
+func (a *App) applyConfig(ctx context.Context, cfg config.Config) error {
 	rt, err := guishared.BuildRuntime(ctx, cfg, a.repo)
 	if err != nil {
 		return fmt.Errorf("gui: %w", err)
 	}
 
 	oldCore, oldLogger := a.replaceRuntime(cfg, rt.Core, rt.Logger)
-	a.rebindLogStreams(oldLogger, rt.Logger)
+	a.rebindLogStreams(ctx, oldLogger, rt.Logger)
 
 	if oldCore != nil {
 		_ = oldCore.Close()

--- a/internal/guiapp/app_core_test.go
+++ b/internal/guiapp/app_core_test.go
@@ -170,7 +170,7 @@ func TestGUIRequestsUseSingleRuntimeSnapshot(t *testing.T) {
 	}
 }
 
-func TestRunSingleTrackerUploadUsesJobRuntimeConfig(t *testing.T) {
+func TestRunSingleTrackerUploadUsesJobUploadOptionsSnapshot(t *testing.T) {
 	t.Parallel()
 
 	errs := make(chan error, 1)
@@ -182,7 +182,7 @@ func TestRunSingleTrackerUploadUsesJobRuntimeConfig(t *testing.T) {
 	app := &App{cfg: currentCfg}
 	job := &trackerUploadJob{
 		sourcePath:           "C:\\releases\\Example.mkv",
-		cfg:                  jobCfg,
+		uploadOptions:        buildRunUploadOptions(jobCfg, runOptions{}),
 		runOptions:           runOptions{},
 		core:                 &guiSnapshotGuardCore{wantScreens: 1, errs: errs},
 		descriptionGroups:    nil,

--- a/internal/guiapp/app_core_test.go
+++ b/internal/guiapp/app_core_test.go
@@ -5,15 +5,18 @@ package guiapp
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/autobrr/upbrr/internal/authmaterial"
 	"github.com/autobrr/upbrr/internal/config"
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -53,6 +56,207 @@ func TestFetchMetadataPropagatesSkipAutoTorrentSetting(t *testing.T) {
 	}
 	if !coreSvc.fetchReq.Options.SkipAutoTorrent {
 		t.Fatalf("expected skip_auto_torrent request option, got %#v", coreSvc.fetchReq.Options)
+	}
+}
+
+type guiSnapshotGuardCore struct {
+	closeCounterCore
+	wantScreens int
+	errs        chan<- error
+}
+
+func (c *guiSnapshotGuardCore) check(req api.Request, method string) {
+	if req.Options.Screens != c.wantScreens {
+		select {
+		case c.errs <- errors.New(method + " used mismatched runtime options"):
+		default:
+		}
+	}
+}
+
+func (c *guiSnapshotGuardCore) FetchScreenshotPlan(_ context.Context, req api.Request) (api.ScreenshotPlan, error) {
+	c.check(req, "FetchScreenshotPlan")
+	return api.ScreenshotPlan{}, nil
+}
+
+func (c *guiSnapshotGuardCore) GenerateScreenshots(_ context.Context, req api.Request, _ []api.ScreenshotSelection, _ api.ScreenshotPurpose) (api.ScreenshotResult, error) {
+	c.check(req, "GenerateScreenshots")
+	return api.ScreenshotResult{}, nil
+}
+
+func (c *guiSnapshotGuardCore) ListUploadCandidates(_ context.Context, req api.Request) ([]api.ScreenshotImage, error) {
+	c.check(req, "ListUploadCandidates")
+	return nil, nil
+}
+
+func (c *guiSnapshotGuardCore) ListUploadedImages(_ context.Context, req api.Request) ([]api.UploadedImageLink, error) {
+	c.check(req, "ListUploadedImages")
+	return nil, nil
+}
+
+func (c *guiSnapshotGuardCore) UploadImages(_ context.Context, req api.Request, _ string, _ []api.ScreenshotImage) (api.UploadImagesResult, error) {
+	c.check(req, "UploadImages")
+	return api.UploadImagesResult{}, nil
+}
+
+func (c *guiSnapshotGuardCore) RunUploadPrepared(_ context.Context, req api.Request) (api.Result, error) {
+	c.check(req, "RunUploadPrepared")
+	return api.Result{}, nil
+}
+
+func (c *guiSnapshotGuardCore) ExportGUICachedPreparedMeta(_ context.Context, req api.Request) (api.PreparedMetadata, bool, error) {
+	c.check(req, "ExportGUICachedPreparedMeta")
+	return api.PreparedMetadata{}, false, nil
+}
+
+func TestGUIRequestsUseSingleRuntimeSnapshot(t *testing.T) {
+	t.Parallel()
+
+	errs := make(chan error, 1)
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-runtime-snapshot.db")
+	cfgA := guiConfigTestConfig(repoPath)
+	cfgA.ScreenshotHandling.Screens = 1
+	cfgB := cfgA
+	cfgB.ScreenshotHandling.Screens = 2
+	app := &App{
+		cfg:  cfgA,
+		core: &guiSnapshotGuardCore{wantScreens: 1, errs: errs},
+		repo: repo,
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if i%2 == 0 {
+				app.replaceRuntime(cfgB, &guiSnapshotGuardCore{wantScreens: 2, errs: errs}, nil)
+			} else {
+				app.replaceRuntime(cfgA, &guiSnapshotGuardCore{wantScreens: 1, errs: errs}, nil)
+			}
+		}
+	})
+	t.Cleanup(func() {
+		close(stop)
+		wg.Wait()
+	})
+
+	for range 200 {
+		if _, err := app.FetchScreenshotPlan("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}); err != nil {
+			t.Fatalf("fetch screenshot plan: %v", err)
+		}
+		if _, err := app.GenerateScreenshots("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil, api.ScreenshotPurposeFinal); err != nil {
+			t.Fatalf("generate screenshots: %v", err)
+		}
+		if _, err := app.ListUploadCandidates("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}); err != nil {
+			t.Fatalf("list upload candidates: %v", err)
+		}
+		if _, err := app.ListUploadedImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}); err != nil {
+			t.Fatalf("list uploaded images: %v", err)
+		}
+		if _, err := app.UploadImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil, "host", []api.ScreenshotImage{{Path: "image.jpg"}}); err != nil {
+			t.Fatalf("upload images: %v", err)
+		}
+		_, _ = app.FetchTrackerDryRun("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil, nil, nil, nil, false, false, "")
+		select {
+		case err := <-errs:
+			t.Fatal(err)
+		default:
+		}
+	}
+}
+
+func TestRunSingleTrackerUploadUsesJobRuntimeConfig(t *testing.T) {
+	t.Parallel()
+
+	errs := make(chan error, 1)
+	repoPath := filepath.Join(t.TempDir(), "gui-upload-job.db")
+	jobCfg := guiConfigTestConfig(repoPath)
+	jobCfg.ScreenshotHandling.Screens = 1
+	currentCfg := jobCfg
+	currentCfg.ScreenshotHandling.Screens = 2
+	app := &App{cfg: currentCfg}
+	job := &trackerUploadJob{
+		sourcePath:           "C:\\releases\\Example.mkv",
+		cfg:                  jobCfg,
+		runOptions:           runOptions{},
+		core:                 &guiSnapshotGuardCore{wantScreens: 1, errs: errs},
+		descriptionGroups:    nil,
+		trackers:             []string{"BTN"},
+		questionnaireAnswers: map[string]map[string]string{},
+	}
+
+	if _, err := app.runSingleTrackerUpload(context.Background(), job, "BTN"); err != nil {
+		t.Fatalf("run single tracker upload: %v", err)
+	}
+	select {
+	case err := <-errs:
+		t.Fatal(err)
+	default:
+	}
+}
+
+func TestSaveConfigAcceptsSameDatabasePathAlias(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-save-dbpath-alias.db")
+	initial := guiConfigTestConfig(repoPath)
+	app := &App{
+		cfg:  initial,
+		repo: repo,
+	}
+	t.Cleanup(func() {
+		if coreSvc := app.currentCore(); coreSvc != nil {
+			_ = coreSvc.Close()
+		}
+		if logger := app.currentLogger(); logger != nil {
+			_ = logger.Close()
+		}
+	})
+
+	updated := initial
+	updated.MainSettings.DBPath = filepath.Dir(repoPath) + string(filepath.Separator) + "." + string(filepath.Separator) + filepath.Base(repoPath)
+	updated.Metadata.SkipAutoTorrent = true
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	if err := app.SaveConfig(payload); err != nil {
+		t.Fatalf("save config with DBPath alias: %v", err)
+	}
+	if got := app.currentConfig().MainSettings.DBPath; got != repoPath {
+		t.Fatalf("runtime DBPath: got %q want %q", got, repoPath)
+	}
+}
+
+func TestSaveConfigRejectsDifferentDatabasePath(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-save-dbpath-change.db")
+	initial := guiConfigTestConfig(repoPath)
+	app := &App{
+		cfg:  initial,
+		repo: repo,
+	}
+
+	updated := initial
+	updated.MainSettings.DBPath = filepath.Join(t.TempDir(), "different.db")
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	err = app.SaveConfig(payload)
+	if err == nil {
+		t.Fatal("expected DBPath change rejection")
+	}
+	if !strings.Contains(err.Error(), "requires restart") {
+		t.Fatalf("expected restart error, got %v", err)
 	}
 }
 
@@ -165,6 +369,491 @@ func TestSaveConfigRejectsInvalidEnvRuntimeConfig(t *testing.T) {
 	if _, loadErr := config.LoadFromDatabase(context.Background(), repo); loadErr == nil {
 		t.Fatal("expected invalid runtime config to be rejected before database save")
 	}
+}
+
+func TestSaveConfigBuildRuntimeFailureLeavesDatabaseAndRuntimeUnchanged(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-save-runtime-build-failure.db")
+	initial := guiConfigTestConfig(repoPath)
+	if err := config.SaveToDatabase(context.Background(), &initial, repo); err != nil {
+		t.Fatalf("save initial config: %v", err)
+	}
+	previousCore := &closeCounterCore{}
+	app := &App{
+		cfg:  initial,
+		core: previousCore,
+		repo: repo,
+	}
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	updated.Logging.Level = "invalid-level"
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	err = app.SaveConfig(payload)
+	if err == nil {
+		t.Fatal("expected runtime build failure")
+	}
+
+	assertGUIStoredAndRuntimeConfigUnchanged(t, app, repo, initial, previousCore)
+}
+
+func TestGetConfigFallsBackToRuntimeConfigWhenDatabaseConfigMissing(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-get-missing-config.db")
+	cfg := guiConfigTestConfig(repoPath)
+	app := &App{
+		cfg:  cfg,
+		repo: repo,
+	}
+
+	payload, err := app.GetConfig()
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	exported, err := config.ImportFromJSONEncrypted(payload)
+	if err != nil {
+		t.Fatalf("parse exported config: %v", err)
+	}
+	if exported.MainSettings.DBPath != repoPath {
+		t.Fatalf("DBPath: got %q want %q", exported.MainSettings.DBPath, repoPath)
+	}
+	if _, loadErr := config.LoadFromDatabase(context.Background(), repo); !errors.Is(loadErr, internalerrors.ErrNotFound) {
+		t.Fatalf("fallback should not persist config rows, load err=%v", loadErr)
+	}
+}
+
+func TestGetConfigFallbackUsesSingleRuntimeSnapshot(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	repoPath := filepath.Join(tempDir, "gui-empty-snapshot.db")
+	repo, err := db.OpenWithLogger(repoPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repo: %v", err)
+	}
+
+	pathA := filepath.Join(tempDir, "runtime-a.db")
+	pathB := filepath.Join(tempDir, "runtime-b.db")
+	cfgA := config.Config{
+		MainSettings:       config.MainSettingsConfig{DBPath: pathA},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+	}
+	cfgB := config.Config{
+		MainSettings:       config.MainSettingsConfig{DBPath: pathB},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 2},
+	}
+	app := &App{
+		cfg:  cfgA,
+		repo: repo,
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				app.replaceRuntime(cfgA, nil, nil)
+				app.replaceRuntime(cfgB, nil, nil)
+			}
+		}
+	})
+	defer func() {
+		close(stop)
+		wg.Wait()
+	}()
+
+	for range 2000 {
+		payload, err := app.GetConfig()
+		if err != nil {
+			t.Fatalf("get config: %v", err)
+		}
+		exported, err := config.ImportFromJSONEncrypted(payload)
+		if err != nil {
+			t.Fatalf("parse exported config: %v", err)
+		}
+		switch exported.MainSettings.DBPath {
+		case pathA:
+			if exported.ScreenshotHandling.Screens != cfgA.ScreenshotHandling.Screens {
+				t.Fatalf("mixed fallback snapshot for %q: screens=%d", pathA, exported.ScreenshotHandling.Screens)
+			}
+		case pathB:
+			if exported.ScreenshotHandling.Screens != cfgB.ScreenshotHandling.Screens {
+				t.Fatalf("mixed fallback snapshot for %q: screens=%d", pathB, exported.ScreenshotHandling.Screens)
+			}
+		default:
+			t.Fatalf("unexpected fallback DBPath %q", exported.MainSettings.DBPath)
+		}
+	}
+	if _, loadErr := config.LoadFromDatabase(context.Background(), repo); !errors.Is(loadErr, internalerrors.ErrNotFound) {
+		t.Fatalf("fallback should not persist config rows, load err=%v", loadErr)
+	}
+}
+
+func TestExportConfigToPathFallsBackToRuntimeConfigWhenDatabaseConfigMissing(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-export-missing-config.db")
+	cfg := guiConfigTestConfig(repoPath)
+	app := &App{
+		cfg:  cfg,
+		repo: repo,
+	}
+
+	outputBase := filepath.Join(t.TempDir(), "config-export")
+	outputPath, err := app.exportConfigToPath(context.Background(), outputBase)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+	wantPath := outputBase + ".yaml"
+	if outputPath != wantPath {
+		t.Fatalf("output path: got %q want %q", outputPath, wantPath)
+	}
+	exported, err := config.ImportFromYAML(outputPath)
+	if err != nil {
+		t.Fatalf("parse exported config: %v", err)
+	}
+	if exported.MainSettings.DBPath != repoPath {
+		t.Fatalf("DBPath: got %q want %q", exported.MainSettings.DBPath, repoPath)
+	}
+	if exported.Trackers.Trackers == nil {
+		t.Fatal("expected fallback export to include nonnil tracker map")
+	}
+	if _, loadErr := config.LoadFromDatabase(context.Background(), repo); !errors.Is(loadErr, internalerrors.ErrNotFound) {
+		t.Fatalf("fallback should not persist config rows, load err=%v", loadErr)
+	}
+}
+
+func TestExportConfigToPathUsesDatabaseConfigWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-export-stored-config.db")
+	runtimeCfg := guiConfigTestConfig(repoPath)
+	runtimeCfg.ScreenshotHandling.Screens = 1
+	storedCfg := guiConfigTestConfig(repoPath)
+	storedCfg.ScreenshotHandling.Screens = 7
+	if err := config.SaveToDatabase(context.Background(), &storedCfg, repo); err != nil {
+		t.Fatalf("save stored config: %v", err)
+	}
+	app := &App{
+		cfg:  runtimeCfg,
+		repo: repo,
+	}
+
+	outputPath, err := app.exportConfigToPath(context.Background(), filepath.Join(t.TempDir(), "stored.yaml"))
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+	exported, err := config.ImportFromYAML(outputPath)
+	if err != nil {
+		t.Fatalf("parse exported config: %v", err)
+	}
+	if exported.ScreenshotHandling.Screens != storedCfg.ScreenshotHandling.Screens {
+		t.Fatalf("screens: got %d want %d", exported.ScreenshotHandling.Screens, storedCfg.ScreenshotHandling.Screens)
+	}
+}
+
+func TestExportConfigToPathAuthorizesAgainstExportSnapshotDBPath(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-export-snapshot-auth.db")
+	tempDir := filepath.Dir(repoPath)
+	runtimeDBPath := filepath.Join(tempDir, "runtime", "state.db")
+	storedDBPath := filepath.Join(tempDir, "stored", "state.db")
+	writeGUIAuthFile(t, runtimeDBPath, false)
+	writeGUIAuthFile(t, storedDBPath, true)
+
+	runtimeCfg := guiConfigTestConfig(runtimeDBPath)
+	runtimeCfg.MainSettings.TMDBAPI = "runtime-secret"
+	storedCfg := guiConfigTestConfig(storedDBPath)
+	storedCfg.MainSettings.TMDBAPI = "stored-secret"
+	if err := config.SaveToDatabase(context.Background(), &storedCfg, repo); err != nil {
+		t.Fatalf("save stored config: %v", err)
+	}
+	app := &App{
+		cfg:  runtimeCfg,
+		repo: repo,
+	}
+
+	outputPath, err := app.exportConfigToPath(context.Background(), filepath.Join(t.TempDir(), "stored.yaml"))
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+	payload, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read exported config: %v", err)
+	}
+	exported := string(payload)
+	if !strings.Contains(exported, "stored-secret") {
+		t.Fatalf("expected plaintext stored secret authorized by stored DB path, payload=%s", exported)
+	}
+	if strings.Contains(exported, "runtime-secret") {
+		t.Fatalf("export used runtime secret, payload=%s", exported)
+	}
+}
+
+func TestExportConfigToPathFallbackRespectsUnencryptedExportAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                   string
+		allowUnencryptedExport bool
+		expectPlaintext        bool
+		expectEncryptedMarker  bool
+	}{
+		{
+			name:                   "allow unencrypted export",
+			allowUnencryptedExport: true,
+			expectPlaintext:        true,
+			expectEncryptedMarker:  false,
+		},
+		{
+			name:                   "deny unencrypted export",
+			allowUnencryptedExport: false,
+			expectPlaintext:        false,
+			expectEncryptedMarker:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo, repoPath := openGUIConfigTestRepo(t, "gui-export-auth.db")
+			writeGUIAuthFile(t, repoPath, tc.allowUnencryptedExport)
+			cfg := guiConfigTestConfig(repoPath)
+			cfg.MainSettings.TMDBAPI = "plain-secret"
+			app := &App{
+				cfg:  cfg,
+				repo: repo,
+			}
+
+			outputPath, err := app.exportConfigToPath(context.Background(), filepath.Join(t.TempDir(), "auth.yaml"))
+			if err != nil {
+				t.Fatalf("export config: %v", err)
+			}
+			payload, err := os.ReadFile(outputPath)
+			if err != nil {
+				t.Fatalf("read exported config: %v", err)
+			}
+			exported := string(payload)
+			if got := strings.Contains(exported, "plain-secret"); got != tc.expectPlaintext {
+				t.Fatalf("plaintext presence = %t, want %t; payload=%s", got, tc.expectPlaintext, exported)
+			}
+			if got := strings.Contains(exported, "upbrr-enc:v1:"); got != tc.expectEncryptedMarker {
+				t.Fatalf("encrypted marker presence = %t, want %t; payload=%s", got, tc.expectEncryptedMarker, exported)
+			}
+		})
+	}
+}
+
+func TestExportConfigToPathBlankPathNoops(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-export-blank-path.db")
+	app := &App{
+		cfg:  guiConfigTestConfig(repoPath),
+		repo: repo,
+	}
+
+	outputPath, err := app.exportConfigToPath(context.Background(), "   ")
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+	if outputPath != "" {
+		t.Fatalf("output path: got %q want empty", outputPath)
+	}
+}
+
+func TestSaveConfigMalformedWebAuthFailsBeforeConfigSave(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-save-malformed-auth.db")
+	initial := guiConfigTestConfig(repoPath)
+	app := &App{
+		cfg:  initial,
+		repo: repo,
+	}
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+	if err := os.WriteFile(authmaterial.AuthFilePath(repoPath), []byte(`{`), 0o600); err != nil {
+		t.Fatalf("write malformed auth file: %v", err)
+	}
+
+	err = app.SaveConfig(payload)
+	if err == nil {
+		t.Fatal("expected malformed web auth to fail before save")
+	}
+
+	assertGUIFailedConfigSaveRowsAbsent(t, repo)
+	if got := app.currentConfig().Metadata.SkipAutoTorrent; got {
+		t.Fatal("expected runtime config not to be applied after failed auth sync")
+	}
+}
+
+func TestImportConfigMalformedWebAuthFailsBeforeConfigSave(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-import-malformed-auth.db")
+	initial := guiConfigTestConfig(repoPath)
+	app := &App{
+		cfg:  initial,
+		repo: repo,
+	}
+
+	imported := initial
+	imported.Metadata.SkipAutoTorrent = true
+	path := exportGUIConfigYAML(t, &imported)
+	if err := os.WriteFile(authmaterial.AuthFilePath(repoPath), []byte(`{`), 0o600); err != nil {
+		t.Fatalf("write malformed auth file: %v", err)
+	}
+
+	_, err := app.importConfigFromPath(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected malformed web auth to fail before imported config save")
+	}
+
+	assertGUIFailedConfigSaveRowsAbsent(t, repo)
+	if got := app.currentConfig().Metadata.SkipAutoTorrent; got {
+		t.Fatal("expected runtime config not to be applied after failed auth sync")
+	}
+}
+
+func TestImportConfigBuildRuntimeFailureLeavesDatabaseAndRuntimeUnchanged(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-import-runtime-build-failure.db")
+	initial := guiConfigTestConfig(repoPath)
+	if err := config.SaveToDatabase(context.Background(), &initial, repo); err != nil {
+		t.Fatalf("save initial config: %v", err)
+	}
+	previousCore := &closeCounterCore{}
+	app := &App{
+		cfg:  initial,
+		core: previousCore,
+		repo: repo,
+	}
+
+	imported := initial
+	imported.Metadata.SkipAutoTorrent = true
+	imported.Logging.Level = "invalid-level"
+	path := exportGUIConfigYAML(t, &imported)
+
+	result, err := app.importConfigFromPath(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected runtime build failure")
+	}
+	if result.Message != "" || len(result.Warnings) != 0 {
+		t.Fatalf("expected empty import result on failed apply, got %#v", result)
+	}
+
+	assertGUIStoredAndRuntimeConfigUnchanged(t, app, repo, initial, previousCore)
+}
+
+func TestSaveConfigSyncsUsableWebAuthBeforeSave(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-save-usable-auth.db")
+	if err := authmaterial.BootstrapAuthFile(repoPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	initial := guiConfigTestConfig(repoPath)
+	app := &App{
+		cfg:  initial,
+		repo: repo,
+	}
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	if err := app.SaveConfig(payload); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	assertGUICookieAuthStatePresent(t, repo)
+}
+
+func TestSaveConfigCookieSyncRollsBackWhenConfigSaveFails(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-save-cookie-rollback.db")
+	if err := authmaterial.BootstrapAuthFile(repoPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	installGUIFailMainSettingsTrigger(t, repo)
+	initial := guiConfigTestConfig(repoPath)
+	app := &App{
+		cfg:  initial,
+		repo: repo,
+	}
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	err = app.SaveConfig(payload)
+	if err == nil {
+		t.Fatal("expected save config to fail")
+	}
+
+	assertGUIFailedConfigSaveRowsAbsent(t, repo)
+	if got := app.currentConfig().Metadata.SkipAutoTorrent; got {
+		t.Fatal("expected runtime config not to be applied after failed config save")
+	}
+}
+
+func TestSaveConfigRepositoryRejectsAuthChangeAfterValidation(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-save-auth-drift.db")
+	if err := authmaterial.BootstrapAuthFile(repoPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := validateCookieAuthMaterial(repoPath); err != nil {
+		t.Fatalf("prevalidate auth material: %v", err)
+	}
+	if err := os.WriteFile(authmaterial.AuthFilePath(repoPath), []byte(`{`), 0o600); err != nil {
+		t.Fatalf("replace auth file: %v", err)
+	}
+	initial := guiConfigTestConfig(repoPath)
+	app := &App{
+		cfg:  initial,
+		repo: repo,
+	}
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	err := app.saveConfigToRepository(context.Background(), &updated, repoPath)
+	if err == nil {
+		t.Fatal("expected auth drift to malformed helper to fail")
+	}
+	assertGUIFailedConfigSaveRowsAbsent(t, repo)
 }
 
 func TestListHistoryUsesRepositoryWhenCoreDisabled(t *testing.T) {
@@ -340,6 +1029,131 @@ func openGUIAppTestRepo(t *testing.T) *db.SQLiteRepository {
 	return repo
 }
 
+func openGUIConfigTestRepo(t *testing.T, name string) (*db.SQLiteRepository, string) {
+	t.Helper()
+
+	repoPath := filepath.Join(t.TempDir(), name)
+	repo, err := db.OpenWithLogger(repoPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repo: %v", err)
+	}
+	return repo, repoPath
+}
+
+func guiConfigTestConfig(repoPath string) config.Config {
+	return config.Config{
+		MainSettings:       config.MainSettingsConfig{TMDBAPI: "x", DBPath: repoPath},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+		Logging:            config.LoggingConfig{Level: "info"},
+	}
+}
+
+func exportGUIConfigYAML(t *testing.T, cfg *config.Config) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := config.ExportToYAML(cfg, path); err != nil {
+		t.Fatalf("export config yaml: %v", err)
+	}
+	return path
+}
+
+func writeGUIAuthFile(t *testing.T, dbPath string, allowUnencryptedExport bool) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	authJSON := `{"username":"tester","password_hash":"hash","encryption_key_seed":"seed","allow_unencrypted_export":false}`
+	if allowUnencryptedExport {
+		authJSON = `{"username":"tester","password_hash":"hash","encryption_key_seed":"seed","allow_unencrypted_export":true}`
+	}
+	if err := os.WriteFile(authmaterial.AuthFilePath(dbPath), []byte(authJSON), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+}
+
+func assertGUIFailedConfigSaveRowsAbsent(t *testing.T, repo *db.SQLiteRepository) {
+	t.Helper()
+
+	for _, section := range []string{
+		"MainSettings",
+		"cookies_encryption_salt",
+		"cookies_encryption_auth_state",
+	} {
+		var data string
+		err := repo.RawDB().QueryRowContext(context.Background(),
+			`SELECT data FROM config_settings WHERE section = ?`,
+			section,
+		).Scan(&data)
+		if !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("expected %s to be absent after failed sync, got row=%q err=%v", section, data, err)
+		}
+	}
+}
+
+func assertGUICookieAuthStatePresent(t *testing.T, repo *db.SQLiteRepository) {
+	t.Helper()
+
+	var authState string
+	if err := repo.RawDB().QueryRowContext(context.Background(),
+		`SELECT data FROM config_settings WHERE section = ?`,
+		"cookies_encryption_auth_state",
+	).Scan(&authState); err != nil {
+		t.Fatalf("query cookie auth state: %v", err)
+	}
+	if !strings.Contains(authState, "fingerprint") {
+		t.Fatalf("expected synced cookie auth fingerprint, got %s", authState)
+	}
+}
+
+func installGUIFailMainSettingsTrigger(t *testing.T, repo *db.SQLiteRepository) {
+	t.Helper()
+
+	if _, err := repo.RawDB().ExecContext(context.Background(), `
+		CREATE TRIGGER fail_main_settings_save
+		BEFORE INSERT ON config_settings
+		WHEN NEW.section = 'MainSettings'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced main settings failure');
+		END
+	`); err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+}
+
+func assertGUIStoredAndRuntimeConfigUnchanged(t *testing.T, app *App, repo *db.SQLiteRepository, want config.Config, wantCore api.Core) {
+	t.Helper()
+
+	stored, err := config.LoadFromDatabase(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("load stored config: %v", err)
+	}
+	if stored.Metadata.SkipAutoTorrent != want.Metadata.SkipAutoTorrent {
+		t.Fatalf("stored skip_auto_torrent: got %v want %v", stored.Metadata.SkipAutoTorrent, want.Metadata.SkipAutoTorrent)
+	}
+	if stored.Logging.Level != want.Logging.Level {
+		t.Fatalf("stored logging level: got %q want %q", stored.Logging.Level, want.Logging.Level)
+	}
+
+	runtimeCfg := app.currentConfig()
+	if runtimeCfg.Metadata.SkipAutoTorrent != want.Metadata.SkipAutoTorrent {
+		t.Fatalf("runtime skip_auto_torrent: got %v want %v", runtimeCfg.Metadata.SkipAutoTorrent, want.Metadata.SkipAutoTorrent)
+	}
+	if runtimeCfg.Logging.Level != want.Logging.Level {
+		t.Fatalf("runtime logging level: got %q want %q", runtimeCfg.Logging.Level, want.Logging.Level)
+	}
+	if gotCore := app.currentCore(); gotCore != wantCore {
+		t.Fatalf("runtime core changed: got %T want %T", gotCore, wantCore)
+	}
+}
+
 func TestApplyConfigKeepsSharedRepositoryUsable(t *testing.T) {
 	t.Parallel()
 
@@ -373,7 +1187,7 @@ func TestApplyConfigKeepsSharedRepositoryUsable(t *testing.T) {
 		}
 	})
 
-	if err := app.applyConfig(cfg); err != nil {
+	if err := app.applyConfig(context.Background(), cfg); err != nil {
 		t.Fatalf("apply config: %v", err)
 	}
 	if app.core == nil {
@@ -453,7 +1267,7 @@ func TestAppAllowUnencryptedExportFromWebAuth(t *testing.T) {
 		},
 	}
 
-	allow, err := app.allowUnencryptedExport()
+	allow, err := app.allowUnencryptedExport(repoPath)
 	if err != nil {
 		t.Fatalf("allowUnencryptedExport: %v", err)
 	}

--- a/internal/guiapp/logging.go
+++ b/internal/guiapp/logging.go
@@ -4,6 +4,7 @@
 package guiapp
 
 import (
+	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -21,6 +22,8 @@ import (
 
 const logStreamEventPrefix = "log:stream:"
 const logExclusionsSection = "log_exclusions"
+
+var emitLogStreamEvent = runtime.EventsEmit
 
 // LogExclusions stores muted log patterns for the UI.
 type LogExclusions struct {
@@ -67,7 +70,7 @@ func (a *App) StartLogStream() (string, error) {
 		done:      make(chan struct{}),
 	}
 	a.streams[streamID] = session
-	a.startStreamLocked(session)
+	a.startStreamLocked(a.runtimeContext(), session)
 	return streamID, nil
 }
 
@@ -126,17 +129,19 @@ func (a *App) UpdateLogExclusions(patterns []string) error {
 	return nil
 }
 
-func (a *App) startStreamLocked(session *logStreamSession) {
+func (a *App) startStreamLocked(ctx context.Context, session *logStreamSession) {
+	if session == nil {
+		return
+	}
 	logger := a.currentLogger()
-	if session == nil || logger == nil {
+	if logger == nil {
+		close(session.done)
 		return
 	}
 
 	subID, ch := logger.Subscribe(0)
 	session.logger = logger
 	session.subID = subID
-
-	ctx := a.runtimeContext()
 
 	stop := session.stop
 	done := session.done
@@ -150,11 +155,9 @@ func (a *App) startStreamLocked(session *logStreamSession) {
 				if !ok {
 					return
 				}
-				runtime.EventsEmit(ctx, eventName, entry)
+				emitLogStreamEvent(ctx, eventName, entry)
 			case <-stop:
-				if session.logger != nil {
-					session.logger.Unsubscribe(session.subID)
-				}
+				logger.Unsubscribe(subID)
 				return
 			}
 		}
@@ -186,7 +189,10 @@ func (a *App) stopAllLogStreams() {
 	a.streamMu.Unlock()
 }
 
-func (a *App) rebindLogStreams(oldLogger *logging.Logger, newLogger *logging.Logger) {
+// rebindLogStreams moves active UI log streams from oldLogger to newLogger.
+// Existing stream goroutines are stopped and waited on before replacement
+// subscriptions start, so old subscriptions cannot emit after the rebind.
+func (a *App) rebindLogStreams(ctx context.Context, oldLogger *logging.Logger, newLogger *logging.Logger) {
 	if a == nil {
 		return
 	}
@@ -194,15 +200,40 @@ func (a *App) rebindLogStreams(oldLogger *logging.Logger, newLogger *logging.Log
 		return
 	}
 
+	type stoppedStream struct {
+		session *logStreamSession
+		done    <-chan struct{}
+	}
+
 	a.streamMu.Lock()
+	stopped := make([]stoppedStream, 0, len(a.streams))
 	for _, session := range a.streams {
 		if session == nil {
 			continue
 		}
+		stopped = append(stopped, stoppedStream{
+			session: session,
+			done:    session.done,
+		})
 		a.stopStreamLocked(session)
+	}
+	a.streamMu.Unlock()
+
+	for _, stream := range stopped {
+		if stream.done != nil {
+			<-stream.done
+		}
+	}
+
+	a.streamMu.Lock()
+	for _, stream := range stopped {
+		session := stream.session
+		if session == nil || a.streams[session.id] != session {
+			continue
+		}
 		session.stop = make(chan struct{})
 		session.done = make(chan struct{})
-		a.startStreamLocked(session)
+		a.startStreamLocked(ctx, session)
 	}
 	a.streamMu.Unlock()
 }

--- a/internal/guiapp/logging.go
+++ b/internal/guiapp/logging.go
@@ -129,6 +129,8 @@ func (a *App) UpdateLogExclusions(patterns []string) error {
 	return nil
 }
 
+// startStreamLocked subscribes session to the current logger while streamMu is
+// held; callers keep ownership of session registration and later shutdown.
 func (a *App) startStreamLocked(ctx context.Context, session *logStreamSession) {
 	if session == nil {
 		return

--- a/internal/guiapp/logging_test.go
+++ b/internal/guiapp/logging_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package guiapp
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/logging"
+)
+
+func TestRebindLogStreamsStopsOldSubscriptionWithoutStoppingNewStream(t *testing.T) {
+	oldLogger := newGUIAppLogStreamTestLogger(t)
+	newLogger := newGUIAppLogStreamTestLogger(t)
+	oldEmitStarted := make(chan struct{})
+	releaseOldEmit := make(chan struct{})
+	newEntryReceived := make(chan struct{}, 1)
+
+	previousEmitter := emitLogStreamEvent
+	t.Cleanup(func() {
+		emitLogStreamEvent = previousEmitter
+	})
+	emitLogStreamEvent = func(_ context.Context, _ string, data ...any) {
+		entry, ok := data[0].(logging.Entry)
+		if !ok {
+			return
+		}
+		switch entry.Message {
+		case "old":
+			close(oldEmitStarted)
+			<-releaseOldEmit
+		case "new":
+			newEntryReceived <- struct{}{}
+		}
+	}
+
+	app := &App{
+		logger:  oldLogger,
+		streams: make(map[string]*logStreamSession),
+	}
+	session := &logStreamSession{
+		id:        "stream",
+		eventName: logStreamEventPrefix + "stream",
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	app.streams[session.id] = session
+	app.startStreamLocked(context.Background(), session)
+	oldStop := session.stop
+	oldDone := session.done
+
+	oldLogger.Errorf("old")
+	waitForLogStreamTestSignal(t, oldEmitStarted, "old stream emit")
+
+	rebindDone := make(chan struct{})
+	go func() {
+		app.replaceRuntime(config.Config{}, nil, newLogger)
+		app.rebindLogStreams(context.Background(), oldLogger, newLogger)
+		close(rebindDone)
+	}()
+
+	waitForLogStreamTestSignal(t, oldStop, "old stream stop signal")
+	assertLogStreamBlocked(t, rebindDone, "rebind before old stream stop")
+	if got := loggerSubscriberCount(newLogger); got != 0 {
+		t.Fatalf("new logger subscribers before old stop: got %d want 0", got)
+	}
+
+	close(releaseOldEmit)
+
+	waitForLogStreamTestSignal(t, oldDone, "old stream stop")
+	waitForLogStreamTestSignal(t, rebindDone, "rebind completion")
+	newDone := session.done
+	if got := loggerSubscriberCount(oldLogger); got != 0 {
+		t.Fatalf("old logger subscribers: got %d want 0", got)
+	}
+	if got := loggerSubscriberCount(newLogger); got != 1 {
+		t.Fatalf("new logger subscribers after old stop: got %d want 1", got)
+	}
+	assertLogStreamStillRunning(t, newDone, "new stream after old stop")
+
+	newLogger.Errorf("new")
+	waitForLogStreamTestSignal(t, newEntryReceived, "new stream entry")
+
+	if err := app.StopLogStream(session.id); err != nil {
+		t.Fatalf("stop log stream: %v", err)
+	}
+	waitForLogStreamTestSignal(t, newDone, "new stream stop")
+	if got := loggerSubscriberCount(newLogger); got != 0 {
+		t.Fatalf("new logger subscribers after explicit stop: got %d want 0", got)
+	}
+}
+
+func TestRebindLogStreamsSameLoggerDoesNotRestartStream(t *testing.T) {
+	logger := newGUIAppLogStreamTestLogger(t)
+	app := &App{
+		logger:  logger,
+		streams: make(map[string]*logStreamSession),
+	}
+	session := &logStreamSession{
+		id:        "stream",
+		eventName: logStreamEventPrefix + "stream",
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	app.streams[session.id] = session
+	app.startStreamLocked(context.Background(), session)
+	stop := session.stop
+	done := session.done
+
+	app.rebindLogStreams(context.Background(), logger, logger)
+
+	if session.stop != stop {
+		t.Fatal("same-logger rebind replaced stop channel")
+	}
+	if session.done != done {
+		t.Fatal("same-logger rebind replaced done channel")
+	}
+	if got := loggerSubscriberCount(logger); got != 1 {
+		t.Fatalf("logger subscribers after same-logger rebind: got %d want 1", got)
+	}
+	assertLogStreamStillRunning(t, done, "same-logger stream")
+}
+
+func TestRebindLogStreamsNilLoggerDoesNotBlockNextRebind(t *testing.T) {
+	oldLogger := newGUIAppLogStreamTestLogger(t)
+	newLogger := newGUIAppLogStreamTestLogger(t)
+	app := &App{
+		logger:  oldLogger,
+		streams: make(map[string]*logStreamSession),
+	}
+	session := &logStreamSession{
+		id:        "stream",
+		eventName: logStreamEventPrefix + "stream",
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	app.streams[session.id] = session
+	app.startStreamLocked(context.Background(), session)
+
+	app.replaceRuntime(config.Config{}, nil, nil)
+	app.rebindLogStreams(context.Background(), oldLogger, nil)
+	waitForLogStreamTestSignal(t, session.done, "nil logger rebind done")
+
+	rebindDone := make(chan struct{})
+	go func() {
+		app.replaceRuntime(config.Config{}, nil, newLogger)
+		app.rebindLogStreams(context.Background(), nil, newLogger)
+		close(rebindDone)
+	}()
+	waitForLogStreamTestSignal(t, rebindDone, "next logger rebind")
+	if got := loggerSubscriberCount(newLogger); got != 1 {
+		t.Fatalf("new logger subscribers after nil rebind recovery: got %d want 1", got)
+	}
+}
+
+func newGUIAppLogStreamTestLogger(t *testing.T) *logging.Logger {
+	t.Helper()
+
+	logger, err := logging.New(config.LoggingConfig{Level: "error"}, "")
+	if err != nil {
+		t.Fatalf("new logger: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.Close()
+	})
+	return logger
+}
+
+func loggerSubscriberCount(logger *logging.Logger) int {
+	return reflect.ValueOf(logger).Elem().FieldByName("subs").Len()
+}
+
+func waitForLogStreamTestSignal(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}
+
+func assertLogStreamStillRunning(t *testing.T, done <-chan struct{}, name string) {
+	t.Helper()
+
+	select {
+	case <-done:
+		t.Fatalf("%s stopped unexpectedly", name)
+	default:
+	}
+}
+
+func assertLogStreamBlocked(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+		t.Fatalf("%s completed unexpectedly", name)
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/internal/guiapp/run_options.go
+++ b/internal/guiapp/run_options.go
@@ -45,6 +45,8 @@ func (a *App) buildRunOptions(debug bool, noSeed bool, runLogLevel string) (runO
 	}, nil
 }
 
+// buildRunCoreFromSnapshot creates a per-run core and logger from the same
+// runtime snapshot used to build upload options.
 func (a *App) buildRunCoreFromSnapshot(rt appRuntimeSnapshot, opts runOptions) (api.Core, *logging.Logger, error) {
 	if a.repo == nil {
 		return nil, nil, errors.New("config repository not initialized")

--- a/internal/guiapp/run_options.go
+++ b/internal/guiapp/run_options.go
@@ -45,11 +45,7 @@ func (a *App) buildRunOptions(debug bool, noSeed bool, runLogLevel string) (runO
 	}, nil
 }
 
-func (a *App) buildRunCore(opts runOptions) (api.Core, *logging.Logger, error) {
-	rt, err := a.requireRuntime()
-	if err != nil {
-		return nil, nil, err
-	}
+func (a *App) buildRunCoreFromSnapshot(rt appRuntimeSnapshot, opts runOptions) (api.Core, *logging.Logger, error) {
 	if a.repo == nil {
 		return nil, nil, errors.New("config repository not initialized")
 	}

--- a/internal/guiapp/run_options_test.go
+++ b/internal/guiapp/run_options_test.go
@@ -22,6 +22,7 @@ import (
 
 type closeCounter struct {
 	count      atomic.Int32
+	closeErr   error
 	panicValue any
 }
 
@@ -30,7 +31,7 @@ func (c *closeCounter) Close() error {
 	if c.panicValue != nil {
 		panic(c.panicValue)
 	}
-	return nil
+	return c.closeErr
 }
 
 type closeCounterCore struct {
@@ -310,6 +311,36 @@ func TestTrackerUploadJobCloseResourcesIsIdempotent(t *testing.T) {
 	}
 	if got := loggerCloser.count.Load(); got != 1 {
 		t.Fatalf("expected logger close once, got %d", got)
+	}
+}
+
+func TestCloseTrackerUploadResourceReturnsCloseError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("close failed")
+
+	err := closeTrackerUploadResource("logger", &closeCounter{closeErr: wantErr})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected close error, got %v", err)
+	}
+}
+
+func TestCloseTrackerUploadResourceReturnsPanicError(t *testing.T) {
+	t.Parallel()
+
+	closeErr := errors.New("close failed")
+
+	err := closeTrackerUploadResource("logger", &closeCounter{closeErr: closeErr, panicValue: "close panic"})
+
+	if err == nil {
+		t.Fatal("expected panic error")
+	}
+	if !strings.Contains(err.Error(), "logger close panicked") {
+		t.Fatalf("expected panic context, got %v", err)
+	}
+	if errors.Is(err, closeErr) {
+		t.Fatalf("expected panic error to take precedence over close error, got %v", err)
 	}
 }
 

--- a/internal/guiapp/run_options_test.go
+++ b/internal/guiapp/run_options_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -20,11 +21,15 @@ import (
 )
 
 type closeCounter struct {
-	count atomic.Int32
+	count      atomic.Int32
+	panicValue any
 }
 
 func (c *closeCounter) Close() error {
 	c.count.Add(1)
+	if c.panicValue != nil {
+		panic(c.panicValue)
+	}
 	return nil
 }
 
@@ -44,6 +49,7 @@ type uploadPreparedResponse struct {
 	result       api.Result
 	err          error
 	beforeReturn func()
+	panicValue   any
 }
 
 func (c *closeCounterCore) RunUpload(context.Context, api.Request) (api.Result, error) {
@@ -56,6 +62,9 @@ func (c *closeCounterCore) RunUploadPrepared(context.Context, api.Request) (api.
 		c.uploadCalls++
 		if response.beforeReturn != nil {
 			response.beforeReturn()
+		}
+		if response.panicValue != nil {
+			panic(response.panicValue)
 		}
 		return response.result, response.err
 	}
@@ -293,14 +302,204 @@ func TestTrackerUploadJobCloseResourcesIsIdempotent(t *testing.T) {
 		logger: loggerCloser,
 	}
 
-	job.closeResources()
-	job.closeResources()
+	_ = job.closeResources()
+	_ = job.closeResources()
 
 	if got := coreCloser.count.Load(); got != 1 {
 		t.Fatalf("expected core close once, got %d", got)
 	}
 	if got := loggerCloser.count.Load(); got != 1 {
 		t.Fatalf("expected logger close once, got %d", got)
+	}
+}
+
+func TestTrackerUploadRetryRequestUsesStoredUploadOptions(t *testing.T) {
+	t.Parallel()
+
+	job := &trackerUploadJob{
+		sourcePath:     `C:\Media\Movie.mkv`,
+		uploadOptions:  api.UploadOptions{Screens: 1, SkipAutoTorrent: true},
+		runOptions:     runOptions{Debug: true, NoSeed: true, RunLogLevel: "debug"},
+		failedTrackers: []string{"BLU"},
+		ignoreDupesFor: []string{"AITHER"},
+	}
+
+	retry, err := trackerUploadRetryRequestFromJob(job)
+	if err != nil {
+		t.Fatalf("retry request: %v", err)
+	}
+
+	job.uploadOptions.Screens = 9
+	job.failedTrackers[0] = "MUTATED"
+	job.ignoreDupesFor[0] = "MUTATED"
+
+	if retry.uploadOptions.Screens != 1 || !retry.uploadOptions.SkipAutoTorrent {
+		t.Fatalf("expected stored upload options snapshot, got %#v", retry.uploadOptions)
+	}
+	if len(retry.failedTrackers) != 1 || retry.failedTrackers[0] != "BLU" {
+		t.Fatalf("expected failed trackers snapshot, got %#v", retry.failedTrackers)
+	}
+	if len(retry.ignoreDupesFor) != 1 || retry.ignoreDupesFor[0] != "AITHER" {
+		t.Fatalf("expected ignore dupes snapshot, got %#v", retry.ignoreDupesFor)
+	}
+	if !retry.runOptions.Debug || !retry.runOptions.NoSeed || retry.runOptions.RunLogLevel != "debug" {
+		t.Fatalf("expected run options snapshot, got %#v", retry.runOptions)
+	}
+}
+
+func TestCancelTrackerUploadDefersResourceCloseUntilWorkerExit(t *testing.T) {
+	coreCloser := &closeCounterCore{}
+	loggerCloser := &closeCounter{}
+	job := &trackerUploadJob{
+		id:     "job-1",
+		core:   coreCloser,
+		logger: loggerCloser,
+		cancel: func() {},
+	}
+	app := &App{
+		uploads: map[string]*trackerUploadJob{job.id: job},
+	}
+
+	if err := app.CancelTrackerUpload(job.id); err != nil {
+		t.Fatalf("cancel upload: %v", err)
+	}
+
+	if got := coreCloser.count.Load(); got != 0 {
+		t.Fatalf("expected cancel not to close core before worker exit, got %d", got)
+	}
+	if got := loggerCloser.count.Load(); got != 0 {
+		t.Fatalf("expected cancel not to close logger before worker exit, got %d", got)
+	}
+
+	_ = job.closeResources()
+}
+
+func TestStopAllUploadJobsWaitsForWorkersBeforeClosingResources(t *testing.T) {
+	coreCloser := &closeCounterCore{}
+	loggerCloser := &closeCounter{}
+	released := make(chan struct{})
+	cancelCalled := make(chan struct{})
+	workerFinished := make(chan struct{})
+	job := &trackerUploadJob{
+		id:     "job-1",
+		core:   coreCloser,
+		logger: loggerCloser,
+	}
+	app := &App{
+		uploads: map[string]*trackerUploadJob{job.id: job},
+	}
+	app.uploadWG.Add(1)
+	job.cancel = func() {
+		close(cancelCalled)
+		go func() {
+			<-released
+			app.uploadWG.Done()
+			close(workerFinished)
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		app.stopAllUploadJobs()
+		close(done)
+	}()
+
+	select {
+	case <-cancelCalled:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("expected stopAllUploadJobs to cancel active upload")
+	}
+
+	select {
+	case <-done:
+		t.Fatal("expected stopAllUploadJobs to wait for active worker")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if got := coreCloser.count.Load(); got != 0 {
+		t.Fatalf("expected core to remain open while worker is active, got close count %d", got)
+	}
+	if got := loggerCloser.count.Load(); got != 0 {
+		t.Fatalf("expected logger to remain open while worker is active, got close count %d", got)
+	}
+
+	close(released)
+
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("expected stopAllUploadJobs to return after worker finishes")
+	}
+	<-workerFinished
+	if got := coreCloser.count.Load(); got != 1 {
+		t.Fatalf("expected core close after worker exit, got %d", got)
+	}
+	if got := loggerCloser.count.Load(); got != 1 {
+		t.Fatalf("expected logger close after worker exit, got %d", got)
+	}
+}
+
+func TestStopAllUploadJobsWaitsForPublishedPreStartUpload(t *testing.T) {
+	coreCloser := &closeCounterCore{}
+	loggerCloser := &closeCounter{}
+	cancelCalled := make(chan struct{})
+	job := &trackerUploadJob{
+		id:     "job-1",
+		core:   coreCloser,
+		logger: loggerCloser,
+		cancel: func() {
+			close(cancelCalled)
+		},
+	}
+	app := &App{
+		uploads: map[string]*trackerUploadJob{},
+	}
+
+	app.publishTrackerUploadJob(job)
+	released := atomic.Bool{}
+	t.Cleanup(func() {
+		if released.CompareAndSwap(false, true) {
+			app.uploadWG.Done()
+		}
+	})
+
+	done := make(chan struct{})
+	go func() {
+		app.stopAllUploadJobs()
+		close(done)
+	}()
+
+	select {
+	case <-cancelCalled:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("expected stopAllUploadJobs to cancel published upload")
+	}
+
+	select {
+	case <-done:
+		t.Fatal("expected stopAllUploadJobs to wait for pre-start upload enrollment")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if got := coreCloser.count.Load(); got != 0 {
+		t.Fatalf("expected core to remain open before pre-start upload is released, got close count %d", got)
+	}
+	if got := loggerCloser.count.Load(); got != 0 {
+		t.Fatalf("expected logger to remain open before pre-start upload is released, got close count %d", got)
+	}
+
+	if released.CompareAndSwap(false, true) {
+		app.uploadWG.Done()
+	}
+
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("expected stopAllUploadJobs to return after pre-start upload release")
+	}
+	if got := coreCloser.count.Load(); got != 1 {
+		t.Fatalf("expected core close after pre-start release, got %d", got)
+	}
+	if got := loggerCloser.count.Load(); got != 1 {
+		t.Fatalf("expected logger close after pre-start release, got %d", got)
 	}
 }
 
@@ -390,6 +589,60 @@ func TestRunTrackerUploadJobCountsCanceledPartialWithoutFailedTracker(t *testing
 	}
 	if len(job.failedTrackers) != 0 {
 		t.Fatalf("expected no failed trackers after cancellation, got %#v", job.failedTrackers)
+	}
+}
+
+func TestRunTrackerUploadJobRecoversRunUploadPreparedPanic(t *testing.T) {
+	app := &App{}
+	coreSvc := &closeCounterCore{uploads: []uploadPreparedResponse{
+		{
+			panicValue: "https://tracker.invalid/announce?api_token=secret-value",
+		},
+	}}
+	job := newTrackerUploadJobTestJob(coreSvc, []string{"BLU"})
+
+	app.runTrackerUploadJob(context.Background(), context.Background(), job)
+
+	if got := job.status; got != "failed" {
+		t.Fatalf("expected failed status after upload panic, got %q", got)
+	}
+	if !strings.Contains(job.errorMessage, "upload worker panicked") {
+		t.Fatalf("expected panic error message, got %q", job.errorMessage)
+	}
+	if strings.Contains(job.errorMessage, "secret-value") {
+		t.Fatalf("expected panic error message to redact secrets, got %q", job.errorMessage)
+	}
+	if got := coreSvc.count.Load(); got != 1 {
+		t.Fatalf("expected core close after upload panic, got %d", got)
+	}
+	if job.cancel != nil {
+		t.Fatal("expected upload panic to clear cancel func")
+	}
+}
+
+func TestRunTrackerUploadJobContainsCleanupPanic(t *testing.T) {
+	app := &App{}
+	coreSvc := &closeCounterCore{uploads: []uploadPreparedResponse{
+		{
+			result: api.Result{UploadedCount: 1},
+		},
+	}}
+	coreSvc.panicValue = "https://tracker.invalid/announce?api_token=secret-value"
+	job := newTrackerUploadJobTestJob(coreSvc, []string{"BLU"})
+
+	app.runTrackerUploadJob(context.Background(), context.Background(), job)
+
+	if got := job.status; got != "failed" {
+		t.Fatalf("expected failed status after cleanup panic, got %q", got)
+	}
+	if !strings.Contains(job.errorMessage, "core close panicked") {
+		t.Fatalf("expected cleanup panic message, got %q", job.errorMessage)
+	}
+	if strings.Contains(job.errorMessage, "secret-value") {
+		t.Fatalf("expected cleanup panic message to redact secrets, got %q", job.errorMessage)
+	}
+	if got := coreSvc.count.Load(); got != 1 {
+		t.Fatalf("expected core close attempt once, got %d", got)
 	}
 }
 

--- a/internal/guiapp/runtime_snapshot.go
+++ b/internal/guiapp/runtime_snapshot.go
@@ -78,6 +78,12 @@ func (a *App) baseUploadOptions() api.UploadOptions {
 	return buildBaseUploadOptions(a.currentConfig())
 }
 
+// baseUploadOptions returns upload options derived from the same runtime
+// snapshot as the core selected for a request.
+func (rt appRuntimeSnapshot) baseUploadOptions() api.UploadOptions {
+	return buildBaseUploadOptions(rt.cfg)
+}
+
 func (a *App) replaceRuntime(cfg config.Config, core api.Core, logger *logging.Logger) (api.Core, *logging.Logger) {
 	a.runtimeMu.Lock()
 	defer a.runtimeMu.Unlock()

--- a/internal/guiapp/runtime_snapshot.go
+++ b/internal/guiapp/runtime_snapshot.go
@@ -74,6 +74,7 @@ func (a *App) currentCore() api.Core {
 	return a.core
 }
 
+// baseUploadOptions returns upload options from the current runtime config.
 func (a *App) baseUploadOptions() api.UploadOptions {
 	return buildBaseUploadOptions(a.currentConfig())
 }

--- a/internal/guiapp/upload_jobs.go
+++ b/internal/guiapp/upload_jobs.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 
+	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/guishared"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -71,6 +72,7 @@ type trackerUploadJob struct {
 	cleanupOnce          sync.Once
 	id                   string
 	sourcePath           string
+	cfg                  config.Config
 	runOptions           runOptions
 	core                 api.Core
 	logger               interface{ Close() error }
@@ -123,7 +125,8 @@ func (j *trackerUploadJob) closeResources() {
 // returns its job ID. Snapshots preserve partial upload counts returned with
 // later tracker errors or cancellation.
 func (a *App) StartTrackerUpload(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (string, error) {
-	if err := a.requireCore(); err != nil {
+	rt, err := a.requireRuntime()
+	if err != nil {
 		return "", err
 	}
 	trimmedPath := strings.TrimSpace(path)
@@ -140,7 +143,7 @@ func (a *App) StartTrackerUpload(path string, overrides api.ExternalIDOverrides,
 	}
 	baseCtx := a.runtimeContext()
 
-	runCore, runLogger, err := a.buildRunCore(runOpts)
+	runCore, runLogger, err := a.buildRunCoreFromSnapshot(rt, runOpts)
 	if err != nil {
 		return "", err
 	}
@@ -154,7 +157,7 @@ func (a *App) StartTrackerUpload(path string, overrides api.ExternalIDOverrides,
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
-	if err := guishared.SeedRunCorePreparedMeta(baseCtx, a.currentCore(), runCore, seedReq); err != nil {
+	if err := guishared.SeedRunCorePreparedMeta(baseCtx, rt.core, runCore, seedReq); err != nil {
 		_ = runCore.Close()
 		_ = runLogger.Close()
 		return "", fmt.Errorf("gui: %w", err)
@@ -164,6 +167,7 @@ func (a *App) StartTrackerUpload(path string, overrides api.ExternalIDOverrides,
 	job := &trackerUploadJob{
 		id:                   jobID,
 		sourcePath:           trimmedPath,
+		cfg:                  rt.cfg,
 		runOptions:           runOpts,
 		core:                 runCore,
 		logger:               runLogger,
@@ -420,7 +424,7 @@ func (a *App) runSingleTrackerUpload(ctx context.Context, job *trackerUploadJob,
 		Trackers:                    []string{tracker},
 		IgnoreDupesFor:              append([]string(nil), job.ignoreDupesFor...),
 		IgnoreTrackerRuleFailures:   false,
-		Options:                     buildRunUploadOptions(a.currentConfig(), job.runOptions),
+		Options:                     buildRunUploadOptions(job.cfg, job.runOptions),
 		ExternalIDOverrides:         job.overrides,
 		ReleaseNameOverrides:        job.nameOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(job.questionnaireAnswers),

--- a/internal/guiapp/upload_jobs.go
+++ b/internal/guiapp/upload_jobs.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 
-	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/guishared"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -68,11 +68,13 @@ type TrackerUploadSnapshot struct {
 }
 
 type trackerUploadJob struct {
-	mu                   sync.Mutex
-	cleanupOnce          sync.Once
-	id                   string
-	sourcePath           string
-	cfg                  config.Config
+	mu          sync.Mutex
+	cleanupOnce sync.Once
+	id          string
+	sourcePath  string
+	// uploadOptions is the per-job runtime snapshot needed for upload requests;
+	// the full config may contain secrets and must not be retained in job state.
+	uploadOptions        api.UploadOptions
 	runOptions           runOptions
 	core                 api.Core
 	logger               interface{ Close() error }
@@ -99,11 +101,24 @@ type trackerUploadJob struct {
 	cancel               context.CancelFunc
 }
 
-func (j *trackerUploadJob) closeResources() {
+type trackerUploadRetryRequest struct {
+	sourcePath           string
+	overrides            api.ExternalIDOverrides
+	nameOverrides        api.ReleaseNameOverrides
+	questionnaireAnswers map[string]map[string]string
+	descriptionGroups    []api.DescriptionBuilderGroup
+	failedTrackers       []string
+	ignoreDupesFor       []string
+	runOptions           runOptions
+	uploadOptions        api.UploadOptions
+}
+
+func (j *trackerUploadJob) closeResources() error {
 	if j == nil {
-		return
+		return nil
 	}
 
+	var closeErr error
 	j.cleanupOnce.Do(func() {
 		j.mu.Lock()
 		coreSvc := j.core
@@ -113,18 +128,49 @@ func (j *trackerUploadJob) closeResources() {
 		j.mu.Unlock()
 
 		if coreSvc != nil {
-			_ = coreSvc.Close()
+			closeErr = errors.Join(closeErr, closeTrackerUploadResource("core", coreSvc))
 		}
 		if logger != nil {
-			_ = logger.Close()
+			closeErr = errors.Join(closeErr, closeTrackerUploadResource("logger", logger))
 		}
 	})
+	return closeErr
+}
+
+func trackerUploadRetryRequestFromJob(job *trackerUploadJob) (trackerUploadRetryRequest, error) {
+	if job == nil {
+		return trackerUploadRetryRequest{}, errors.New("upload job not found")
+	}
+
+	job.mu.Lock()
+	defer job.mu.Unlock()
+
+	if len(job.failedTrackers) == 0 {
+		return trackerUploadRetryRequest{}, errors.New("no failed trackers to retry")
+	}
+
+	return trackerUploadRetryRequest{
+		sourcePath:           job.sourcePath,
+		overrides:            job.overrides,
+		nameOverrides:        job.nameOverrides,
+		questionnaireAnswers: cloneQuestionnaireAnswers(job.questionnaireAnswers),
+		descriptionGroups:    api.CloneDescriptionBuilderGroups(job.descriptionGroups),
+		failedTrackers:       append([]string(nil), job.failedTrackers...),
+		ignoreDupesFor:       append([]string(nil), job.ignoreDupesFor...),
+		runOptions:           job.runOptions,
+		uploadOptions:        job.uploadOptions,
+	}, nil
 }
 
 // StartTrackerUpload starts a Wails upload job for selected trackers and
 // returns its job ID. Snapshots preserve partial upload counts returned with
-// later tracker errors or cancellation.
+// later tracker errors or cancellation. The job captures upload options at
+// start time so failed-tracker retries reuse the original option set.
 func (a *App) StartTrackerUpload(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (string, error) {
+	return a.startTrackerUpload(path, overrides, nameOverrides, trackers, ignoreDupesFor, questionnaireAnswers, descriptionGroups, debug, noSeed, runLogLevel, nil)
+}
+
+func (a *App) startTrackerUpload(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string, uploadOptions *api.UploadOptions) (string, error) {
 	rt, err := a.requireRuntime()
 	if err != nil {
 		return "", err
@@ -164,10 +210,14 @@ func (a *App) StartTrackerUpload(path string, overrides api.ExternalIDOverrides,
 	}
 
 	jobID := randomUploadJobID()
+	jobUploadOptions := buildRunUploadOptions(rt.cfg, runOpts)
+	if uploadOptions != nil {
+		jobUploadOptions = *uploadOptions
+	}
 	job := &trackerUploadJob{
 		id:                   jobID,
 		sourcePath:           trimmedPath,
-		cfg:                  rt.cfg,
+		uploadOptions:        jobUploadOptions,
 		runOptions:           runOpts,
 		core:                 runCore,
 		logger:               runLogger,
@@ -188,15 +238,8 @@ func (a *App) StartTrackerUpload(path string, overrides api.ExternalIDOverrides,
 	jobCtx, cancel := context.WithCancel(baseCtx)
 	job.cancel = cancel
 
-	a.uploadMu.Lock()
-	a.uploads[jobID] = job
-	a.uploadMu.Unlock()
-
+	a.startTrackerUploadWorker(jobCtx, baseCtx, job, cancel)
 	a.emitTrackerUploadSnapshot(baseCtx, job)
-	go func() {
-		defer cancel()
-		a.runTrackerUploadJob(jobCtx, baseCtx, job)
-	}()
 
 	return jobID, nil
 }
@@ -222,12 +265,13 @@ func (a *App) CancelTrackerUpload(jobID string) error {
 	if cancel != nil {
 		cancel()
 	}
-	job.closeResources()
 	return nil
 }
 
 // RetryFailedTrackerUpload starts a new Wails upload job for trackers that
-// failed in the original job.
+// failed in the original job. The retry reuses the original job's run options,
+// upload options, questionnaire answers, description groups, and ignore-dupe
+// list instead of rebuilding them from current settings.
 func (a *App) RetryFailedTrackerUpload(jobID string) (string, error) {
 	if a == nil {
 		return "", errors.New("app not initialized")
@@ -242,22 +286,12 @@ func (a *App) RetryFailedTrackerUpload(jobID string) (string, error) {
 		return "", errors.New("upload job not found")
 	}
 
-	job.mu.Lock()
-	failedTrackers := append([]string(nil), job.failedTrackers...)
-	sourcePath := job.sourcePath
-	overrides := job.overrides
-	nameOverrides := job.nameOverrides
-	questionnaireAnswers := cloneQuestionnaireAnswers(job.questionnaireAnswers)
-	descriptionGroups := api.CloneDescriptionBuilderGroups(job.descriptionGroups)
-	ignoreDupesFor := append([]string(nil), job.ignoreDupesFor...)
-	runOptions := job.runOptions
-	job.mu.Unlock()
-
-	if len(failedTrackers) == 0 {
-		return "", errors.New("no failed trackers to retry")
+	retry, err := trackerUploadRetryRequestFromJob(job)
+	if err != nil {
+		return "", err
 	}
 
-	return a.StartTrackerUpload(sourcePath, overrides, nameOverrides, failedTrackers, ignoreDupesFor, questionnaireAnswers, descriptionGroups, runOptions.Debug, runOptions.NoSeed, runOptions.RunLogLevel)
+	return a.startTrackerUpload(retry.sourcePath, retry.overrides, retry.nameOverrides, retry.failedTrackers, retry.ignoreDupesFor, retry.questionnaireAnswers, retry.descriptionGroups, retry.runOptions.Debug, retry.runOptions.NoSeed, retry.runOptions.RunLogLevel, &retry.uploadOptions)
 }
 
 // GetTrackerUploadSnapshot returns the current Wails tracker upload job state.
@@ -284,6 +318,11 @@ func (a *App) runTrackerUploadJob(ctx context.Context, eventCtx context.Context,
 	if a == nil || job == nil {
 		return
 	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			a.failTrackerUploadJob(eventCtx, job, trackerUploadPanicMessage("upload worker panicked", recovered))
+		}
+	}()
 
 	job.mu.Lock()
 	job.status = "running"
@@ -366,7 +405,10 @@ func (a *App) runTrackerUploadJob(ctx context.Context, eventCtx context.Context,
 	}
 	job.cancel = nil
 	job.mu.Unlock()
-	job.closeResources()
+	if err := job.closeResources(); err != nil {
+		a.failTrackerUploadJob(eventCtx, job, err.Error())
+		return
+	}
 	a.emitTrackerUploadSnapshot(eventCtx, job)
 }
 
@@ -424,7 +466,7 @@ func (a *App) runSingleTrackerUpload(ctx context.Context, job *trackerUploadJob,
 		Trackers:                    []string{tracker},
 		IgnoreDupesFor:              append([]string(nil), job.ignoreDupesFor...),
 		IgnoreTrackerRuleFailures:   false,
-		Options:                     buildRunUploadOptions(job.cfg, job.runOptions),
+		Options:                     job.uploadOptions,
 		ExternalIDOverrides:         job.overrides,
 		ReleaseNameOverrides:        job.nameOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(job.questionnaireAnswers),
@@ -434,11 +476,105 @@ func (a *App) runSingleTrackerUpload(ctx context.Context, job *trackerUploadJob,
 }
 
 func (a *App) emitTrackerUploadSnapshot(ctx context.Context, job *trackerUploadJob) {
-	if a == nil || ctx == nil || job == nil {
+	if a == nil || ctx == nil || job == nil || ctx.Value("events") == nil {
 		return
 	}
+	defer func() {
+		_ = recover()
+	}()
 	snapshot := buildTrackerUploadSnapshot(job)
 	runtime.EventsEmit(ctx, trackerUploadEventPrefix+job.id, snapshot)
+}
+
+// startTrackerUploadWorker publishes job only after WaitGroup enrollment so
+// shutdown waits for the worker before closing per-job resources.
+func (a *App) startTrackerUploadWorker(ctx context.Context, eventCtx context.Context, job *trackerUploadJob, cancel context.CancelFunc) {
+	a.publishTrackerUploadJob(job)
+
+	go func() {
+		defer a.uploadWG.Done()
+		defer cancel()
+		a.runTrackerUploadJob(ctx, eventCtx, job)
+	}()
+}
+
+// publishTrackerUploadJob enrolls job work and exposes the job under one lock
+// so stopAllUploadJobs observes both states together.
+func (a *App) publishTrackerUploadJob(job *trackerUploadJob) {
+	a.uploadMu.Lock()
+	a.uploadWG.Add(1)
+	a.uploads[job.id] = job
+	a.uploadMu.Unlock()
+}
+
+// failTrackerUploadJob marks unfinished tracker states failed, closes per-job
+// resources once, and emits the terminal snapshot.
+func (a *App) failTrackerUploadJob(eventCtx context.Context, job *trackerUploadJob, message string) {
+	if a == nil || job == nil {
+		return
+	}
+
+	job.mu.Lock()
+	now := time.Now().UTC()
+	if job.finishedAt.IsZero() {
+		job.finishedAt = now
+	}
+	job.status = "failed"
+	job.errorMessage = strings.TrimSpace(message)
+	if job.errorMessage == "" {
+		job.errorMessage = "upload failed"
+	}
+	for _, tracker := range job.trackers {
+		state := job.states[tracker]
+		if state.Status == "queued" || state.Status == "running" {
+			state.Status = "failed"
+			state.Message = job.errorMessage
+			state.FinishedAt = job.finishedAt.Format(time.RFC3339)
+			job.states[tracker] = state
+		}
+	}
+	job.cancel = nil
+	job.mu.Unlock()
+
+	if err := job.closeResources(); err != nil {
+		job.mu.Lock()
+		if job.errorMessage == "" {
+			job.errorMessage = err.Error()
+		} else if !strings.Contains(job.errorMessage, err.Error()) {
+			job.errorMessage += "; " + err.Error()
+		}
+		for _, tracker := range job.trackers {
+			state := job.states[tracker]
+			if state.Status == "failed" && state.Message == message {
+				state.Message = job.errorMessage
+				job.states[tracker] = state
+			}
+		}
+		job.mu.Unlock()
+	}
+	a.emitTrackerUploadSnapshot(eventCtx, job)
+}
+
+// closeTrackerUploadResource converts Close panics into redacted errors for
+// upload worker terminal state handling.
+func closeTrackerUploadResource(name string, resource interface{ Close() error }) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = errors.New(trackerUploadPanicMessage(name+" close panicked", recovered))
+		}
+	}()
+	_ = resource.Close()
+	return nil
+}
+
+// trackerUploadPanicMessage redacts recovered panic text before it is stored in
+// upload job state or sent over the Wails event bridge.
+func trackerUploadPanicMessage(prefix string, recovered any) string {
+	detail := strings.TrimSpace(redaction.RedactValue(fmt.Sprint(recovered), nil))
+	if detail == "" {
+		return prefix
+	}
+	return prefix + ": " + detail
 }
 
 func buildTrackerUploadSnapshot(job *trackerUploadJob) TrackerUploadSnapshot {
@@ -518,7 +654,12 @@ func (a *App) stopAllUploadJobs() {
 		if cancel != nil {
 			cancel()
 		}
-		job.closeResources()
+	}
+	a.uploadWG.Wait()
+	for _, job := range jobs {
+		if job != nil {
+			_ = job.closeResources()
+		}
 	}
 }
 

--- a/internal/guiapp/upload_jobs.go
+++ b/internal/guiapp/upload_jobs.go
@@ -563,7 +563,9 @@ func closeTrackerUploadResource(name string, resource interface{ Close() error }
 			err = errors.New(trackerUploadPanicMessage(name+" close panicked", recovered))
 		}
 	}()
-	_ = resource.Close()
+	if closeErr := resource.Close(); closeErr != nil {
+		return fmt.Errorf("%s close failed: %w", name, closeErr)
+	}
 	return nil
 }
 

--- a/internal/guishared/runtime.go
+++ b/internal/guishared/runtime.go
@@ -42,7 +42,8 @@ func BuildRuntime(ctx context.Context, cfg config.Config, repo *db.SQLiteReposit
 		Services: api.ServiceSet{
 			Filesystem: filesystem.NewValidator(),
 		},
-		Repository: repo,
+		Repository:          repo,
+		SkipCookieMigration: true,
 	})
 	if err != nil {
 		_ = logger.Close()

--- a/internal/services/db/sqlite.go
+++ b/internal/services/db/sqlite.go
@@ -2845,6 +2845,8 @@ func (r *SQLiteRepository) LoadConfigSection(ctx context.Context, section string
 	return nil
 }
 
+// prepareFullConfigSections converts a full config into per-section JSON
+// payloads matching config_settings section names.
 func prepareFullConfigSections(cfg any) (map[string]string, error) {
 	// Marshal the full config to inspect its structure.
 	cfgData, err := json.MarshalIndent(cfg, "", "  ")
@@ -2914,6 +2916,8 @@ func (r *SQLiteRepository) SaveFullConfigWithPreSave(ctx context.Context, cfg an
 	return nil
 }
 
+// saveFullConfigSections writes prepared section payloads in one transaction,
+// optionally running preSave in that same transaction before section writes.
 func (r *SQLiteRepository) saveFullConfigSections(ctx context.Context, sections map[string]string, preSave func(context.Context, *sql.Tx) error) error {
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 

--- a/internal/services/db/sqlite.go
+++ b/internal/services/db/sqlite.go
@@ -2845,6 +2845,30 @@ func (r *SQLiteRepository) LoadConfigSection(ctx context.Context, section string
 	return nil
 }
 
+func prepareFullConfigSections(cfg any) (map[string]string, error) {
+	// Marshal the full config to inspect its structure.
+	cfgData, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("db save full config: marshal: %w", err)
+	}
+
+	var cfgMap map[string]any
+	if err := json.Unmarshal(cfgData, &cfgMap); err != nil {
+		return nil, fmt.Errorf("db save full config: unmarshal to map: %w", err)
+	}
+
+	sections := make(map[string]string, len(cfgMap))
+	for section, value := range cfgMap {
+		payload, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("db save full config: marshal section %s: %w", section, err)
+		}
+		sections[section] = string(payload)
+	}
+
+	return sections, nil
+}
+
 // SaveFullConfig persists the entire config to all sections.
 // This is called when exporting to database from YAML or UI updates.
 func (r *SQLiteRepository) SaveFullConfig(ctx context.Context, cfg any) error {
@@ -2855,28 +2879,50 @@ func (r *SQLiteRepository) SaveFullConfig(ctx context.Context, cfg any) error {
 		return internalerrors.ErrInvalidInput
 	}
 
-	// Marshal the full config to inspect its structure.
-	cfgData, err := json.MarshalIndent(cfg, "", "  ")
+	sections, err := prepareFullConfigSections(cfg)
 	if err != nil {
-		return fmt.Errorf("db save full config: marshal: %w", err)
+		return err
 	}
 
-	var cfgMap map[string]any
-	if err := json.Unmarshal(cfgData, &cfgMap); err != nil {
-		return fmt.Errorf("db save full config: unmarshal to map: %w", err)
+	if err := r.saveFullConfigSections(ctx, sections, nil); err != nil {
+		return err
 	}
 
+	return nil
+}
+
+// SaveFullConfigWithPreSave persists the entire config and runs preSave in the
+// same write transaction immediately before config sections are written. If
+// preSave or any section write fails, the transaction is rolled back.
+func (r *SQLiteRepository) SaveFullConfigWithPreSave(ctx context.Context, cfg any, preSave func(context.Context, *sql.Tx) error) error {
+	if r == nil || r.db == nil {
+		return errors.New("db: repository not initialized")
+	}
+	if cfg == nil {
+		return internalerrors.ErrInvalidInput
+	}
+
+	sections, err := prepareFullConfigSections(cfg)
+	if err != nil {
+		return err
+	}
+
+	if err := r.saveFullConfigSections(ctx, sections, preSave); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *SQLiteRepository) saveFullConfigSections(ctx context.Context, sections map[string]string, preSave func(context.Context, *sql.Tx) error) error {
 	now := time.Now().UTC().Format(time.RFC3339Nano)
-	sections := make(map[string]string, len(cfgMap))
-	for section, value := range cfgMap {
-		payload, err := json.Marshal(value)
-		if err != nil {
-			return fmt.Errorf("db save full config: marshal section %s: %w", section, err)
-		}
-		sections[section] = string(payload)
-	}
 
 	if err := r.withWriteTx(ctx, "save full config", func(tx *sql.Tx) error {
+		if preSave != nil {
+			if err := preSave(ctx, tx); err != nil {
+				return err
+			}
+		}
 		for section, payload := range sections {
 			if _, err := tx.ExecContext(ctx, `
 			INSERT INTO config_settings (section, data, updated_at) VALUES (?, ?, ?)

--- a/internal/webserver/auth_rewrap.go
+++ b/internal/webserver/auth_rewrap.go
@@ -5,8 +5,11 @@ package webserver
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/autobrr/upbrr/internal/authmaterial"
@@ -18,6 +21,11 @@ func generateStableEncryptionSeed() (string, error) {
 	return wrapWebResult(authmaterial.GenerateSeed())
 }
 
+// rewrapProtectedDataForAuthChange resumes pending auth upgrades by advancing
+// through cookie and config-secret rewrap phases. If a previous prepared-phase
+// attempt already re-encrypted cookies but failed before persisting the phase,
+// the cookie phase verifies readability with the target auth material and
+// records the recovered cookie auth state before continuing.
 func (s *Server) rewrapProtectedDataForAuthChange(ctx context.Context, oldRecord, newRecord authRecord) error {
 	if s == nil || s.backend == nil || s.backend.repo == nil {
 		return errors.New("auth_rewrap: missing server/backend/repo configuration (s.backend.repo unavailable)")
@@ -47,7 +55,7 @@ func (s *Server) rewrapProtectedDataForAuthChange(ctx context.Context, oldRecord
 	}
 
 	if pending.Stage == authmaterial.UpgradeStagePrepared {
-		if err := cookies.RewrapCookiesWithAuthChange(ctx, s.backend.repo.RawDB(), oldMaterial, newMaterial); err != nil {
+		if err := rewrapCookiesForAuthChange(ctx, s.backend.repo.RawDB(), oldMaterial, newMaterial); err != nil {
 			return fmt.Errorf("web: %w", err)
 		}
 		if err := s.auth.AdvancePendingUpgrade(oldRecord.Username, authmaterial.UpgradeStageCookiesRewrapped); err != nil {
@@ -68,4 +76,109 @@ func (s *Server) rewrapProtectedDataForAuthChange(ctx context.Context, oldRecord
 	}
 
 	return nil
+}
+
+// rewrapCookiesForAuthChange retries an interrupted prepared-phase cookie
+// upgrade by accepting already-rewrapped cookies only after verifying they
+// decrypt with the target auth material.
+func rewrapCookiesForAuthChange(ctx context.Context, db *sql.DB, oldMaterial, newMaterial authmaterial.Material) error {
+	err := cookies.RewrapCookiesWithAuthChange(ctx, db, oldMaterial, newMaterial)
+	if err == nil {
+		return nil
+	}
+	if !isCookieRewrapDecryptFailure(err) {
+		return fmt.Errorf("auth rewrap: rewrap cookies: %w", err)
+	}
+
+	if verifyErr := verifyCookiesReadableWithAuthMaterial(ctx, db, newMaterial); verifyErr != nil {
+		return errors.Join(err, fmt.Errorf("auth rewrap: verify recovered cookies: %w", verifyErr))
+	}
+	if markerErr := cookies.RewrapCookiesWithAuthChange(ctx, db, newMaterial, newMaterial); markerErr != nil {
+		return fmt.Errorf("auth rewrap: persist recovered cookie auth state: %w", markerErr)
+	}
+
+	return nil
+}
+
+func isCookieRewrapDecryptFailure(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "failed to decrypt cookie")
+}
+
+// verifyCookiesReadableWithAuthMaterial checks every encrypted cookie row
+// against material without modifying cookie data or auth-state metadata.
+func verifyCookiesReadableWithAuthMaterial(ctx context.Context, db *sql.DB, material authmaterial.Material) error {
+	if ctx == nil {
+		return cookies.ErrNilContext
+	}
+	if db == nil {
+		return errors.New("cookies: database connection is required")
+	}
+
+	helper, _, err := material.PrimaryHelper()
+	if err != nil {
+		return fmt.Errorf("cookies: derive auth helper: %w", err)
+	}
+
+	salt, err := loadCookieEncryptionSalt(ctx, db)
+	if err != nil {
+		return err
+	}
+	key, err := cookies.DeriveEncryptionKey(helper, salt)
+	if err != nil {
+		return fmt.Errorf("cookies: derive encryption key: %w", err)
+	}
+
+	rows, err := db.QueryContext(ctx, `SELECT tracker_id, cookie_name, encrypted_value, nonce, auth_tag FROM tracker_cookies`)
+	if err != nil {
+		return fmt.Errorf("cookies: query encrypted cookies: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var trackerID, cookieName string
+		var encoded cookies.EncodedEncryptedCookie
+		if err := rows.Scan(&trackerID, &cookieName, &encoded.CiphertextB64, &encoded.NonceB64, &encoded.AuthTagB64); err != nil {
+			return fmt.Errorf("cookies: scan encrypted cookie: %w", err)
+		}
+
+		encrypted, err := cookies.DecodeFromStorage(encoded)
+		if err != nil {
+			return fmt.Errorf("cookies: decode recovered cookie for tracker %s cookie %s: %w", trackerID, cookieName, err)
+		}
+		if _, err := cookies.DecryptCookieValue(encrypted, key); err != nil {
+			return fmt.Errorf("cookies: decrypt recovered cookie for tracker %s cookie %s: %w", trackerID, cookieName, err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("cookies: iterate encrypted cookies: %w", err)
+	}
+
+	return nil
+}
+
+// loadCookieEncryptionSalt loads the stored cookie encryption salt required to
+// derive a key outside the normal rewrap transaction.
+func loadCookieEncryptionSalt(ctx context.Context, db *sql.DB) (string, error) {
+	var raw string
+	err := db.QueryRowContext(ctx, `SELECT data FROM config_settings WHERE section = ?`, "cookies_encryption_salt").Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", errors.New("cookies: encryption salt missing")
+	}
+	if err != nil {
+		return "", fmt.Errorf("cookies: query encryption salt: %w", err)
+	}
+
+	var payload struct {
+		Salt string `json:"salt"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return "", fmt.Errorf("cookies: parse encryption salt: %w", err)
+	}
+
+	salt := strings.TrimSpace(payload.Salt)
+	if salt == "" {
+		return "", errors.New("cookies: encryption salt missing")
+	}
+
+	return salt, nil
 }

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -6,6 +6,7 @@ package webserver
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -18,6 +19,8 @@ import (
 	"github.com/autobrr/upbrr/internal/authmaterial"
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/config/importer"
+	"github.com/autobrr/upbrr/internal/configstore"
+	"github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/core"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/filesystem"
@@ -35,6 +38,7 @@ import (
 
 const previewTimeout = 30 * time.Minute
 
+// Backend owns the embedded web API runtime and request-scoped background jobs.
 type Backend struct {
 	runtimeMu   sync.RWMutex
 	cfg         config.Config
@@ -72,10 +76,14 @@ type runOptions struct {
 	RunLogLevel string
 }
 
+// NewBackend constructs a Backend using a background context.
 func NewBackend(cfg config.Config, hub *eventHub) (*Backend, error) {
 	return NewBackendWithContext(context.Background(), cfg, hub)
 }
 
+// NewBackendWithContext opens the shared repository, creates the logger, and
+// starts the core service when cfg validates. Invalid config keeps settings
+// routes usable while core-backed routes report the initialization error.
 func NewBackendWithContext(ctx context.Context, cfg config.Config, hub *eventHub) (*Backend, error) {
 	if ctx == nil {
 		return nil, errors.New("webserver: context is required")
@@ -130,6 +138,7 @@ func NewBackendWithContext(ctx context.Context, cfg config.Config, hub *eventHub
 	}, nil
 }
 
+// Close stops active background work and releases runtime, repository, and log resources.
 func (b *Backend) Close() error {
 	b.stopAllLogStreams()
 	b.stopAllDupeJobs()
@@ -169,7 +178,8 @@ func (b *Backend) DetectDiscType(ctx context.Context, path string) (string, erro
 }
 
 func (b *Backend) FetchMetadata(sessionID string, path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, confirmBDMVRescan bool) (api.MetadataPreview, error) {
-	if err := b.requireCore(); err != nil {
+	rt, err := b.requireRuntime()
+	if err != nil {
 		return api.MetadataPreview{}, err
 	}
 	trimmedPath := strings.TrimSpace(path)
@@ -194,14 +204,14 @@ func (b *Backend) FetchMetadata(sessionID string, path string, sourceLookupURL s
 		Mode:            api.ModeGUI,
 		Trackers:        append([]string{}, trackersList...),
 		SourceLookupURL: strings.TrimSpace(sourceLookupURL),
-		Options:         b.baseUploadOptions(),
+		Options:         rt.baseUploadOptions(),
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 		ConfirmBDMVRescan:    confirmBDMVRescan,
 	}
 
-	return wrapWebResult(b.currentCore().FetchMetadataPreview(progressCtx, req))
+	return wrapWebResult(rt.core.FetchMetadataPreview(progressCtx, req))
 }
 
 type blurayCandidateSelector interface {
@@ -375,17 +385,16 @@ func (b *Backend) FetchPreparation(sessionID string, path string, overrides api.
 }
 
 func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (api.TrackerDryRunPreview, error) {
-	if err := b.requireCore(); err != nil {
+	rt, err := b.requireRuntime()
+	if err != nil {
 		return api.TrackerDryRunPreview{}, err
 	}
 	runOpts, err := b.buildRunOptions(debug, noSeed, runLogLevel)
 	if err != nil {
 		return api.TrackerDryRunPreview{}, err
 	}
-	if logger := b.currentLogger(); logger != nil {
-		logger.Debugf("web: tracker dry-run request path=%s debug=%t no_seed=%t run_log_level=%s", strings.TrimSpace(path), debug, noSeed, runOpts.RunLogLevel)
-	}
-	runCore, runLogger, err := b.buildRunCore(runOpts)
+	b.logDebugf("web: tracker dry-run request path=%s debug=%t no_seed=%t run_log_level=%s", strings.TrimSpace(path), debug, noSeed, runOpts.RunLogLevel)
+	runCore, runLogger, err := b.buildRunCoreFromSnapshot(rt, runOpts)
 	if err != nil {
 		return api.TrackerDryRunPreview{}, err
 	}
@@ -402,13 +411,13 @@ func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides ap
 		Trackers:                    append([]string{}, trackersList...),
 		IgnoreDupesFor:              normalizeTrackerList(ignoreDupesFor),
 		IgnoreTrackerRuleFailures:   false,
-		Options:                     buildRunUploadOptions(b.currentConfig(), runOpts),
+		Options:                     buildRunUploadOptions(rt.cfg, runOpts),
 		ExternalIDOverrides:         overrides,
 		ReleaseNameOverrides:        nameOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(questionnaireAnswers),
 	}
 	req.Options.DryRun = true
-	if err := guishared.SeedRunCorePreparedMeta(ctx, b.currentCore(), runCore, req); err != nil {
+	if err := guishared.SeedRunCorePreparedMeta(ctx, rt.core, runCore, req); err != nil {
 		return api.TrackerDryRunPreview{}, fmt.Errorf("web: %w", err)
 	}
 	progressCtx := api.WithUploadProgressReporter(ctx, func(update api.UploadProgressUpdate) {
@@ -656,15 +665,16 @@ func (b *Backend) ReadScreenshotImage(path string) (string, error) {
 }
 
 func (b *Backend) ListUploadCandidates(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) ([]api.ScreenshotImage, error) {
-	if err := b.requireCore(); err != nil {
+	rt, err := b.requireRuntime()
+	if err != nil {
 		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebResult(b.currentCore().ListUploadCandidates(ctx, api.Request{
+	return wrapWebResult(rt.core.ListUploadCandidates(ctx, api.Request{
 		Paths:   []string{path},
 		Mode:    api.ModeGUI,
-		Options: b.baseUploadOptions(),
+		Options: rt.baseUploadOptions(),
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
@@ -672,15 +682,16 @@ func (b *Backend) ListUploadCandidates(path string, overrides api.ExternalIDOver
 }
 
 func (b *Backend) ListUploadedImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) ([]api.UploadedImageLink, error) {
-	if err := b.requireCore(); err != nil {
+	rt, err := b.requireRuntime()
+	if err != nil {
 		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebResult(b.currentCore().ListUploadedImages(ctx, api.Request{
+	return wrapWebResult(rt.core.ListUploadedImages(ctx, api.Request{
 		Paths:   []string{path},
 		Mode:    api.ModeGUI,
-		Options: b.baseUploadOptions(),
+		Options: rt.baseUploadOptions(),
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
@@ -688,15 +699,16 @@ func (b *Backend) ListUploadedImages(path string, overrides api.ExternalIDOverri
 }
 
 func (b *Backend) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, host string, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
-	if err := b.requireCore(); err != nil {
+	rt, err := b.requireRuntime()
+	if err != nil {
 		return api.UploadImagesResult{}, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
 	defer cancel()
-	return wrapWebResult(b.currentCore().UploadImages(ctx, api.Request{
+	return wrapWebResult(rt.core.UploadImages(ctx, api.Request{
 		Paths:   []string{path},
 		Mode:    api.ModeGUI,
-		Options: b.baseUploadOptions(),
+		Options: rt.baseUploadOptions(),
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
@@ -716,8 +728,10 @@ func (b *Backend) DeleteUploadedImage(path string, imagePath string, host string
 	}, imagePath, host))
 }
 
+// GetConfig returns the current exportable config as JSON with encrypted
+// secret fields for browser settings consumers.
 func (b *Backend) GetConfig() (string, error) {
-	cfg, err := b.exportableConfig()
+	cfg, _, err := b.exportableConfig()
 	if err != nil {
 		return "", err
 	}
@@ -728,13 +742,16 @@ func (b *Backend) GetApplicationInfo() (api.ApplicationInfo, error) {
 	return api.CurrentApplicationInfo(), nil
 }
 
+// ExportConfig returns the exportable config, using plaintext secrets only
+// when auth material for the exported snapshot's DB path explicitly allows
+// unencrypted export.
 func (b *Backend) ExportConfig() (string, error) {
-	cfg, err := b.exportableConfig()
+	cfg, authDBPath, err := b.exportableConfig()
 	if err != nil {
 		return "", err
 	}
 
-	allowPlaintext, err := b.allowUnencryptedExport()
+	allowPlaintext, err := b.allowUnencryptedExport(authDBPath)
 	if err != nil {
 		return "", err
 	}
@@ -753,40 +770,74 @@ func (b *Backend) GetDefaultConfig() (string, error) {
 	return wrapWebResult(config.ExportToJSON(cfg))
 }
 
-func (b *Backend) exportableConfig() (*config.Config, error) {
+// exportableConfig returns the normalized config snapshot and the DB path that
+// must authorize plaintext export for that exact snapshot. Fresh installs with
+// no persisted config export the current runtime config without saving it.
+func (b *Backend) exportableConfig() (*config.Config, string, error) {
 	if b.repo == nil {
-		return nil, errors.New("config repository not initialized")
+		return nil, "", errors.New("config repository not initialized")
 	}
+	rt := b.runtimeSnapshot()
 	cfg, err := config.LoadFromDatabase(context.Background(), b.repo)
 	if err != nil {
 		if errors.Is(err, internalerrors.ErrNotFound) {
 			// Fresh web installs can run from embedded defaults before any config
 			// rows exist, so export the runtime config until the user saves setup.
-			cfg := b.currentConfig()
-			return normalizeExportableConfig(&cfg, b.currentConfig().MainSettings.DBPath), nil
+			cfg, normalizeErr := normalizeExportableConfig(&rt.cfg, rt.cfg.MainSettings.DBPath)
+			if normalizeErr != nil {
+				return nil, "", normalizeErr
+			}
+			return cfg, cfg.MainSettings.DBPath, nil
 		}
+		return nil, "", fmt.Errorf("web: %w", err)
+	}
+	cfg, err = normalizeExportableConfig(cfg, rt.cfg.MainSettings.DBPath)
+	if err != nil {
+		return nil, "", err
+	}
+	return cfg, cfg.MainSettings.DBPath, nil
+}
+
+// normalizeExportableConfig returns a cloned config with tracker defaults,
+// legacy nils, and missing DB path values filled so browser consumers receive
+// stable JSON shapes without mutating the loaded runtime or database config.
+func normalizeExportableConfig(cfg *config.Config, dbPath string) (*config.Config, error) {
+	normalized, err := cloneConfigForExport(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := config.MergeMissingTrackerDefaults(normalized); err != nil {
 		return nil, fmt.Errorf("web: %w", err)
 	}
-	return normalizeExportableConfig(cfg, b.currentConfig().MainSettings.DBPath), nil
+	if strings.TrimSpace(normalized.MainSettings.DBPath) == "" {
+		normalized.MainSettings.DBPath = dbPath
+	}
+	if normalized.Trackers.Trackers == nil {
+		normalized.Trackers.Trackers = map[string]config.TrackerConfig{}
+	}
+	if normalized.Trackers.DefaultTrackers == nil {
+		normalized.Trackers.DefaultTrackers = config.CSVList{}
+	}
+	return normalized, nil
 }
 
-// normalizeExportableConfig fills legacy nils and missing DB path values so
-// browser config consumers receive stable JSON shapes.
-func normalizeExportableConfig(cfg *config.Config, dbPath string) *config.Config {
-	if strings.TrimSpace(cfg.MainSettings.DBPath) == "" {
-		cfg.MainSettings.DBPath = dbPath
+func cloneConfigForExport(cfg *config.Config) (*config.Config, error) {
+	payload, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("web: clone config for export: marshal: %w", err)
 	}
-	if cfg.Trackers.Trackers == nil {
-		cfg.Trackers.Trackers = map[string]config.TrackerConfig{}
+	var cloned config.Config
+	if err := json.Unmarshal(payload, &cloned); err != nil {
+		return nil, fmt.Errorf("web: clone config for export: unmarshal: %w", err)
 	}
-	if cfg.Trackers.DefaultTrackers == nil {
-		cfg.Trackers.DefaultTrackers = config.CSVList{}
-	}
-	return cfg
+	return &cloned, nil
 }
 
-func (b *Backend) allowUnencryptedExport() (bool, error) {
-	material, err := authmaterial.LoadFromDBPath(b.currentConfig().MainSettings.DBPath)
+// allowUnencryptedExport reports whether the auth material for dbPath permits
+// plaintext config export. Missing auth material denies plaintext export;
+// malformed material is returned as an error.
+func (b *Backend) allowUnencryptedExport(dbPath string) (bool, error) {
+	material, err := authmaterial.LoadFromDBPath(dbPath)
 	if err == nil {
 		return material.AllowUnencryptedExport, nil
 	}
@@ -796,6 +847,10 @@ func (b *Backend) allowUnencryptedExport() (bool, error) {
 	return false, fmt.Errorf("web: %w", err)
 }
 
+// SaveConfig validates encrypted browser settings, builds the replacement
+// runtime, then syncs cookie encryption metadata and saves the non-env config.
+// Runtime build or save failures leave the persisted config and active runtime
+// unchanged; env overrides apply only to the installed runtime config.
 func (b *Backend) SaveConfig(payload string) error {
 	if b.repo == nil {
 		return errors.New("config repository not initialized")
@@ -811,9 +866,10 @@ func (b *Backend) SaveConfig(payload string) error {
 	if strings.TrimSpace(cfg.MainSettings.DBPath) == "" {
 		cfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
 	}
-	if cfg.MainSettings.DBPath != currentCfg.MainSettings.DBPath {
+	if !pathutil.SamePath(cfg.MainSettings.DBPath, currentCfg.MainSettings.DBPath) {
 		return errors.New("changing main_settings.db_path requires restart")
 	}
+	cfg.MainSettings.DBPath = currentCfg.MainSettings.DBPath
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("web: %w", err)
 	}
@@ -823,14 +879,15 @@ func (b *Backend) SaveConfig(payload string) error {
 	if err := runtimeCfg.Validate(); err != nil {
 		return fmt.Errorf("web: %w", err)
 	}
-	if err := config.SaveToDatabase(context.Background(), cfg, b.repo); err != nil {
-		return fmt.Errorf("web: %w", err)
-	}
-	return b.applyConfig(runtimeCfg)
+	return b.saveAndApplyConfig(context.Background(), cfg, runtimeCfg, cfg.MainSettings.DBPath)
 }
 
 const configImportMaxBytes = importer.MaxFileBytes
 
+// ImportConfig imports browser-uploaded config content, validates the saved and
+// env-applied runtime forms, builds the replacement runtime, then syncs cookie
+// encryption metadata and saves the non-env config. Runtime build or save
+// failures leave the persisted config and active runtime unchanged.
 func (b *Backend) ImportConfig(fileName, fileContent string) (string, []string, error) {
 	if b.repo == nil {
 		return "", nil, errors.New("config repository not initialized")
@@ -860,11 +917,7 @@ func (b *Backend) ImportConfig(fileName, fileContent string) (string, []string, 
 		return "", nil, fmt.Errorf("validate imported config: %w", err)
 	}
 
-	if err := config.SaveToDatabase(context.Background(), cfg, b.repo); err != nil {
-		return "", nil, fmt.Errorf("web: %w", err)
-	}
-
-	if err := b.applyConfig(runtimeCfg); err != nil {
+	if err := b.saveAndApplyConfig(context.Background(), cfg, runtimeCfg, cfg.MainSettings.DBPath); err != nil {
 		return "", nil, err
 	}
 
@@ -873,6 +926,89 @@ func (b *Backend) ImportConfig(fileName, fileContent string) (string, []string, 
 		result += fmt.Sprintf(" (%d warnings)", len(warnings))
 	}
 	return result, warnings, nil
+}
+
+// saveAndApplyConfig builds the replacement runtime before any repository
+// writes, then persists cfg and installs the runtime as one ordered transition.
+// If persistence fails, the built runtime is closed and the active runtime is
+// left untouched.
+func (b *Backend) saveAndApplyConfig(ctx context.Context, cfg *config.Config, runtimeCfg config.Config, dbPath string) error {
+	if err := validateCookieAuthMaterial(dbPath); err != nil {
+		if !errors.Is(err, cookies.ErrAuthHelperUnavailable) {
+			return fmt.Errorf("web: validate cookie auth before config save: %w", err)
+		}
+	}
+
+	rt, err := b.buildConfigRuntime(ctx, runtimeCfg)
+	if err != nil {
+		return err
+	}
+	if err := b.saveConfigToRepository(ctx, cfg, dbPath); err != nil {
+		closeBuiltRuntime(rt)
+		return err
+	}
+	b.installConfigRuntime(runtimeCfg, rt)
+	return nil
+}
+
+// saveConfigToRepository enforces the shared pre-save cookie encryption sync
+// before persisting browser config changes through the already-open repository.
+func (b *Backend) saveConfigToRepository(ctx context.Context, cfg *config.Config, dbPath string) error {
+	if err := configstore.SaveToRepository(ctx, cfg, b.repo, dbPath); err != nil {
+		return fmt.Errorf("web: %w", err)
+	}
+	return nil
+}
+
+// validateCookieAuthMaterial returns ErrAuthHelperUnavailable only when auth
+// material is absent; malformed material remains an error so callers can abort
+// before cookie encryption metadata is initialized.
+func validateCookieAuthMaterial(dbPath string) error {
+	material, err := authmaterial.LoadFromDBPath(dbPath)
+	if err != nil {
+		if errors.Is(err, authmaterial.ErrUnavailable) {
+			return cookies.ErrAuthHelperUnavailable
+		}
+		return fmt.Errorf("load auth helper: %w", err)
+	}
+	if _, _, err := material.PrimaryHelper(); err != nil {
+		if errors.Is(err, authmaterial.ErrUnavailable) {
+			return cookies.ErrAuthHelperUnavailable
+		}
+		return fmt.Errorf("derive auth helper: %w", err)
+	}
+	return nil
+}
+
+func (b *Backend) buildConfigRuntime(ctx context.Context, cfg config.Config) (guishared.Runtime, error) {
+	rt, err := guishared.BuildRuntime(ctx, cfg, b.repo)
+	if err != nil {
+		return guishared.Runtime{}, fmt.Errorf("web: %w", err)
+	}
+	return rt, nil
+}
+
+func (b *Backend) installConfigRuntime(cfg config.Config, rt guishared.Runtime) {
+	oldCore, oldLogger := b.replaceRuntime(cfg, rt.Core, rt.Logger)
+	if b.hub != nil {
+		b.hub.SetLogger(rt.Logger)
+	}
+	b.rebindLogStreams(oldLogger, rt.Logger)
+	if oldCore != nil {
+		_ = oldCore.Close()
+	}
+	if oldLogger != nil {
+		_ = oldLogger.Close()
+	}
+}
+
+func closeBuiltRuntime(rt guishared.Runtime) {
+	if rt.Core != nil {
+		_ = rt.Core.Close()
+	}
+	if rt.Logger != nil {
+		_ = rt.Logger.Close()
+	}
 }
 
 func (b *Backend) ListKnownTrackers() ([]string, error) {
@@ -949,14 +1085,26 @@ func (b *Backend) UpdateLogExclusions(patterns []string) error {
 	}, b.repo))
 }
 
+// StartLogStream subscribes the browser session to live log events. Active
+// streams are rebound when settings replace the runtime logger. If no logger or
+// event hub is installed, it returns an error without registering a stream.
 func (b *Backend) StartLogStream(sessionID string) (string, error) {
-	logger := b.currentLogger()
-	if logger == nil {
-		return "", errors.New("logger not initialized")
-	}
 	streamID, err := randomString(12)
 	if err != nil {
 		return "", err
+	}
+	if b == nil {
+		return "", errors.New("logger not initialized")
+	}
+	if b.hub == nil {
+		return "", errors.New("event hub not initialized")
+	}
+
+	b.runtimeMu.RLock()
+	logger := b.logger
+	if logger == nil {
+		b.runtimeMu.RUnlock()
+		return "", errors.New("logger not initialized")
 	}
 	session := &backendLogStream{
 		id:        streamID,
@@ -964,31 +1112,86 @@ func (b *Backend) StartLogStream(sessionID string) (string, error) {
 		stop:      make(chan struct{}),
 		done:      make(chan struct{}),
 	}
+	b.streamMu.Lock()
+	b.streams[streamID] = session
+	b.startLogStreamWorker(session, logger)
+	b.streamMu.Unlock()
+	b.runtimeMu.RUnlock()
+
+	return streamID, nil
+}
+
+func (b *Backend) startLogStreamWorker(session *backendLogStream, logger *logging.Logger) {
 	subID, ch := logger.Subscribe(0)
+	stop := session.stop
+	done := session.done
 	session.logger = logger
 	session.subID = subID
 
-	b.streamMu.Lock()
-	b.streams[streamID] = session
-	b.streamMu.Unlock()
-
 	b.streamWG.Go(func() {
-		defer close(session.done)
+		defer close(done)
 		for {
 			select {
 			case entry, ok := <-ch:
 				if !ok {
 					return
 				}
-				b.hub.Emit(sessionID, "log:stream:"+streamID, entry)
-			case <-session.stop:
-				session.logger.Unsubscribe(session.subID)
+				b.hub.Emit(session.sessionID, "log:stream:"+session.id, entry)
+			case <-stop:
+				logger.Unsubscribe(subID)
 				return
 			}
 		}
 	})
+}
 
-	return streamID, nil
+// rebindLogStreams moves streams attached to oldLogger onto newLogger without
+// changing their browser-visible stream IDs.
+func (b *Backend) rebindLogStreams(oldLogger *logging.Logger, newLogger *logging.Logger) {
+	if b == nil || oldLogger == nil || newLogger == nil || oldLogger == newLogger {
+		return
+	}
+
+	type stoppedStream struct {
+		session *backendLogStream
+		done    <-chan struct{}
+	}
+
+	b.streamMu.Lock()
+	stopped := make([]stoppedStream, 0, len(b.streams))
+	for _, session := range b.streams {
+		if session == nil || session.logger != oldLogger {
+			continue
+		}
+		stopped = append(stopped, stoppedStream{
+			session: session,
+			done:    session.done,
+		})
+		select {
+		case <-session.stop:
+		default:
+			close(session.stop)
+		}
+	}
+	b.streamMu.Unlock()
+
+	for _, stream := range stopped {
+		if stream.done != nil {
+			<-stream.done
+		}
+	}
+
+	b.streamMu.Lock()
+	for _, stream := range stopped {
+		session := stream.session
+		if session == nil || b.streams[session.id] != session {
+			continue
+		}
+		session.stop = make(chan struct{})
+		session.done = make(chan struct{})
+		b.startLogStreamWorker(session, newLogger)
+	}
+	b.streamMu.Unlock()
 }
 
 // StopLogStream stops streamID only when it belongs to sessionID.
@@ -1047,11 +1250,7 @@ func (b *Backend) buildRunOptions(debug bool, noSeed bool, runLogLevel string) (
 	return runOptions{Debug: debug, NoSeed: noSeed, RunLogLevel: normalized}, nil
 }
 
-func (b *Backend) buildRunCore(opts runOptions) (api.Core, *logging.Logger, error) {
-	rt, err := b.requireRuntime()
-	if err != nil {
-		return nil, nil, err
-	}
+func (b *Backend) buildRunCoreFromSnapshot(rt backendRuntimeSnapshot, opts runOptions) (api.Core, *logging.Logger, error) {
 	effectiveLogLevel := logging.ResolveEffectiveLevel(rt.cfg.Logging.Level, opts.RunLogLevel, opts.Debug)
 	logger, err := logging.NewWithLevel(rt.cfg.Logging, rt.cfg.MainSettings.DBPath, effectiveLogLevel)
 	if err != nil {
@@ -1091,17 +1290,11 @@ func buildBaseMetadataOptions(cfg config.Config) api.UploadOptions {
 }
 
 func (b *Backend) applyConfig(cfg config.Config) error {
-	rt, err := guishared.BuildRuntime(context.Background(), cfg, b.repo)
+	rt, err := b.buildConfigRuntime(context.Background(), cfg)
 	if err != nil {
-		return fmt.Errorf("web: %w", err)
+		return err
 	}
-	oldCore, oldLogger := b.replaceRuntime(cfg, rt.Core, rt.Logger)
-	if oldCore != nil {
-		_ = oldCore.Close()
-	}
-	if oldLogger != nil {
-		_ = oldLogger.Close()
-	}
+	b.installConfigRuntime(cfg, rt)
 	return nil
 }
 

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -760,6 +760,8 @@ func (b *Backend) exportableConfig() (*config.Config, error) {
 	cfg, err := config.LoadFromDatabase(context.Background(), b.repo)
 	if err != nil {
 		if errors.Is(err, internalerrors.ErrNotFound) {
+			// Fresh web installs can run from embedded defaults before any config
+			// rows exist, so export the runtime config until the user saves setup.
 			cfg := b.currentConfig()
 			return normalizeExportableConfig(&cfg, b.currentConfig().MainSettings.DBPath), nil
 		}
@@ -768,6 +770,8 @@ func (b *Backend) exportableConfig() (*config.Config, error) {
 	return normalizeExportableConfig(cfg, b.currentConfig().MainSettings.DBPath), nil
 }
 
+// normalizeExportableConfig fills legacy nils and missing DB path values so
+// browser config consumers receive stable JSON shapes.
 func normalizeExportableConfig(cfg *config.Config, dbPath string) *config.Config {
 	if strings.TrimSpace(cfg.MainSettings.DBPath) == "" {
 		cfg.MainSettings.DBPath = dbPath

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -821,6 +821,8 @@ func normalizeExportableConfig(cfg *config.Config, dbPath string) (*config.Confi
 	return normalized, nil
 }
 
+// cloneConfigForExport deep-copies config through JSON so export
+// normalization cannot mutate the source snapshot.
 func cloneConfigForExport(cfg *config.Config) (*config.Config, error) {
 	payload, err := json.Marshal(cfg)
 	if err != nil {
@@ -980,6 +982,8 @@ func validateCookieAuthMaterial(dbPath string) error {
 	return nil
 }
 
+// buildConfigRuntime wraps shared runtime construction with web-specific error
+// context.
 func (b *Backend) buildConfigRuntime(ctx context.Context, cfg config.Config) (guishared.Runtime, error) {
 	rt, err := guishared.BuildRuntime(ctx, cfg, b.repo)
 	if err != nil {
@@ -988,6 +992,8 @@ func (b *Backend) buildConfigRuntime(ctx context.Context, cfg config.Config) (gu
 	return rt, nil
 }
 
+// installConfigRuntime swaps in a newly built runtime, rebinds event/log
+// streams, and closes the previous core and logger after replacement.
 func (b *Backend) installConfigRuntime(cfg config.Config, rt guishared.Runtime) {
 	oldCore, oldLogger := b.replaceRuntime(cfg, rt.Core, rt.Logger)
 	if b.hub != nil {
@@ -1002,6 +1008,7 @@ func (b *Backend) installConfigRuntime(cfg config.Config, rt guishared.Runtime) 
 	}
 }
 
+// closeBuiltRuntime closes a runtime that was built but not installed.
 func closeBuiltRuntime(rt guishared.Runtime) {
 	if rt.Core != nil {
 		_ = rt.Core.Close()
@@ -1121,6 +1128,8 @@ func (b *Backend) StartLogStream(sessionID string) (string, error) {
 	return streamID, nil
 }
 
+// startLogStreamWorker subscribes session to logger and forwards entries to
+// the browser event hub until the stream is stopped.
 func (b *Backend) startLogStreamWorker(session *backendLogStream, logger *logging.Logger) {
 	subID, ch := logger.Subscribe(0)
 	stop := session.stop
@@ -1250,6 +1259,8 @@ func (b *Backend) buildRunOptions(debug bool, noSeed bool, runLogLevel string) (
 	return runOptions{Debug: debug, NoSeed: noSeed, RunLogLevel: normalized}, nil
 }
 
+// buildRunCoreFromSnapshot creates a per-run core and logger from the same
+// runtime snapshot used to build upload options.
 func (b *Backend) buildRunCoreFromSnapshot(rt backendRuntimeSnapshot, opts runOptions) (api.Core, *logging.Logger, error) {
 	effectiveLogLevel := logging.ResolveEffectiveLevel(rt.cfg.Logging.Level, opts.RunLogLevel, opts.Debug)
 	logger, err := logging.NewWithLevel(rt.cfg.Logging, rt.cfg.MainSettings.DBPath, effectiveLogLevel)

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -759,10 +759,18 @@ func (b *Backend) exportableConfig() (*config.Config, error) {
 	}
 	cfg, err := config.LoadFromDatabase(context.Background(), b.repo)
 	if err != nil {
+		if errors.Is(err, internalerrors.ErrNotFound) {
+			cfg := b.currentConfig()
+			return normalizeExportableConfig(&cfg, b.currentConfig().MainSettings.DBPath), nil
+		}
 		return nil, fmt.Errorf("web: %w", err)
 	}
+	return normalizeExportableConfig(cfg, b.currentConfig().MainSettings.DBPath), nil
+}
+
+func normalizeExportableConfig(cfg *config.Config, dbPath string) *config.Config {
 	if strings.TrimSpace(cfg.MainSettings.DBPath) == "" {
-		cfg.MainSettings.DBPath = b.currentConfig().MainSettings.DBPath
+		cfg.MainSettings.DBPath = dbPath
 	}
 	if cfg.Trackers.Trackers == nil {
 		cfg.Trackers.Trackers = map[string]config.TrackerConfig{}
@@ -770,7 +778,7 @@ func (b *Backend) exportableConfig() (*config.Config, error) {
 	if cfg.Trackers.DefaultTrackers == nil {
 		cfg.Trackers.DefaultTrackers = config.CSVList{}
 	}
-	return cfg, nil
+	return cfg
 }
 
 func (b *Backend) allowUnencryptedExport() (bool, error) {

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -59,6 +59,8 @@ type Backend struct {
 	uploadMu sync.Mutex
 	uploads  map[string]*trackerUploadJob
 	uploadWG sync.WaitGroup
+
+	sharedCookieMigrator func(context.Context, string, api.Logger) error
 }
 
 type backendLogStream struct {
@@ -850,9 +852,10 @@ func (b *Backend) allowUnencryptedExport(dbPath string) (bool, error) {
 }
 
 // SaveConfig validates encrypted browser settings, builds the replacement
-// runtime, then syncs cookie encryption metadata and saves the non-env config.
-// Runtime build or save failures leave the persisted config and active runtime
-// unchanged; env overrides apply only to the installed runtime config.
+// runtime, persists the non-env config, then attempts shared cookie migration
+// before installing the runtime. Runtime build or save failures leave the
+// persisted config and active runtime unchanged; env overrides apply only to
+// the installed runtime config.
 func (b *Backend) SaveConfig(payload string) error {
 	if b.repo == nil {
 		return errors.New("config repository not initialized")
@@ -887,9 +890,10 @@ func (b *Backend) SaveConfig(payload string) error {
 const configImportMaxBytes = importer.MaxFileBytes
 
 // ImportConfig imports browser-uploaded config content, validates the saved and
-// env-applied runtime forms, builds the replacement runtime, then syncs cookie
-// encryption metadata and saves the non-env config. Runtime build or save
-// failures leave the persisted config and active runtime unchanged.
+// env-applied runtime forms, builds the replacement runtime, persists the
+// non-env config, then attempts shared cookie migration before installing the
+// runtime. Runtime build or save failures leave the persisted config and active
+// runtime unchanged.
 func (b *Backend) ImportConfig(fileName, fileContent string) (string, []string, error) {
 	if b.repo == nil {
 		return "", nil, errors.New("config repository not initialized")
@@ -931,9 +935,9 @@ func (b *Backend) ImportConfig(fileName, fileContent string) (string, []string, 
 }
 
 // saveAndApplyConfig builds the replacement runtime before any repository
-// writes, then persists cfg and installs the runtime as one ordered transition.
-// If persistence fails, the built runtime is closed and the active runtime is
-// left untouched.
+// writes, then persists cfg, attempts shared cookie migration, and installs the
+// runtime as one ordered transition. If persistence fails, the built runtime is
+// closed and the active runtime is left untouched.
 func (b *Backend) saveAndApplyConfig(ctx context.Context, cfg *config.Config, runtimeCfg config.Config, dbPath string) error {
 	if err := validateCookieAuthMaterial(dbPath); err != nil {
 		if !errors.Is(err, cookies.ErrAuthHelperUnavailable) {
@@ -949,12 +953,16 @@ func (b *Backend) saveAndApplyConfig(ctx context.Context, cfg *config.Config, ru
 		closeBuiltRuntime(rt)
 		return err
 	}
+	if err := b.ensureSharedCookieMigrationForRuntime(ctx, dbPath, rt.Logger); err != nil {
+		closeBuiltRuntime(rt)
+		return fmt.Errorf("web: cookie migration failed: %w", err)
+	}
 	b.installConfigRuntime(runtimeCfg, rt)
 	return nil
 }
 
-// saveConfigToRepository enforces the shared pre-save cookie encryption sync
-// before persisting browser config changes through the already-open repository.
+// saveConfigToRepository persists browser config changes through the already-open
+// repository.
 func (b *Backend) saveConfigToRepository(ctx context.Context, cfg *config.Config, dbPath string) error {
 	if err := configstore.SaveToRepository(ctx, cfg, b.repo, dbPath); err != nil {
 		return fmt.Errorf("web: %w", err)
@@ -990,6 +998,49 @@ func (b *Backend) buildConfigRuntime(ctx context.Context, cfg config.Config) (gu
 		return guishared.Runtime{}, fmt.Errorf("web: %w", err)
 	}
 	return rt, nil
+}
+
+// ensureSharedCookieMigration syncs cookie encryption metadata and migrates
+// legacy cookie files against the shared repository before SkipCookieMigration
+// runtimes serve uploads. Missing auth material is logged and treated as
+// retryable on a later settings save.
+func (b *Backend) ensureSharedCookieMigration(ctx context.Context, dbPath string, logger api.Logger) error {
+	if b.repo == nil {
+		return errors.New("repository not initialized")
+	}
+	if logger == nil {
+		logger = api.NopLogger{}
+	}
+	if err := cookies.SyncCookieEncryptionWithAuth(ctx, b.repo.RawDB(), dbPath); err != nil {
+		if errors.Is(err, cookies.ErrAuthHelperUnavailable) {
+			logger.Debugf("web: cookie encryption sync skipped: web auth helper unavailable")
+		} else {
+			return fmt.Errorf("cookies encryption sync: %w", err)
+		}
+	}
+
+	cookiesDir, err := db.CookiePath(dbPath, "")
+	if err != nil {
+		logger.Debugf("web: failed to resolve cookies directory: %v", err)
+		return nil
+	}
+	if err := cookies.EnsureCookieMigration(ctx, b.repo.RawDB(), dbPath, cookiesDir, logger); err != nil {
+		if errors.Is(err, cookies.ErrAuthHelperUnavailable) {
+			logger.Debugf("web: cookie migration skipped: web auth helper unavailable")
+			return nil
+		}
+		return fmt.Errorf("cookies migration: %w", err)
+	}
+	return nil
+}
+
+// ensureSharedCookieMigrationForRuntime runs the configured migration hook and
+// returns hard migration errors before the replacement runtime is installed.
+func (b *Backend) ensureSharedCookieMigrationForRuntime(ctx context.Context, dbPath string, logger api.Logger) error {
+	if b.sharedCookieMigrator != nil {
+		return b.sharedCookieMigrator(ctx, dbPath, logger)
+	}
+	return b.ensureSharedCookieMigration(ctx, dbPath, logger)
 }
 
 // installConfigRuntime swaps in a newly built runtime, rebinds event/log
@@ -1260,7 +1311,8 @@ func (b *Backend) buildRunOptions(debug bool, noSeed bool, runLogLevel string) (
 }
 
 // buildRunCoreFromSnapshot creates a per-run core and logger from the same
-// runtime snapshot used to build upload options.
+// runtime snapshot used to build upload options. The transient core skips
+// startup-only legacy cookie migration while sharing the backend repository.
 func (b *Backend) buildRunCoreFromSnapshot(rt backendRuntimeSnapshot, opts runOptions) (api.Core, *logging.Logger, error) {
 	effectiveLogLevel := logging.ResolveEffectiveLevel(rt.cfg.Logging.Level, opts.RunLogLevel, opts.Debug)
 	logger, err := logging.NewWithLevel(rt.cfg.Logging, rt.cfg.MainSettings.DBPath, effectiveLogLevel)
@@ -1273,7 +1325,8 @@ func (b *Backend) buildRunCoreFromSnapshot(rt backendRuntimeSnapshot, opts runOp
 		Services: api.ServiceSet{
 			Filesystem: filesystem.NewValidator(),
 		},
-		Repository: b.repo,
+		Repository:          b.repo,
+		SkipCookieMigration: true,
 	})
 	if err != nil {
 		_ = logger.Close()

--- a/internal/webserver/backend_repo_test.go
+++ b/internal/webserver/backend_repo_test.go
@@ -5,6 +5,7 @@ package webserver
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -132,6 +134,51 @@ func TestBackendGetLogExclusionsReturnsEmptySliceWhenMissing(t *testing.T) {
 	}
 	if len(patterns) != 0 {
 		t.Fatalf("expected no exclusions, got %#v", patterns)
+	}
+}
+
+func TestBackendGetConfigFallsBackToRuntimeConfigWhenDatabaseConfigMissing(t *testing.T) {
+	t.Parallel()
+
+	repoPath := filepath.Join(t.TempDir(), "backend-empty-config.db")
+	repo, err := db.OpenWithLogger(repoPath, nil)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repo: %v", err)
+	}
+
+	cfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("load embedded config: %v", err)
+	}
+	cfg.MainSettings.DBPath = repoPath
+	backend := &Backend{
+		cfg:  *cfg,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	payload, err := backend.GetConfig()
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	exported, err := config.ImportFromJSONEncrypted(payload)
+	if err != nil {
+		t.Fatalf("parse exported config: %v", err)
+	}
+	if exported.MainSettings.DBPath != repoPath {
+		t.Fatalf("DBPath: got %q want %q", exported.MainSettings.DBPath, repoPath)
+	}
+	if len(exported.Trackers.Trackers) == 0 {
+		t.Fatal("expected runtime tracker defaults in fallback config")
+	}
+	if _, loadErr := config.LoadFromDatabase(context.Background(), repo); !errors.Is(loadErr, internalerrors.ErrNotFound) {
+		t.Fatalf("fallback should not persist config rows, load err=%v", loadErr)
 	}
 }
 

--- a/internal/webserver/backend_repo_test.go
+++ b/internal/webserver/backend_repo_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/cookies"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/services/db"
@@ -537,7 +538,7 @@ func TestBackendRequestsUseSingleRuntimeSnapshot(t *testing.T) {
 	}
 }
 
-func TestBackendRunSingleTrackerUploadUsesJobRuntimeConfig(t *testing.T) {
+func TestBackendRunSingleTrackerUploadUsesJobUploadOptionsSnapshot(t *testing.T) {
 	t.Parallel()
 
 	errs := make(chan error, 1)
@@ -549,7 +550,7 @@ func TestBackendRunSingleTrackerUploadUsesJobRuntimeConfig(t *testing.T) {
 	backend := &Backend{cfg: currentCfg}
 	job := &trackerUploadJob{
 		sourcePath:           "C:\\releases\\Example.mkv",
-		cfg:                  jobCfg,
+		uploadOptions:        buildRunUploadOptions(jobCfg, runOptions{}),
 		runOptions:           runOptions{},
 		core:                 &backendSnapshotGuardCore{wantScreens: 1, errs: errs},
 		descriptionGroups:    nil,
@@ -689,6 +690,94 @@ func TestBackendSaveConfigAppliesRuntimeConfigImmediately(t *testing.T) {
 	options := buildRunUploadOptions(runtimeCfg, runOptions{})
 	if !options.SkipAutoTorrent || !options.KeepImages || options.Screens != 5 {
 		t.Fatalf("expected upload options from saved config, got %#v", options)
+	}
+}
+
+func TestBackendSaveConfigAfterInvalidStartupMigratesLegacyCookies(t *testing.T) {
+	t.Parallel()
+
+	repoPath := filepath.Join(t.TempDir(), "backend-save-invalid-startup-cookies.db")
+	if err := BootstrapAuthFile(repoPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("bootstrap auth file: %v", err)
+	}
+	legacyPath := writeBackendLegacyCookieFile(t, repoPath, "BLU", `{"session":"from-legacy"}`)
+
+	startupCfg := backendConfigTestConfig(repoPath)
+	startupCfg.MainSettings.TMDBAPI = ""
+	backend, err := NewBackend(startupCfg, newEventHub())
+	if err != nil {
+		t.Fatalf("new backend: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = backend.Close()
+	})
+	if backend.currentCore() != nil {
+		t.Fatal("expected invalid startup to leave core disabled")
+	}
+
+	repaired := backendConfigTestConfig(repoPath)
+	payload, err := config.ExportToJSON(&repaired)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+	if err := backend.SaveConfig(payload); err != nil {
+		t.Fatalf("save repaired config: %v", err)
+	}
+	if _, err := os.Stat(legacyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected legacy cookie file to be removed after migration, err=%v", err)
+	}
+	values, err := cookies.LoadTrackerCookieMap(context.Background(), repoPath, "BLU")
+	if err != nil {
+		t.Fatalf("load migrated tracker cookies: %v", err)
+	}
+	if got := values["session"]; got != "from-legacy" {
+		t.Fatalf("migrated session cookie: got %q want %q", got, "from-legacy")
+	}
+}
+
+func TestBackendSaveConfigRetriesLegacyCookieMigrationAfterAuthAppears(t *testing.T) {
+	t.Parallel()
+
+	repoPath := filepath.Join(t.TempDir(), "backend-save-cookie-retry.db")
+	legacyPath := writeBackendLegacyCookieFile(t, repoPath, "BLU", `{"session":"from-retry"}`)
+
+	startupCfg := backendConfigTestConfig(repoPath)
+	startupCfg.MainSettings.TMDBAPI = ""
+	backend, err := NewBackend(startupCfg, newEventHub())
+	if err != nil {
+		t.Fatalf("new backend: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = backend.Close()
+	})
+
+	repaired := backendConfigTestConfig(repoPath)
+	payload, err := config.ExportToJSON(&repaired)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+	if err := backend.SaveConfig(payload); err != nil {
+		t.Fatalf("save repaired config without auth: %v", err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("expected legacy cookie file to remain without auth helper: %v", err)
+	}
+
+	if err := BootstrapAuthFile(repoPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("bootstrap auth file: %v", err)
+	}
+	if err := backend.SaveConfig(payload); err != nil {
+		t.Fatalf("retry save repaired config: %v", err)
+	}
+	if _, err := os.Stat(legacyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected legacy cookie file to be removed after retry, err=%v", err)
+	}
+	values, err := cookies.LoadTrackerCookieMap(context.Background(), repoPath, "BLU")
+	if err != nil {
+		t.Fatalf("load migrated tracker cookies: %v", err)
+	}
+	if got := values["session"]; got != "from-retry" {
+		t.Fatalf("migrated session cookie after retry: got %q want %q", got, "from-retry")
 	}
 }
 
@@ -1080,6 +1169,82 @@ func TestBackendSaveConfigCookieSyncRollsBackWhenConfigSaveFails(t *testing.T) {
 	}
 }
 
+func TestBackendSaveConfigHardCookieMigrationErrorDoesNotInstallRuntime(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-save-cookie-migration-hard-error.db")
+	initial := backendConfigTestConfig(repoPath)
+	if err := config.SaveToDatabase(context.Background(), &initial, repo); err != nil {
+		t.Fatalf("save initial config: %v", err)
+	}
+	backend := &Backend{
+		cfg:  initial,
+		repo: repo,
+		hub:  newEventHub(),
+		sharedCookieMigrator: func(context.Context, string, api.Logger) error {
+			return errors.New("forced migration failure")
+		},
+	}
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	err = backend.SaveConfig(payload)
+	if err == nil {
+		t.Fatal("expected hard cookie migration error")
+	}
+	if !strings.Contains(err.Error(), "forced migration failure") {
+		t.Fatalf("expected forced migration failure, got %v", err)
+	}
+	assertStoredSkipAutoTorrent(t, repo, true)
+	if got := backend.currentConfig().Metadata.SkipAutoTorrent; got {
+		t.Fatal("expected runtime config not to be applied after hard migration failure")
+	}
+	if backend.currentCore() != nil {
+		t.Fatal("expected runtime core not to be installed after hard migration failure")
+	}
+}
+
+func TestBackendImportConfigHardCookieMigrationErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-import-cookie-migration-hard-error.db")
+	initial := backendConfigTestConfig(repoPath)
+	if err := config.SaveToDatabase(context.Background(), &initial, repo); err != nil {
+		t.Fatalf("save initial config: %v", err)
+	}
+	backend := &Backend{
+		cfg:  initial,
+		repo: repo,
+		hub:  newEventHub(),
+		sharedCookieMigrator: func(context.Context, string, api.Logger) error {
+			return errors.New("forced migration failure")
+		},
+	}
+
+	imported := initial
+	imported.Metadata.SkipAutoTorrent = true
+	content := exportConfigYAMLString(t, &imported)
+
+	_, _, err := backend.ImportConfig("config.yaml", content)
+	if err == nil {
+		t.Fatal("expected hard cookie migration error")
+	}
+	if !strings.Contains(err.Error(), "forced migration failure") {
+		t.Fatalf("expected forced migration failure, got %v", err)
+	}
+	if got := backend.currentConfig().Metadata.SkipAutoTorrent; got {
+		t.Fatal("expected runtime config not to be applied after imported hard migration failure")
+	}
+	if backend.currentCore() != nil {
+		t.Fatal("expected runtime core not to be installed after imported hard migration failure")
+	}
+}
+
 func TestBackendSaveConfigRepositoryRejectsAuthChangeAfterValidation(t *testing.T) {
 	t.Parallel()
 
@@ -1132,6 +1297,19 @@ func backendConfigTestConfig(repoPath string) config.Config {
 		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
 		Logging:            config.LoggingConfig{Level: "info"},
 	}
+}
+
+func writeBackendLegacyCookieFile(t *testing.T, repoPath, trackerID, payload string) string {
+	t.Helper()
+
+	legacyPath, err := db.CookiePath(repoPath, trackerID+".json")
+	if err != nil {
+		t.Fatalf("resolve legacy cookie path: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write legacy cookie file: %v", err)
+	}
+	return legacyPath
 }
 
 func exportConfigYAMLString(t *testing.T, cfg *config.Config) string {

--- a/internal/webserver/backend_repo_test.go
+++ b/internal/webserver/backend_repo_test.go
@@ -5,15 +5,19 @@ package webserver
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -182,6 +186,231 @@ func TestBackendGetConfigFallsBackToRuntimeConfigWhenDatabaseConfigMissing(t *te
 	}
 }
 
+func TestNormalizeExportableConfigDoesNotMutateSource(t *testing.T) {
+	t.Parallel()
+
+	source := config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: " \t "},
+		Trackers: config.TrackersConfig{
+			DefaultTrackers: config.CSVList{"AITHER"},
+			Trackers: map[string]config.TrackerConfig{
+				"AITHER": {APIKey: "source-token"},
+			},
+		},
+	}
+
+	normalized, err := normalizeExportableConfig(&source, "runtime.db")
+	if err != nil {
+		t.Fatalf("normalize config: %v", err)
+	}
+	defaults, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("load embedded defaults: %v", err)
+	}
+	for trackerName := range defaults.Trackers.Trackers {
+		if _, ok := normalized.Trackers.Trackers[trackerName]; !ok {
+			t.Fatalf("normalized config missing default tracker %q", trackerName)
+		}
+	}
+	if normalized.MainSettings.DBPath != "runtime.db" {
+		t.Fatalf("normalized DBPath: got %q want runtime.db", normalized.MainSettings.DBPath)
+	}
+	if source.MainSettings.DBPath != " \t " {
+		t.Fatalf("source DBPath mutated: got %q", source.MainSettings.DBPath)
+	}
+
+	tracker := normalized.Trackers.Trackers["AITHER"]
+	tracker.APIKey = "changed-token"
+	normalized.Trackers.Trackers["AITHER"] = tracker
+	normalized.Trackers.DefaultTrackers[0] = "BTN"
+
+	if got := source.Trackers.Trackers["AITHER"].APIKey; got != "source-token" {
+		t.Fatalf("source tracker map mutated: got %q", got)
+	}
+	if got := source.Trackers.DefaultTrackers[0]; got != "AITHER" {
+		t.Fatalf("source default tracker slice mutated: got %q", got)
+	}
+
+	nilSource := config.Config{}
+	nilNormalized, err := normalizeExportableConfig(&nilSource, "runtime.db")
+	if err != nil {
+		t.Fatalf("normalize nil trackers: %v", err)
+	}
+	if nilNormalized.Trackers.Trackers == nil {
+		t.Fatal("expected normalized tracker map")
+	}
+	if nilNormalized.Trackers.DefaultTrackers == nil {
+		t.Fatal("expected normalized default tracker list")
+	}
+	if nilSource.Trackers.Trackers != nil {
+		t.Fatal("source tracker map mutated from nil")
+	}
+	if nilSource.Trackers.DefaultTrackers != nil {
+		t.Fatal("source default tracker list mutated from nil")
+	}
+}
+
+func TestBackendGetConfigFallbackUsesSingleRuntimeSnapshot(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	repoPath := filepath.Join(tempDir, "backend-empty-snapshot.db")
+	repo, err := db.OpenWithLogger(repoPath, nil)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repo: %v", err)
+	}
+
+	pathA := filepath.Join(tempDir, "runtime-a.db")
+	pathB := filepath.Join(tempDir, "runtime-b.db")
+	cfgA := config.Config{
+		MainSettings:       config.MainSettingsConfig{DBPath: pathA},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+	}
+	cfgB := config.Config{
+		MainSettings:       config.MainSettingsConfig{DBPath: pathB},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 2},
+	}
+	backend := &Backend{
+		cfg:  cfgA,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				backend.replaceRuntime(cfgA, nil, nil)
+				backend.replaceRuntime(cfgB, nil, nil)
+			}
+		}
+	})
+	defer func() {
+		close(stop)
+		wg.Wait()
+	}()
+
+	for range 2000 {
+		payload, err := backend.GetConfig()
+		if err != nil {
+			t.Fatalf("get config: %v", err)
+		}
+		exported, err := config.ImportFromJSONEncrypted(payload)
+		if err != nil {
+			t.Fatalf("parse exported config: %v", err)
+		}
+		switch exported.MainSettings.DBPath {
+		case pathA:
+			if exported.ScreenshotHandling.Screens != cfgA.ScreenshotHandling.Screens {
+				t.Fatalf("mixed fallback snapshot for %q: screens=%d", pathA, exported.ScreenshotHandling.Screens)
+			}
+		case pathB:
+			if exported.ScreenshotHandling.Screens != cfgB.ScreenshotHandling.Screens {
+				t.Fatalf("mixed fallback snapshot for %q: screens=%d", pathB, exported.ScreenshotHandling.Screens)
+			}
+		default:
+			t.Fatalf("unexpected fallback DBPath %q", exported.MainSettings.DBPath)
+		}
+	}
+	if _, loadErr := config.LoadFromDatabase(context.Background(), repo); !errors.Is(loadErr, internalerrors.ErrNotFound) {
+		t.Fatalf("fallback should not persist config rows, load err=%v", loadErr)
+	}
+}
+
+func TestBackendGetConfigDatabaseConfigUsesSingleRuntimeSnapshotForDBPath(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	repoPath := filepath.Join(tempDir, "backend-db-snapshot.db")
+	repo, err := db.OpenWithLogger(repoPath, nil)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repo: %v", err)
+	}
+
+	stored := config.Config{
+		MainSettings:       config.MainSettingsConfig{TMDBAPI: "stored"},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 9},
+		Logging:            config.LoggingConfig{Level: "info"},
+	}
+	if err := config.SaveToDatabase(context.Background(), &stored, repo); err != nil {
+		t.Fatalf("save stored config: %v", err)
+	}
+
+	pathA := filepath.Join(tempDir, "runtime-a.db")
+	pathB := filepath.Join(tempDir, "runtime-b.db")
+	cfgA := config.Config{
+		MainSettings:       config.MainSettingsConfig{TMDBAPI: "runtime-a", DBPath: pathA},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+		Logging:            config.LoggingConfig{Level: "info"},
+	}
+	cfgB := config.Config{
+		MainSettings:       config.MainSettingsConfig{TMDBAPI: "runtime-b", DBPath: pathB},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 2},
+		Logging:            config.LoggingConfig{Level: "info"},
+	}
+	backend := &Backend{
+		cfg:  cfgA,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				backend.replaceRuntime(cfgA, nil, nil)
+				backend.replaceRuntime(cfgB, nil, nil)
+			}
+		}
+	})
+	defer func() {
+		close(stop)
+		wg.Wait()
+	}()
+
+	for range 2000 {
+		payload, err := backend.GetConfig()
+		if err != nil {
+			t.Fatalf("get config: %v", err)
+		}
+		exported, err := config.ImportFromJSONEncrypted(payload)
+		if err != nil {
+			t.Fatalf("parse exported config: %v", err)
+		}
+		if exported.ScreenshotHandling.Screens != stored.ScreenshotHandling.Screens {
+			t.Fatalf("expected DB-loaded screens=%d, got %d", stored.ScreenshotHandling.Screens, exported.ScreenshotHandling.Screens)
+		}
+		if exported.MainSettings.TMDBAPI != stored.MainSettings.TMDBAPI {
+			t.Fatalf("expected DB-loaded TMDB API, got %q", exported.MainSettings.TMDBAPI)
+		}
+		switch exported.MainSettings.DBPath {
+		case pathA, pathB:
+		default:
+			t.Fatalf("unexpected DBPath fallback %q", exported.MainSettings.DBPath)
+		}
+	}
+}
+
 func TestBackendFetchMetadataPropagatesSkipAutoTorrentSetting(t *testing.T) {
 	t.Parallel()
 
@@ -201,6 +430,202 @@ func TestBackendFetchMetadataPropagatesSkipAutoTorrentSetting(t *testing.T) {
 	}
 	if !coreSvc.fetchReq.Options.SkipAutoTorrent {
 		t.Fatalf("expected skip_auto_torrent request option, got %#v", coreSvc.fetchReq.Options)
+	}
+}
+
+type backendSnapshotGuardCore struct {
+	preparedMetaTestCore
+	wantScreens int
+	errs        chan<- error
+}
+
+func (c *backendSnapshotGuardCore) check(req api.Request, method string) {
+	if req.Options.Screens != c.wantScreens {
+		select {
+		case c.errs <- errors.New(method + " used mismatched runtime options"):
+		default:
+		}
+	}
+}
+
+func (c *backendSnapshotGuardCore) FetchMetadataPreview(_ context.Context, req api.Request) (api.MetadataPreview, error) {
+	c.check(req, "FetchMetadataPreview")
+	return api.MetadataPreview{}, nil
+}
+
+func (c *backendSnapshotGuardCore) ListUploadCandidates(_ context.Context, req api.Request) ([]api.ScreenshotImage, error) {
+	c.check(req, "ListUploadCandidates")
+	return nil, nil
+}
+
+func (c *backendSnapshotGuardCore) ListUploadedImages(_ context.Context, req api.Request) ([]api.UploadedImageLink, error) {
+	c.check(req, "ListUploadedImages")
+	return nil, nil
+}
+
+func (c *backendSnapshotGuardCore) UploadImages(_ context.Context, req api.Request, _ string, _ []api.ScreenshotImage) (api.UploadImagesResult, error) {
+	c.check(req, "UploadImages")
+	return api.UploadImagesResult{}, nil
+}
+
+func (c *backendSnapshotGuardCore) RunUploadPrepared(_ context.Context, req api.Request) (api.Result, error) {
+	c.check(req, "RunUploadPrepared")
+	return api.Result{}, nil
+}
+
+func (c *backendSnapshotGuardCore) ExportGUICachedPreparedMeta(_ context.Context, req api.Request) (api.PreparedMetadata, bool, error) {
+	c.check(req, "ExportGUICachedPreparedMeta")
+	return api.PreparedMetadata{}, false, nil
+}
+
+func TestBackendRequestsUseSingleRuntimeSnapshot(t *testing.T) {
+	t.Parallel()
+
+	errs := make(chan error, 1)
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-runtime-snapshot.db")
+	cfgA := backendConfigTestConfig(repoPath)
+	cfgA.ScreenshotHandling.Screens = 1
+	cfgB := cfgA
+	cfgB.ScreenshotHandling.Screens = 2
+	backend := &Backend{
+		cfg:  cfgA,
+		core: &backendSnapshotGuardCore{wantScreens: 1, errs: errs},
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if i%2 == 0 {
+				backend.replaceRuntime(cfgB, &backendSnapshotGuardCore{wantScreens: 2, errs: errs}, nil)
+			} else {
+				backend.replaceRuntime(cfgA, &backendSnapshotGuardCore{wantScreens: 1, errs: errs}, nil)
+			}
+		}
+	})
+	t.Cleanup(func() {
+		close(stop)
+		wg.Wait()
+	})
+
+	for range 200 {
+		if _, err := backend.FetchMetadata("session", "C:\\releases\\Example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil, false); err != nil {
+			t.Fatalf("fetch metadata: %v", err)
+		}
+		if _, err := backend.UploadImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil, "host", []api.ScreenshotImage{{Path: "image.jpg"}}); err != nil {
+			t.Fatalf("upload images: %v", err)
+		}
+		if _, err := backend.ListUploadCandidates("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}); err != nil {
+			t.Fatalf("list upload candidates: %v", err)
+		}
+		if _, err := backend.ListUploadedImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}); err != nil {
+			t.Fatalf("list uploaded images: %v", err)
+		}
+		_, _ = backend.FetchTrackerDryRun("session", "C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil, nil, nil, nil, false, false, "")
+		select {
+		case err := <-errs:
+			t.Fatal(err)
+		default:
+		}
+	}
+}
+
+func TestBackendRunSingleTrackerUploadUsesJobRuntimeConfig(t *testing.T) {
+	t.Parallel()
+
+	errs := make(chan error, 1)
+	repoPath := filepath.Join(t.TempDir(), "web-upload-job.db")
+	jobCfg := backendConfigTestConfig(repoPath)
+	jobCfg.ScreenshotHandling.Screens = 1
+	currentCfg := jobCfg
+	currentCfg.ScreenshotHandling.Screens = 2
+	backend := &Backend{cfg: currentCfg}
+	job := &trackerUploadJob{
+		sourcePath:           "C:\\releases\\Example.mkv",
+		cfg:                  jobCfg,
+		runOptions:           runOptions{},
+		core:                 &backendSnapshotGuardCore{wantScreens: 1, errs: errs},
+		descriptionGroups:    nil,
+		trackers:             []string{"BTN"},
+		questionnaireAnswers: map[string]map[string]string{},
+	}
+
+	if _, err := backend.runSingleTrackerUpload(context.Background(), job, "BTN"); err != nil {
+		t.Fatalf("run single tracker upload: %v", err)
+	}
+	select {
+	case err := <-errs:
+		t.Fatal(err)
+	default:
+	}
+}
+
+func TestBackendSaveConfigAcceptsSameDatabasePathAlias(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-save-dbpath-alias.db")
+	initial := backendConfigTestConfig(repoPath)
+	backend := &Backend{
+		cfg:  initial,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+	t.Cleanup(func() {
+		if coreSvc := backend.currentCore(); coreSvc != nil {
+			_ = coreSvc.Close()
+		}
+		if logger := backend.currentLogger(); logger != nil {
+			_ = logger.Close()
+		}
+	})
+
+	updated := initial
+	updated.MainSettings.DBPath = filepath.Dir(repoPath) + string(filepath.Separator) + "." + string(filepath.Separator) + filepath.Base(repoPath)
+	updated.Metadata.SkipAutoTorrent = true
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	if err := backend.SaveConfig(payload); err != nil {
+		t.Fatalf("save config with DBPath alias: %v", err)
+	}
+	if got := backend.currentConfig().MainSettings.DBPath; got != repoPath {
+		t.Fatalf("runtime DBPath: got %q want %q", got, repoPath)
+	}
+}
+
+func TestBackendSaveConfigRejectsDifferentDatabasePath(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-save-dbpath-change.db")
+	initial := backendConfigTestConfig(repoPath)
+	backend := &Backend{
+		cfg:  initial,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	updated := initial
+	updated.MainSettings.DBPath = filepath.Join(t.TempDir(), "different.db")
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	err = backend.SaveConfig(payload)
+	if err == nil {
+		t.Fatal("expected DBPath change rejection")
+	}
+	if !strings.Contains(err.Error(), "requires restart") {
+		t.Fatalf("expected restart error, got %v", err)
 	}
 }
 
@@ -267,6 +692,146 @@ func TestBackendSaveConfigAppliesRuntimeConfigImmediately(t *testing.T) {
 	}
 }
 
+func TestBackendLogStreamContinuesAcrossSaveConfigRuntimeReplacement(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-save-log-stream.db")
+	initial := backendConfigTestConfig(repoPath)
+	initialLogger, err := logging.New(initial.Logging, repoPath)
+	if err != nil {
+		t.Fatalf("new logger: %v", err)
+	}
+	backend := &Backend{
+		cfg:     initial,
+		logger:  initialLogger,
+		repo:    repo,
+		hub:     newEventHub(),
+		streams: make(map[string]*backendLogStream),
+	}
+	t.Cleanup(func() {
+		backend.stopAllLogStreams()
+		if coreSvc := backend.currentCore(); coreSvc != nil {
+			_ = coreSvc.Close()
+		}
+		if logger := backend.currentLogger(); logger != nil {
+			_ = logger.Close()
+		}
+	})
+	events, unsubscribe := backend.hub.Subscribe("session-save")
+	t.Cleanup(unsubscribe)
+
+	streamID, err := backend.StartLogStream("session-save")
+	if err != nil {
+		t.Fatalf("start log stream: %v", err)
+	}
+	initialLogger.Infof("before save")
+	expectLogStreamMessage(t, events, streamID, "before save")
+
+	updated := initial
+	updated.ScreenshotHandling.Screens = 3
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+	if err := backend.SaveConfig(payload); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	if backend.currentLogger() == initialLogger {
+		t.Fatal("expected save config to replace logger")
+	}
+
+	drainLogStreamEvents(events)
+	initialLogger.Infof("stale after save")
+	assertNoLogStreamEvent(t, events, "old logger should be unsubscribed after save rebind")
+	backend.currentLogger().Infof("after save")
+	expectLogStreamMessage(t, events, streamID, "after save")
+}
+
+func TestBackendStartLogStreamRejectsNilHubWithoutRegisteringStream(t *testing.T) {
+	t.Parallel()
+
+	logger, err := logging.New(config.LoggingConfig{Level: "info"}, filepath.Join(t.TempDir(), "nil-hub-log-stream.db"))
+	if err != nil {
+		t.Fatalf("new logger: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.Close()
+	})
+	backend := &Backend{
+		logger:  logger,
+		streams: make(map[string]*backendLogStream),
+	}
+
+	streamID, err := backend.StartLogStream("session-nil-hub")
+	if err == nil {
+		t.Fatal("expected nil hub error")
+	}
+	if !strings.Contains(err.Error(), "event hub not initialized") {
+		t.Fatalf("expected event hub error, got %v", err)
+	}
+	if streamID != "" {
+		t.Fatalf("expected empty stream ID, got %q", streamID)
+	}
+	backend.streamMu.Lock()
+	streamCount := len(backend.streams)
+	backend.streamMu.Unlock()
+	if streamCount != 0 {
+		t.Fatalf("expected no registered streams, got %d", streamCount)
+	}
+}
+
+func TestBackendLogStreamContinuesAcrossImportConfigRuntimeReplacement(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-import-log-stream.db")
+	initial := backendConfigTestConfig(repoPath)
+	initialLogger, err := logging.New(initial.Logging, repoPath)
+	if err != nil {
+		t.Fatalf("new logger: %v", err)
+	}
+	backend := &Backend{
+		cfg:     initial,
+		logger:  initialLogger,
+		repo:    repo,
+		hub:     newEventHub(),
+		streams: make(map[string]*backendLogStream),
+	}
+	t.Cleanup(func() {
+		backend.stopAllLogStreams()
+		if coreSvc := backend.currentCore(); coreSvc != nil {
+			_ = coreSvc.Close()
+		}
+		if logger := backend.currentLogger(); logger != nil {
+			_ = logger.Close()
+		}
+	})
+	events, unsubscribe := backend.hub.Subscribe("session-import")
+	t.Cleanup(unsubscribe)
+
+	streamID, err := backend.StartLogStream("session-import")
+	if err != nil {
+		t.Fatalf("start log stream: %v", err)
+	}
+	initialLogger.Infof("before import")
+	expectLogStreamMessage(t, events, streamID, "before import")
+
+	imported := initial
+	imported.ScreenshotHandling.Screens = 4
+	content := exportConfigYAMLString(t, &imported)
+	if _, _, err := backend.ImportConfig("config.yaml", content); err != nil {
+		t.Fatalf("import config: %v", err)
+	}
+	if backend.currentLogger() == initialLogger {
+		t.Fatal("expected import config to replace logger")
+	}
+
+	drainLogStreamEvents(events)
+	initialLogger.Infof("stale after import")
+	assertNoLogStreamEvent(t, events, "old logger should be unsubscribed after import rebind")
+	backend.currentLogger().Infof("after import")
+	expectLogStreamMessage(t, events, streamID, "after import")
+}
+
 func TestBackendSaveConfigRejectsInvalidEnvRuntimeConfig(t *testing.T) {
 	t.Setenv("UA_DEFAULT_SCREENS", "0")
 
@@ -315,6 +880,381 @@ func TestBackendSaveConfigRejectsInvalidEnvRuntimeConfig(t *testing.T) {
 	}
 	if _, loadErr := config.LoadFromDatabase(context.Background(), repo); loadErr == nil {
 		t.Fatal("expected invalid runtime config to be rejected before database save")
+	}
+}
+
+func TestBackendSaveConfigBuildRuntimeFailureDoesNotPersist(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-save-build-failure.db")
+	initial := backendConfigTestConfig(repoPath)
+	if err := config.SaveToDatabase(context.Background(), &initial, repo); err != nil {
+		t.Fatalf("save initial config: %v", err)
+	}
+	backend := &Backend{
+		cfg:  initial,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	updated.Logging.FileEnabled = true
+	updated.Logging.MaxTotalSizeMB = 1
+	updated.Logging.MaxFiles = 1
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+	blockBackendLogDir(t, repoPath)
+
+	err = backend.SaveConfig(payload)
+	if err == nil {
+		t.Fatal("expected runtime build failure")
+	}
+
+	assertStoredSkipAutoTorrent(t, repo, false)
+	if got := backend.currentConfig().Metadata.SkipAutoTorrent; got {
+		t.Fatal("expected runtime config to remain unchanged")
+	}
+	if backend.currentCore() != nil {
+		t.Fatal("expected runtime core not to be rebuilt")
+	}
+}
+
+func TestBackendImportConfigBuildRuntimeFailureDoesNotPersist(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-import-build-failure.db")
+	initial := backendConfigTestConfig(repoPath)
+	if err := config.SaveToDatabase(context.Background(), &initial, repo); err != nil {
+		t.Fatalf("save initial config: %v", err)
+	}
+	backend := &Backend{
+		cfg:  initial,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	imported := initial
+	imported.Metadata.SkipAutoTorrent = true
+	imported.Logging.FileEnabled = true
+	imported.Logging.MaxTotalSizeMB = 1
+	imported.Logging.MaxFiles = 1
+	content := exportConfigYAMLString(t, &imported)
+	blockBackendLogDir(t, repoPath)
+
+	_, _, err := backend.ImportConfig("config.yaml", content)
+	if err == nil {
+		t.Fatal("expected runtime build failure")
+	}
+
+	assertStoredSkipAutoTorrent(t, repo, false)
+	if got := backend.currentConfig().Metadata.SkipAutoTorrent; got {
+		t.Fatal("expected runtime config to remain unchanged")
+	}
+	if backend.currentCore() != nil {
+		t.Fatal("expected runtime core not to be rebuilt")
+	}
+}
+
+func TestBackendSaveConfigMalformedWebAuthFailsBeforeConfigSave(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-save-malformed-auth.db")
+	initial := backendConfigTestConfig(repoPath)
+	backend := &Backend{
+		cfg:  initial,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+	if err := os.WriteFile(AuthFilePath(repoPath), []byte(`{`), 0o600); err != nil {
+		t.Fatalf("write malformed auth file: %v", err)
+	}
+
+	err = backend.SaveConfig(payload)
+	if err == nil {
+		t.Fatal("expected malformed web auth to fail before save")
+	}
+
+	assertFailedConfigSaveRowsAbsent(t, repo)
+	if got := backend.currentConfig().Metadata.SkipAutoTorrent; got {
+		t.Fatal("expected runtime config not to be applied after failed auth sync")
+	}
+}
+
+func TestBackendImportConfigMalformedWebAuthFailsBeforeConfigSave(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-import-malformed-auth.db")
+	initial := backendConfigTestConfig(repoPath)
+	backend := &Backend{
+		cfg:  initial,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	imported := initial
+	imported.Metadata.SkipAutoTorrent = true
+	content := exportConfigYAMLString(t, &imported)
+	if err := os.WriteFile(AuthFilePath(repoPath), []byte(`{`), 0o600); err != nil {
+		t.Fatalf("write malformed auth file: %v", err)
+	}
+
+	_, _, err := backend.ImportConfig("config.yaml", content)
+	if err == nil {
+		t.Fatal("expected malformed web auth to fail before imported config save")
+	}
+
+	assertFailedConfigSaveRowsAbsent(t, repo)
+	if got := backend.currentConfig().Metadata.SkipAutoTorrent; got {
+		t.Fatal("expected runtime config not to be applied after failed auth sync")
+	}
+}
+
+func TestBackendSaveConfigSyncsUsableWebAuthBeforeSave(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-save-usable-auth.db")
+	if err := BootstrapAuthFile(repoPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	initial := backendConfigTestConfig(repoPath)
+	backend := &Backend{
+		cfg:  initial,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	if err := backend.SaveConfig(payload); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	assertCookieAuthStatePresent(t, repo)
+}
+
+func TestBackendSaveConfigCookieSyncRollsBackWhenConfigSaveFails(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-save-cookie-rollback.db")
+	if err := BootstrapAuthFile(repoPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	installBackendFailMainSettingsTrigger(t, repo)
+	initial := backendConfigTestConfig(repoPath)
+	backend := &Backend{
+		cfg:  initial,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	err = backend.SaveConfig(payload)
+	if err == nil {
+		t.Fatal("expected save config to fail")
+	}
+
+	assertFailedConfigSaveRowsAbsent(t, repo)
+	if got := backend.currentConfig().Metadata.SkipAutoTorrent; got {
+		t.Fatal("expected runtime config not to be applied after failed config save")
+	}
+}
+
+func TestBackendSaveConfigRepositoryRejectsAuthChangeAfterValidation(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-save-auth-drift.db")
+	if err := BootstrapAuthFile(repoPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := validateCookieAuthMaterial(repoPath); err != nil {
+		t.Fatalf("prevalidate auth material: %v", err)
+	}
+	if err := os.WriteFile(AuthFilePath(repoPath), []byte(`{`), 0o600); err != nil {
+		t.Fatalf("replace auth file: %v", err)
+	}
+	initial := backendConfigTestConfig(repoPath)
+	backend := &Backend{
+		cfg:  initial,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	err := backend.saveConfigToRepository(context.Background(), &updated, repoPath)
+	if err == nil {
+		t.Fatal("expected auth drift to malformed helper to fail")
+	}
+	assertFailedConfigSaveRowsAbsent(t, repo)
+}
+
+func openBackendConfigTestRepo(t *testing.T, name string) (*db.SQLiteRepository, string) {
+	t.Helper()
+
+	repoPath := filepath.Join(t.TempDir(), name)
+	repo, err := db.OpenWithLogger(repoPath, nil)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repo: %v", err)
+	}
+	return repo, repoPath
+}
+
+func backendConfigTestConfig(repoPath string) config.Config {
+	return config.Config{
+		MainSettings:       config.MainSettingsConfig{TMDBAPI: "x", DBPath: repoPath},
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+		Logging:            config.LoggingConfig{Level: "info"},
+	}
+}
+
+func exportConfigYAMLString(t *testing.T, cfg *config.Config) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := config.ExportToYAML(cfg, path); err != nil {
+		t.Fatalf("export config yaml: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config yaml: %v", err)
+	}
+	return string(raw)
+}
+
+func assertFailedConfigSaveRowsAbsent(t *testing.T, repo *db.SQLiteRepository) {
+	t.Helper()
+
+	for _, section := range []string{
+		"MainSettings",
+		"cookies_encryption_salt",
+		"cookies_encryption_auth_state",
+	} {
+		var data string
+		err := repo.RawDB().QueryRowContext(context.Background(),
+			`SELECT data FROM config_settings WHERE section = ?`,
+			section,
+		).Scan(&data)
+		if !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("expected %s to be absent after failed sync, got row=%q err=%v", section, data, err)
+		}
+	}
+}
+
+func expectLogStreamMessage(t *testing.T, events <-chan serverEvent, streamID string, want string) {
+	t.Helper()
+
+	select {
+	case event := <-events:
+		if event.Name != "log:stream:"+streamID {
+			t.Fatalf("event name: got %q want %q", event.Name, "log:stream:"+streamID)
+		}
+		var entry logging.Entry
+		if err := json.Unmarshal(event.Data, &entry); err != nil {
+			t.Fatalf("decode log entry: %v", err)
+		}
+		if entry.Message != want {
+			t.Fatalf("log message: got %q want %q", entry.Message, want)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("timed out waiting for log stream message %q", want)
+	}
+}
+
+func assertNoLogStreamEvent(t *testing.T, events <-chan serverEvent, reason string) {
+	t.Helper()
+
+	select {
+	case event := <-events:
+		t.Fatalf("%s: unexpected event %q", reason, event.Name)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func drainLogStreamEvents(events <-chan serverEvent) {
+	for {
+		select {
+		case <-events:
+		default:
+			return
+		}
+	}
+}
+
+func assertStoredSkipAutoTorrent(t *testing.T, repo *db.SQLiteRepository, want bool) {
+	t.Helper()
+
+	stored, err := config.LoadFromDatabase(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("load stored config: %v", err)
+	}
+	if got := stored.Metadata.SkipAutoTorrent; got != want {
+		t.Fatalf("stored skip_auto_torrent: got %t want %t", got, want)
+	}
+}
+
+func blockBackendLogDir(t *testing.T, dbPath string) {
+	t.Helper()
+
+	logDir := filepath.Join(filepath.Dir(dbPath), "logs")
+	if err := os.WriteFile(logDir, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("block log dir: %v", err)
+	}
+}
+
+func assertCookieAuthStatePresent(t *testing.T, repo *db.SQLiteRepository) {
+	t.Helper()
+
+	var authState string
+	if err := repo.RawDB().QueryRowContext(context.Background(),
+		`SELECT data FROM config_settings WHERE section = ?`,
+		"cookies_encryption_auth_state",
+	).Scan(&authState); err != nil {
+		t.Fatalf("query cookie auth state: %v", err)
+	}
+	if !strings.Contains(authState, "fingerprint") {
+		t.Fatalf("expected synced cookie auth fingerprint, got %s", authState)
+	}
+}
+
+func installBackendFailMainSettingsTrigger(t *testing.T, repo *db.SQLiteRepository) {
+	t.Helper()
+
+	if _, err := repo.RawDB().ExecContext(context.Background(), `
+		CREATE TRIGGER fail_main_settings_save
+		BEFORE INSERT ON config_settings
+		WHEN NEW.section = 'MainSettings'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced main settings failure');
+		END
+	`); err != nil {
+		t.Fatalf("create failure trigger: %v", err)
 	}
 }
 
@@ -408,5 +1348,100 @@ func TestBackendExportConfigRespectsAllowUnencryptedExport(t *testing.T) {
 				t.Fatalf("GetConfig encrypted marker presence = %t, want %t; payload=%s", got, tc.expectGetConfigEncrypted, editingPayload)
 			}
 		})
+	}
+}
+
+func TestBackendExportConfigAuthorizesAgainstExportSnapshotDBPath(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openBackendConfigTestRepo(t, "backend-export-snapshot-auth.db")
+	tempDir := filepath.Dir(repoPath)
+	pathA := filepath.Join(tempDir, "runtime-a", "state.db")
+	pathB := filepath.Join(tempDir, "runtime-b", "state.db")
+	writeBackendAuthFile(t, pathA, false)
+	writeBackendAuthFile(t, pathB, true)
+
+	cfgA := backendConfigTestConfig(pathA)
+	cfgA.MainSettings.TMDBAPI = "snapshot-secret-a"
+	cfgB := backendConfigTestConfig(pathB)
+	cfgB.MainSettings.TMDBAPI = "snapshot-secret-b"
+	if err := config.SaveToDatabase(context.Background(), &cfgB, repo); err != nil {
+		t.Fatalf("save stored config: %v", err)
+	}
+	backend := &Backend{
+		cfg:  cfgA,
+		repo: repo,
+		hub:  newEventHub(),
+	}
+
+	snapshotCfg, authDBPath, err := backend.exportableConfig()
+	if err != nil {
+		t.Fatalf("exportable config: %v", err)
+	}
+	if snapshotCfg.MainSettings.DBPath != pathB {
+		t.Fatalf("snapshot DBPath: got %q want %q", snapshotCfg.MainSettings.DBPath, pathB)
+	}
+	if authDBPath != pathB {
+		t.Fatalf("auth DBPath: got %q want %q", authDBPath, pathB)
+	}
+
+	backend.replaceRuntime(cfgA, nil, nil)
+	allowPlaintext, err := backend.allowUnencryptedExport(authDBPath)
+	if err != nil {
+		t.Fatalf("allow unencrypted export: %v", err)
+	}
+	if !allowPlaintext {
+		t.Fatal("expected plaintext export to remain authorized by snapshot DBPath after runtime replacement")
+	}
+
+	payload, err := backend.ExportConfig()
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+	if !strings.Contains(payload, "snapshot-secret-b") {
+		t.Fatalf("expected plaintext stored snapshot secret in export, payload=%s", payload)
+	}
+	if strings.Contains(payload, "snapshot-secret-a") {
+		t.Fatalf("export used runtime secret, payload=%s", payload)
+	}
+
+	editingPayload, err := backend.GetConfig()
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	if !strings.Contains(editingPayload, "upbrr-enc:v1:") {
+		t.Fatalf("GetConfig should remain encrypted, payload=%s", editingPayload)
+	}
+}
+
+func TestBackendAllowUnencryptedExportMalformedAuthReturnsError(t *testing.T) {
+	t.Parallel()
+
+	repoPath := filepath.Join(t.TempDir(), "malformed-auth.db")
+	if err := os.WriteFile(AuthFilePath(repoPath), []byte(`{`), 0o600); err != nil {
+		t.Fatalf("write malformed auth file: %v", err)
+	}
+
+	allowPlaintext, err := (&Backend{}).allowUnencryptedExport(repoPath)
+	if err == nil {
+		t.Fatal("expected malformed web auth to return an error")
+	}
+	if allowPlaintext {
+		t.Fatal("malformed web auth must not allow plaintext export")
+	}
+}
+
+func writeBackendAuthFile(t *testing.T, dbPath string, allowUnencryptedExport bool) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	authJSON := `{"username":"tester","password_hash":"hash","encryption_key_seed":"seed","allow_unencrypted_export":false}`
+	if allowUnencryptedExport {
+		authJSON = `{"username":"tester","password_hash":"hash","encryption_key_seed":"seed","allow_unencrypted_export":true}`
+	}
+	if err := os.WriteFile(AuthFilePath(dbPath), []byte(authJSON), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
 	}
 }

--- a/internal/webserver/jobs.go
+++ b/internal/webserver/jobs.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/guishared"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -115,6 +116,7 @@ type trackerUploadJob struct {
 	sessionID            string
 	id                   string
 	sourcePath           string
+	cfg                  config.Config
 	runOptions           runOptions
 	core                 api.Core
 	logger               interface{ Close() error }
@@ -405,7 +407,8 @@ func (j *trackerUploadJob) closeResources() {
 // trackers and returns its job ID. Snapshots preserve partial upload counts
 // returned with later tracker errors or cancellation.
 func (b *Backend) StartTrackerUpload(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (string, error) {
-	if err := b.requireCore(); err != nil {
+	rt, err := b.requireRuntime()
+	if err != nil {
 		return "", err
 	}
 	trimmedPath := strings.TrimSpace(path)
@@ -420,7 +423,7 @@ func (b *Backend) StartTrackerUpload(sessionID string, path string, overrides ap
 	if err != nil {
 		return "", err
 	}
-	runCore, runLogger, err := b.buildRunCore(runOpts)
+	runCore, runLogger, err := b.buildRunCoreFromSnapshot(rt, runOpts)
 	if err != nil {
 		return "", err
 	}
@@ -435,7 +438,7 @@ func (b *Backend) StartTrackerUpload(sessionID string, path string, overrides ap
 	}
 	seedCtx, cancel := context.WithTimeout(context.Background(), seedPreparedMetaTimeout)
 	defer cancel()
-	if err := guishared.SeedRunCorePreparedMeta(seedCtx, b.currentCore(), runCore, seedReq); err != nil {
+	if err := guishared.SeedRunCorePreparedMeta(seedCtx, rt.core, runCore, seedReq); err != nil {
 		_ = runCore.Close()
 		_ = runLogger.Close()
 		return "", fmt.Errorf("web: %w", err)
@@ -446,6 +449,7 @@ func (b *Backend) StartTrackerUpload(sessionID string, path string, overrides ap
 		sessionID:            sessionID,
 		id:                   jobID,
 		sourcePath:           trimmedPath,
+		cfg:                  rt.cfg,
 		runOptions:           runOpts,
 		core:                 runCore,
 		logger:               runLogger,
@@ -696,7 +700,7 @@ func (b *Backend) runSingleTrackerUpload(ctx context.Context, job *trackerUpload
 		Trackers:                    []string{tracker},
 		IgnoreDupesFor:              append([]string(nil), job.ignoreDupesFor...),
 		IgnoreTrackerRuleFailures:   false,
-		Options:                     buildRunUploadOptions(b.currentConfig(), job.runOptions),
+		Options:                     buildRunUploadOptions(job.cfg, job.runOptions),
 		ExternalIDOverrides:         job.overrides,
 		ReleaseNameOverrides:        job.nameOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(job.questionnaireAnswers),

--- a/internal/webserver/jobs.go
+++ b/internal/webserver/jobs.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/guishared"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -111,12 +110,14 @@ type TrackerUploadSnapshot struct {
 }
 
 type trackerUploadJob struct {
-	mu                   sync.Mutex
-	cleanupOnce          sync.Once
-	sessionID            string
-	id                   string
-	sourcePath           string
-	cfg                  config.Config
+	mu          sync.Mutex
+	cleanupOnce sync.Once
+	sessionID   string
+	id          string
+	sourcePath  string
+	// uploadOptions is the per-job runtime snapshot needed for upload requests;
+	// the full config may contain secrets and must not be retained in job state.
+	uploadOptions        api.UploadOptions
 	runOptions           runOptions
 	core                 api.Core
 	logger               interface{ Close() error }
@@ -143,6 +144,19 @@ type trackerUploadJob struct {
 	startedAt            time.Time
 	finishedAt           time.Time
 	cancel               context.CancelFunc
+}
+
+type trackerUploadRetryRequest struct {
+	sessionID            string
+	sourcePath           string
+	overrides            api.ExternalIDOverrides
+	nameOverrides        api.ReleaseNameOverrides
+	questionnaireAnswers map[string]map[string]string
+	descriptionGroups    []api.DescriptionBuilderGroup
+	failedTrackers       []string
+	ignoreDupesFor       []string
+	runOptions           runOptions
+	uploadOptions        api.UploadOptions
 }
 
 const trackerUploadSnapshotThrottle = 200 * time.Millisecond
@@ -403,10 +417,41 @@ func (j *trackerUploadJob) closeResources() {
 	})
 }
 
+func trackerUploadRetryRequestFromJob(job *trackerUploadJob) (trackerUploadRetryRequest, error) {
+	if job == nil {
+		return trackerUploadRetryRequest{}, errors.New("upload job not found")
+	}
+
+	job.mu.Lock()
+	defer job.mu.Unlock()
+
+	if len(job.failedTrackers) == 0 {
+		return trackerUploadRetryRequest{}, errors.New("no failed trackers to retry")
+	}
+
+	return trackerUploadRetryRequest{
+		sessionID:            job.sessionID,
+		sourcePath:           job.sourcePath,
+		overrides:            job.overrides,
+		nameOverrides:        job.nameOverrides,
+		questionnaireAnswers: cloneQuestionnaireAnswers(job.questionnaireAnswers),
+		descriptionGroups:    api.CloneDescriptionBuilderGroups(job.descriptionGroups),
+		failedTrackers:       append([]string(nil), job.failedTrackers...),
+		ignoreDupesFor:       append([]string(nil), job.ignoreDupesFor...),
+		runOptions:           job.runOptions,
+		uploadOptions:        job.uploadOptions,
+	}, nil
+}
+
 // StartTrackerUpload starts an upload job owned by sessionID for selected
 // trackers and returns its job ID. Snapshots preserve partial upload counts
-// returned with later tracker errors or cancellation.
+// returned with later tracker errors or cancellation. The job captures upload
+// options at start time so failed-tracker retries reuse the original option set.
 func (b *Backend) StartTrackerUpload(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (string, error) {
+	return b.startTrackerUpload(sessionID, path, overrides, nameOverrides, trackers, ignoreDupesFor, questionnaireAnswers, descriptionGroups, debug, noSeed, runLogLevel, nil)
+}
+
+func (b *Backend) startTrackerUpload(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string, uploadOptions *api.UploadOptions) (string, error) {
 	rt, err := b.requireRuntime()
 	if err != nil {
 		return "", err
@@ -445,11 +490,15 @@ func (b *Backend) StartTrackerUpload(sessionID string, path string, overrides ap
 	}
 
 	jobID := randomJobID()
+	jobUploadOptions := buildRunUploadOptions(rt.cfg, runOpts)
+	if uploadOptions != nil {
+		jobUploadOptions = *uploadOptions
+	}
 	job := &trackerUploadJob{
 		sessionID:            sessionID,
 		id:                   jobID,
 		sourcePath:           trimmedPath,
-		cfg:                  rt.cfg,
+		uploadOptions:        jobUploadOptions,
 		runOptions:           runOpts,
 		core:                 runCore,
 		logger:               runLogger,
@@ -501,28 +550,19 @@ func (b *Backend) CancelTrackerUpload(sessionID string, jobID string) error {
 }
 
 // RetryFailedTrackerUpload starts a retry job for failed trackers only when
-// sessionID owns the original upload job.
+// sessionID owns the original upload job. The retry reuses the original job's
+// run options, upload options, questionnaire answers, description groups, and
+// ignore-dupe list instead of rebuilding them from current settings.
 func (b *Backend) RetryFailedTrackerUpload(sessionID string, jobID string) (string, error) {
 	job := b.getTrackerUploadJobForSession(strings.TrimSpace(sessionID), strings.TrimSpace(jobID))
 	if job == nil {
 		return "", errors.New("upload job not found")
 	}
-	job.mu.Lock()
-	failedTrackers := append([]string(nil), job.failedTrackers...)
-	sourcePath := job.sourcePath
-	retrySessionID := job.sessionID
-	overrides := job.overrides
-	nameOverrides := job.nameOverrides
-	questionnaireAnswers := cloneQuestionnaireAnswers(job.questionnaireAnswers)
-	descriptionGroups := api.CloneDescriptionBuilderGroups(job.descriptionGroups)
-	ignoreDupesFor := append([]string(nil), job.ignoreDupesFor...)
-	runOptions := job.runOptions
-	job.mu.Unlock()
-
-	if len(failedTrackers) == 0 {
-		return "", errors.New("no failed trackers to retry")
+	retry, err := trackerUploadRetryRequestFromJob(job)
+	if err != nil {
+		return "", err
 	}
-	return b.StartTrackerUpload(retrySessionID, sourcePath, overrides, nameOverrides, failedTrackers, ignoreDupesFor, questionnaireAnswers, descriptionGroups, runOptions.Debug, runOptions.NoSeed, runOptions.RunLogLevel)
+	return b.startTrackerUpload(retry.sessionID, retry.sourcePath, retry.overrides, retry.nameOverrides, retry.failedTrackers, retry.ignoreDupesFor, retry.questionnaireAnswers, retry.descriptionGroups, retry.runOptions.Debug, retry.runOptions.NoSeed, retry.runOptions.RunLogLevel, &retry.uploadOptions)
 }
 
 // GetTrackerUploadSnapshot returns an upload job snapshot only to the session
@@ -700,7 +740,7 @@ func (b *Backend) runSingleTrackerUpload(ctx context.Context, job *trackerUpload
 		Trackers:                    []string{tracker},
 		IgnoreDupesFor:              append([]string(nil), job.ignoreDupesFor...),
 		IgnoreTrackerRuleFailures:   false,
-		Options:                     buildRunUploadOptions(job.cfg, job.runOptions),
+		Options:                     job.uploadOptions,
 		ExternalIDOverrides:         job.overrides,
 		ReleaseNameOverrides:        job.nameOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(job.questionnaireAnswers),

--- a/internal/webserver/jobs_test.go
+++ b/internal/webserver/jobs_test.go
@@ -291,6 +291,42 @@ func TestTrackerUploadJobAccessRequiresOwningSession(t *testing.T) {
 	}
 }
 
+func TestTrackerUploadRetryRequestUsesStoredUploadOptions(t *testing.T) {
+	job := &trackerUploadJob{
+		sessionID:      "session-a",
+		sourcePath:     `C:\Media\Movie.mkv`,
+		uploadOptions:  api.UploadOptions{Screens: 1, SkipAutoTorrent: true},
+		runOptions:     runOptions{Debug: true, NoSeed: true, RunLogLevel: "debug"},
+		failedTrackers: []string{"BLU"},
+		ignoreDupesFor: []string{"AITHER"},
+	}
+
+	retry, err := trackerUploadRetryRequestFromJob(job)
+	if err != nil {
+		t.Fatalf("retry request: %v", err)
+	}
+
+	job.uploadOptions.Screens = 9
+	job.failedTrackers[0] = "MUTATED"
+	job.ignoreDupesFor[0] = "MUTATED"
+
+	if retry.sessionID != "session-a" {
+		t.Fatalf("expected retry session snapshot, got %q", retry.sessionID)
+	}
+	if retry.uploadOptions.Screens != 1 || !retry.uploadOptions.SkipAutoTorrent {
+		t.Fatalf("expected stored upload options snapshot, got %#v", retry.uploadOptions)
+	}
+	if len(retry.failedTrackers) != 1 || retry.failedTrackers[0] != "BLU" {
+		t.Fatalf("expected failed trackers snapshot, got %#v", retry.failedTrackers)
+	}
+	if len(retry.ignoreDupesFor) != 1 || retry.ignoreDupesFor[0] != "AITHER" {
+		t.Fatalf("expected ignore dupes snapshot, got %#v", retry.ignoreDupesFor)
+	}
+	if !retry.runOptions.Debug || !retry.runOptions.NoSeed || retry.runOptions.RunLogLevel != "debug" {
+		t.Fatalf("expected run options snapshot, got %#v", retry.runOptions)
+	}
+}
+
 func TestRunTrackerUploadJobCountsPartialErrorAndContinues(t *testing.T) {
 	backend := &Backend{hub: newEventHub()}
 	coreSvc := &preparedMetaTestCore{uploads: []uploadPreparedResponse{

--- a/internal/webserver/routes.go
+++ b/internal/webserver/routes.go
@@ -238,25 +238,21 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request, _ session) 
 	if record.PendingUpgrade != nil {
 		target := record.PendingUpgrade.Target
 		if err := s.rewrapProtectedDataForAuthChange(r.Context(), record, target); err != nil {
-			if s.backend != nil && s.backend.logger != nil {
-				s.backend.logger.Errorf(
-					"web: auth upgrade failed incident=%s username=%s",
-					"auth_upgrade_resume_rewrap_failed",
-					redactAuthUsername(record.Username),
-				)
-			}
+			s.logErrorf(
+				"web: auth upgrade failed incident=%s username=%s",
+				"auth_upgrade_resume_rewrap_failed",
+				redactAuthUsername(record.Username),
+			)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to refresh credentials"})
 			return
 		}
 		finalized, err := s.auth.FinalizePendingUpgrade(record.Username)
 		if err != nil {
-			if s.backend != nil && s.backend.logger != nil {
-				s.backend.logger.Errorf(
-					"web: auth upgrade failed incident=%s username=%s",
-					"auth_upgrade_resume_finalize_failed",
-					redactAuthUsername(record.Username),
-				)
-			}
+			s.logErrorf(
+				"web: auth upgrade failed incident=%s username=%s",
+				"auth_upgrade_resume_finalize_failed",
+				redactAuthUsername(record.Username),
+			)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to refresh credentials"})
 			return
 		}
@@ -278,25 +274,21 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request, _ session) 
 			upgradedRecord.EncryptionKeySeed = seed
 		}
 		if err := s.rewrapProtectedDataForAuthChange(r.Context(), record, upgradedRecord); err != nil {
-			if s.backend != nil && s.backend.logger != nil {
-				s.backend.logger.Errorf(
-					"web: auth upgrade failed incident=%s username=%s",
-					"auth_upgrade_rewrap_failed",
-					redactAuthUsername(record.Username),
-				)
-			}
+			s.logErrorf(
+				"web: auth upgrade failed incident=%s username=%s",
+				"auth_upgrade_rewrap_failed",
+				redactAuthUsername(record.Username),
+			)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to refresh credentials"})
 			return
 		}
 		finalized, err := s.auth.FinalizePendingUpgrade(record.Username)
 		if err != nil {
-			if s.backend != nil && s.backend.logger != nil {
-				s.backend.logger.Errorf(
-					"web: auth upgrade failed incident=%s username=%s",
-					"auth_upgrade_finalize_failed",
-					redactAuthUsername(record.Username),
-				)
-			}
+			s.logErrorf(
+				"web: auth upgrade failed incident=%s username=%s",
+				"auth_upgrade_finalize_failed",
+				redactAuthUsername(record.Username),
+			)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to refresh credentials"})
 			return
 		}
@@ -328,9 +320,7 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request, current se
 		return
 	}
 	if err := s.sessions.Delete(current.ID); err != nil {
-		if s != nil && s.backend != nil && s.backend.logger != nil {
-			s.backend.logger.Errorf("web: failed to delete session during logout: %v", err)
-		}
+		s.logErrorf("web: failed to delete session during logout: %v", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to clear session"})
 		return
 	}

--- a/internal/webserver/routes_auth_test.go
+++ b/internal/webserver/routes_auth_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/authmaterial"
+	"github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/services/db"
 
 	"golang.org/x/crypto/argon2"
@@ -265,6 +266,87 @@ func TestLoginFinalizesPendingAuthUpgradeAfterInterruptedRewrap(t *testing.T) {
 	}
 	if !verifyPassword(password, updated.PasswordHash) {
 		t.Fatal("expected finalized hash to verify")
+	}
+}
+
+func TestRewrapProtectedDataForAuthChangeRecoversPreparedCookiesAfterPhasePersistFailure(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
+	server := newAuthTestServer(t, dbPath)
+	ctx := context.Background()
+
+	oldRecord := authRecord{
+		Username:     "admin",
+		PasswordHash: "old-password-hash",
+		CreatedAt:    time.Now().UTC(),
+	}
+	newRecord := authRecord{
+		Username:          "admin",
+		PasswordHash:      "new-password-hash",
+		EncryptionKeySeed: "stable-seed-after-interrupt",
+		CreatedAt:         oldRecord.CreatedAt,
+	}
+	oldRecord.PendingUpgrade = &authmaterial.PendingUpgrade{
+		Stage:     authmaterial.UpgradeStagePrepared,
+		Target:    newRecord,
+		UpdatedAt: time.Now().UTC(),
+	}
+	raw, err := json.MarshalIndent(oldRecord, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	if err := os.WriteFile(AuthFilePath(dbPath), raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	rawDB := server.backend.repo.RawDB()
+	oldKey, err := cookies.NewKeyManager(rawDB).InitializeEncryptionKey(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("initialize old cookie key: %v", err)
+	}
+	store, err := cookies.NewCookieStore(rawDB)
+	if err != nil {
+		t.Fatalf("create cookie store: %v", err)
+	}
+	if err := store.SaveCookie(ctx, "tracker", "session", "cookie-value", oldKey); err != nil {
+		t.Fatalf("save old cookie: %v", err)
+	}
+	if err := cookies.RewrapCookiesWithAuthChange(ctx, rawDB, oldRecord.AuthMaterial(), newRecord.AuthMaterial()); err != nil {
+		t.Fatalf("simulate cookie rewrap before phase persistence: %v", err)
+	}
+
+	if err := server.rewrapProtectedDataForAuthChange(ctx, oldRecord, newRecord); err != nil {
+		t.Fatalf("retry prepared auth rewrap: %v", err)
+	}
+
+	updated, err := server.auth.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if updated.PendingUpgrade == nil {
+		t.Fatal("expected pending upgrade to remain until login finalizes it")
+	}
+	if updated.PendingUpgrade.Stage != authmaterial.UpgradeStageDataRewrapped {
+		t.Fatalf("pending stage = %q, want %q", updated.PendingUpgrade.Stage, authmaterial.UpgradeStageDataRewrapped)
+	}
+
+	newHelper, _, err := newRecord.AuthMaterial().PrimaryHelper()
+	if err != nil {
+		t.Fatalf("new auth helper: %v", err)
+	}
+	salt, err := loadCookieEncryptionSalt(ctx, rawDB)
+	if err != nil {
+		t.Fatalf("load cookie salt: %v", err)
+	}
+	newKey, err := cookies.DeriveEncryptionKey(newHelper, salt)
+	if err != nil {
+		t.Fatalf("derive new cookie key: %v", err)
+	}
+	value, err := store.GetCookie(ctx, "tracker", "session", newKey)
+	if err != nil {
+		t.Fatalf("decrypt recovered cookie with new key: %v", err)
+	}
+	if value != "cookie-value" {
+		t.Fatalf("recovered cookie = %q, want %q", value, "cookie-value")
 	}
 }
 

--- a/internal/webserver/runtime_snapshot.go
+++ b/internal/webserver/runtime_snapshot.go
@@ -135,6 +135,7 @@ func (s *Server) logErrorf(format string, args ...any) {
 	s.backend.logErrorf(format, args...)
 }
 
+// baseUploadOptions returns upload options from the current runtime config.
 func (b *Backend) baseUploadOptions() api.UploadOptions {
 	return buildBaseMetadataOptions(b.currentConfig())
 }

--- a/internal/webserver/runtime_snapshot.go
+++ b/internal/webserver/runtime_snapshot.go
@@ -19,6 +19,7 @@ type backendRuntimeSnapshot struct {
 	logger      *logging.Logger
 }
 
+// runtimeSnapshot returns a consistent copy of runtime fields guarded by runtimeMu.
 func (b *Backend) runtimeSnapshot() backendRuntimeSnapshot {
 	if b == nil {
 		return backendRuntimeSnapshot{}
@@ -47,6 +48,7 @@ func (b *Backend) requireRuntime() (backendRuntimeSnapshot, error) {
 	return backendRuntimeSnapshot{}, errors.New("core not initialized")
 }
 
+// currentConfig returns the active runtime config under the runtime lock.
 func (b *Backend) currentConfig() config.Config {
 	if b == nil {
 		return config.Config{}
@@ -56,6 +58,7 @@ func (b *Backend) currentConfig() config.Config {
 	return b.cfg
 }
 
+// currentCore returns the active core service under the runtime lock.
 func (b *Backend) currentCore() api.Core {
 	if b == nil {
 		return nil
@@ -65,6 +68,7 @@ func (b *Backend) currentCore() api.Core {
 	return b.core
 }
 
+// currentLogger returns the active logger under the runtime lock.
 func (b *Backend) currentLogger() *logging.Logger {
 	if b == nil {
 		return nil
@@ -74,10 +78,76 @@ func (b *Backend) currentLogger() *logging.Logger {
 	return b.logger
 }
 
+// logDebugf writes through the active logger while holding the runtime read
+// lock so replacement cannot close the selected logger before the write
+// completes.
+func (b *Backend) logDebugf(format string, args ...any) {
+	if b == nil {
+		return
+	}
+	b.runtimeMu.RLock()
+	defer b.runtimeMu.RUnlock()
+	if b.logger != nil {
+		b.logger.Debugf(format, args...)
+	}
+}
+
+// logInfof writes through the active logger while holding the runtime read lock.
+func (b *Backend) logInfof(format string, args ...any) {
+	if b == nil {
+		return
+	}
+	b.runtimeMu.RLock()
+	defer b.runtimeMu.RUnlock()
+	if b.logger != nil {
+		b.logger.Infof(format, args...)
+	}
+}
+
+// logWarnf writes through the active logger while holding the runtime read lock.
+func (b *Backend) logWarnf(format string, args ...any) {
+	if b == nil {
+		return
+	}
+	b.runtimeMu.RLock()
+	defer b.runtimeMu.RUnlock()
+	if b.logger != nil {
+		b.logger.Warnf(format, args...)
+	}
+}
+
+// logErrorf writes through the active logger while holding the runtime read lock.
+func (b *Backend) logErrorf(format string, args ...any) {
+	if b == nil {
+		return
+	}
+	b.runtimeMu.RLock()
+	defer b.runtimeMu.RUnlock()
+	if b.logger != nil {
+		b.logger.Errorf(format, args...)
+	}
+}
+
+func (s *Server) logErrorf(format string, args ...any) {
+	if s == nil || s.backend == nil {
+		return
+	}
+	s.backend.logErrorf(format, args...)
+}
+
 func (b *Backend) baseUploadOptions() api.UploadOptions {
 	return buildBaseMetadataOptions(b.currentConfig())
 }
 
+// baseUploadOptions returns upload options derived from the same runtime
+// snapshot as the core selected for a request.
+func (rt backendRuntimeSnapshot) baseUploadOptions() api.UploadOptions {
+	return buildBaseMetadataOptions(rt.cfg)
+}
+
+// replaceRuntime swaps all runtime-owned fields under one write lock and
+// returns the previous core and logger for shutdown after callers finish
+// follow-up work such as log stream rebinding.
 func (b *Backend) replaceRuntime(cfg config.Config, core api.Core, logger *logging.Logger) (api.Core, *logging.Logger) {
 	b.runtimeMu.Lock()
 	defer b.runtimeMu.Unlock()

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -58,6 +58,13 @@ type Server struct {
 	developmentSession session
 }
 
+var (
+	newBackendWithContextForServer = NewBackendWithContext
+	resolveWebAssetsForServer      = resolveWebAssets
+	newSessionManagerForServer     = newSessionManager
+	randomStringForServer          = randomString
+)
+
 // New constructs a server from application and web CLI configuration.
 // It rejects development no-auth mode for non-loopback hosts.
 func New(opts Options) (*Server, error) {
@@ -72,19 +79,31 @@ func New(opts Options) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	backend, err := NewBackendWithContext(context.Background(), cfg, hub)
+	backend, err := newBackendWithContextForServer(context.Background(), cfg, hub)
 	if err != nil {
 		return nil, err
 	}
-	hub.SetLogger(backend.logger)
-	assets, err := resolveWebAssets()
+	backendClosed := false
+	defer func() {
+		if !backendClosed {
+			_ = backend.Close()
+		}
+	}()
+	hub.SetLogger(backend.currentLogger())
+	assets, err := resolveWebAssetsForServer()
 	if err != nil {
 		return nil, err
 	}
-	sessions, err := newSessionManager(cliCfg.SessionTTL, cfg.MainSettings.DBPath)
+	sessions, err := newSessionManagerForServer(cliCfg.SessionTTL, cfg.MainSettings.DBPath)
 	if err != nil {
 		return nil, err
 	}
+	sessionsClosed := false
+	defer func() {
+		if !sessionsClosed {
+			sessions.Close()
+		}
+	}()
 	srv := &Server{
 		cfg:            cfg,
 		cliCfg:         cliCfg,
@@ -99,7 +118,7 @@ func New(opts Options) (*Server, error) {
 		assets:         assets,
 	}
 	if opts.DevelopmentNoAuth {
-		csrf, err := randomString(24)
+		csrf, err := randomStringForServer(24)
 		if err != nil {
 			return nil, err
 		}
@@ -112,7 +131,7 @@ func New(opts Options) (*Server, error) {
 		}
 	}
 	sessions.SetLogger(func(format string, args ...any) {
-		backend.logger.Warnf(format, args...)
+		backend.logWarnf(format, args...)
 	})
 	mux := http.NewServeMux()
 	srv.registerRoutes(mux)
@@ -121,6 +140,8 @@ func New(opts Options) (*Server, error) {
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
+	backendClosed = true
+	sessionsClosed = true
 	return srv, nil
 }
 
@@ -223,17 +244,24 @@ func (s *Server) serve(ctx context.Context, listener net.Listener) error {
 }
 
 // logServeAddress records the effective listener address after a successful
-// bind, along with a redacted browser URL when one is available.
+// bind, along with a redacted browser URL when one is available. It writes
+// while holding the backend runtime read lock so runtime replacement cannot
+// close the selected logger during the log call.
 func (s *Server) logServeAddress(addr net.Addr, browserURL string) {
-	if s == nil || s.backend == nil || s.backend.logger == nil || addr == nil {
+	if addr == nil {
 		return
 	}
+	addrText := addr.String()
 	loggedBrowserURL := redactLoggedBrowserURL(browserURL)
-	if loggedBrowserURL == "" {
-		s.backend.logger.Infof("web: serving web UI on %s", addr.String())
+	if s == nil || s.backend == nil {
 		return
 	}
-	s.backend.logger.Infof("web: serving web UI on %s (browser URL %s)", addr.String(), loggedBrowserURL)
+
+	if loggedBrowserURL == "" {
+		s.backend.logInfof("web: serving web UI on %s", addrText)
+		return
+	}
+	s.backend.logInfof("web: serving web UI on %s (browser URL %s)", addrText, loggedBrowserURL)
 }
 
 // redactLoggedBrowserURL returns a log-safe browser URL, removing userinfo and

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -6,17 +6,30 @@ package webserver
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"net"
 	"net/http"
 	"net/url"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/logging"
 )
+
+type serverCloseCore struct {
+	preparedMetaTestCore
+	closed *bool
+}
+
+func (c *serverCloseCore) Close() error {
+	*c.closed = true
+	return nil
+}
 
 func TestNewRejectsDevelopmentNoAuthOnNonLoopbackHost(t *testing.T) {
 	_, err := New(Options{
@@ -57,6 +70,103 @@ func TestIsDevelopmentNoAuthHost(t *testing.T) {
 				t.Fatalf("isDevelopmentNoAuthHost(%q) = %v, want %v", tc.host, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestNewClosesBackendWhenAssetSetupFails(t *testing.T) {
+	oldNewBackend := newBackendWithContextForServer
+	oldResolveAssets := resolveWebAssetsForServer
+	oldNewSessionManager := newSessionManagerForServer
+	oldRandomString := randomStringForServer
+	t.Cleanup(func() {
+		newBackendWithContextForServer = oldNewBackend
+		resolveWebAssetsForServer = oldResolveAssets
+		newSessionManagerForServer = oldNewSessionManager
+		randomStringForServer = oldRandomString
+	})
+
+	closed := false
+	newBackendWithContextForServer = func(_ context.Context, cfg config.Config, _ *eventHub) (*Backend, error) {
+		return &Backend{
+			cfg:  cfg,
+			core: &serverCloseCore{closed: &closed},
+		}, nil
+	}
+	resolveWebAssetsForServer = func() (fs.FS, error) {
+		return nil, errors.New("asset setup failed")
+	}
+	newSessionManagerForServer = func(int, string) (*sessionManager, error) {
+		t.Fatal("session manager should not be created after asset setup failure")
+		return nil, nil
+	}
+
+	_, err := New(Options{
+		Config: config.Config{
+			MainSettings:       config.MainSettingsConfig{DBPath: filepath.Join(t.TempDir(), "state.db")},
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+			Logging:            config.LoggingConfig{Level: "info"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected asset setup failure")
+	}
+	if !closed {
+		t.Fatal("expected backend core to close after post-construction startup failure")
+	}
+}
+
+func TestNewClosesSessionManagerWhenDevelopmentCSRFFails(t *testing.T) {
+	oldNewBackend := newBackendWithContextForServer
+	oldResolveAssets := resolveWebAssetsForServer
+	oldNewSessionManager := newSessionManagerForServer
+	oldRandomString := randomStringForServer
+	t.Cleanup(func() {
+		newBackendWithContextForServer = oldNewBackend
+		resolveWebAssetsForServer = oldResolveAssets
+		newSessionManagerForServer = oldNewSessionManager
+		randomStringForServer = oldRandomString
+	})
+
+	newBackendWithContextForServer = func(_ context.Context, cfg config.Config, _ *eventHub) (*Backend, error) {
+		return &Backend{cfg: cfg}, nil
+	}
+	resolveWebAssetsForServer = func() (fs.FS, error) {
+		return fstest.MapFS{"index.html": {Data: []byte("ok")}}, nil
+	}
+	sessionClosed := make(chan struct{})
+	newSessionManagerForServer = func(int, string) (*sessionManager, error) {
+		manager := &sessionManager{
+			stopCh:   make(chan struct{}),
+			doneCh:   make(chan struct{}),
+			sessions: make(map[string]session),
+		}
+		go func() {
+			<-manager.stopCh
+			close(sessionClosed)
+			close(manager.doneCh)
+		}()
+		return manager, nil
+	}
+	randomStringForServer = func(int) (string, error) {
+		return "", errors.New("csrf failure")
+	}
+
+	_, err := New(Options{
+		Config: config.Config{
+			MainSettings:       config.MainSettingsConfig{DBPath: filepath.Join(t.TempDir(), "state.db")},
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+			Logging:            config.LoggingConfig{Level: "info"},
+		},
+		CLIConfig:         CLIConfig{Host: "127.0.0.1"},
+		DevelopmentNoAuth: true,
+	})
+	if err == nil {
+		t.Fatal("expected CSRF failure")
+	}
+	select {
+	case <-sessionClosed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for session manager close")
 	}
 }
 
@@ -145,6 +255,58 @@ func TestLogServeAddressRedactsBrowserURLSecrets(t *testing.T) {
 	}
 	if !strings.Contains(message, "https://example.test/upbrr/") {
 		t.Fatalf("expected safe browser URL host/path retained, got %q", message)
+	}
+}
+
+func TestServerLoggerAccessSynchronizedDuringRuntimeReplacement(t *testing.T) {
+	t.Parallel()
+
+	loggingConfig := config.LoggingConfig{
+		Level:          "info",
+		FileEnabled:    true,
+		MaxTotalSizeMB: 1,
+		MaxFiles:       1,
+	}
+	loggerA, err := logging.NewWithLevel(loggingConfig, filepath.Join(t.TempDir(), "runtime-a.db"), "")
+	if err != nil {
+		t.Fatalf("new logger A: %v", err)
+	}
+
+	backend := &Backend{logger: loggerA}
+	server := &Server{backend: backend}
+	addr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7480}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				logger, err := logging.NewWithLevel(loggingConfig, filepath.Join(t.TempDir(), "runtime-replacement.db"), "")
+				if err != nil {
+					t.Errorf("new replacement logger: %v", err)
+					return
+				}
+				_, oldLogger := backend.replaceRuntime(config.Config{}, nil, logger)
+				if oldLogger != nil {
+					_ = oldLogger.Close()
+				}
+			}
+		}
+	})
+	defer func() {
+		close(stop)
+		wg.Wait()
+		if logger := backend.currentLogger(); logger != nil {
+			_ = logger.Close()
+		}
+	}()
+
+	for range 2000 {
+		server.logServeAddress(addr, "http://127.0.0.1:7480")
+		backend.logWarnf("web: retained session persistence check")
 	}
 }
 

--- a/internal/webserver/server_test.go
+++ b/internal/webserver/server_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -278,13 +279,14 @@ func TestServerLoggerAccessSynchronizedDuringRuntimeReplacement(t *testing.T) {
 
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
+	replacementLogDir := t.TempDir()
 	wg.Go(func() {
-		for {
+		for i := 0; ; i++ {
 			select {
 			case <-stop:
 				return
 			default:
-				logger, err := logging.NewWithLevel(loggingConfig, filepath.Join(t.TempDir(), "runtime-replacement.db"), "")
+				logger, err := logging.NewWithLevel(loggingConfig, filepath.Join(replacementLogDir, "runtime-replacement-"+strconv.Itoa(i)+".db"), "")
 				if err != nil {
 					t.Errorf("new replacement logger: %v", err)
 					return

--- a/internal/webserver/tracker_icons.go
+++ b/internal/webserver/tracker_icons.go
@@ -50,9 +50,7 @@ func (s *Server) handleTrackerIcon(w http.ResponseWriter, r *http.Request, _ ses
 			return
 		}
 		if s.backend != nil {
-			if logger := s.backend.currentLogger(); logger != nil {
-				logger.Errorf("trackericon: get tracker icon %s: %v", sanitized, err)
-			}
+			s.backend.logErrorf("trackericon: get tracker icon %s: %v", sanitized, err)
 		}
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -7,13 +7,18 @@ import (
 	"context"
 )
 
+// Mode identifies the entrypoint building a core request.
 type Mode string
 
 const (
+	// ModeCLI marks requests started from the command-line entrypoint.
 	ModeCLI Mode = "cli"
+	// ModeGUI marks requests started from GUI or embedded web entrypoints.
 	ModeGUI Mode = "gui"
 )
 
+// Request carries one core operation across CLI, Wails, and embedded web.
+// Paths and path-keyed maps use host filesystem source paths as keys.
 type Request struct {
 	Paths                        []string
 	Mode                         Mode
@@ -49,6 +54,7 @@ type Request struct {
 	ConfirmBDMVRescan            bool
 }
 
+// ExecutionOptions controls queued and site-check execution behavior.
 type ExecutionOptions struct {
 	QueueName         string
 	QueueLimit        int
@@ -56,6 +62,7 @@ type ExecutionOptions struct {
 	SiteUploadTracker string
 }
 
+// ExternalIDSelection records the external metadata IDs chosen for one source path.
 type ExternalIDSelection struct {
 	TMDBID   *int
 	IMDBID   *int
@@ -63,6 +70,7 @@ type ExternalIDSelection struct {
 	TVmazeID *int
 }
 
+// UploadOptions contains per-run upload and preview behavior flags.
 type UploadOptions struct {
 	Debug           bool
 	DryRun          bool
@@ -76,6 +84,7 @@ type UploadOptions struct {
 	InteractionMode InteractionMode
 }
 
+// TrackerConfigOverrides supplies optional per-request tracker setting overrides.
 type TrackerConfigOverrides struct {
 	Anon    *bool
 	Draft   *bool
@@ -83,10 +92,12 @@ type TrackerConfigOverrides struct {
 	Channel *string
 }
 
+// TrackerSiteOverrides groups tracker-specific site override payloads.
 type TrackerSiteOverrides struct {
 	TIK TIKOverrides
 }
 
+// TIKOverrides carries TIK-specific upload flags selected outside static config.
 type TIKOverrides struct {
 	Foreign  *bool
 	Opera    *bool
@@ -94,10 +105,13 @@ type TIKOverrides struct {
 	DiscType *string
 }
 
+// Result summarizes a completed core upload run.
 type Result struct {
 	UploadedCount int
 }
 
+// Core defines the shared upload, preview, history, screenshot, and description
+// operations used by CLI, Wails, and embedded web entrypoints.
 type Core interface {
 	RunUpload(ctx context.Context, req Request) (Result, error)
 	RunUploadPrepared(ctx context.Context, req Request) (Result, error)
@@ -143,13 +157,17 @@ type Config interface {
 	Validate() error
 }
 
+// CoreDependencies supplies the externally owned services used to construct a Core.
 type CoreDependencies struct {
-	Config     Config
-	Logger     Logger
-	Services   ServiceSet
-	Repository MetadataRepository
+	Config              Config
+	Logger              Logger
+	Services            ServiceSet
+	Repository          MetadataRepository
+	SkipCookieMigration bool
 }
 
+// CoreImpl is the exported concrete-core contract used by packages that accept
+// any current core implementation.
 type CoreImpl interface {
 	Core
 }

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -159,10 +159,16 @@ type Config interface {
 
 // CoreDependencies supplies the externally owned services used to construct a Core.
 type CoreDependencies struct {
-	Config              Config
-	Logger              Logger
-	Services            ServiceSet
-	Repository          MetadataRepository
+	// Config is validated before the core is created.
+	Config Config
+	// Logger receives core initialization and runtime messages. Nil uses NopLogger.
+	Logger Logger
+	// Services supplies optional service overrides; zero values use the core defaults.
+	Services ServiceSet
+	// Repository stores metadata and history. Nil opens and owns a SQLite repository from Config.
+	Repository MetadataRepository
+	// SkipCookieMigration skips legacy cookie migration for callers that already
+	// synchronize cookie encryption state with the shared repository.
 	SkipCookieMigration bool
 }
 


### PR DESCRIPTION
## Summary
- Preserve default config values when importing partial YAML or JSON configs.
- Load provided YAML through the importer path so secret handling and default overlays stay consistent.
- Validate CLI-provided configs before persisting them to the database, preventing invalid config from replacing valid stored state.

## Impact
- Fresh or partial config imports retain expected defaults.
- `upbrr --config` rejects invalid provided config before DB persistence.
- GUI/web startup paths can still allow incomplete setup config where needed.

## Validation
- `go test ./internal/config/importer ./internal/configstore ./cmd/upbrr -count=1`
- `git diff --check`
- pre-commit hook: Go format, logpolicy, pathpolicy
- pre-push hook: Go lint, frontend typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration imports now support encrypted secrets, including automatic re-encryption for storage.
  * Configuration save/load now uses a transactional flow to sync cookie encryption/auth state safely.
* **Bug Fixes**
  * Import validation is stricter: unknown keys/sections and destructive overlays are rejected; tracker custom fields are preserved.
  * Tracker credential handling now uses deterministic, ASCII-only name aliasing for legacy token resolution.
  * Cookie rewrap can recover from specific decrypt failures without losing prepared auth upgrades.
* **Tests**
  * Expanded end-to-end coverage for import/merge/save behavior, rollback/immutability, runtime snapshot consistency, and concurrency/log streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->