### PR TITLE
fix(config): survive data-dir upgrades (legacy fallback + runtime decrypt dir)

### DIFF
--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -265,7 +265,7 @@ func LoadFromDatabaseWithRepairReport(ctx context.Context, repo fullConfigLoader
 		return nil, DatabaseRepairReport{}, err
 	}
 
-	decryptedCfg, err := DecryptConfigSecrets(&cfg)
+	decryptedCfg, err := decryptConfigSecretsWithDBDir(&cfg, repoDBPath(repo))
 	if err != nil {
 		return nil, DatabaseRepairReport{}, fmt.Errorf("config load from database: decrypt secrets: %w", err)
 	}
@@ -847,10 +847,16 @@ func secretPathRoot(path string) string {
 	return path[:end]
 }
 
-// repoDBPath returns the on-disk database path for repositories that expose one
-// (e.g. *db.SQLiteRepository), or "" for in-memory or path-less repositories.
+// databasePathProvider is implemented by repositories that can expose the
+// resolved on-disk database path used to locate sibling auth/helper files.
+type databasePathProvider interface {
+	DBPath() string
+}
+
+// repoDBPath returns the resolved on-disk database path for repositories that
+// expose one (e.g. *db.SQLiteRepository), or "" for in-memory/path-less repos.
 func repoDBPath(repo any) string {
-	if r, ok := repo.(interface{ DBPath() string }); ok {
+	if r, ok := repo.(databasePathProvider); ok {
 		return strings.TrimSpace(r.DBPath())
 	}
 	return ""
@@ -858,10 +864,10 @@ func repoDBPath(repo any) string {
 
 // decryptConfigSecretsWithDBDir decrypts cfg using the secret-encryption helper
 // (web-auth.json) resolved from the config's stored db_path. If that helper is
-// unavailable (e.g. the persisted db_path is empty or points at a pre-upgrade
-// location), it retries anchored to runtimeDBPath — the repository's actual
-// on-disk database directory — without changing the returned config's stored
-// db_path. The stored-path-first order preserves existing behavior for callers
+// fails (e.g. the persisted db_path is empty, points at a pre-upgrade location,
+// or has stale helper material), it retries anchored to runtimeDBPath, the
+// repository's actual on-disk database, without changing the returned config's
+// stored db_path. The stored-path-first order preserves existing behavior for callers
 // that intentionally rely on the snapshot's db_path.
 func decryptConfigSecretsWithDBDir(cfg *Config, runtimeDBPath string) (*Config, error) {
 	decrypted, err := DecryptConfigSecrets(cfg)
@@ -870,8 +876,7 @@ func decryptConfigSecretsWithDBDir(cfg *Config, runtimeDBPath string) (*Config, 
 	}
 
 	runtimeDBPath = strings.TrimSpace(runtimeDBPath)
-	if runtimeDBPath == "" || runtimeDBPath == strings.TrimSpace(cfg.MainSettings.DBPath) ||
-		!errors.Is(err, ErrSecretEncryptionHelperUnavailable) {
+	if runtimeDBPath == "" || runtimeDBPath == strings.TrimSpace(cfg.MainSettings.DBPath) {
 		return nil, err
 	}
 
@@ -879,10 +884,30 @@ func decryptConfigSecretsWithDBDir(cfg *Config, runtimeDBPath string) (*Config, 
 	probe.MainSettings.DBPath = runtimeDBPath
 	retried, retryErr := DecryptConfigSecrets(&probe)
 	if retryErr != nil {
-		return nil, err
+		return nil, errors.Join(err, fmt.Errorf("runtime db path decrypt retry: %w", retryErr))
 	}
 	retried.MainSettings.DBPath = cfg.MainSettings.DBPath
 	return retried, nil
+}
+
+func encryptConfigSecretsForSectionsWithDBDir(cfg *Config, sections []string, runtimeDBPath string) (*Config, error) {
+	runtimeDBPath = strings.TrimSpace(runtimeDBPath)
+	if runtimeDBPath == "" || runtimeDBPath == strings.TrimSpace(cfg.MainSettings.DBPath) {
+		return encryptConfigSecretsForSections(cfg, sections)
+	}
+
+	probe, err := cloneConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	storedDBPath := probe.MainSettings.DBPath
+	probe.MainSettings.DBPath = runtimeDBPath
+	encrypted, err := encryptConfigSecretsForSections(probe, sections)
+	if err != nil {
+		return nil, err
+	}
+	encrypted.MainSettings.DBPath = storedDBPath
+	return encrypted, nil
 }
 
 // SaveToDatabase persists the config to the repository.
@@ -939,7 +964,7 @@ func SaveSectionsToDatabase(ctx context.Context, cfg *Config, sections []string,
 		return fmt.Errorf("config save sections to database: %w", err)
 	}
 
-	encryptedCfg, err := encryptConfigSecretsForSections(cfg, sections)
+	encryptedCfg, err := encryptConfigSecretsForSectionsWithDBDir(cfg, sections, repoDBPath(repo))
 	if err != nil {
 		return fmt.Errorf("config save sections to database: encrypt secrets: %w", err)
 	}

--- a/internal/config/persistence.go
+++ b/internal/config/persistence.go
@@ -208,12 +208,54 @@ func LoadFromDatabase(ctx context.Context, repo interface {
 		return nil, fmt.Errorf("config load from database: %w", err)
 	}
 
-	decryptedCfg, err := DecryptConfigSecrets(&cfg)
+	// Decrypt using the secret-encryption helper located next to the
+	// repository's actual on-disk database, not the db_path persisted inside the
+	// config (which may be empty or point at a pre-upgrade path). The returned
+	// config keeps its stored db_path so callers still control path resolution.
+	decryptedCfg, err := decryptConfigSecretsWithDBDir(&cfg, repoDBPath(repo))
 	if err != nil {
 		return nil, fmt.Errorf("config load from database: decrypt secrets: %w", err)
 	}
 
 	return decryptedCfg, nil
+}
+
+// repoDBPath returns the on-disk database path for repositories that expose one
+// (e.g. *db.SQLiteRepository), or "" for in-memory or path-less repositories.
+func repoDBPath(repo any) string {
+	if r, ok := repo.(interface{ DBPath() string }); ok {
+		return strings.TrimSpace(r.DBPath())
+	}
+	return ""
+}
+
+// decryptConfigSecretsWithDBDir decrypts cfg using the secret-encryption helper
+// (web-auth.json) resolved from the config's stored db_path. If that helper is
+// unavailable (e.g. the persisted db_path is empty or points at a pre-upgrade
+// location), it retries anchored to runtimeDBPath — the repository's actual
+// on-disk database directory — without changing the returned config's stored
+// db_path. The stored-path-first order preserves existing behavior for callers
+// that intentionally rely on the snapshot's db_path.
+func decryptConfigSecretsWithDBDir(cfg *Config, runtimeDBPath string) (*Config, error) {
+	decrypted, err := DecryptConfigSecrets(cfg)
+	if err == nil {
+		return decrypted, nil
+	}
+
+	runtimeDBPath = strings.TrimSpace(runtimeDBPath)
+	if runtimeDBPath == "" || runtimeDBPath == strings.TrimSpace(cfg.MainSettings.DBPath) ||
+		!errors.Is(err, ErrSecretEncryptionHelperUnavailable) {
+		return nil, err
+	}
+
+	probe := *cfg
+	probe.MainSettings.DBPath = runtimeDBPath
+	retried, retryErr := DecryptConfigSecrets(&probe)
+	if retryErr != nil {
+		return nil, err
+	}
+	retried.MainSettings.DBPath = cfg.MainSettings.DBPath
+	return retried, nil
 }
 
 // SaveToDatabase persists the config to the repository.

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -649,8 +649,16 @@ func defaultDatabaseConfigMap(t *testing.T) map[string]any {
 
 func writeWebAuthFixture(t *testing.T, dbPath string) {
 	t.Helper()
+	writeWebAuthFixtureWithSeed(t, dbPath, "stable-seed-for-tests")
+}
+
+func writeWebAuthFixtureWithSeed(t *testing.T, dbPath string, seed string) {
+	t.Helper()
 	authPath := filepath.Join(filepath.Dir(dbPath), webAuthFileName)
-	payload := `{"username":"tester","password_hash":"very-secret-password-hash","encryption_key_seed":"stable-seed-for-tests"}`
+	if err := os.MkdirAll(filepath.Dir(authPath), 0o700); err != nil {
+		t.Fatalf("mkdir web auth fixture: %v", err)
+	}
+	payload := fmt.Sprintf(`{"username":"tester","password_hash":"very-secret-password-hash","encryption_key_seed":%q}`, seed)
 	if err := os.WriteFile(authPath, []byte(payload), 0600); err != nil {
 		t.Fatalf("write web auth fixture: %v", err)
 	}
@@ -1580,21 +1588,19 @@ type runtimePathRepo struct {
 }
 
 func (r *runtimePathRepo) LoadFullConfig(_ context.Context, dest any) error {
-	target, ok := dest.(*Config)
-	if !ok {
-		return fmt.Errorf("unexpected dest type %T", dest)
+	payload, err := json.Marshal(r.cfg)
+	if err != nil {
+		return fmt.Errorf("marshal runtime path config: %w", err)
 	}
-	*target = r.cfg
+	if err := json.Unmarshal(payload, dest); err != nil {
+		return fmt.Errorf("unmarshal runtime path config: %w", err)
+	}
 	return nil
 }
 
 func (r *runtimePathRepo) DBPath() string { return r.dbPath }
 
 func TestLoadFromDatabaseDecryptsViaRuntimeDBDir(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission bits are ACL-backed on Windows")
-	}
-
 	// web-auth.json (the secret-encryption helper) lives next to the *runtime*
 	// database. Encrypt a secret against that helper.
 	runtimeDBPath := filepath.Join(t.TempDir(), "db.sqlite")
@@ -1625,6 +1631,128 @@ func TestLoadFromDatabaseDecryptsViaRuntimeDBDir(t *testing.T) {
 	if got.MainSettings.DBPath != staleDBPath {
 		t.Fatalf("stored db_path not preserved: got %q want %q", got.MainSettings.DBPath, staleDBPath)
 	}
+}
+
+func TestLoadFromDatabaseWithRepairReportDecryptsViaRuntimeDBDir(t *testing.T) {
+	runtimeDBPath := filepath.Join(t.TempDir(), "db.sqlite")
+	writeWebAuthFixture(t, runtimeDBPath)
+	plain := &Config{MainSettings: MainSettingsConfig{DBPath: runtimeDBPath, TMDBAPI: "super-secret-token"}}
+	encrypted, err := EncryptConfigSecrets(plain)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	staleDBPath := filepath.Join(t.TempDir(), "old", "db.sqlite")
+	encrypted.MainSettings.DBPath = staleDBPath
+
+	repo := &runtimePathRepo{dbPath: runtimeDBPath, cfg: *encrypted}
+	got, _, err := LoadFromDatabaseWithRepairReport(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("LoadFromDatabaseWithRepairReport: %v", err)
+	}
+	if got.MainSettings.TMDBAPI != "super-secret-token" {
+		t.Fatalf("secret not decrypted via runtime DB dir: got %q", got.MainSettings.TMDBAPI)
+	}
+	if got.MainSettings.DBPath != staleDBPath {
+		t.Fatalf("stored db_path not preserved: got %q want %q", got.MainSettings.DBPath, staleDBPath)
+	}
+}
+
+func TestLoadFromDatabaseRetriesRuntimeDBDirAfterWrongStoredHelper(t *testing.T) {
+	runtimeDBPath := filepath.Join(t.TempDir(), "runtime", "db.sqlite")
+	writeWebAuthFixtureWithSeed(t, runtimeDBPath, "runtime-seed")
+	plain := &Config{MainSettings: MainSettingsConfig{DBPath: runtimeDBPath, TMDBAPI: "super-secret-token"}}
+	encrypted, err := EncryptConfigSecrets(plain)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	staleDBPath := filepath.Join(t.TempDir(), "old", "db.sqlite")
+	writeWebAuthFixtureWithSeed(t, staleDBPath, "wrong-seed")
+	encrypted.MainSettings.DBPath = staleDBPath
+
+	repo := &runtimePathRepo{dbPath: runtimeDBPath, cfg: *encrypted}
+	got, err := LoadFromDatabase(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("LoadFromDatabase: %v", err)
+	}
+	if got.MainSettings.TMDBAPI != "super-secret-token" {
+		t.Fatalf("secret not decrypted via runtime DB dir: got %q", got.MainSettings.TMDBAPI)
+	}
+}
+
+func TestDecryptConfigSecretsWithDBDirReportsRuntimeRetryError(t *testing.T) {
+	goodDBPath := filepath.Join(t.TempDir(), "good", "db.sqlite")
+	writeWebAuthFixtureWithSeed(t, goodDBPath, "good-seed")
+	plain := &Config{MainSettings: MainSettingsConfig{DBPath: goodDBPath, TMDBAPI: "super-secret-token"}}
+	encrypted, err := EncryptConfigSecrets(plain)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	staleDBPath := filepath.Join(t.TempDir(), "missing", "db.sqlite")
+	runtimeDBPath := filepath.Join(t.TempDir(), "runtime", "db.sqlite")
+	writeWebAuthFixtureWithSeed(t, runtimeDBPath, "wrong-seed")
+	encrypted.MainSettings.DBPath = staleDBPath
+
+	_, err = decryptConfigSecretsWithDBDir(encrypted, runtimeDBPath)
+	if err == nil {
+		t.Fatalf("expected decrypt error")
+	}
+	if !errors.Is(err, ErrSecretEncryptionHelperUnavailable) {
+		t.Fatalf("expected original helper unavailable error to be preserved, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "runtime db path decrypt retry") {
+		t.Fatalf("expected runtime retry error context, got %v", err)
+	}
+}
+
+func TestSaveSectionsToDatabaseEncryptsViaRuntimeDBDir(t *testing.T) {
+	runtimeDBPath := filepath.Join(t.TempDir(), "runtime", "db.sqlite")
+	writeWebAuthFixture(t, runtimeDBPath)
+	staleDBPath := filepath.Join(t.TempDir(), "old", "db.sqlite")
+
+	repo := &runtimeSectionRepo{dbPath: runtimeDBPath}
+	cfg := validMinimalConfig()
+	cfg.MainSettings.DBPath = staleDBPath
+	cfg.MainSettings.TMDBAPI = "super-secret-token"
+
+	if err := SaveSectionsToDatabase(context.Background(), cfg, []string{"MainSettings"}, repo); err != nil {
+		t.Fatalf("SaveSectionsToDatabase: %v", err)
+	}
+	mainSettings, ok := repo.sections["MainSettings"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected MainSettings map, got %#v", repo.sections["MainSettings"])
+	}
+	if got := mainSettings["DBPath"]; got != staleDBPath {
+		t.Fatalf("stored DBPath got %#v want %q", got, staleDBPath)
+	}
+	token, ok := mainSettings["TMDBAPI"].(string)
+	if !ok || !strings.HasPrefix(token, encryptedEnvelopePrefix) {
+		t.Fatalf("expected TMDBAPI to be encrypted via runtime helper, got %#v", mainSettings["TMDBAPI"])
+	}
+}
+
+type runtimeSectionRepo struct {
+	dbPath   string
+	sections map[string]any
+}
+
+func (r *runtimeSectionRepo) DBPath() string { return r.dbPath }
+
+func (r *runtimeSectionRepo) SaveConfigSection(_ context.Context, section string, data any) error {
+	if r.sections == nil {
+		r.sections = map[string]any{}
+	}
+	payload, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshal section %s: %w", section, err)
+	}
+	var stored any
+	if err := json.Unmarshal(payload, &stored); err != nil {
+		return fmt.Errorf("unmarshal section %s: %w", section, err)
+	}
+	r.sections[section] = stored
+	return nil
 }
 
 func TestRepoDBPath(t *testing.T) {

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -1002,3 +1002,65 @@ func TestExportFromDatabaseToYAMLLoadFailure(t *testing.T) {
 		t.Fatalf("expected load error, got nil")
 	}
 }
+
+type runtimePathRepo struct {
+	dbPath string
+	cfg    Config
+}
+
+func (r *runtimePathRepo) LoadFullConfig(_ context.Context, dest any) error {
+	target, ok := dest.(*Config)
+	if !ok {
+		return fmt.Errorf("unexpected dest type %T", dest)
+	}
+	*target = r.cfg
+	return nil
+}
+
+func (r *runtimePathRepo) DBPath() string { return r.dbPath }
+
+func TestLoadFromDatabaseDecryptsViaRuntimeDBDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are ACL-backed on Windows")
+	}
+
+	// web-auth.json (the secret-encryption helper) lives next to the *runtime*
+	// database. Encrypt a secret against that helper.
+	runtimeDBPath := filepath.Join(t.TempDir(), "db.sqlite")
+	writeWebAuthFixture(t, runtimeDBPath)
+	plain := &Config{MainSettings: MainSettingsConfig{DBPath: runtimeDBPath, TMDBAPI: "super-secret-token"}}
+	encrypted, err := EncryptConfigSecrets(plain)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if encrypted.MainSettings.TMDBAPI == "super-secret-token" {
+		t.Fatalf("expected TMDBAPI to be encrypted, got plaintext")
+	}
+
+	// Simulate a stored config whose db_path points at a pre-upgrade dir that no
+	// longer holds web-auth.json. Decryption must still succeed by anchoring to
+	// the repo's runtime DB dir, and the stored db_path must be preserved.
+	staleDBPath := filepath.Join(t.TempDir(), "old", "db.sqlite")
+	encrypted.MainSettings.DBPath = staleDBPath
+
+	repo := &runtimePathRepo{dbPath: runtimeDBPath, cfg: *encrypted}
+	got, err := LoadFromDatabase(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("LoadFromDatabase: %v", err)
+	}
+	if got.MainSettings.TMDBAPI != "super-secret-token" {
+		t.Fatalf("secret not decrypted via runtime DB dir: got %q", got.MainSettings.TMDBAPI)
+	}
+	if got.MainSettings.DBPath != staleDBPath {
+		t.Fatalf("stored db_path not preserved: got %q want %q", got.MainSettings.DBPath, staleDBPath)
+	}
+}
+
+func TestRepoDBPath(t *testing.T) {
+	if got := repoDBPath(&runtimePathRepo{dbPath: "  /a/b  "}); got != "/a/b" {
+		t.Fatalf("repoDBPath got %q, want /a/b", got)
+	}
+	if got := repoDBPath(struct{}{}); got != "" {
+		t.Fatalf("repoDBPath for repo without DBPath got %q, want empty", got)
+	}
+}

--- a/internal/configstore/dbloader_test.go
+++ b/internal/configstore/dbloader_test.go
@@ -92,6 +92,85 @@ func TestLoadFromDBPathBackfillsMissingTrackerDefaults(t *testing.T) {
 	}
 }
 
+func TestLoadFromDBPathRepairPersistsSecretsWithRuntimeDBPath(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	runtimeDBPath := filepath.Join(t.TempDir(), "runtime", "guiapp.db")
+	if err := webserver.BootstrapAuthFile(runtimeDBPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile runtime: %v", err)
+	}
+	staleDBPath := filepath.Join(t.TempDir(), "old", "guiapp.db")
+	if err := webserver.BootstrapAuthFile(staleDBPath, "tester", "different-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile stale: %v", err)
+	}
+
+	cfg, err := config.LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("load embedded config: %v", err)
+	}
+	cfg.MainSettings.DBPath = runtimeDBPath
+	cfg.MainSettings.TMDBAPI = "runtime-secret"
+	if err := configstore.SaveToDBPath(ctx, cfg, runtimeDBPath); err != nil {
+		t.Fatalf("SaveToDBPath: %v", err)
+	}
+
+	repo, err := db.OpenContext(ctx, runtimeDBPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	var mainSettingsJSON string
+	if err := repo.RawDB().QueryRowContext(ctx,
+		`SELECT data FROM config_settings WHERE section = ?`,
+		"MainSettings",
+	).Scan(&mainSettingsJSON); err != nil {
+		_ = repo.Close()
+		t.Fatalf("query main settings: %v", err)
+	}
+	var mainSettings map[string]any
+	if err := json.Unmarshal([]byte(mainSettingsJSON), &mainSettings); err != nil {
+		_ = repo.Close()
+		t.Fatalf("unmarshal main settings: %v", err)
+	}
+	mainSettings["DBPath"] = staleDBPath
+	delete(mainSettings, "UseFavicons")
+	updated, err := json.Marshal(mainSettings)
+	if err != nil {
+		_ = repo.Close()
+		t.Fatalf("marshal patched main settings: %v", err)
+	}
+	if _, err := repo.RawDB().ExecContext(ctx,
+		`UPDATE config_settings SET data = ? WHERE section = ?`,
+		string(updated),
+		"MainSettings",
+	); err != nil {
+		_ = repo.Close()
+		t.Fatalf("patch main settings: %v", err)
+	}
+	_ = repo.Close()
+
+	loaded, err := configstore.LoadFromDBPath(ctx, runtimeDBPath)
+	if err != nil {
+		t.Fatalf("LoadFromDBPath: %v", err)
+	}
+	if loaded.MainSettings.TMDBAPI != "runtime-secret" {
+		t.Fatalf("secret not decrypted via runtime DB path: got %q", loaded.MainSettings.TMDBAPI)
+	}
+	if loaded.MainSettings.DBPath != staleDBPath {
+		t.Fatalf("stored DBPath got %q want %q", loaded.MainSettings.DBPath, staleDBPath)
+	}
+	if err := os.Remove(webserver.AuthFilePath(staleDBPath)); err != nil {
+		t.Fatalf("remove stale auth helper: %v", err)
+	}
+	reloaded, err := configstore.LoadFromDBPath(ctx, runtimeDBPath)
+	if err != nil {
+		t.Fatalf("LoadFromDBPath after stale helper removal: %v", err)
+	}
+	if reloaded.MainSettings.TMDBAPI != "runtime-secret" {
+		t.Fatalf("secret not decryptable from runtime helper after repair save: got %q", reloaded.MainSettings.TMDBAPI)
+	}
+}
+
 // TestLoadFromDBPathPersistsMergedTrackerDefaults verifies legacy metadata BTN
 // tokens move into tracker defaults without keeping a duplicate metadata copy.
 func TestLoadFromDBPathPersistsMergedTrackerDefaults(t *testing.T) {

--- a/internal/services/db/paths.go
+++ b/internal/services/db/paths.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -14,7 +15,7 @@ const defaultDirName = ".upbrr"
 const defaultDBName = "db.sqlite"
 
 func DefaultPath() (string, error) {
-	if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
 		preferred := filepath.Join(xdg, "upbrr", defaultDBName)
 		if dbFileExists(preferred) {
 			return preferred, nil
@@ -27,7 +28,7 @@ func DefaultPath() (string, error) {
 		if legacy := filepath.Join(xdg, defaultDirName, defaultDBName); dbFileExists(legacy) {
 			return legacy, nil
 		}
-		if home := strings.TrimSpace(os.Getenv("HOME")); home != "" {
+		if home := os.Getenv("HOME"); home != "" && sameConfigRoot(home, xdg) {
 			if legacy := filepath.Join(home, defaultDirName, defaultDBName); dbFileExists(legacy) {
 				return legacy, nil
 			}
@@ -43,8 +44,17 @@ func DefaultPath() (string, error) {
 
 // dbFileExists reports whether path is an existing regular file.
 func dbFileExists(path string) bool {
-	info, err := os.Stat(path) //nolint:gosec // Existence probe for a default/legacy DB path derived from trusted env config.
-	return err == nil && !info.IsDir()
+	info, err := os.Lstat(path) //nolint:gosec // Existence probe for a default/legacy DB path derived from trusted env config.
+	return err == nil && info.Mode().IsRegular()
+}
+
+func sameConfigRoot(a, b string) bool {
+	cleanA := filepath.Clean(a)
+	cleanB := filepath.Clean(b)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(cleanA, cleanB)
+	}
+	return cleanA == cleanB
 }
 
 func RootDir(dbPath string) (string, error) {

--- a/internal/services/db/paths.go
+++ b/internal/services/db/paths.go
@@ -14,14 +14,37 @@ const defaultDirName = ".upbrr"
 const defaultDBName = "db.sqlite"
 
 func DefaultPath() (string, error) {
-	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
-		return filepath.Join(xdg, "upbrr", defaultDBName), nil
+	if xdg := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdg != "" {
+		preferred := filepath.Join(xdg, "upbrr", defaultDBName)
+		if dbFileExists(preferred) {
+			return preferred, nil
+		}
+		// Migration fallback: installs predating the XDG move keep their data in
+		// a dotted ".upbrr" dir. The documented Docker setup ran with
+		// HOME=/config (== XDG_CONFIG_HOME here), so that data lives at
+		// $XDG_CONFIG_HOME/.upbrr; older $HOME-based installs at $HOME/.upbrr.
+		// Prefer an existing legacy DB so upgrades do not orphan it.
+		if legacy := filepath.Join(xdg, defaultDirName, defaultDBName); dbFileExists(legacy) {
+			return legacy, nil
+		}
+		if home := strings.TrimSpace(os.Getenv("HOME")); home != "" {
+			if legacy := filepath.Join(home, defaultDirName, defaultDBName); dbFileExists(legacy) {
+				return legacy, nil
+			}
+		}
+		return preferred, nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("database: user home dir: %w", err)
 	}
 	return filepath.Join(home, defaultDirName, defaultDBName), nil
+}
+
+// dbFileExists reports whether path is an existing regular file.
+func dbFileExists(path string) bool {
+	info, err := os.Stat(path) //nolint:gosec // Existence probe for a default/legacy DB path derived from trusted env config.
+	return err == nil && !info.IsDir()
 }
 
 func RootDir(dbPath string) (string, error) {

--- a/internal/services/db/paths_test.go
+++ b/internal/services/db/paths_test.go
@@ -51,20 +51,21 @@ func TestDefaultPathFallsBackToLegacyDottedDirUnderXDG(t *testing.T) {
 	}
 }
 
-func TestDefaultPathFallsBackToLegacyHomeDir(t *testing.T) {
+func TestDefaultPathIgnoresDistinctLegacyHomeDirWhenXDGSet(t *testing.T) {
 	xdg := t.TempDir()
 	home := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", xdg)
 	t.Setenv("HOME", home)
 	legacy := filepath.Join(home, defaultDirName, defaultDBName)
 	writeMarkerFile(t, legacy)
+	want := filepath.Join(xdg, "upbrr", defaultDBName)
 
 	got, err := DefaultPath()
 	if err != nil {
 		t.Fatalf("DefaultPath: %v", err)
 	}
-	if got != legacy {
-		t.Fatalf("got %q want legacy %q", got, legacy)
+	if got != want {
+		t.Fatalf("got %q want canonical %q", got, want)
 	}
 }
 
@@ -83,6 +84,33 @@ func TestDefaultPathNewInstallUsesXDGCanonical(t *testing.T) {
 	}
 }
 
+func TestDefaultPathPreservesXDGWhitespace(t *testing.T) {
+	xdg := " " + filepath.Join(t.TempDir(), "xdg") + " "
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+	want := filepath.Join(xdg, "upbrr", defaultDBName)
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestDBFileExistsRejectsSymlink(t *testing.T) {
+	target := filepath.Join(t.TempDir(), defaultDBName)
+	writeMarkerFile(t, target)
+	link := filepath.Join(t.TempDir(), defaultDBName)
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if dbFileExists(link) {
+		t.Fatalf("expected symlink %q not to count as regular DB file", link)
+	}
+}
+
 func TestSQLiteRepositoryDBPath(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "x.db")
 	repo, err := Open(path)
@@ -92,5 +120,36 @@ func TestSQLiteRepositoryDBPath(t *testing.T) {
 	t.Cleanup(func() { _ = repo.Close() })
 	if repo.DBPath() != path {
 		t.Fatalf("DBPath got %q want %q", repo.DBPath(), path)
+	}
+}
+
+func TestSQLiteRepositoryDBPathUsesResolvedDefault(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+	want := filepath.Join(xdg, "upbrr", defaultDBName)
+
+	repo, err := Open("")
+	if err != nil {
+		t.Fatalf("open default: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	if repo.DBPath() != want {
+		t.Fatalf("DBPath got %q want resolved default %q", repo.DBPath(), want)
+	}
+}
+
+func TestSQLiteRepositoryDBPathEmptyForSentinelInputs(t *testing.T) {
+	for _, path := range []string{":memory:", "file:memdb1?mode=memory&cache=shared"} {
+		t.Run(path, func(t *testing.T) {
+			repo, err := Open(path)
+			if err != nil {
+				t.Fatalf("open: %v", err)
+			}
+			t.Cleanup(func() { _ = repo.Close() })
+			if repo.DBPath() != "" {
+				t.Fatalf("DBPath got %q want empty for sentinel input %q", repo.DBPath(), path)
+			}
+		})
 	}
 }

--- a/internal/services/db/paths_test.go
+++ b/internal/services/db/paths_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeMarkerFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestDefaultPathPrefersXDGCanonical(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	want := filepath.Join(xdg, "upbrr", defaultDBName)
+	writeMarkerFile(t, want)
+	// A legacy dir also present must not win over the canonical path.
+	writeMarkerFile(t, filepath.Join(xdg, defaultDirName, defaultDBName))
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestDefaultPathFallsBackToLegacyDottedDirUnderXDG(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	legacy := filepath.Join(xdg, defaultDirName, defaultDBName)
+	writeMarkerFile(t, legacy)
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if got != legacy {
+		t.Fatalf("got %q want legacy %q", got, legacy)
+	}
+}
+
+func TestDefaultPathFallsBackToLegacyHomeDir(t *testing.T) {
+	xdg := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", home)
+	legacy := filepath.Join(home, defaultDirName, defaultDBName)
+	writeMarkerFile(t, legacy)
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if got != legacy {
+		t.Fatalf("got %q want legacy %q", got, legacy)
+	}
+}
+
+func TestDefaultPathNewInstallUsesXDGCanonical(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir()) // no legacy DB anywhere
+	want := filepath.Join(xdg, "upbrr", defaultDBName)
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestSQLiteRepositoryDBPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "x.db")
+	repo, err := Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	if repo.DBPath() != path {
+		t.Fatalf("DBPath got %q want %q", repo.DBPath(), path)
+	}
+}

--- a/internal/services/db/sqlite.go
+++ b/internal/services/db/sqlite.go
@@ -25,6 +25,7 @@ import (
 type SQLiteRepository struct {
 	db     *sql.DB
 	logger Logger
+	path   string
 }
 
 const sqliteBusyTimeout = 5000
@@ -106,7 +107,17 @@ func OpenWithLoggerContext(ctx context.Context, path string, logger Logger) (*SQ
 		}
 	}
 
-	return &SQLiteRepository{db: db, logger: logger}, nil
+	return &SQLiteRepository{db: db, logger: logger, path: path}, nil
+}
+
+// DBPath returns the filesystem path the repository was opened with. Callers
+// use it to locate sibling files (e.g. web-auth.json) next to the actual
+// database rather than relying on a path persisted inside the config.
+func (r *SQLiteRepository) DBPath() string {
+	if r == nil {
+		return ""
+	}
+	return r.path
 }
 
 func (r *SQLiteRepository) Close() error {

--- a/internal/services/db/sqlite.go
+++ b/internal/services/db/sqlite.go
@@ -28,7 +28,9 @@ import (
 type SQLiteRepository struct {
 	db     *sql.DB
 	logger Logger
-	path   string
+	// path is empty for SQLite sentinel/URI inputs whose sibling helper-file
+	// location is intentionally not inferred from the opened DB string.
+	path string
 }
 
 const sqliteBusyTimeout = 5000
@@ -110,12 +112,13 @@ func OpenWithLoggerContext(ctx context.Context, path string, logger Logger) (*SQ
 		}
 	}
 
-	return &SQLiteRepository{db: db, logger: logger, path: path}, nil
+	return &SQLiteRepository{db: db, logger: logger, path: repositoryDBPath(path, resolved)}, nil
 }
 
-// DBPath returns the filesystem path the repository was opened with. Callers
-// use it to locate sibling files (e.g. web-auth.json) next to the actual
-// database rather than relying on a path persisted inside the config.
+// DBPath returns the resolved on-disk database path when the repository was
+// opened from a normal filesystem path. It returns empty for SQLite sentinel or
+// URI inputs so callers do not invent helper-file locations for in-memory DBs
+// or opaque SQLite connection strings.
 func (r *SQLiteRepository) DBPath() string {
 	if r == nil {
 		return ""
@@ -2827,6 +2830,14 @@ func resolvePath(path string) (string, error) {
 	}
 
 	return cleaned, nil
+}
+
+func repositoryDBPath(input, resolved string) string {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == ":memory:" || strings.HasPrefix(trimmed, "file:") {
+		return ""
+	}
+	return resolved
 }
 
 // SaveConfigSection persists a single config section as JSON.


### PR DESCRIPTION
## Summary

Existing installs get orphaned on upgrade because the default data dir moved
from `$HOME/.upbrr` to `$XDG_CONFIG_HOME/upbrr` (#133 set `XDG_CONFIG_HOME=/config`,
#135 made `DefaultPath` prefer XDG) with no migration, and secret decryption
locates `web-auth.json` from the db_path stored *in the config* rather than the
database that was actually opened. The result: after upgrading the Docker image,
upbrr starts "unconfigured" (empty config, loopback bind), and once the data dir
is corrected, decryption fails with "config secret encryption helper unavailable".

This adds two upgrade-safety fixes so operators don't have to hand-set
`HOME`/`XDG_CONFIG_HOME` env workarounds.

## Changes

**`DefaultPath()` legacy fallback** (`internal/services/db/paths.go`)
When `XDG_CONFIG_HOME` is set but the canonical `$XDG_CONFIG_HOME/upbrr/db.sqlite`
doesn't exist, prefer an existing legacy database at:
1. `$XDG_CONFIG_HOME/.upbrr/db.sqlite` (the documented `HOME=/config` Docker layout), then
2. `$HOME/.upbrr/db.sqlite` (older `$HOME`-based installs).

New installs still use the canonical XDG path.

**Decrypt helper anchored to the runtime DB dir** (`internal/config/persistence.go`)
`LoadFromDatabase` now decrypts via the config's stored db_path first
(preserving existing export-snapshot behavior), and only if that helper is
*unavailable* retries anchored to the repository's actual on-disk DB directory.
The returned config keeps its stored db_path. `*db.SQLiteRepository` exposes a
new `DBPath()` accessor for this.

Together: an upgraded install finds its legacy data automatically, and decrypts
its secrets next to the real database even if the persisted db_path is stale or
empty — letting operators drop the `HOME`/`XDG_CONFIG_HOME` env workarounds.

## Tests

- `internal/services/db/paths_test.go`: XDG canonical preferred; fallback to
  `.upbrr` under XDG; fallback to `$HOME/.upbrr`; new install uses canonical;
  `SQLiteRepository.DBPath()` returns the opened path.
- `internal/config/persistence_test.go`: `LoadFromDatabase` decrypts a secret
  via the runtime DB dir when the stored db_path's helper is missing, while
  preserving the stored db_path; `repoDBPath` helper.

## Validation

- `go test ./...` — clean (incl. the export-snapshot/db-path-snapshot tests,
  which keep their stored-path-first behavior)
- `go test -race ./internal/config/... ./internal/services/db/...` — clean
- `make lint` — 0 issues; pathpolicy / logpolicy / gofmt / whitespace clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database path resolution by preferring the canonical XDG config location when an existing database is found, with automatic fallback to legacy locations (including careful HOME/XDG handling).
  * Made secret encryption/decryption resilient to moved or stale database directories by retrying with the runtime database location while preserving the originally stored database path.
* **Tests**
  * Added coverage for runtime vs stored database directory handling, retry behavior, and correct behavior for sentinel (e.g., in-memory) database inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->