### PR TITLE
fix(config): load all default options not in existing config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1045,39 +1045,48 @@ func trackerAPIKeyForExactName(trackers map[string]TrackerConfig, name string) s
 // create a duplicate canonical "BTN" entry.
 // CZT keeps user credentials in Passkey only, so stale URL, APIKey, and
 // AnnounceURL values are removed while preserving the passkey.
-func MergeMissingTrackerDefaults(cfg *Config) error {
+// The returned flag reports whether cfg was modified.
+func MergeMissingTrackerDefaults(cfg *Config) (bool, error) {
 	if cfg == nil {
-		return nil
+		return false, nil
 	}
+	changed := false
 	if cfg.Trackers.Trackers == nil {
 		cfg.Trackers.Trackers = map[string]TrackerConfig{}
+		changed = true
 	}
 	if cfg.Trackers.DefaultTrackers == nil {
 		cfg.Trackers.DefaultTrackers = CSVList{}
+		changed = true
 	}
 	defaults, err := loadEmbeddedDefaultConfigRaw()
 	if err != nil || defaults == nil || len(defaults.Trackers.Trackers) == 0 {
 		if err != nil {
-			return fmt.Errorf("load embedded tracker defaults: %w", err)
+			return false, fmt.Errorf("load embedded tracker defaults: %w", err)
 		}
-		return errors.New("load embedded tracker defaults: embedded default trackers missing")
+		return false, errors.New("load embedded tracker defaults: embedded default trackers missing")
 	}
 	for trackerName, trackerCfg := range defaults.Trackers.Trackers {
 		existingName, existing, ok := trackerDefaultMergeEntry(cfg.Trackers.Trackers, trackerName)
 		if !ok {
 			cfg.Trackers.Trackers[trackerName] = trackerCfg
+			changed = true
 			continue
 		}
 		if asciiEqualFold(trackerName, "CZT") {
-			existing.URL = ""
-			existing.APIKey = ""
-			existing.AnnounceURL = ""
-			cfg.Trackers.Trackers[existingName] = existing
+			if strings.TrimSpace(existing.URL) != "" || strings.TrimSpace(existing.APIKey) != "" || strings.TrimSpace(existing.AnnounceURL) != "" {
+				existing.URL = ""
+				existing.APIKey = ""
+				existing.AnnounceURL = ""
+				cfg.Trackers.Trackers[existingName] = existing
+				changed = true
+			}
 			continue
 		}
 		if strings.TrimSpace(existing.URL) == "" && strings.TrimSpace(trackerCfg.URL) != "" {
 			existing.URL = trackerCfg.URL
 			cfg.Trackers.Trackers[existingName] = existing
+			changed = true
 		}
 	}
 	if token := strings.TrimSpace(cfg.Metadata.BTNAPI); token != "" && trackerAPIKeyByName(cfg.Trackers.Trackers, "BTN") == "" {
@@ -1086,6 +1095,7 @@ func MergeMissingTrackerDefaults(cfg *Config) error {
 		if strings.TrimSpace(btnCfg.APIKey) == "" {
 			btnCfg.APIKey = token
 			cfg.Trackers.Trackers[btnName] = btnCfg
+			changed = true
 		}
 	}
 	for trackerName, trackerCfg := range cfg.Trackers.Trackers {
@@ -1099,8 +1109,9 @@ func MergeMissingTrackerDefaults(cfg *Config) error {
 		trackerCfg.URL = ""
 		trackerCfg.AnnounceURL = ""
 		cfg.Trackers.Trackers[trackerName] = trackerCfg
+		changed = true
 	}
-	return nil
+	return changed, nil
 }
 
 // trackerDefaultMergeEntry returns the exact tracker entry when present, then

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1045,32 +1045,58 @@ func trackerAPIKeyForExactName(trackers map[string]TrackerConfig, name string) s
 // create a duplicate canonical "BTN" entry.
 // CZT keeps user credentials in Passkey only, so stale URL, APIKey, and
 // AnnounceURL values are removed while preserving the passkey.
+// Legacy Metadata.BTNAPI is moved into the BTN tracker APIKey when needed, then
+// cleared once a tracker token is available.
 // The returned flag reports whether cfg was modified.
 func MergeMissingTrackerDefaults(cfg *Config) (bool, error) {
-	if cfg == nil {
-		return false, nil
+	report, err := MergeMissingTrackerDefaultsWithReport(cfg)
+	return report.Changed, err
+}
+
+// TrackerDefaultsMergeReport describes semantic tracker-default changes made by
+// [MergeMissingTrackerDefaultsWithReport]. Changed reports whether cfg was
+// modified; ChangedSections contains sorted JSON root section names to persist,
+// including Metadata when a legacy metadata BTN token is cleared.
+type TrackerDefaultsMergeReport struct {
+	Changed         bool
+	ChangedSections []string
+}
+
+func (r *TrackerDefaultsMergeReport) markChanged(section string) {
+	r.Changed = true
+	if section != "" {
+		r.ChangedSections = append(r.ChangedSections, section)
 	}
-	changed := false
+}
+
+// MergeMissingTrackerDefaultsWithReport backfills semantic tracker defaults and
+// reports the root sections that should be persisted. It may initialize nil
+// tracker maps for runtime use without marking cfg changed. Legacy
+// Metadata.BTNAPI is copied to the BTN tracker before Metadata is marked for
+// clearing so callers can persist both affected sections together.
+func MergeMissingTrackerDefaultsWithReport(cfg *Config) (TrackerDefaultsMergeReport, error) {
+	var report TrackerDefaultsMergeReport
+	if cfg == nil {
+		return report, nil
+	}
 	if cfg.Trackers.Trackers == nil {
 		cfg.Trackers.Trackers = map[string]TrackerConfig{}
-		changed = true
 	}
 	if cfg.Trackers.DefaultTrackers == nil {
 		cfg.Trackers.DefaultTrackers = CSVList{}
-		changed = true
 	}
 	defaults, err := loadEmbeddedDefaultConfigRaw()
 	if err != nil || defaults == nil || len(defaults.Trackers.Trackers) == 0 {
 		if err != nil {
-			return false, fmt.Errorf("load embedded tracker defaults: %w", err)
+			return report, fmt.Errorf("load embedded tracker defaults: %w", err)
 		}
-		return false, errors.New("load embedded tracker defaults: embedded default trackers missing")
+		return report, errors.New("load embedded tracker defaults: embedded default trackers missing")
 	}
 	for trackerName, trackerCfg := range defaults.Trackers.Trackers {
 		existingName, existing, ok := trackerDefaultMergeEntry(cfg.Trackers.Trackers, trackerName)
 		if !ok {
 			cfg.Trackers.Trackers[trackerName] = trackerCfg
-			changed = true
+			report.markChanged("Trackers")
 			continue
 		}
 		if asciiEqualFold(trackerName, "CZT") {
@@ -1079,23 +1105,29 @@ func MergeMissingTrackerDefaults(cfg *Config) (bool, error) {
 				existing.APIKey = ""
 				existing.AnnounceURL = ""
 				cfg.Trackers.Trackers[existingName] = existing
-				changed = true
+				report.markChanged("Trackers")
 			}
 			continue
 		}
 		if strings.TrimSpace(existing.URL) == "" && strings.TrimSpace(trackerCfg.URL) != "" {
 			existing.URL = trackerCfg.URL
 			cfg.Trackers.Trackers[existingName] = existing
-			changed = true
+			report.markChanged("Trackers")
 		}
 	}
-	if token := strings.TrimSpace(cfg.Metadata.BTNAPI); token != "" && trackerAPIKeyByName(cfg.Trackers.Trackers, "BTN") == "" {
-		btnName := trackerBTNMergeName(cfg.Trackers.Trackers)
-		btnCfg := cfg.Trackers.Trackers[btnName]
-		if strings.TrimSpace(btnCfg.APIKey) == "" {
-			btnCfg.APIKey = token
-			cfg.Trackers.Trackers[btnName] = btnCfg
-			changed = true
+	if token := strings.TrimSpace(cfg.Metadata.BTNAPI); token != "" {
+		if trackerAPIKeyByName(cfg.Trackers.Trackers, "BTN") == "" {
+			btnName := trackerBTNMergeName(cfg.Trackers.Trackers)
+			btnCfg := cfg.Trackers.Trackers[btnName]
+			if strings.TrimSpace(btnCfg.APIKey) == "" {
+				btnCfg.APIKey = token
+				cfg.Trackers.Trackers[btnName] = btnCfg
+				report.markChanged("Trackers")
+			}
+		}
+		if trackerAPIKeyByName(cfg.Trackers.Trackers, "BTN") != "" {
+			cfg.Metadata.BTNAPI = ""
+			report.markChanged("Metadata")
 		}
 	}
 	for trackerName, trackerCfg := range cfg.Trackers.Trackers {
@@ -1109,9 +1141,10 @@ func MergeMissingTrackerDefaults(cfg *Config) (bool, error) {
 		trackerCfg.URL = ""
 		trackerCfg.AnnounceURL = ""
 		cfg.Trackers.Trackers[trackerName] = trackerCfg
-		changed = true
+		report.markChanged("Trackers")
 	}
-	return changed, nil
+	report.ChangedSections = sortedUniqueStrings(report.ChangedSections)
+	return report, nil
 }
 
 // trackerDefaultMergeEntry returns the exact tracker entry when present, then

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -724,8 +724,12 @@ func TestMergeMissingTrackerDefaults(t *testing.T) {
 		},
 	}
 
-	if err := MergeMissingTrackerDefaults(cfg); err != nil {
+	changed, err := MergeMissingTrackerDefaults(cfg)
+	if err != nil {
 		t.Fatalf("merge missing tracker defaults: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected merge missing tracker defaults to report changes")
 	}
 
 	if _, ok := cfg.Trackers.Trackers["BTN"]; !ok {
@@ -934,8 +938,12 @@ func TestMergeMissingTrackerDefaultsBackfillsLegacyBTNAPIIntoTrackerConfig(t *te
 		},
 	}
 
-	if err := MergeMissingTrackerDefaults(cfg); err != nil {
+	changed, err := MergeMissingTrackerDefaults(cfg)
+	if err != nil {
 		t.Fatalf("merge missing tracker defaults: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected merge missing tracker defaults to report changes")
 	}
 
 	if got := cfg.Trackers.Trackers["BTN"].APIKey; got != "legacy-token" {
@@ -955,8 +963,12 @@ func TestMergeMissingTrackerDefaultsDoesNotBackfillLegacyBTNAPIOverLowercaseTrac
 		},
 	}
 
-	if err := MergeMissingTrackerDefaults(cfg); err != nil {
+	changed, err := MergeMissingTrackerDefaults(cfg)
+	if err != nil {
 		t.Fatalf("merge missing tracker defaults: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected merge missing tracker defaults to report changes")
 	}
 
 	if got := ResolveBTNAPIToken(*cfg); got != "lowercase-token" {
@@ -982,8 +994,12 @@ func TestMergeMissingTrackerDefaultsReconcilesLowercaseBTNWithoutToken(t *testin
 		},
 	}
 
-	if err := MergeMissingTrackerDefaults(cfg); err != nil {
+	changed, err := MergeMissingTrackerDefaults(cfg)
+	if err != nil {
 		t.Fatalf("merge missing tracker defaults: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected merge missing tracker defaults to report changes")
 	}
 
 	if _, ok := cfg.Trackers.Trackers["BTN"]; ok {
@@ -1016,8 +1032,12 @@ func TestMergeMissingTrackerDefaultsUsesASCIICaseBTNTrackerConfig(t *testing.T) 
 		},
 	}
 
-	if err := MergeMissingTrackerDefaults(cfg); err != nil {
+	changed, err := MergeMissingTrackerDefaults(cfg)
+	if err != nil {
 		t.Fatalf("merge missing tracker defaults: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected merge missing tracker defaults to report changes")
 	}
 
 	if got := ResolveBTNAPIToken(*cfg); got != "legacy-token" {
@@ -1044,8 +1064,12 @@ func TestMergeMissingTrackerDefaultsClearsCZTSensitiveFields(t *testing.T) {
 		},
 	}
 
-	if err := MergeMissingTrackerDefaults(cfg); err != nil {
+	changed, err := MergeMissingTrackerDefaults(cfg)
+	if err != nil {
 		t.Fatalf("merge missing tracker defaults: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected merge missing tracker defaults to report changes")
 	}
 	czt := cfg.Trackers.Trackers["CZT"]
 	if czt.APIKey != "" {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -40,7 +40,7 @@ func LoadEmbeddedDefaultConfig() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := MergeMissingTrackerDefaults(cfg); err != nil {
+	if _, err := MergeMissingTrackerDefaults(cfg); err != nil {
 		return nil, err
 	}
 	return cfg, nil

--- a/internal/config/importer/importer.go
+++ b/internal/config/importer/importer.go
@@ -119,7 +119,7 @@ func parseNative(filename string, data []byte) (*config.Config, error) {
 		cfg.TorrentClients = make(map[string]config.TorrentClientConfig)
 	}
 
-	if err := config.MergeMissingTrackerDefaults(cfg); err != nil {
+	if _, err := config.MergeMissingTrackerDefaults(cfg); err != nil {
 		return nil, fmt.Errorf("import config: merge tracker defaults: %w", err)
 	}
 

--- a/internal/config/legacy/legacy.go
+++ b/internal/config/legacy/legacy.go
@@ -44,7 +44,7 @@ func importFromData(data []byte) (*config.Config, []string, error) {
 		return nil, nil, err
 	}
 
-	if err := config.MergeMissingTrackerDefaults(cfg); err != nil {
+	if _, err := config.MergeMissingTrackerDefaults(cfg); err != nil {
 		return nil, nil, fmt.Errorf("merge tracker defaults: %w", err)
 	}
 

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -446,8 +446,10 @@ func mergeStoredConfigMapWithReport(base map[string]any, overlay map[string]any,
 	return report, nil
 }
 
-// mergeStoredDynamicConfigValue inserts a stored dynamic entry or folds it into
-// a single existing ASCII-case tracker or field alias.
+// mergeStoredDynamicConfigValue inserts an object-shaped stored dynamic entry
+// or folds it into a single existing ASCII-case tracker or field alias. Dynamic
+// tracker and torrent-client entries that are not objects are skipped without
+// marking the section changed.
 func mergeStoredDynamicConfigValue(base map[string]any, key string, overlayValue any, path string) (storedConfigMergeReport, error) {
 	report := newStoredConfigMergeReport()
 	if usesASCIIStoredTrackerKeys(path) {
@@ -458,8 +460,14 @@ func mergeStoredDynamicConfigValue(base map[string]any, key string, overlayValue
 		if ok {
 			baseMap, baseOK := base[existingKey].(map[string]any)
 			overlayMap, overlayOK := overlayValue.(map[string]any)
-			if baseOK && overlayOK {
+			if baseOK {
+				if !overlayOK {
+					return report, nil
+				}
 				return mergeStoredConfigMapWithReport(baseMap, overlayMap, configMapPath(path, existingKey))
+			}
+			if !overlayOK {
+				return report, nil
 			}
 			base[existingKey] = overlayValue
 			report.markChanged(configMapPath(path, existingKey))
@@ -478,6 +486,11 @@ func mergeStoredDynamicConfigValue(base map[string]any, key string, overlayValue
 		}
 	}
 
+	if allowsStoredDynamicConfigEntry(path) {
+		if _, overlayOK := overlayValue.(map[string]any); !overlayOK {
+			return report, nil
+		}
+	}
 	base[key] = overlayValue
 	return report, nil
 }
@@ -646,26 +659,64 @@ func sortedUniqueStrings(values []string) []string {
 }
 
 // mergeStoredUnknownConfigValues copies stored object keys that are absent from
-// current without overwriting known current values. It recurses through object
-// values so selected-section repair saves keep forward-compatible same-root
-// fields while still writing repaired known fields.
-func mergeStoredUnknownConfigValues(current, stored any) {
+// current without overwriting known current values. It recurses using canonical
+// tracker names and fields so selected-section repair saves preserve distinct
+// future same-root fields without reintroducing folded aliases.
+func mergeStoredUnknownConfigValues(current, stored any, path string) error {
 	currentMap, ok := current.(map[string]any)
 	if !ok {
-		return
+		return nil
 	}
 	storedMap, ok := stored.(map[string]any)
 	if !ok {
-		return
+		return nil
 	}
 	for key, storedValue := range storedMap {
-		currentValue, exists := currentMap[key]
+		currentKey, currentValue, exists, err := storedUnknownConfigMergeTarget(currentMap, key, path)
+		if err != nil {
+			return err
+		}
 		if !exists {
 			currentMap[key] = storedValue
 			continue
 		}
-		mergeStoredUnknownConfigValues(currentValue, storedValue)
+		if err := mergeStoredUnknownConfigValues(currentValue, storedValue, configMapPath(path, currentKey)); err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+// storedUnknownConfigMergeTarget resolves a stored key to the current key that
+// should receive recursive unknown-field preservation at path. Tracker names
+// and direct tracker-entry fields use the same ASCII folding rules as load-time
+// repair; all other paths require exact keys.
+func storedUnknownConfigMergeTarget(current map[string]any, key, path string) (string, any, bool, error) {
+	currentValue, exists := current[key]
+	if exists {
+		return key, currentValue, true, nil
+	}
+
+	var (
+		currentKey string
+		ok         bool
+		err        error
+	)
+	switch {
+	case usesASCIIStoredTrackerKeys(path):
+		currentKey, ok, err = asciiConfigMapKey(current, key)
+	case isStoredTrackerEntryPath(path):
+		currentKey, ok, err = trackerFieldConfigMapKey(current, key)
+	default:
+		return key, nil, false, nil
+	}
+	if err != nil {
+		return "", nil, false, err
+	}
+	if !ok {
+		return key, nil, false, nil
+	}
+	return currentKey, current[currentKey], true, nil
 }
 
 // preserveStoredUnknownConfigValues merges unknown stored fields into selected
@@ -688,7 +739,9 @@ func preserveStoredUnknownConfigValues(ctx context.Context, repo any, sections m
 		return fmt.Errorf("load stored sections: %w", err)
 	}
 	for section, current := range sections {
-		mergeStoredUnknownConfigValues(current, stored[section])
+		if err := mergeStoredUnknownConfigValues(current, stored[section], section); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -219,7 +220,7 @@ func LoadFromDatabaseWithDefaultBackfill(ctx context.Context, repo fullConfigLoa
 		return nil, false, errors.New("config load: nil repository")
 	}
 
-	cfg, backfilledDefaults, err := loadFullConfigOverlayingDefaults(ctx, repo)
+	cfg, report, err := loadFullConfigOverlayingDefaults(ctx, repo)
 	if err != nil {
 		return nil, false, err
 	}
@@ -229,45 +230,92 @@ func LoadFromDatabaseWithDefaultBackfill(ctx context.Context, repo fullConfigLoa
 		return nil, false, fmt.Errorf("config load from database: decrypt secrets: %w", err)
 	}
 
-	return decryptedCfg, backfilledDefaults, nil
+	return decryptedCfg, report.BackfilledDefaults, nil
+}
+
+// DatabaseRepairReport describes load-time repairs needed after overlaying
+// stored config onto embedded defaults. BackfilledDefaults reports missing
+// defaults, invalid stored objects, or legacy fallback context repaired in
+// memory. ChangedSections contains sorted JSON root section names that should
+// be persisted; roots with invalid object-shaped input are excluded because the
+// stored subtree was not safely reusable. InvalidPaths contains dotted
+// raw-config paths whose stored value could not be used as an object.
+type DatabaseRepairReport struct {
+	BackfilledDefaults bool
+	ChangedSections    []string
+	InvalidPaths       []string
+}
+
+// LoadFromDatabaseWithRepairReport loads and decrypts full config from repo,
+// overlaying stored raw sections onto embedded defaults. The returned report
+// identifies repaired root sections; if raw section-map loading fails but
+// legacy struct loading succeeds, the report carries repair context without
+// scheduling section persistence. On error the returned config is nil.
+func LoadFromDatabaseWithRepairReport(ctx context.Context, repo fullConfigLoader) (*Config, DatabaseRepairReport, error) {
+	if repo == nil {
+		return nil, DatabaseRepairReport{}, errors.New("config load: nil repository")
+	}
+
+	cfg, report, err := loadFullConfigOverlayingDefaults(ctx, repo)
+	if err != nil {
+		return nil, DatabaseRepairReport{}, err
+	}
+
+	decryptedCfg, err := DecryptConfigSecrets(&cfg)
+	if err != nil {
+		return nil, DatabaseRepairReport{}, fmt.Errorf("config load from database: decrypt secrets: %w", err)
+	}
+
+	return decryptedCfg, report, nil
 }
 
 // loadFullConfigOverlayingDefaults overlays raw stored JSON sections onto the
 // embedded default config and reports whether any default keys were absent from
 // storage. Raw overlay is required because unmarshaled structs cannot
 // distinguish omitted fields from explicit false, zero, or empty values.
-func loadFullConfigOverlayingDefaults(ctx context.Context, repo fullConfigLoader) (Config, bool, error) {
+func loadFullConfigOverlayingDefaults(ctx context.Context, repo fullConfigLoader) (Config, DatabaseRepairReport, error) {
 	defaults, err := LoadEmbeddedDefaultConfig()
 	if err != nil {
-		return Config{}, false, fmt.Errorf("config load from database: load defaults: %w", err)
+		return Config{}, DatabaseRepairReport{}, fmt.Errorf("config load from database: load defaults: %w", err)
 	}
 	// Template clients are examples, not persisted user configuration.
 	defaults.TorrentClients = map[string]TorrentClientConfig{}
 
 	base, err := configJSONMap(defaults)
 	if err != nil {
-		return Config{}, false, fmt.Errorf("config load from database: marshal defaults: %w", err)
+		return Config{}, DatabaseRepairReport{}, fmt.Errorf("config load from database: marshal defaults: %w", err)
 	}
 
 	stored := map[string]any{}
 	if err := repo.LoadFullConfig(ctx, &stored); err != nil {
 		cfg := *defaults
 		if err := repo.LoadFullConfig(ctx, &cfg); err != nil {
-			return Config{}, false, fmt.Errorf("config load from database: %w", err)
+			return Config{}, DatabaseRepairReport{}, fmt.Errorf("config load from database: %w", err)
 		}
-		return cfg, false, nil
+		return cfg, DatabaseRepairReport{
+			BackfilledDefaults: true,
+			InvalidPaths:       []string{"raw-config"},
+		}, nil
 	}
-	missingDefaultPaths := mergeStoredConfigMap(base, stored, "")
+	mergeReport, err := mergeStoredConfigMapWithReport(base, stored, "")
+	if err != nil {
+		return Config{}, DatabaseRepairReport{}, fmt.Errorf("config load from database: merge stored config: %w", err)
+	}
 
 	merged, err := json.Marshal(base)
 	if err != nil {
-		return Config{}, false, fmt.Errorf("config load from database: marshal merged defaults: %w", err)
+		return Config{}, DatabaseRepairReport{}, fmt.Errorf("config load from database: marshal merged defaults: %w", err)
 	}
 	var cfg Config
 	if err := json.Unmarshal(merged, &cfg); err != nil {
-		return Config{}, false, fmt.Errorf("config load from database: unmarshal merged defaults: %w", err)
+		return Config{}, DatabaseRepairReport{}, fmt.Errorf("config load from database: unmarshal merged defaults: %w", err)
 	}
-	return cfg, len(missingDefaultPaths) > 0, nil
+	report := DatabaseRepairReport{
+		BackfilledDefaults: len(mergeReport.missingDefaultPaths) > 0 || len(mergeReport.invalidPaths) > 0,
+		ChangedSections:    mergeReport.changedRootSections(),
+		InvalidPaths:       append([]string(nil), mergeReport.invalidPaths...),
+	}
+	return cfg, report, nil
 }
 
 // configJSONMap converts cfg to the same exported-field JSON shape used by DB
@@ -287,14 +335,66 @@ func configJSONMap(cfg *Config) (map[string]any, error) {
 // mergeStoredConfigMap recursively overlays stored config onto defaults and
 // returns default-key paths absent from the stored JSON shape. Raw presence is
 // tracked before Config unmarshaling so explicit false, zero, and empty values
-// are not confused with omitted fields. Overlay keys are processed in sorted
-// order so duplicate tracker case variants fold into canonical entries
-// deterministically.
-func mergeStoredConfigMap(base map[string]any, overlay map[string]any, path string) []string {
-	var missingDefaultPaths []string
+// are not confused with omitted fields. Duplicate case-folded tracker names or
+// fields are rejected instead of choosing an order-dependent winner.
+type storedConfigMergeReport struct {
+	missingDefaultPaths []string
+	invalidPaths        []string
+	changedSections     map[string]struct{}
+	invalidSections     map[string]struct{}
+}
+
+func newStoredConfigMergeReport() storedConfigMergeReport {
+	return storedConfigMergeReport{
+		changedSections: map[string]struct{}{},
+		invalidSections: map[string]struct{}{},
+	}
+}
+
+func (r *storedConfigMergeReport) append(other storedConfigMergeReport) {
+	r.missingDefaultPaths = append(r.missingDefaultPaths, other.missingDefaultPaths...)
+	r.invalidPaths = append(r.invalidPaths, other.invalidPaths...)
+	for section := range other.changedSections {
+		r.changedSections[section] = struct{}{}
+	}
+	for section := range other.invalidSections {
+		r.invalidSections[section] = struct{}{}
+	}
+}
+
+func (r *storedConfigMergeReport) markChanged(path string) {
+	if section := configMapRoot(path); section != "" {
+		r.changedSections[section] = struct{}{}
+	}
+}
+
+func (r *storedConfigMergeReport) markInvalid(path string) {
+	if section := configMapRoot(path); section != "" {
+		r.invalidSections[section] = struct{}{}
+	}
+}
+
+func (r *storedConfigMergeReport) changedRootSections() []string {
+	changed := make(map[string]struct{}, len(r.changedSections))
+	for section := range r.changedSections {
+		if _, invalid := r.invalidSections[section]; invalid {
+			continue
+		}
+		changed[section] = struct{}{}
+	}
+	return sortedStringSet(changed)
+}
+
+// mergeStoredConfigMapWithReport mutates base by applying overlay and reports
+// missing defaults, invalid object-shaped overlays, and root sections changed by
+// repair. It returns an error for ambiguous tracker name or field collisions.
+func mergeStoredConfigMapWithReport(base map[string]any, overlay map[string]any, path string) (storedConfigMergeReport, error) {
+	report := newStoredConfigMergeReport()
 	for key := range base {
 		if _, exists := overlay[key]; !exists {
-			missingDefaultPaths = append(missingDefaultPaths, configMapPath(path, key))
+			missingPath := configMapPath(path, key)
+			report.missingDefaultPaths = append(report.missingDefaultPaths, missingPath)
+			report.markChanged(missingPath)
 		}
 	}
 
@@ -303,13 +403,20 @@ func mergeStoredConfigMap(base map[string]any, overlay map[string]any, path stri
 		overlayKeys = append(overlayKeys, key)
 	}
 	sort.Strings(overlayKeys)
+	if err := validateStoredOverlayKeys(base, overlayKeys, path); err != nil {
+		return report, err
+	}
 
 	for _, key := range overlayKeys {
 		overlayValue := overlay[key]
 		baseValue, exists := base[key]
 		if !exists {
 			if allowsStoredDynamicConfigEntry(path) || isStoredTrackerEntryPath(path) {
-				missingDefaultPaths = append(missingDefaultPaths, mergeStoredDynamicConfigValue(base, key, overlayValue, path)...)
+				childReport, err := mergeStoredDynamicConfigValue(base, key, overlayValue, path)
+				if err != nil {
+					return report, err
+				}
+				report.append(childReport)
 			}
 			continue
 		}
@@ -318,56 +425,151 @@ func mergeStoredConfigMap(base map[string]any, overlay map[string]any, path stri
 		overlayMap, overlayOK := overlayValue.(map[string]any)
 		if baseOK {
 			if !overlayOK {
+				invalidPath := configMapPath(path, key)
+				report.invalidPaths = append(report.invalidPaths, invalidPath)
+				report.markInvalid(invalidPath)
 				continue
 			}
 			childPath := key
 			if path != "" {
 				childPath = path + "." + key
 			}
-			missingDefaultPaths = append(missingDefaultPaths, mergeStoredConfigMap(baseMap, overlayMap, childPath)...)
+			childReport, err := mergeStoredConfigMapWithReport(baseMap, overlayMap, childPath)
+			if err != nil {
+				return report, err
+			}
+			report.append(childReport)
 			continue
 		}
 		base[key] = overlayValue
 	}
-	return missingDefaultPaths
+	return report, nil
 }
 
 // mergeStoredDynamicConfigValue inserts a stored dynamic entry or folds it into
-// an existing tracker entry that differs only by case.
-func mergeStoredDynamicConfigValue(base map[string]any, key string, overlayValue any, path string) []string {
-	if usesCaseInsensitiveStoredTrackerKeys(path) {
-		if existingKey, ok := caseInsensitiveConfigMapKey(base, key); ok {
+// a single existing ASCII-case tracker or field alias.
+func mergeStoredDynamicConfigValue(base map[string]any, key string, overlayValue any, path string) (storedConfigMergeReport, error) {
+	report := newStoredConfigMergeReport()
+	if usesASCIIStoredTrackerKeys(path) {
+		existingKey, ok, err := asciiConfigMapKey(base, key)
+		if err != nil {
+			return report, err
+		}
+		if ok {
 			baseMap, baseOK := base[existingKey].(map[string]any)
 			overlayMap, overlayOK := overlayValue.(map[string]any)
 			if baseOK && overlayOK {
-				return mergeStoredConfigMap(baseMap, overlayMap, configMapPath(path, existingKey))
+				return mergeStoredConfigMapWithReport(baseMap, overlayMap, configMapPath(path, existingKey))
 			}
 			base[existingKey] = overlayValue
-			return nil
+			report.markChanged(configMapPath(path, existingKey))
+			return report, nil
+		}
+	}
+	if isStoredTrackerEntryPath(path) {
+		existingKey, ok, err := trackerFieldConfigMapKey(base, key)
+		if err != nil {
+			return report, err
+		}
+		if ok {
+			base[existingKey] = overlayValue
+			report.markChanged(configMapPath(path, existingKey))
+			return report, nil
 		}
 	}
 
 	base[key] = overlayValue
+	return report, nil
+}
+
+// asciiConfigMapKey returns the exact key or one deterministic ASCII-case key.
+// It rejects multiple ASCII-case matches because callers cannot choose a safe
+// winner without schema-specific precedence.
+func asciiConfigMapKey(values map[string]any, key string) (string, bool, error) {
+	if _, ok := values[key]; ok {
+		return key, true, nil
+	}
+	matches := make([]string, 0, 1)
+	for existingKey := range values {
+		if existingKey != key && asciiEqualFold(existingKey, key) {
+			matches = append(matches, existingKey)
+		}
+	}
+	sort.Strings(matches)
+	switch len(matches) {
+	case 0:
+		return "", false, nil
+	case 1:
+		return matches[0], true, nil
+	default:
+		return "", false, fmt.Errorf("ambiguous case-folded config key %q matches %v", key, matches)
+	}
+}
+
+// trackerFieldConfigMapKey returns the exact tracker field or one ASCII-case
+// match. It intentionally does not Unicode-fold fields such as APIKelvinKey into
+// APIKey, and rejects ambiguous folded fields such as APIKey versus ApiKey.
+func trackerFieldConfigMapKey(values map[string]any, key string) (string, bool, error) {
+	if _, ok := values[key]; ok {
+		return key, true, nil
+	}
+	matches := make([]string, 0, 1)
+	for existingKey := range values {
+		if existingKey != key && asciiEqualFold(existingKey, key) {
+			matches = append(matches, existingKey)
+		}
+	}
+	sort.Strings(matches)
+	switch len(matches) {
+	case 0:
+		return "", false, nil
+	case 1:
+		return matches[0], true, nil
+	default:
+		return "", false, fmt.Errorf("ambiguous tracker field %q matches %v", key, matches)
+	}
+}
+
+// validateStoredOverlayKeys rejects duplicate stored keys that would fold into
+// the same tracker name or tracker field before mutation starts.
+func validateStoredOverlayKeys(base map[string]any, keys []string, path string) error {
+	seen := map[string]string{}
+	for _, key := range keys {
+		foldKey := key
+		switch {
+		case usesASCIIStoredTrackerKeys(path):
+			existingKey, ok, err := asciiConfigMapKey(base, key)
+			if err != nil {
+				return err
+			}
+			if ok {
+				foldKey = existingKey
+			} else {
+				foldKey = asciiFoldKey(key)
+			}
+		case isStoredTrackerEntryPath(path):
+			existingKey, ok, err := trackerFieldConfigMapKey(base, key)
+			if err != nil {
+				return err
+			}
+			if ok {
+				foldKey = existingKey
+			}
+		default:
+			continue
+		}
+		if previous, ok := seen[foldKey]; ok && previous != key {
+			return fmt.Errorf("duplicate folded config keys %q and %q at %q", previous, key, path)
+		}
+		seen[foldKey] = key
+	}
 	return nil
 }
 
-// caseInsensitiveConfigMapKey returns the first map key equal to key under
-// Unicode case folding. Callers use it only where config keys are already
-// constrained by tracker schema paths.
-func caseInsensitiveConfigMapKey(values map[string]any, key string) (string, bool) {
-	for existingKey := range values {
-		if strings.EqualFold(existingKey, key) {
-			return existingKey, true
-		}
-	}
-	return "", false
-}
-
-// usesCaseInsensitiveStoredTrackerKeys reports whether a stored JSON path is a
-// tracker map or tracker field map where casing drift should not create
-// duplicate entries.
-func usesCaseInsensitiveStoredTrackerKeys(path string) bool {
-	return path == "Trackers.Trackers" || isStoredTrackerEntryPath(path)
+// usesASCIIStoredTrackerKeys reports paths whose dynamic child names are
+// tracker IDs and may use ASCII-case aliases.
+func usesASCIIStoredTrackerKeys(path string) bool {
+	return path == "Trackers.Trackers"
 }
 
 // configMapPath appends key to a dotted raw-config path.
@@ -378,12 +580,214 @@ func configMapPath(path, key string) string {
 	return path + "." + key
 }
 
+// configMapRoot returns the top-level JSON config section for a dotted path.
+func configMapRoot(path string) string {
+	if path == "" {
+		return ""
+	}
+	if before, _, ok := strings.Cut(path, "."); ok {
+		return before
+	}
+	return path
+}
+
+// allowsStoredDynamicConfigEntry reports raw JSON maps whose child keys are
+// user-defined entries rather than fixed struct fields.
 func allowsStoredDynamicConfigEntry(path string) bool {
 	return path == "Trackers.Trackers" || path == "TorrentClients"
 }
 
+// isStoredTrackerEntryPath reports direct tracker-entry maps only; deeper
+// extension maps are preserved without tracker-field case folding.
 func isStoredTrackerEntryPath(path string) bool {
-	return strings.HasPrefix(path, "Trackers.Trackers.")
+	const prefix = "Trackers.Trackers."
+	if !strings.HasPrefix(path, prefix) {
+		return false
+	}
+	return !strings.Contains(strings.TrimPrefix(path, prefix), ".")
+}
+
+// asciiFoldKey lowercases ASCII letters without treating Unicode lookalikes as
+// equivalent.
+func asciiFoldKey(value string) string {
+	out := []byte(value)
+	for i, b := range out {
+		if 'A' <= b && b <= 'Z' {
+			out[i] = b + ('a' - 'A')
+		}
+	}
+	return string(out)
+}
+
+// sortedStringSet returns map keys in stable order.
+func sortedStringSet(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sortedUniqueStrings removes blanks and duplicates, returning stable order.
+func sortedUniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		set[trimmed] = struct{}{}
+	}
+	return sortedStringSet(set)
+}
+
+// mergeStoredUnknownConfigValues copies stored object keys that are absent from
+// current without overwriting known current values. It recurses through object
+// values so selected-section repair saves keep forward-compatible same-root
+// fields while still writing repaired known fields.
+func mergeStoredUnknownConfigValues(current, stored any) {
+	currentMap, ok := current.(map[string]any)
+	if !ok {
+		return
+	}
+	storedMap, ok := stored.(map[string]any)
+	if !ok {
+		return
+	}
+	for key, storedValue := range storedMap {
+		currentValue, exists := currentMap[key]
+		if !exists {
+			currentMap[key] = storedValue
+			continue
+		}
+		mergeStoredUnknownConfigValues(currentValue, storedValue)
+	}
+}
+
+// preserveStoredUnknownConfigValues merges unknown stored fields into selected
+// section payloads when the repository can load the full raw config. A missing
+// stored config is treated as no data to preserve; other load errors abort
+// before any section write.
+func preserveStoredUnknownConfigValues(ctx context.Context, repo any, sections map[string]any) error {
+	loader, ok := repo.(interface {
+		LoadFullConfig(ctx context.Context, dest any) error
+	})
+	if !ok {
+		return nil
+	}
+
+	stored := map[string]any{}
+	if err := loader.LoadFullConfig(ctx, &stored); err != nil {
+		if errors.Is(err, internalerrors.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("load stored sections: %w", err)
+	}
+	for section, current := range sections {
+		mergeStoredUnknownConfigValues(current, stored[section])
+	}
+	return nil
+}
+
+// canonicalConfigSectionNames resolves requested root names to exported JSON
+// section names before any persistence happens. It accepts exported field names
+// plus yaml/json tag aliases from [Config], trims blanks, de-duplicates, and
+// rejects the whole request if any section is unknown.
+func canonicalConfigSectionNames(sectionData map[string]any, sections []string) ([]string, error) {
+	aliases := configRootSectionAliases()
+	canonicalSet := make(map[string]struct{}, len(sections))
+	for _, section := range sections {
+		trimmed := strings.TrimSpace(section)
+		if trimmed == "" {
+			continue
+		}
+		canonical := trimmed
+		if alias, ok := aliases[trimmed]; ok {
+			canonical = alias
+		}
+		if _, ok := sectionData[canonical]; !ok {
+			return nil, fmt.Errorf("unknown section %q", section)
+		}
+		canonicalSet[canonical] = struct{}{}
+	}
+	return sortedStringSet(canonicalSet), nil
+}
+
+// configRootSectionAliases maps every supported root-section spelling to the
+// exported field name used by database section storage.
+func configRootSectionAliases() map[string]string {
+	aliases := map[string]string{}
+	t := reflect.TypeFor[Config]()
+	for field := range t.Fields() {
+		if !field.IsExported() {
+			continue
+		}
+		aliases[field.Name] = field.Name
+
+		yamlName := strings.TrimSpace(strings.Split(field.Tag.Get("yaml"), ",")[0])
+		if yamlName != "" && yamlName != "-" {
+			aliases[yamlName] = field.Name
+		}
+
+		jsonName := strings.TrimSpace(strings.Split(field.Tag.Get("json"), ",")[0])
+		if jsonName != "" && jsonName != "-" {
+			aliases[jsonName] = field.Name
+		}
+	}
+	return aliases
+}
+
+// encryptConfigSecretsForSections prepares a copy for section persistence while
+// leaving secrets outside the selected root sections empty. This avoids
+// requiring unavailable helpers for unrelated encrypted envelopes but still
+// validates and encrypts secrets that would be written.
+func encryptConfigSecretsForSections(cfg *Config, sections []string) (*Config, error) {
+	selected := make(map[string]struct{}, len(sections))
+	for _, section := range sections {
+		selected[section] = struct{}{}
+	}
+
+	encryptionCfg, err := cloneConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	selectedSecret := false
+	if err := walkSecretFields(encryptionCfg, func(path string, value *string) error {
+		if value == nil {
+			return nil
+		}
+		if _, ok := selected[secretPathRoot(path)]; ok {
+			if strings.TrimSpace(*value) != "" {
+				selectedSecret = true
+			}
+			return nil
+		}
+		*value = ""
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	encryptionCfg.secretReencryptionRequired = cfg.secretReencryptionRequired && selectedSecret
+
+	return EncryptConfigSecrets(encryptionCfg)
+}
+
+// secretPathRoot returns the top-level config section for a dotted or indexed
+// secret field path.
+func secretPathRoot(path string) string {
+	end := len(path)
+	if idx := strings.IndexByte(path, '.'); idx >= 0 && idx < end {
+		end = idx
+	}
+	if idx := strings.IndexByte(path, '['); idx >= 0 && idx < end {
+		end = idx
+	}
+	return path[:end]
 }
 
 // SaveToDatabase persists the config to the repository.
@@ -406,6 +810,76 @@ func SaveToDatabase(ctx context.Context, cfg *Config, repo interface {
 		return fmt.Errorf("config save to database: %w", err)
 	}
 
+	return nil
+}
+
+// SaveSectionsToDatabase persists only selected root config sections. Section
+// names may use exported field names or root yaml/json tag aliases, and every
+// requested name is canonicalized before any write. Only selected sections are
+// prepared for secret encryption; repositories that support batch section saves
+// receive all selected payloads in one call, preserving same-root unknown
+// stored fields when the full raw config is available. Repositories without
+// batch support can save one canonical section only; multi-section requests
+// fail before any write.
+func SaveSectionsToDatabase(ctx context.Context, cfg *Config, sections []string, repo interface {
+	SaveConfigSection(ctx context.Context, section string, data any) error
+}) error {
+	if cfg == nil {
+		return internalerrors.ErrInvalidInput
+	}
+	if repo == nil {
+		return errors.New("config save sections: nil repository")
+	}
+	sections = sortedUniqueStrings(sections)
+	if len(sections) == 0 {
+		return nil
+	}
+
+	plainSectionData, err := configJSONMap(cfg)
+	if err != nil {
+		return fmt.Errorf("config save sections to database: section map: %w", err)
+	}
+	sections, err = canonicalConfigSectionNames(plainSectionData, sections)
+	if err != nil {
+		return fmt.Errorf("config save sections to database: %w", err)
+	}
+
+	encryptedCfg, err := encryptConfigSecretsForSections(cfg, sections)
+	if err != nil {
+		return fmt.Errorf("config save sections to database: encrypt secrets: %w", err)
+	}
+	sectionData, err := configJSONMap(encryptedCfg)
+	if err != nil {
+		return fmt.Errorf("config save sections to database: section map: %w", err)
+	}
+	sectionPayloads := make(map[string]any, len(sections))
+	for _, section := range sections {
+		data, ok := sectionData[section]
+		if !ok {
+			return fmt.Errorf("config save sections to database: unknown section %q", section)
+		}
+		sectionPayloads[section] = data
+	}
+	if repo, ok := repo.(interface {
+		SaveConfigSections(ctx context.Context, sections map[string]any) error
+	}); ok {
+		if err := preserveStoredUnknownConfigValues(ctx, repo, sectionPayloads); err != nil {
+			return fmt.Errorf("config save sections to database: preserve stored fields: %w", err)
+		}
+		if err := repo.SaveConfigSections(ctx, sectionPayloads); err != nil {
+			return fmt.Errorf("config save sections to database: %w", err)
+		}
+		return nil
+	}
+	if len(sections) > 1 {
+		return errors.New("config save sections to database: repository requires batch section save for multiple sections")
+	}
+	for _, section := range sections {
+		data := sectionPayloads[section]
+		if err := repo.SaveConfigSection(ctx, section, data); err != nil {
+			return fmt.Errorf("config save section %s to database: %w", section, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -212,23 +211,14 @@ func LoadFromDatabase(ctx context.Context, repo fullConfigLoader) (*Config, erro
 
 // LoadFromDatabaseWithDefaultBackfill returns a loaded config plus a changed
 // flag indicating whether embedded defaults filled fields missing from storage.
-// The flag is computed after secret decryption so callers can persist only real
-// config backfills instead of encryption envelope differences.
+// The flag is based on raw stored JSON key presence before Config unmarshaling,
+// so explicit false, zero, and empty values do not look like missing fields.
 func LoadFromDatabaseWithDefaultBackfill(ctx context.Context, repo fullConfigLoader) (*Config, bool, error) {
 	if repo == nil {
 		return nil, false, errors.New("config load: nil repository")
 	}
 
-	var stored Config
-	if err := repo.LoadFullConfig(ctx, &stored); err != nil {
-		return nil, false, fmt.Errorf("config load from database: %w", err)
-	}
-	decryptedStored, err := DecryptConfigSecrets(&stored)
-	if err != nil {
-		return nil, false, fmt.Errorf("config load from database: decrypt secrets: %w", err)
-	}
-
-	cfg, err := loadFullConfigOverlayingDefaults(ctx, repo)
+	cfg, backfilledDefaults, err := loadFullConfigOverlayingDefaults(ctx, repo)
 	if err != nil {
 		return nil, false, err
 	}
@@ -238,44 +228,45 @@ func LoadFromDatabaseWithDefaultBackfill(ctx context.Context, repo fullConfigLoa
 		return nil, false, fmt.Errorf("config load from database: decrypt secrets: %w", err)
 	}
 
-	return decryptedCfg, !reflect.DeepEqual(decryptedStored, decryptedCfg), nil
+	return decryptedCfg, backfilledDefaults, nil
 }
 
 // loadFullConfigOverlayingDefaults overlays raw stored JSON sections onto the
-// embedded default config. Raw overlay is required because unmarshaled structs
-// cannot distinguish omitted fields from explicit false, zero, or empty values.
-func loadFullConfigOverlayingDefaults(ctx context.Context, repo fullConfigLoader) (Config, error) {
+// embedded default config and reports whether any default keys were absent from
+// storage. Raw overlay is required because unmarshaled structs cannot
+// distinguish omitted fields from explicit false, zero, or empty values.
+func loadFullConfigOverlayingDefaults(ctx context.Context, repo fullConfigLoader) (Config, bool, error) {
 	defaults, err := LoadEmbeddedDefaultConfig()
 	if err != nil {
-		return Config{}, fmt.Errorf("config load from database: load defaults: %w", err)
+		return Config{}, false, fmt.Errorf("config load from database: load defaults: %w", err)
 	}
 	// Template clients are examples, not persisted user configuration.
 	defaults.TorrentClients = map[string]TorrentClientConfig{}
 
 	base, err := configJSONMap(defaults)
 	if err != nil {
-		return Config{}, fmt.Errorf("config load from database: marshal defaults: %w", err)
+		return Config{}, false, fmt.Errorf("config load from database: marshal defaults: %w", err)
 	}
 
 	stored := map[string]any{}
 	if err := repo.LoadFullConfig(ctx, &stored); err != nil {
 		cfg := *defaults
 		if err := repo.LoadFullConfig(ctx, &cfg); err != nil {
-			return Config{}, fmt.Errorf("config load from database: %w", err)
+			return Config{}, false, fmt.Errorf("config load from database: %w", err)
 		}
-		return cfg, nil
+		return cfg, false, nil
 	}
-	mergeStoredConfigMap(base, stored, "")
+	missingDefaultPaths := mergeStoredConfigMap(base, stored, "")
 
 	merged, err := json.Marshal(base)
 	if err != nil {
-		return Config{}, fmt.Errorf("config load from database: marshal merged defaults: %w", err)
+		return Config{}, false, fmt.Errorf("config load from database: marshal merged defaults: %w", err)
 	}
 	var cfg Config
 	if err := json.Unmarshal(merged, &cfg); err != nil {
-		return Config{}, fmt.Errorf("config load from database: unmarshal merged defaults: %w", err)
+		return Config{}, false, fmt.Errorf("config load from database: unmarshal merged defaults: %w", err)
 	}
-	return cfg, nil
+	return cfg, len(missingDefaultPaths) > 0, nil
 }
 
 // configJSONMap converts cfg to the same exported-field JSON shape used by DB
@@ -292,15 +283,23 @@ func configJSONMap(cfg *Config) (map[string]any, error) {
 	return out, nil
 }
 
-// mergeStoredConfigMap recursively overlays stored config onto defaults,
-// preserving dynamic tracker and torrent-client entries while ignoring unknown
-// non-dynamic fields that are no longer part of the current schema.
-func mergeStoredConfigMap(base map[string]any, overlay map[string]any, path string) {
+// mergeStoredConfigMap recursively overlays stored config onto defaults and
+// returns default-key paths absent from the stored JSON shape. Raw presence is
+// tracked before Config unmarshaling so explicit false, zero, and empty values
+// are not confused with omitted fields.
+func mergeStoredConfigMap(base map[string]any, overlay map[string]any, path string) []string {
+	var missingDefaultPaths []string
+	for key := range base {
+		if _, exists := overlay[key]; !exists {
+			missingDefaultPaths = append(missingDefaultPaths, configMapPath(path, key))
+		}
+	}
+
 	for key, overlayValue := range overlay {
 		baseValue, exists := base[key]
 		if !exists {
 			if allowsStoredDynamicConfigEntry(path) || isStoredTrackerEntryPath(path) {
-				base[key] = overlayValue
+				missingDefaultPaths = append(missingDefaultPaths, mergeStoredDynamicConfigValue(base, key, overlayValue, path)...)
 			}
 			continue
 		}
@@ -315,11 +314,58 @@ func mergeStoredConfigMap(base map[string]any, overlay map[string]any, path stri
 			if path != "" {
 				childPath = path + "." + key
 			}
-			mergeStoredConfigMap(baseMap, overlayMap, childPath)
+			missingDefaultPaths = append(missingDefaultPaths, mergeStoredConfigMap(baseMap, overlayMap, childPath)...)
 			continue
 		}
 		base[key] = overlayValue
 	}
+	return missingDefaultPaths
+}
+
+// mergeStoredDynamicConfigValue inserts a stored dynamic entry or folds it into
+// an existing tracker entry that differs only by case.
+func mergeStoredDynamicConfigValue(base map[string]any, key string, overlayValue any, path string) []string {
+	if usesCaseInsensitiveStoredTrackerKeys(path) {
+		if existingKey, ok := caseInsensitiveConfigMapKey(base, key); ok {
+			baseMap, baseOK := base[existingKey].(map[string]any)
+			overlayMap, overlayOK := overlayValue.(map[string]any)
+			if baseOK && overlayOK {
+				return mergeStoredConfigMap(baseMap, overlayMap, configMapPath(path, existingKey))
+			}
+			base[existingKey] = overlayValue
+			return nil
+		}
+	}
+
+	base[key] = overlayValue
+	return nil
+}
+
+// caseInsensitiveConfigMapKey returns the first map key equal to key under
+// Unicode case folding. Callers use it only where config keys are already
+// constrained by tracker schema paths.
+func caseInsensitiveConfigMapKey(values map[string]any, key string) (string, bool) {
+	for existingKey := range values {
+		if strings.EqualFold(existingKey, key) {
+			return existingKey, true
+		}
+	}
+	return "", false
+}
+
+// usesCaseInsensitiveStoredTrackerKeys reports whether a stored JSON path is a
+// tracker map or tracker field map where casing drift should not create
+// duplicate entries.
+func usesCaseInsensitiveStoredTrackerKeys(path string) bool {
+	return path == "Trackers.Trackers" || isStoredTrackerEntryPath(path)
+}
+
+// configMapPath appends key to a dotted raw-config path.
+func configMapPath(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
 }
 
 func allowsStoredDynamicConfigEntry(path string) bool {

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -195,25 +196,138 @@ func BackupToYAML(cfg *Config, baseDir string) (string, error) {
 	return backupPath, nil
 }
 
-// LoadFromDatabase loads the full config from the repository.
-func LoadFromDatabase(ctx context.Context, repo interface {
+// fullConfigLoader reconstructs persisted config data into either the Config
+// struct or a raw section map. Production repositories support both forms.
+type fullConfigLoader interface {
 	LoadFullConfig(ctx context.Context, dest any) error
-}) (*Config, error) {
+}
+
+// LoadFromDatabase loads the full config from the repository, overlaying saved
+// sections onto embedded defaults so older persisted configs pick up newly
+// added options while preserving explicit zero values and decrypted secrets.
+func LoadFromDatabase(ctx context.Context, repo fullConfigLoader) (*Config, error) {
+	cfg, _, err := LoadFromDatabaseWithDefaultBackfill(ctx, repo)
+	return cfg, err
+}
+
+// LoadFromDatabaseWithDefaultBackfill returns a loaded config plus a changed
+// flag indicating whether embedded defaults filled fields missing from storage.
+// The flag is computed after secret decryption so callers can persist only real
+// config backfills instead of encryption envelope differences.
+func LoadFromDatabaseWithDefaultBackfill(ctx context.Context, repo fullConfigLoader) (*Config, bool, error) {
 	if repo == nil {
-		return nil, errors.New("config load: nil repository")
+		return nil, false, errors.New("config load: nil repository")
 	}
 
-	var cfg Config
-	if err := repo.LoadFullConfig(ctx, &cfg); err != nil {
-		return nil, fmt.Errorf("config load from database: %w", err)
+	var stored Config
+	if err := repo.LoadFullConfig(ctx, &stored); err != nil {
+		return nil, false, fmt.Errorf("config load from database: %w", err)
+	}
+	decryptedStored, err := DecryptConfigSecrets(&stored)
+	if err != nil {
+		return nil, false, fmt.Errorf("config load from database: decrypt secrets: %w", err)
+	}
+
+	cfg, err := loadFullConfigOverlayingDefaults(ctx, repo)
+	if err != nil {
+		return nil, false, err
 	}
 
 	decryptedCfg, err := DecryptConfigSecrets(&cfg)
 	if err != nil {
-		return nil, fmt.Errorf("config load from database: decrypt secrets: %w", err)
+		return nil, false, fmt.Errorf("config load from database: decrypt secrets: %w", err)
 	}
 
-	return decryptedCfg, nil
+	return decryptedCfg, !reflect.DeepEqual(decryptedStored, decryptedCfg), nil
+}
+
+// loadFullConfigOverlayingDefaults overlays raw stored JSON sections onto the
+// embedded default config. Raw overlay is required because unmarshaled structs
+// cannot distinguish omitted fields from explicit false, zero, or empty values.
+func loadFullConfigOverlayingDefaults(ctx context.Context, repo fullConfigLoader) (Config, error) {
+	defaults, err := LoadEmbeddedDefaultConfig()
+	if err != nil {
+		return Config{}, fmt.Errorf("config load from database: load defaults: %w", err)
+	}
+	// Template clients are examples, not persisted user configuration.
+	defaults.TorrentClients = map[string]TorrentClientConfig{}
+
+	base, err := configJSONMap(defaults)
+	if err != nil {
+		return Config{}, fmt.Errorf("config load from database: marshal defaults: %w", err)
+	}
+
+	stored := map[string]any{}
+	if err := repo.LoadFullConfig(ctx, &stored); err != nil {
+		cfg := *defaults
+		if err := repo.LoadFullConfig(ctx, &cfg); err != nil {
+			return Config{}, fmt.Errorf("config load from database: %w", err)
+		}
+		return cfg, nil
+	}
+	mergeStoredConfigMap(base, stored, "")
+
+	merged, err := json.Marshal(base)
+	if err != nil {
+		return Config{}, fmt.Errorf("config load from database: marshal merged defaults: %w", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(merged, &cfg); err != nil {
+		return Config{}, fmt.Errorf("config load from database: unmarshal merged defaults: %w", err)
+	}
+	return cfg, nil
+}
+
+// configJSONMap converts cfg to the same exported-field JSON shape used by DB
+// section storage and native JSON exports.
+func configJSONMap(cfg *Config) (map[string]any, error) {
+	payload, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal config json map: %w", err)
+	}
+	out := map[string]any{}
+	if err := json.Unmarshal(payload, &out); err != nil {
+		return nil, fmt.Errorf("unmarshal config json map: %w", err)
+	}
+	return out, nil
+}
+
+// mergeStoredConfigMap recursively overlays stored config onto defaults,
+// preserving dynamic tracker and torrent-client entries while ignoring unknown
+// non-dynamic fields that are no longer part of the current schema.
+func mergeStoredConfigMap(base map[string]any, overlay map[string]any, path string) {
+	for key, overlayValue := range overlay {
+		baseValue, exists := base[key]
+		if !exists {
+			if allowsStoredDynamicConfigEntry(path) || isStoredTrackerEntryPath(path) {
+				base[key] = overlayValue
+			}
+			continue
+		}
+
+		baseMap, baseOK := baseValue.(map[string]any)
+		overlayMap, overlayOK := overlayValue.(map[string]any)
+		if baseOK {
+			if !overlayOK {
+				continue
+			}
+			childPath := key
+			if path != "" {
+				childPath = path + "." + key
+			}
+			mergeStoredConfigMap(baseMap, overlayMap, childPath)
+			continue
+		}
+		base[key] = overlayValue
+	}
+}
+
+func allowsStoredDynamicConfigEntry(path string) bool {
+	return path == "Trackers.Trackers" || path == "TorrentClients"
+}
+
+func isStoredTrackerEntryPath(path string) bool {
+	return strings.HasPrefix(path, "Trackers.Trackers.")
 }
 
 // SaveToDatabase persists the config to the repository.

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -286,7 +287,9 @@ func configJSONMap(cfg *Config) (map[string]any, error) {
 // mergeStoredConfigMap recursively overlays stored config onto defaults and
 // returns default-key paths absent from the stored JSON shape. Raw presence is
 // tracked before Config unmarshaling so explicit false, zero, and empty values
-// are not confused with omitted fields.
+// are not confused with omitted fields. Overlay keys are processed in sorted
+// order so duplicate tracker case variants fold into canonical entries
+// deterministically.
 func mergeStoredConfigMap(base map[string]any, overlay map[string]any, path string) []string {
 	var missingDefaultPaths []string
 	for key := range base {
@@ -295,7 +298,14 @@ func mergeStoredConfigMap(base map[string]any, overlay map[string]any, path stri
 		}
 	}
 
-	for key, overlayValue := range overlay {
+	overlayKeys := make([]string, 0, len(overlay))
+	for key := range overlay {
+		overlayKeys = append(overlayKeys, key)
+	}
+	sort.Strings(overlayKeys)
+
+	for _, key := range overlayKeys {
+		overlayValue := overlay[key]
 		baseValue, exists := base[key]
 		if !exists {
 			if allowsStoredDynamicConfigEntry(path) || isStoredTrackerEntryPath(path) {

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -637,6 +638,8 @@ func TestLoadFromDatabaseWithDefaultBackfillIgnoresExplicitZeroDefaultKey(t *tes
 	}
 }
 
+// TestLoadFromDatabaseMergesCaseInsensitiveStoredTrackerName verifies stored
+// tracker names fold into canonical defaults and still report backfilled keys.
 func TestLoadFromDatabaseMergesCaseInsensitiveStoredTrackerName(t *testing.T) {
 	t.Parallel()
 
@@ -655,9 +658,12 @@ func TestLoadFromDatabaseMergesCaseInsensitiveStoredTrackerName(t *testing.T) {
 		"URL":    "https://stored.btn.example",
 	}
 
-	loaded, _, err := LoadFromDatabaseWithDefaultBackfill(context.Background(), &rawConfigRepo{raw: raw})
+	loaded, backfilledDefaults, err := LoadFromDatabaseWithDefaultBackfill(context.Background(), &rawConfigRepo{raw: raw})
 	if err != nil {
 		t.Fatalf("LoadFromDatabaseWithDefaultBackfill failed: %v", err)
+	}
+	if !backfilledDefaults {
+		t.Fatalf("expected case-normalized tracker entry to report backfilled defaults")
 	}
 	if _, ok := loaded.Trackers.Trackers["btn"]; ok {
 		t.Fatalf("expected lowercase stored tracker to merge into canonical BTN entry")
@@ -671,6 +677,8 @@ func TestLoadFromDatabaseMergesCaseInsensitiveStoredTrackerName(t *testing.T) {
 	}
 }
 
+// TestMergeStoredConfigMapMergesCaseInsensitiveStoredTrackerField verifies
+// case-normalized tracker fields preserve the missing canonical default path.
 func TestMergeStoredConfigMapMergesCaseInsensitiveStoredTrackerField(t *testing.T) {
 	t.Parallel()
 
@@ -682,13 +690,49 @@ func TestMergeStoredConfigMapMergesCaseInsensitiveStoredTrackerField(t *testing.
 		"apikey": "stored-token",
 	}
 
-	mergeStoredConfigMap(base, overlay, "Trackers.Trackers.BTN")
+	missingDefaultPaths := mergeStoredConfigMap(base, overlay, "Trackers.Trackers.BTN")
 
 	if _, ok := base["apikey"]; ok {
 		t.Fatalf("expected lowercase tracker field to merge into canonical APIKey")
 	}
 	if got := base["APIKey"]; got != "stored-token" {
 		t.Fatalf("expected stored API key on canonical field, got %#v", got)
+	}
+	if !slices.Contains(missingDefaultPaths, "Trackers.Trackers.BTN.APIKey") {
+		t.Fatalf("expected case-normalized tracker field to report missing canonical default, got %#v", missingDefaultPaths)
+	}
+}
+
+// TestMergeStoredConfigMapUsesSortedOverlayOrderForTrackerCaseVariants verifies
+// duplicate tracker names differing only by case fold in sorted overlay order.
+func TestMergeStoredConfigMapUsesSortedOverlayOrderForTrackerCaseVariants(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"BTN": map[string]any{
+			"APIKey": "",
+		},
+	}
+	overlay := map[string]any{
+		"btn": map[string]any{
+			"apikey": "lower-token",
+		},
+		"BTN": map[string]any{
+			"APIKey": "upper-token",
+		},
+	}
+
+	mergeStoredConfigMap(base, overlay, "Trackers.Trackers")
+
+	if _, ok := base["btn"]; ok {
+		t.Fatalf("expected lowercase tracker to merge into canonical BTN")
+	}
+	btn, ok := base["BTN"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected canonical BTN map")
+	}
+	if got := btn["APIKey"]; got != "lower-token" {
+		t.Fatalf("expected sorted duplicate-case overlay to be stable, got %#v", got)
 	}
 }
 

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -503,6 +503,10 @@ type jsonRoundTripRepo struct {
 	saved *Config
 }
 
+type rawConfigRepo struct {
+	raw map[string]any
+}
+
 func (r *secretRoundTripRepo) SaveFullConfig(_ context.Context, cfg any) error {
 	typed, ok := cfg.(*Config)
 	if !ok {
@@ -549,6 +553,33 @@ func (r *jsonRoundTripRepo) LoadFullConfig(_ context.Context, dest any) error {
 	return nil
 }
 
+func (r *rawConfigRepo) LoadFullConfig(_ context.Context, dest any) error {
+	payload, err := json.Marshal(r.raw)
+	if err != nil {
+		return fmt.Errorf("marshal raw config: %w", err)
+	}
+	if err := json.Unmarshal(payload, dest); err != nil {
+		return fmt.Errorf("unmarshal raw config: %w", err)
+	}
+	return nil
+}
+
+func defaultDatabaseConfigMap(t *testing.T) map[string]any {
+	t.Helper()
+
+	defaults, err := LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("LoadEmbeddedDefaultConfig failed: %v", err)
+	}
+	defaults.TorrentClients = map[string]TorrentClientConfig{}
+
+	raw, err := configJSONMap(defaults)
+	if err != nil {
+		t.Fatalf("configJSONMap failed: %v", err)
+	}
+	return raw
+}
+
 func writeWebAuthFixture(t *testing.T, dbPath string) {
 	t.Helper()
 	authPath := filepath.Join(filepath.Dir(dbPath), webAuthFileName)
@@ -563,6 +594,102 @@ func configureConfigSecretEncryption(t *testing.T, cfg *Config) {
 	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
 	writeWebAuthFixture(t, dbPath)
 	cfg.MainSettings.DBPath = dbPath
+}
+
+func TestLoadFromDatabaseWithDefaultBackfillReportsMissingZeroDefaultKey(t *testing.T) {
+	t.Parallel()
+
+	raw := defaultDatabaseConfigMap(t)
+	torrentCreation, ok := raw["TorrentCreation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected TorrentCreation defaults map")
+	}
+	delete(torrentCreation, "RehashCooldown")
+
+	loaded, backfilledDefaults, err := LoadFromDatabaseWithDefaultBackfill(context.Background(), &rawConfigRepo{raw: raw})
+	if err != nil {
+		t.Fatalf("LoadFromDatabaseWithDefaultBackfill failed: %v", err)
+	}
+	if !backfilledDefaults {
+		t.Fatalf("expected missing zero-value default key to report backfilled defaults")
+	}
+	if loaded.TorrentCreation.RehashCooldown != 0 {
+		t.Fatalf("expected zero default rehash cooldown, got %d", loaded.TorrentCreation.RehashCooldown)
+	}
+}
+
+func TestLoadFromDatabaseWithDefaultBackfillIgnoresExplicitZeroDefaultKey(t *testing.T) {
+	t.Parallel()
+
+	raw := defaultDatabaseConfigMap(t)
+	torrentCreation, ok := raw["TorrentCreation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected TorrentCreation defaults map")
+	}
+	torrentCreation["RehashCooldown"] = float64(0)
+
+	_, backfilledDefaults, err := LoadFromDatabaseWithDefaultBackfill(context.Background(), &rawConfigRepo{raw: raw})
+	if err != nil {
+		t.Fatalf("LoadFromDatabaseWithDefaultBackfill failed: %v", err)
+	}
+	if backfilledDefaults {
+		t.Fatalf("expected explicit zero-value key to avoid default backfill")
+	}
+}
+
+func TestLoadFromDatabaseMergesCaseInsensitiveStoredTrackerName(t *testing.T) {
+	t.Parallel()
+
+	raw := defaultDatabaseConfigMap(t)
+	trackerSection, ok := raw["Trackers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected Trackers defaults map")
+	}
+	trackers, ok := trackerSection["Trackers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected Trackers.Trackers defaults map")
+	}
+	delete(trackers, "BTN")
+	trackers["btn"] = map[string]any{
+		"APIKey": "stored-token",
+		"URL":    "https://stored.btn.example",
+	}
+
+	loaded, _, err := LoadFromDatabaseWithDefaultBackfill(context.Background(), &rawConfigRepo{raw: raw})
+	if err != nil {
+		t.Fatalf("LoadFromDatabaseWithDefaultBackfill failed: %v", err)
+	}
+	if _, ok := loaded.Trackers.Trackers["btn"]; ok {
+		t.Fatalf("expected lowercase stored tracker to merge into canonical BTN entry")
+	}
+	btn := loaded.Trackers.Trackers["BTN"]
+	if btn.APIKey != "stored-token" {
+		t.Fatalf("expected stored BTN API key, got %q", btn.APIKey)
+	}
+	if btn.URL != "https://stored.btn.example" {
+		t.Fatalf("expected stored BTN URL, got %q", btn.URL)
+	}
+}
+
+func TestMergeStoredConfigMapMergesCaseInsensitiveStoredTrackerField(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"APIKey": "",
+		"URL":    "https://default.example",
+	}
+	overlay := map[string]any{
+		"apikey": "stored-token",
+	}
+
+	mergeStoredConfigMap(base, overlay, "Trackers.Trackers.BTN")
+
+	if _, ok := base["apikey"]; ok {
+		t.Fatalf("expected lowercase tracker field to merge into canonical APIKey")
+	}
+	if got := base["APIKey"]; got != "stored-token" {
+		t.Fatalf("expected stored API key on canonical field, got %#v", got)
+	}
 }
 
 func TestExportToJSONFallsBackToPlaintextWithPermissiveWebAuthPermissions(t *testing.T) {

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -508,6 +508,19 @@ type rawConfigRepo struct {
 	raw map[string]any
 }
 
+type fallbackConfigRepo struct {
+	cfg Config
+}
+
+type sectionCaptureRepo struct {
+	saved []string
+	err   error
+}
+
+type sectionBatchPreserveRepo struct {
+	raw map[string]any
+}
+
 func (r *secretRoundTripRepo) SaveFullConfig(_ context.Context, cfg any) error {
 	typed, ok := cfg.(*Config)
 	if !ok {
@@ -561,6 +574,59 @@ func (r *rawConfigRepo) LoadFullConfig(_ context.Context, dest any) error {
 	}
 	if err := json.Unmarshal(payload, dest); err != nil {
 		return fmt.Errorf("unmarshal raw config: %w", err)
+	}
+	return nil
+}
+
+func (r *fallbackConfigRepo) LoadFullConfig(_ context.Context, dest any) error {
+	switch out := dest.(type) {
+	case *map[string]any:
+		return errors.New("raw map load failed")
+	case *Config:
+		*out = r.cfg
+		return nil
+	default:
+		return errors.New("unexpected destination type")
+	}
+}
+
+func (r *sectionCaptureRepo) SaveConfigSection(_ context.Context, section string, _ any) error {
+	if r.err != nil {
+		return r.err
+	}
+	r.saved = append(r.saved, section)
+	return nil
+}
+
+func (r *sectionBatchPreserveRepo) LoadFullConfig(_ context.Context, dest any) error {
+	payload, err := json.Marshal(r.raw)
+	if err != nil {
+		return fmt.Errorf("marshal raw config: %w", err)
+	}
+	if err := json.Unmarshal(payload, dest); err != nil {
+		return fmt.Errorf("unmarshal raw config: %w", err)
+	}
+	return nil
+}
+
+func (r *sectionBatchPreserveRepo) SaveConfigSection(ctx context.Context, section string, data any) error {
+	return r.SaveConfigSections(ctx, map[string]any{section: data})
+}
+
+func (r *sectionBatchPreserveRepo) SaveConfigSections(_ context.Context, sections map[string]any) error {
+	if r.raw == nil {
+		r.raw = map[string]any{}
+	}
+	for section, data := range sections {
+		payload, err := json.Marshal(data)
+		if err != nil {
+			return fmt.Errorf("marshal section %s: %w", section, err)
+		}
+		var stored any
+		if err := json.Unmarshal(payload, &stored); err != nil {
+			return fmt.Errorf("unmarshal section %s: %w", section, err)
+		}
+		r.raw[section] = stored
 	}
 	return nil
 }
@@ -638,6 +704,180 @@ func TestLoadFromDatabaseWithDefaultBackfillIgnoresExplicitZeroDefaultKey(t *tes
 	}
 }
 
+func TestLoadFromDatabaseWithRepairReportDoesNotPersistInvalidObjectRoots(t *testing.T) {
+	t.Parallel()
+
+	for name, value := range map[string]any{
+		"null":   nil,
+		"scalar": "not-an-object",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := defaultDatabaseConfigMap(t)
+			raw["Trackers"] = value
+
+			loaded, report, err := LoadFromDatabaseWithRepairReport(context.Background(), &rawConfigRepo{raw: raw})
+			if err != nil {
+				t.Fatalf("LoadFromDatabaseWithRepairReport failed: %v", err)
+			}
+			if loaded.Trackers.Trackers == nil {
+				t.Fatalf("expected runtime config to retain default Trackers object")
+			}
+			if !report.BackfilledDefaults {
+				t.Fatalf("expected invalid object to report repaired defaults")
+			}
+			if !slices.Contains(report.InvalidPaths, "Trackers") {
+				t.Fatalf("expected invalid Trackers path, got %#v", report.InvalidPaths)
+			}
+			if slices.Contains(report.ChangedSections, "Trackers") {
+				t.Fatalf("expected invalid object root not to be scheduled for persistence, got %#v", report.ChangedSections)
+			}
+		})
+	}
+}
+
+func TestLoadFromDatabaseWithRepairReportFallbackExposesRepairContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		MainSettings:       MainSettingsConfig{TMDBAPI: "fallback-token"},
+		ScreenshotHandling: ScreenshotHandlingConfig{Screens: 3},
+	}
+	loaded, report, err := LoadFromDatabaseWithRepairReport(context.Background(), &fallbackConfigRepo{cfg: cfg})
+	if err != nil {
+		t.Fatalf("LoadFromDatabaseWithRepairReport failed: %v", err)
+	}
+	if loaded.MainSettings.TMDBAPI != "fallback-token" {
+		t.Fatalf("expected struct fallback config to load, got %q", loaded.MainSettings.TMDBAPI)
+	}
+	if !report.BackfilledDefaults {
+		t.Fatalf("expected fallback report to expose repair context")
+	}
+	if !slices.Contains(report.InvalidPaths, "raw-config") {
+		t.Fatalf("expected raw-config diagnostic, got %#v", report.InvalidPaths)
+	}
+	if len(report.ChangedSections) != 0 {
+		t.Fatalf("expected fallback compatibility without section persistence, got %#v", report.ChangedSections)
+	}
+}
+
+func TestSaveSectionsToDatabasePrevalidatesSectionNamesBeforeWrites(t *testing.T) {
+	t.Parallel()
+
+	repo := &sectionCaptureRepo{}
+	cfg := validMinimalConfig()
+
+	err := SaveSectionsToDatabase(context.Background(), cfg, []string{"Logging", "unknown_section"}, repo)
+	if err == nil {
+		t.Fatalf("expected unknown section error")
+	}
+	if len(repo.saved) != 0 {
+		t.Fatalf("expected no sections saved before unknown section error, got %#v", repo.saved)
+	}
+}
+
+func TestSaveSectionsToDatabaseMapsYAMLRootAliases(t *testing.T) {
+	t.Parallel()
+
+	repo := &sectionCaptureRepo{}
+	cfg := validMinimalConfig()
+
+	if err := SaveSectionsToDatabase(context.Background(), cfg, []string{" main_settings ", "MainSettings"}, repo); err != nil {
+		t.Fatalf("SaveSectionsToDatabase failed: %v", err)
+	}
+	if got, want := repo.saved, []string{"MainSettings"}; !slices.Equal(got, want) {
+		t.Fatalf("saved sections mismatch: got %#v want %#v", got, want)
+	}
+}
+
+func TestSaveSectionsToDatabaseIgnoresUnrelatedEncryptedSecrets(t *testing.T) {
+	t.Parallel()
+
+	repo := &sectionCaptureRepo{}
+	cfg := validMinimalConfig()
+	cfg.MainSettings.DBPath = filepath.Join(t.TempDir(), "upbrr.db")
+	cfg.MainSettings.TMDBAPI = encryptedEnvelopePrefix + "opaque"
+
+	if err := SaveSectionsToDatabase(context.Background(), cfg, []string{"Logging"}, repo); err != nil {
+		t.Fatalf("SaveSectionsToDatabase failed for unrelated encrypted secret: %v", err)
+	}
+	if got, want := repo.saved, []string{"Logging"}; !slices.Equal(got, want) {
+		t.Fatalf("saved sections mismatch: got %#v want %#v", got, want)
+	}
+}
+
+func TestSaveSectionsToDatabaseRequiresHelperForSelectedEncryptedSecret(t *testing.T) {
+	t.Parallel()
+
+	repo := &sectionCaptureRepo{}
+	cfg := validMinimalConfig()
+	cfg.MainSettings.DBPath = filepath.Join(t.TempDir(), "upbrr.db")
+	cfg.MainSettings.TMDBAPI = encryptedEnvelopePrefix + "opaque"
+
+	err := SaveSectionsToDatabase(context.Background(), cfg, []string{"MainSettings"}, repo)
+	if !errors.Is(err, ErrSecretEncryptionHelperUnavailable) {
+		t.Fatalf("expected helper unavailable error, got %v", err)
+	}
+	if len(repo.saved) != 0 {
+		t.Fatalf("expected no sections saved after selected encrypted secret failure, got %#v", repo.saved)
+	}
+}
+
+func TestSaveSectionsToDatabaseRejectsMultiSectionFallbackBeforeWrites(t *testing.T) {
+	t.Parallel()
+
+	repo := &sectionCaptureRepo{}
+	cfg := validMinimalConfig()
+
+	err := SaveSectionsToDatabase(context.Background(), cfg, []string{"Logging", "PostUpload"}, repo)
+	if err == nil {
+		t.Fatal("expected multi-section fallback error")
+	}
+	if !strings.Contains(err.Error(), "requires batch section save") {
+		t.Fatalf("expected batch requirement error, got %v", err)
+	}
+	if len(repo.saved) != 0 {
+		t.Fatalf("expected no fallback sections saved, got %#v", repo.saved)
+	}
+}
+
+func TestSaveSectionsToDatabasePreservesStoredUnknownSameRootFields(t *testing.T) {
+	t.Parallel()
+
+	raw := defaultDatabaseConfigMap(t)
+	postUpload, ok := raw["PostUpload"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected PostUpload defaults map")
+	}
+	postUpload["FutureOption"] = map[string]any{"Nested": "keep"}
+	delete(postUpload, "MaxConcurrentTrackers")
+	repo := &sectionBatchPreserveRepo{raw: raw}
+
+	loaded, report, err := LoadFromDatabaseWithRepairReport(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("LoadFromDatabaseWithRepairReport failed: %v", err)
+	}
+	if !slices.Contains(report.ChangedSections, "PostUpload") {
+		t.Fatalf("expected PostUpload repair section, got %#v", report.ChangedSections)
+	}
+	if err := SaveSectionsToDatabase(context.Background(), loaded, report.ChangedSections, repo); err != nil {
+		t.Fatalf("SaveSectionsToDatabase failed: %v", err)
+	}
+
+	persisted, ok := repo.raw["PostUpload"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected persisted PostUpload map")
+	}
+	future, ok := persisted["FutureOption"].(map[string]any)
+	if !ok || future["Nested"] != "keep" {
+		t.Fatalf("expected unknown same-root field to survive, got %#v", persisted["FutureOption"])
+	}
+	if got, ok := persisted["MaxConcurrentTrackers"].(float64); !ok || got != 4 {
+		t.Fatalf("expected repaired max concurrent tracker uploads, got %#v", persisted["MaxConcurrentTrackers"])
+	}
+}
+
 // TestLoadFromDatabaseMergesCaseInsensitiveStoredTrackerName verifies stored
 // tracker names fold into canonical defaults and still report backfilled keys.
 func TestLoadFromDatabaseMergesCaseInsensitiveStoredTrackerName(t *testing.T) {
@@ -690,7 +930,11 @@ func TestMergeStoredConfigMapMergesCaseInsensitiveStoredTrackerField(t *testing.
 		"apikey": "stored-token",
 	}
 
-	missingDefaultPaths := mergeStoredConfigMap(base, overlay, "Trackers.Trackers.BTN")
+	report, err := mergeStoredConfigMapWithReport(base, overlay, "Trackers.Trackers.BTN")
+	if err != nil {
+		t.Fatalf("merge stored config map: %v", err)
+	}
+	missingDefaultPaths := report.missingDefaultPaths
 
 	if _, ok := base["apikey"]; ok {
 		t.Fatalf("expected lowercase tracker field to merge into canonical APIKey")
@@ -703,9 +947,9 @@ func TestMergeStoredConfigMapMergesCaseInsensitiveStoredTrackerField(t *testing.
 	}
 }
 
-// TestMergeStoredConfigMapUsesSortedOverlayOrderForTrackerCaseVariants verifies
-// duplicate tracker names differing only by case fold in sorted overlay order.
-func TestMergeStoredConfigMapUsesSortedOverlayOrderForTrackerCaseVariants(t *testing.T) {
+// TestMergeStoredConfigMapRejectsDuplicateTrackerCaseVariants verifies duplicate
+// tracker names differing only by case fold are not resolved by lexical order.
+func TestMergeStoredConfigMapRejectsDuplicateTrackerCaseVariants(t *testing.T) {
 	t.Parallel()
 
 	base := map[string]any{
@@ -722,17 +966,45 @@ func TestMergeStoredConfigMapUsesSortedOverlayOrderForTrackerCaseVariants(t *tes
 		},
 	}
 
-	mergeStoredConfigMap(base, overlay, "Trackers.Trackers")
+	if _, err := mergeStoredConfigMapWithReport(base, overlay, "Trackers.Trackers"); err == nil {
+		t.Fatalf("expected duplicate case-folded tracker keys to fail")
+	}
+}
 
-	if _, ok := base["btn"]; ok {
-		t.Fatalf("expected lowercase tracker to merge into canonical BTN")
+func TestMergeStoredConfigMapRejectsAmbiguousTrackerField(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"APIKey": "",
+		"ApiKey": "",
 	}
-	btn, ok := base["BTN"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected canonical BTN map")
+	overlay := map[string]any{
+		"apikey": "stored-token",
 	}
-	if got := btn["APIKey"]; got != "lower-token" {
-		t.Fatalf("expected sorted duplicate-case overlay to be stable, got %#v", got)
+
+	if _, err := mergeStoredConfigMapWithReport(base, overlay, "Trackers.Trackers.BTN"); err == nil {
+		t.Fatalf("expected ambiguous tracker field to fail")
+	}
+}
+
+func TestMergeStoredConfigMapDoesNotUnicodeFoldTrackerField(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"APIKey": "",
+	}
+	overlay := map[string]any{
+		"API\u212Aey": "stored-token",
+	}
+
+	if _, err := mergeStoredConfigMapWithReport(base, overlay, "Trackers.Trackers.BTN"); err != nil {
+		t.Fatalf("merge stored config map: %v", err)
+	}
+	if got := base["APIKey"]; got != "" {
+		t.Fatalf("expected unicode folded field not to overwrite APIKey, got %#v", got)
+	}
+	if got := base["API\u212Aey"]; got != "stored-token" {
+		t.Fatalf("expected unicode field to remain distinct, got %#v", got)
 	}
 }
 

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -878,6 +878,62 @@ func TestSaveSectionsToDatabasePreservesStoredUnknownSameRootFields(t *testing.T
 	}
 }
 
+func TestSaveSectionsToDatabaseDoesNotPreserveRepairedTrackerAliases(t *testing.T) {
+	t.Parallel()
+
+	raw := defaultDatabaseConfigMap(t)
+	trackerSection, ok := raw["Trackers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected Trackers defaults map")
+	}
+	trackers, ok := trackerSection["Trackers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected Trackers.Trackers defaults map")
+	}
+	delete(trackers, "BTN")
+	trackers["btn"] = map[string]any{
+		"apikey":     "stored-token",
+		"FutureFlag": true,
+	}
+	repo := &sectionBatchPreserveRepo{raw: raw}
+
+	loaded, report, err := LoadFromDatabaseWithRepairReport(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("LoadFromDatabaseWithRepairReport failed: %v", err)
+	}
+	if !slices.Contains(report.ChangedSections, "Trackers") {
+		t.Fatalf("expected Trackers repair section, got %#v", report.ChangedSections)
+	}
+	if err := SaveSectionsToDatabase(context.Background(), loaded, report.ChangedSections, repo); err != nil {
+		t.Fatalf("SaveSectionsToDatabase failed: %v", err)
+	}
+
+	persistedTrackers, ok := repo.raw["Trackers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected persisted Trackers map")
+	}
+	persistedEntries, ok := persistedTrackers["Trackers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected persisted Trackers.Trackers map")
+	}
+	if _, ok := persistedEntries["btn"]; ok {
+		t.Fatalf("expected folded tracker alias not to be preserved, got %#v", persistedEntries["btn"])
+	}
+	btn, ok := persistedEntries["BTN"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected canonical BTN entry, got %#v", persistedEntries["BTN"])
+	}
+	if _, ok := btn["apikey"]; ok {
+		t.Fatalf("expected folded tracker field alias not to be preserved, got %#v", btn["apikey"])
+	}
+	if got := btn["APIKey"]; got != "stored-token" {
+		t.Fatalf("expected canonical APIKey to keep stored value, got %#v", got)
+	}
+	if got := btn["FutureFlag"]; got != true {
+		t.Fatalf("expected distinct unknown tracker field to be preserved, got %#v", got)
+	}
+}
+
 // TestLoadFromDatabaseMergesCaseInsensitiveStoredTrackerName verifies stored
 // tracker names fold into canonical defaults and still report backfilled keys.
 func TestLoadFromDatabaseMergesCaseInsensitiveStoredTrackerName(t *testing.T) {
@@ -914,6 +970,78 @@ func TestLoadFromDatabaseMergesCaseInsensitiveStoredTrackerName(t *testing.T) {
 	}
 	if btn.URL != "https://stored.btn.example" {
 		t.Fatalf("expected stored BTN URL, got %q", btn.URL)
+	}
+}
+
+func TestMergeStoredDynamicConfigValueSkipsNonObjectCaseFoldedTrackerEntry(t *testing.T) {
+	t.Parallel()
+
+	base := map[string]any{
+		"BTN": map[string]any{
+			"APIKey": "",
+		},
+	}
+
+	report, err := mergeStoredDynamicConfigValue(base, "btn", "not-an-object", "Trackers.Trackers")
+	if err != nil {
+		t.Fatalf("merge stored dynamic config value: %v", err)
+	}
+
+	btn, ok := base["BTN"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected canonical BTN entry to remain an object, got %T", base["BTN"])
+	}
+	if got := btn["APIKey"]; got != "" {
+		t.Fatalf("expected canonical BTN entry to remain unchanged, got APIKey %#v", got)
+	}
+	if changed := report.changedRootSections(); len(changed) != 0 {
+		t.Fatalf("expected skipped scalar entry not to mark changes, got %#v", changed)
+	}
+}
+
+func TestMergeStoredConfigMapSkipsNonObjectDynamicEntries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		path         string
+		key          string
+		overlayValue any
+	}{
+		{
+			name:         "tracker entry scalar",
+			path:         "Trackers.Trackers",
+			key:          "NEW",
+			overlayValue: "not-an-object",
+		},
+		{
+			name:         "torrent client array",
+			path:         "TorrentClients",
+			key:          "client",
+			overlayValue: []any{"not-an-object"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			base := map[string]any{}
+			overlay := map[string]any{
+				test.key: test.overlayValue,
+			}
+
+			report, err := mergeStoredConfigMapWithReport(base, overlay, test.path)
+			if err != nil {
+				t.Fatalf("merge stored config map: %v", err)
+			}
+			if _, ok := base[test.key]; ok {
+				t.Fatalf("expected non-object dynamic entry %q not to be inserted", test.key)
+			}
+			if changed := report.changedRootSections(); len(changed) != 0 {
+				t.Fatalf("expected skipped dynamic entry not to mark changes, got %#v", changed)
+			}
+		})
 	}
 }
 

--- a/internal/configstore/dbloader.go
+++ b/internal/configstore/dbloader.go
@@ -101,17 +101,22 @@ func loadFromDBPath(ctx context.Context, dbPath string, applyEnv bool) (*config.
 		return nil, fmt.Errorf("config store: %w", err)
 	}
 
-	loaded, backfilledDefaults, err := config.LoadFromDatabaseWithDefaultBackfill(ctx, repo)
+	loaded, repairReport, err := config.LoadFromDatabaseWithRepairReport(ctx, repo)
 	if err != nil {
 		return nil, fmt.Errorf("config store: %w", err)
 	}
-	mergedTrackerDefaults, err := config.MergeMissingTrackerDefaults(loaded)
+	changedSections := append([]string(nil), repairReport.ChangedSections...)
+	mergeReport, err := config.MergeMissingTrackerDefaultsWithReport(loaded)
 	if err != nil {
 		return nil, fmt.Errorf("config store: %w", err)
 	}
+	changedSections = append(changedSections, mergeReport.ChangedSections...)
 	sanitizedTrackers := len(config.DisableUnsupportedTrackerImageRehosts(loaded)) > 0
-	if backfilledDefaults || mergedTrackerDefaults || sanitizedTrackers {
-		if err := config.SaveToDatabase(ctx, loaded, repo); err != nil {
+	if sanitizedTrackers {
+		changedSections = append(changedSections, "Trackers")
+	}
+	if repairReport.BackfilledDefaults || mergeReport.Changed || sanitizedTrackers {
+		if err := config.SaveSectionsToDatabase(ctx, loaded, changedSections, repo); err != nil {
 			return nil, fmt.Errorf("config store: %w", err)
 		}
 	}

--- a/internal/configstore/dbloader.go
+++ b/internal/configstore/dbloader.go
@@ -76,9 +76,9 @@ func LoadFromPathOrEmbedded(path string) (*config.Config, error) {
 }
 
 // LoadFromDBPath opens the sqlite database at dbPath, runs migrations, loads
-// the full configuration, backfills any missing tracker defaults, disables
-// unsupported tracker image rehosts (persisting the sanitized config back to
-// the database when changes are made), and applies environment overrides.
+// the full configuration, backfills missing embedded defaults, disables
+// unsupported tracker image rehosts, persists any load-time fixes back to the
+// database, and applies environment overrides.
 //
 // Callers decide whether to validate the returned config — the CLI fails fast
 // while the web/GUI start with invalid config so users can fix it via the UI.
@@ -87,7 +87,9 @@ func LoadFromDBPath(ctx context.Context, dbPath string) (*config.Config, error) 
 }
 
 // loadFromDBPath loads persisted config and optionally applies environment
-// overrides to the returned runtime copy.
+// overrides to the returned runtime copy. Missing defaults and sanitized
+// tracker settings are written before env overrides so persisted config remains
+// environment-neutral.
 func loadFromDBPath(ctx context.Context, dbPath string, applyEnv bool) (*config.Config, error) {
 	repo, err := db.OpenContext(ctx, dbPath)
 	if err != nil {
@@ -99,14 +101,15 @@ func loadFromDBPath(ctx context.Context, dbPath string, applyEnv bool) (*config.
 		return nil, fmt.Errorf("config store: %w", err)
 	}
 
-	loaded, err := config.LoadFromDatabase(ctx, repo)
+	loaded, backfilledDefaults, err := config.LoadFromDatabaseWithDefaultBackfill(ctx, repo)
 	if err != nil {
 		return nil, fmt.Errorf("config store: %w", err)
 	}
 	if err := config.MergeMissingTrackerDefaults(loaded); err != nil {
 		return nil, fmt.Errorf("config store: %w", err)
 	}
-	if len(config.DisableUnsupportedTrackerImageRehosts(loaded)) > 0 {
+	sanitizedTrackers := len(config.DisableUnsupportedTrackerImageRehosts(loaded)) > 0
+	if backfilledDefaults || sanitizedTrackers {
 		if err := config.SaveToDatabase(ctx, loaded, repo); err != nil {
 			return nil, fmt.Errorf("config store: %w", err)
 		}

--- a/internal/configstore/dbloader.go
+++ b/internal/configstore/dbloader.go
@@ -87,9 +87,9 @@ func LoadFromDBPath(ctx context.Context, dbPath string) (*config.Config, error) 
 }
 
 // loadFromDBPath loads persisted config and optionally applies environment
-// overrides to the returned runtime copy. Missing defaults and sanitized
-// tracker settings are written before env overrides so persisted config remains
-// environment-neutral.
+// overrides to the returned runtime copy. Missing stored defaults, merged
+// tracker defaults, and sanitized tracker settings are written before env
+// overrides so persisted config remains environment-neutral.
 func loadFromDBPath(ctx context.Context, dbPath string, applyEnv bool) (*config.Config, error) {
 	repo, err := db.OpenContext(ctx, dbPath)
 	if err != nil {
@@ -105,11 +105,12 @@ func loadFromDBPath(ctx context.Context, dbPath string, applyEnv bool) (*config.
 	if err != nil {
 		return nil, fmt.Errorf("config store: %w", err)
 	}
-	if err := config.MergeMissingTrackerDefaults(loaded); err != nil {
+	mergedTrackerDefaults, err := config.MergeMissingTrackerDefaults(loaded)
+	if err != nil {
 		return nil, fmt.Errorf("config store: %w", err)
 	}
 	sanitizedTrackers := len(config.DisableUnsupportedTrackerImageRehosts(loaded)) > 0
-	if backfilledDefaults || sanitizedTrackers {
+	if backfilledDefaults || mergedTrackerDefaults || sanitizedTrackers {
 		if err := config.SaveToDatabase(ctx, loaded, repo); err != nil {
 			return nil, fmt.Errorf("config store: %w", err)
 		}
@@ -384,7 +385,7 @@ func loadStoredConfigForProvidedMerge(ctx context.Context, dbPath string) (*conf
 	if err != nil {
 		return nil, fmt.Errorf("config store: %w", err)
 	}
-	if err := config.MergeMissingTrackerDefaults(loaded); err != nil {
+	if _, err := config.MergeMissingTrackerDefaults(loaded); err != nil {
 		return nil, fmt.Errorf("config store: %w", err)
 	}
 	config.DisableUnsupportedTrackerImageRehosts(loaded)
@@ -601,7 +602,7 @@ func finalizeMergedConfig(cfg *config.Config) (*config.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("config store: decrypt merged config: %w", err)
 	}
-	if err := config.MergeMissingTrackerDefaults(decrypted); err != nil {
+	if _, err := config.MergeMissingTrackerDefaults(decrypted); err != nil {
 		return nil, fmt.Errorf("config store: merge tracker defaults: %w", err)
 	}
 	config.DisableUnsupportedTrackerImageRehosts(decrypted)

--- a/internal/configstore/dbloader_test.go
+++ b/internal/configstore/dbloader_test.go
@@ -92,6 +92,70 @@ func TestLoadFromDBPathBackfillsMissingTrackerDefaults(t *testing.T) {
 	}
 }
 
+func TestLoadFromDBPathPersistsMergedTrackerDefaults(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "guiapp.db")
+	repo, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	if err := repo.Migrate(); err != nil {
+		_ = repo.Close()
+		t.Fatalf("migrate repo: %v", err)
+	}
+
+	cfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		_ = repo.Close()
+		t.Fatalf("load embedded config: %v", err)
+	}
+	cfg.MainSettings.DBPath = dbPath
+	cfg.Metadata.BTNAPI = "legacy-btn-token"
+	btn := cfg.Trackers.Trackers["BTN"]
+	btn.APIKey = ""
+	cfg.Trackers.Trackers["BTN"] = btn
+
+	if err := config.SaveToDatabase(ctx, cfg, repo); err != nil {
+		_ = repo.Close()
+		t.Fatalf("save config: %v", err)
+	}
+	_ = repo.Close()
+
+	loaded, err := configstore.LoadFromDBPath(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("load config from database: %v", err)
+	}
+	if got := loaded.Trackers.Trackers["BTN"].APIKey; got != "legacy-btn-token" {
+		t.Fatalf("expected runtime BTN API key to be merged, got %q", got)
+	}
+
+	repo, err = db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	var trackersJSON string
+	if err := repo.RawDB().QueryRowContext(ctx,
+		`SELECT data FROM config_settings WHERE section = ?`,
+		"Trackers",
+	).Scan(&trackersJSON); err != nil {
+		t.Fatalf("query trackers: %v", err)
+	}
+	var persisted struct {
+		Trackers map[string]config.TrackerConfig `json:"Trackers"`
+	}
+	if err := json.Unmarshal([]byte(trackersJSON), &persisted); err != nil {
+		t.Fatalf("unmarshal trackers: %v", err)
+	}
+	if got := persisted.Trackers["BTN"].APIKey; got != "legacy-btn-token" {
+		t.Fatalf("expected persisted BTN API key to be merged, got %q", got)
+	}
+}
+
 func TestLoadFromDBPathBackfillsMissingStoredOptions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/configstore/dbloader_test.go
+++ b/internal/configstore/dbloader_test.go
@@ -93,7 +93,7 @@ func TestLoadFromDBPathBackfillsMissingTrackerDefaults(t *testing.T) {
 }
 
 // TestLoadFromDBPathPersistsMergedTrackerDefaults verifies legacy metadata BTN
-// tokens remain available after being merged into tracker defaults.
+// tokens move into tracker defaults without keeping a duplicate metadata copy.
 func TestLoadFromDBPathPersistsMergedTrackerDefaults(t *testing.T) {
 	t.Parallel()
 
@@ -132,8 +132,8 @@ func TestLoadFromDBPathPersistsMergedTrackerDefaults(t *testing.T) {
 	if got := loaded.Trackers.Trackers["BTN"].APIKey; got != "legacy-btn-token" {
 		t.Fatalf("expected runtime BTN API key to be merged, got %q", got)
 	}
-	if got := loaded.Metadata.BTNAPI; got != "legacy-btn-token" {
-		t.Fatalf("expected legacy BTN metadata API key to be preserved, got %q", got)
+	if got := loaded.Metadata.BTNAPI; got != "" {
+		t.Fatalf("expected legacy BTN metadata API key to be cleared, got %q", got)
 	}
 
 	repo, err = db.Open(dbPath)
@@ -158,6 +158,99 @@ func TestLoadFromDBPathPersistsMergedTrackerDefaults(t *testing.T) {
 	}
 	if got := persisted.Trackers["BTN"].APIKey; got != "legacy-btn-token" {
 		t.Fatalf("expected persisted BTN API key to be merged, got %q", got)
+	}
+	var metadataJSON string
+	if err := repo.RawDB().QueryRowContext(ctx,
+		`SELECT data FROM config_settings WHERE section = ?`,
+		"Metadata",
+	).Scan(&metadataJSON); err != nil {
+		t.Fatalf("query metadata: %v", err)
+	}
+	var metadata config.MetadataConfig
+	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if got := metadata.BTNAPI; got != "" {
+		t.Fatalf("expected persisted metadata BTN API key to be cleared, got %q", got)
+	}
+}
+
+func TestLoadFromDBPathRollsBackMultiSectionRepairOnLaterFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "guiapp.db")
+	repo, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	if err := repo.Migrate(); err != nil {
+		_ = repo.Close()
+		t.Fatalf("migrate repo: %v", err)
+	}
+
+	cfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		_ = repo.Close()
+		t.Fatalf("load embedded config: %v", err)
+	}
+	cfg.MainSettings.DBPath = dbPath
+	cfg.Metadata.BTNAPI = "legacy-btn-token"
+	btn := cfg.Trackers.Trackers["BTN"]
+	btn.APIKey = ""
+	cfg.Trackers.Trackers["BTN"] = btn
+
+	if err := config.SaveToDatabase(ctx, cfg, repo); err != nil {
+		_ = repo.Close()
+		t.Fatalf("save config: %v", err)
+	}
+	_ = repo.Close()
+
+	installFailTrackersSectionTrigger(ctx, t, dbPath)
+
+	_, err = configstore.LoadFromDBPath(ctx, dbPath)
+	if err == nil {
+		t.Fatal("expected load repair save to fail")
+	}
+
+	repo, err = db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+
+	var metadataJSON string
+	if err := repo.RawDB().QueryRowContext(ctx,
+		`SELECT data FROM config_settings WHERE section = ?`,
+		"Metadata",
+	).Scan(&metadataJSON); err != nil {
+		t.Fatalf("query metadata: %v", err)
+	}
+	var metadata config.MetadataConfig
+	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if got := metadata.BTNAPI; got != "legacy-btn-token" {
+		t.Fatalf("expected metadata BTN token rollback, got %q", got)
+	}
+
+	var trackersJSON string
+	if err := repo.RawDB().QueryRowContext(ctx,
+		`SELECT data FROM config_settings WHERE section = ?`,
+		"Trackers",
+	).Scan(&trackersJSON); err != nil {
+		t.Fatalf("query trackers: %v", err)
+	}
+	var trackers struct {
+		Trackers map[string]config.TrackerConfig `json:"Trackers"`
+	}
+	if err := json.Unmarshal([]byte(trackersJSON), &trackers); err != nil {
+		t.Fatalf("unmarshal trackers: %v", err)
+	}
+	if got := trackers.Trackers["BTN"].APIKey; got != "" {
+		t.Fatalf("expected tracker BTN API key rollback, got %q", got)
 	}
 }
 
@@ -486,6 +579,27 @@ func installFailMainSettingsTrigger(ctx context.Context, t *testing.T, dbPath st
 		END
 	`); err != nil {
 		t.Fatalf("create failure trigger: %v", err)
+	}
+}
+
+func installFailTrackersSectionTrigger(ctx context.Context, t *testing.T, dbPath string) {
+	t.Helper()
+
+	repo, err := db.OpenContext(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	defer repo.Close()
+	if err := repo.MigrateContext(ctx); err != nil {
+		t.Fatalf("migrate repo: %v", err)
+	}
+	for _, statement := range []string{
+		`CREATE TRIGGER fail_trackers_section_insert BEFORE INSERT ON config_settings WHEN NEW.section = 'Trackers' BEGIN SELECT RAISE(FAIL, 'forced config section failure'); END`,
+		`CREATE TRIGGER fail_trackers_section_update BEFORE UPDATE ON config_settings WHEN NEW.section = 'Trackers' BEGIN SELECT RAISE(FAIL, 'forced config section failure'); END`,
+	} {
+		if _, err := repo.RawDB().ExecContext(ctx, statement); err != nil {
+			t.Fatalf("create failure trigger: %v", err)
+		}
 	}
 }
 

--- a/internal/configstore/dbloader_test.go
+++ b/internal/configstore/dbloader_test.go
@@ -92,6 +92,68 @@ func TestLoadFromDBPathBackfillsMissingTrackerDefaults(t *testing.T) {
 	}
 }
 
+func TestLoadFromDBPathBackfillsMissingStoredOptions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "guiapp.db")
+	repo, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	if err := repo.Migrate(); err != nil {
+		_ = repo.Close()
+		t.Fatalf("migrate repo: %v", err)
+	}
+	if _, err := repo.RawDB().ExecContext(ctx, `
+		INSERT INTO config_settings (section, data, updated_at)
+		VALUES ('PostUpload', '{"CrossSeeding":false}', datetime('now'))
+	`); err != nil {
+		_ = repo.Close()
+		t.Fatalf("insert partial config: %v", err)
+	}
+	_ = repo.Close()
+
+	loaded, err := configstore.LoadFromDBPath(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("load config from database: %v", err)
+	}
+	if got := loaded.PostUpload.MaxConcurrentTrackers; got != 4 {
+		t.Fatalf("expected max concurrent tracker uploads default, got %d", got)
+	}
+	if loaded.PostUpload.CrossSeeding {
+		t.Fatal("expected explicit cross_seeding=false to be preserved")
+	}
+	if len(loaded.TorrentClients) != 0 {
+		t.Fatalf("expected template torrent clients to stay stripped, got %d", len(loaded.TorrentClients))
+	}
+
+	repo, err = db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	var postUploadJSON string
+	if err := repo.RawDB().QueryRowContext(ctx,
+		`SELECT data FROM config_settings WHERE section = ?`,
+		"PostUpload",
+	).Scan(&postUploadJSON); err != nil {
+		t.Fatalf("query post_upload: %v", err)
+	}
+	var persisted map[string]any
+	if err := json.Unmarshal([]byte(postUploadJSON), &persisted); err != nil {
+		t.Fatalf("unmarshal post_upload: %v", err)
+	}
+	if got, ok := persisted["MaxConcurrentTrackers"].(float64); !ok || got != 4 {
+		t.Fatalf("expected persisted max concurrent tracker uploads default, got %#v", persisted["MaxConcurrentTrackers"])
+	}
+	if got, ok := persisted["CrossSeeding"].(bool); !ok || got {
+		t.Fatalf("expected persisted explicit cross_seeding=false, got %#v", persisted["CrossSeeding"])
+	}
+}
+
 func TestSaveToDBPathSyncsCookieEncryptionStateWhenWebAuthExists(t *testing.T) {
 	t.Parallel()
 

--- a/internal/configstore/dbloader_test.go
+++ b/internal/configstore/dbloader_test.go
@@ -92,6 +92,8 @@ func TestLoadFromDBPathBackfillsMissingTrackerDefaults(t *testing.T) {
 	}
 }
 
+// TestLoadFromDBPathPersistsMergedTrackerDefaults verifies legacy metadata BTN
+// tokens remain available after being merged into tracker defaults.
 func TestLoadFromDBPathPersistsMergedTrackerDefaults(t *testing.T) {
 	t.Parallel()
 
@@ -129,6 +131,9 @@ func TestLoadFromDBPathPersistsMergedTrackerDefaults(t *testing.T) {
 	}
 	if got := loaded.Trackers.Trackers["BTN"].APIKey; got != "legacy-btn-token" {
 		t.Fatalf("expected runtime BTN API key to be merged, got %q", got)
+	}
+	if got := loaded.Metadata.BTNAPI; got != "legacy-btn-token" {
+		t.Fatalf("expected legacy BTN metadata API key to be preserved, got %q", got)
 	}
 
 	repo, err = db.Open(dbPath)

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -1251,7 +1251,7 @@ func (a *App) SaveConfig(payload string) error {
 	if err != nil {
 		return fmt.Errorf("gui: %w", err)
 	}
-	if err := config.MergeMissingTrackerDefaults(cfg); err != nil {
+	if _, err := config.MergeMissingTrackerDefaults(cfg); err != nil {
 		return fmt.Errorf("gui: %w", err)
 	}
 	currentCfg := a.currentConfig()
@@ -1283,7 +1283,7 @@ func normalizeGUIConfigForExport(cfg *config.Config, dbPath string) (*config.Con
 	if err != nil {
 		return nil, err
 	}
-	if err := config.MergeMissingTrackerDefaults(normalized); err != nil {
+	if _, err := config.MergeMissingTrackerDefaults(normalized); err != nil {
 		return nil, fmt.Errorf("gui: %w", err)
 	}
 	if strings.TrimSpace(normalized.MainSettings.DBPath) == "" {

--- a/internal/services/db/config_test.go
+++ b/internal/services/db/config_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -185,6 +186,40 @@ func TestFullConfigSaveLoad(t *testing.T) {
 	}
 	if _, ok := loaded["torrent_creation"]; !ok {
 		t.Errorf("torrent_creation section missing")
+	}
+}
+
+func TestLoadFullConfigRejectsDuplicateRawSectionKeys(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	repo, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open repository: %v", err)
+	}
+	defer repo.Close()
+
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := repo.RawDB().ExecContext(ctx, `
+		INSERT INTO config_settings (section, data, updated_at)
+		VALUES ('Trackers', '{"Trackers":{"BTN":{"APIKey":"one","APIKey":"two"}}}', datetime('now'))
+	`); err != nil {
+		t.Fatalf("insert duplicate raw section: %v", err)
+	}
+
+	var loaded map[string]any
+	err = repo.LoadFullConfig(ctx, &loaded)
+	if err == nil {
+		t.Fatal("expected duplicate raw key error")
+	}
+	if !strings.Contains(err.Error(), `duplicate JSON object key "APIKey"`) {
+		t.Fatalf("expected duplicate key error, got %v", err)
 	}
 }
 

--- a/internal/services/db/sqlite.go
+++ b/internal/services/db/sqlite.go
@@ -4,12 +4,15 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -2816,6 +2819,37 @@ func (r *SQLiteRepository) SaveConfigSection(ctx context.Context, section string
 	return nil
 }
 
+// SaveConfigSections persists multiple prepared config sections in one
+// transaction. The map keys are config root section names and values are
+// marshaled before the transaction starts; if any section write fails, no
+// selected section is committed.
+func (r *SQLiteRepository) SaveConfigSections(ctx context.Context, sections map[string]any) error {
+	if r == nil || r.db == nil {
+		return errors.New("db: repository not initialized")
+	}
+	if len(sections) == 0 {
+		return nil
+	}
+
+	prepared := make(map[string]string, len(sections))
+	for section, data := range sections {
+		if section == "" {
+			return internalerrors.ErrInvalidInput
+		}
+		payload, err := json.Marshal(data)
+		if err != nil {
+			return fmt.Errorf("db save config: marshal section %s: %w", section, err)
+		}
+		prepared[section] = string(payload)
+	}
+
+	if err := r.saveFullConfigSections(ctx, prepared, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // LoadConfigSection retrieves a single config section from the database.
 func (r *SQLiteRepository) LoadConfigSection(ctx context.Context, section string, dest any) error {
 	if r == nil || r.db == nil {
@@ -2927,7 +2961,13 @@ func (r *SQLiteRepository) saveFullConfigSections(ctx context.Context, sections 
 				return err
 			}
 		}
-		for section, payload := range sections {
+		sectionNames := make([]string, 0, len(sections))
+		for section := range sections {
+			sectionNames = append(sectionNames, section)
+		}
+		sort.Strings(sectionNames)
+		for _, section := range sectionNames {
+			payload := sections[section]
 			if _, err := tx.ExecContext(ctx, `
 			INSERT INTO config_settings (section, data, updated_at) VALUES (?, ?, ?)
 			ON CONFLICT(section) DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at
@@ -2943,7 +2983,10 @@ func (r *SQLiteRepository) saveFullConfigSections(ctx context.Context, sections 
 	return nil
 }
 
-// LoadFullConfig reconstructs the entire config from all sections.
+// LoadFullConfig reconstructs the entire config from all sections. Each raw
+// section is rejected if it contains duplicate JSON object names before the
+// sections are joined, so malformed stored data cannot collapse duplicate keys
+// during unmarshaling.
 func (r *SQLiteRepository) LoadFullConfig(ctx context.Context, dest any) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
@@ -2965,6 +3008,9 @@ func (r *SQLiteRepository) LoadFullConfig(ctx context.Context, dest any) error {
 		if err := rows.Scan(&section, &payload); err != nil {
 			return fmt.Errorf("db load full config: scan: %w", err)
 		}
+		if err := validateJSONNoDuplicateObjectNames([]byte(payload)); err != nil {
+			return fmt.Errorf("db load full config section %s: %w", section, err)
+		}
 		sections[section] = json.RawMessage(payload)
 	}
 	if err := rows.Err(); err != nil {
@@ -2985,6 +3031,90 @@ func (r *SQLiteRepository) LoadFullConfig(ctx context.Context, dest any) error {
 		return fmt.Errorf("db load full config: unmarshal to dest: %w", err)
 	}
 
+	return nil
+}
+
+// validateJSONNoDuplicateObjectNames scans one JSON value and rejects duplicate
+// object member names before the standard decoder can collapse them into a map.
+func validateJSONNoDuplicateObjectNames(payload []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	dec.UseNumber()
+	if err := validateJSONValueNoDuplicateObjectNames(dec, ""); err != nil {
+		return err
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return fmt.Errorf("read trailing JSON token: %w", err)
+	}
+	return nil
+}
+
+// validateJSONValueNoDuplicateObjectNames consumes one JSON value from dec and
+// reports duplicate object member names with a dotted path to the object.
+func validateJSONValueNoDuplicateObjectNames(dec *json.Decoder, path string) error {
+	token, err := dec.Token()
+	if err != nil {
+		return fmt.Errorf("read JSON token at %q: %w", path, err)
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+
+	switch delim {
+	case '{':
+		seen := map[string]struct{}{}
+		for dec.More() {
+			keyToken, err := dec.Token()
+			if err != nil {
+				return fmt.Errorf("read JSON object key at %q: %w", path, err)
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return fmt.Errorf("invalid JSON object key at %q", path)
+			}
+			if _, exists := seen[key]; exists {
+				if path == "" {
+					return fmt.Errorf("duplicate JSON object key %q", key)
+				}
+				return fmt.Errorf("duplicate JSON object key %q at %q", key, path)
+			}
+			seen[key] = struct{}{}
+			childPath := key
+			if path != "" {
+				childPath = path + "." + key
+			}
+			if err := validateJSONValueNoDuplicateObjectNames(dec, childPath); err != nil {
+				return err
+			}
+		}
+		return consumeJSONDelim(dec, '}')
+	case '[':
+		index := 0
+		for dec.More() {
+			childPath := fmt.Sprintf("%s[%d]", path, index)
+			if err := validateJSONValueNoDuplicateObjectNames(dec, childPath); err != nil {
+				return err
+			}
+			index++
+		}
+		return consumeJSONDelim(dec, ']')
+	default:
+		return fmt.Errorf("unexpected JSON delimiter %q at %q", delim, path)
+	}
+}
+
+// consumeJSONDelim consumes and verifies the expected closing JSON delimiter.
+func consumeJSONDelim(dec *json.Decoder, want json.Delim) error {
+	token, err := dec.Token()
+	if err != nil {
+		return fmt.Errorf("read JSON delimiter %q: %w", want, err)
+	}
+	if delim, ok := token.(json.Delim); !ok || delim != want {
+		return fmt.Errorf("expected JSON delimiter %q", want)
+	}
 	return nil
 }
 

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -808,7 +808,7 @@ func normalizeExportableConfig(cfg *config.Config, dbPath string) (*config.Confi
 	if err != nil {
 		return nil, err
 	}
-	if err := config.MergeMissingTrackerDefaults(normalized); err != nil {
+	if _, err := config.MergeMissingTrackerDefaults(normalized); err != nil {
 		return nil, fmt.Errorf("web: %w", err)
 	}
 	if strings.TrimSpace(normalized.MainSettings.DBPath) == "" {
@@ -864,7 +864,7 @@ func (b *Backend) SaveConfig(payload string) error {
 	if err != nil {
 		return fmt.Errorf("web: %w", err)
 	}
-	if err := config.MergeMissingTrackerDefaults(cfg); err != nil {
+	if _, err := config.MergeMissingTrackerDefaults(cfg); err != nil {
 		return fmt.Errorf("web: %w", err)
 	}
 	currentCfg := b.currentConfig()


### PR DESCRIPTION
will self populate new options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading by overlaying embedded defaults onto stored settings before decrypting secrets, while preserving explicitly stored `false`/`0`/empty values.
  * More robust tracker default merging (including case-insensitive handling) with correct, persisted repairs and safer handling of invalid or ambiguous tracker data.
  * Prevents partial write-back on repair failures and now rejects malformed saved JSON that contains duplicate keys.

* **Tests**
  * Expanded coverage for default backfill/repair reporting, rollback behavior, tracker merge edge cases, and duplicate-key rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->