### PR TITLE
fix: prevent placeholder history data

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -394,7 +394,8 @@ func (c *Core) persistPreparedInfoHash(ctx context.Context, sourcePath string, i
 		if !errors.Is(err, internalerrors.ErrNotFound) {
 			return fmt.Errorf("lookup existing metadata: %w", err)
 		}
-		metadata = db.FileMetadata{Path: trimmedPath}
+		c.logger.Debugf("metadata: skip info hash persistence without stored metadata for %s", trimmedPath)
+		return nil
 	} else if strings.TrimSpace(metadata.Path) == "" {
 		metadata.Path = trimmedPath
 	}

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -1945,7 +1945,7 @@ func TestFetchMetadataPreviewRunsPathedSearchWithSourceURLOverride(t *testing.T)
 	}
 }
 
-func TestRunUploadPersistsInfoHash(t *testing.T) {
+func TestRunUploadSkipsInfoHashPersistenceWithoutHistoryMetadata(t *testing.T) {
 	t.Parallel()
 
 	repo := &recordingRepo{}
@@ -1972,11 +1972,8 @@ func TestRunUploadPersistsInfoHash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run upload: %v", err)
 	}
-	if len(repo.saved) != 1 {
-		t.Fatalf("expected 1 metadata save, got %d", len(repo.saved))
-	}
-	if repo.saved[0].InfoHash != "hash123" {
-		t.Fatalf("expected info hash saved, got %q", repo.saved[0].InfoHash)
+	if len(repo.saved) != 0 {
+		t.Fatalf("expected no placeholder metadata save, got %d", len(repo.saved))
 	}
 }
 

--- a/internal/services/db/sqlite.go
+++ b/internal/services/db/sqlite.go
@@ -1399,6 +1399,31 @@ func (r *SQLiteRepository) ListHistoryEntries(ctx context.Context) ([]HistoryEnt
 			ORDER BY created_at DESC, id DESC
 			LIMIT 1
 		)
+		WHERE NOT (
+			fm.source_size = 0
+			AND TRIM(fm.disc_type) = ""
+			AND TRIM(fm.video_path) = ""
+			AND TRIM(fm.file_list) IN ("", "[]")
+			AND TRIM(fm.release_type) = ""
+			AND TRIM(fm.release_artist) = ""
+			AND TRIM(fm.release_title) = ""
+			AND TRIM(fm.release_subtitle) = ""
+			AND TRIM(fm.release_alt) = ""
+			AND fm.release_year = 0
+			AND fm.release_month = 0
+			AND fm.release_day = 0
+			AND TRIM(fm.release_source) = ""
+			AND TRIM(fm.release_resolution) = ""
+			AND TRIM(fm.release_ext) = ""
+			AND TRIM(fm.release_site) = ""
+			AND TRIM(fm.release_genre) = ""
+			AND TRIM(fm.release_channels) = ""
+			AND TRIM(fm.release_collection) = ""
+			AND TRIM(fm.release_region) = ""
+			AND TRIM(fm.release_size) = ""
+			AND TRIM(fm.release_group) = ""
+			AND TRIM(fm.release_disc) = ""
+		)
 		ORDER BY fm.updated_at DESC, fm.path ASC
 	`)
 	if err != nil {

--- a/internal/services/db/sqlite_test.go
+++ b/internal/services/db/sqlite_test.go
@@ -451,6 +451,52 @@ func TestSQLiteRepositoryConcurrentMigrateAndAccessOnDisk(t *testing.T) {
 	}
 }
 
+func TestSQLiteRepositoryListHistoryEntriesSkipsInfoHashOnlyPlaceholders(t *testing.T) {
+	t.Parallel()
+
+	repo, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := repo.Save(ctx, FileMetadata{
+		Path:      "/media/placeholder.mkv",
+		InfoHash:  "abc123",
+		UpdatedAt: now.Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("save placeholder metadata: %v", err)
+	}
+	if err := repo.Save(ctx, FileMetadata{
+		Path:       "/media/release.mkv",
+		Title:      "Real Release",
+		VideoPath:  "/media/release.mkv",
+		FileList:   []string{"/media/release.mkv"},
+		SourceSize: 123,
+		UpdatedAt:  now,
+	}); err != nil {
+		t.Fatalf("save release metadata: %v", err)
+	}
+
+	entries, err := repo.ListHistoryEntries(ctx)
+	if err != nil {
+		t.Fatalf("list history entries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected one visible history entry, got %#v", entries)
+	}
+	if entries[0].SourcePath != "/media/release.mkv" {
+		t.Fatalf("expected release history entry, got %q", entries[0].SourcePath)
+	}
+}
+
 func TestSQLiteRepositoryConcurrentDistinctPathWritesOnDisk(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * History now filters out incomplete placeholder entries, displaying only fully populated records for a cleaner view
  * Upload process improved to avoid creating metadata placeholders without complete information, ensuring better data integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->