### PR TITLE
Implement tracker auth core

### DIFF
--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -262,6 +262,24 @@ func trackerRuleFailuresForPreview(preview api.MetadataPreview, tracker string) 
 	return nil
 }
 
+// cliTrackerRuleFailuresIgnored reports whether a preview rule failure should
+// be bypassed for a tracker, using the global flag or a per-tracker override.
+func cliTrackerRuleFailuresIgnored(req api.Request, tracker string) bool {
+	if req.IgnoreTrackerRuleFailures {
+		return true
+	}
+	name := strings.ToUpper(strings.TrimSpace(tracker))
+	if name == "" {
+		return false
+	}
+	for _, allowed := range req.IgnoreTrackerRuleFailuresFor {
+		if strings.EqualFold(strings.TrimSpace(allowed), name) {
+			return true
+		}
+	}
+	return false
+}
+
 // removeUnreadyCLIAuthTrackers keeps only trackers marked ready to continue
 // after auth filtering, including unmanaged trackers that need no auth call.
 // An empty ready list means auth filtering ran and no candidate remained ready.
@@ -344,7 +362,7 @@ func ensureCLITrackerAuthBeforeDupeCheckWithServiceAndLogger(ctx context.Context
 			readyByTracker[name] = struct{}{}
 			continue
 		}
-		if !req.IgnoreTrackerRuleFailures && len(trackerRuleFailuresForPreview(preview, name)) > 0 {
+		if !cliTrackerRuleFailuresIgnored(req, name) && len(trackerRuleFailuresForPreview(preview, name)) > 0 {
 			logger.Debugf("cli auth: tracker=%s skipped before auth due to rule failure", name)
 			continue
 		}
@@ -505,9 +523,9 @@ func cliAuthLogTrackerID(trackerID string) string {
 }
 
 // cliAuthStatusMessageForLog returns the same status detail shown to users,
-// passed through the log redaction policy.
+// already passed through the auth redaction policy.
 func cliAuthStatusMessageForLog(status api.TrackerAuthStatus) string {
-	return cliAuthLogField(cliTrackerAuthStatusMessage(status))
+	return cliTrackerAuthStatusMessage(status)
 }
 
 // cliAuthLogError formats an error for logs after applying redaction.
@@ -542,12 +560,12 @@ func cliTrackerAuthReady(status api.TrackerAuthStatus) bool {
 	}
 }
 
-// cliTrackerAuthStatusMessage selects the safest user-visible status detail
-// available for CLI prompts and errors.
+// cliTrackerAuthStatusMessage selects and redacts the safest user-visible status
+// detail available for CLI prompts and errors.
 func cliTrackerAuthStatusMessage(status api.TrackerAuthStatus) string {
 	for _, value := range []string{status.Message, status.LastError, status.State} {
 		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
+			return cliAuthLogField(trimmed)
 		}
 	}
 	return "auth not ready"

--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -18,6 +18,7 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	"github.com/autobrr/upbrr/internal/redaction"
+	"github.com/autobrr/upbrr/internal/trackerauth"
 	"github.com/autobrr/upbrr/internal/trackers"
 
 	"github.com/autobrr/upbrr/pkg/api"
@@ -25,11 +26,32 @@ import (
 
 const dryRunPayloadPreviewLimit = 240
 
-func runInteractiveCLIPath(ctx context.Context, coreSvc api.Core, baseArgs []string, opts cliOptions, visited map[string]bool, sourcePath string, screens int, cfg config.Config) error {
-	return runInteractiveCLIPathWithInput(ctx, coreSvc, baseArgs, opts, visited, sourcePath, screens, cfg, os.Stdin)
+// cliTrackerAuthService is the CLI-facing subset of tracker auth operations
+// needed to verify and refresh tracker auth before dupe checking.
+type cliTrackerAuthService interface {
+	Capabilities(ctx context.Context) ([]api.TrackerAuthCapability, error)
+	Validate(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error)
+	Submit2FA(ctx context.Context, challengeID string, code string) (api.TrackerAuthStatus, error)
+}
+
+func runInteractiveCLIPath(ctx context.Context, coreSvc api.Core, opts cliOptions, visited map[string]bool, sourcePath string, cfg config.Config) error {
+	return runInteractiveCLIPathWithInputAndLogger(ctx, coreSvc, nil, opts, visited, sourcePath, 1, cfg, os.Stdin, api.NopLogger{})
+}
+
+// runInteractiveCLIPathWithLogger runs one interactive CLI upload path and
+// sends CLI-only tracker auth decisions to logger.
+func runInteractiveCLIPathWithLogger(ctx context.Context, coreSvc api.Core, baseArgs []string, opts cliOptions, visited map[string]bool, sourcePath string, screens int, cfg config.Config, logger api.Logger) error {
+	return runInteractiveCLIPathWithInputAndLogger(ctx, coreSvc, baseArgs, opts, visited, sourcePath, screens, cfg, os.Stdin, logger)
 }
 
 func runInteractiveCLIPathWithInput(ctx context.Context, coreSvc api.Core, baseArgs []string, opts cliOptions, visited map[string]bool, sourcePath string, screens int, cfg config.Config, stdin io.Reader) error {
+	return runInteractiveCLIPathWithInputAndLogger(ctx, coreSvc, baseArgs, opts, visited, sourcePath, screens, cfg, stdin, api.NopLogger{})
+}
+
+// runInteractiveCLIPathWithInputAndLogger is the injectable form of
+// runInteractiveCLIPathWithLogger used when tests need controlled stdin.
+func runInteractiveCLIPathWithInputAndLogger(ctx context.Context, coreSvc api.Core, baseArgs []string, opts cliOptions, visited map[string]bool, sourcePath string, screens int, cfg config.Config, stdin io.Reader, logger api.Logger) error {
+	logger = cliAuthLogger(logger)
 	reader := bufio.NewReader(stdin)
 	currentArgs := append([]string(nil), baseArgs...)
 	currentOpts := opts
@@ -113,6 +135,18 @@ func runInteractiveCLIPathWithInput(ctx context.Context, coreSvc api.Core, baseA
 	}
 	req.Trackers = candidateTrackers
 	req.TrackersRemove = appendTrackerRemovals(req.TrackersRemove, unselectedTrackers(removalBase, candidateTrackers)...)
+
+	readyAuthTrackers, err := ensureCLITrackerAuthBeforeDupeCheckWithLogger(ctx, reader, cfg, req, candidateTrackers, metadataPreview, logger)
+	if err != nil {
+		return err
+	}
+	candidateTrackers = removeUnreadyCLIAuthTrackers(candidateTrackers, readyAuthTrackers)
+	req.TrackersRemove = appendTrackerRemovals(req.TrackersRemove, unselectedTrackers(req.Trackers, candidateTrackers)...)
+	req.Trackers = candidateTrackers
+	if len(candidateTrackers) == 0 {
+		fmt.Printf("No trackers selected for %s\n", sourcePath)
+		return nil
+	}
 
 	dupeSummary, err := runCLIDupeCheck(ctx, coreSvc, req)
 	if err != nil {
@@ -208,6 +242,315 @@ func resolveCLIUploadTrackers(visited map[string]bool, req api.Request, preview 
 		available = trackers.ResolveTrackers(cfg, req.Trackers, remove, api.NopLogger{})
 	}
 	return available, removalBase
+}
+
+// trackerRuleFailuresForPreview returns preview-time rule failures for a
+// tracker, accepting mixed-case map keys from older or test-built payloads.
+func trackerRuleFailuresForPreview(preview api.MetadataPreview, tracker string) []api.RuleFailure {
+	if len(preview.TrackerRuleFailures) == 0 {
+		return nil
+	}
+	name := strings.ToUpper(strings.TrimSpace(tracker))
+	if failures, ok := preview.TrackerRuleFailures[name]; ok {
+		return failures
+	}
+	for key, failures := range preview.TrackerRuleFailures {
+		if strings.EqualFold(strings.TrimSpace(key), name) {
+			return failures
+		}
+	}
+	return nil
+}
+
+// removeUnreadyCLIAuthTrackers keeps only trackers marked ready to continue
+// after auth filtering, including unmanaged trackers that need no auth call.
+// An empty ready list means auth filtering ran and no candidate remained ready.
+func removeUnreadyCLIAuthTrackers(candidateTrackers []string, readyTrackers []string) []string {
+	if len(candidateTrackers) == 0 {
+		return candidateTrackers
+	}
+	ready := make(map[string]struct{}, len(readyTrackers))
+	for _, tracker := range readyTrackers {
+		if name := strings.ToUpper(strings.TrimSpace(tracker)); name != "" {
+			ready[name] = struct{}{}
+		}
+	}
+
+	filtered := make([]string, 0, len(candidateTrackers))
+	for _, tracker := range candidateTrackers {
+		name := strings.ToUpper(strings.TrimSpace(tracker))
+		if name == "" {
+			continue
+		}
+		if _, isReady := ready[name]; !isReady {
+			continue
+		}
+		filtered = append(filtered, name)
+	}
+	return filtered
+}
+
+// ensureCLITrackerAuthBeforeDupeCheckWithLogger validates tracker auth using a
+// service that shares the CLI logger for service-level and CLI decision logs.
+func ensureCLITrackerAuthBeforeDupeCheckWithLogger(ctx context.Context, reader *bufio.Reader, cfg config.Config, req api.Request, trackerNames []string, preview api.MetadataPreview, logger api.Logger) ([]string, error) {
+	if len(trackerNames) == 0 {
+		return trackerNames, nil
+	}
+	logger = cliAuthLogger(logger)
+	return ensureCLITrackerAuthBeforeDupeCheckWithServiceAndLogger(ctx, reader, trackerauth.NewServiceWithLogger(cfg, logger), req, trackerNames, preview, logger)
+}
+
+// ensureCLITrackerAuthBeforeDupeCheckWithService is the injectable form of
+// ensureCLITrackerAuthBeforeDupeCheck used by tests.
+func ensureCLITrackerAuthBeforeDupeCheckWithService(ctx context.Context, reader *bufio.Reader, authSvc cliTrackerAuthService, req api.Request, trackerNames []string) ([]string, error) {
+	return ensureCLITrackerAuthBeforeDupeCheckWithServiceAndLogger(ctx, reader, authSvc, req, trackerNames, api.MetadataPreview{}, api.NopLogger{})
+}
+
+// ensureCLITrackerAuthBeforeDupeCheckWithServiceAndLogger applies CLI-specific
+// keep/skip behavior and logs redacted outcomes for managed-auth trackers.
+// Preview rule failures suppress managed-auth checks only after capability
+// classification and leave those managed trackers out of the ready result, so
+// static API-key/passkey trackers stay quiet here.
+func ensureCLITrackerAuthBeforeDupeCheckWithServiceAndLogger(ctx context.Context, reader *bufio.Reader, authSvc cliTrackerAuthService, req api.Request, trackerNames []string, preview api.MetadataPreview, logger api.Logger) ([]string, error) {
+	logger = cliAuthLogger(logger)
+
+	capabilities, err := authSvc.Capabilities(ctx)
+	if err != nil {
+		logger.Warnf("cli auth: capability load failed error=%s", cliAuthLogError(err))
+		return nil, fmt.Errorf("upbrr: tracker auth capabilities: %w", err)
+	}
+	logger.Debugf("cli auth: capabilities loaded count=%d", len(capabilities))
+	capabilityByTracker := make(map[string]api.TrackerAuthCapability, len(capabilities))
+	for _, capability := range capabilities {
+		name := strings.ToUpper(strings.TrimSpace(capability.TrackerID))
+		if name != "" {
+			capabilityByTracker[name] = capability
+		}
+	}
+
+	readyByTracker := make(map[string]struct{}, len(trackerNames))
+	authCheckTrackers := make([]string, 0, len(trackerNames))
+	for _, trackerName := range trackerNames {
+		name := strings.ToUpper(strings.TrimSpace(trackerName))
+		if name == "" {
+			continue
+		}
+		capability, ok := capabilityByTracker[name]
+		if !ok {
+			readyByTracker[name] = struct{}{}
+			continue
+		}
+		if !cliTrackerAuthApplies(capability) {
+			readyByTracker[name] = struct{}{}
+			continue
+		}
+		if !req.IgnoreTrackerRuleFailures && len(trackerRuleFailuresForPreview(preview, name)) > 0 {
+			logger.Debugf("cli auth: tracker=%s skipped before auth due to rule failure", name)
+			continue
+		}
+		authCheckTrackers = append(authCheckTrackers, name)
+	}
+
+	logger.Infof("cli auth: pre-dupe check start trackers=%d", len(authCheckTrackers))
+	for _, name := range authCheckTrackers {
+		capability := capabilityByTracker[name]
+
+		logger.Infof("cli auth: validating tracker=%s auth_kind=%s", name, cliAuthLogField(capability.AuthKind))
+		status, err := authSvc.Validate(ctx, name)
+		if err != nil {
+			logger.Warnf("cli auth: validation failed tracker=%s error=%s", name, cliAuthLogError(err))
+			return nil, fmt.Errorf("upbrr: tracker auth %s: %w", name, err)
+		}
+		logCLITrackerAuthStatus(logger, "validation result", status)
+		status, keep, err := handleCLITrackerAuthStatusWithLogger(ctx, reader, authSvc, capability, status, req, logger)
+		if err != nil {
+			return nil, err
+		}
+		if cliTrackerAuthReady(status) {
+			logger.Infof("cli auth: tracker=%s decision=ready state=%s", name, cliAuthLogField(status.State))
+			readyByTracker[name] = struct{}{}
+			continue
+		}
+		if keep {
+			logger.Infof("cli auth: tracker=%s decision=keep state=%s", name, cliAuthLogField(status.State))
+			readyByTracker[name] = struct{}{}
+			continue
+		}
+		logger.Warnf("cli auth: tracker=%s decision=skip state=%s reason=%s", name, cliAuthLogField(status.State), cliAuthStatusMessageForLog(status))
+	}
+
+	ready := make([]string, 0, len(trackerNames))
+	for _, trackerName := range trackerNames {
+		name := strings.ToUpper(strings.TrimSpace(trackerName))
+		if _, ok := readyByTracker[name]; ok {
+			ready = append(ready, name)
+		}
+	}
+	logger.Infof("cli auth: pre-dupe check complete ready=%d skipped=%d", len(ready), len(trackerNames)-len(ready))
+	return ready, nil
+}
+
+// cliTrackerAuthApplies reports whether a capability represents managed auth
+// work, matching the frontend tracker-auth settings filter instead of static
+// API-key/passkey config.
+func cliTrackerAuthApplies(capability api.TrackerAuthCapability) bool {
+	authKind := strings.ToLower(strings.TrimSpace(capability.AuthKind))
+	return capability.SupportsCookieFile ||
+		capability.SupportsLogin ||
+		capability.SupportsAutoLogin ||
+		capability.SupportsTOTP ||
+		capability.SupportsManual2FA ||
+		strings.Contains(authKind, "refresh") ||
+		strings.Contains(authKind, "2fa")
+}
+
+// handleCLITrackerAuthStatusWithLogger converts one auth status into a CLI
+// decision and logs blocked, prompt, and skip outcomes without secret material.
+func handleCLITrackerAuthStatusWithLogger(ctx context.Context, reader *bufio.Reader, authSvc cliTrackerAuthService, capability api.TrackerAuthCapability, status api.TrackerAuthStatus, req api.Request, logger api.Logger) (api.TrackerAuthStatus, bool, error) {
+	logger = cliAuthLogger(logger)
+	if cliTrackerAuthReady(status) {
+		return status, true, nil
+	}
+	trackerID := strings.ToUpper(strings.TrimSpace(status.TrackerID))
+	if trackerID == "" {
+		trackerID = strings.ToUpper(strings.TrimSpace(capability.TrackerID))
+	}
+
+	if status.Needs2FA && strings.TrimSpace(status.ChallengeID) != "" {
+		if isUnattendedNoConfirm(req) {
+			logger.Warnf("cli auth: tracker=%s decision=blocked reason=2fa_required unattended=true", trackerID)
+			return status, false, fmt.Errorf("upbrr: tracker auth %s requires 2FA before dupe check", trackerID)
+		}
+		logger.Infof("cli auth: tracker=%s decision=prompt_2fa", trackerID)
+		return promptCLITrackerAuth2FAWithLogger(ctx, reader, authSvc, trackerID, status, logger)
+	}
+
+	message := cliTrackerAuthStatusMessage(status)
+	if isUnattendedNoConfirm(req) {
+		logger.Warnf("cli auth: tracker=%s decision=blocked reason=%s unattended=true", trackerID, cliAuthStatusMessageForLog(status))
+		return status, false, fmt.Errorf("upbrr: tracker auth %s not ready before dupe check: %s", trackerID, message)
+	}
+	fmt.Printf("Skipping %s before dupe check: tracker auth not ready (%s).\n", trackerID, message)
+	return status, false, nil
+}
+
+// promptCLITrackerAuth2FAWithLogger prompts for manual 2FA and logs only the
+// submitted outcome; it never logs codes or challenge identifiers.
+func promptCLITrackerAuth2FAWithLogger(ctx context.Context, reader *bufio.Reader, authSvc cliTrackerAuthService, trackerID string, status api.TrackerAuthStatus, logger api.Logger) (api.TrackerAuthStatus, bool, error) {
+	logger = cliAuthLogger(logger)
+	for {
+		fmt.Printf("\n[%s Auth]\n%s\n", trackerID, cliTrackerAuthStatusMessage(status))
+		code, err := promptLine(reader, trackerID+" 2FA code (blank to skip tracker): ")
+		if err != nil {
+			logger.Warnf("cli auth: tracker=%s 2fa prompt failed error=%s", trackerID, cliAuthLogError(err))
+			return status, false, err
+		}
+		if strings.TrimSpace(code) == "" {
+			logger.Warnf("cli auth: tracker=%s decision=skip reason=2fa_code_not_provided", trackerID)
+			fmt.Printf("Skipping %s before dupe check: 2FA code not provided.\n", trackerID)
+			return status, false, nil
+		}
+		nextStatus, err := authSvc.Submit2FA(ctx, status.ChallengeID, code)
+		if err != nil {
+			logger.Warnf("cli auth: tracker=%s 2fa submit failed error=%s", trackerID, cliAuthLogError(err))
+			return status, false, fmt.Errorf("upbrr: tracker auth %s 2FA: %w", trackerID, err)
+		}
+		status = nextStatus
+		logCLITrackerAuthStatus(logger, "2fa result", status)
+		if cliTrackerAuthReady(status) {
+			logger.Infof("cli auth: tracker=%s decision=ready state=%s", trackerID, cliAuthLogField(status.State))
+			fmt.Printf("%s auth ready.\n", trackerID)
+			return status, true, nil
+		}
+		if !status.Needs2FA || strings.TrimSpace(status.ChallengeID) == "" {
+			logger.Warnf("cli auth: tracker=%s decision=skip state=%s reason=%s", trackerID, cliAuthLogField(status.State), cliAuthStatusMessageForLog(status))
+			fmt.Printf("Skipping %s before dupe check: tracker auth not ready (%s).\n", trackerID, cliTrackerAuthStatusMessage(status))
+			return status, false, nil
+		}
+		logger.Infof("cli auth: tracker=%s decision=prompt_2fa_again state=%s", trackerID, cliAuthLogField(status.State))
+	}
+}
+
+// cliAuthLogger returns a no-op logger when callers do not provide one.
+func cliAuthLogger(logger api.Logger) api.Logger {
+	if logger == nil {
+		return api.NopLogger{}
+	}
+	return logger
+}
+
+// logCLITrackerAuthStatus records status metadata that is safe for logs: state,
+// cookie count, encrypted-storage availability, and whether 2FA is still needed.
+func logCLITrackerAuthStatus(logger api.Logger, operation string, status api.TrackerAuthStatus) {
+	logger = cliAuthLogger(logger)
+	logger.Infof(
+		"cli auth: %s tracker=%s state=%s cookies=%d encrypted_storage=%t needs_2fa=%t",
+		cliAuthLogField(operation),
+		cliAuthLogTrackerID(status.TrackerID),
+		cliAuthLogField(status.State),
+		status.CookieCount,
+		status.EncryptedStorage,
+		status.Needs2FA,
+	)
+}
+
+// cliAuthLogTrackerID normalizes tracker IDs for log fields and avoids empty
+// tracker values when status construction fails before a tracker is known.
+func cliAuthLogTrackerID(trackerID string) string {
+	trackerID = strings.ToUpper(strings.TrimSpace(trackerID))
+	if trackerID == "" {
+		return "unknown"
+	}
+	return cliAuthLogField(trackerID)
+}
+
+// cliAuthStatusMessageForLog returns the same status detail shown to users,
+// passed through the log redaction policy.
+func cliAuthStatusMessageForLog(status api.TrackerAuthStatus) string {
+	return cliAuthLogField(cliTrackerAuthStatusMessage(status))
+}
+
+// cliAuthLogError formats an error for logs after applying redaction.
+func cliAuthLogError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return cliAuthLogField(err.Error())
+}
+
+// cliAuthLogField trims and redacts a single log field, returning "none" for
+// empty values so structured key/value-style messages stay readable.
+func cliAuthLogField(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "none"
+	}
+	return redaction.RedactValue(value, nil)
+}
+
+// cliTrackerAuthReady reports whether a tracker-auth status is usable without
+// further user input before CLI dupe checking.
+func cliTrackerAuthReady(status api.TrackerAuthStatus) bool {
+	if status.Needs2FA {
+		return false
+	}
+	switch strings.TrimSpace(status.State) {
+	case trackerauth.StateConfigured, trackerauth.StateHasCookies:
+		return true
+	default:
+		return false
+	}
+}
+
+// cliTrackerAuthStatusMessage selects the safest user-visible status detail
+// available for CLI prompts and errors.
+func cliTrackerAuthStatusMessage(status api.TrackerAuthStatus) string {
+	for _, value := range []string{status.Message, status.LastError, status.State} {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return "auth not ready"
 }
 
 func matchedPreviewTrackers(preview api.MetadataPreview) []string {

--- a/cmd/upbrr/interactive_test.go
+++ b/cmd/upbrr/interactive_test.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/autobrr/upbrr/internal/config"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	"github.com/autobrr/upbrr/internal/trackerauth"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -24,7 +26,7 @@ func TestRunInteractiveCLIPathReturnsNilAfterSuccessfulUpload(t *testing.T) {
 	coreSvc := &cliCoreForTest{
 		review: api.UploadReview{Trackers: []api.TrackerReview{{Tracker: "BLU"}}},
 	}
-	err := runInteractiveCLIPath(context.Background(), coreSvc, nil, cliOptions{Unattended: true}, map[string]bool{}, "movie.mkv", 1, config.Config{
+	err := runInteractiveCLIPath(context.Background(), coreSvc, cliOptions{Unattended: true}, map[string]bool{}, "movie.mkv", config.Config{
 		Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
 	})
 	if err != nil {
@@ -47,7 +49,7 @@ func TestRunInteractiveCLIPathHandlesScreenshotsBeforeReview(t *testing.T) {
 		},
 		review: api.UploadReview{Trackers: []api.TrackerReview{{Tracker: "BLU"}}},
 	}
-	err := runInteractiveCLIPath(context.Background(), coreSvc, nil, cliOptions{Unattended: true}, map[string]bool{}, "movie.mkv", 1, config.Config{
+	err := runInteractiveCLIPath(context.Background(), coreSvc, cliOptions{Unattended: true}, map[string]bool{}, "movie.mkv", config.Config{
 		Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
 	})
 	if err != nil {
@@ -95,7 +97,7 @@ func TestRunInteractiveCLIPathDoubleDupeBeforeScreenshotAndReview(t *testing.T) 
 		},
 		review: api.UploadReview{Trackers: []api.TrackerReview{{Tracker: "BLU"}}},
 	}
-	err := runInteractiveCLIPath(context.Background(), coreSvc, nil, cliOptions{Unattended: true, DoubleDupeCheck: true}, map[string]bool{}, "movie.mkv", 1, config.Config{
+	err := runInteractiveCLIPath(context.Background(), coreSvc, cliOptions{Unattended: true, DoubleDupeCheck: true}, map[string]bool{}, "movie.mkv", config.Config{
 		Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
 	})
 	if err != nil {
@@ -118,7 +120,7 @@ func TestRunInteractiveCLIPathDryRunSkipsScreenshotSideEffects(t *testing.T) {
 		},
 		review: api.UploadReview{Trackers: []api.TrackerReview{{Tracker: "BLU"}}},
 	}
-	err := runInteractiveCLIPath(context.Background(), coreSvc, nil, cliOptions{Unattended: true, DryRun: true}, map[string]bool{}, "movie.mkv", 1, config.Config{
+	err := runInteractiveCLIPath(context.Background(), coreSvc, cliOptions{Unattended: true, DryRun: true}, map[string]bool{}, "movie.mkv", config.Config{
 		Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
 	})
 	if err != nil {
@@ -145,7 +147,7 @@ func TestRunInteractiveCLIPathDryRunPreservesExplicitNoSeed(t *testing.T) {
 	coreSvc := &cliCoreForTest{
 		review: api.UploadReview{Trackers: []api.TrackerReview{{Tracker: "BLU"}}},
 	}
-	err := runInteractiveCLIPath(context.Background(), coreSvc, nil, cliOptions{Unattended: true, DryRun: true, NoSeed: true}, map[string]bool{}, "movie.mkv", 1, config.Config{
+	err := runInteractiveCLIPath(context.Background(), coreSvc, cliOptions{Unattended: true, DryRun: true, NoSeed: true}, map[string]bool{}, "movie.mkv", config.Config{
 		Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
 	})
 	if err != nil {
@@ -170,7 +172,7 @@ func TestRunInteractiveCLIPathDebugHandlesScreenshotsBeforeReview(t *testing.T) 
 		},
 		review: api.UploadReview{Trackers: []api.TrackerReview{{Tracker: "BLU"}}},
 	}
-	err := runInteractiveCLIPath(context.Background(), coreSvc, nil, cliOptions{Unattended: true, Debug: true}, map[string]bool{}, "movie.mkv", 1, config.Config{
+	err := runInteractiveCLIPath(context.Background(), coreSvc, cliOptions{Unattended: true, Debug: true}, map[string]bool{}, "movie.mkv", config.Config{
 		Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
 	})
 	if err != nil {
@@ -202,11 +204,9 @@ func TestRunInteractiveCLIPathUsesResolvedPreviewSourceForPreparedUpload(t *test
 	err := runInteractiveCLIPath(
 		context.Background(),
 		coreSvc,
-		nil,
 		cliOptions{Unattended: true, Rehash: true},
 		map[string]bool{"rehash": true},
 		"folder",
-		1,
 		config.Config{Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}}},
 	)
 	if err != nil {
@@ -391,6 +391,252 @@ func TestResolveCLIUploadTrackersExplicitTrackersSuppressDefaults(t *testing.T) 
 	}
 	if got := unselectedTrackers(removalBase, selected); len(got) != 1 || got[0] != "AITHER" {
 		t.Fatalf("expected AITHER removal from defaults, got %#v", got)
+	}
+}
+
+func TestEnsureCLITrackerAuthBeforeDupeCheckValidatesApplicableTrackers(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &cliTrackerAuthForTest{
+		capabilities: []api.TrackerAuthCapability{
+			{
+				TrackerID:         "PTP",
+				SupportsLogin:     true,
+				SupportsAutoLogin: true,
+			},
+			{
+				TrackerID:      "AITHER",
+				AuthKind:       "api_key",
+				RequiresAPIKey: true,
+			},
+		},
+		validateStatus: map[string]api.TrackerAuthStatus{
+			"PTP": {TrackerID: "PTP", State: trackerauth.StateConfigured},
+		},
+	}
+
+	got, err := ensureCLITrackerAuthBeforeDupeCheckWithService(
+		context.Background(),
+		bufio.NewReader(strings.NewReader("")),
+		authSvc,
+		api.Request{Options: api.UploadOptions{InteractionMode: api.InteractionModeInteractive}},
+		[]string{"PTP", "AITHER", "BLU"},
+	)
+	if err != nil {
+		t.Fatalf("ensureCLITrackerAuthBeforeDupeCheck: %v", err)
+	}
+	if strings.Join(got, ",") != "PTP,AITHER,BLU" {
+		t.Fatalf("expected PTP and non-applicable trackers to continue, got %#v", got)
+	}
+	if strings.Join(authSvc.validated, ",") != "PTP" {
+		t.Fatalf("expected only applicable PTP validation, got %#v", authSvc.validated)
+	}
+}
+
+func TestEnsureCLITrackerAuthBeforeDupeCheckLogsRuleFailureSkipOnlyForManagedAuth(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &cliTrackerAuthForTest{
+		capabilities: []api.TrackerAuthCapability{
+			{TrackerID: "MTV", AuthKind: "api_key_cookies_login_manual_2fa", SupportsCookieFile: true, SupportsLogin: true, SupportsManual2FA: true, RequiresAPIKey: true},
+			{TrackerID: "NBL", AuthKind: "api_key", RequiresAPIKey: true},
+			{TrackerID: "PTP", AuthKind: "cookies_login_manual_2fa", SupportsCookieFile: true, SupportsLogin: true, SupportsManual2FA: true},
+		},
+		validateStatus: map[string]api.TrackerAuthStatus{
+			"PTP": {TrackerID: "PTP", State: trackerauth.StateConfigured},
+		},
+	}
+	logger := &cliAuthRecordingLogger{}
+
+	got, err := ensureCLITrackerAuthBeforeDupeCheckWithServiceAndLogger(
+		context.Background(),
+		bufio.NewReader(strings.NewReader("")),
+		authSvc,
+		api.Request{Options: api.UploadOptions{InteractionMode: api.InteractionModeInteractive}},
+		[]string{"MTV", "NBL", "PTP"},
+		api.MetadataPreview{TrackerRuleFailures: map[string][]api.RuleFailure{
+			"MTV": {{Rule: "extra_check", Reason: "managed auth rule failure"}},
+			"NBL": {{Rule: "require_tv_only", Reason: "static api key rule failure"}},
+		}},
+		logger,
+	)
+	if err != nil {
+		t.Fatalf("ensureCLITrackerAuthBeforeDupeCheck: %v", err)
+	}
+	if strings.Join(got, ",") != "NBL,PTP" {
+		t.Fatalf("expected managed rule-failed tracker removed while static tracker remains eligible, got %#v", got)
+	}
+	if strings.Join(authSvc.validated, ",") != "PTP" {
+		t.Fatalf("expected only rule-eligible managed auth tracker to validate, got %#v", authSvc.validated)
+	}
+
+	logs := strings.Join(append(append(append([]string{}, logger.debug...), logger.info...), logger.warn...), "\n")
+	if !strings.Contains(logs, "cli auth: tracker=MTV skipped before auth due to rule failure") {
+		t.Fatalf("expected managed auth rule-failure skip log, got:\n%s", logs)
+	}
+	if strings.Contains(logs, "tracker=NBL skipped before auth due to rule failure") {
+		t.Fatalf("static api-key tracker should not log auth rule-failure skip, got:\n%s", logs)
+	}
+}
+
+func TestRemoveUnreadyCLIAuthTrackersKeepsUncheckedCandidates(t *testing.T) {
+	t.Parallel()
+
+	got := removeUnreadyCLIAuthTrackers(
+		[]string{"AITHER", "MTV", "NBL", "PTP"},
+		[]string{"AITHER", "NBL", "PTP"},
+	)
+	if strings.Join(got, ",") != "AITHER,NBL,PTP" {
+		t.Fatalf("expected static trackers kept while unready MTV removed, got %#v", got)
+	}
+}
+
+func TestRemoveUnreadyCLIAuthTrackersRemovesAllWhenNoneReady(t *testing.T) {
+	t.Parallel()
+
+	got := removeUnreadyCLIAuthTrackers(
+		[]string{"MTV", "PTP"},
+		nil,
+	)
+	if len(got) != 0 {
+		t.Fatalf("expected all auth-unready trackers removed, got %#v", got)
+	}
+}
+
+func TestEnsureCLITrackerAuthBeforeDupeCheckLogsRedactedDecisions(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &cliTrackerAuthForTest{
+		capabilities: []api.TrackerAuthCapability{
+			{
+				TrackerID:         "PTP",
+				AuthKind:          "credential_login",
+				SupportsLogin:     true,
+				SupportsAutoLogin: true,
+			},
+			{
+				TrackerID:          "HDB",
+				AuthKind:           "cookies",
+				SupportsCookieFile: true,
+				RequiresPasskey:    true,
+			},
+		},
+		validateStatus: map[string]api.TrackerAuthStatus{
+			"PTP": {TrackerID: "PTP", State: trackerauth.StateConfigured, CookieCount: 2, EncryptedStorage: true},
+			"HDB": {
+				TrackerID: "HDB",
+				State:     trackerauth.StateLoginRequired,
+				Message:   `{"password":"hunter2","state":"bad"}`,
+			},
+		},
+	}
+	logger := &cliAuthRecordingLogger{}
+
+	got, err := ensureCLITrackerAuthBeforeDupeCheckWithServiceAndLogger(
+		context.Background(),
+		bufio.NewReader(strings.NewReader("")),
+		authSvc,
+		api.Request{Options: api.UploadOptions{InteractionMode: api.InteractionModeInteractive}},
+		[]string{"PTP", "HDB"},
+		api.MetadataPreview{},
+		logger,
+	)
+	if err != nil {
+		t.Fatalf("ensureCLITrackerAuthBeforeDupeCheck: %v", err)
+	}
+	if strings.Join(got, ",") != "PTP" {
+		t.Fatalf("expected only ready PTP to continue, got %#v", got)
+	}
+
+	logs := strings.Join(append(append([]string{}, logger.info...), logger.warn...), "\n")
+	for _, expected := range []string{
+		"cli auth: pre-dupe check start trackers=2",
+		"cli auth: validating tracker=PTP auth_kind=credential_login",
+		"cli auth: tracker=PTP decision=ready state=configured",
+		"cli auth: tracker=HDB decision=skip state=login_required",
+	} {
+		if !strings.Contains(logs, expected) {
+			t.Fatalf("expected log %q in:\n%s", expected, logs)
+		}
+	}
+	if strings.Contains(logs, "hunter2") {
+		t.Fatalf("auth logs leaked password: %s", logs)
+	}
+	if !strings.Contains(logs, `"password":"[REDACTED]"`) {
+		t.Fatalf("expected redacted password in auth logs, got:\n%s", logs)
+	}
+}
+
+func TestEnsureCLITrackerAuthBeforeDupeCheckPromptsForManual2FA(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &cliTrackerAuthForTest{
+		capabilities: []api.TrackerAuthCapability{{
+			TrackerID:         "PTP",
+			SupportsLogin:     true,
+			SupportsAutoLogin: true,
+			SupportsManual2FA: true,
+		}},
+		validateStatus: map[string]api.TrackerAuthStatus{
+			"PTP": {
+				TrackerID:   "PTP",
+				State:       trackerauth.StateLoginRequired,
+				Needs2FA:    true,
+				ChallengeID: "challenge-1",
+				Message:     "2FA required",
+			},
+		},
+		submitStatus: api.TrackerAuthStatus{TrackerID: "PTP", State: trackerauth.StateConfigured},
+	}
+
+	got, err := ensureCLITrackerAuthBeforeDupeCheckWithService(
+		context.Background(),
+		bufio.NewReader(strings.NewReader("123456\n")),
+		authSvc,
+		api.Request{Options: api.UploadOptions{InteractionMode: api.InteractionModeInteractive}},
+		[]string{"PTP"},
+	)
+	if err != nil {
+		t.Fatalf("ensureCLITrackerAuthBeforeDupeCheck: %v", err)
+	}
+	if strings.Join(got, ",") != "PTP" {
+		t.Fatalf("expected PTP to continue after 2FA, got %#v", got)
+	}
+	if authSvc.submittedChallenge != "challenge-1" || authSvc.submittedCode != "123456" {
+		t.Fatalf("expected submitted 2FA challenge/code, got challenge=%q code=%q", authSvc.submittedChallenge, authSvc.submittedCode)
+	}
+}
+
+func TestEnsureCLITrackerAuthBeforeDupeCheckFailsUnattendedAuthRequired(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &cliTrackerAuthForTest{
+		capabilities: []api.TrackerAuthCapability{{
+			TrackerID:          "HDB",
+			SupportsCookieFile: true,
+			RequiresPasskey:    true,
+		}},
+		validateStatus: map[string]api.TrackerAuthStatus{
+			"HDB": {
+				TrackerID: "HDB",
+				State:     trackerauth.StateLoginRequired,
+				Message:   "login credentials or imported cookies required",
+			},
+		},
+	}
+
+	_, err := ensureCLITrackerAuthBeforeDupeCheckWithService(
+		context.Background(),
+		bufio.NewReader(strings.NewReader("")),
+		authSvc,
+		api.Request{Options: api.UploadOptions{InteractionMode: api.InteractionModeUnattended}},
+		[]string{"HDB"},
+	)
+	if err == nil {
+		t.Fatal("expected unattended auth-required error")
+	}
+	if !strings.Contains(err.Error(), "tracker auth HDB not ready before dupe check") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -891,6 +1137,53 @@ type cliCoreForTest struct {
 	savedDescriptionRaw    []string
 	savedDescriptionReqs   []api.Request
 	savedDescriptionGroup  api.DescriptionBuilderGroup
+}
+
+type cliTrackerAuthForTest struct {
+	capabilities       []api.TrackerAuthCapability
+	validateStatus     map[string]api.TrackerAuthStatus
+	submitStatus       api.TrackerAuthStatus
+	validated          []string
+	submittedChallenge string
+	submittedCode      string
+}
+
+type cliAuthRecordingLogger struct {
+	api.NopLogger
+	debug []string
+	info  []string
+	warn  []string
+}
+
+func (l *cliAuthRecordingLogger) Debugf(format string, args ...any) {
+	l.debug = append(l.debug, fmt.Sprintf(format, args...))
+}
+
+func (l *cliAuthRecordingLogger) Infof(format string, args ...any) {
+	l.info = append(l.info, fmt.Sprintf(format, args...))
+}
+
+func (l *cliAuthRecordingLogger) Warnf(format string, args ...any) {
+	l.warn = append(l.warn, fmt.Sprintf(format, args...))
+}
+
+func (s *cliTrackerAuthForTest) Capabilities(context.Context) ([]api.TrackerAuthCapability, error) {
+	return append([]api.TrackerAuthCapability(nil), s.capabilities...), nil
+}
+
+func (s *cliTrackerAuthForTest) Validate(_ context.Context, trackerID string) (api.TrackerAuthStatus, error) {
+	name := strings.ToUpper(strings.TrimSpace(trackerID))
+	s.validated = append(s.validated, name)
+	if status, ok := s.validateStatus[name]; ok {
+		return status, nil
+	}
+	return api.TrackerAuthStatus{TrackerID: name, State: trackerauth.StateConfigured}, nil
+}
+
+func (s *cliTrackerAuthForTest) Submit2FA(_ context.Context, challengeID string, code string) (api.TrackerAuthStatus, error) {
+	s.submittedChallenge = challengeID
+	s.submittedCode = code
+	return s.submitStatus, nil
 }
 
 type cliCoreRequestForTest struct {

--- a/cmd/upbrr/interactive_test.go
+++ b/cmd/upbrr/interactive_test.go
@@ -479,6 +479,47 @@ func TestEnsureCLITrackerAuthBeforeDupeCheckLogsRuleFailureSkipOnlyForManagedAut
 	}
 }
 
+func TestEnsureCLITrackerAuthBeforeDupeCheckHonorsPerTrackerRuleFailureOverride(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &cliTrackerAuthForTest{
+		capabilities: []api.TrackerAuthCapability{
+			{TrackerID: "MTV", AuthKind: "api_key_cookies_login_manual_2fa", SupportsCookieFile: true, SupportsLogin: true, SupportsManual2FA: true},
+			{TrackerID: "PTP", AuthKind: "cookies_login_manual_2fa", SupportsCookieFile: true, SupportsLogin: true, SupportsManual2FA: true},
+		},
+	}
+	logger := &cliAuthRecordingLogger{}
+
+	got, err := ensureCLITrackerAuthBeforeDupeCheckWithServiceAndLogger(
+		context.Background(),
+		bufio.NewReader(strings.NewReader("")),
+		authSvc,
+		api.Request{
+			Options:                      api.UploadOptions{InteractionMode: api.InteractionModeInteractive},
+			IgnoreTrackerRuleFailuresFor: []string{" mtv "},
+		},
+		[]string{"MTV", "PTP"},
+		api.MetadataPreview{TrackerRuleFailures: map[string][]api.RuleFailure{
+			"mTv": {{Rule: "extra_check", Reason: "managed auth rule failure"}},
+		}},
+		logger,
+	)
+	if err != nil {
+		t.Fatalf("ensureCLITrackerAuthBeforeDupeCheck: %v", err)
+	}
+	if strings.Join(got, ",") != "MTV,PTP" {
+		t.Fatalf("expected per-tracker rule-failure override to keep MTV eligible, got %#v", got)
+	}
+	if strings.Join(authSvc.validated, ",") != "MTV,PTP" {
+		t.Fatalf("expected overridden managed tracker to validate, got %#v", authSvc.validated)
+	}
+
+	logs := strings.Join(append(append(append([]string{}, logger.debug...), logger.info...), logger.warn...), "\n")
+	if strings.Contains(logs, "tracker=MTV skipped before auth due to rule failure") {
+		t.Fatalf("overridden tracker should not log auth rule-failure skip, got:\n%s", logs)
+	}
+}
+
 func TestRemoveUnreadyCLIAuthTrackersKeepsUncheckedCandidates(t *testing.T) {
 	t.Parallel()
 
@@ -564,6 +605,42 @@ func TestEnsureCLITrackerAuthBeforeDupeCheckLogsRedactedDecisions(t *testing.T) 
 	}
 	if !strings.Contains(logs, `"password":"[REDACTED]"`) {
 		t.Fatalf("expected redacted password in auth logs, got:\n%s", logs)
+	}
+}
+
+func TestCLITrackerAuthStatusMessageRedactsUserVisibleStatusText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status api.TrackerAuthStatus
+	}{
+		{
+			name:   "message",
+			status: api.TrackerAuthStatus{Message: `{"password":"hunter2","state":"bad"}`},
+		},
+		{
+			name:   "last error",
+			status: api.TrackerAuthStatus{LastError: `{"api_key":"secret-token"}`},
+		},
+		{
+			name:   "state fallback",
+			status: api.TrackerAuthStatus{State: `{"passkey":"secret-token"}`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := cliTrackerAuthStatusMessage(tt.status)
+			if strings.Contains(got, "hunter2") || strings.Contains(got, "secret-token") {
+				t.Fatalf("status message leaked secret: %q", got)
+			}
+			if !strings.Contains(got, "[REDACTED]") {
+				t.Fatalf("expected redacted status message, got %q", got)
+			}
+		})
 	}
 }
 

--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -277,7 +277,7 @@ func run() error {
 			}
 			continue
 		}
-		if err := runInteractiveCLIPath(ctx, coreSvc, os.Args[1:], opts, visitedFlags, sourcePath, screens, cfg); err != nil {
+		if err := runInteractiveCLIPathWithLogger(ctx, coreSvc, os.Args[1:], opts, visitedFlags, sourcePath, screens, cfg, logger); err != nil {
 			return exitError(1, err)
 		}
 	}

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -57,6 +57,9 @@ import type {
   ScreenshotResult,
   ScreenshotSelection,
   TrackerQuestionnaire,
+  TrackerAuthCapability,
+  TrackerAuthLoginRequest,
+  TrackerAuthStatus,
   TrackerDryRunPreview,
   TrackerUploadSnapshot,
   WebAuthStatus,
@@ -505,6 +508,24 @@ declare global {
             GetLogExclusions: () => Promise<string[]>;
             UpdateLogExclusions: (patterns: string[]) => Promise<void>;
             ListKnownTrackers: () => Promise<string[]>;
+            ListTrackerAuthCapabilities?: () => Promise<TrackerAuthCapability[]>;
+            GetTrackerAuthStatus?: (tracker: string) => Promise<TrackerAuthStatus>;
+            ImportTrackerAuthCookies?: (tracker: string) => Promise<TrackerAuthStatus>;
+            ImportTrackerAuthCookieContent?: (
+              tracker: string,
+              fileName: string,
+              content: string,
+            ) => Promise<TrackerAuthStatus>;
+            TestTrackerAuth?: (tracker: string) => Promise<TrackerAuthStatus>;
+            LoginTrackerAuth?: (
+              tracker: string,
+              req: TrackerAuthLoginRequest,
+            ) => Promise<TrackerAuthStatus>;
+            SubmitTrackerAuth2FA?: (
+              challengeID: string,
+              code: string,
+            ) => Promise<TrackerAuthStatus>;
+            DeleteTrackerAuth?: (tracker: string) => Promise<TrackerAuthStatus>;
             GetImageHostPolicyMetadata: () => Promise<ImageHostPolicyMetadata>;
             ListHistory: () => Promise<HistoryEntry[]>;
             GetHistoryOverview: (sourcePath: string) => Promise<HistoryOverview>;

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -4098,6 +4098,7 @@ export default function App() {
               dismissConfigOpStatus={dismissConfigOpStatus}
               settingsSection={settingsSection}
               settingsSections={settingsSections}
+              trackerSelectionNames={trackerSelectionNames}
               showAdvancedToggle={showAdvancedToggle}
               advancedOpen={advancedOpen}
               setSettingsSection={setSettingsSection}

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -158,6 +158,7 @@ const emptyPreview: MetadataPreview = {
   ExternalPreview: [],
   Bluray: undefined,
   TrackerData: [],
+  TrackerRuleFailures: {},
 };
 
 const emptyTrackerDryRun: TrackerDryRunPreview = {

--- a/gui/frontend/src/hooks/useSettingsState.tsx
+++ b/gui/frontend/src/hooks/useSettingsState.tsx
@@ -512,6 +512,7 @@ const trackerSchemas: Record<string, FieldMeta[]> = {
     trackerFieldMeta.Username,
     trackerFieldMeta.Password,
     trackerFieldMeta.AnnounceURL,
+    trackerFieldMeta.OTPURI,
   ],
   PTS: [trackerFieldMeta.FaviconURL, trackerFieldMeta.LinkDirName, trackerFieldMeta.AnnounceURL],
   PTT: [

--- a/gui/frontend/src/pages/settings/index.test.tsx
+++ b/gui/frontend/src/pages/settings/index.test.tsx
@@ -74,7 +74,7 @@ describe("SettingsPage", () => {
       within(settingsTags as HTMLElement)
         .getAllByRole("button")
         .map((button) => button.textContent),
-    ).toEqual(["Main", "Trackers", "Application Details"]);
+    ).toEqual(["Main", "Trackers", "Application Details", "Tracker Auth"]);
     expect(screen.queryByText("autobrr/upbrr")).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "Application Details" }));
@@ -92,5 +92,23 @@ describe("SettingsPage", () => {
     expect(screen.getByText("autobrr/upbrr")).toBeInTheDocument();
     expect(screen.queryByText("Copyright")).not.toBeInTheDocument();
     expect(screen.queryByText("Copyright (c) 2026 autobrr")).not.toBeInTheDocument();
+  });
+
+  it("renders tracker auth as the bottom tab", async () => {
+    const setSettingsSection = vi.fn();
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: vi.fn().mockResolvedValue([]),
+          GetTrackerAuthStatus: vi.fn(),
+        },
+      },
+    });
+
+    render(<SettingsPage {...baseProps} setSettingsSection={setSettingsSection} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Tracker Auth" }));
+
+    expect(setSettingsSection).toHaveBeenCalledWith("tracker_auth");
   });
 });

--- a/gui/frontend/src/pages/settings/index.test.tsx
+++ b/gui/frontend/src/pages/settings/index.test.tsx
@@ -21,10 +21,12 @@ const baseProps = {
     "AR",
     "COOKIE",
     "FAST",
+    "HDB",
     "MTV",
     "PTP",
     "RTF",
     "SLOW",
+    "ASC",
     "PLAINAPI",
     "PLAINPASS",
   ],
@@ -160,7 +162,7 @@ describe("SettingsPage", () => {
     expect(setSettingsSection).toHaveBeenCalledWith("tracker_auth");
   });
 
-  it("shows Check Auth only for adapter-backed tracker auth", async () => {
+  it("shows Check Auth only for remote-validation tracker auth", async () => {
     vi.stubGlobal("go", {
       guiapp: {
         App: {
@@ -182,8 +184,44 @@ describe("SettingsPage", () => {
               displayName: "AR",
               authKind: "cookies_login",
               supportsCookieFile: true,
+              supportsLogin: false,
+              supportsAutoLogin: false,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: false,
+              requiresPasskey: false,
+            },
+            {
+              trackerID: "HDB",
+              displayName: "HDB",
+              authKind: "passkey_cookies",
+              supportsCookieFile: true,
+              supportsLogin: false,
+              supportsAutoLogin: false,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: false,
+              requiresPasskey: true,
+            },
+            {
+              trackerID: "RTF",
+              displayName: "RTF",
+              authKind: "api_key_credential_refresh",
+              supportsCookieFile: false,
               supportsLogin: true,
               supportsAutoLogin: true,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: true,
+              requiresPasskey: false,
+            },
+            {
+              trackerID: "ASC",
+              displayName: "ASC",
+              authKind: "cookies",
+              supportsCookieFile: true,
+              supportsLogin: false,
+              supportsAutoLogin: false,
               supportsTOTP: false,
               supportsManual2FA: false,
               requiresAPIKey: false,
@@ -215,16 +253,34 @@ describe("SettingsPage", () => {
 
     const mtvTitle = await screen.findByText("MTV");
     const arTitle = await screen.findByText("AR");
+    const hdbTitle = await screen.findByText("HDB");
+    const rtfTitle = await screen.findByText("RTF");
+    const ascTitle = await screen.findByText("ASC");
     const mtvCard = mtvTitle.closest(".tracker-auth-card");
     const arCard = arTitle.closest(".tracker-auth-card");
+    const hdbCard = hdbTitle.closest(".tracker-auth-card");
+    const rtfCard = rtfTitle.closest(".tracker-auth-card");
+    const ascCard = ascTitle.closest(".tracker-auth-card");
 
     expect(mtvCard).not.toBeNull();
     expect(arCard).not.toBeNull();
+    expect(hdbCard).not.toBeNull();
+    expect(rtfCard).not.toBeNull();
+    expect(ascCard).not.toBeNull();
     expect(
       within(mtvCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
     ).toBeInTheDocument();
     expect(
-      within(arCard as HTMLElement).queryByRole("button", { name: "Check Auth" }),
+      within(arCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
+    ).toBeInTheDocument();
+    expect(
+      within(hdbCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
+    ).toBeInTheDocument();
+    expect(
+      within(rtfCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
+    ).toBeInTheDocument();
+    expect(
+      within(ascCard as HTMLElement).queryByRole("button", { name: "Check Auth" }),
     ).not.toBeInTheDocument();
   });
 

--- a/gui/frontend/src/pages/settings/index.test.tsx
+++ b/gui/frontend/src/pages/settings/index.test.tsx
@@ -160,7 +160,7 @@ describe("SettingsPage", () => {
     expect(setSettingsSection).toHaveBeenCalledWith("tracker_auth");
   });
 
-  it("shows Test Auth only for adapter-backed tracker auth", async () => {
+  it("shows Check Auth only for adapter-backed tracker auth", async () => {
     vi.stubGlobal("go", {
       guiapp: {
         App: {
@@ -221,10 +221,10 @@ describe("SettingsPage", () => {
     expect(mtvCard).not.toBeNull();
     expect(arCard).not.toBeNull();
     expect(
-      within(mtvCard as HTMLElement).getByRole("button", { name: "Test Auth" }),
+      within(mtvCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
     ).toBeInTheDocument();
     expect(
-      within(arCard as HTMLElement).queryByRole("button", { name: "Test Auth" }),
+      within(arCard as HTMLElement).queryByRole("button", { name: "Check Auth" }),
     ).not.toBeInTheDocument();
   });
 
@@ -447,7 +447,7 @@ describe("SettingsPage", () => {
 
   it.each([
     ["Import Cookies", "ImportTrackerAuthCookies"],
-    ["Test Auth", "TestTrackerAuth"],
+    ["Check Auth", "TestTrackerAuth"],
     ["Delete Auth", "DeleteTrackerAuth"],
   ])(
     "keeps newer %s status when initial status resolves late",
@@ -589,10 +589,10 @@ describe("SettingsPage", () => {
     expect(mtvCard).not.toBeNull();
     expect(ptpCard).not.toBeNull();
     await userEvent.click(
-      within(mtvCard as HTMLElement).getByRole("button", { name: "Test Auth" }),
+      within(mtvCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
     );
     await userEvent.click(
-      within(ptpCard as HTMLElement).getByRole("button", { name: "Test Auth" }),
+      within(ptpCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
     );
     expect(await screen.findByText("new action ready")).toBeInTheDocument();
 
@@ -607,7 +607,7 @@ describe("SettingsPage", () => {
     });
 
     await userEvent.click(
-      within(ptpCard as HTMLElement).getByRole("button", { name: "Test Auth" }),
+      within(ptpCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
     );
 
     await waitFor(() => {
@@ -635,7 +635,7 @@ describe("SettingsPage", () => {
     );
 
     expect(await screen.findByText("initial ready")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: "Test Auth" }));
+    await userEvent.click(screen.getByRole("button", { name: "Check Auth" }));
 
     rerender(
       <SettingsPage {...baseProps} settingsSection="main_settings" setSettingsSection={vi.fn()} />,
@@ -793,8 +793,8 @@ describe("SettingsPage", () => {
     );
 
     expect(await screen.findByText("initial ready")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: "Test Auth" }));
-    expect(screen.getByRole("button", { name: "Testing..." })).toBeDisabled();
+    await userEvent.click(screen.getByRole("button", { name: "Check Auth" }));
+    expect(screen.getByRole("button", { name: "Checking..." })).toBeDisabled();
 
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
     expect(await screen.findByText("after save")).toBeInTheDocument();
@@ -804,7 +804,7 @@ describe("SettingsPage", () => {
     await waitFor(() => {
       expect(screen.getByText("after save")).toBeInTheDocument();
       expect(screen.queryByText("action stale")).not.toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Test Auth" })).toBeEnabled();
+      expect(screen.getByRole("button", { name: "Check Auth" })).toBeEnabled();
     });
   });
 
@@ -913,8 +913,8 @@ describe("SettingsPage", () => {
     const { rerender } = render(<SettingsPage {...props} />);
 
     expect(await screen.findByText("initial ready")).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: "Test Auth" }));
-    expect(screen.getByRole("button", { name: "Testing..." })).toBeDisabled();
+    await userEvent.click(screen.getByRole("button", { name: "Check Auth" }));
+    expect(screen.getByRole("button", { name: "Checking..." })).toBeDisabled();
 
     rerender(<SettingsPage {...props} importConfirmOpen />);
 
@@ -928,7 +928,7 @@ describe("SettingsPage", () => {
     await waitFor(() => {
       expect(screen.getByText("after import")).toBeInTheDocument();
       expect(screen.queryByText("action stale")).not.toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Test Auth", hidden: true })).toBeEnabled();
+      expect(screen.getByRole("button", { name: "Check Auth", hidden: true })).toBeEnabled();
     });
   });
 

--- a/gui/frontend/src/pages/settings/index.test.tsx
+++ b/gui/frontend/src/pages/settings/index.test.tsx
@@ -17,6 +17,17 @@ const baseProps = {
   settingsDirty: false,
   settingsSaved: "",
   settingsError: "",
+  trackerSelectionNames: [
+    "AR",
+    "COOKIE",
+    "FAST",
+    "MTV",
+    "PTP",
+    "RTF",
+    "SLOW",
+    "PLAINAPI",
+    "PLAINPASS",
+  ],
   configOpStatus: null,
   dismissConfigOpStatus: vi.fn(),
   settingsSection: "main_settings",
@@ -293,6 +304,145 @@ describe("SettingsPage", () => {
     });
 
     expect(await screen.findByText("slow ready")).toBeInTheDocument();
+  });
+
+  it("hides plain tracker auth capabilities before loading statuses", async () => {
+    const getStatus = vi.fn().mockImplementation((trackerID: string) =>
+      Promise.resolve({
+        trackerID,
+        displayName: trackerID,
+        state: "configured",
+        cookieCount: 0,
+        lastCheckedAt: "",
+        lastError: "",
+        encryptedStorage: true,
+        needs2FA: false,
+        challengeID: "",
+        message: `${trackerID} ready`,
+      }),
+    );
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: vi.fn().mockResolvedValue([
+            {
+              trackerID: "PLAINAPI",
+              displayName: "PLAINAPI",
+              authKind: "api_key",
+              supportsCookieFile: false,
+              supportsLogin: false,
+              supportsAutoLogin: false,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: true,
+              requiresPasskey: false,
+            },
+            {
+              trackerID: "PLAINPASS",
+              displayName: "PLAINPASS",
+              authKind: "passkey",
+              supportsCookieFile: false,
+              supportsLogin: false,
+              supportsAutoLogin: false,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: false,
+              requiresPasskey: true,
+            },
+            {
+              trackerID: "COOKIE",
+              displayName: "COOKIE",
+              authKind: "cookies",
+              supportsCookieFile: true,
+              supportsLogin: false,
+              supportsAutoLogin: false,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: false,
+              requiresPasskey: false,
+            },
+            {
+              trackerID: "RTF",
+              displayName: "RTF",
+              authKind: "api_key_credential_refresh",
+              supportsCookieFile: false,
+              supportsLogin: false,
+              supportsAutoLogin: false,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: true,
+              requiresPasskey: false,
+            },
+          ]),
+          GetTrackerAuthStatus: getStatus,
+        },
+      },
+    });
+
+    render(
+      <SettingsPage {...baseProps} settingsSection="tracker_auth" setSettingsSection={vi.fn()} />,
+    );
+
+    expect(await screen.findByText("COOKIE ready")).toBeInTheDocument();
+    expect(await screen.findByText("RTF ready")).toBeInTheDocument();
+    expect(screen.queryByText("PLAINAPI")).not.toBeInTheDocument();
+    expect(screen.queryByText("PLAINPASS")).not.toBeInTheDocument();
+    expect(getStatus).toHaveBeenCalledTimes(2);
+    expect(getStatus).toHaveBeenCalledWith("COOKIE");
+    expect(getStatus).toHaveBeenCalledWith("RTF");
+  });
+
+  it("hides managed tracker auth capabilities for trackers not configured in main trackers", async () => {
+    const getStatus = vi.fn().mockImplementation((trackerID: string) =>
+      Promise.resolve({
+        trackerID,
+        displayName: trackerID,
+        state: "configured",
+        cookieCount: 0,
+        lastCheckedAt: "",
+        lastError: "",
+        encryptedStorage: true,
+        needs2FA: false,
+        challengeID: "",
+        message: `${trackerID} ready`,
+      }),
+    );
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: vi.fn().mockResolvedValue([
+            {
+              trackerID: "ASC",
+              displayName: "ASC",
+              authKind: "cookies",
+              supportsCookieFile: true,
+              supportsLogin: false,
+              supportsAutoLogin: false,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: false,
+              requiresPasskey: false,
+            },
+            trackerAuthCapability,
+          ]),
+          GetTrackerAuthStatus: getStatus,
+        },
+      },
+    });
+
+    render(
+      <SettingsPage
+        {...baseProps}
+        settingsSection="tracker_auth"
+        trackerSelectionNames={["MTV"]}
+        setSettingsSection={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("MTV ready")).toBeInTheDocument();
+    expect(screen.queryByText("ASC")).not.toBeInTheDocument();
+    expect(getStatus).toHaveBeenCalledTimes(1);
+    expect(getStatus).toHaveBeenCalledWith("MTV");
   });
 
   it.each([

--- a/gui/frontend/src/pages/settings/index.test.tsx
+++ b/gui/frontend/src/pages/settings/index.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { screen, within } from "@testing-library/dom";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -55,9 +55,46 @@ const baseProps = {
   sectionFieldMeta: {},
 };
 
+const trackerAuthCapability = {
+  trackerID: "MTV",
+  displayName: "MTV",
+  authKind: "api_key_cookies_login",
+  supportsCookieFile: true,
+  supportsLogin: true,
+  supportsAutoLogin: true,
+  supportsTOTP: true,
+  supportsManual2FA: true,
+  requiresAPIKey: true,
+  requiresPasskey: false,
+};
+
+const trackerAuthStatus = (message: string) => ({
+  trackerID: "MTV",
+  displayName: "MTV",
+  state: "configured",
+  cookieCount: 1,
+  lastCheckedAt: "",
+  lastError: "",
+  encryptedStorage: true,
+  needs2FA: false,
+  challengeID: "",
+  message,
+});
+
+const deferred = <T,>() => {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+};
+
 describe("SettingsPage", () => {
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
     vi.clearAllMocks();
     delete (globalThis as any).go;
   });
@@ -178,5 +215,600 @@ describe("SettingsPage", () => {
     expect(
       within(arCard as HTMLElement).queryByRole("button", { name: "Test Auth" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("renders fast tracker auth statuses before slow statuses resolve", async () => {
+    let resolveSlow: (value: unknown) => void = () => undefined;
+    const slowStatus = new Promise((resolve) => {
+      resolveSlow = resolve;
+    });
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: vi.fn().mockResolvedValue([
+            {
+              trackerID: "FAST",
+              displayName: "FAST",
+              authKind: "cookies",
+              supportsCookieFile: true,
+              supportsLogin: false,
+              supportsAutoLogin: false,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: false,
+              requiresPasskey: false,
+            },
+            {
+              trackerID: "SLOW",
+              displayName: "SLOW",
+              authKind: "cookies",
+              supportsCookieFile: true,
+              supportsLogin: false,
+              supportsAutoLogin: false,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: false,
+              requiresPasskey: false,
+            },
+          ]),
+          GetTrackerAuthStatus: vi.fn().mockImplementation((trackerID: string) => {
+            if (trackerID === "SLOW") {
+              return slowStatus;
+            }
+            return Promise.resolve({
+              trackerID,
+              displayName: trackerID,
+              state: "configured",
+              cookieCount: 0,
+              lastCheckedAt: "",
+              lastError: "",
+              encryptedStorage: true,
+              needs2FA: false,
+              challengeID: "",
+              message: "fast ready",
+            });
+          }),
+        },
+      },
+    });
+
+    render(
+      <SettingsPage {...baseProps} settingsSection="tracker_auth" setSettingsSection={vi.fn()} />,
+    );
+
+    expect(await screen.findByText("fast ready")).toBeInTheDocument();
+    expect(screen.queryByText("slow ready")).not.toBeInTheDocument();
+
+    resolveSlow({
+      trackerID: "SLOW",
+      displayName: "SLOW",
+      state: "configured",
+      cookieCount: 0,
+      lastCheckedAt: "",
+      lastError: "",
+      encryptedStorage: true,
+      needs2FA: false,
+      challengeID: "",
+      message: "slow ready",
+    });
+
+    expect(await screen.findByText("slow ready")).toBeInTheDocument();
+  });
+
+  it.each([
+    ["Import Cookies", "ImportTrackerAuthCookies"],
+    ["Test Auth", "TestTrackerAuth"],
+    ["Delete Auth", "DeleteTrackerAuth"],
+  ])(
+    "keeps newer %s status when initial status resolves late",
+    async (buttonName, bridgeMethod) => {
+      const initialStatus = deferred<ReturnType<typeof trackerAuthStatus>>();
+      vi.stubGlobal("go", {
+        guiapp: {
+          App: {
+            ListTrackerAuthCapabilities: vi.fn().mockResolvedValue([trackerAuthCapability]),
+            GetTrackerAuthStatus: vi.fn().mockReturnValue(initialStatus.promise),
+            ImportTrackerAuthCookies: vi.fn().mockResolvedValue(trackerAuthStatus("action ready")),
+            TestTrackerAuth: vi.fn().mockResolvedValue(trackerAuthStatus("action ready")),
+            DeleteTrackerAuth: vi.fn().mockResolvedValue(trackerAuthStatus("action ready")),
+          },
+        },
+      });
+
+      render(
+        <SettingsPage {...baseProps} settingsSection="tracker_auth" setSettingsSection={vi.fn()} />,
+      );
+
+      expect(await screen.findByText("MTV")).toBeInTheDocument();
+      await userEvent.click(screen.getByRole("button", { name: buttonName }));
+
+      expect((globalThis as any).go.guiapp.App[bridgeMethod]).toHaveBeenCalledWith("MTV");
+      expect(await screen.findByText("action ready")).toBeInTheDocument();
+
+      initialStatus.resolve(trackerAuthStatus("initial stale"));
+
+      await waitFor(() => {
+        expect(screen.getByText("action ready")).toBeInTheDocument();
+        expect(screen.queryByText("initial stale")).not.toBeInTheDocument();
+      });
+    },
+  );
+
+  it("clears tracker auth cards when refresh fails after an action", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce([trackerAuthCapability])
+      .mockRejectedValueOnce(new Error("refresh failed"));
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: list,
+          GetTrackerAuthStatus: vi.fn().mockResolvedValue(trackerAuthStatus("initial ready")),
+          ImportTrackerAuthCookies: vi.fn().mockResolvedValue(trackerAuthStatus("action ready")),
+        },
+      },
+    });
+
+    const { rerender } = render(
+      <SettingsPage {...baseProps} settingsSection="tracker_auth" setSettingsSection={vi.fn()} />,
+    );
+
+    expect(await screen.findByText("initial ready")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Import Cookies" }));
+    expect(await screen.findByText("action ready")).toBeInTheDocument();
+
+    rerender(
+      <SettingsPage {...baseProps} settingsSection="main_settings" setSettingsSection={vi.fn()} />,
+    );
+    rerender(
+      <SettingsPage {...baseProps} settingsSection="tracker_auth" setSettingsSection={vi.fn()} />,
+    );
+
+    expect(await screen.findByText("Error: refresh failed")).toBeInTheDocument();
+    expect(screen.queryByText("MTV")).not.toBeInTheDocument();
+    expect(screen.queryByText("action ready")).not.toBeInTheDocument();
+  });
+
+  it("keeps stale tracker auth status failures from overwriting newer action state", async () => {
+    const initialStatus = deferred<ReturnType<typeof trackerAuthStatus>>();
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: vi.fn().mockResolvedValue([trackerAuthCapability]),
+          GetTrackerAuthStatus: vi.fn().mockReturnValue(initialStatus.promise),
+          ImportTrackerAuthCookies: vi.fn().mockResolvedValue(trackerAuthStatus("action ready")),
+        },
+      },
+    });
+
+    render(
+      <SettingsPage {...baseProps} settingsSection="tracker_auth" setSettingsSection={vi.fn()} />,
+    );
+
+    expect(await screen.findByText("MTV")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Import Cookies" }));
+    expect(await screen.findByText("action ready")).toBeInTheDocument();
+
+    initialStatus.reject(new Error("stale failure"));
+
+    await waitFor(() => {
+      expect(screen.getByText("action ready")).toBeInTheDocument();
+      expect(screen.queryByText("Error: stale failure")).not.toBeInTheDocument();
+    });
+  });
+
+  it("reports tracker auth action failures only on the originating tracker", async () => {
+    const staleAction = deferred<ReturnType<typeof trackerAuthStatus>>();
+    const newerCapability = { ...trackerAuthCapability, trackerID: "PTP", displayName: "PTP" };
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: vi
+            .fn()
+            .mockResolvedValue([trackerAuthCapability, newerCapability]),
+          GetTrackerAuthStatus: vi.fn().mockImplementation((trackerID: string) =>
+            Promise.resolve({
+              ...trackerAuthStatus(`${trackerID} initial ready`),
+              trackerID,
+              displayName: trackerID,
+            }),
+          ),
+          TestTrackerAuth: vi.fn().mockImplementation((trackerID: string) => {
+            if (trackerID === "MTV") {
+              return staleAction.promise;
+            }
+            return Promise.resolve({
+              ...trackerAuthStatus("new action ready"),
+              trackerID,
+              displayName: trackerID,
+            });
+          }),
+        },
+      },
+    });
+
+    render(
+      <SettingsPage {...baseProps} settingsSection="tracker_auth" setSettingsSection={vi.fn()} />,
+    );
+
+    const mtvTitle = await screen.findByText("MTV");
+    const ptpTitle = await screen.findByText("PTP");
+    const mtvCard = mtvTitle.closest(".tracker-auth-card");
+    const ptpCard = ptpTitle.closest(".tracker-auth-card");
+
+    expect(mtvCard).not.toBeNull();
+    expect(ptpCard).not.toBeNull();
+    await userEvent.click(
+      within(mtvCard as HTMLElement).getByRole("button", { name: "Test Auth" }),
+    );
+    await userEvent.click(
+      within(ptpCard as HTMLElement).getByRole("button", { name: "Test Auth" }),
+    );
+    expect(await screen.findByText("new action ready")).toBeInTheDocument();
+
+    staleAction.reject(new Error("stale failure"));
+
+    await waitFor(() => {
+      expect(within(ptpCard as HTMLElement).getByText("new action ready")).toBeInTheDocument();
+      expect(within(mtvCard as HTMLElement).getByText("Error: stale failure")).toBeInTheDocument();
+      expect(
+        within(ptpCard as HTMLElement).queryByText("Error: stale failure"),
+      ).not.toBeInTheDocument();
+    });
+
+    await userEvent.click(
+      within(ptpCard as HTMLElement).getByRole("button", { name: "Test Auth" }),
+    );
+
+    await waitFor(() => {
+      expect(within(mtvCard as HTMLElement).getByText("Error: stale failure")).toBeInTheDocument();
+      expect(
+        within(ptpCard as HTMLElement).queryByText("Error: stale failure"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("ignores tracker auth action failures after leaving the tracker auth section", async () => {
+    const action = deferred<ReturnType<typeof trackerAuthStatus>>();
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: vi.fn().mockResolvedValue([trackerAuthCapability]),
+          GetTrackerAuthStatus: vi.fn().mockResolvedValue(trackerAuthStatus("initial ready")),
+          TestTrackerAuth: vi.fn().mockReturnValue(action.promise),
+        },
+      },
+    });
+
+    const { rerender } = render(
+      <SettingsPage {...baseProps} settingsSection="tracker_auth" setSettingsSection={vi.fn()} />,
+    );
+
+    expect(await screen.findByText("initial ready")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Test Auth" }));
+
+    rerender(
+      <SettingsPage {...baseProps} settingsSection="main_settings" setSettingsSection={vi.fn()} />,
+    );
+    action.reject(new Error("late failure"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Error: late failure")).not.toBeInTheDocument();
+    });
+  });
+
+  it("clears tracker auth loading after leaving and reentering with old status pending", async () => {
+    const oldStatus = deferred<ReturnType<typeof trackerAuthStatus>>();
+    const getStatus = vi
+      .fn()
+      .mockReturnValueOnce(oldStatus.promise)
+      .mockResolvedValueOnce(trackerAuthStatus("after reenter"));
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: vi.fn().mockResolvedValue([trackerAuthCapability]),
+          GetTrackerAuthStatus: getStatus,
+        },
+      },
+    });
+
+    const { rerender } = render(
+      <SettingsPage {...baseProps} settingsSection="tracker_auth" setSettingsSection={vi.fn()} />,
+    );
+
+    expect(await screen.findByText("MTV")).toBeInTheDocument();
+    expect(screen.getByText("Loading tracker auth...")).toBeInTheDocument();
+
+    rerender(
+      <SettingsPage {...baseProps} settingsSection="main_settings" setSettingsSection={vi.fn()} />,
+    );
+    rerender(
+      <SettingsPage {...baseProps} settingsSection="tracker_auth" setSettingsSection={vi.fn()} />,
+    );
+
+    expect(await screen.findByText("after reenter")).toBeInTheDocument();
+    oldStatus.resolve(trackerAuthStatus("old ready"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Loading tracker auth...")).not.toBeInTheDocument();
+      expect(screen.getByText("after reenter")).toBeInTheDocument();
+      expect(screen.queryByText("old ready")).not.toBeInTheDocument();
+    });
+  });
+
+  it("refreshes tracker auth after saving settings while tracker auth is selected", async () => {
+    const list = vi.fn().mockResolvedValue([trackerAuthCapability]);
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce(trackerAuthStatus("initial ready"))
+      .mockResolvedValueOnce(trackerAuthStatus("after save"));
+    const handleSaveSettings = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: list,
+          GetTrackerAuthStatus: getStatus,
+        },
+      },
+    });
+
+    render(
+      <SettingsPage
+        {...baseProps}
+        settingsDirty
+        settingsSection="tracker_auth"
+        setSettingsSection={vi.fn()}
+        handleSaveSettings={handleSaveSettings}
+      />,
+    );
+
+    expect(await screen.findByText("initial ready")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(handleSaveSettings).toHaveBeenCalledTimes(1);
+      expect(list).toHaveBeenCalledTimes(2);
+      expect(getStatus).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("after save")).toBeInTheDocument();
+    });
+  });
+
+  it("keeps pending old tracker auth status from overwriting save reload status", async () => {
+    const initialStatus = deferred<ReturnType<typeof trackerAuthStatus>>();
+    const list = vi.fn().mockResolvedValue([trackerAuthCapability]);
+    const getStatus = vi
+      .fn()
+      .mockReturnValueOnce(initialStatus.promise)
+      .mockResolvedValueOnce(trackerAuthStatus("after save"));
+    const handleSaveSettings = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: list,
+          GetTrackerAuthStatus: getStatus,
+        },
+      },
+    });
+
+    render(
+      <SettingsPage
+        {...baseProps}
+        settingsDirty
+        settingsSection="tracker_auth"
+        setSettingsSection={vi.fn()}
+        handleSaveSettings={handleSaveSettings}
+      />,
+    );
+
+    expect(await screen.findByText("MTV")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(await screen.findByText("after save")).toBeInTheDocument();
+
+    initialStatus.resolve(trackerAuthStatus("initial stale"));
+
+    await waitFor(() => {
+      expect(screen.getByText("after save")).toBeInTheDocument();
+      expect(screen.queryByText("initial stale")).not.toBeInTheDocument();
+      expect(list).toHaveBeenCalledTimes(2);
+      expect(getStatus).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("clears pending tracker auth action busy state after save reload", async () => {
+    const action = deferred<ReturnType<typeof trackerAuthStatus>>();
+    const list = vi.fn().mockResolvedValue([trackerAuthCapability]);
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce(trackerAuthStatus("initial ready"))
+      .mockResolvedValueOnce(trackerAuthStatus("after save"));
+    const handleSaveSettings = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: list,
+          GetTrackerAuthStatus: getStatus,
+          TestTrackerAuth: vi.fn().mockReturnValue(action.promise),
+        },
+      },
+    });
+
+    render(
+      <SettingsPage
+        {...baseProps}
+        settingsDirty
+        settingsSection="tracker_auth"
+        setSettingsSection={vi.fn()}
+        handleSaveSettings={handleSaveSettings}
+      />,
+    );
+
+    expect(await screen.findByText("initial ready")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Test Auth" }));
+    expect(screen.getByRole("button", { name: "Testing..." })).toBeDisabled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(await screen.findByText("after save")).toBeInTheDocument();
+
+    action.resolve(trackerAuthStatus("action stale"));
+
+    await waitFor(() => {
+      expect(screen.getByText("after save")).toBeInTheDocument();
+      expect(screen.queryByText("action stale")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Test Auth" })).toBeEnabled();
+    });
+  });
+
+  it("refreshes tracker auth after confirming config import while tracker auth is selected", async () => {
+    const list = vi.fn().mockResolvedValue([trackerAuthCapability]);
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce(trackerAuthStatus("initial ready"))
+      .mockResolvedValueOnce(trackerAuthStatus("after import"));
+    const handleImportConfigConfirm = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: list,
+          GetTrackerAuthStatus: getStatus,
+        },
+      },
+    });
+
+    render(
+      <SettingsPage
+        {...baseProps}
+        settingsSection="tracker_auth"
+        setSettingsSection={vi.fn()}
+        importConfirmOpen
+        handleImportConfigConfirm={handleImportConfigConfirm}
+      />,
+    );
+
+    expect(await screen.findByText("initial ready")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Choose file & import" }));
+
+    await waitFor(() => {
+      expect(handleImportConfigConfirm).toHaveBeenCalledTimes(1);
+      expect(list).toHaveBeenCalledTimes(2);
+      expect(getStatus).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("after import")).toBeInTheDocument();
+    });
+  });
+
+  it("keeps pending old tracker auth status from overwriting import reload status", async () => {
+    const initialStatus = deferred<ReturnType<typeof trackerAuthStatus>>();
+    const list = vi.fn().mockResolvedValue([trackerAuthCapability]);
+    const getStatus = vi
+      .fn()
+      .mockReturnValueOnce(initialStatus.promise)
+      .mockResolvedValueOnce(trackerAuthStatus("after import"));
+    const handleImportConfigConfirm = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: list,
+          GetTrackerAuthStatus: getStatus,
+        },
+      },
+    });
+
+    render(
+      <SettingsPage
+        {...baseProps}
+        settingsSection="tracker_auth"
+        setSettingsSection={vi.fn()}
+        importConfirmOpen
+        handleImportConfigConfirm={handleImportConfigConfirm}
+      />,
+    );
+
+    expect(await screen.findByText("MTV")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Choose file & import" }));
+    expect(await screen.findByText("after import")).toBeInTheDocument();
+
+    initialStatus.resolve(trackerAuthStatus("initial stale"));
+
+    await waitFor(() => {
+      expect(screen.getByText("after import")).toBeInTheDocument();
+      expect(screen.queryByText("initial stale")).not.toBeInTheDocument();
+      expect(list).toHaveBeenCalledTimes(2);
+      expect(getStatus).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("clears pending tracker auth action busy state after import reload", async () => {
+    const action = deferred<ReturnType<typeof trackerAuthStatus>>();
+    const list = vi.fn().mockResolvedValue([trackerAuthCapability]);
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce(trackerAuthStatus("initial ready"))
+      .mockResolvedValueOnce(trackerAuthStatus("after import"));
+    const handleImportConfigConfirm = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: list,
+          GetTrackerAuthStatus: getStatus,
+          TestTrackerAuth: vi.fn().mockReturnValue(action.promise),
+        },
+      },
+    });
+
+    const props = {
+      ...baseProps,
+      settingsSection: "tracker_auth",
+      setSettingsSection: vi.fn(),
+      handleImportConfigConfirm,
+    };
+    const { rerender } = render(<SettingsPage {...props} />);
+
+    expect(await screen.findByText("initial ready")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Test Auth" }));
+    expect(screen.getByRole("button", { name: "Testing..." })).toBeDisabled();
+
+    rerender(<SettingsPage {...props} importConfirmOpen />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Choose file & import" }));
+    expect(await screen.findByText("after import")).toBeInTheDocument();
+
+    rerender(<SettingsPage {...props} />);
+
+    action.resolve(trackerAuthStatus("action stale"));
+
+    await waitFor(() => {
+      expect(screen.getByText("after import")).toBeInTheDocument();
+      expect(screen.queryByText("action stale")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Test Auth", hidden: true })).toBeEnabled();
+    });
+  });
+
+  it("keeps config save refresh lazy outside tracker auth", async () => {
+    const list = vi.fn().mockResolvedValue([trackerAuthCapability]);
+    const handleSaveSettings = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: list,
+          GetTrackerAuthStatus: vi.fn().mockResolvedValue(trackerAuthStatus("ready")),
+        },
+      },
+    });
+
+    render(
+      <SettingsPage
+        {...baseProps}
+        settingsDirty
+        settingsSection="main_settings"
+        setSettingsSection={vi.fn()}
+        handleSaveSettings={handleSaveSettings}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(handleSaveSettings).toHaveBeenCalledTimes(1);
+    });
+    expect(list).not.toHaveBeenCalled();
   });
 });

--- a/gui/frontend/src/pages/settings/index.test.tsx
+++ b/gui/frontend/src/pages/settings/index.test.tsx
@@ -21,10 +21,13 @@ const baseProps = {
     "AR",
     "COOKIE",
     "FAST",
+    "FF",
+    "FL",
     "HDB",
     "MTV",
     "PTP",
     "RTF",
+    "THR",
     "SLOW",
     "ASC",
     "PLAINAPI",
@@ -204,6 +207,30 @@ describe("SettingsPage", () => {
               requiresPasskey: true,
             },
             {
+              trackerID: "FF",
+              displayName: "FF",
+              authKind: "cookies_login",
+              supportsCookieFile: true,
+              supportsLogin: true,
+              supportsAutoLogin: true,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: false,
+              requiresPasskey: false,
+            },
+            {
+              trackerID: "FL",
+              displayName: "FL",
+              authKind: "cookies_login",
+              supportsCookieFile: true,
+              supportsLogin: true,
+              supportsAutoLogin: true,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: false,
+              requiresPasskey: false,
+            },
+            {
               trackerID: "RTF",
               displayName: "RTF",
               authKind: "api_key_credential_refresh",
@@ -213,6 +240,18 @@ describe("SettingsPage", () => {
               supportsTOTP: false,
               supportsManual2FA: false,
               requiresAPIKey: true,
+              requiresPasskey: false,
+            },
+            {
+              trackerID: "THR",
+              displayName: "THR",
+              authKind: "credential_login",
+              supportsCookieFile: false,
+              supportsLogin: true,
+              supportsAutoLogin: true,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: false,
               requiresPasskey: false,
             },
             {
@@ -254,18 +293,27 @@ describe("SettingsPage", () => {
     const mtvTitle = await screen.findByText("MTV");
     const arTitle = await screen.findByText("AR");
     const hdbTitle = await screen.findByText("HDB");
+    const ffTitle = await screen.findByText("FF");
+    const flTitle = await screen.findByText("FL");
     const rtfTitle = await screen.findByText("RTF");
+    const thrTitle = await screen.findByText("THR");
     const ascTitle = await screen.findByText("ASC");
     const mtvCard = mtvTitle.closest(".tracker-auth-card");
     const arCard = arTitle.closest(".tracker-auth-card");
     const hdbCard = hdbTitle.closest(".tracker-auth-card");
+    const ffCard = ffTitle.closest(".tracker-auth-card");
+    const flCard = flTitle.closest(".tracker-auth-card");
     const rtfCard = rtfTitle.closest(".tracker-auth-card");
+    const thrCard = thrTitle.closest(".tracker-auth-card");
     const ascCard = ascTitle.closest(".tracker-auth-card");
 
     expect(mtvCard).not.toBeNull();
     expect(arCard).not.toBeNull();
     expect(hdbCard).not.toBeNull();
+    expect(ffCard).not.toBeNull();
+    expect(flCard).not.toBeNull();
     expect(rtfCard).not.toBeNull();
+    expect(thrCard).not.toBeNull();
     expect(ascCard).not.toBeNull();
     expect(
       within(mtvCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
@@ -277,7 +325,16 @@ describe("SettingsPage", () => {
       within(hdbCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
     ).toBeInTheDocument();
     expect(
+      within(ffCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
+    ).toBeInTheDocument();
+    expect(
+      within(flCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
+    ).toBeInTheDocument();
+    expect(
       within(rtfCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
+    ).toBeInTheDocument();
+    expect(
+      within(thrCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
     ).toBeInTheDocument();
     expect(
       within(ascCard as HTMLElement).queryByRole("button", { name: "Check Auth" }),

--- a/gui/frontend/src/pages/settings/index.test.tsx
+++ b/gui/frontend/src/pages/settings/index.test.tsx
@@ -111,4 +111,72 @@ describe("SettingsPage", () => {
 
     expect(setSettingsSection).toHaveBeenCalledWith("tracker_auth");
   });
+
+  it("shows Test Auth only for adapter-backed tracker auth", async () => {
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: vi.fn().mockResolvedValue([
+            {
+              trackerID: "MTV",
+              displayName: "MTV",
+              authKind: "api_key_cookies_login",
+              supportsCookieFile: true,
+              supportsLogin: true,
+              supportsAutoLogin: true,
+              supportsTOTP: true,
+              supportsManual2FA: true,
+              requiresAPIKey: true,
+              requiresPasskey: false,
+            },
+            {
+              trackerID: "AR",
+              displayName: "AR",
+              authKind: "cookies_login",
+              supportsCookieFile: true,
+              supportsLogin: true,
+              supportsAutoLogin: true,
+              supportsTOTP: false,
+              supportsManual2FA: false,
+              requiresAPIKey: false,
+              requiresPasskey: false,
+            },
+          ]),
+          GetTrackerAuthStatus: vi.fn().mockImplementation((trackerID: string) =>
+            Promise.resolve({
+              trackerID,
+              displayName: trackerID,
+              state: "configured",
+              cookieCount: 0,
+              lastCheckedAt: "",
+              lastError: "",
+              encryptedStorage: true,
+              needs2FA: false,
+              challengeID: "",
+              message: "required config auth material is present",
+            }),
+          ),
+          TestTrackerAuth: vi.fn(),
+        },
+      },
+    });
+
+    render(
+      <SettingsPage {...baseProps} settingsSection="tracker_auth" setSettingsSection={vi.fn()} />,
+    );
+
+    const mtvTitle = await screen.findByText("MTV");
+    const arTitle = await screen.findByText("AR");
+    const mtvCard = mtvTitle.closest(".tracker-auth-card");
+    const arCard = arTitle.closest(".tracker-auth-card");
+
+    expect(mtvCard).not.toBeNull();
+    expect(arCard).not.toBeNull();
+    expect(
+      within(mtvCard as HTMLElement).getByRole("button", { name: "Test Auth" }),
+    ).toBeInTheDocument();
+    expect(
+      within(arCard as HTMLElement).queryByRole("button", { name: "Test Auth" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/gui/frontend/src/pages/settings/index.tsx
+++ b/gui/frontend/src/pages/settings/index.tsx
@@ -32,8 +32,10 @@ const trackerAuthSection = {
 
 const settingsInputClass =
   "h-8 rounded-md border border-white/10 bg-slate-950/45 px-2.5 text-sm text-[var(--text)] outline-none transition placeholder:text-[var(--muted)] focus:border-[var(--accent-2)] focus:ring-2 focus:ring-[rgba(53,194,193,0.18)]";
+// Tracker-supplied auth kinds can be long adapter descriptors; keep chips
+// wrapped inside the auth card on narrow screens.
 const trackerAuthChipClass =
-  "rounded-full border border-slate-400/20 bg-slate-950/35 px-[0.45rem] py-[0.2rem] text-[0.74rem] leading-none text-[var(--muted)]";
+  "max-w-full whitespace-normal rounded-full border border-slate-400/20 bg-slate-950/35 px-[0.45rem] py-[0.2rem] text-[0.74rem] leading-none text-[var(--muted)] [overflow-wrap:anywhere]";
 const trackerAuthMetaClass = "m-0 text-[0.8rem] text-[var(--muted)]";
 
 /** Trackers with backend adapters that can perform a remote auth check. */
@@ -473,13 +475,13 @@ export default function SettingsPage(props: Props) {
             );
             return (
               <div
-                className="settings-card tracker-auth-card grid gap-3"
+                className="settings-card tracker-auth-card grid min-w-0 gap-3"
                 key={capability.trackerID}
               >
-                <div className="flex flex-wrap items-center justify-between gap-[0.6rem]">
-                  <div>
+                <div className="flex min-w-0 flex-wrap items-center justify-between gap-[0.6rem]">
+                  <div className="min-w-0 flex-1">
                     <p className="settings-detail-card__label">Tracker</p>
-                    <h2 className="m-0 mt-[0.1rem] text-[1.05rem] leading-tight">
+                    <h2 className="m-0 mt-[0.1rem] text-[1.05rem] leading-tight [overflow-wrap:anywhere]">
                       {capability.displayName || capability.trackerID}
                     </h2>
                   </div>
@@ -487,7 +489,7 @@ export default function SettingsPage(props: Props) {
                     {formatTrackerAuthState(status?.state)}
                   </span>
                 </div>
-                <div className="flex flex-wrap items-center gap-[0.6rem]">
+                <div className="flex min-w-0 flex-wrap items-center gap-[0.6rem]">
                   <span className={trackerAuthChipClass}>{capability.authKind}</span>
                   {capability.supportsCookieFile ? (
                     <span className={trackerAuthChipClass}>cookie import</span>
@@ -520,11 +522,15 @@ export default function SettingsPage(props: Props) {
                     Storage: {status?.encryptedStorage ? "encrypted" : "unavailable"}
                   </p>
                 </div>
-                {status?.message ? <p className="helper">{status.message}</p> : null}
-                {status?.lastError ? <p className="error">{status.lastError}</p> : null}
+                {status?.message ? (
+                  <p className="helper [overflow-wrap:anywhere]">{status.message}</p>
+                ) : null}
+                {status?.lastError ? (
+                  <p className="error [overflow-wrap:anywhere]">{status.lastError}</p>
+                ) : null}
                 {actionError ? <p className="error">{actionError}</p> : null}
                 {(capability.notes ?? []).map((note) => (
-                  <p className="muted" key={note}>
+                  <p className="muted [overflow-wrap:anywhere]" key={note}>
                     {note}
                   </p>
                 ))}

--- a/gui/frontend/src/pages/settings/index.tsx
+++ b/gui/frontend/src/pages/settings/index.tsx
@@ -34,7 +34,7 @@ const settingsInputClass =
   "h-8 rounded-md border border-white/10 bg-slate-950/45 px-2.5 text-sm text-[var(--text)] outline-none transition placeholder:text-[var(--muted)] focus:border-[var(--accent-2)] focus:ring-2 focus:ring-[rgba(53,194,193,0.18)]";
 
 /** Trackers with backend adapters that can perform a remote auth check. */
-const remoteAuthValidationTrackers = new Set(["AR", "HDB", "MTV", "PTP", "RTF"]);
+const remoteAuthValidationTrackers = new Set(["AR", "FF", "FL", "HDB", "MTV", "PTP", "RTF", "THR"]);
 
 /** Builds the case-insensitive key shared by main tracker config and tracker auth rows. */
 const trackerNameKey = (name: string) => name.trim().toLowerCase();

--- a/gui/frontend/src/pages/settings/index.tsx
+++ b/gui/frontend/src/pages/settings/index.tsx
@@ -32,6 +32,9 @@ const trackerAuthSection = {
 
 const settingsInputClass =
   "h-8 rounded-md border border-white/10 bg-slate-950/45 px-2.5 text-sm text-[var(--text)] outline-none transition placeholder:text-[var(--muted)] focus:border-[var(--accent-2)] focus:ring-2 focus:ring-[rgba(53,194,193,0.18)]";
+const trackerAuthChipClass =
+  "rounded-full border border-slate-400/20 bg-slate-950/35 px-[0.45rem] py-[0.2rem] text-[0.74rem] leading-none text-[var(--muted)]";
+const trackerAuthMetaClass = "m-0 text-[0.8rem] text-[var(--muted)]";
 
 /** Trackers with backend adapters that can perform a remote auth check. */
 const remoteAuthValidationTrackers = new Set(["AR", "FF", "FL", "HDB", "MTV", "PTP", "RTF", "THR"]);
@@ -433,7 +436,7 @@ export default function SettingsPage(props: Props) {
       (status) => status.encryptedStorage,
     );
     return (
-      <div className="settings-form tracker-auth-panel">
+      <div className="settings-form gap-4">
         <div className="settings-subgroup">
           <div className="settings-subgroup__title">Tracker Auth</div>
           <div className="settings-auth-status">
@@ -447,7 +450,7 @@ export default function SettingsPage(props: Props) {
               can relogin automatically during unattended uploads.
             </p>
           </div>
-          <label className="settings-field tracker-auth-filter">
+          <label className="settings-field max-w-[360px]">
             <span>Filter trackers</span>
             <input
               className={settingsInputClass}
@@ -459,7 +462,7 @@ export default function SettingsPage(props: Props) {
         </div>
         {trackerAuthLoading ? <p className="muted">Loading tracker auth...</p> : null}
         {trackerAuthError ? <p className="error">{trackerAuthError}</p> : null}
-        <div className="tracker-auth-list">
+        <div className="grid gap-[0.85rem]">
           {capabilities.map((capability) => {
             const status = trackerAuthStatuses[capability.trackerID];
             const busy = trackerAuthActions[capability.trackerID] || "";
@@ -469,11 +472,14 @@ export default function SettingsPage(props: Props) {
               capability.trackerID.trim().toUpperCase(),
             );
             return (
-              <div className="settings-card tracker-auth-card" key={capability.trackerID}>
-                <div className="tracker-auth-card__header">
+              <div
+                className="settings-card tracker-auth-card grid gap-3"
+                key={capability.trackerID}
+              >
+                <div className="flex flex-wrap items-center justify-between gap-[0.6rem]">
                   <div>
                     <p className="settings-detail-card__label">Tracker</p>
-                    <h2 className="tracker-auth-card__title">
+                    <h2 className="m-0 mt-[0.1rem] text-[1.05rem] leading-tight">
                       {capability.displayName || capability.trackerID}
                     </h2>
                   </div>
@@ -481,33 +487,51 @@ export default function SettingsPage(props: Props) {
                     {formatTrackerAuthState(status?.state)}
                   </span>
                 </div>
-                <div className="tracker-auth-chips">
-                  <span>{capability.authKind}</span>
-                  {capability.supportsCookieFile ? <span>cookie import</span> : null}
-                  {capability.supportsLogin ? <span>login</span> : null}
-                  {capability.supportsAutoLogin ? <span>auto relogin</span> : null}
-                  {capability.supportsTOTP ? <span>TOTP</span> : null}
-                  {capability.supportsManual2FA ? <span>manual 2FA</span> : null}
-                  {capability.requiresAPIKey ? <span>API key</span> : null}
-                  {capability.requiresPasskey ? <span>passkey</span> : null}
+                <div className="flex flex-wrap items-center gap-[0.6rem]">
+                  <span className={trackerAuthChipClass}>{capability.authKind}</span>
+                  {capability.supportsCookieFile ? (
+                    <span className={trackerAuthChipClass}>cookie import</span>
+                  ) : null}
+                  {capability.supportsLogin ? (
+                    <span className={trackerAuthChipClass}>login</span>
+                  ) : null}
+                  {capability.supportsAutoLogin ? (
+                    <span className={trackerAuthChipClass}>auto relogin</span>
+                  ) : null}
+                  {capability.supportsTOTP ? (
+                    <span className={trackerAuthChipClass}>TOTP</span>
+                  ) : null}
+                  {capability.supportsManual2FA ? (
+                    <span className={trackerAuthChipClass}>manual 2FA</span>
+                  ) : null}
+                  {capability.requiresAPIKey ? (
+                    <span className={trackerAuthChipClass}>API key</span>
+                  ) : null}
+                  {capability.requiresPasskey ? (
+                    <span className={trackerAuthChipClass}>passkey</span>
+                  ) : null}
                 </div>
-                <div className="tracker-auth-card__meta">
-                  <p>Cookies: {status?.cookieCount ?? 0}</p>
-                  <p>Checked: {formatTrackerAuthDate(status?.lastCheckedAt)}</p>
-                  <p>Storage: {status?.encryptedStorage ? "encrypted" : "unavailable"}</p>
+                <div className="flex flex-wrap items-center gap-[0.6rem]">
+                  <p className={trackerAuthMetaClass}>Cookies: {status?.cookieCount ?? 0}</p>
+                  <p className={trackerAuthMetaClass}>
+                    Checked: {formatTrackerAuthDate(status?.lastCheckedAt)}
+                  </p>
+                  <p className={trackerAuthMetaClass}>
+                    Storage: {status?.encryptedStorage ? "encrypted" : "unavailable"}
+                  </p>
                 </div>
                 {status?.message ? <p className="helper">{status.message}</p> : null}
                 {status?.lastError ? <p className="error">{status.lastError}</p> : null}
                 {actionError ? <p className="error">{actionError}</p> : null}
-                {capability.notes?.map((note) => (
+                {(capability.notes ?? []).map((note) => (
                   <p className="muted" key={note}>
                     {note}
                   </p>
                 ))}
                 {status?.needs2FA ? (
-                  <div className="tracker-auth-2fa">
+                  <div className="flex flex-wrap items-center gap-[0.6rem]">
                     <input
-                      className={`${settingsInputClass} tracker-auth-2fa__input`}
+                      className={`${settingsInputClass} w-36`}
                       value={code}
                       inputMode="numeric"
                       autoComplete="one-time-code"

--- a/gui/frontend/src/pages/settings/index.tsx
+++ b/gui/frontend/src/pages/settings/index.tsx
@@ -13,6 +13,9 @@ import type {
   ConfigMap,
   ConfigValue,
   FieldMeta,
+  TrackerAuthCapability,
+  TrackerAuthLoginRequest,
+  TrackerAuthStatus,
   WebAuthStatus,
 } from "../../types";
 
@@ -21,6 +24,11 @@ type SettingsSection = { key: string; jsonKey: string; label: string };
 const applicationDetailsSection = {
   key: "application_details",
   label: "Application Details",
+};
+
+const trackerAuthSection = {
+  key: "tracker_auth",
+  label: "Tracker Auth",
 };
 
 const settingsInputClass =
@@ -35,6 +43,16 @@ type ConfigOpStatus = {
 
 type AppBridgeWithApplicationInfo = {
   GetApplicationInfo?: () => Promise<ApplicationInfo>;
+};
+
+type AppBridgeWithTrackerAuth = {
+  ListTrackerAuthCapabilities?: () => Promise<TrackerAuthCapability[]>;
+  GetTrackerAuthStatus?: (tracker: string) => Promise<TrackerAuthStatus>;
+  ImportTrackerAuthCookies?: (tracker: string) => Promise<TrackerAuthStatus>;
+  TestTrackerAuth?: (tracker: string) => Promise<TrackerAuthStatus>;
+  LoginTrackerAuth?: (tracker: string, req: TrackerAuthLoginRequest) => Promise<TrackerAuthStatus>;
+  SubmitTrackerAuth2FA?: (challengeID: string, code: string) => Promise<TrackerAuthStatus>;
+  DeleteTrackerAuth?: (tracker: string) => Promise<TrackerAuthStatus>;
 };
 
 type Props = {
@@ -128,6 +146,17 @@ export default function SettingsPage(props: Props) {
   const [applicationInfoLoading, setApplicationInfoLoading] = useState(false);
   const [applicationInfoFetchedAt, setApplicationInfoFetchedAt] = useState<number | null>(null);
   const [uptimeTick, setUptimeTick] = useState(() => Date.now());
+  const [trackerAuthCapabilities, setTrackerAuthCapabilities] = useState<TrackerAuthCapability[]>(
+    [],
+  );
+  const [trackerAuthStatuses, setTrackerAuthStatuses] = useState<Record<string, TrackerAuthStatus>>(
+    {},
+  );
+  const [trackerAuthLoading, setTrackerAuthLoading] = useState(false);
+  const [trackerAuthError, setTrackerAuthError] = useState("");
+  const [trackerAuthFilter, setTrackerAuthFilter] = useState("");
+  const [trackerAuthActions, setTrackerAuthActions] = useState<Record<string, string>>({});
+  const [trackerAuthCodes, setTrackerAuthCodes] = useState<Record<string, string>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -176,6 +205,258 @@ export default function SettingsPage(props: Props) {
     }, 1000);
     return () => window.clearInterval(timer);
   }, [applicationInfo]);
+
+  useEffect(() => {
+    if (settingsSection !== trackerAuthSection.key) {
+      return undefined;
+    }
+    let cancelled = false;
+    const bridge = globalThis.go?.guiapp?.App as AppBridgeWithTrackerAuth | undefined;
+    const list = bridge?.ListTrackerAuthCapabilities;
+    const getStatus = bridge?.GetTrackerAuthStatus;
+    if (!list || !getStatus) {
+      setTrackerAuthError("Tracker auth is unavailable in this build.");
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setTrackerAuthLoading(true);
+    setTrackerAuthError("");
+    void list()
+      .then(async (capabilities) => {
+        if (cancelled) {
+          return;
+        }
+        setTrackerAuthCapabilities(capabilities);
+        const entries = await Promise.all(
+          capabilities.map(async (capability) => {
+            try {
+              const status = await getStatus(capability.trackerID);
+              return [capability.trackerID, status] as const;
+            } catch (error) {
+              return [
+                capability.trackerID,
+                {
+                  trackerID: capability.trackerID,
+                  displayName: capability.displayName,
+                  state: "error",
+                  cookieCount: 0,
+                  lastCheckedAt: "",
+                  lastError: String(error),
+                  encryptedStorage: false,
+                  needs2FA: false,
+                  challengeID: "",
+                  message: "",
+                },
+              ] as const;
+            }
+          }),
+        );
+        if (!cancelled) {
+          setTrackerAuthStatuses(Object.fromEntries(entries));
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setTrackerAuthError(String(error));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setTrackerAuthLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [settingsSection]);
+
+  const runTrackerAuthAction = async (
+    trackerID: string,
+    action: string,
+    fn: () => Promise<TrackerAuthStatus>,
+  ) => {
+    setTrackerAuthActions((prev) => ({ ...prev, [trackerID]: action }));
+    setTrackerAuthError("");
+    try {
+      const status = await fn();
+      setTrackerAuthStatuses((prev) => ({ ...prev, [trackerID]: status }));
+    } catch (error) {
+      setTrackerAuthError(String(error));
+    } finally {
+      setTrackerAuthActions((prev) => ({ ...prev, [trackerID]: "" }));
+    }
+  };
+
+  const trackerAuthPanel = (() => {
+    const bridge = globalThis.go?.guiapp?.App as AppBridgeWithTrackerAuth | undefined;
+    const filter = trackerAuthFilter.trim().toLowerCase();
+    const capabilities = trackerAuthCapabilities.filter((capability) => {
+      if (!filter) return true;
+      return (
+        capability.trackerID.toLowerCase().includes(filter) ||
+        capability.authKind.toLowerCase().includes(filter)
+      );
+    });
+    const storageReady = Object.values(trackerAuthStatuses).some(
+      (status) => status.encryptedStorage,
+    );
+    return (
+      <div className="settings-form tracker-auth-panel">
+        <div className="settings-subgroup">
+          <div className="settings-subgroup__title">Tracker Auth</div>
+          <div className="settings-auth-status">
+            <span className={`settings-auth-badge ${storageReady ? "is-ready" : "is-warning"}`}>
+              {storageReady
+                ? "Encrypted cookie storage ready"
+                : "Encrypted cookie storage unavailable"}
+            </span>
+            <p className="helper">
+              Import Netscape or JSON cookies, check local auth state, and confirm which trackers
+              can relogin automatically during unattended uploads.
+            </p>
+          </div>
+          <label className="settings-field tracker-auth-filter">
+            <span>Filter trackers</span>
+            <input
+              className={settingsInputClass}
+              value={trackerAuthFilter}
+              onChange={(event) => setTrackerAuthFilter(event.target.value)}
+              placeholder="MTV, cookies, api"
+            />
+          </label>
+        </div>
+        {trackerAuthLoading ? <p className="muted">Loading tracker auth...</p> : null}
+        {trackerAuthError ? <p className="error">{trackerAuthError}</p> : null}
+        <div className="tracker-auth-list">
+          {capabilities.map((capability) => {
+            const status = trackerAuthStatuses[capability.trackerID];
+            const busy = trackerAuthActions[capability.trackerID] || "";
+            const code = trackerAuthCodes[capability.trackerID] || "";
+            return (
+              <div className="settings-card tracker-auth-card" key={capability.trackerID}>
+                <div className="tracker-auth-card__header">
+                  <div>
+                    <p className="settings-detail-card__label">Tracker</p>
+                    <h2 className="tracker-auth-card__title">
+                      {capability.displayName || capability.trackerID}
+                    </h2>
+                  </div>
+                  <span className={`settings-auth-badge ${statusBadgeClass(status?.state)}`}>
+                    {formatTrackerAuthState(status?.state)}
+                  </span>
+                </div>
+                <div className="tracker-auth-chips">
+                  <span>{capability.authKind}</span>
+                  {capability.supportsCookieFile ? <span>cookie import</span> : null}
+                  {capability.supportsLogin ? <span>login</span> : null}
+                  {capability.supportsAutoLogin ? <span>auto relogin</span> : null}
+                  {capability.supportsTOTP ? <span>TOTP</span> : null}
+                  {capability.supportsManual2FA ? <span>manual 2FA</span> : null}
+                  {capability.requiresAPIKey ? <span>API key</span> : null}
+                  {capability.requiresPasskey ? <span>passkey</span> : null}
+                </div>
+                <div className="tracker-auth-card__meta">
+                  <p>Cookies: {status?.cookieCount ?? 0}</p>
+                  <p>Checked: {formatTrackerAuthDate(status?.lastCheckedAt)}</p>
+                  <p>Storage: {status?.encryptedStorage ? "encrypted" : "unavailable"}</p>
+                </div>
+                {status?.message ? <p className="helper">{status.message}</p> : null}
+                {status?.lastError ? <p className="error">{status.lastError}</p> : null}
+                {capability.notes?.map((note) => (
+                  <p className="muted" key={note}>
+                    {note}
+                  </p>
+                ))}
+                {status?.needs2FA ? (
+                  <div className="tracker-auth-2fa">
+                    <input
+                      className={`${settingsInputClass} tracker-auth-2fa__input`}
+                      value={code}
+                      inputMode="numeric"
+                      autoComplete="one-time-code"
+                      onChange={(event) =>
+                        setTrackerAuthCodes((prev) => ({
+                          ...prev,
+                          [capability.trackerID]: event.target.value,
+                        }))
+                      }
+                      placeholder="2FA code"
+                    />
+                    <Button
+                      type="button"
+                      disabled={
+                        !bridge?.SubmitTrackerAuth2FA || !status.challengeID || !code.trim()
+                      }
+                      onClick={() =>
+                        runTrackerAuthAction(capability.trackerID, "2fa", () =>
+                          bridge!.SubmitTrackerAuth2FA!(status.challengeID, code),
+                        )
+                      }
+                    >
+                      Submit 2FA
+                    </Button>
+                  </div>
+                ) : null}
+                <div className="settings-auth-actions">
+                  {capability.supportsCookieFile ? (
+                    <Button
+                      type="button"
+                      disabled={!bridge?.ImportTrackerAuthCookies || Boolean(busy)}
+                      onClick={() =>
+                        runTrackerAuthAction(capability.trackerID, "import", () =>
+                          bridge!.ImportTrackerAuthCookies!(capability.trackerID),
+                        )
+                      }
+                    >
+                      {busy === "import" ? "Importing..." : "Import Cookies"}
+                    </Button>
+                  ) : null}
+                  <Button
+                    type="button"
+                    disabled={!bridge?.TestTrackerAuth || Boolean(busy)}
+                    onClick={() =>
+                      runTrackerAuthAction(capability.trackerID, "test", () =>
+                        bridge!.TestTrackerAuth!(capability.trackerID),
+                      )
+                    }
+                  >
+                    {busy === "test" ? "Testing..." : "Test Auth"}
+                  </Button>
+                  {capability.supportsLogin ? (
+                    <Button
+                      type="button"
+                      disabled={!bridge?.LoginTrackerAuth || Boolean(busy)}
+                      onClick={() =>
+                        runTrackerAuthAction(capability.trackerID, "login", () =>
+                          bridge!.LoginTrackerAuth!(capability.trackerID, {}),
+                        )
+                      }
+                    >
+                      {busy === "login" ? "Checking..." : "Login/Test"}
+                    </Button>
+                  ) : null}
+                  <Button
+                    type="button"
+                    disabled={!bridge?.DeleteTrackerAuth || Boolean(busy)}
+                    onClick={() =>
+                      runTrackerAuthAction(capability.trackerID, "delete", () =>
+                        bridge!.DeleteTrackerAuth!(capability.trackerID),
+                      )
+                    }
+                  >
+                    {busy === "delete" ? "Deleting..." : "Delete Auth"}
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  })();
 
   const uptimeSeconds =
     applicationInfo && applicationInfoFetchedAt !== null
@@ -405,11 +686,27 @@ export default function SettingsPage(props: Props) {
             >
               {applicationDetailsSection.label}
             </button>
+            <button
+              key={trackerAuthSection.key}
+              type="button"
+              className={cn(
+                "flex h-8 w-full items-center rounded-md px-3 text-left text-sm font-medium transition",
+                settingsSection === trackerAuthSection.key
+                  ? "bg-[var(--accent)] text-slate-950 shadow-[0_8px_24px_rgba(245,185,66,0.16)]"
+                  : "text-[var(--muted)] hover:bg-white/10 hover:text-[var(--text)]",
+              )}
+              onClick={() => setSettingsSection(trackerAuthSection.key)}
+            >
+              {trackerAuthSection.label}
+            </button>
           </div>
 
           <div className="settings-body">
             {settingsSection === applicationDetailsSection.key ? applicationDetailsPanel : null}
-            {settingsSection !== applicationDetailsSection.key && webAuthAvailable ? (
+            {settingsSection === trackerAuthSection.key ? trackerAuthPanel : null}
+            {settingsSection !== applicationDetailsSection.key &&
+            settingsSection !== trackerAuthSection.key &&
+            webAuthAvailable ? (
               <details className="settings-subgroup settings-subgroup--collapsible settings-subgroup--auth">
                 <summary>Secret Encryption</summary>
                 <div>
@@ -500,7 +797,8 @@ export default function SettingsPage(props: Props) {
                 </div>
               </details>
             ) : null}
-            {settingsSection === applicationDetailsSection.key ? null : configData ? (
+            {settingsSection === applicationDetailsSection.key ||
+            settingsSection === trackerAuthSection.key ? null : configData ? (
               <div className="settings-form">
                 {showAdvancedToggle ? (
                   <div className="settings-switch-row">
@@ -656,4 +954,46 @@ function formatApplicationUptime(totalSeconds: number) {
   parts.push(`${seconds}s`);
 
   return parts.join(" ");
+}
+
+function formatTrackerAuthState(state?: string) {
+  switch (state) {
+    case "configured":
+      return "Configured";
+    case "has_cookies":
+      return "Has cookies";
+    case "login_required":
+      return "Login required";
+    case "encrypted_storage_unavailable":
+      return "Storage unavailable";
+    case "error":
+      return "Error";
+    default:
+      return "Not configured";
+  }
+}
+
+function statusBadgeClass(state?: string) {
+  switch (state) {
+    case "configured":
+    case "has_cookies":
+      return "is-ready";
+    case "login_required":
+    case "encrypted_storage_unavailable":
+    case "error":
+      return "is-warning";
+    default:
+      return "is-idle";
+  }
+}
+
+function formatTrackerAuthDate(value?: string) {
+  if (!value) {
+    return "Never";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
 }

--- a/gui/frontend/src/pages/settings/index.tsx
+++ b/gui/frontend/src/pages/settings/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026, Audionut and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import * as AlertDialog from "@radix-ui/react-alert-dialog";
 import { Button } from "../../components/ui/button";
@@ -77,9 +77,9 @@ type Props = {
   handleExportSettings: () => void;
   handleImportConfig: () => void;
   importConfirmOpen: boolean;
-  handleImportConfigConfirm: () => void;
+  handleImportConfigConfirm: () => void | Promise<void>;
   handleImportConfigCancel: () => void;
-  handleSaveSettings: () => void;
+  handleSaveSettings: () => void | Promise<void>;
   webAuthAvailable: boolean;
   webAuthStatus: WebAuthStatus | null;
   webAuthLoading: boolean;
@@ -99,7 +99,11 @@ type Props = {
   sectionFieldMeta: Record<string, Record<string, FieldMeta>>;
 };
 
-/** Renders the settings view and calls the app bridge for application info and tracker auth actions. */
+/**
+ * Renders settings plus tracker auth controls with generation-gated async state
+ * so config saves/imports, section changes, and per-tracker actions ignore
+ * stale tracker auth responses.
+ */
 export default function SettingsPage(props: Props) {
   const {
     configData,
@@ -157,9 +161,36 @@ export default function SettingsPage(props: Props) {
   );
   const [trackerAuthLoading, setTrackerAuthLoading] = useState(false);
   const [trackerAuthError, setTrackerAuthError] = useState("");
+  const [trackerAuthActionErrors, setTrackerAuthActionErrors] = useState<Record<string, string>>(
+    {},
+  );
   const [trackerAuthFilter, setTrackerAuthFilter] = useState("");
   const [trackerAuthActions, setTrackerAuthActions] = useState<Record<string, string>>({});
   const [trackerAuthCodes, setTrackerAuthCodes] = useState<Record<string, string>>({});
+  const [trackerAuthReloadRevision, setTrackerAuthReloadRevision] = useState(0);
+  const trackerAuthStatusVersions = useRef<Record<string, number>>({});
+  const trackerAuthActionSequences = useRef<Record<string, number>>({});
+  const trackerAuthLoadGeneration = useRef(0);
+  const trackerAuthSectionActiveRef = useRef(settingsSection === trackerAuthSection.key);
+
+  const invalidateTrackerAuthStatusVersions = useCallback(() => {
+    Object.keys(trackerAuthStatusVersions.current).forEach((trackerID) => {
+      trackerAuthStatusVersions.current[trackerID] =
+        (trackerAuthStatusVersions.current[trackerID] ?? 0) + 1;
+    });
+  }, []);
+
+  useEffect(() => {
+    const active = settingsSection === trackerAuthSection.key;
+    trackerAuthSectionActiveRef.current = active;
+    if (!active) {
+      invalidateTrackerAuthStatusVersions();
+      trackerAuthLoadGeneration.current += 1;
+      setTrackerAuthLoading(false);
+      setTrackerAuthActions({});
+      setTrackerAuthActionErrors({});
+    }
+  }, [invalidateTrackerAuthStatusVersions, settingsSection]);
 
   useEffect(() => {
     let cancelled = false;
@@ -214,6 +245,8 @@ export default function SettingsPage(props: Props) {
       return undefined;
     }
     let cancelled = false;
+    const loadGeneration = trackerAuthLoadGeneration.current + 1;
+    trackerAuthLoadGeneration.current = loadGeneration;
     const bridge = globalThis.go?.guiapp?.App as AppBridgeWithTrackerAuth | undefined;
     const list = bridge?.ListTrackerAuthCapabilities;
     const getStatus = bridge?.GetTrackerAuthStatus;
@@ -226,47 +259,77 @@ export default function SettingsPage(props: Props) {
 
     setTrackerAuthLoading(true);
     setTrackerAuthError("");
+    setTrackerAuthActionErrors({});
     void list()
-      .then(async (capabilities) => {
+      .then((capabilities) => {
         if (cancelled) {
           return;
         }
         setTrackerAuthCapabilities(capabilities);
-        const entries = await Promise.all(
-          capabilities.map(async (capability) => {
-            try {
-              const status = await getStatus(capability.trackerID);
-              return [capability.trackerID, status] as const;
-            } catch (error) {
-              return [
-                capability.trackerID,
-                {
-                  trackerID: capability.trackerID,
-                  displayName: capability.displayName,
-                  state: "error",
-                  cookieCount: 0,
-                  lastCheckedAt: "",
-                  lastError: String(error),
-                  encryptedStorage: false,
-                  needs2FA: false,
-                  challengeID: "",
-                  message: "",
-                },
-              ] as const;
-            }
-          }),
-        );
-        if (!cancelled) {
-          setTrackerAuthStatuses(Object.fromEntries(entries));
+        setTrackerAuthStatuses({});
+        if (capabilities.length === 0) {
+          setTrackerAuthLoading(false);
+          return;
         }
+        let pendingStatuses = capabilities.length;
+        const markStatusComplete = () => {
+          pendingStatuses -= 1;
+          if (
+            pendingStatuses === 0 &&
+            !cancelled &&
+            trackerAuthLoadGeneration.current === loadGeneration
+          ) {
+            setTrackerAuthLoading(false);
+          }
+        };
+        capabilities.forEach((capability) => {
+          const statusVersion = trackerAuthStatusVersions.current[capability.trackerID] ?? 0;
+          void getStatus(capability.trackerID)
+            .then((status) => {
+              if (
+                !cancelled &&
+                (trackerAuthStatusVersions.current[capability.trackerID] ?? 0) === statusVersion
+              ) {
+                setTrackerAuthStatuses((prev) => ({
+                  ...prev,
+                  [capability.trackerID]: status,
+                }));
+              }
+            })
+            .catch((error) => {
+              if (
+                !cancelled &&
+                (trackerAuthStatusVersions.current[capability.trackerID] ?? 0) === statusVersion
+              ) {
+                setTrackerAuthStatuses((prev) => ({
+                  ...prev,
+                  [capability.trackerID]: {
+                    trackerID: capability.trackerID,
+                    displayName: capability.displayName,
+                    state: "error",
+                    cookieCount: 0,
+                    lastCheckedAt: "",
+                    lastError: String(error),
+                    encryptedStorage: false,
+                    needs2FA: false,
+                    challengeID: "",
+                    message: "",
+                  },
+                }));
+              }
+            })
+            .finally(() => {
+              if (!cancelled) {
+                markStatusComplete();
+              }
+            });
+        });
       })
       .catch((error) => {
         if (!cancelled) {
+          setTrackerAuthCapabilities([]);
+          setTrackerAuthStatuses({});
           setTrackerAuthError(String(error));
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
           setTrackerAuthLoading(false);
         }
       });
@@ -274,22 +337,57 @@ export default function SettingsPage(props: Props) {
     return () => {
       cancelled = true;
     };
-  }, [settingsSection]);
+  }, [settingsSection, trackerAuthReloadRevision]);
+
+  const reloadTrackerAuthAfterConfigChange = useCallback(
+    async (handler: () => void | Promise<void>) => {
+      await handler();
+      invalidateTrackerAuthStatusVersions();
+      setTrackerAuthActions({});
+      setTrackerAuthActionErrors({});
+      setTrackerAuthReloadRevision((revision) => revision + 1);
+    },
+    [invalidateTrackerAuthStatusVersions],
+  );
 
   const runTrackerAuthAction = async (
     trackerID: string,
     action: string,
     fn: () => Promise<TrackerAuthStatus>,
   ) => {
+    const actionVersion = (trackerAuthStatusVersions.current[trackerID] ?? 0) + 1;
+    trackerAuthStatusVersions.current[trackerID] = actionVersion;
+    const actionSequence = (trackerAuthActionSequences.current[trackerID] ?? 0) + 1;
+    trackerAuthActionSequences.current[trackerID] = actionSequence;
     setTrackerAuthActions((prev) => ({ ...prev, [trackerID]: action }));
-    setTrackerAuthError("");
+    setTrackerAuthActionErrors((prev) => {
+      const next = { ...prev };
+      delete next[trackerID];
+      return next;
+    });
     try {
       const status = await fn();
-      setTrackerAuthStatuses((prev) => ({ ...prev, [trackerID]: status }));
+      if (
+        trackerAuthSectionActiveRef.current &&
+        trackerAuthStatusVersions.current[trackerID] === actionVersion
+      ) {
+        setTrackerAuthStatuses((prev) => ({ ...prev, [trackerID]: status }));
+      }
     } catch (error) {
-      setTrackerAuthError(String(error));
+      if (
+        trackerAuthSectionActiveRef.current &&
+        trackerAuthActionSequences.current[trackerID] === actionSequence &&
+        trackerAuthStatusVersions.current[trackerID] === actionVersion
+      ) {
+        setTrackerAuthActionErrors((prev) => ({ ...prev, [trackerID]: String(error) }));
+      }
     } finally {
-      setTrackerAuthActions((prev) => ({ ...prev, [trackerID]: "" }));
+      if (
+        trackerAuthSectionActiveRef.current &&
+        trackerAuthActionSequences.current[trackerID] === actionSequence
+      ) {
+        setTrackerAuthActions((prev) => ({ ...prev, [trackerID]: "" }));
+      }
     }
   };
 
@@ -337,6 +435,7 @@ export default function SettingsPage(props: Props) {
           {capabilities.map((capability) => {
             const status = trackerAuthStatuses[capability.trackerID];
             const busy = trackerAuthActions[capability.trackerID] || "";
+            const actionError = trackerAuthActionErrors[capability.trackerID] || "";
             const code = trackerAuthCodes[capability.trackerID] || "";
             const canTestAuth = remoteAuthValidationTrackers.has(
               capability.trackerID.trim().toUpperCase(),
@@ -371,6 +470,7 @@ export default function SettingsPage(props: Props) {
                 </div>
                 {status?.message ? <p className="helper">{status.message}</p> : null}
                 {status?.lastError ? <p className="error">{status.lastError}</p> : null}
+                {actionError ? <p className="error">{actionError}</p> : null}
                 {capability.notes?.map((note) => (
                   <p className="muted" key={note}>
                     {note}
@@ -568,7 +668,9 @@ export default function SettingsPage(props: Props) {
             <Button
               variant="primary"
               type="button"
-              onClick={handleSaveSettings}
+              onClick={() => {
+                void reloadTrackerAuthAfterConfigChange(handleSaveSettings);
+              }}
               disabled={settingsLoading || settingsExporting || settingsImporting || !settingsDirty}
             >
               Save
@@ -928,7 +1030,7 @@ export default function SettingsPage(props: Props) {
                   className="import-confirm-dialog__confirm"
                   onClick={(event) => {
                     event.preventDefault();
-                    handleImportConfigConfirm();
+                    void reloadTrackerAuthAfterConfigChange(handleImportConfigConfirm);
                   }}
                   disabled={settingsImporting}
                 >

--- a/gui/frontend/src/pages/settings/index.tsx
+++ b/gui/frontend/src/pages/settings/index.tsx
@@ -14,7 +14,6 @@ import type {
   ConfigValue,
   FieldMeta,
   TrackerAuthCapability,
-  TrackerAuthLoginRequest,
   TrackerAuthStatus,
   WebAuthStatus,
 } from "../../types";
@@ -72,7 +71,6 @@ type AppBridgeWithTrackerAuth = {
   GetTrackerAuthStatus?: (tracker: string) => Promise<TrackerAuthStatus>;
   ImportTrackerAuthCookies?: (tracker: string) => Promise<TrackerAuthStatus>;
   TestTrackerAuth?: (tracker: string) => Promise<TrackerAuthStatus>;
-  LoginTrackerAuth?: (tracker: string, req: TrackerAuthLoginRequest) => Promise<TrackerAuthStatus>;
   SubmitTrackerAuth2FA?: (challengeID: string, code: string) => Promise<TrackerAuthStatus>;
   DeleteTrackerAuth?: (tracker: string) => Promise<TrackerAuthStatus>;
 };
@@ -559,20 +557,7 @@ export default function SettingsPage(props: Props) {
                         )
                       }
                     >
-                      {busy === "test" ? "Testing..." : "Test Auth"}
-                    </Button>
-                  ) : null}
-                  {capability.supportsLogin ? (
-                    <Button
-                      type="button"
-                      disabled={!bridge?.LoginTrackerAuth || Boolean(busy)}
-                      onClick={() =>
-                        runTrackerAuthAction(capability.trackerID, "login", () =>
-                          bridge!.LoginTrackerAuth!(capability.trackerID, {}),
-                        )
-                      }
-                    >
-                      {busy === "login" ? "Checking..." : "Login/Test"}
+                      {busy === "test" ? "Checking..." : "Check Auth"}
                     </Button>
                   ) : null}
                   <Button

--- a/gui/frontend/src/pages/settings/index.tsx
+++ b/gui/frontend/src/pages/settings/index.tsx
@@ -36,6 +36,26 @@ const settingsInputClass =
 
 const remoteAuthValidationTrackers = new Set(["MTV", "PTP"]);
 
+/** Builds the case-insensitive key shared by main tracker config and tracker auth rows. */
+const trackerNameKey = (name: string) => name.trim().toLowerCase();
+
+/**
+ * Returns true for tracker auth capabilities that perform stored-cookie,
+ * relogin, refresh, or 2FA handling beyond static API-key/passkey config.
+ */
+const isManagedTrackerAuthCapability = (capability: TrackerAuthCapability) => {
+  const authKind = capability.authKind.toLowerCase();
+  return (
+    capability.supportsCookieFile ||
+    capability.supportsLogin ||
+    capability.supportsAutoLogin ||
+    capability.supportsTOTP ||
+    capability.supportsManual2FA ||
+    authKind.includes("refresh") ||
+    authKind.includes("2fa")
+  );
+};
+
 type ConfigOpStatus = {
   type: "success" | "error" | "warning";
   title: string;
@@ -69,6 +89,8 @@ type Props = {
   dismissConfigOpStatus: () => void;
   settingsSection: string;
   settingsSections: SettingsSection[];
+  /** Tracker names already enabled by the main tracker settings panel. */
+  trackerSelectionNames: string[];
   showAdvancedToggle: boolean;
   advancedOpen: boolean;
   setSettingsSection: Dispatch<SetStateAction<string>>;
@@ -117,6 +139,7 @@ export default function SettingsPage(props: Props) {
     dismissConfigOpStatus,
     settingsSection,
     settingsSections,
+    trackerSelectionNames,
     showAdvancedToggle,
     advancedOpen,
     setSettingsSection,
@@ -265,13 +288,19 @@ export default function SettingsPage(props: Props) {
         if (cancelled) {
           return;
         }
-        setTrackerAuthCapabilities(capabilities);
+        const configuredTrackerNames = new Set(trackerSelectionNames.map(trackerNameKey));
+        const managedCapabilities = capabilities.filter(
+          (capability) =>
+            configuredTrackerNames.has(trackerNameKey(capability.trackerID)) &&
+            isManagedTrackerAuthCapability(capability),
+        );
+        setTrackerAuthCapabilities(managedCapabilities);
         setTrackerAuthStatuses({});
-        if (capabilities.length === 0) {
+        if (managedCapabilities.length === 0) {
           setTrackerAuthLoading(false);
           return;
         }
-        let pendingStatuses = capabilities.length;
+        let pendingStatuses = managedCapabilities.length;
         const markStatusComplete = () => {
           pendingStatuses -= 1;
           if (
@@ -282,7 +311,7 @@ export default function SettingsPage(props: Props) {
             setTrackerAuthLoading(false);
           }
         };
-        capabilities.forEach((capability) => {
+        managedCapabilities.forEach((capability) => {
           const statusVersion = trackerAuthStatusVersions.current[capability.trackerID] ?? 0;
           void getStatus(capability.trackerID)
             .then((status) => {
@@ -337,7 +366,7 @@ export default function SettingsPage(props: Props) {
     return () => {
       cancelled = true;
     };
-  }, [settingsSection, trackerAuthReloadRevision]);
+  }, [settingsSection, trackerAuthReloadRevision, trackerSelectionNames]);
 
   const reloadTrackerAuthAfterConfigChange = useCallback(
     async (handler: () => void | Promise<void>) => {

--- a/gui/frontend/src/pages/settings/index.tsx
+++ b/gui/frontend/src/pages/settings/index.tsx
@@ -34,6 +34,8 @@ const trackerAuthSection = {
 const settingsInputClass =
   "h-8 rounded-md border border-white/10 bg-slate-950/45 px-2.5 text-sm text-[var(--text)] outline-none transition placeholder:text-[var(--muted)] focus:border-[var(--accent-2)] focus:ring-2 focus:ring-[rgba(53,194,193,0.18)]";
 
+const remoteAuthValidationTrackers = new Set(["MTV", "PTP"]);
+
 type ConfigOpStatus = {
   type: "success" | "error" | "warning";
   title: string;
@@ -97,6 +99,7 @@ type Props = {
   sectionFieldMeta: Record<string, Record<string, FieldMeta>>;
 };
 
+/** Renders the settings view and calls the app bridge for application info and tracker auth actions. */
 export default function SettingsPage(props: Props) {
   const {
     configData,
@@ -335,6 +338,9 @@ export default function SettingsPage(props: Props) {
             const status = trackerAuthStatuses[capability.trackerID];
             const busy = trackerAuthActions[capability.trackerID] || "";
             const code = trackerAuthCodes[capability.trackerID] || "";
+            const canTestAuth = remoteAuthValidationTrackers.has(
+              capability.trackerID.trim().toUpperCase(),
+            );
             return (
               <div className="settings-card tracker-auth-card" key={capability.trackerID}>
                 <div className="tracker-auth-card__header">
@@ -414,17 +420,19 @@ export default function SettingsPage(props: Props) {
                       {busy === "import" ? "Importing..." : "Import Cookies"}
                     </Button>
                   ) : null}
-                  <Button
-                    type="button"
-                    disabled={!bridge?.TestTrackerAuth || Boolean(busy)}
-                    onClick={() =>
-                      runTrackerAuthAction(capability.trackerID, "test", () =>
-                        bridge!.TestTrackerAuth!(capability.trackerID),
-                      )
-                    }
-                  >
-                    {busy === "test" ? "Testing..." : "Test Auth"}
-                  </Button>
+                  {canTestAuth ? (
+                    <Button
+                      type="button"
+                      disabled={!bridge?.TestTrackerAuth || Boolean(busy)}
+                      onClick={() =>
+                        runTrackerAuthAction(capability.trackerID, "test", () =>
+                          bridge!.TestTrackerAuth!(capability.trackerID),
+                        )
+                      }
+                    >
+                      {busy === "test" ? "Testing..." : "Test Auth"}
+                    </Button>
+                  ) : null}
                   {capability.supportsLogin ? (
                     <Button
                       type="button"

--- a/gui/frontend/src/pages/settings/index.tsx
+++ b/gui/frontend/src/pages/settings/index.tsx
@@ -33,7 +33,8 @@ const trackerAuthSection = {
 const settingsInputClass =
   "h-8 rounded-md border border-white/10 bg-slate-950/45 px-2.5 text-sm text-[var(--text)] outline-none transition placeholder:text-[var(--muted)] focus:border-[var(--accent-2)] focus:ring-2 focus:ring-[rgba(53,194,193,0.18)]";
 
-const remoteAuthValidationTrackers = new Set(["MTV", "PTP"]);
+/** Trackers with backend adapters that can perform a remote auth check. */
+const remoteAuthValidationTrackers = new Set(["AR", "HDB", "MTV", "PTP", "RTF"]);
 
 /** Builds the case-insensitive key shared by main tracker config and tracker auth rows. */
 const trackerNameKey = (name: string) => name.trim().toLowerCase();

--- a/gui/frontend/src/styles.css
+++ b/gui/frontend/src/styles.css
@@ -332,6 +332,64 @@ body {
   border-color: rgba(120, 141, 173, 0.35);
 }
 
+.tracker-auth-panel {
+  gap: 1rem;
+}
+
+.tracker-auth-filter {
+  max-width: 360px;
+}
+
+.tracker-auth-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.tracker-auth-card {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.tracker-auth-card__header,
+.tracker-auth-card__meta,
+.tracker-auth-2fa,
+.tracker-auth-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.tracker-auth-card__header {
+  justify-content: space-between;
+}
+
+.tracker-auth-card__title {
+  margin: 0.1rem 0 0;
+  font-size: 1.05rem;
+  line-height: 1.2;
+}
+
+.tracker-auth-chips span {
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 999px;
+  padding: 0.2rem 0.45rem;
+  background: rgba(15, 23, 42, 0.34);
+  color: var(--muted);
+  font-size: 0.74rem;
+  line-height: 1;
+}
+
+.tracker-auth-card__meta p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.tracker-auth-2fa__input {
+  width: 9rem;
+}
+
 .settings-saved {
   margin-top: 9px;
   color: var(--success);

--- a/gui/frontend/src/styles.css
+++ b/gui/frontend/src/styles.css
@@ -332,64 +332,6 @@ body {
   border-color: rgba(120, 141, 173, 0.35);
 }
 
-.tracker-auth-panel {
-  gap: 1rem;
-}
-
-.tracker-auth-filter {
-  max-width: 360px;
-}
-
-.tracker-auth-list {
-  display: grid;
-  gap: 0.85rem;
-}
-
-.tracker-auth-card {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.tracker-auth-card__header,
-.tracker-auth-card__meta,
-.tracker-auth-2fa,
-.tracker-auth-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-  align-items: center;
-}
-
-.tracker-auth-card__header {
-  justify-content: space-between;
-}
-
-.tracker-auth-card__title {
-  margin: 0.1rem 0 0;
-  font-size: 1.05rem;
-  line-height: 1.2;
-}
-
-.tracker-auth-chips span {
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  border-radius: 999px;
-  padding: 0.2rem 0.45rem;
-  background: rgba(15, 23, 42, 0.34);
-  color: var(--muted);
-  font-size: 0.74rem;
-  line-height: 1;
-}
-
-.tracker-auth-card__meta p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.8rem;
-}
-
-.tracker-auth-2fa__input {
-  width: 9rem;
-}
-
 .settings-saved {
   margin-top: 9px;
   color: var(--success);

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -284,9 +284,12 @@ export type ApplicationInfo = {
   uptimeSeconds: number;
 };
 
+/** Tracker auth support metadata returned by the app bridge. */
 export type TrackerAuthCapability = {
+  /** Normalized tracker code used in tracker auth bridge calls. */
   trackerID: string;
   displayName: string;
+  /** Compact capability label such as "cookies", "credential_login", or "api_key_cookies_login". */
   authKind: string;
   supportsCookieFile: boolean;
   supportsLogin: boolean;
@@ -298,20 +301,27 @@ export type TrackerAuthCapability = {
   notes?: string[];
 };
 
+/** Current tracker auth state returned after status, import, login, validation, 2FA, or delete actions. */
 export type TrackerAuthStatus = {
   trackerID: string;
   displayName: string;
+  /** Backend state string such as "configured", "has_cookies", or "login_required". */
   state: string;
   cookieCount: number;
+  /** RFC3339 UTC timestamp generated when the backend evaluated the status. */
   lastCheckedAt: string;
+  /** Redacted failure text from the most recent local or remote auth check. */
   lastError: string;
   encryptedStorage: boolean;
   needs2FA: boolean;
+  /** Opaque manual-2FA continuation token; empty unless needs2FA is true. */
   challengeID: string;
   message: string;
 };
 
+/** Optional login data for tracker auth flows. */
 export type TrackerAuthLoginRequest = {
+  /** One-time 2FA code for adapters that accept it during login. */
   code?: string;
 };
 

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -284,6 +284,37 @@ export type ApplicationInfo = {
   uptimeSeconds: number;
 };
 
+export type TrackerAuthCapability = {
+  trackerID: string;
+  displayName: string;
+  authKind: string;
+  supportsCookieFile: boolean;
+  supportsLogin: boolean;
+  supportsAutoLogin: boolean;
+  supportsTOTP: boolean;
+  supportsManual2FA: boolean;
+  requiresAPIKey: boolean;
+  requiresPasskey: boolean;
+  notes?: string[];
+};
+
+export type TrackerAuthStatus = {
+  trackerID: string;
+  displayName: string;
+  state: string;
+  cookieCount: number;
+  lastCheckedAt: string;
+  lastError: string;
+  encryptedStorage: boolean;
+  needs2FA: boolean;
+  challengeID: string;
+  message: string;
+};
+
+export type TrackerAuthLoginRequest = {
+  code?: string;
+};
+
 export type ExternalPreview = {
   Provider: string;
   ID: number;

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -298,7 +298,8 @@ export type TrackerAuthCapability = {
   supportsManual2FA: boolean;
   requiresAPIKey: boolean;
   requiresPasskey: boolean;
-  notes?: string[];
+  /** Optional tracker-specific UI notes; Go bridge may serialize a nil slice as null. */
+  notes?: string[] | null;
 };
 
 /** Current tracker auth state returned after status, import, login, validation, 2FA, or delete actions. */

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -436,6 +436,12 @@ export type TrackerPreview = {
   UpdatedAt: string;
 };
 
+/** Upload rule failure attached to a tracker before dupe checking or upload. */
+export type RuleFailure = {
+  Rule: string;
+  Reason: string;
+};
+
 export type DupeEntry = {
   Name: string;
   SizeBytes: number;
@@ -546,6 +552,8 @@ export type MetadataPreview = {
   ExternalPreview: ExternalPreview[];
   Bluray?: BlurayMetadata;
   TrackerData: TrackerPreview[];
+  /** Preview-time upload rule failures keyed by normalized tracker code. */
+  TrackerRuleFailures?: Record<string, RuleFailure[]>;
 };
 
 export type MetadataProgressUpdate = {

--- a/gui/frontend/src/utils/runtime.test.ts
+++ b/gui/frontend/src/utils/runtime.test.ts
@@ -32,6 +32,7 @@ describe("browser runtime bridge", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -211,5 +212,136 @@ describe("browser runtime bridge", () => {
 
     initializeBrowserBridge("csrf-token", true, false);
     expect(isRuntimePathCaseInsensitive()).toBe(false);
+  });
+
+  it("rejects oversized decoded tracker cookie content before posting", async () => {
+    const originalCreateElement = document.createElement.bind(document);
+    const input = document.createElement("input");
+    Object.defineProperty(input, "files", {
+      configurable: true,
+      value: [new File(["x"], "cookies.txt")],
+    });
+    vi.spyOn(input, "click").mockImplementation(() => {
+      input.dispatchEvent(new Event("change"));
+    });
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      if (tagName === "input") {
+        return input;
+      }
+      return originalCreateElement(tagName);
+    });
+    const readAsText = vi.fn();
+    vi.stubGlobal(
+      "FileReader",
+      vi.fn().mockImplementation(function (this: any) {
+        this.readAsText = readAsText.mockImplementation(() => {
+          Object.defineProperty(this, "result", {
+            configurable: true,
+            value: "x".repeat(1024 * 1024 + 1),
+          });
+          this.onload?.(new ProgressEvent("load"));
+        });
+      }),
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { initializeBrowserBridge } = await import("./runtime");
+    initializeBrowserBridge("csrf-token", true);
+
+    await expect((globalThis as any).go.guiapp.App.ImportTrackerAuthCookies("PTP")).rejects.toThrow(
+      "cookie file content exceeds 1048576 byte limit",
+    );
+    expect(readAsText).toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized raw tracker cookie files before decoding", async () => {
+    const originalCreateElement = document.createElement.bind(document);
+    const input = document.createElement("input");
+    const file = new File(["x"], "cookies.txt");
+    Object.defineProperty(file, "size", { configurable: true, value: 1024 * 1024 + 1 });
+    Object.defineProperty(input, "files", {
+      configurable: true,
+      value: [file],
+    });
+    vi.spyOn(input, "click").mockImplementation(() => {
+      input.dispatchEvent(new Event("change"));
+    });
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      if (tagName === "input") {
+        return input;
+      }
+      return originalCreateElement(tagName);
+    });
+    const readAsText = vi.fn();
+    vi.stubGlobal(
+      "FileReader",
+      vi.fn().mockImplementation(function (this: any) {
+        this.readAsText = readAsText.mockImplementation(() => {
+          Object.defineProperty(this, "result", { configurable: true, value: "session=abc" });
+          this.onload?.(new ProgressEvent("load"));
+        });
+      }),
+    );
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ trackerID: "PTP" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { initializeBrowserBridge } = await import("./runtime");
+    initializeBrowserBridge("csrf-token", true);
+
+    await expect((globalThis as any).go.guiapp.App.ImportTrackerAuthCookies("PTP")).rejects.toThrow(
+      "cookie file content exceeds 1048576 byte limit",
+    );
+    expect(readAsText).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts valid tracker cookie files from the browser bridge", async () => {
+    const originalCreateElement = document.createElement.bind(document);
+    const input = document.createElement("input");
+    Object.defineProperty(input, "files", {
+      configurable: true,
+      value: [new File(["session=abc"], "cookies.txt")],
+    });
+    vi.spyOn(input, "click").mockImplementation(() => {
+      input.dispatchEvent(new Event("change"));
+    });
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      if (tagName === "input") {
+        return input;
+      }
+      return originalCreateElement(tagName);
+    });
+    vi.stubGlobal(
+      "FileReader",
+      vi.fn().mockImplementation(function (this: any) {
+        this.readAsText = vi.fn(() => {
+          Object.defineProperty(this, "result", { configurable: true, value: "session=abc" });
+          this.onload?.(new ProgressEvent("load"));
+        });
+      }),
+    );
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ trackerID: "PTP" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { initializeBrowserBridge } = await import("./runtime");
+    initializeBrowserBridge("csrf-token", true);
+
+    await expect(
+      (globalThis as any).go.guiapp.App.ImportTrackerAuthCookies("PTP"),
+    ).resolves.toEqual({
+      trackerID: "PTP",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/app/ImportTrackerAuthCookieContent",
+      expect.objectContaining({
+        body: JSON.stringify({
+          Tracker: "PTP",
+          FileName: "cookies.txt",
+          Content: "session=abc",
+        }),
+      }),
+    );
   });
 });

--- a/gui/frontend/src/utils/runtime.ts
+++ b/gui/frontend/src/utils/runtime.ts
@@ -577,6 +577,52 @@ export const initializeBrowserBridge = (
         UpdateLogExclusions: (patterns: string[]) =>
           call("UpdateLogExclusions", { Patterns: patterns }),
         ListKnownTrackers: () => call("ListKnownTrackers"),
+        ListTrackerAuthCapabilities: () => call("ListTrackerAuthCapabilities"),
+        GetTrackerAuthStatus: (tracker: string) =>
+          call("GetTrackerAuthStatus", { Tracker: tracker }),
+        ImportTrackerAuthCookies: async (tracker: string) => {
+          const fileData = await new Promise<{ name: string; content: string }>(
+            (resolve, reject) => {
+              const input = document.createElement("input");
+              input.type = "file";
+              input.accept = ".txt,.json";
+              input.onchange = () => {
+                const file = input.files?.[0];
+                if (!file) {
+                  resolve({ name: "", content: "" });
+                  return;
+                }
+                const reader = new FileReader();
+                reader.onload = () =>
+                  resolve({ name: file.name, content: reader.result as string });
+                reader.onerror = () => reject(reader.error);
+                reader.readAsText(file);
+              };
+              input.addEventListener("cancel", () => resolve({ name: "", content: "" }));
+              input.click();
+            },
+          );
+          if (!fileData.name) {
+            return call("GetTrackerAuthStatus", { Tracker: tracker });
+          }
+          return call("ImportTrackerAuthCookieContent", {
+            Tracker: tracker,
+            FileName: fileData.name,
+            Content: fileData.content,
+          });
+        },
+        ImportTrackerAuthCookieContent: (tracker: string, fileName: string, content: string) =>
+          call("ImportTrackerAuthCookieContent", {
+            Tracker: tracker,
+            FileName: fileName,
+            Content: content,
+          }),
+        TestTrackerAuth: (tracker: string) => call("TestTrackerAuth", { Tracker: tracker }),
+        LoginTrackerAuth: (tracker: string, login: unknown) =>
+          call("LoginTrackerAuth", { Tracker: tracker, Login: login }),
+        SubmitTrackerAuth2FA: (challengeID: string, code: string) =>
+          call("SubmitTrackerAuth2FA", { ChallengeID: challengeID, Code: code }),
+        DeleteTrackerAuth: (tracker: string) => call("DeleteTrackerAuth", { Tracker: tracker }),
         GetImageHostPolicyMetadata: () => call("GetImageHostPolicyMetadata"),
         ListHistory: () => call("ListHistory"),
         GetHistoryOverview: (sourcePath: string) =>

--- a/gui/frontend/src/utils/runtime.ts
+++ b/gui/frontend/src/utils/runtime.ts
@@ -14,6 +14,10 @@ let csrfToken = "";
 let nativeBrowseEnabled = false;
 let caseInsensitivePaths = navigator.platform.toLowerCase().startsWith("win");
 
+// Mirrors trackerauth.MaxCookieImportContentBytes so browser imports reject
+// over-limit files before decode and over-limit decoded text before posting.
+const maxCookieImportContentBytes = 1024 * 1024;
+const encodedTextByteLength = (value: string) => new TextEncoder().encode(value).length;
 const sessionChangedMessage =
   "Web session changed in another tab. Reload this tab to continue with the active login.";
 
@@ -592,9 +596,27 @@ export const initializeBrowserBridge = (
                   resolve({ name: "", content: "" });
                   return;
                 }
+                if (file.size > maxCookieImportContentBytes) {
+                  reject(
+                    new Error(
+                      `tracker auth: cookie file content exceeds ${maxCookieImportContentBytes} byte limit`,
+                    ),
+                  );
+                  return;
+                }
                 const reader = new FileReader();
-                reader.onload = () =>
-                  resolve({ name: file.name, content: reader.result as string });
+                reader.onload = () => {
+                  const content = reader.result as string;
+                  if (encodedTextByteLength(content) > maxCookieImportContentBytes) {
+                    reject(
+                      new Error(
+                        `tracker auth: cookie file content exceeds ${maxCookieImportContentBytes} byte limit`,
+                      ),
+                    );
+                    return;
+                  }
+                  resolve({ name: file.name, content });
+                };
                 reader.onerror = () => reject(reader.error);
                 reader.readAsText(file);
               };
@@ -666,11 +688,13 @@ export const initializeBrowserBridge = (
   recreateEventSource();
 };
 
+/** Returns whether app calls should use the browser HTTP bridge instead of Wails. */
 export const isBrowserMode = () => {
   browserMode = isWebUIRuntime();
   return browserMode;
 };
 
+/** Reports native browse availability, defaulting to true for desktop Wails builds. */
 export const isBrowserNativeBrowseAvailable = () => {
   if (!isBrowserMode()) {
     return true;
@@ -684,6 +708,7 @@ export const isBrowserNativeBrowseAvailable = () => {
  */
 export const isRuntimePathCaseInsensitive = () => caseInsensitivePaths;
 
+/** Subscribes to browser native-browse availability changes and returns an unsubscribe callback. */
 export const subscribeBrowserNativeBrowseAvailability = (listener: () => void) => {
   nativeBrowseAvailabilityListeners.add(listener);
   return () => {
@@ -703,6 +728,7 @@ export const updateBrowserCSRFToken = (token: string, runtimeCaseInsensitivePath
   recreateEventSource();
 };
 
+/** Browser-mode auth API wrappers that preserve cookie credentials on every request. */
 export const browserAuth = {
   status: async () => {
     const response = await fetch("/api/auth/status", { credentials: "include" });

--- a/internal/config/defaults/example.yaml
+++ b/internal/config/defaults/example.yaml
@@ -383,6 +383,7 @@ trackers:
     password: ""
     url: "https://passthepopcorn.me"
     announce_url: ""
+    otp_uri: ""
   PTS:
     link_dir_name: ""
     url: "https://ptskit.org"

--- a/internal/cookies/loader.go
+++ b/internal/cookies/loader.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io/fs"
 	"maps"
 	"net/http"
 	"os"
@@ -23,7 +24,7 @@ import (
 )
 
 // LoadTrackerCookieMap returns cookies for trackerID from encrypted database
-// storage and legacy cookie files. Legacy file values override database values
+// storage and legacy cookie files. Database values override legacy file values
 // when both sources contain the same cookie name.
 func LoadTrackerCookieMap(ctx context.Context, dbPath string, trackerID string) (map[string]string, error) {
 	if ctx == nil {
@@ -55,7 +56,7 @@ func LoadTrackerCookieMap(ctx context.Context, dbPath string, trackerID string) 
 
 	fileValues, err := loadTrackerCookieMapFromFiles(dbPath, normalizedTrackerID)
 	if err == nil {
-		return mergeCookieMaps(storedValues, fileValues), nil
+		return mergeCookieMaps(fileValues, storedValues), nil
 	}
 	if len(storedValues) > 0 {
 		return storedValues, nil
@@ -96,7 +97,7 @@ func LoadTrackerHTTPCookies(ctx context.Context, dbPath string, trackerID string
 
 	fileCookies, err := loadTrackerHTTPCookiesFromFiles(dbPath, normalizedTrackerID, domain)
 	if err == nil {
-		return CookieMapToHTTPCookies(mergeCookieMaps(storedValues, httpCookiesToMap(fileCookies)), domain), nil
+		return CookieMapToHTTPCookies(mergeCookieMaps(httpCookiesToMap(fileCookies), storedValues), domain), nil
 	}
 	if len(storedValues) > 0 {
 		return CookieMapToHTTPCookies(storedValues, domain), nil
@@ -106,7 +107,9 @@ func LoadTrackerHTTPCookies(ctx context.Context, dbPath string, trackerID string
 }
 
 // SaveTrackerCookieMap replaces trackerID's encrypted database cookies with
-// non-empty entries from values. It requires usable web auth material.
+// non-empty entries from values. It requires usable web auth material and does
+// not remove legacy cookie files; later loads let database values override
+// same-named legacy file values.
 func SaveTrackerCookieMap(ctx context.Context, dbPath string, trackerID string, values map[string]string) error {
 	if ctx == nil {
 		return errors.New("cookies: context is required")
@@ -154,7 +157,10 @@ func SaveTrackerHTTPCookies(ctx context.Context, dbPath string, trackerID string
 }
 
 // DeleteTrackerCookies removes trackerID cookies from encrypted database
-// storage and deletes matching legacy cookie files when present.
+// storage and deletes matching legacy cookie files when present. Database
+// delete failures stop before legacy files are touched; legacy delete failures
+// restore earlier removed legacy candidates and prior database cookies before
+// returning.
 func DeleteTrackerCookies(ctx context.Context, dbPath string, trackerID string) error {
 	if ctx == nil {
 		return errors.New("cookies: context is required")
@@ -165,27 +171,192 @@ func DeleteTrackerCookies(ctx context.Context, dbPath string, trackerID string) 
 		return errors.New("cookies: tracker id is required")
 	}
 
-	var deleteErr error
-	if store, _, repo, err := openTrackerCookieStore(ctx, dbPath); err == nil {
+	var (
+		dbStore      *CookieStore
+		dbKey        []byte
+		storedValues map[string]string
+		dbDeleted    bool
+	)
+	if store, key, repo, err := openTrackerCookieStore(ctx, dbPath); err == nil {
+		defer func() {
+			_ = repo.Close()
+		}()
+		dbStore = store
+		dbKey = key
+		var err error
+		storedValues, err = store.GetAllTrackerCookies(ctx, normalizedTrackerID, key)
+		if err != nil {
+			return fmt.Errorf("cookies: snapshot tracker %s from db: %w", normalizedTrackerID, err)
+		}
 		if err := store.DeleteAllTrackerCookies(ctx, normalizedTrackerID); err != nil {
-			deleteErr = fmt.Errorf("cookies: delete tracker %s from db: %w", normalizedTrackerID, err)
+			return fmt.Errorf("cookies: delete tracker %s from db: %w", normalizedTrackerID, err)
 		}
-		_ = repo.Close()
+		dbDeleted = true
 	} else if !errors.Is(err, ErrAuthHelperUnavailable) {
-		deleteErr = err
+		return err
 	}
 
+	var removedLegacy []legacyCookieCandidateSnapshot
 	for _, candidate := range commonhttp.CookiePathCandidates(dbPath, normalizedTrackerID, ".txt", ".json") {
-		if removeErr := os.Remove(candidate); removeErr != nil && !os.IsNotExist(removeErr) && deleteErr == nil {
-			deleteErr = fmt.Errorf("cookies: delete tracker %s legacy cookie file %s: %w", normalizedTrackerID, candidate, removeErr)
+		snapshot, removed, removeErr := removeLegacyCookieCandidate(candidate)
+		if removeErr != nil {
+			deleteErr := fmt.Errorf("cookies: delete tracker %s legacy cookie file %s: %w", normalizedTrackerID, candidate, removeErr)
+			legacyRestoreErr := restoreLegacyCookieCandidates(removedLegacy)
+			if dbDeleted && len(storedValues) > 0 {
+				if restoreErr := restoreTrackerCookies(contextWithoutCancel(ctx), dbStore, dbKey, normalizedTrackerID, storedValues); restoreErr != nil {
+					return errors.Join(deleteErr, legacyRestoreErr, restoreErr)
+				}
+			}
+			return errors.Join(deleteErr, legacyRestoreErr)
+		}
+		if removed {
+			removedLegacy = append(removedLegacy, snapshot)
 		}
 	}
 
-	return deleteErr
+	return nil
 }
 
-// CookieMapToHTTPCookies converts non-empty cookie name/value pairs to HTTP
-// cookies scoped to domain and path "/".
+// legacyCookieCandidateKind records the filesystem object type needed to
+// recreate a removed legacy cookie candidate during rollback.
+type legacyCookieCandidateKind int
+
+const (
+	legacyCookieCandidateFile legacyCookieCandidateKind = iota + 1
+	legacyCookieCandidateDir
+	legacyCookieCandidateSymlink
+)
+
+// legacyCookieCandidateSnapshot captures enough state to restore a removed
+// legacy cookie file, empty directory, or symlink if a later delete fails.
+type legacyCookieCandidateSnapshot struct {
+	path       string
+	mode       fs.FileMode
+	kind       legacyCookieCandidateKind
+	data       []byte
+	linkTarget string
+}
+
+// removeLegacyCookieCandidate snapshots and removes a single legacy cookie
+// candidate. Missing paths are ignored; unsupported types and non-empty
+// directories return errors without reporting the candidate as removed.
+func removeLegacyCookieCandidate(path string) (legacyCookieCandidateSnapshot, bool, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return legacyCookieCandidateSnapshot{}, false, nil
+	}
+	if err != nil {
+		return legacyCookieCandidateSnapshot{}, false, fmt.Errorf("stat legacy cookie candidate %s: %w", path, err)
+	}
+
+	snapshot := legacyCookieCandidateSnapshot{path: path, mode: info.Mode()}
+	switch {
+	case info.Mode()&fs.ModeSymlink != 0:
+		target, err := os.Readlink(path)
+		if err != nil {
+			return legacyCookieCandidateSnapshot{}, false, fmt.Errorf("read legacy cookie symlink %s: %w", path, err)
+		}
+		snapshot.kind = legacyCookieCandidateSymlink
+		snapshot.linkTarget = target
+	case info.IsDir():
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return legacyCookieCandidateSnapshot{}, false, fmt.Errorf("read legacy cookie dir %s: %w", path, err)
+		}
+		if len(entries) > 0 {
+			if err := os.Remove(path); err != nil {
+				return legacyCookieCandidateSnapshot{}, false, fmt.Errorf("remove non-empty legacy cookie dir %s: %w", path, err)
+			}
+			return legacyCookieCandidateSnapshot{}, false, nil
+		}
+		snapshot.kind = legacyCookieCandidateDir
+	case info.Mode().IsRegular():
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return legacyCookieCandidateSnapshot{}, false, fmt.Errorf("read legacy cookie file %s: %w", path, err)
+		}
+		snapshot.kind = legacyCookieCandidateFile
+		snapshot.data = data
+	default:
+		return legacyCookieCandidateSnapshot{}, false, fmt.Errorf("unsupported legacy cookie candidate type %s", info.Mode().Type())
+	}
+
+	if err := os.Remove(path); err != nil {
+		return legacyCookieCandidateSnapshot{}, false, fmt.Errorf("remove legacy cookie candidate %s: %w", path, err)
+	}
+	return snapshot, true, nil
+}
+
+// restoreLegacyCookieCandidates restores removed candidates in reverse order so
+// rollback rebuilds parent paths after later candidates have been handled.
+func restoreLegacyCookieCandidates(snapshots []legacyCookieCandidateSnapshot) error {
+	var errs []error
+	for i := len(snapshots) - 1; i >= 0; i-- {
+		if err := snapshots[i].restore(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// restore recreates the recorded legacy cookie candidate at its original path.
+func (s legacyCookieCandidateSnapshot) restore() error {
+	switch s.kind {
+	case legacyCookieCandidateFile:
+		if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+			return fmt.Errorf("cookies: restore legacy cookie file dir %s: %w", s.path, err)
+		}
+		if err := os.WriteFile(s.path, s.data, s.mode.Perm()); err != nil {
+			return fmt.Errorf("cookies: restore legacy cookie file %s: %w", s.path, err)
+		}
+	case legacyCookieCandidateDir:
+		if err := os.MkdirAll(s.path, s.mode.Perm()); err != nil {
+			return fmt.Errorf("cookies: restore legacy cookie dir %s: %w", s.path, err)
+		}
+	case legacyCookieCandidateSymlink:
+		if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+			return fmt.Errorf("cookies: restore legacy cookie symlink dir %s: %w", s.path, err)
+		}
+		if err := os.Symlink(s.linkTarget, s.path); err != nil {
+			return fmt.Errorf("cookies: restore legacy cookie symlink %s: %w", s.path, err)
+		}
+	default:
+		return fmt.Errorf("cookies: restore legacy cookie candidate %s: unknown snapshot kind", s.path)
+	}
+	return nil
+}
+
+// restoreTrackerCookies replaces trackerID's database cookies with values after
+// a partial legacy-file cleanup failure.
+func restoreTrackerCookies(ctx context.Context, store *CookieStore, key []byte, trackerID string, values map[string]string) error {
+	if store == nil {
+		return errors.New("cookies: restore tracker cookies: store is required")
+	}
+	return store.RunInTransaction(ctx, func(tx *sql.Tx) error {
+		if err := store.DeleteAllTrackerCookiesTx(ctx, tx, trackerID); err != nil {
+			return err
+		}
+		for name, value := range values {
+			if err := store.SaveCookieTx(ctx, tx, trackerID, name, value, key); err != nil {
+				return fmt.Errorf("restore cookie %s: %w", name, err)
+			}
+		}
+		return nil
+	})
+}
+
+// contextWithoutCancel preserves context values for rollback work while
+// detaching cancellation and deadline state.
+func contextWithoutCancel(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return context.WithoutCancel(ctx)
+}
+
+// CookieMapToHTTPCookies converts entries with non-blank names and non-empty
+// values to HTTP cookies scoped to domain and path "/". Names and domain are
+// trimmed; values are copied unchanged.
 func CookieMapToHTTPCookies(values map[string]string, domain string) []*http.Cookie {
 	trimmedDomain := strings.TrimSpace(domain)
 	result := make([]*http.Cookie, 0, len(values))

--- a/internal/cookies/loader_test.go
+++ b/internal/cookies/loader_test.go
@@ -84,7 +84,7 @@ func initTestCookieDBSchema(t *testing.T, dbPath string) {
 	}
 }
 
-func TestLoadTrackerCookieMapStartupCookieOverridesStoredValue(t *testing.T) {
+func TestLoadTrackerCookieMapStoredValueOverridesStartupCookie(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -120,8 +120,8 @@ func TestLoadTrackerCookieMapStartupCookieOverridesStoredValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadTrackerCookieMap: %v", err)
 	}
-	if values["session"] != "from-startup" {
-		t.Fatalf("expected startup cookie to override db value, got %#v", values)
+	if values["session"] != "from-db" {
+		t.Fatalf("expected db cookie to override startup value, got %#v", values)
 	}
 	if values["persisted"] != "keep-me" {
 		t.Fatalf("expected db-only cookie to remain available, got %#v", values)
@@ -131,7 +131,26 @@ func TestLoadTrackerCookieMapStartupCookieOverridesStoredValue(t *testing.T) {
 	}
 }
 
-func TestLoadTrackerHTTPCookiesStartupCookieOverridesStoredValue(t *testing.T) {
+func TestCookieMapToHTTPCookiesPreservesCookieValueWhitespace(t *testing.T) {
+	t.Parallel()
+
+	paddedName := " session "
+	got := CookieMapToHTTPCookies(map[string]string{
+		paddedName: " padded ",
+		"empty":    "",
+	}, " .example.org ")
+	if len(got) != 1 {
+		t.Fatalf("expected one HTTP cookie, got %#v", got)
+	}
+	if got[0].Name != "session" || got[0].Value != " padded " {
+		t.Fatalf("expected cookie value whitespace to be preserved, got %#v", got[0])
+	}
+	if got[0].Domain != ".example.org" {
+		t.Fatalf("expected trimmed domain, got %#v", got[0])
+	}
+}
+
+func TestLoadTrackerHTTPCookiesStoredValueOverridesStartupCookie(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -169,8 +188,8 @@ func TestLoadTrackerHTTPCookiesStartupCookieOverridesStoredValue(t *testing.T) {
 	}
 
 	values := httpCookiesToMap(loaded)
-	if values["session"] != "from-startup" {
-		t.Fatalf("expected startup cookie to override db value, got %#v", values)
+	if values["session"] != "from-db" {
+		t.Fatalf("expected db cookie to override startup value, got %#v", values)
 	}
 	if values["persisted"] != "keep-me" {
 		t.Fatalf("expected db-only cookie to remain available, got %#v", values)
@@ -186,4 +205,240 @@ func TestLoadTrackerHTTPCookiesStartupCookieOverridesStoredValue(t *testing.T) {
 			t.Fatalf("expected domain to be applied, got cookie %#v", cookie)
 		}
 	}
+}
+
+func TestDeleteTrackerCookiesRestoresDBCookiesWhenLegacyDeleteFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := writeWebAuthFile(t, "tester", "password-hash")
+	initTestCookieDBSchema(t, dbPath)
+	if err := SaveTrackerCookieMap(ctx, dbPath, "AR", map[string]string{"session": "from-db"}); err != nil {
+		t.Fatalf("seed db cookies: %v", err)
+	}
+
+	candidates := commonhttp.CookiePathCandidates(dbPath, "AR", ".txt")
+	if len(candidates) != 1 {
+		t.Fatalf("expected one legacy cookie path, got %#v", candidates)
+	}
+	if err := os.MkdirAll(filepath.Dir(candidates[0]), 0o700); err != nil {
+		t.Fatalf("mkdir cookie dir: %v", err)
+	}
+	if err := os.Mkdir(candidates[0], 0o700); err != nil {
+		t.Fatalf("create blocking cookie dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(candidates[0], "child"), []byte("blocks remove"), 0o600); err != nil {
+		t.Fatalf("write blocking cookie child: %v", err)
+	}
+
+	err := DeleteTrackerCookies(ctx, dbPath, "AR")
+	if err == nil {
+		t.Fatal("expected legacy cookie delete failure")
+	}
+	if !strings.Contains(err.Error(), "legacy cookie file") {
+		t.Fatalf("expected legacy cookie delete error, got %v", err)
+	}
+
+	values, err := LoadTrackerCookieMap(ctx, dbPath, "AR")
+	if err != nil {
+		t.Fatalf("load restored cookies: %v", err)
+	}
+	if values["session"] != "from-db" {
+		t.Fatalf("expected DB cookie restore after legacy failure, got %#v", values)
+	}
+}
+
+func TestDeleteTrackerCookiesRestoresRemovedLegacyCandidateWhenLaterLegacyDeleteFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := writeWebAuthFile(t, "tester", "password-hash")
+	initTestCookieDBSchema(t, dbPath)
+	if err := SaveTrackerCookieMap(ctx, dbPath, "AR", map[string]string{"session": "from-db"}); err != nil {
+		t.Fatalf("seed db cookies: %v", err)
+	}
+
+	candidates := commonhttp.CookiePathCandidates(dbPath, "AR", ".txt", ".json")
+	if len(candidates) != 2 {
+		t.Fatalf("expected txt/json cookie paths, got %#v", candidates)
+	}
+	txtPath := candidates[0]
+	jsonPath := candidates[1]
+	txtContent := []byte(".alpharatio.cc\tTRUE\t/\tTRUE\t0\tlegacy\tfrom-file\n")
+	if err := os.MkdirAll(filepath.Dir(txtPath), 0o700); err != nil {
+		t.Fatalf("mkdir cookie dir: %v", err)
+	}
+	if err := os.WriteFile(txtPath, txtContent, 0o600); err != nil {
+		t.Fatalf("write txt legacy cookie: %v", err)
+	}
+	if err := os.Mkdir(jsonPath, 0o700); err != nil {
+		t.Fatalf("create blocking json cookie dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(jsonPath, "child"), []byte("blocks remove"), 0o600); err != nil {
+		t.Fatalf("write blocking json child: %v", err)
+	}
+
+	err := DeleteTrackerCookies(ctx, dbPath, "AR")
+	if err == nil {
+		t.Fatal("expected json legacy cookie delete failure")
+	}
+	if !strings.Contains(err.Error(), "legacy cookie file") {
+		t.Fatalf("expected legacy cookie delete error, got %v", err)
+	}
+
+	restoredTxt, err := os.ReadFile(txtPath)
+	if err != nil {
+		t.Fatalf("expected txt legacy cookie to be restored: %v", err)
+	}
+	if string(restoredTxt) != string(txtContent) {
+		t.Fatalf("unexpected restored txt cookie content: %q", restoredTxt)
+	}
+	if _, err := os.Stat(filepath.Join(jsonPath, "child")); err != nil {
+		t.Fatalf("expected blocking json directory to remain: %v", err)
+	}
+	values, err := LoadTrackerCookieMap(ctx, dbPath, "AR")
+	if err != nil {
+		t.Fatalf("load restored cookies: %v", err)
+	}
+	if values["session"] != "from-db" {
+		t.Fatalf("expected DB cookie restore after legacy failure, got %#v", values)
+	}
+}
+
+func TestDeleteTrackerCookiesDBDeleteErrorPreservesLegacyFiles(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := writeWebAuthFile(t, "tester", "password-hash")
+	initTestCookieDBSchema(t, dbPath)
+
+	if err := SaveTrackerCookieMap(ctx, dbPath, "BLU", map[string]string{"session": "from-db"}); err != nil {
+		t.Fatalf("seed db cookies: %v", err)
+	}
+	legacyPaths := writeLegacyCookieCandidates(t, dbPath, "BLU")
+	rejectTrackerCookieDeletes(ctx, t, dbPath)
+
+	err := DeleteTrackerCookies(ctx, dbPath, "BLU")
+	if err == nil {
+		t.Fatal("expected db delete error")
+	}
+	if !strings.Contains(err.Error(), "delete tracker BLU from db") {
+		t.Fatalf("expected wrapped db delete error, got %v", err)
+	}
+	for _, path := range legacyPaths {
+		if _, statErr := os.Stat(path); statErr != nil {
+			t.Fatalf("expected legacy file to remain after db delete failure: %v", statErr)
+		}
+	}
+}
+
+func TestDeleteTrackerCookiesSuccessRemovesLegacyCandidatesOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := writeWebAuthFile(t, "tester", "password-hash")
+	initTestCookieDBSchema(t, dbPath)
+
+	if err := SaveTrackerCookieMap(ctx, dbPath, "BLU", map[string]string{"session": "from-db"}); err != nil {
+		t.Fatalf("seed db cookies: %v", err)
+	}
+	legacyPaths := writeLegacyCookieCandidates(t, dbPath, "BLU")
+	untouchedPath := filepath.Join(filepath.Dir(legacyPaths[0]), "BLU.bak")
+	if err := os.WriteFile(untouchedPath, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write unrelated legacy file: %v", err)
+	}
+
+	if err := DeleteTrackerCookies(ctx, dbPath, "BLU"); err != nil {
+		t.Fatalf("DeleteTrackerCookies: %v", err)
+	}
+	for _, path := range legacyPaths {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected legacy candidate %s to be removed, got %v", path, err)
+		}
+	}
+	if _, err := os.Stat(untouchedPath); err != nil {
+		t.Fatalf("expected non-candidate legacy file to remain: %v", err)
+	}
+	if got := countTrackerCookies(ctx, t, dbPath, "BLU"); got != 0 {
+		t.Fatalf("expected db cookies to be removed, got %d", got)
+	}
+}
+
+func TestDeleteTrackerCookiesHelperUnavailableRemovesLegacyFiles(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.sqlite")
+	legacyPaths := writeLegacyCookieCandidates(t, dbPath, "BTN")
+
+	if err := DeleteTrackerCookies(ctx, dbPath, "BTN"); err != nil {
+		t.Fatalf("DeleteTrackerCookies: %v", err)
+	}
+	for _, path := range legacyPaths {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected legacy file %s to be removed with unavailable helper, got %v", path, err)
+		}
+	}
+}
+
+func TestDeleteTrackerCookiesMissingLegacyFilesIgnored(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.sqlite")
+
+	if err := DeleteTrackerCookies(ctx, dbPath, "BTN"); err != nil {
+		t.Fatalf("DeleteTrackerCookies: %v", err)
+	}
+}
+
+func writeLegacyCookieCandidates(t *testing.T, dbPath string, trackerID string) []string {
+	t.Helper()
+
+	candidates := commonhttp.CookiePathCandidates(dbPath, trackerID, ".txt", ".json")
+	if len(candidates) != 2 {
+		t.Fatalf("expected txt/json cookie paths, got %#v", candidates)
+	}
+	for _, candidate := range candidates {
+		if err := os.MkdirAll(filepath.Dir(candidate), 0o755); err != nil {
+			t.Fatalf("mkdir cookie dir: %v", err)
+		}
+		if err := os.WriteFile(candidate, []byte("cookie"), 0o600); err != nil {
+			t.Fatalf("write legacy cookie candidate: %v", err)
+		}
+	}
+	return candidates
+}
+
+func rejectTrackerCookieDeletes(ctx context.Context, t *testing.T, dbPath string) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(ctx, `CREATE TRIGGER reject_tracker_cookie_delete BEFORE DELETE ON tracker_cookies
+		BEGIN
+			SELECT RAISE(ABORT, 'blocked cookie delete');
+		END`); err != nil {
+		t.Fatalf("create cookie delete rejection trigger: %v", err)
+	}
+}
+
+func countTrackerCookies(ctx context.Context, t *testing.T, dbPath string, trackerID string) int {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM tracker_cookies WHERE tracker_id = ?`, trackerID).Scan(&count); err != nil {
+		t.Fatalf("count tracker cookies: %v", err)
+	}
+	return count
 }

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -4071,6 +4071,7 @@ func buildMetadataPreview(meta api.PreparedMetadata, cfg config.Config) api.Meta
 		ExternalPreview:      buildExternalPreviews(meta.ExternalIDs, meta.ExternalMetadata),
 		Bluray:               deepCopyBlurayMetadata(meta.ExternalMetadata.Bluray),
 		TrackerData:          buildTrackerPreview(meta.TrackerData, cfg),
+		TrackerRuleFailures:  deepCopyTrackerRuleFailures(meta.TrackerRuleFailures),
 	}
 }
 

--- a/internal/core/preview_test.go
+++ b/internal/core/preview_test.go
@@ -31,6 +31,9 @@ func TestBuildMetadataPreviewMapsExternalData(t *testing.T) {
 		TrackerData: []api.TrackerMetadata{
 			{Tracker: "AITHER", TMDBID: 123},
 		},
+		TrackerRuleFailures: map[string][]api.RuleFailure{
+			"NBL": {{Rule: "require_tv_only", Reason: "category movie is not tv"}},
+		},
 	}
 
 	preview := buildMetadataPreview(meta, config.Config{})
@@ -63,6 +66,13 @@ func TestBuildMetadataPreviewMapsExternalData(t *testing.T) {
 	}
 	if previewItem.PosterURL == "" || previewItem.BackdropURL == "" {
 		t.Fatalf("expected poster and backdrop URLs to be populated")
+	}
+	if got := preview.TrackerRuleFailures["NBL"]; len(got) != 1 || got[0].Rule != "require_tv_only" {
+		t.Fatalf("expected tracker rule failures in preview, got %#v", preview.TrackerRuleFailures)
+	}
+	preview.TrackerRuleFailures["NBL"][0].Rule = "mutated"
+	if meta.TrackerRuleFailures["NBL"][0].Rule != "require_tv_only" {
+		t.Fatalf("preview rule failures must not alias prepared metadata, got %#v", meta.TrackerRuleFailures)
 	}
 }
 

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -41,6 +41,8 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+var openTrackerAuthCookieDialog = runtime.OpenFileDialog
+
 const previewTimeout = 30 * time.Minute
 const bdinfoProgressEvent = "bdinfo:progress"
 const metadataProgressEvent = "metadata:progress"
@@ -61,6 +63,8 @@ type App struct {
 	uploadMu    sync.Mutex
 	uploads     map[string]*trackerUploadJob
 	uploadWG    sync.WaitGroup
+
+	sharedCookieMigrator func(context.Context, string, api.Logger) error
 }
 
 type blurayCandidateSelector interface {
@@ -1241,7 +1245,9 @@ func (a *App) GetTrackerAuthStatus(tracker string) (api.TrackerAuthStatus, error
 	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Status(context.Background(), tracker))
 }
 
-// ImportTrackerAuthCookies opens a native file picker, imports selected cookie content, and returns updated tracker auth status.
+// ImportTrackerAuthCookies opens a native file picker, reads the selected file
+// with the shared bounded reader, and returns updated tracker auth status. A
+// cancelled picker or empty selection returns the current status without error.
 func (a *App) ImportTrackerAuthCookies(tracker string) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
@@ -1250,7 +1256,7 @@ func (a *App) ImportTrackerAuthCookies(tracker string) (api.TrackerAuthStatus, e
 	if err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
-	selection, err := runtime.OpenFileDialog(ctx, runtime.OpenDialogOptions{
+	selection, err := openTrackerAuthCookieDialog(ctx, runtime.OpenDialogOptions{
 		Title: "Import tracker cookies",
 		Filters: []runtime.FileFilter{
 			{DisplayName: "Cookie files (*.txt;*.json)", Pattern: "*.txt;*.json"},
@@ -1258,56 +1264,80 @@ func (a *App) ImportTrackerAuthCookies(tracker string) (api.TrackerAuthStatus, e
 		},
 	})
 	if err != nil {
+		if isDialogCancelledErr(err) {
+			return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Status(context.Background(), tracker))
+		}
 		return api.TrackerAuthStatus{}, fmt.Errorf("gui: open tracker cookie dialog: %w", err)
 	}
 	if strings.TrimSpace(selection) == "" {
 		return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Status(context.Background(), tracker))
 	}
-	payload, err := os.ReadFile(selection)
-	if err != nil {
-		return api.TrackerAuthStatus{}, fmt.Errorf("gui: read tracker cookie file: %w", err)
-	}
-	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).ImportCookies(context.Background(), tracker, filepath.Base(selection), string(payload)))
+	return importTrackerAuthCookieFile(ctx, trackerauth.NewService(a.currentConfig()), tracker, selection)
 }
 
-// ImportTrackerAuthCookieContent imports caller-supplied cookie content for one tracker and returns updated auth status.
+// ImportTrackerAuthCookieContent imports caller-supplied cookie content for one
+// tracker using the current Wails runtime context and returns updated auth
+// status.
 func (a *App) ImportTrackerAuthCookieContent(tracker string, fileName string, content string) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
 	}
-	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).ImportCookies(context.Background(), tracker, fileName, content))
+	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).ImportCookies(a.runtimeContext(), tracker, fileName, content))
 }
 
-// TestTrackerAuth validates tracker auth remotely when supported and otherwise returns local status with an unsupported message.
+// importTrackerAuthCookieFile imports one host cookie file without reading past
+// the shared raw content limit before rejection.
+func importTrackerAuthCookieFile(ctx context.Context, service *trackerauth.Service, tracker string, path string) (api.TrackerAuthStatus, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return api.TrackerAuthStatus{}, fmt.Errorf("gui: read tracker cookie file: %w", err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	content, err := trackerauth.ReadCookieImportContent(file)
+	if err != nil {
+		return api.TrackerAuthStatus{}, fmt.Errorf("gui: read tracker cookie file: %w", err)
+	}
+	return wrapGUIResult(service.ImportCookies(ctx, tracker, filepath.Base(path), content))
+}
+
+// TestTrackerAuth validates tracker auth remotely when supported, using the
+// current Wails runtime context so cancellation can stop remote validation.
+// Unsupported trackers return local status with an unsupported message.
 func (a *App) TestTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
 	}
-	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Validate(context.Background(), tracker))
+	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Validate(a.runtimeContext(), tracker))
 }
 
-// LoginTrackerAuth attempts credential-based tracker auth and returns status for missing credentials, unsupported login, or 2FA.
+// LoginTrackerAuth attempts credential-based tracker auth with the current
+// Wails runtime context and returns status for missing credentials, unsupported
+// login, or 2FA.
 func (a *App) LoginTrackerAuth(tracker string, req api.TrackerAuthLoginRequest) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
 	}
-	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Login(context.Background(), tracker, req))
+	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Login(a.runtimeContext(), tracker, req))
 }
 
-// SubmitTrackerAuth2FA submits a manual 2FA code for an active tracker auth challenge.
+// SubmitTrackerAuth2FA submits a manual 2FA code for an active tracker auth
+// challenge using the current Wails runtime context.
 func (a *App) SubmitTrackerAuth2FA(challengeID string, code string) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
 	}
-	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Submit2FA(context.Background(), challengeID, code))
+	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Submit2FA(a.runtimeContext(), challengeID, code))
 }
 
-// DeleteTrackerAuth removes stored auth material for one tracker and returns refreshed local status.
+// DeleteTrackerAuth removes stored auth material for one tracker and returns
+// refreshed local status using the current Wails runtime context.
 func (a *App) DeleteTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
 	}
-	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Delete(context.Background(), tracker))
+	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Delete(a.runtimeContext(), tracker))
 }
 
 func (a *App) GetImageHostPolicyMetadata() (imagehostpolicy.Metadata, error) {
@@ -1319,9 +1349,9 @@ func (a *App) GetImageHostPolicyMetadata() (imagehostpolicy.Metadata, error) {
 }
 
 // SaveConfig validates encrypted GUI settings, builds the replacement runtime,
-// then syncs cookie encryption metadata and saves the non-env config. Runtime
-// build or save failures leave the persisted config and active runtime unchanged;
-// env overrides apply only to the installed runtime config.
+// migrates shared cookies, then saves the non-env config. Runtime build,
+// migration, or save failures leave the persisted config and active runtime
+// unchanged; env overrides apply only to the installed runtime config.
 func (a *App) SaveConfig(payload string) error {
 	if a == nil {
 		return errors.New("app not initialized")
@@ -1637,9 +1667,10 @@ func (a *App) CreateWebAuth(username string, password string) (WebAuthStatus, er
 }
 
 // ImportConfig opens a native file picker, imports the selected config, builds
-// the replacement runtime, then syncs cookie encryption metadata and saves the
-// non-env config. Runtime build or save failures leave the persisted config and
-// active runtime unchanged; env overrides apply only to the installed runtime.
+// the replacement runtime, migrates shared cookies, then saves the non-env
+// config. Runtime build, migration, or save failures leave the persisted config
+// and active runtime unchanged; env overrides apply only to the installed
+// runtime config.
 func (a *App) ImportConfig() (ImportResult, error) {
 	if a == nil {
 		return ImportResult{}, errors.New("app not initialized")
@@ -1704,8 +1735,8 @@ func (a *App) importConfigFromPath(ctx context.Context, path string) (ImportResu
 	return ImportResult{Message: message, Warnings: warnings}, nil
 }
 
-// saveConfigToRepository enforces the shared pre-save cookie encryption sync
-// before persisting GUI config changes through the already-open repository.
+// saveConfigToRepository persists GUI config changes through the already-open
+// repository.
 func (a *App) saveConfigToRepository(ctx context.Context, cfg *config.Config, dbPath string) error {
 	if err := configstore.SaveToRepository(ctx, cfg, a.repo, dbPath); err != nil {
 		return fmt.Errorf("gui: %w", err)
@@ -1734,9 +1765,9 @@ func validateCookieAuthMaterial(dbPath string) error {
 }
 
 // saveAndApplyConfig builds the replacement runtime before any repository
-// writes, then persists cfg and installs the runtime as one ordered transition.
-// If persistence fails, the built runtime is closed and the active runtime is
-// left untouched.
+// writes, then migrates shared cookies, persists cfg, and installs the runtime
+// as one ordered transition. If migration or persistence fails, the built
+// runtime is closed and the active runtime is left untouched.
 func (a *App) saveAndApplyConfig(ctx context.Context, storedCfg *config.Config, runtimeCfg config.Config, dbPath string) error {
 	if err := validateCookieAuthMaterial(dbPath); err != nil {
 		if !errors.Is(err, cookies.ErrAuthHelperUnavailable) {
@@ -1762,6 +1793,10 @@ func (a *App) saveAndApplyConfig(ctx context.Context, storedCfg *config.Config, 
 		}
 	}()
 
+	if err := a.ensureSharedCookieMigrationForRuntime(ctx, dbPath, rt.Logger); err != nil {
+		return fmt.Errorf("gui: cookie migration failed: %w", err)
+	}
+
 	if err := a.saveConfigToRepository(ctx, storedCfg, dbPath); err != nil {
 		return err
 	}
@@ -1778,6 +1813,46 @@ func (a *App) saveAndApplyConfig(ctx context.Context, storedCfg *config.Config, 
 	}
 
 	return nil
+}
+
+// ensureSharedCookieMigration syncs cookie encryption metadata and migrates
+// legacy cookie files against the shared repository before SkipCookieMigration
+// runtimes serve uploads. Missing auth material is retryable on a later save.
+func (a *App) ensureSharedCookieMigration(ctx context.Context, dbPath string, logger api.Logger) error {
+	if a.repo == nil {
+		return errors.New("repository not initialized")
+	}
+	if logger == nil {
+		logger = api.NopLogger{}
+	}
+	if err := cookies.SyncCookieEncryptionWithAuth(ctx, a.repo.RawDB(), dbPath); err != nil {
+		if errors.Is(err, cookies.ErrAuthHelperUnavailable) {
+			logger.Debugf("gui: cookie encryption sync skipped: web auth helper unavailable")
+		} else {
+			return fmt.Errorf("cookies encryption sync: %w", err)
+		}
+	}
+
+	cookiesDir, err := db.CookiePath(dbPath, "")
+	if err != nil {
+		logger.Debugf("gui: failed to resolve cookies directory: %v", err)
+		return nil
+	}
+	if err := cookies.EnsureCookieMigration(ctx, a.repo.RawDB(), dbPath, cookiesDir, logger); err != nil {
+		if errors.Is(err, cookies.ErrAuthHelperUnavailable) {
+			logger.Debugf("gui: cookie migration skipped: web auth helper unavailable")
+			return nil
+		}
+		return fmt.Errorf("cookies migration: %w", err)
+	}
+	return nil
+}
+
+func (a *App) ensureSharedCookieMigrationForRuntime(ctx context.Context, dbPath string, logger api.Logger) error {
+	if a.sharedCookieMigrator != nil {
+		return a.sharedCookieMigrator(ctx, dbPath, logger)
+	}
+	return a.ensureSharedCookieMigration(ctx, dbPath, logger)
 }
 
 // applyConfig builds and installs a runtime from cfg without writing cfg to the

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -1225,6 +1225,7 @@ func (a *App) ListKnownTrackers() ([]string, error) {
 	return trackers.KnownTrackers(), nil
 }
 
+// ListTrackerAuthCapabilities returns tracker auth support metadata through the Wails bridge.
 func (a *App) ListTrackerAuthCapabilities() ([]api.TrackerAuthCapability, error) {
 	if a == nil {
 		return nil, errors.New("app not initialized")
@@ -1232,6 +1233,7 @@ func (a *App) ListTrackerAuthCapabilities() ([]api.TrackerAuthCapability, error)
 	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Capabilities(context.Background()))
 }
 
+// GetTrackerAuthStatus returns the current local auth status for one tracker.
 func (a *App) GetTrackerAuthStatus(tracker string) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
@@ -1239,6 +1241,7 @@ func (a *App) GetTrackerAuthStatus(tracker string) (api.TrackerAuthStatus, error
 	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Status(context.Background(), tracker))
 }
 
+// ImportTrackerAuthCookies opens a native file picker, imports selected cookie content, and returns updated tracker auth status.
 func (a *App) ImportTrackerAuthCookies(tracker string) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
@@ -1267,6 +1270,7 @@ func (a *App) ImportTrackerAuthCookies(tracker string) (api.TrackerAuthStatus, e
 	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).ImportCookies(context.Background(), tracker, filepath.Base(selection), string(payload)))
 }
 
+// ImportTrackerAuthCookieContent imports caller-supplied cookie content for one tracker and returns updated auth status.
 func (a *App) ImportTrackerAuthCookieContent(tracker string, fileName string, content string) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
@@ -1274,6 +1278,7 @@ func (a *App) ImportTrackerAuthCookieContent(tracker string, fileName string, co
 	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).ImportCookies(context.Background(), tracker, fileName, content))
 }
 
+// TestTrackerAuth validates tracker auth remotely when supported and otherwise returns local status with an unsupported message.
 func (a *App) TestTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
@@ -1281,6 +1286,7 @@ func (a *App) TestTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
 	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Validate(context.Background(), tracker))
 }
 
+// LoginTrackerAuth attempts credential-based tracker auth and returns status for missing credentials, unsupported login, or 2FA.
 func (a *App) LoginTrackerAuth(tracker string, req api.TrackerAuthLoginRequest) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
@@ -1288,6 +1294,7 @@ func (a *App) LoginTrackerAuth(tracker string, req api.TrackerAuthLoginRequest) 
 	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Login(context.Background(), tracker, req))
 }
 
+// SubmitTrackerAuth2FA submits a manual 2FA code for an active tracker auth challenge.
 func (a *App) SubmitTrackerAuth2FA(challengeID string, code string) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
@@ -1295,6 +1302,7 @@ func (a *App) SubmitTrackerAuth2FA(challengeID string, code string) (api.Tracker
 	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Submit2FA(context.Background(), challengeID, code))
 }
 
+// DeleteTrackerAuth removes stored auth material for one tracker and returns refreshed local status.
 func (a *App) DeleteTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -36,6 +36,7 @@ import (
 	"github.com/autobrr/upbrr/internal/services/bdinfo"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/services/trackericon"
+	"github.com/autobrr/upbrr/internal/trackerauth"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -1222,6 +1223,83 @@ func (a *App) ListKnownTrackers() ([]string, error) {
 	}
 
 	return trackers.KnownTrackers(), nil
+}
+
+func (a *App) ListTrackerAuthCapabilities() ([]api.TrackerAuthCapability, error) {
+	if a == nil {
+		return nil, errors.New("app not initialized")
+	}
+	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Capabilities(context.Background()))
+}
+
+func (a *App) GetTrackerAuthStatus(tracker string) (api.TrackerAuthStatus, error) {
+	if a == nil {
+		return api.TrackerAuthStatus{}, errors.New("app not initialized")
+	}
+	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Status(context.Background(), tracker))
+}
+
+func (a *App) ImportTrackerAuthCookies(tracker string) (api.TrackerAuthStatus, error) {
+	if a == nil {
+		return api.TrackerAuthStatus{}, errors.New("app not initialized")
+	}
+	ctx, err := a.readyRuntimeContext()
+	if err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+	selection, err := runtime.OpenFileDialog(ctx, runtime.OpenDialogOptions{
+		Title: "Import tracker cookies",
+		Filters: []runtime.FileFilter{
+			{DisplayName: "Cookie files (*.txt;*.json)", Pattern: "*.txt;*.json"},
+			{DisplayName: "All files", Pattern: "*.*"},
+		},
+	})
+	if err != nil {
+		return api.TrackerAuthStatus{}, fmt.Errorf("gui: open tracker cookie dialog: %w", err)
+	}
+	if strings.TrimSpace(selection) == "" {
+		return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Status(context.Background(), tracker))
+	}
+	payload, err := os.ReadFile(selection)
+	if err != nil {
+		return api.TrackerAuthStatus{}, fmt.Errorf("gui: read tracker cookie file: %w", err)
+	}
+	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).ImportCookies(context.Background(), tracker, filepath.Base(selection), string(payload)))
+}
+
+func (a *App) ImportTrackerAuthCookieContent(tracker string, fileName string, content string) (api.TrackerAuthStatus, error) {
+	if a == nil {
+		return api.TrackerAuthStatus{}, errors.New("app not initialized")
+	}
+	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).ImportCookies(context.Background(), tracker, fileName, content))
+}
+
+func (a *App) TestTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
+	if a == nil {
+		return api.TrackerAuthStatus{}, errors.New("app not initialized")
+	}
+	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Validate(context.Background(), tracker))
+}
+
+func (a *App) LoginTrackerAuth(tracker string, req api.TrackerAuthLoginRequest) (api.TrackerAuthStatus, error) {
+	if a == nil {
+		return api.TrackerAuthStatus{}, errors.New("app not initialized")
+	}
+	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Login(context.Background(), tracker, req))
+}
+
+func (a *App) SubmitTrackerAuth2FA(challengeID string, code string) (api.TrackerAuthStatus, error) {
+	if a == nil {
+		return api.TrackerAuthStatus{}, errors.New("app not initialized")
+	}
+	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Submit2FA(context.Background(), challengeID, code))
+}
+
+func (a *App) DeleteTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
+	if a == nil {
+		return api.TrackerAuthStatus{}, errors.New("app not initialized")
+	}
+	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Delete(context.Background(), tracker))
 }
 
 func (a *App) GetImageHostPolicyMetadata() (imagehostpolicy.Metadata, error) {

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -1234,7 +1234,7 @@ func (a *App) ListTrackerAuthCapabilities() ([]api.TrackerAuthCapability, error)
 	if a == nil {
 		return nil, errors.New("app not initialized")
 	}
-	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Capabilities(context.Background()))
+	return wrapGUIResult(trackerauth.NewServiceWithLogger(a.currentConfig(), a.currentLogger()).Capabilities(context.Background()))
 }
 
 // GetTrackerAuthStatus returns the current local auth status for one tracker.
@@ -1242,7 +1242,7 @@ func (a *App) GetTrackerAuthStatus(tracker string) (api.TrackerAuthStatus, error
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
 	}
-	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Status(context.Background(), tracker))
+	return wrapGUIResult(trackerauth.NewServiceWithLogger(a.currentConfig(), a.currentLogger()).Status(context.Background(), tracker))
 }
 
 // ImportTrackerAuthCookies opens a native file picker, reads the selected file
@@ -1265,14 +1265,14 @@ func (a *App) ImportTrackerAuthCookies(tracker string) (api.TrackerAuthStatus, e
 	})
 	if err != nil {
 		if isDialogCancelledErr(err) {
-			return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Status(context.Background(), tracker))
+			return wrapGUIResult(trackerauth.NewServiceWithLogger(a.currentConfig(), a.currentLogger()).Status(context.Background(), tracker))
 		}
 		return api.TrackerAuthStatus{}, fmt.Errorf("gui: open tracker cookie dialog: %w", err)
 	}
 	if strings.TrimSpace(selection) == "" {
-		return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Status(context.Background(), tracker))
+		return wrapGUIResult(trackerauth.NewServiceWithLogger(a.currentConfig(), a.currentLogger()).Status(context.Background(), tracker))
 	}
-	return importTrackerAuthCookieFile(ctx, trackerauth.NewService(a.currentConfig()), tracker, selection)
+	return importTrackerAuthCookieFile(ctx, trackerauth.NewServiceWithLogger(a.currentConfig(), a.currentLogger()), tracker, selection)
 }
 
 // ImportTrackerAuthCookieContent imports caller-supplied cookie content for one
@@ -1282,7 +1282,7 @@ func (a *App) ImportTrackerAuthCookieContent(tracker string, fileName string, co
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
 	}
-	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).ImportCookies(a.runtimeContext(), tracker, fileName, content))
+	return wrapGUIResult(trackerauth.NewServiceWithLogger(a.currentConfig(), a.currentLogger()).ImportCookies(a.runtimeContext(), tracker, fileName, content))
 }
 
 // importTrackerAuthCookieFile imports one host cookie file without reading past
@@ -1309,7 +1309,7 @@ func (a *App) TestTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
 	}
-	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Validate(a.runtimeContext(), tracker))
+	return wrapGUIResult(trackerauth.NewServiceWithLogger(a.currentConfig(), a.currentLogger()).Validate(a.runtimeContext(), tracker))
 }
 
 // LoginTrackerAuth attempts credential-based tracker auth with the current
@@ -1319,7 +1319,7 @@ func (a *App) LoginTrackerAuth(tracker string, req api.TrackerAuthLoginRequest) 
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
 	}
-	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Login(a.runtimeContext(), tracker, req))
+	return wrapGUIResult(trackerauth.NewServiceWithLogger(a.currentConfig(), a.currentLogger()).Login(a.runtimeContext(), tracker, req))
 }
 
 // SubmitTrackerAuth2FA submits a manual 2FA code for an active tracker auth
@@ -1328,7 +1328,7 @@ func (a *App) SubmitTrackerAuth2FA(challengeID string, code string) (api.Tracker
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
 	}
-	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Submit2FA(a.runtimeContext(), challengeID, code))
+	return wrapGUIResult(trackerauth.NewServiceWithLogger(a.currentConfig(), a.currentLogger()).Submit2FA(a.runtimeContext(), challengeID, code))
 }
 
 // DeleteTrackerAuth removes stored auth material for one tracker and returns
@@ -1337,7 +1337,7 @@ func (a *App) DeleteTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
 	if a == nil {
 		return api.TrackerAuthStatus{}, errors.New("app not initialized")
 	}
-	return wrapGUIResult(trackerauth.NewService(a.currentConfig()).Delete(a.runtimeContext(), tracker))
+	return wrapGUIResult(trackerauth.NewServiceWithLogger(a.currentConfig(), a.currentLogger()).Delete(a.runtimeContext(), tracker))
 }
 
 func (a *App) GetImageHostPolicyMetadata() (imagehostpolicy.Metadata, error) {

--- a/internal/guiapp/app_core_test.go
+++ b/internal/guiapp/app_core_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/autobrr/upbrr/internal/authmaterial"
 	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/cookies"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
@@ -726,6 +727,74 @@ func TestImportConfigMalformedWebAuthFailsBeforeConfigSave(t *testing.T) {
 	}
 }
 
+func TestSaveConfigHardCookieMigrationErrorDoesNotSaveOrInstallRuntime(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-save-cookie-migration-hard-error.db")
+	initial := guiConfigTestConfig(repoPath)
+	if err := config.SaveToDatabase(context.Background(), &initial, repo); err != nil {
+		t.Fatalf("save initial config: %v", err)
+	}
+	app := &App{
+		cfg:  initial,
+		repo: repo,
+		sharedCookieMigrator: func(context.Context, string, api.Logger) error {
+			return errors.New("forced migration failure")
+		},
+	}
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+
+	err = app.SaveConfig(payload)
+	if err == nil {
+		t.Fatal("expected hard cookie migration error")
+	}
+	if !strings.Contains(err.Error(), "forced migration failure") {
+		t.Fatalf("expected forced migration failure, got %v", err)
+	}
+	assertGUIStoredAndRuntimeConfigUnchanged(t, app, repo, initial, nil)
+}
+
+func TestSaveConfigMigratesLegacyCookies(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-save-legacy-cookies.db")
+	if err := authmaterial.BootstrapAuthFile(repoPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	legacyPath := writeGUILegacyCookieFile(t, repoPath, "BLU", `{"session":"from-legacy"}`)
+	initial := guiConfigTestConfig(repoPath)
+	app := &App{
+		cfg:  initial,
+		repo: repo,
+	}
+
+	updated := initial
+	updated.Metadata.SkipAutoTorrent = true
+	payload, err := config.ExportToJSON(&updated)
+	if err != nil {
+		t.Fatalf("export config: %v", err)
+	}
+	if err := app.SaveConfig(payload); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	if _, err := os.Stat(legacyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected legacy cookie file to be removed after migration, err=%v", err)
+	}
+	values, err := cookies.LoadTrackerCookieMap(context.Background(), repoPath, "BLU")
+	if err != nil {
+		t.Fatalf("LoadTrackerCookieMap: %v", err)
+	}
+	if got := values["session"]; got != "from-legacy" {
+		t.Fatalf("migrated session cookie: got %q want %q", got, "from-legacy")
+	}
+}
+
 func TestImportConfigBuildRuntimeFailureLeavesDatabaseAndRuntimeUnchanged(t *testing.T) {
 	t.Parallel()
 
@@ -757,6 +826,41 @@ func TestImportConfigBuildRuntimeFailureLeavesDatabaseAndRuntimeUnchanged(t *tes
 	assertGUIStoredAndRuntimeConfigUnchanged(t, app, repo, initial, previousCore)
 }
 
+func TestImportConfigHardCookieMigrationErrorDoesNotSaveOrInstallRuntime(t *testing.T) {
+	t.Parallel()
+
+	repo, repoPath := openGUIConfigTestRepo(t, "gui-import-cookie-migration-hard-error.db")
+	initial := guiConfigTestConfig(repoPath)
+	if err := config.SaveToDatabase(context.Background(), &initial, repo); err != nil {
+		t.Fatalf("save initial config: %v", err)
+	}
+	previousCore := &closeCounterCore{}
+	app := &App{
+		cfg:  initial,
+		core: previousCore,
+		repo: repo,
+		sharedCookieMigrator: func(context.Context, string, api.Logger) error {
+			return errors.New("forced migration failure")
+		},
+	}
+
+	imported := initial
+	imported.Metadata.SkipAutoTorrent = true
+	path := exportGUIConfigYAML(t, &imported)
+
+	result, err := app.importConfigFromPath(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected hard cookie migration error")
+	}
+	if !strings.Contains(err.Error(), "forced migration failure") {
+		t.Fatalf("expected forced migration failure, got %v", err)
+	}
+	if result.Message != "" || len(result.Warnings) != 0 {
+		t.Fatalf("expected empty import result on failed apply, got %#v", result)
+	}
+	assertGUIStoredAndRuntimeConfigUnchanged(t, app, repo, initial, previousCore)
+}
+
 func TestSaveConfigSyncsUsableWebAuthBeforeSave(t *testing.T) {
 	t.Parallel()
 
@@ -784,7 +888,7 @@ func TestSaveConfigSyncsUsableWebAuthBeforeSave(t *testing.T) {
 	assertGUICookieAuthStatePresent(t, repo)
 }
 
-func TestSaveConfigCookieSyncRollsBackWhenConfigSaveFails(t *testing.T) {
+func TestSaveConfigLeavesConfigUnchangedWhenRepositorySaveFailsAfterCookieSync(t *testing.T) {
 	t.Parallel()
 
 	repo, repoPath := openGUIConfigTestRepo(t, "gui-save-cookie-rollback.db")
@@ -810,7 +914,8 @@ func TestSaveConfigCookieSyncRollsBackWhenConfigSaveFails(t *testing.T) {
 		t.Fatal("expected save config to fail")
 	}
 
-	assertGUIFailedConfigSaveRowsAbsent(t, repo)
+	assertGUIConfigRowsAbsent(t, repo)
+	assertGUICookieAuthStatePresent(t, repo)
 	if got := app.currentConfig().Metadata.SkipAutoTorrent; got {
 		t.Fatal("expected runtime config not to be applied after failed config save")
 	}
@@ -1052,6 +1157,22 @@ func exportGUIConfigYAML(t *testing.T, cfg *config.Config) string {
 	return path
 }
 
+func writeGUILegacyCookieFile(t *testing.T, repoPath, trackerID, payload string) string {
+	t.Helper()
+
+	path, err := db.CookiePath(repoPath, trackerID+".json")
+	if err != nil {
+		t.Fatalf("resolve legacy cookie path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir legacy cookie dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write legacy cookie file: %v", err)
+	}
+	return path
+}
+
 func writeGUIAuthFile(t *testing.T, dbPath string, allowUnencryptedExport bool) {
 	t.Helper()
 
@@ -1083,6 +1204,19 @@ func assertGUIFailedConfigSaveRowsAbsent(t *testing.T, repo *db.SQLiteRepository
 		if !errors.Is(err, sql.ErrNoRows) {
 			t.Fatalf("expected %s to be absent after failed sync, got row=%q err=%v", section, data, err)
 		}
+	}
+}
+
+func assertGUIConfigRowsAbsent(t *testing.T, repo *db.SQLiteRepository) {
+	t.Helper()
+
+	var data string
+	err := repo.RawDB().QueryRowContext(context.Background(),
+		`SELECT data FROM config_settings WHERE section = ?`,
+		"MainSettings",
+	).Scan(&data)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected MainSettings to be absent after failed save, got row=%q err=%v", data, err)
 	}
 }
 

--- a/internal/guiapp/tracker_auth_import_test.go
+++ b/internal/guiapp/tracker_auth_import_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package guiapp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+
+	"github.com/autobrr/upbrr/internal/authmaterial"
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/cookies"
+	servicedb "github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/internal/trackerauth"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestAppImportTrackerAuthCookieContentRejectsOverCap(t *testing.T) {
+	t.Parallel()
+
+	_, err := (&App{}).ImportTrackerAuthCookieContent(
+		"AR",
+		"cookies.txt",
+		strings.Repeat("x", trackerauth.MaxCookieImportContentBytes+1),
+	)
+	if err == nil {
+		t.Fatal("expected over-cap import error")
+	}
+	if !strings.Contains(err.Error(), "cookie file content exceeds") {
+		t.Fatalf("expected shared content cap error, got %v", err)
+	}
+}
+
+func TestImportTrackerAuthCookieFileRejectsOverCap(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "cookies.txt")
+	if err := os.WriteFile(path, []byte(strings.Repeat("x", trackerauth.MaxCookieImportContentBytes+1)), 0o600); err != nil {
+		t.Fatalf("write oversized cookie file: %v", err)
+	}
+
+	_, err := importTrackerAuthCookieFile(context.Background(), trackerauth.NewService(config.Config{}), "AR", path)
+	if err == nil {
+		t.Fatal("expected over-cap import error")
+	}
+	if !strings.Contains(err.Error(), "cookie file content exceeds") {
+		t.Fatalf("expected shared content cap error, got %v", err)
+	}
+}
+
+func TestImportTrackerAuthCookieFileImportsValidFile(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newGUITrackerAuthTestDB(t)
+	path := filepath.Join(t.TempDir(), "cookies.txt")
+	if err := os.WriteFile(path, []byte(".example.test\tTRUE\t/\tTRUE\t0\tsession\tabc\n"), 0o600); err != nil {
+		t.Fatalf("write cookie file: %v", err)
+	}
+	service := trackerauth.NewService(config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}})
+
+	status, err := importTrackerAuthCookieFile(context.Background(), service, "AR", path)
+	if err != nil {
+		t.Fatalf("importTrackerAuthCookieFile: %v", err)
+	}
+	if status.CookieCount != 1 {
+		t.Fatalf("expected imported cookie count, got %#v", status)
+	}
+}
+
+func TestAppImportTrackerAuthCookiesTreatsDialogCancelAsNoop(t *testing.T) {
+	oldOpen := openTrackerAuthCookieDialog
+	t.Cleanup(func() { openTrackerAuthCookieDialog = oldOpen })
+	openTrackerAuthCookieDialog = func(context.Context, runtime.OpenDialogOptions) (string, error) {
+		return "", errors.New("shellItem is nil")
+	}
+	app := &App{runtimeCtx: newAppRuntimeContext(context.Background())}
+
+	status, err := app.ImportTrackerAuthCookies("AR")
+	if err != nil {
+		t.Fatalf("ImportTrackerAuthCookies: %v", err)
+	}
+	if status.TrackerID != "AR" {
+		t.Fatalf("expected current AR status on cancel, got %#v", status)
+	}
+}
+
+func TestAppImportTrackerAuthCookiesPreservesRealDialogError(t *testing.T) {
+	oldOpen := openTrackerAuthCookieDialog
+	t.Cleanup(func() { openTrackerAuthCookieDialog = oldOpen })
+	openTrackerAuthCookieDialog = func(context.Context, runtime.OpenDialogOptions) (string, error) {
+		return "", errors.New("dialog failed")
+	}
+	app := &App{runtimeCtx: newAppRuntimeContext(context.Background())}
+
+	_, err := app.ImportTrackerAuthCookies("AR")
+	if err == nil {
+		t.Fatal("expected dialog error")
+	}
+	if !strings.Contains(err.Error(), "open tracker cookie dialog") {
+		t.Fatalf("expected wrapped dialog error, got %v", err)
+	}
+}
+
+func TestAppImportTrackerAuthCookieContentCanceledContextDoesNotPersistCookies(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newGUITrackerAuthTestDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	app := &App{
+		runtimeCtx: newAppRuntimeContext(ctx),
+		cfg:        config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}},
+	}
+
+	_, err := app.ImportTrackerAuthCookieContent("AR", "cookies.txt", ".example.test\tTRUE\t/\tTRUE\t0\tsession\tabc\n")
+	if err == nil {
+		t.Fatal("expected canceled import error")
+	}
+	if _, loadErr := cookies.LoadTrackerCookieMap(context.Background(), dbPath, "AR"); loadErr == nil {
+		t.Fatal("canceled import persisted cookies")
+	}
+}
+
+func TestAppTestTrackerAuthUsesRuntimeContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	app := &App{
+		runtimeCtx: newAppRuntimeContext(ctx),
+		cfg: config.Config{
+			Trackers: config.TrackersConfig{
+				Trackers: map[string]config.TrackerConfig{
+					"MTV": {
+						URL:      "http://127.0.0.1:1",
+						Username: "user",
+						Password: "pass",
+					},
+				},
+			},
+		},
+	}
+
+	status, err := app.TestTrackerAuth("MTV")
+	if err != nil {
+		t.Fatalf("TestTrackerAuth: %v", err)
+	}
+	if !strings.Contains(status.LastError, "context canceled") {
+		t.Fatalf("expected context canceled status, got %#v", status)
+	}
+}
+
+func newGUITrackerAuthTestDB(t *testing.T) string {
+	t.Helper()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	repo, err := servicedb.OpenWithLoggerContext(ctx, dbPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("OpenWithLoggerContext: %v", err)
+	}
+	if err := repo.MigrateContext(ctx); err != nil {
+		_ = repo.Close()
+		t.Fatalf("MigrateContext: %v", err)
+	}
+	_ = repo.Close()
+	return dbPath
+}

--- a/internal/services/db/migrations.go
+++ b/internal/services/db/migrations.go
@@ -55,6 +55,7 @@ var migrationRegistry = []migrationStep{
 	{id: "2026_04_add_tracker_cookies", dependsOn: []string{"2026_04_normalize_description_overrides"}, apply: migrateAddTrackerCookies},
 	{id: "2026_04_add_release_category", dependsOn: []string{"2026_04_add_tracker_cookies"}, apply: migrateAddReleaseCategory},
 	{id: "2026_05_add_bluray_external_metadata", dependsOn: []string{"2026_04_add_release_category"}, apply: migrateAddBlurayExternalMetadata},
+	{id: "2026_06_add_tracker_auth_state", dependsOn: []string{"2026_05_add_bluray_external_metadata"}, apply: migrateAddTrackerAuthState},
 }
 
 var legacyVersionToMigrationIDs = map[int][]string{
@@ -329,6 +330,33 @@ func migrateAddBlurayExternalMetadata(ctx context.Context, exec migrationExecuto
 	if _, err := exec.ExecContext(ctx, `ALTER TABLE external_metadata ADD COLUMN bluray_json TEXT NOT NULL DEFAULT ""`); err != nil {
 		return fmt.Errorf("db: %w", err)
 	}
+	return nil
+}
+
+func migrateAddTrackerAuthState(ctx context.Context, exec migrationExecutor) error {
+	statements := []string{
+		`
+		CREATE TABLE IF NOT EXISTS tracker_auth_state (
+			tracker_id TEXT NOT NULL,
+			state_key TEXT NOT NULL,
+			encrypted_value TEXT NOT NULL,
+			nonce TEXT NOT NULL,
+			auth_tag TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY (tracker_id, state_key)
+		)
+		`,
+		`CREATE INDEX IF NOT EXISTS idx_tracker_auth_state_tracker_id ON tracker_auth_state (tracker_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_tracker_auth_state_updated_at ON tracker_auth_state (updated_at)`,
+	}
+
+	for _, statement := range statements {
+		if _, err := exec.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("db: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/services/db/migrations_test.go
+++ b/internal/services/db/migrations_test.go
@@ -57,6 +57,9 @@ func TestMigrateCreatesTrackerCookiesSchema(t *testing.T) {
 	if !slices.Contains(ids, "2026_04_add_tracker_cookies") {
 		t.Fatalf("expected tracker cookies migration id to be recorded, got %v", ids)
 	}
+	if !slices.Contains(ids, "2026_06_add_tracker_auth_state") {
+		t.Fatalf("expected tracker auth state migration id to be recorded, got %v", ids)
+	}
 
 	objects := []struct {
 		typ  string
@@ -65,6 +68,9 @@ func TestMigrateCreatesTrackerCookiesSchema(t *testing.T) {
 		{typ: "table", name: "tracker_cookies"},
 		{typ: "index", name: "idx_tracker_cookies_tracker_id"},
 		{typ: "index", name: "idx_tracker_cookies_created_at"},
+		{typ: "table", name: "tracker_auth_state"},
+		{typ: "index", name: "idx_tracker_auth_state_tracker_id"},
+		{typ: "index", name: "idx_tracker_auth_state_updated_at"},
 	}
 
 	for _, item := range objects {

--- a/internal/trackerauth/adapters.go
+++ b/internal/trackerauth/adapters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/trackers/impl/mtv"
 	"github.com/autobrr/upbrr/internal/trackers/impl/ptp"
+	"github.com/autobrr/upbrr/internal/trackers/impl/rtf"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -28,13 +29,30 @@ func defaultAdapters() map[string]Adapter {
 	adapters := map[string]Adapter{}
 	for _, spec := range builtInSpecs() {
 		switch spec.id {
+		case "AR":
+			adapters[spec.id] = trackerAdapter{capability: validationOnlyCapability(spec), resolve: resolveARStoredSessionForTrackerAuth}
+		case "HDB":
+			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: resolveHDBStoredSessionForTrackerAuth}
 		case "MTV":
 			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: mtv.ResolveSessionForTrackerAuthLogin}
 		case "PTP":
 			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: ptp.ResolveSessionForTrackerAuthLogin}
+		case "RTF":
+			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: rtf.ResolveSessionForTrackerAuthLogin}
 		}
 	}
 	return adapters
+}
+
+// validationOnlyCapability keeps cookie import visible while hiding credential
+// login actions for adapters that can only test existing auth material.
+func validationOnlyCapability(spec trackerSpec) api.TrackerAuthCapability {
+	capability := capabilityFromSpec(spec)
+	capability.SupportsLogin = false
+	capability.SupportsAutoLogin = false
+	capability.SupportsTOTP = false
+	capability.SupportsManual2FA = false
+	return capability
 }
 
 func (s *Service) adapterFor(trackerID string) (Adapter, bool) {
@@ -106,6 +124,18 @@ func (a trackerAdapter) Delete(ctx context.Context, dbPath string) error {
 func classifyAdapterError(trackerID string, err error) error {
 	if err == nil {
 		return nil
+	}
+	var authRequired *AuthRequiredError
+	if errors.As(err, &authRequired) {
+		return authRequired
+	}
+	var needs2FA *Needs2FAError
+	if errors.As(err, &needs2FA) {
+		return needs2FA
+	}
+	var unsupported *UnsupportedAuthError
+	if errors.As(err, &unsupported) {
+		return unsupported
 	}
 	if validation, ok := asValidationError(err); ok {
 		return validation

--- a/internal/trackerauth/adapters.go
+++ b/internal/trackerauth/adapters.go
@@ -94,9 +94,18 @@ func (a trackerAdapter) Delete(ctx context.Context, dbPath string) error {
 	return nil
 }
 
+// classifyAdapterError maps tracker adapter failures to typed auth errors used
+// by EnsureSession. Parser/layout failures remain transient unless the message
+// proves stored credentials are invalid.
 func classifyAdapterError(trackerID string, err error) error {
 	if err == nil {
 		return nil
+	}
+	if validation, ok := asValidationError(err); ok {
+		return validation
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return &ValidationError{TrackerID: trackerID, Transient: true, Reason: "remote validation unavailable", Err: err}
 	}
 	lower := strings.ToLower(err.Error())
 	switch {
@@ -104,10 +113,6 @@ func classifyAdapterError(trackerID string, err error) error {
 		return &Needs2FAError{TrackerID: trackerID, Reason: "2FA required", Err: err}
 	case strings.Contains(lower, "username") || strings.Contains(lower, "password") || strings.Contains(lower, "announce_url") || strings.Contains(lower, "not configured"):
 		return &AuthRequiredError{TrackerID: trackerID, Reason: "credentials missing", Err: err}
-	case strings.Contains(lower, "auth key not found") || strings.Contains(lower, "anti csrf token not found") || strings.Contains(lower, "cookie invalid") || strings.Contains(lower, "no cookies found"):
-		return &ValidationError{TrackerID: trackerID, ConfirmedInvalid: true, Reason: "stored session invalid", Err: err}
-	case errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled):
-		return &ValidationError{TrackerID: trackerID, Transient: true, Reason: "remote validation unavailable", Err: err}
 	default:
 		return &ValidationError{TrackerID: trackerID, Transient: true, Reason: "remote validation failed", Err: err}
 	}

--- a/internal/trackerauth/adapters.go
+++ b/internal/trackerauth/adapters.go
@@ -17,7 +17,7 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-type sessionResolver func(context.Context, config.TrackerConfig, string) error
+type sessionResolver func(context.Context, config.TrackerConfig, string, api.TrackerAuthLoginRequest) error
 
 type trackerAdapter struct {
 	capability api.TrackerAuthCapability
@@ -29,9 +29,9 @@ func defaultAdapters() map[string]Adapter {
 	for _, spec := range builtInSpecs() {
 		switch spec.id {
 		case "MTV":
-			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: mtv.ResolveSessionForTrackerAuth}
+			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: mtv.ResolveSessionForTrackerAuthLogin}
 		case "PTP":
-			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: ptp.ResolveSessionForTrackerAuth}
+			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: ptp.ResolveSessionForTrackerAuthLogin}
 		}
 	}
 	return adapters
@@ -73,18 +73,24 @@ func (a trackerAdapter) Validate(ctx context.Context, cfg config.TrackerConfig, 
 	if a.resolve == nil {
 		return Session{}, &UnsupportedAuthError{TrackerID: a.capability.TrackerID, Reason: "remote validation unavailable"}
 	}
-	if err := a.resolve(ctx, cfg, dbPath); err != nil {
+	if err := a.resolve(ctx, cfg, dbPath, api.TrackerAuthLoginRequest{}); err != nil {
 		return Session{}, classifyAdapterError(a.capability.TrackerID, err)
 	}
 	return Session{TrackerID: normalizeTrackerID(a.capability.TrackerID), State: SessionStateReady, Message: "session ready"}, nil
 }
 
-func (a trackerAdapter) Login(ctx context.Context, cfg config.TrackerConfig, dbPath string, _ api.TrackerAuthLoginRequest) (Session, error) {
-	return a.Validate(ctx, cfg, dbPath)
+func (a trackerAdapter) Login(ctx context.Context, cfg config.TrackerConfig, dbPath string, req api.TrackerAuthLoginRequest) (Session, error) {
+	if a.resolve == nil {
+		return Session{}, &UnsupportedAuthError{TrackerID: a.capability.TrackerID, Reason: "remote login unavailable"}
+	}
+	if err := a.resolve(ctx, cfg, dbPath, req); err != nil {
+		return Session{}, classifyAdapterError(a.capability.TrackerID, err)
+	}
+	return Session{TrackerID: normalizeTrackerID(a.capability.TrackerID), State: SessionStateReady, Message: "session ready"}, nil
 }
 
-func (a trackerAdapter) Submit2FA(_ context.Context, _ string, _ string) (Session, error) {
-	return Session{}, &UnsupportedAuthError{TrackerID: a.capability.TrackerID, Reason: "manual 2FA continuation unavailable"}
+func (a trackerAdapter) Submit2FA(ctx context.Context, cfg config.TrackerConfig, dbPath string, req api.TrackerAuthLoginRequest) (Session, error) {
+	return a.Login(ctx, cfg, dbPath, req)
 }
 
 func (a trackerAdapter) Delete(ctx context.Context, dbPath string) error {
@@ -95,8 +101,8 @@ func (a trackerAdapter) Delete(ctx context.Context, dbPath string) error {
 }
 
 // classifyAdapterError maps tracker adapter failures to typed auth errors used
-// by EnsureSession. Parser/layout failures remain transient unless the message
-// proves stored credentials are invalid.
+// by EnsureSession. Only explicit 2FA-required failures become manual
+// challenges; parser/layout failures and other remote failures remain transient.
 func classifyAdapterError(trackerID string, err error) error {
 	if err == nil {
 		return nil
@@ -104,16 +110,51 @@ func classifyAdapterError(trackerID string, err error) error {
 	if validation, ok := asValidationError(err); ok {
 		return validation
 	}
+	if isSubmitted2FARejected(err) {
+		return &ValidationError{TrackerID: trackerID, Transient: true, Submitted2FARejected: true, Reason: "submitted 2FA rejected", Err: err}
+	}
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return &ValidationError{TrackerID: trackerID, Transient: true, Reason: "remote validation unavailable", Err: err}
 	}
 	lower := strings.ToLower(err.Error())
 	switch {
-	case strings.Contains(lower, "2fa") || strings.Contains(lower, "tfa") || strings.Contains(lower, "otp_uri"):
+	case contains2FARequiredText(lower):
 		return &Needs2FAError{TrackerID: trackerID, Reason: "2FA required", Err: err}
 	case strings.Contains(lower, "username") || strings.Contains(lower, "password") || strings.Contains(lower, "announce_url") || strings.Contains(lower, "not configured"):
 		return &AuthRequiredError{TrackerID: trackerID, Reason: "credentials missing", Err: err}
 	default:
 		return &ValidationError{TrackerID: trackerID, Transient: true, Reason: "remote validation failed", Err: err}
 	}
+}
+
+func isSubmitted2FARejected(err error) bool {
+	return errors.Is(err, ptp.ErrSubmitted2FARejected) || errors.Is(err, mtv.ErrSubmitted2FARejected)
+}
+
+// contains2FARequiredText matches only the standalone "2FA required" phrase so
+// parser details such as token names or setup URLs do not create manual 2FA
+// challenges.
+func contains2FARequiredText(lower string) bool {
+	const phrase = "2fa required"
+	for offset := 0; offset < len(lower); {
+		idx := strings.Index(lower[offset:], phrase)
+		if idx < 0 {
+			return false
+		}
+		start := offset + idx
+		end := start + len(phrase)
+		if isClassifierBoundary(lower, start-1) && isClassifierBoundary(lower, end) {
+			return true
+		}
+		offset = start + 1
+	}
+	return false
+}
+
+func isClassifierBoundary(s string, idx int) bool {
+	if idx < 0 || idx >= len(s) {
+		return true
+	}
+	c := s[idx]
+	return (c < 'a' || c > 'z') && (c < '0' || c > '9')
 }

--- a/internal/trackerauth/adapters.go
+++ b/internal/trackerauth/adapters.go
@@ -31,6 +31,10 @@ func defaultAdapters() map[string]Adapter {
 		switch spec.id {
 		case "AR":
 			adapters[spec.id] = trackerAdapter{capability: validationOnlyCapability(spec), resolve: resolveARStoredSessionForTrackerAuth}
+		case "FF":
+			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: resolveFFSessionForTrackerAuth}
+		case "FL":
+			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: resolveFLSessionForTrackerAuth}
 		case "HDB":
 			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: resolveHDBStoredSessionForTrackerAuth}
 		case "MTV":
@@ -39,6 +43,8 @@ func defaultAdapters() map[string]Adapter {
 			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: ptp.ResolveSessionForTrackerAuthLogin}
 		case "RTF":
 			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: rtf.ResolveSessionForTrackerAuthLogin}
+		case "THR":
+			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: resolveTHRSessionForTrackerAuth}
 		}
 	}
 	return adapters

--- a/internal/trackerauth/adapters.go
+++ b/internal/trackerauth/adapters.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackerauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/cookies"
+	"github.com/autobrr/upbrr/internal/trackers/impl/mtv"
+	"github.com/autobrr/upbrr/internal/trackers/impl/ptp"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+type sessionResolver func(context.Context, config.TrackerConfig, string) error
+
+type trackerAdapter struct {
+	capability api.TrackerAuthCapability
+	resolve    sessionResolver
+}
+
+func defaultAdapters() map[string]Adapter {
+	adapters := map[string]Adapter{}
+	for _, spec := range builtInSpecs() {
+		switch spec.id {
+		case "MTV":
+			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: mtv.ResolveSessionForTrackerAuth}
+		case "PTP":
+			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: ptp.ResolveSessionForTrackerAuth}
+		}
+	}
+	return adapters
+}
+
+func (s *Service) adapterFor(trackerID string) (Adapter, bool) {
+	if s.adapters == nil {
+		s.adapters = defaultAdapters()
+	}
+	adapter, ok := s.adapters[normalizeTrackerID(trackerID)]
+	return adapter, ok
+}
+
+func (a trackerAdapter) Capability() api.TrackerAuthCapability {
+	return a.capability
+}
+
+func (a trackerAdapter) Status(ctx context.Context, cfg config.TrackerConfig, dbPath string) (api.TrackerAuthStatus, error) {
+	_ = cfg
+	trackerID := normalizeTrackerID(a.capability.TrackerID)
+	status := api.TrackerAuthStatus{
+		TrackerID:        trackerID,
+		DisplayName:      trackerID,
+		State:            StateNotConfigured,
+		LastCheckedAt:    time.Now().UTC().Format(time.RFC3339),
+		EncryptedStorage: strings.TrimSpace(dbPath) != "",
+	}
+	if a.capability.SupportsCookieFile {
+		values, err := cookies.LoadTrackerCookieMap(ctx, dbPath, trackerID)
+		if err == nil && len(values) > 0 {
+			status.CookieCount = len(values)
+			status.State = StateHasCookies
+		}
+	}
+	return status, nil
+}
+
+func (a trackerAdapter) Validate(ctx context.Context, cfg config.TrackerConfig, dbPath string) (Session, error) {
+	if a.resolve == nil {
+		return Session{}, &UnsupportedAuthError{TrackerID: a.capability.TrackerID, Reason: "remote validation unavailable"}
+	}
+	if err := a.resolve(ctx, cfg, dbPath); err != nil {
+		return Session{}, classifyAdapterError(a.capability.TrackerID, err)
+	}
+	return Session{TrackerID: normalizeTrackerID(a.capability.TrackerID), State: SessionStateReady, Message: "session ready"}, nil
+}
+
+func (a trackerAdapter) Login(ctx context.Context, cfg config.TrackerConfig, dbPath string, _ api.TrackerAuthLoginRequest) (Session, error) {
+	return a.Validate(ctx, cfg, dbPath)
+}
+
+func (a trackerAdapter) Submit2FA(_ context.Context, _ string, _ string) (Session, error) {
+	return Session{}, &UnsupportedAuthError{TrackerID: a.capability.TrackerID, Reason: "manual 2FA continuation unavailable"}
+}
+
+func (a trackerAdapter) Delete(ctx context.Context, dbPath string) error {
+	if err := cookies.DeleteTrackerCookies(ctx, dbPath, normalizeTrackerID(a.capability.TrackerID)); err != nil {
+		return fmt.Errorf("tracker auth: delete %s cookies: %w", normalizeTrackerID(a.capability.TrackerID), err)
+	}
+	return nil
+}
+
+func classifyAdapterError(trackerID string, err error) error {
+	if err == nil {
+		return nil
+	}
+	lower := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(lower, "2fa") || strings.Contains(lower, "tfa") || strings.Contains(lower, "otp_uri"):
+		return &Needs2FAError{TrackerID: trackerID, Reason: "2FA required", Err: err}
+	case strings.Contains(lower, "username") || strings.Contains(lower, "password") || strings.Contains(lower, "announce_url") || strings.Contains(lower, "not configured"):
+		return &AuthRequiredError{TrackerID: trackerID, Reason: "credentials missing", Err: err}
+	case strings.Contains(lower, "auth key not found") || strings.Contains(lower, "anti csrf token not found") || strings.Contains(lower, "cookie invalid") || strings.Contains(lower, "no cookies found"):
+		return &ValidationError{TrackerID: trackerID, ConfirmedInvalid: true, Reason: "stored session invalid", Err: err}
+	case errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled):
+		return &ValidationError{TrackerID: trackerID, Transient: true, Reason: "remote validation unavailable", Err: err}
+	default:
+		return &ValidationError{TrackerID: trackerID, Transient: true, Reason: "remote validation failed", Err: err}
+	}
+}

--- a/internal/trackerauth/challenge.go
+++ b/internal/trackerauth/challenge.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackerauth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultChallengeTTL = 5 * time.Minute
+
+type Challenge struct {
+	ID        string
+	TrackerID string
+	ExpiresAt time.Time
+}
+
+type ChallengeManager struct {
+	mu  sync.Mutex
+	ttl time.Duration
+	now func() time.Time
+	ids func() (string, error)
+
+	items map[string]Challenge
+}
+
+func NewChallengeManager(ttl time.Duration) *ChallengeManager {
+	if ttl <= 0 {
+		ttl = defaultChallengeTTL
+	}
+	return &ChallengeManager{
+		ttl:   ttl,
+		now:   time.Now,
+		ids:   randomChallengeID,
+		items: map[string]Challenge{},
+	}
+}
+
+func (m *ChallengeManager) Create(ctx context.Context, trackerID string) string {
+	if ctx != nil && ctx.Err() != nil {
+		return ""
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.cleanupLocked()
+	id, err := m.ids()
+	if err != nil {
+		return ""
+	}
+	trackerID = normalizeTrackerID(trackerID)
+	m.items[id] = Challenge{
+		ID:        id,
+		TrackerID: trackerID,
+		ExpiresAt: m.now().UTC().Add(m.ttl),
+	}
+	return id
+}
+
+func (m *ChallengeManager) Get(challengeID string) (Challenge, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.cleanupLocked()
+	challenge, ok := m.items[strings.TrimSpace(challengeID)]
+	return challenge, ok
+}
+
+func (m *ChallengeManager) Consume(challengeID string, trackerID string) (Challenge, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.cleanupLocked()
+	challengeID = strings.TrimSpace(challengeID)
+	challenge, ok := m.items[challengeID]
+	if !ok {
+		return Challenge{}, errors.New("tracker auth: no active manual 2FA challenge")
+	}
+	if !strings.EqualFold(challenge.TrackerID, strings.TrimSpace(trackerID)) {
+		return Challenge{}, errors.New("tracker auth: challenge tracker mismatch")
+	}
+	delete(m.items, challengeID)
+	return challenge, nil
+}
+
+func (m *ChallengeManager) cleanupLocked() {
+	now := m.now().UTC()
+	for id, challenge := range m.items {
+		if !challenge.ExpiresAt.After(now) {
+			delete(m.items, id)
+		}
+	}
+}
+
+func randomChallengeID() (string, error) {
+	buf := make([]byte, 24)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("tracker auth: generate challenge id: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/internal/trackerauth/challenge.go
+++ b/internal/trackerauth/challenge.go
@@ -16,12 +16,19 @@ import (
 
 const defaultChallengeTTL = 5 * time.Minute
 
+var sharedChallengeManager = NewChallengeManager(defaultChallengeTTL)
+
+// Challenge identifies one manual 2FA continuation for a tracker auth login.
 type Challenge struct {
-	ID        string
+	// ID is the opaque token returned to the UI and later supplied to Submit2FA.
+	ID string
+	// TrackerID is the normalized tracker code that owns the challenge.
 	TrackerID string
+	// ExpiresAt is the UTC deadline after which the challenge is discarded.
 	ExpiresAt time.Time
 }
 
+// ChallengeManager stores time-limited manual 2FA challenges for tracker auth.
 type ChallengeManager struct {
 	mu  sync.Mutex
 	ttl time.Duration
@@ -31,6 +38,7 @@ type ChallengeManager struct {
 	items map[string]Challenge
 }
 
+// NewChallengeManager returns a challenge manager with ttl, using the default TTL when ttl is not positive.
 func NewChallengeManager(ttl time.Duration) *ChallengeManager {
 	if ttl <= 0 {
 		ttl = defaultChallengeTTL
@@ -43,6 +51,7 @@ func NewChallengeManager(ttl time.Duration) *ChallengeManager {
 	}
 }
 
+// Create registers a challenge for trackerID and returns its opaque ID.
 func (m *ChallengeManager) Create(ctx context.Context, trackerID string) string {
 	if ctx != nil && ctx.Err() != nil {
 		return ""
@@ -64,6 +73,7 @@ func (m *ChallengeManager) Create(ctx context.Context, trackerID string) string 
 	return id
 }
 
+// Get returns an active challenge by ID after pruning expired challenges.
 func (m *ChallengeManager) Get(challengeID string) (Challenge, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -73,6 +83,7 @@ func (m *ChallengeManager) Get(challengeID string) (Challenge, bool) {
 	return challenge, ok
 }
 
+// Consume validates that challengeID belongs to trackerID, removes it, and returns the consumed challenge.
 func (m *ChallengeManager) Consume(challengeID string, trackerID string) (Challenge, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/trackerauth/challenge.go
+++ b/internal/trackerauth/challenge.go
@@ -24,11 +24,14 @@ type Challenge struct {
 	ID string
 	// TrackerID is the normalized tracker code that owns the challenge.
 	TrackerID string
+	// OwnerKey binds the challenge to the config generation that created it.
+	OwnerKey string
 	// ExpiresAt is the UTC deadline after which the challenge is discarded.
 	ExpiresAt time.Time
 }
 
-// ChallengeManager stores time-limited manual 2FA challenges for tracker auth.
+// ChallengeManager stores time-limited manual 2FA challenges and rejects
+// continuations whose owner key no longer matches the creating config.
 type ChallengeManager struct {
 	mu  sync.Mutex
 	ttl time.Duration
@@ -51,8 +54,10 @@ func NewChallengeManager(ttl time.Duration) *ChallengeManager {
 	}
 }
 
-// Create registers a challenge for trackerID and returns its opaque ID.
-func (m *ChallengeManager) Create(ctx context.Context, trackerID string) string {
+// Create registers a challenge for trackerID and returns its opaque ID. The
+// optional owner key is stored with the challenge so later submissions can be
+// rejected after a config change.
+func (m *ChallengeManager) Create(ctx context.Context, trackerID string, ownerKey ...string) string {
 	if ctx != nil && ctx.Err() != nil {
 		return ""
 	}
@@ -68,6 +73,7 @@ func (m *ChallengeManager) Create(ctx context.Context, trackerID string) string 
 	m.items[id] = Challenge{
 		ID:        id,
 		TrackerID: trackerID,
+		OwnerKey:  firstOwnerKey(ownerKey),
 		ExpiresAt: m.now().UTC().Add(m.ttl),
 	}
 	return id
@@ -83,8 +89,9 @@ func (m *ChallengeManager) Get(challengeID string) (Challenge, bool) {
 	return challenge, ok
 }
 
-// Consume validates that challengeID belongs to trackerID, removes it, and returns the consumed challenge.
-func (m *ChallengeManager) Consume(challengeID string, trackerID string) (Challenge, error) {
+// Consume validates that challengeID belongs to trackerID and ownerKey, removes
+// it, and returns the consumed challenge.
+func (m *ChallengeManager) Consume(challengeID string, trackerID string, ownerKey ...string) (Challenge, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -97,8 +104,22 @@ func (m *ChallengeManager) Consume(challengeID string, trackerID string) (Challe
 	if !strings.EqualFold(challenge.TrackerID, strings.TrimSpace(trackerID)) {
 		return Challenge{}, errors.New("tracker auth: challenge tracker mismatch")
 	}
+	if !challengeOwnerMatches(challenge, firstOwnerKey(ownerKey)) {
+		return Challenge{}, errors.New("tracker auth: stale manual 2FA challenge")
+	}
 	delete(m.items, challengeID)
 	return challenge, nil
+}
+
+func firstOwnerKey(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(values[0])
+}
+
+func challengeOwnerMatches(challenge Challenge, ownerKey string) bool {
+	return strings.TrimSpace(challenge.OwnerKey) == strings.TrimSpace(ownerKey)
 }
 
 func (m *ChallengeManager) cleanupLocked() {

--- a/internal/trackerauth/challenge_test.go
+++ b/internal/trackerauth/challenge_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackerauth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestChallengeManagerExpiresChallenges(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC)
+	manager := NewChallengeManager(time.Minute)
+	manager.now = func() time.Time { return now }
+	manager.ids = func() (string, error) { return "challenge-1", nil }
+
+	id := manager.Create(context.Background(), "mtv")
+	if id != "challenge-1" {
+		t.Fatalf("challenge id: got %q", id)
+	}
+	if challenge, ok := manager.Get(id); !ok || challenge.TrackerID != "MTV" {
+		t.Fatalf("expected active MTV challenge, got %#v ok=%v", challenge, ok)
+	}
+
+	now = now.Add(time.Minute)
+	if _, ok := manager.Get(id); ok {
+		t.Fatal("expected challenge to expire at ttl")
+	}
+}
+
+func TestChallengeManagerConsumesTrackerScopedChallenge(t *testing.T) {
+	t.Parallel()
+
+	manager := NewChallengeManager(time.Minute)
+	manager.ids = func() (string, error) { return "challenge-1", nil }
+
+	id := manager.Create(context.Background(), "PTP")
+	if _, err := manager.Consume(id, "MTV"); err == nil {
+		t.Fatal("expected tracker mismatch")
+	}
+	if _, err := manager.Consume(id, "PTP"); err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+	if _, ok := manager.Get(id); ok {
+		t.Fatal("expected consumed challenge to be removed")
+	}
+}

--- a/internal/trackerauth/challenge_test.go
+++ b/internal/trackerauth/challenge_test.go
@@ -48,3 +48,24 @@ func TestChallengeManagerConsumesTrackerScopedChallenge(t *testing.T) {
 		t.Fatal("expected consumed challenge to be removed")
 	}
 }
+
+func TestChallengeManagerRejectsStaleOwnerKey(t *testing.T) {
+	t.Parallel()
+
+	manager := NewChallengeManager(time.Minute)
+	manager.ids = func() (string, error) { return "challenge-1", nil }
+
+	id := manager.Create(context.Background(), "PTP", "old-owner")
+	if _, err := manager.Consume(id, "PTP", "new-owner"); err == nil {
+		t.Fatal("expected stale owner key rejection")
+	}
+	if _, ok := manager.Get(id); !ok {
+		t.Fatal("stale owner key rejection consumed challenge")
+	}
+	if _, err := manager.Consume(id, "PTP", "old-owner"); err != nil {
+		t.Fatalf("Consume with original owner key: %v", err)
+	}
+	if _, ok := manager.Get(id); ok {
+		t.Fatal("expected consumed challenge to be removed")
+	}
+}

--- a/internal/trackerauth/ensure.go
+++ b/internal/trackerauth/ensure.go
@@ -11,6 +11,7 @@ import (
 )
 
 // EnsureSession validates stored tracker auth, optionally attempts credential login, and returns the ready session or a typed auth error.
+// When AutoLogin is false, it returns [AuthRequiredError] without calling tracker adapter validation or login.
 func (s *Service) EnsureSession(ctx context.Context, req EnsureRequest) (Session, error) {
 	if ctx == nil {
 		return Session{}, errors.New("tracker auth: context is required")
@@ -23,6 +24,9 @@ func (s *Service) EnsureSession(ctx context.Context, req EnsureRequest) (Session
 	adapter, ok := s.adapterFor(trackerID)
 	if !ok {
 		return Session{}, newUnknownTrackerError(trackerID)
+	}
+	if !req.AutoLogin {
+		return Session{}, &AuthRequiredError{TrackerID: trackerID, Reason: "login required"}
 	}
 
 	session, err := adapter.Validate(ctx, req.Config, req.DBPath)
@@ -63,9 +67,6 @@ func (s *Service) EnsureSession(ctx context.Context, req EnsureRequest) (Session
 			return Session{}, &AuthRequiredError{TrackerID: trackerID, Reason: "stored session expired", Err: err}
 		}
 		return Session{}, &UnsupportedAuthError{TrackerID: trackerID, Reason: "credential login unsupported", Err: err}
-	}
-	if !req.AutoLogin {
-		return Session{}, &AuthRequiredError{TrackerID: trackerID, Reason: "login required", Err: err}
 	}
 	if !hasLoginCredentials(req.Config) {
 		return Session{}, &AuthRequiredError{TrackerID: trackerID, Reason: "username/password missing", Err: err}

--- a/internal/trackerauth/ensure.go
+++ b/internal/trackerauth/ensure.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackerauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func (s *Service) EnsureSession(ctx context.Context, req EnsureRequest) (Session, error) {
+	if ctx == nil {
+		return Session{}, errors.New("tracker auth: context is required")
+	}
+	trackerID := normalizeTrackerID(req.TrackerID)
+	if trackerID == "" {
+		return Session{}, errors.New("tracker auth: tracker id is required")
+	}
+
+	adapter, ok := s.adapterFor(trackerID)
+	if !ok {
+		return Session{}, newUnknownTrackerError(trackerID)
+	}
+
+	session, err := adapter.Validate(ctx, req.Config, req.DBPath)
+	if err == nil {
+		if strings.TrimSpace(session.State) == "" {
+			session.State = SessionStateReady
+		}
+		if strings.TrimSpace(session.TrackerID) == "" {
+			session.TrackerID = trackerID
+		}
+		return session, nil
+	}
+
+	if needs2FA, ok := asNeeds2FAError(err); ok {
+		return s.needs2FASession(ctx, trackerID, adapter, needs2FA)
+	}
+
+	confirmedInvalid := false
+	if validationErr, ok := asValidationError(err); ok {
+		if validationErr.Transient && !validationErr.ConfirmedInvalid {
+			return Session{}, validationErr
+		}
+		confirmedInvalid = validationErr.ConfirmedInvalid
+	}
+	if confirmedInvalid {
+		if deleteErr := adapter.Delete(ctx, req.DBPath); deleteErr != nil {
+			return Session{}, errors.Join(err, deleteErr)
+		}
+	}
+
+	capability := adapter.Capability()
+	if !capability.SupportsLogin {
+		if confirmedInvalid {
+			return Session{}, &AuthRequiredError{TrackerID: trackerID, Reason: "stored session expired", Err: err}
+		}
+		return Session{}, &UnsupportedAuthError{TrackerID: trackerID, Reason: "credential login unsupported", Err: err}
+	}
+	if !req.AutoLogin {
+		return Session{}, &AuthRequiredError{TrackerID: trackerID, Reason: "login required", Err: err}
+	}
+	if !hasLoginCredentials(req.Config) {
+		return Session{}, &AuthRequiredError{TrackerID: trackerID, Reason: "username/password missing", Err: err}
+	}
+
+	session, loginErr := adapter.Login(ctx, req.Config, req.DBPath, req.Login)
+	if loginErr != nil {
+		if needs2FA, ok := asNeeds2FAError(loginErr); ok {
+			return s.needs2FASession(ctx, trackerID, adapter, needs2FA)
+		}
+		return Session{}, fmt.Errorf("tracker auth: login %s: %w", trackerID, loginErr)
+	}
+	if strings.TrimSpace(session.State) == "" {
+		session.State = SessionStateReady
+	}
+	if strings.TrimSpace(session.TrackerID) == "" {
+		session.TrackerID = trackerID
+	}
+	return session, nil
+}
+
+func asNeeds2FAError(err error) (*Needs2FAError, bool) {
+	var needsErr *Needs2FAError
+	if errors.As(err, &needsErr) {
+		return needsErr, true
+	}
+	return nil, false
+}
+
+func (s *Service) needs2FASession(ctx context.Context, trackerID string, adapter Adapter, needsErr *Needs2FAError) (Session, error) {
+	capability := adapter.Capability()
+	if !capability.SupportsManual2FA {
+		return Session{}, needsErr
+	}
+	challengeID := strings.TrimSpace(needsErr.ChallengeID)
+	if challengeID == "" {
+		challengeID = s.challenges.Create(ctx, trackerID)
+	}
+	needsErr.ChallengeID = challengeID
+	return Session{
+		TrackerID:   trackerID,
+		State:       SessionStateNeeds2FA,
+		ChallengeID: challengeID,
+		Message:     "2FA code required",
+	}, needsErr
+}

--- a/internal/trackerauth/ensure.go
+++ b/internal/trackerauth/ensure.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 )
 
+// EnsureSession validates stored tracker auth, optionally attempts credential login, and returns the ready session or a typed auth error.
 func (s *Service) EnsureSession(ctx context.Context, req EnsureRequest) (Session, error) {
 	if ctx == nil {
 		return Session{}, errors.New("tracker auth: context is required")
@@ -97,7 +98,7 @@ func (s *Service) needs2FASession(ctx context.Context, trackerID string, adapter
 	}
 	challengeID := strings.TrimSpace(needsErr.ChallengeID)
 	if challengeID == "" {
-		challengeID = s.challenges.Create(ctx, trackerID)
+		challengeID = s.challengeManager().Create(ctx, trackerID)
 	}
 	needsErr.ChallengeID = challengeID
 	return Session{

--- a/internal/trackerauth/ensure.go
+++ b/internal/trackerauth/ensure.go
@@ -98,7 +98,11 @@ func (s *Service) needs2FASession(ctx context.Context, trackerID string, adapter
 	}
 	challengeID := strings.TrimSpace(needsErr.ChallengeID)
 	if challengeID == "" {
-		challengeID = s.challengeManager().Create(ctx, trackerID)
+		ownerKey, err := s.challengeOwnerKey(trackerID)
+		if err != nil {
+			return Session{}, err
+		}
+		challengeID = s.challengeManager().Create(ctx, trackerID, ownerKey)
 	}
 	needsErr.ChallengeID = challengeID
 	return Session{

--- a/internal/trackerauth/ensure.go
+++ b/internal/trackerauth/ensure.go
@@ -40,6 +40,10 @@ func (s *Service) EnsureSession(ctx context.Context, req EnsureRequest) (Session
 		return s.needs2FASession(ctx, trackerID, adapter, needs2FA)
 	}
 
+	if authRequired, ok := asAuthRequiredError(err); ok && !adapter.Capability().SupportsLogin {
+		return Session{}, authRequired
+	}
+
 	confirmedInvalid := false
 	if validationErr, ok := asValidationError(err); ok {
 		if validationErr.Transient && !validationErr.ConfirmedInvalid {
@@ -87,6 +91,14 @@ func asNeeds2FAError(err error) (*Needs2FAError, bool) {
 	var needsErr *Needs2FAError
 	if errors.As(err, &needsErr) {
 		return needsErr, true
+	}
+	return nil, false
+}
+
+func asAuthRequiredError(err error) (*AuthRequiredError, bool) {
+	var authRequired *AuthRequiredError
+	if errors.As(err, &authRequired) {
+		return authRequired, true
 	}
 	return nil, false
 }

--- a/internal/trackerauth/ensure_test.go
+++ b/internal/trackerauth/ensure_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackerauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+type fakeAdapter struct {
+	capability api.TrackerAuthCapability
+	validate   func() (Session, error)
+	login      func() (Session, error)
+	deleted    bool
+}
+
+func (a *fakeAdapter) Capability() api.TrackerAuthCapability {
+	return a.capability
+}
+
+func (a *fakeAdapter) Status(context.Context, config.TrackerConfig, string) (api.TrackerAuthStatus, error) {
+	return api.TrackerAuthStatus{TrackerID: a.capability.TrackerID}, nil
+}
+
+func (a *fakeAdapter) Validate(context.Context, config.TrackerConfig, string) (Session, error) {
+	return a.validate()
+}
+
+func (a *fakeAdapter) Login(context.Context, config.TrackerConfig, string, api.TrackerAuthLoginRequest) (Session, error) {
+	return a.login()
+}
+
+func (a *fakeAdapter) Submit2FA(context.Context, string, string) (Session, error) {
+	return Session{TrackerID: a.capability.TrackerID, State: SessionStateReady}, nil
+}
+
+func (a *fakeAdapter) Delete(context.Context, string) error {
+	a.deleted = true
+	return nil
+}
+
+func TestEnsureSessionReturnsValidStoredSession(t *testing.T) {
+	t.Parallel()
+
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{TrackerID: "FAKE", SupportsLogin: true},
+		validate: func() (Session, error) {
+			return Session{TrackerID: "FAKE", State: SessionStateReady}, nil
+		},
+	}
+	service := &Service{adapters: map[string]Adapter{"FAKE": adapter}, challenges: NewChallengeManager(defaultChallengeTTL)}
+
+	session, err := service.EnsureSession(context.Background(), EnsureRequest{TrackerID: "fake"})
+	if err != nil {
+		t.Fatalf("EnsureSession: %v", err)
+	}
+	if session.TrackerID != "FAKE" || session.State != SessionStateReady {
+		t.Fatalf("unexpected session: %#v", session)
+	}
+	if adapter.deleted {
+		t.Fatal("did not expect valid cookies to be deleted")
+	}
+}
+
+func TestEnsureSessionDeletesConfirmedInvalidAndLogsIn(t *testing.T) {
+	t.Parallel()
+
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{TrackerID: "FAKE", SupportsLogin: true},
+		validate: func() (Session, error) {
+			return Session{}, &ValidationError{TrackerID: "FAKE", ConfirmedInvalid: true, Err: errors.New("expired")}
+		},
+		login: func() (Session, error) {
+			return Session{TrackerID: "FAKE", State: SessionStateReady}, nil
+		},
+	}
+	service := &Service{adapters: map[string]Adapter{"FAKE": adapter}, challenges: NewChallengeManager(defaultChallengeTTL)}
+
+	_, err := service.EnsureSession(context.Background(), EnsureRequest{
+		TrackerID: "FAKE",
+		Config:    config.TrackerConfig{Username: "user", Password: "pass"},
+		AutoLogin: true,
+	})
+	if err != nil {
+		t.Fatalf("EnsureSession: %v", err)
+	}
+	if !adapter.deleted {
+		t.Fatal("expected confirmed-invalid session to be deleted before login")
+	}
+}
+
+func TestEnsureSessionKeepsCookiesOnTransientValidationFailure(t *testing.T) {
+	t.Parallel()
+
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{TrackerID: "FAKE", SupportsLogin: true},
+		validate: func() (Session, error) {
+			return Session{}, &ValidationError{TrackerID: "FAKE", Transient: true, Err: errors.New("timeout")}
+		},
+	}
+	service := &Service{adapters: map[string]Adapter{"FAKE": adapter}, challenges: NewChallengeManager(defaultChallengeTTL)}
+
+	_, err := service.EnsureSession(context.Background(), EnsureRequest{TrackerID: "FAKE", AutoLogin: true})
+	if err == nil {
+		t.Fatal("expected transient validation error")
+	}
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) || !validationErr.Transient {
+		t.Fatalf("expected transient validation error, got %v", err)
+	}
+	if adapter.deleted {
+		t.Fatal("transient validation failure must not delete stored session")
+	}
+}
+
+func TestEnsureSessionCreatesManual2FAChallenge(t *testing.T) {
+	t.Parallel()
+
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{TrackerID: "FAKE", SupportsLogin: true, SupportsManual2FA: true},
+		validate: func() (Session, error) {
+			return Session{}, &Needs2FAError{TrackerID: "FAKE"}
+		},
+	}
+	service := &Service{adapters: map[string]Adapter{"FAKE": adapter}, challenges: NewChallengeManager(defaultChallengeTTL)}
+
+	session, err := service.EnsureSession(context.Background(), EnsureRequest{TrackerID: "FAKE"})
+	if err == nil {
+		t.Fatal("expected Needs2FAError")
+	}
+	var needsErr *Needs2FAError
+	if !errors.As(err, &needsErr) {
+		t.Fatalf("expected Needs2FAError, got %v", err)
+	}
+	if session.ChallengeID == "" || needsErr.ChallengeID != session.ChallengeID {
+		t.Fatalf("expected challenge id in session and error, got session=%#v err=%#v", session, needsErr)
+	}
+	if _, ok := service.challenges.Get(session.ChallengeID); !ok {
+		t.Fatal("expected challenge to be stored")
+	}
+}

--- a/internal/trackerauth/ensure_test.go
+++ b/internal/trackerauth/ensure_test.go
@@ -14,11 +14,13 @@ import (
 )
 
 type fakeAdapter struct {
-	capability api.TrackerAuthCapability
-	validate   func() (Session, error)
-	login      func() (Session, error)
-	submit     func(context.Context, config.TrackerConfig, string, api.TrackerAuthLoginRequest) (Session, error)
-	deleted    bool
+	capability    api.TrackerAuthCapability
+	validate      func() (Session, error)
+	login         func() (Session, error)
+	submit        func(context.Context, config.TrackerConfig, string, api.TrackerAuthLoginRequest) (Session, error)
+	validateCalls int
+	loginCalls    int
+	deleteCalls   int
 }
 
 func (a *fakeAdapter) Capability() api.TrackerAuthCapability {
@@ -30,10 +32,18 @@ func (a *fakeAdapter) Status(context.Context, config.TrackerConfig, string) (api
 }
 
 func (a *fakeAdapter) Validate(context.Context, config.TrackerConfig, string) (Session, error) {
+	a.validateCalls++
+	if a.validate == nil {
+		return Session{}, errors.New("unexpected validate")
+	}
 	return a.validate()
 }
 
 func (a *fakeAdapter) Login(context.Context, config.TrackerConfig, string, api.TrackerAuthLoginRequest) (Session, error) {
+	a.loginCalls++
+	if a.login == nil {
+		return Session{}, errors.New("unexpected login")
+	}
 	return a.login()
 }
 
@@ -45,7 +55,7 @@ func (a *fakeAdapter) Submit2FA(ctx context.Context, cfg config.TrackerConfig, d
 }
 
 func (a *fakeAdapter) Delete(context.Context, string) error {
-	a.deleted = true
+	a.deleteCalls++
 	return nil
 }
 
@@ -60,15 +70,42 @@ func TestEnsureSessionReturnsValidStoredSession(t *testing.T) {
 	}
 	service := &Service{adapters: map[string]Adapter{"FAKE": adapter}, challenges: NewChallengeManager(defaultChallengeTTL)}
 
-	session, err := service.EnsureSession(context.Background(), EnsureRequest{TrackerID: "fake"})
+	session, err := service.EnsureSession(context.Background(), EnsureRequest{TrackerID: "fake", AutoLogin: true})
 	if err != nil {
 		t.Fatalf("EnsureSession: %v", err)
 	}
 	if session.TrackerID != "FAKE" || session.State != SessionStateReady {
 		t.Fatalf("unexpected session: %#v", session)
 	}
-	if adapter.deleted {
+	if adapter.deleteCalls != 0 {
 		t.Fatal("did not expect valid cookies to be deleted")
+	}
+}
+
+func TestEnsureSessionAutoLoginFalseSkipsAdapterValidation(t *testing.T) {
+	t.Parallel()
+
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{TrackerID: "FAKE", SupportsLogin: true},
+		validate: func() (Session, error) {
+			return Session{TrackerID: "FAKE", State: SessionStateReady}, nil
+		},
+		login: func() (Session, error) {
+			return Session{TrackerID: "FAKE", State: SessionStateReady}, nil
+		},
+	}
+	service := &Service{adapters: map[string]Adapter{"FAKE": adapter}, challenges: NewChallengeManager(defaultChallengeTTL)}
+
+	_, err := service.EnsureSession(context.Background(), EnsureRequest{TrackerID: "FAKE"})
+	if err == nil {
+		t.Fatal("expected auth required error")
+	}
+	var authRequired *AuthRequiredError
+	if !errors.As(err, &authRequired) {
+		t.Fatalf("expected AuthRequiredError, got %v", err)
+	}
+	if adapter.validateCalls != 0 || adapter.loginCalls != 0 || adapter.deleteCalls != 0 {
+		t.Fatalf("AutoLogin=false must not call adapter methods, got validate=%d login=%d delete=%d", adapter.validateCalls, adapter.loginCalls, adapter.deleteCalls)
 	}
 }
 
@@ -94,7 +131,7 @@ func TestEnsureSessionDeletesConfirmedInvalidAndLogsIn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EnsureSession: %v", err)
 	}
-	if !adapter.deleted {
+	if adapter.deleteCalls == 0 {
 		t.Fatal("expected confirmed-invalid session to be deleted before login")
 	}
 }
@@ -118,7 +155,7 @@ func TestEnsureSessionKeepsCookiesOnTransientValidationFailure(t *testing.T) {
 	if !errors.As(err, &validationErr) || !validationErr.Transient {
 		t.Fatalf("expected transient validation error, got %v", err)
 	}
-	if adapter.deleted {
+	if adapter.deleteCalls != 0 {
 		t.Fatal("transient validation failure must not delete stored session")
 	}
 }
@@ -142,7 +179,7 @@ func TestEnsureSessionKeepsCookiesOnPTPMissingAntiCSRFToken(t *testing.T) {
 	if !errors.As(err, &validationErr) || validationErr.ConfirmedInvalid {
 		t.Fatalf("expected non-confirmed validation error, got %v", err)
 	}
-	if adapter.deleted {
+	if adapter.deleteCalls != 0 {
 		t.Fatal("PTP parser miss must not delete stored session")
 	}
 }
@@ -170,7 +207,7 @@ func TestEnsureSessionKeepsCookiesOnPTPAuthKeyNotFoundText(t *testing.T) {
 	if !errors.As(err, &validationErr) || !validationErr.Transient || validationErr.ConfirmedInvalid {
 		t.Fatalf("expected transient non-confirmed validation error, got %v", err)
 	}
-	if adapter.deleted {
+	if adapter.deleteCalls != 0 {
 		t.Fatal("free-text auth key miss must not delete stored session")
 	}
 }
@@ -194,7 +231,7 @@ func TestEnsureSessionKeepsCookiesOnInvalidLookingTransientAdapterText(t *testin
 	if !errors.As(err, &validationErr) || !validationErr.Transient || validationErr.ConfirmedInvalid {
 		t.Fatalf("expected transient non-confirmed validation error, got %v", err)
 	}
-	if adapter.deleted {
+	if adapter.deleteCalls != 0 {
 		t.Fatal("transient invalid-looking text must not delete stored session")
 	}
 }
@@ -293,7 +330,7 @@ func TestEnsureSessionCreatesManual2FAChallenge(t *testing.T) {
 	}
 	service := &Service{adapters: map[string]Adapter{"FAKE": adapter}, challenges: NewChallengeManager(defaultChallengeTTL)}
 
-	session, err := service.EnsureSession(context.Background(), EnsureRequest{TrackerID: "FAKE"})
+	session, err := service.EnsureSession(context.Background(), EnsureRequest{TrackerID: "FAKE", AutoLogin: true})
 	if err == nil {
 		t.Fatal("expected Needs2FAError")
 	}

--- a/internal/trackerauth/ensure_test.go
+++ b/internal/trackerauth/ensure_test.go
@@ -17,7 +17,7 @@ type fakeAdapter struct {
 	capability api.TrackerAuthCapability
 	validate   func() (Session, error)
 	login      func() (Session, error)
-	submit     func(context.Context, string, string) (Session, error)
+	submit     func(context.Context, config.TrackerConfig, string, api.TrackerAuthLoginRequest) (Session, error)
 	deleted    bool
 }
 
@@ -37,9 +37,9 @@ func (a *fakeAdapter) Login(context.Context, config.TrackerConfig, string, api.T
 	return a.login()
 }
 
-func (a *fakeAdapter) Submit2FA(ctx context.Context, challengeID string, code string) (Session, error) {
+func (a *fakeAdapter) Submit2FA(ctx context.Context, cfg config.TrackerConfig, dbPath string, req api.TrackerAuthLoginRequest) (Session, error) {
 	if a.submit != nil {
-		return a.submit(ctx, challengeID, code)
+		return a.submit(ctx, cfg, dbPath, req)
 	}
 	return Session{TrackerID: a.capability.TrackerID, State: SessionStateReady}, nil
 }
@@ -206,6 +206,79 @@ func TestClassifyAdapterErrorKeepsWrappedContextCancellationTransient(t *testing
 	var validationErr *ValidationError
 	if !errors.As(err, &validationErr) || !validationErr.Transient || validationErr.ConfirmedInvalid {
 		t.Fatalf("expected context cancellation to stay transient, got %v", err)
+	}
+}
+
+func TestClassifyAdapterErrorRequiresExplicit2FARequiredText(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		message string
+		want2FA bool
+	}{
+		"explicit missing code": {
+			message: "trackers: MTV 2FA required but otp_uri invalid: empty otp_uri",
+			want2FA: true,
+		},
+		"separator colon": {
+			message: "trackers: MTV 2FA required: enter code",
+			want2FA: true,
+		},
+		"separator punctuation": {
+			message: "trackers: MTV 2FA required, enter code",
+			want2FA: true,
+		},
+		"separator newline": {
+			message: "trackers: MTV 2FA required\nenter code",
+			want2FA: true,
+		},
+		"separator parentheses": {
+			message: "trackers: MTV (2FA required)",
+			want2FA: true,
+		},
+		"missing form token": {
+			message: "trackers: MTV 2FA token not found",
+		},
+		"otp uri parser": {
+			message: "trackers: MTV parse otp_uri: missing secret",
+		},
+		"tfa layout text": {
+			message: "trackers: PTP tfa layout token missing",
+		},
+		"url path text": {
+			message: "trackers: GET https://example.invalid/2fa/setup failed",
+		},
+		"prefixed phrase": {
+			message: "trackers: MTV x2FA required",
+		},
+		"suffixed phrase": {
+			message: "trackers: MTV 2FA requiredx",
+		},
+		"empty message": {},
+		"whitespace message": {
+			message: "   ",
+		},
+		"grouped parser text": {
+			message: "trackers: MTV otp_uri contains token2FA required value",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := classifyAdapterError("MTV", errors.New(tt.message))
+			var needsErr *Needs2FAError
+			got2FA := errors.As(err, &needsErr)
+			if got2FA != tt.want2FA {
+				t.Fatalf("Needs2FA=%t, want %t for %v", got2FA, tt.want2FA, err)
+			}
+			if !tt.want2FA {
+				var validationErr *ValidationError
+				if !errors.As(err, &validationErr) || !validationErr.Transient {
+					t.Fatalf("expected transient validation error, got %v", err)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/trackerauth/ensure_test.go
+++ b/internal/trackerauth/ensure_test.go
@@ -6,6 +6,7 @@ package trackerauth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/config"
@@ -16,6 +17,7 @@ type fakeAdapter struct {
 	capability api.TrackerAuthCapability
 	validate   func() (Session, error)
 	login      func() (Session, error)
+	submit     func(context.Context, string, string) (Session, error)
 	deleted    bool
 }
 
@@ -35,7 +37,10 @@ func (a *fakeAdapter) Login(context.Context, config.TrackerConfig, string, api.T
 	return a.login()
 }
 
-func (a *fakeAdapter) Submit2FA(context.Context, string, string) (Session, error) {
+func (a *fakeAdapter) Submit2FA(ctx context.Context, challengeID string, code string) (Session, error) {
+	if a.submit != nil {
+		return a.submit(ctx, challengeID, code)
+	}
 	return Session{TrackerID: a.capability.TrackerID, State: SessionStateReady}, nil
 }
 
@@ -115,6 +120,92 @@ func TestEnsureSessionKeepsCookiesOnTransientValidationFailure(t *testing.T) {
 	}
 	if adapter.deleted {
 		t.Fatal("transient validation failure must not delete stored session")
+	}
+}
+
+func TestEnsureSessionKeepsCookiesOnPTPMissingAntiCSRFToken(t *testing.T) {
+	t.Parallel()
+
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{TrackerID: "PTP", SupportsLogin: true},
+		validate: func() (Session, error) {
+			return Session{}, classifyAdapterError("PTP", errors.New("trackers: PTP anti csrf token not found"))
+		},
+	}
+	service := &Service{adapters: map[string]Adapter{"PTP": adapter}, challenges: NewChallengeManager(defaultChallengeTTL)}
+
+	_, err := service.EnsureSession(context.Background(), EnsureRequest{TrackerID: "PTP", AutoLogin: true})
+	if err == nil {
+		t.Fatal("expected transient validation error")
+	}
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) || validationErr.ConfirmedInvalid {
+		t.Fatalf("expected non-confirmed validation error, got %v", err)
+	}
+	if adapter.deleted {
+		t.Fatal("PTP parser miss must not delete stored session")
+	}
+}
+
+func TestEnsureSessionKeepsCookiesOnPTPAuthKeyNotFoundText(t *testing.T) {
+	t.Parallel()
+
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{TrackerID: "PTP", SupportsLogin: true},
+		validate: func() (Session, error) {
+			return Session{}, classifyAdapterError("PTP", errors.New("trackers: PTP auth key not found"))
+		},
+	}
+	service := &Service{adapters: map[string]Adapter{"PTP": adapter}, challenges: NewChallengeManager(defaultChallengeTTL)}
+
+	_, err := service.EnsureSession(context.Background(), EnsureRequest{
+		TrackerID: "PTP",
+		Config:    config.TrackerConfig{Username: "user", Password: "pass"},
+		AutoLogin: true,
+	})
+	if err == nil {
+		t.Fatal("expected transient validation error")
+	}
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) || !validationErr.Transient || validationErr.ConfirmedInvalid {
+		t.Fatalf("expected transient non-confirmed validation error, got %v", err)
+	}
+	if adapter.deleted {
+		t.Fatal("free-text auth key miss must not delete stored session")
+	}
+}
+
+func TestEnsureSessionKeepsCookiesOnInvalidLookingTransientAdapterText(t *testing.T) {
+	t.Parallel()
+
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{TrackerID: "MTV", SupportsLogin: true},
+		validate: func() (Session, error) {
+			return Session{}, classifyAdapterError("MTV", errors.New("temporary upstream failure: cookie invalid"))
+		},
+	}
+	service := &Service{adapters: map[string]Adapter{"MTV": adapter}, challenges: NewChallengeManager(defaultChallengeTTL)}
+
+	_, err := service.EnsureSession(context.Background(), EnsureRequest{TrackerID: "MTV", AutoLogin: true})
+	if err == nil {
+		t.Fatal("expected transient validation error")
+	}
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) || !validationErr.Transient || validationErr.ConfirmedInvalid {
+		t.Fatalf("expected transient non-confirmed validation error, got %v", err)
+	}
+	if adapter.deleted {
+		t.Fatal("transient invalid-looking text must not delete stored session")
+	}
+}
+
+func TestClassifyAdapterErrorKeepsWrappedContextCancellationTransient(t *testing.T) {
+	t.Parallel()
+
+	err := classifyAdapterError("MTV", fmt.Errorf("cookie invalid after retry: %w", context.Canceled))
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) || !validationErr.Transient || validationErr.ConfirmedInvalid {
+		t.Fatalf("expected context cancellation to stay transient, got %v", err)
 	}
 }
 

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -1,0 +1,558 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackerauth
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/authmaterial"
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/cookies"
+	"github.com/autobrr/upbrr/internal/redaction"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+const (
+	StateConfigured                  = "configured"
+	StateHasCookies                  = "has_cookies"
+	StateNotConfigured               = "not_configured"
+	StateLoginRequired               = "login_required"
+	StateEncryptedStorageUnavailable = "encrypted_storage_unavailable"
+)
+
+type Service struct {
+	cfg        config.Config
+	adapters   map[string]Adapter
+	challenges *ChallengeManager
+}
+
+type trackerSpec struct {
+	id               string
+	authKind         string
+	cookies          bool
+	login            bool
+	autoLogin        bool
+	totp             bool
+	manual2FA        bool
+	apiKey           bool
+	passkey          bool
+	needsCredentials bool
+	notes            []string
+}
+
+func NewService(cfg config.Config) *Service {
+	return &Service{
+		cfg:        cfg,
+		adapters:   defaultAdapters(),
+		challenges: NewChallengeManager(defaultChallengeTTL),
+	}
+}
+
+func (s *Service) Capabilities(_ context.Context) ([]api.TrackerAuthCapability, error) {
+	specs := s.specs()
+	out := make([]api.TrackerAuthCapability, 0, len(specs))
+	for _, spec := range specs {
+		out = append(out, capabilityFromSpec(spec))
+	}
+	return out, nil
+}
+
+func (s *Service) Status(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error) {
+	spec, err := s.specFor(trackerID)
+	if err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+	return s.statusForSpec(ctx, spec)
+}
+
+func (s *Service) ImportCookies(ctx context.Context, trackerID string, fileName string, content string) (api.TrackerAuthStatus, error) {
+	spec, err := s.specFor(trackerID)
+	if err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+	if !spec.cookies {
+		return api.TrackerAuthStatus{}, fmt.Errorf("tracker auth: %s does not support cookie import", spec.id)
+	}
+	values, err := ParseCookieContent(fileName, content)
+	if err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+	if err := cookies.SaveTrackerCookieMap(ctx, s.cfg.MainSettings.DBPath, spec.id, values); err != nil {
+		return api.TrackerAuthStatus{}, fmt.Errorf("tracker auth: import %s cookies: %w", spec.id, err)
+	}
+	status, err := s.statusForSpec(ctx, spec)
+	if err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+	status.State = StateHasCookies
+	status.CookieCount = len(values)
+	status.Message = "cookies imported"
+	return status, nil
+}
+
+func (s *Service) Validate(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error) {
+	spec, err := s.specFor(trackerID)
+	if err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+	status, err := s.statusForSpec(ctx, spec)
+	if err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+
+	if _, ok := s.adapterFor(spec.id); ok {
+		session, ensureErr := s.EnsureSession(ctx, EnsureRequest{
+			TrackerID: spec.id,
+			Config:    mustTrackerConfig(s.cfg, spec.id),
+			DBPath:    s.cfg.MainSettings.DBPath,
+			AutoLogin: true,
+		})
+		if ensureErr != nil {
+			applyEnsureErrorToStatus(&status, ensureErr)
+			if session.ChallengeID != "" {
+				status.ChallengeID = session.ChallengeID
+			}
+			return status, nil
+		}
+		status.State = StateConfigured
+		status.Message = "remote auth check succeeded"
+		return status, nil
+	}
+	status.Message = validationMessage(spec, status)
+	return status, nil
+}
+
+func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAuthLoginRequest) (api.TrackerAuthStatus, error) {
+	spec, err := s.specFor(trackerID)
+	if err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+	if !spec.login {
+		return api.TrackerAuthStatus{}, fmt.Errorf("tracker auth: %s does not support credential login", spec.id)
+	}
+	status, err := s.statusForSpec(ctx, spec)
+	if err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+	if status.State == StateLoginRequired {
+		status.Message = "username/password missing"
+		return status, nil
+	}
+	if status.Needs2FA {
+		status.Message = "manual 2FA is supported only during an active tracker login challenge"
+		return status, nil
+	}
+
+	if _, ok := s.adapterFor(spec.id); ok {
+		session, ensureErr := s.EnsureSession(ctx, EnsureRequest{
+			TrackerID: spec.id,
+			Config:    mustTrackerConfig(s.cfg, spec.id),
+			DBPath:    s.cfg.MainSettings.DBPath,
+			AutoLogin: true,
+			Login:     req,
+		})
+		if ensureErr != nil {
+			applyEnsureErrorToStatus(&status, ensureErr)
+			if session.ChallengeID != "" {
+				status.ChallengeID = session.ChallengeID
+			}
+			return status, nil
+		}
+		status.State = StateConfigured
+		status.Message = "remote login/auth check succeeded"
+		return status, nil
+	}
+	status.State = StateConfigured
+	status.Message = "remote login/auth check succeeded"
+	return status, nil
+}
+
+func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string) (api.TrackerAuthStatus, error) {
+	if strings.TrimSpace(challengeID) == "" {
+		return api.TrackerAuthStatus{}, errors.New("tracker auth: challenge id is required")
+	}
+	if strings.TrimSpace(code) == "" {
+		return api.TrackerAuthStatus{}, errors.New("tracker auth: 2FA code is required")
+	}
+	if s.challenges == nil {
+		s.challenges = NewChallengeManager(defaultChallengeTTL)
+	}
+	challenge, ok := s.challenges.Get(challengeID)
+	if !ok {
+		return api.TrackerAuthStatus{}, errors.New("tracker auth: no active manual 2FA challenge")
+	}
+	adapter, ok := s.adapterFor(challenge.TrackerID)
+	if !ok {
+		return api.TrackerAuthStatus{}, newUnknownTrackerError(challenge.TrackerID)
+	}
+	session, err := adapter.Submit2FA(ctx, challengeID, code)
+	if err != nil {
+		status, statusErr := s.Status(ctx, challenge.TrackerID)
+		if statusErr != nil {
+			return api.TrackerAuthStatus{}, statusErr
+		}
+		applyEnsureErrorToStatus(&status, err)
+		status.ChallengeID = challengeID
+		return status, nil
+	}
+	if _, err := s.challenges.Consume(challengeID, challenge.TrackerID); err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+	status, err := s.Status(ctx, challenge.TrackerID)
+	if err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+	if strings.TrimSpace(session.State) == "" || session.State == SessionStateReady {
+		status.State = StateConfigured
+	}
+	status.Needs2FA = false
+	status.ChallengeID = ""
+	status.Message = "2FA auth completed"
+	return status, nil
+}
+
+func (s *Service) Delete(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error) {
+	spec, err := s.specFor(trackerID)
+	if err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+	if err := cookies.DeleteTrackerCookies(ctx, s.cfg.MainSettings.DBPath, spec.id); err != nil {
+		return api.TrackerAuthStatus{}, fmt.Errorf("tracker auth: delete %s cookies: %w", spec.id, err)
+	}
+	status, err := s.statusForSpec(ctx, spec)
+	if err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+	status.CookieCount = 0
+	status.Message = "stored cookies deleted"
+	return status, nil
+}
+
+func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) (api.TrackerAuthStatus, error) {
+	encryptedStorage := s.encryptedStorageAvailable()
+	status := api.TrackerAuthStatus{
+		TrackerID:        spec.id,
+		DisplayName:      spec.id,
+		State:            StateNotConfigured,
+		LastCheckedAt:    time.Now().UTC().Format(time.RFC3339),
+		EncryptedStorage: encryptedStorage,
+	}
+
+	cfg, hasCfg := trackerConfig(s.cfg, spec.id)
+	if spec.cookies {
+		values, err := cookies.LoadTrackerCookieMap(ctx, s.cfg.MainSettings.DBPath, spec.id)
+		if err == nil && len(values) > 0 {
+			status.CookieCount = len(values)
+			status.State = StateHasCookies
+		} else if err != nil && !strings.Contains(strings.ToLower(err.Error()), "no cookies found") {
+			status.LastError = redact(err.Error())
+		}
+	}
+
+	if spec.apiKey && configAPIKey(cfg) != "" {
+		status.State = StateConfigured
+	}
+	if spec.passkey && strings.TrimSpace(cfg.Passkey) != "" {
+		status.State = StateConfigured
+	}
+	if spec.login {
+		hasCredentials := hasCfg && strings.TrimSpace(cfg.Username) != "" && strings.TrimSpace(cfg.Password) != ""
+		if hasCredentials {
+			if status.State == StateNotConfigured {
+				status.State = StateConfigured
+			}
+			if spec.totp && strings.TrimSpace(cfg.OTPURI) == "" && spec.manual2FA {
+				status.Needs2FA = true
+			}
+		} else if status.CookieCount == 0 && spec.needsCredentials {
+			status.State = StateLoginRequired
+		}
+	}
+	if spec.cookies && status.CookieCount == 0 && !encryptedStorage {
+		status.State = StateEncryptedStorageUnavailable
+	}
+	status.Message = validationMessage(spec, status)
+	return status, nil
+}
+
+func (s *Service) encryptedStorageAvailable() bool {
+	if strings.TrimSpace(s.cfg.MainSettings.DBPath) == "" {
+		return false
+	}
+	_, err := authmaterial.LoadFromDBPath(s.cfg.MainSettings.DBPath)
+	return err == nil
+}
+
+func (s *Service) specFor(trackerID string) (trackerSpec, error) {
+	needle := strings.TrimSpace(trackerID)
+	if needle == "" {
+		return trackerSpec{}, errors.New("tracker auth: tracker id is required")
+	}
+	for _, spec := range s.specs() {
+		if strings.EqualFold(spec.id, needle) {
+			return spec, nil
+		}
+	}
+	return trackerSpec{}, fmt.Errorf("tracker auth: unknown tracker %s", needle)
+}
+
+func (s *Service) specs() []trackerSpec {
+	index := map[string]trackerSpec{}
+	for _, spec := range builtInSpecs() {
+		index[spec.id] = spec
+	}
+	for id, cfg := range s.cfg.Trackers.Trackers {
+		trimmedID := strings.TrimSpace(id)
+		if trimmedID == "" {
+			continue
+		}
+		upperID := strings.ToUpper(trimmedID)
+		spec, ok := index[upperID]
+		if !ok {
+			spec = trackerSpec{id: upperID, authKind: "config"}
+		}
+		if configAPIKey(cfg) != "" {
+			spec.apiKey = true
+			if spec.authKind == "config" {
+				spec.authKind = "api_key"
+			}
+		}
+		if strings.TrimSpace(cfg.Passkey) != "" {
+			spec.passkey = true
+			if spec.authKind == "config" {
+				spec.authKind = "passkey"
+			}
+		}
+		if strings.TrimSpace(cfg.Username) != "" || strings.TrimSpace(cfg.Password) != "" {
+			spec.login = true
+			spec.autoLogin = spec.autoLogin || spec.id == "AR" || spec.id == "FL" || spec.id == "MTV" || spec.id == "PTP" || spec.id == "THR" || spec.id == "RTF"
+			if spec.authKind == "config" {
+				spec.authKind = "credential_login"
+			}
+		}
+		index[upperID] = spec
+	}
+
+	out := make([]trackerSpec, 0, len(index))
+	for _, spec := range index {
+		out = append(out, spec)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].id < out[j].id })
+	return out
+}
+
+func builtInSpecs() []trackerSpec {
+	return []trackerSpec{
+		{id: "AR", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
+		{id: "FL", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
+		{id: "MTV", authKind: "api_key_cookies_login", cookies: true, login: true, autoLogin: true, totp: true, manual2FA: true, apiKey: true, needsCredentials: true, notes: []string{"API key covers Torznab/search; cookies/login cover upload authkey."}},
+		{id: "PTP", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, totp: true, manual2FA: true, needsCredentials: true},
+		{id: "THR", authKind: "credential_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
+		{id: "RTF", authKind: "api_key_credential_refresh", login: true, autoLogin: true, apiKey: true, needsCredentials: false},
+		{id: "ASC", authKind: "cookies", cookies: true},
+		{id: "AZ", authKind: "cookies", cookies: true},
+		{id: "BJS", authKind: "cookies", cookies: true},
+		{id: "BT", authKind: "cookies", cookies: true},
+		{id: "CZ", authKind: "cookies", cookies: true},
+		{id: "HDB", authKind: "passkey_cookies", cookies: true, passkey: true},
+		{id: "HDS", authKind: "cookies", cookies: true},
+		{id: "HDT", authKind: "cookies", cookies: true},
+		{id: "IS", authKind: "cookies", cookies: true},
+		{id: "PHD", authKind: "cookies", cookies: true},
+		{id: "PTS", authKind: "cookies", cookies: true},
+		{id: "PTER", authKind: "cookies", cookies: true},
+		{id: "TL", authKind: "cookies", cookies: true},
+		{id: "TTG", authKind: "cookies_manual_2fa", cookies: true, manual2FA: true},
+	}
+}
+
+func capabilityFromSpec(spec trackerSpec) api.TrackerAuthCapability {
+	return api.TrackerAuthCapability{
+		TrackerID:          spec.id,
+		DisplayName:        spec.id,
+		AuthKind:           spec.authKind,
+		SupportsCookieFile: spec.cookies,
+		SupportsLogin:      spec.login,
+		SupportsAutoLogin:  spec.autoLogin,
+		SupportsTOTP:       spec.totp,
+		SupportsManual2FA:  spec.manual2FA,
+		RequiresAPIKey:     spec.apiKey,
+		RequiresPasskey:    spec.passkey,
+		Notes:              append([]string{}, spec.notes...),
+	}
+}
+
+func trackerConfig(cfg config.Config, trackerID string) (config.TrackerConfig, bool) {
+	for key, value := range cfg.Trackers.Trackers {
+		if strings.EqualFold(strings.TrimSpace(key), strings.TrimSpace(trackerID)) {
+			return value, true
+		}
+	}
+	return config.TrackerConfig{}, false
+}
+
+func configAPIKey(cfg config.TrackerConfig) string {
+	if key := strings.TrimSpace(cfg.APIKey); key != "" {
+		return key
+	}
+	return strings.TrimSpace(cfg.PTPAPIKey)
+}
+
+func validationMessage(spec trackerSpec, status api.TrackerAuthStatus) string {
+	switch status.State {
+	case StateHasCookies:
+		return fmt.Sprintf("%d stored cookie(s); tracker upload/search will validate remotely when used", status.CookieCount)
+	case StateConfigured:
+		return "required config auth material is present"
+	case StateLoginRequired:
+		return "login credentials or imported cookies required"
+	case StateEncryptedStorageUnavailable:
+		return "encrypted cookie storage unavailable; create web-auth.json before importing cookies"
+	default:
+		if spec.cookies || spec.login || spec.apiKey || spec.passkey {
+			return "auth material not configured"
+		}
+		return "no tracker-specific auth handling"
+	}
+}
+
+func ParseCookieContent(fileName string, content string) (map[string]string, error) {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return nil, errors.New("tracker auth: cookie file content is required")
+	}
+	if strings.EqualFold(filepath.Ext(strings.TrimSpace(fileName)), ".json") || strings.HasPrefix(trimmed, "{") {
+		return parseJSONCookieContent([]byte(trimmed))
+	}
+	return parseNetscapeCookieContent(trimmed)
+}
+
+func parseJSONCookieContent(payload []byte) (map[string]string, error) {
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return nil, fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+	}
+	out := make(map[string]string)
+	for key, value := range decoded {
+		name := strings.TrimSpace(key)
+		if name == "" {
+			continue
+		}
+		switch typed := value.(type) {
+		case string:
+			if trimmed := strings.TrimSpace(typed); trimmed != "" {
+				out[name] = trimmed
+			}
+		case map[string]any:
+			if raw, ok := typed["value"]; ok {
+				if trimmed := strings.TrimSpace(fmt.Sprint(raw)); trimmed != "" {
+					out[name] = trimmed
+				}
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil, errors.New("tracker auth: cookie content has no entries")
+	}
+	return out, nil
+}
+
+func parseNetscapeCookieContent(content string) (map[string]string, error) {
+	out := make(map[string]string)
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "#HttpOnly_") {
+			line = strings.TrimPrefix(line, "#HttpOnly_")
+		} else if strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 7 {
+			continue
+		}
+		name := strings.TrimSpace(fields[5])
+		value := strings.TrimSpace(strings.Join(fields[6:], "\t"))
+		if name != "" && value != "" {
+			out[name] = value
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("tracker auth: scan Netscape cookies: %w", err)
+	}
+	if len(out) == 0 {
+		return nil, errors.New("tracker auth: cookie content has no entries")
+	}
+	return out, nil
+}
+
+func redact(value string) string {
+	return strings.TrimSpace(redaction.RedactValue(value, nil))
+}
+
+func mustTrackerConfig(cfg config.Config, trackerID string) config.TrackerConfig {
+	trackerCfg, _ := trackerConfig(cfg, trackerID)
+	return trackerCfg
+}
+
+func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
+	status.LastError = redact(err.Error())
+	status.Message = "remote auth test failed"
+
+	var authRequired *AuthRequiredError
+	if errors.As(err, &authRequired) {
+		status.State = StateLoginRequired
+		status.Message = "login credentials or imported cookies required"
+		return
+	}
+
+	var needs2FA *Needs2FAError
+	if errors.As(err, &needs2FA) {
+		status.Needs2FA = true
+		status.ChallengeID = strings.TrimSpace(needs2FA.ChallengeID)
+		status.State = StateLoginRequired
+		status.Message = "2FA required"
+		return
+	}
+
+	var unsupported *UnsupportedAuthError
+	if errors.As(err, &unsupported) {
+		status.Message = "remote auth validation is not supported"
+		return
+	}
+
+	var validation *ValidationError
+	if errors.As(err, &validation) && validation.ConfirmedInvalid {
+		status.State = StateLoginRequired
+		status.CookieCount = 0
+		status.Message = "stored session expired or invalid"
+	}
+}
+
+func CookiesToMap(values []*http.Cookie) map[string]string {
+	out := make(map[string]string)
+	for _, cookie := range values {
+		if cookie == nil {
+			continue
+		}
+		name := strings.TrimSpace(cookie.Name)
+		value := strings.TrimSpace(cookie.Value)
+		if name != "" && value != "" {
+			out[name] = value
+		}
+	}
+	return out
+}

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -348,7 +348,7 @@ func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string
 			return api.TrackerAuthStatus{}, statusErr
 		}
 		applyEnsureErrorToStatus(&status, err)
-		if validation, ok := asValidationError(err); ok && validation.Transient && !validation.ConfirmedInvalid && !shouldKeepSubmitted2FARetryVisible(challenge.TrackerID, err) {
+		if !shouldKeepSubmitted2FARetryVisible(challenge.TrackerID, err) {
 			return status, nil
 		}
 		status.Needs2FA = true
@@ -1004,8 +1004,8 @@ func parseNetscapeCookieContent(content string) (map[string]string, error) {
 		if trimmedLine == "" {
 			continue
 		}
-		if httpOnlyLine, ok := strings.CutPrefix(trimmedLine, "#HttpOnly_"); ok {
-			line = httpOnlyLine
+		if strings.HasPrefix(trimmedLine, "#HttpOnly_") {
+			line = line[strings.Index(line, "#HttpOnly_")+len("#HttpOnly_"):]
 		} else if strings.HasPrefix(trimmedLine, "#") {
 			continue
 		}

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -51,6 +51,7 @@ type Service struct {
 	cfg                config.Config
 	adapters           map[string]Adapter
 	challenges         *ChallengeManager
+	logger             api.Logger
 	afterDeleteCleanup func()
 }
 
@@ -70,15 +71,81 @@ type trackerSpec struct {
 
 // NewService builds a tracker auth service with default remote adapters and the shared manual 2FA challenge manager.
 func NewService(cfg config.Config) *Service {
+	return NewServiceWithLogger(cfg, api.NopLogger{})
+}
+
+// NewServiceWithLogger builds a tracker auth service that writes auth operation
+// outcomes to logger without logging cookie values, credentials, 2FA codes, or
+// challenge identifiers. Nil logger uses [api.NopLogger].
+func NewServiceWithLogger(cfg config.Config, logger api.Logger) *Service {
+	if logger == nil {
+		logger = api.NopLogger{}
+	}
 	return &Service{
 		cfg:        cfg,
 		adapters:   defaultAdapters(),
 		challenges: sharedChallengeManager,
+		logger:     logger,
 	}
 }
 
+func (s *Service) logInfof(format string, args ...any) {
+	if s == nil || s.logger == nil {
+		return
+	}
+	s.logger.Infof(format, args...)
+}
+
+func (s *Service) logWarnf(format string, args ...any) {
+	if s == nil || s.logger == nil {
+		return
+	}
+	s.logger.Warnf(format, args...)
+}
+
+// logStatus records the user-visible auth state returned to callers, keeping
+// the log payload to tracker ID, state, cookie count, encrypted-storage state,
+// 2FA requirement, and already-redacted status errors.
+func (s *Service) logStatus(operation string, status api.TrackerAuthStatus) {
+	s.logInfof(
+		"tracker auth: %s tracker=%s state=%s cookies=%d encrypted_storage=%t needs_2fa=%t",
+		operation,
+		trackerLogID(status.TrackerID),
+		status.State,
+		status.CookieCount,
+		status.EncryptedStorage,
+		status.Needs2FA,
+	)
+	if strings.TrimSpace(status.LastError) != "" {
+		s.logWarnf(
+			"tracker auth: %s warning tracker=%s state=%s error=%s",
+			operation,
+			trackerLogID(status.TrackerID),
+			status.State,
+			status.LastError,
+		)
+	}
+}
+
+// trackerLogID normalizes tracker IDs for log messages and avoids empty tracker
+// fields when validation fails before a concrete tracker is resolved.
+func trackerLogID(trackerID string) string {
+	trackerID = normalizeTrackerID(trackerID)
+	if trackerID == "" {
+		return "unknown"
+	}
+	return trackerID
+}
+
 // Capabilities returns tracker auth support metadata for built-in trackers and configured custom trackers.
-func (s *Service) Capabilities(_ context.Context) ([]api.TrackerAuthCapability, error) {
+func (s *Service) Capabilities(_ context.Context) (caps []api.TrackerAuthCapability, err error) {
+	defer func() {
+		if err != nil {
+			s.logWarnf("tracker auth: capabilities failed: %v", err)
+			return
+		}
+		s.logInfof("tracker auth: capabilities loaded count=%d", len(caps))
+	}()
 	if err := s.validateTrackerConfigIDs(); err != nil {
 		return nil, err
 	}
@@ -91,7 +158,14 @@ func (s *Service) Capabilities(_ context.Context) ([]api.TrackerAuthCapability, 
 }
 
 // Status returns local tracker auth state derived from config, encrypted cookie storage, and stored cookies.
-func (s *Service) Status(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error) {
+func (s *Service) Status(ctx context.Context, trackerID string) (status api.TrackerAuthStatus, err error) {
+	defer func() {
+		if err != nil {
+			s.logWarnf("tracker auth: status failed tracker=%s: %v", trackerLogID(trackerID), err)
+			return
+		}
+		s.logStatus("status checked", status)
+	}()
 	if err := s.validateTrackerConfigIDs(); err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
@@ -99,13 +173,20 @@ func (s *Service) Status(ctx context.Context, trackerID string) (api.TrackerAuth
 	if err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
-	return s.statusForSpec(ctx, spec)
+	return s.statusForSpec(ctx, spec), nil
 }
 
 // ImportCookies parses supplied cookie content, saves it for trackerID, and
 // returns refreshed auth status from persisted cookie/auth state. Parser errors
 // leave existing stored cookies unchanged.
-func (s *Service) ImportCookies(ctx context.Context, trackerID string, fileName string, content string) (api.TrackerAuthStatus, error) {
+func (s *Service) ImportCookies(ctx context.Context, trackerID string, fileName string, content string) (status api.TrackerAuthStatus, err error) {
+	defer func() {
+		if err != nil {
+			s.logWarnf("tracker auth: cookie import failed tracker=%s bytes=%d: %v", trackerLogID(trackerID), len(content), err)
+			return
+		}
+		s.logStatus("cookies imported", status)
+	}()
 	if err := s.validateTrackerConfigIDs(); err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
@@ -123,10 +204,7 @@ func (s *Service) ImportCookies(ctx context.Context, trackerID string, fileName 
 	if err := cookies.SaveTrackerCookieMap(ctx, s.cfg.MainSettings.DBPath, spec.id, values); err != nil {
 		return api.TrackerAuthStatus{}, fmt.Errorf("tracker auth: import %s cookies: %w", spec.id, err)
 	}
-	status, err := s.statusForSpec(ctx, spec)
-	if err != nil {
-		return api.TrackerAuthStatus{}, err
-	}
+	status = s.statusForSpec(ctx, spec)
 	status.State = StateHasCookies
 	status.Message = "cookies imported"
 	return status, nil
@@ -135,7 +213,14 @@ func (s *Service) ImportCookies(ctx context.Context, trackerID string, fileName 
 // Validate returns tracker auth status after a remote validation check when the
 // tracker has an adapter. Confirmed-invalid stored sessions are deleted and
 // reported as login-required status without returning an error.
-func (s *Service) Validate(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error) {
+func (s *Service) Validate(ctx context.Context, trackerID string) (status api.TrackerAuthStatus, err error) {
+	defer func() {
+		if err != nil {
+			s.logWarnf("tracker auth: validation failed tracker=%s: %v", trackerLogID(trackerID), err)
+			return
+		}
+		s.logStatus("validation completed", status)
+	}()
 	if err := s.validateTrackerConfigIDs(); err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
@@ -143,10 +228,7 @@ func (s *Service) Validate(ctx context.Context, trackerID string) (api.TrackerAu
 	if err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
-	status, err := s.statusForSpec(ctx, spec)
-	if err != nil {
-		return api.TrackerAuthStatus{}, err
-	}
+	status = s.statusForSpec(ctx, spec)
 
 	if _, ok := s.adapterFor(spec.id); ok {
 		session, ensureErr := s.EnsureSession(ctx, EnsureRequest{
@@ -171,7 +253,14 @@ func (s *Service) Validate(ctx context.Context, trackerID string) (api.TrackerAu
 }
 
 // Login runs credential-based tracker auth when supported and returns status for missing credentials, unsupported remote login, or 2FA.
-func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAuthLoginRequest) (api.TrackerAuthStatus, error) {
+func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAuthLoginRequest) (status api.TrackerAuthStatus, err error) {
+	defer func() {
+		if err != nil {
+			s.logWarnf("tracker auth: login failed tracker=%s: %v", trackerLogID(trackerID), err)
+			return
+		}
+		s.logStatus("login completed", status)
+	}()
 	if err := s.validateTrackerConfigIDs(); err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
@@ -182,10 +271,7 @@ func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAu
 	if !spec.login {
 		return api.TrackerAuthStatus{}, fmt.Errorf("tracker auth: %s does not support credential login", spec.id)
 	}
-	status, err := s.statusForSpec(ctx, spec)
-	if err != nil {
-		return api.TrackerAuthStatus{}, err
-	}
+	status = s.statusForSpec(ctx, spec)
 	if status.State == StateLoginRequired {
 		status.Message = "username/password missing"
 		return status, nil
@@ -215,7 +301,18 @@ func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAu
 }
 
 // Submit2FA completes an active manual 2FA challenge and consumes the challenge only after adapter success.
-func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string) (api.TrackerAuthStatus, error) {
+func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string) (status api.TrackerAuthStatus, err error) {
+	logTrackerID := ""
+	defer func() {
+		if logTrackerID == "" {
+			logTrackerID = status.TrackerID
+		}
+		if err != nil {
+			s.logWarnf("tracker auth: 2FA submit failed tracker=%s: %v", trackerLogID(logTrackerID), err)
+			return
+		}
+		s.logStatus("2FA completed", status)
+	}()
 	if strings.TrimSpace(challengeID) == "" {
 		return api.TrackerAuthStatus{}, errors.New("tracker auth: challenge id is required")
 	}
@@ -227,6 +324,7 @@ func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string
 	if !ok {
 		return api.TrackerAuthStatus{}, errors.New("tracker auth: no active manual 2FA challenge")
 	}
+	logTrackerID = challenge.TrackerID
 	ownerKey, err := s.challengeOwnerKey(challenge.TrackerID)
 	if err != nil {
 		return api.TrackerAuthStatus{}, err
@@ -251,7 +349,7 @@ func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string
 	if _, err := challenges.Consume(challengeID, challenge.TrackerID, ownerKey); err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
-	status, err := s.Status(ctx, challenge.TrackerID)
+	status, err = s.Status(ctx, challenge.TrackerID)
 	if err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
@@ -275,7 +373,14 @@ func (s *Service) challengeManager() *ChallengeManager {
 // the refreshed local auth status. AR auth-state and cookie cleanup failures
 // restore the previous AR auth state before returning the error even when the
 // caller's context has been canceled.
-func (s *Service) Delete(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error) {
+func (s *Service) Delete(ctx context.Context, trackerID string) (status api.TrackerAuthStatus, err error) {
+	defer func() {
+		if err != nil {
+			s.logWarnf("tracker auth: delete failed tracker=%s: %v", trackerLogID(trackerID), err)
+			return
+		}
+		s.logStatus("auth deleted", status)
+	}()
 	if err := s.validateTrackerConfigIDs(); err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
@@ -306,10 +411,7 @@ func (s *Service) Delete(ctx context.Context, trackerID string) (api.TrackerAuth
 	if s.afterDeleteCleanup != nil {
 		s.afterDeleteCleanup()
 	}
-	status, err := s.statusForSpec(contextWithoutCancel(ctx), spec)
-	if err != nil {
-		return api.TrackerAuthStatus{}, err
-	}
+	status = s.statusForSpec(contextWithoutCancel(ctx), spec)
 	status.CookieCount = 0
 	status.Message = "stored auth deleted"
 	return status, nil
@@ -318,7 +420,7 @@ func (s *Service) Delete(ctx context.Context, trackerID string) (api.TrackerAuth
 // statusForSpec reports configured auth material without hiding encrypted
 // storage availability; cookie-only trackers still surface unavailable storage
 // as the state when no stronger auth material is configured.
-func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) (api.TrackerAuthStatus, error) {
+func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) api.TrackerAuthStatus {
 	encryptedStorage := s.encryptedStorageAvailable()
 	status := api.TrackerAuthStatus{
 		TrackerID:        spec.id,
@@ -366,7 +468,7 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) (api.Trac
 	if isMTVSpec(spec) && hasAPIKey && status.CookieCount == 0 && !hasCredentials {
 		status.Message = "API key covers Torznab/search; imported cookies or login credentials required for upload auth"
 	}
-	return status, nil
+	return status
 }
 
 func isMTVSpec(spec trackerSpec) bool {

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -663,10 +663,10 @@ func capabilityFromSpec(spec trackerSpec) api.TrackerAuthCapability {
 // capabilityForSpec exposes remote login, auto-login, and 2FA actions only
 // when this service has an adapter that can execute them.
 func (s *Service) capabilityForSpec(spec trackerSpec) api.TrackerAuthCapability {
-	capability := capabilityFromSpec(spec)
-	if _, ok := s.adapterFor(spec.id); ok {
-		return capability
+	if adapter, ok := s.adapterFor(spec.id); ok {
+		return adapter.Capability()
 	}
+	capability := capabilityFromSpec(spec)
 	capability.SupportsLogin = false
 	capability.SupportsAutoLogin = false
 	capability.SupportsTOTP = false

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -56,12 +56,13 @@ type Service struct {
 }
 
 type trackerSpec struct {
-	id               string
-	authKind         string
-	cookies          bool
-	login            bool
-	autoLogin        bool
-	totp             bool
+	id        string
+	authKind  string
+	cookies   bool
+	login     bool
+	autoLogin bool
+	totp      bool
+	// manual2FA permits adapter Needs2FA errors to become reusable Submit2FA challenges.
 	manual2FA        bool
 	apiKey           bool
 	passkey          bool
@@ -300,7 +301,10 @@ func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAu
 	return status, nil
 }
 
-// Submit2FA completes an active manual 2FA challenge and consumes the challenge only after adapter success.
+// Submit2FA completes an active manual 2FA challenge. Adapter failures return
+// refreshed status without consuming the challenge; only failures classified
+// with [ValidationError.Submitted2FARejected] keep the challenge visible for
+// another try.
 func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string) (status api.TrackerAuthStatus, err error) {
 	logTrackerID := ""
 	defer func() {
@@ -336,13 +340,17 @@ func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string
 	if !ok {
 		return api.TrackerAuthStatus{}, newUnknownTrackerError(challenge.TrackerID)
 	}
-	session, err := adapter.Submit2FA(ctx, challengeID, code)
+	session, err := adapter.Submit2FA(ctx, mustTrackerConfig(s.cfg, challenge.TrackerID), s.cfg.MainSettings.DBPath, api.TrackerAuthLoginRequest{Code: code})
 	if err != nil {
 		status, statusErr := s.Status(ctx, challenge.TrackerID)
 		if statusErr != nil {
 			return api.TrackerAuthStatus{}, statusErr
 		}
 		applyEnsureErrorToStatus(&status, err)
+		if validation, ok := asValidationError(err); ok && validation.Transient && !validation.ConfirmedInvalid && !shouldKeepSubmitted2FARetryVisible(challenge.TrackerID, err) {
+			return status, nil
+		}
+		status.Needs2FA = true
 		status.ChallengeID = challengeID
 		return status, nil
 	}
@@ -360,6 +368,14 @@ func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string
 	status.ChallengeID = ""
 	status.Message = "2FA auth completed"
 	return status, nil
+}
+
+// shouldKeepSubmitted2FARetryVisible reports whether an adapter proved the
+// submitted manual code reached the tracker and was rejected, so the UI can
+// retry the same active challenge.
+func shouldKeepSubmitted2FARetryVisible(_ string, err error) bool {
+	validation, ok := asValidationError(err)
+	return ok && validation.Transient && !validation.ConfirmedInvalid && validation.Submitted2FARejected
 }
 
 func (s *Service) challengeManager() *ChallengeManager {
@@ -418,8 +434,8 @@ func (s *Service) Delete(ctx context.Context, trackerID string) (status api.Trac
 }
 
 // statusForSpec reports configured auth material without hiding encrypted
-// storage availability; cookie-only trackers still surface unavailable storage
-// as the state when no stronger auth material is configured.
+// storage availability. It does not create manual 2FA status; Login, Validate,
+// and Submit2FA attach active challenges only when a challenge ID exists.
 func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) api.TrackerAuthStatus {
 	encryptedStorage := s.encryptedStorageAvailable()
 	status := api.TrackerAuthStatus{
@@ -453,9 +469,6 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) api.Track
 		if hasCredentials {
 			if status.State == StateNotConfigured {
 				status.State = StateConfigured
-			}
-			if spec.totp && strings.TrimSpace(cfg.OTPURI) == "" && spec.manual2FA {
-				status.Needs2FA = true
 			}
 		} else if status.CookieCount == 0 && spec.needsCredentials {
 			status.State = StateLoginRequired
@@ -584,12 +597,15 @@ func (s *Service) specs() []trackerSpec {
 	return out
 }
 
+// builtInSpecs defines static tracker auth capabilities before adapter support
+// is applied. Manual 2FA is enabled only where login can retry with a submitted
+// api.TrackerAuthLoginRequest.Code.
 func builtInSpecs() []trackerSpec {
 	return []trackerSpec{
 		{id: "AR", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
 		{id: "FL", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
-		{id: "MTV", authKind: "api_key_cookies_login", cookies: true, login: true, autoLogin: true, totp: true, apiKey: true, needsCredentials: true, notes: []string{"API key covers Torznab/search; cookies/login cover upload authkey."}},
-		{id: "PTP", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, totp: true, needsCredentials: true},
+		{id: "MTV", authKind: "api_key_cookies_login_manual_2fa", cookies: true, login: true, autoLogin: true, totp: true, manual2FA: true, apiKey: true, needsCredentials: true, notes: []string{"API key covers Torznab/search; cookies/login cover upload authkey."}},
+		{id: "PTP", authKind: "cookies_login_manual_2fa", cookies: true, login: true, autoLogin: true, totp: true, manual2FA: true, needsCredentials: true},
 		{id: "THR", authKind: "credential_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
 		{id: "RTF", authKind: "api_key_credential_refresh", login: true, autoLogin: true, apiKey: true, needsCredentials: false},
 		{id: "ASC", authKind: "cookies", cookies: true},

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -108,6 +108,16 @@ func (s *Service) logWarnf(format string, args ...any) {
 // the log payload to tracker ID, state, cookie count, encrypted-storage state,
 // 2FA requirement, and already-redacted status errors.
 func (s *Service) logStatus(operation string, status api.TrackerAuthStatus) {
+	if strings.TrimSpace(status.LastError) != "" {
+		s.logWarnf(
+			"tracker auth: %s warning tracker=%s state=%s error=%s",
+			operation,
+			trackerLogID(status.TrackerID),
+			status.State,
+			status.LastError,
+		)
+		return
+	}
 	s.logInfof(
 		"tracker auth: %s tracker=%s state=%s cookies=%d encrypted_storage=%t needs_2fa=%t",
 		operation,
@@ -117,15 +127,6 @@ func (s *Service) logStatus(operation string, status api.TrackerAuthStatus) {
 		status.EncryptedStorage,
 		status.Needs2FA,
 	)
-	if strings.TrimSpace(status.LastError) != "" {
-		s.logWarnf(
-			"tracker auth: %s warning tracker=%s state=%s error=%s",
-			operation,
-			trackerLogID(status.TrackerID),
-			status.State,
-			status.LastError,
-		)
-	}
 }
 
 // trackerLogID normalizes tracker IDs for log messages and avoids empty tracker
@@ -448,6 +449,7 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) api.Track
 
 	cfg, hasCfg := trackerConfig(s.cfg, spec.id)
 	hasAPIKey := spec.apiKey && configAPIKey(cfg) != ""
+	hasPasskey := strings.TrimSpace(cfg.Passkey) != ""
 	hasCredentials := spec.login && hasCfg && hasUsableLoginConfig(spec, cfg)
 	if spec.cookies {
 		values, err := cookies.LoadTrackerCookieMap(ctx, s.cfg.MainSettings.DBPath, spec.id)
@@ -462,8 +464,14 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) api.Track
 	if hasAPIKey && (!isMTVSpec(spec) || status.CookieCount > 0 || hasCredentials) {
 		status.State = StateConfigured
 	}
-	if spec.passkey && strings.TrimSpace(cfg.Passkey) != "" {
+	if passkeyCoversAuth(spec) && hasPasskey {
 		status.State = StateConfigured
+	}
+	if isHDBSpec(spec) && hasPasskey && strings.TrimSpace(cfg.Username) != "" && status.CookieCount > 0 {
+		status.State = StateConfigured
+	}
+	if isHDBSpec(spec) && hasPasskey && strings.TrimSpace(cfg.Username) != "" && status.CookieCount == 0 {
+		status.State = StateLoginRequired
 	}
 	if spec.login {
 		if hasCredentials {
@@ -474,7 +482,7 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) api.Track
 			status.State = StateLoginRequired
 		}
 	}
-	if spec.cookies && status.CookieCount == 0 && !encryptedStorage && authStatusRequiresEncryptedStorage(spec, hasCredentials, hasAPIKey, strings.TrimSpace(cfg.Passkey) != "") {
+	if spec.cookies && status.CookieCount == 0 && !encryptedStorage && authStatusRequiresEncryptedStorage(spec, hasCredentials, hasAPIKey, hasPasskey) {
 		status.State = StateEncryptedStorageUnavailable
 	}
 	status.Message = validationMessage(spec, status)
@@ -486,6 +494,14 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) api.Track
 
 func isMTVSpec(spec trackerSpec) bool {
 	return strings.EqualFold(spec.id, "MTV")
+}
+
+func isHDBSpec(spec trackerSpec) bool {
+	return strings.EqualFold(spec.id, "HDB")
+}
+
+func passkeyCoversAuth(spec trackerSpec) bool {
+	return spec.passkey && !isHDBSpec(spec)
 }
 
 // hasUsableLoginConfig reports whether credential login has every config value
@@ -510,7 +526,7 @@ func (s *Service) encryptedStorageAvailable() bool {
 }
 
 func authStatusRequiresEncryptedStorage(spec trackerSpec, hasCredentials bool, hasAPIKey bool, hasPasskey bool) bool {
-	if spec.passkey && hasPasskey {
+	if passkeyCoversAuth(spec) && hasPasskey {
 		return false
 	}
 	if spec.apiKey && hasAPIKey && !isMTVSpec(spec) {
@@ -580,10 +596,12 @@ func (s *Service) specs() []trackerSpec {
 			}
 		}
 		if strings.TrimSpace(cfg.Username) != "" || strings.TrimSpace(cfg.Password) != "" {
-			spec.login = true
-			spec.autoLogin = spec.autoLogin || spec.id == "AR" || spec.id == "FL" || spec.id == "MTV" || spec.id == "PTP" || spec.id == "THR" || spec.id == "RTF"
-			if spec.authKind == "config" {
-				spec.authKind = "credential_login"
+			if !ok || spec.login {
+				spec.login = true
+				spec.autoLogin = spec.autoLogin || spec.id == "AR" || spec.id == "FF" || spec.id == "FL" || spec.id == "MTV" || spec.id == "PTP" || spec.id == "RTF" || spec.id == "THR"
+				if spec.authKind == "config" {
+					spec.authKind = "credential_login"
+				}
 			}
 		}
 		index[normalizedID] = spec
@@ -603,10 +621,11 @@ func (s *Service) specs() []trackerSpec {
 func builtInSpecs() []trackerSpec {
 	return []trackerSpec{
 		{id: "AR", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
+		{id: "FF", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
 		{id: "FL", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
 		{id: "MTV", authKind: "api_key_cookies_login_manual_2fa", cookies: true, login: true, autoLogin: true, totp: true, manual2FA: true, apiKey: true, needsCredentials: true, notes: []string{"API key covers Torznab/search; cookies/login cover upload authkey."}},
 		{id: "PTP", authKind: "cookies_login_manual_2fa", cookies: true, login: true, autoLogin: true, totp: true, manual2FA: true, needsCredentials: true},
-		{id: "THR", authKind: "credential_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
+		{id: "THR", authKind: "credential_login", login: true, autoLogin: true, needsCredentials: true},
 		{id: "RTF", authKind: "api_key_credential_refresh", login: true, autoLogin: true, apiKey: true, needsCredentials: false},
 		{id: "ASC", authKind: "cookies", cookies: true},
 		{id: "AZ", authKind: "cookies", cookies: true},

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -26,10 +26,15 @@ import (
 
 // Tracker auth status values returned in api.TrackerAuthStatus.State.
 const (
-	StateConfigured                  = "configured"
-	StateHasCookies                  = "has_cookies"
-	StateNotConfigured               = "not_configured"
-	StateLoginRequired               = "login_required"
+	// StateConfigured means required non-cookie config auth material is present.
+	StateConfigured = "configured"
+	// StateHasCookies means encrypted cookie storage contains at least one cookie for the tracker.
+	StateHasCookies = "has_cookies"
+	// StateNotConfigured means no supported auth material is currently configured.
+	StateNotConfigured = "not_configured"
+	// StateLoginRequired means credentials or imported cookies are required before tracker auth can proceed.
+	StateLoginRequired = "login_required"
+	// StateEncryptedStorageUnavailable means cookie import cannot be used until web auth material exists.
 	StateEncryptedStorageUnavailable = "encrypted_storage_unavailable"
 )
 

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -638,9 +638,7 @@ func builtInSpecs() []trackerSpec {
 		{id: "IS", authKind: "cookies", cookies: true},
 		{id: "PHD", authKind: "cookies", cookies: true},
 		{id: "PTS", authKind: "cookies", cookies: true},
-		{id: "PTER", authKind: "cookies", cookies: true},
 		{id: "TL", authKind: "cookies", cookies: true},
-		{id: "TTG", authKind: "cookies_manual_2fa", cookies: true, manual2FA: true},
 	}
 }
 

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -19,9 +20,11 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/redaction"
+	servicedb "github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+// Tracker auth status values returned in api.TrackerAuthStatus.State.
 const (
 	StateConfigured                  = "configured"
 	StateHasCookies                  = "has_cookies"
@@ -30,6 +33,7 @@ const (
 	StateEncryptedStorageUnavailable = "encrypted_storage_unavailable"
 )
 
+// Service reports and manages persisted tracker auth material for configured trackers.
 type Service struct {
 	cfg        config.Config
 	adapters   map[string]Adapter
@@ -50,14 +54,16 @@ type trackerSpec struct {
 	notes            []string
 }
 
+// NewService builds a tracker auth service with default remote adapters and the shared manual 2FA challenge manager.
 func NewService(cfg config.Config) *Service {
 	return &Service{
 		cfg:        cfg,
 		adapters:   defaultAdapters(),
-		challenges: NewChallengeManager(defaultChallengeTTL),
+		challenges: sharedChallengeManager,
 	}
 }
 
+// Capabilities returns tracker auth support metadata for built-in trackers and configured custom trackers.
 func (s *Service) Capabilities(_ context.Context) ([]api.TrackerAuthCapability, error) {
 	specs := s.specs()
 	out := make([]api.TrackerAuthCapability, 0, len(specs))
@@ -67,6 +73,7 @@ func (s *Service) Capabilities(_ context.Context) ([]api.TrackerAuthCapability, 
 	return out, nil
 }
 
+// Status returns local tracker auth state derived from config, encrypted cookie storage, and stored cookies.
 func (s *Service) Status(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error) {
 	spec, err := s.specFor(trackerID)
 	if err != nil {
@@ -75,6 +82,7 @@ func (s *Service) Status(ctx context.Context, trackerID string) (api.TrackerAuth
 	return s.statusForSpec(ctx, spec)
 }
 
+// ImportCookies parses supplied cookie content, saves it for trackerID, and returns the updated auth status.
 func (s *Service) ImportCookies(ctx context.Context, trackerID string, fileName string, content string) (api.TrackerAuthStatus, error) {
 	spec, err := s.specFor(trackerID)
 	if err != nil {
@@ -100,6 +108,7 @@ func (s *Service) ImportCookies(ctx context.Context, trackerID string, fileName 
 	return status, nil
 }
 
+// Validate returns tracker auth status after a remote validation check when the tracker has an adapter.
 func (s *Service) Validate(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error) {
 	spec, err := s.specFor(trackerID)
 	if err != nil {
@@ -128,10 +137,11 @@ func (s *Service) Validate(ctx context.Context, trackerID string) (api.TrackerAu
 		status.Message = "remote auth check succeeded"
 		return status, nil
 	}
-	status.Message = validationMessage(spec, status)
+	status.Message = "remote auth validation is not supported for this tracker"
 	return status, nil
 }
 
+// Login runs credential-based tracker auth when supported and returns status for missing credentials, unsupported remote login, or 2FA.
 func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAuthLoginRequest) (api.TrackerAuthStatus, error) {
 	spec, err := s.specFor(trackerID)
 	if err != nil {
@@ -146,10 +156,6 @@ func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAu
 	}
 	if status.State == StateLoginRequired {
 		status.Message = "username/password missing"
-		return status, nil
-	}
-	if status.Needs2FA {
-		status.Message = "manual 2FA is supported only during an active tracker login challenge"
 		return status, nil
 	}
 
@@ -172,11 +178,11 @@ func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAu
 		status.Message = "remote login/auth check succeeded"
 		return status, nil
 	}
-	status.State = StateConfigured
-	status.Message = "remote login/auth check succeeded"
+	status.Message = "remote credential login is not supported for this tracker"
 	return status, nil
 }
 
+// Submit2FA completes an active manual 2FA challenge and consumes the challenge only after adapter success.
 func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string) (api.TrackerAuthStatus, error) {
 	if strings.TrimSpace(challengeID) == "" {
 		return api.TrackerAuthStatus{}, errors.New("tracker auth: challenge id is required")
@@ -184,10 +190,8 @@ func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string
 	if strings.TrimSpace(code) == "" {
 		return api.TrackerAuthStatus{}, errors.New("tracker auth: 2FA code is required")
 	}
-	if s.challenges == nil {
-		s.challenges = NewChallengeManager(defaultChallengeTTL)
-	}
-	challenge, ok := s.challenges.Get(challengeID)
+	challenges := s.challengeManager()
+	challenge, ok := challenges.Get(challengeID)
 	if !ok {
 		return api.TrackerAuthStatus{}, errors.New("tracker auth: no active manual 2FA challenge")
 	}
@@ -205,7 +209,7 @@ func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string
 		status.ChallengeID = challengeID
 		return status, nil
 	}
-	if _, err := s.challenges.Consume(challengeID, challenge.TrackerID); err != nil {
+	if _, err := challenges.Consume(challengeID, challenge.TrackerID); err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
 	status, err := s.Status(ctx, challenge.TrackerID)
@@ -221,6 +225,14 @@ func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string
 	return status, nil
 }
 
+func (s *Service) challengeManager() *ChallengeManager {
+	if s.challenges == nil {
+		s.challenges = sharedChallengeManager
+	}
+	return s.challenges
+}
+
+// Delete removes stored tracker auth material and returns the refreshed local auth status.
 func (s *Service) Delete(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error) {
 	spec, err := s.specFor(trackerID)
 	if err != nil {
@@ -229,12 +241,15 @@ func (s *Service) Delete(ctx context.Context, trackerID string) (api.TrackerAuth
 	if err := cookies.DeleteTrackerCookies(ctx, s.cfg.MainSettings.DBPath, spec.id); err != nil {
 		return api.TrackerAuthStatus{}, fmt.Errorf("tracker auth: delete %s cookies: %w", spec.id, err)
 	}
+	if err := deleteTrackerAuthState(ctx, s.cfg.MainSettings.DBPath, spec.id); err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
 	status, err := s.statusForSpec(ctx, spec)
 	if err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
 	status.CookieCount = 0
-	status.Message = "stored cookies deleted"
+	status.Message = "stored auth deleted"
 	return status, nil
 }
 
@@ -355,8 +370,8 @@ func builtInSpecs() []trackerSpec {
 	return []trackerSpec{
 		{id: "AR", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
 		{id: "FL", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
-		{id: "MTV", authKind: "api_key_cookies_login", cookies: true, login: true, autoLogin: true, totp: true, manual2FA: true, apiKey: true, needsCredentials: true, notes: []string{"API key covers Torznab/search; cookies/login cover upload authkey."}},
-		{id: "PTP", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, totp: true, manual2FA: true, needsCredentials: true},
+		{id: "MTV", authKind: "api_key_cookies_login", cookies: true, login: true, autoLogin: true, totp: true, apiKey: true, needsCredentials: true, notes: []string{"API key covers Torznab/search; cookies/login cover upload authkey."}},
+		{id: "PTP", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, totp: true, needsCredentials: true},
 		{id: "THR", authKind: "credential_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
 		{id: "RTF", authKind: "api_key_credential_refresh", login: true, autoLogin: true, apiKey: true, needsCredentials: false},
 		{id: "ASC", authKind: "cookies", cookies: true},
@@ -426,6 +441,7 @@ func validationMessage(spec trackerSpec, status api.TrackerAuthStatus) string {
 	}
 }
 
+// ParseCookieContent parses JSON cookie exports or Netscape cookie files into a name/value map.
 func ParseCookieContent(fileName string, content string) (map[string]string, error) {
 	trimmed := strings.TrimSpace(content)
 	if trimmed == "" {
@@ -438,11 +454,32 @@ func ParseCookieContent(fileName string, content string) (map[string]string, err
 }
 
 func parseJSONCookieContent(payload []byte) (map[string]string, error) {
-	var decoded map[string]any
+	var decoded any
 	if err := json.Unmarshal(payload, &decoded); err != nil {
 		return nil, fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
 	}
 	out := make(map[string]string)
+	switch typed := decoded.(type) {
+	case map[string]any:
+		addJSONCookieObject(out, typed)
+	case []any:
+		for _, item := range typed {
+			entry, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			addJSONCookieArrayEntry(out, entry)
+		}
+	default:
+		return nil, errors.New("tracker auth: JSON cookie content must be an object or array")
+	}
+	if len(out) == 0 {
+		return nil, errors.New("tracker auth: cookie content has no entries")
+	}
+	return out, nil
+}
+
+func addJSONCookieObject(out map[string]string, decoded map[string]any) {
 	for key, value := range decoded {
 		name := strings.TrimSpace(key)
 		if name == "" {
@@ -450,21 +487,38 @@ func parseJSONCookieContent(payload []byte) (map[string]string, error) {
 		}
 		switch typed := value.(type) {
 		case string:
-			if trimmed := strings.TrimSpace(typed); trimmed != "" {
-				out[name] = trimmed
-			}
+			addCookieValue(out, name, typed)
 		case map[string]any:
-			if raw, ok := typed["value"]; ok {
-				if trimmed := strings.TrimSpace(fmt.Sprint(raw)); trimmed != "" {
-					out[name] = trimmed
-				}
+			if raw, ok := typed["value"]; ok && raw != nil {
+				addCookieValue(out, name, fmt.Sprint(raw))
 			}
 		}
 	}
-	if len(out) == 0 {
-		return nil, errors.New("tracker auth: cookie content has no entries")
+}
+
+func addJSONCookieArrayEntry(out map[string]string, entry map[string]any) {
+	name, hasName := jsonCookieField(entry, "name")
+	value, hasValue := jsonCookieField(entry, "value")
+	if !hasName || !hasValue {
+		return
 	}
-	return out, nil
+	addCookieValue(out, name, value)
+}
+
+func jsonCookieField(entry map[string]any, key string) (string, bool) {
+	raw, ok := entry[key]
+	if !ok || raw == nil {
+		return "", false
+	}
+	return strings.TrimSpace(fmt.Sprint(raw)), true
+}
+
+func addCookieValue(out map[string]string, name string, value string) {
+	name = strings.TrimSpace(name)
+	value = strings.TrimSpace(value)
+	if name != "" && value != "" {
+		out[name] = value
+	}
 }
 
 func parseNetscapeCookieContent(content string) (map[string]string, error) {
@@ -475,8 +529,8 @@ func parseNetscapeCookieContent(content string) (map[string]string, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "#HttpOnly_") {
-			line = strings.TrimPrefix(line, "#HttpOnly_")
+		if trimmedLine, ok := strings.CutPrefix(line, "#HttpOnly_"); ok {
+			line = trimmedLine
 		} else if strings.HasPrefix(line, "#") {
 			continue
 		}
@@ -542,6 +596,7 @@ func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
 	}
 }
 
+// CookiesToMap converts HTTP cookies to a non-empty name/value map, ignoring nil cookies and blank names or values.
 func CookiesToMap(values []*http.Cookie) map[string]string {
 	out := make(map[string]string)
 	for _, cookie := range values {
@@ -555,4 +610,27 @@ func CookiesToMap(values []*http.Cookie) map[string]string {
 		}
 	}
 	return out
+}
+
+func deleteTrackerAuthState(ctx context.Context, dbPath string, trackerID string) error {
+	if !strings.EqualFold(strings.TrimSpace(trackerID), "AR") {
+		return nil
+	}
+	if err := DeleteAuthState(ctx, dbPath, "AR", "auth_key"); err != nil && encryptedAuthStateMayExist(dbPath) {
+		return fmt.Errorf("tracker auth: delete AR auth state: %w", err)
+	}
+	if legacyPath, err := servicedb.CookiePath(dbPath, "AR_auth.txt"); err == nil {
+		if err := os.Remove(legacyPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("tracker auth: delete AR legacy auth key: %w", err)
+		}
+	}
+	return nil
+}
+
+func encryptedAuthStateMayExist(dbPath string) bool {
+	if strings.TrimSpace(dbPath) == "" {
+		return false
+	}
+	_, err := authmaterial.LoadFromDBPath(dbPath)
+	return err == nil
 }

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -4,14 +4,19 @@
 package trackerauth
 
 import (
-	"bufio"
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -26,6 +31,9 @@ import (
 
 // Tracker auth status values returned in api.TrackerAuthStatus.State.
 const (
+	// MaxCookieImportContentBytes is the shared decoded cookie text byte limit for web, Wails, and service imports.
+	MaxCookieImportContentBytes = 1024 * 1024
+
 	// StateConfigured means required non-cookie config auth material is present.
 	StateConfigured = "configured"
 	// StateHasCookies means encrypted cookie storage contains at least one cookie for the tracker.
@@ -40,9 +48,10 @@ const (
 
 // Service reports and manages persisted tracker auth material for configured trackers.
 type Service struct {
-	cfg        config.Config
-	adapters   map[string]Adapter
-	challenges *ChallengeManager
+	cfg                config.Config
+	adapters           map[string]Adapter
+	challenges         *ChallengeManager
+	afterDeleteCleanup func()
 }
 
 type trackerSpec struct {
@@ -70,16 +79,22 @@ func NewService(cfg config.Config) *Service {
 
 // Capabilities returns tracker auth support metadata for built-in trackers and configured custom trackers.
 func (s *Service) Capabilities(_ context.Context) ([]api.TrackerAuthCapability, error) {
+	if err := s.validateTrackerConfigIDs(); err != nil {
+		return nil, err
+	}
 	specs := s.specs()
 	out := make([]api.TrackerAuthCapability, 0, len(specs))
 	for _, spec := range specs {
-		out = append(out, capabilityFromSpec(spec))
+		out = append(out, s.capabilityForSpec(spec))
 	}
 	return out, nil
 }
 
 // Status returns local tracker auth state derived from config, encrypted cookie storage, and stored cookies.
 func (s *Service) Status(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error) {
+	if err := s.validateTrackerConfigIDs(); err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
 	spec, err := s.specFor(trackerID)
 	if err != nil {
 		return api.TrackerAuthStatus{}, err
@@ -87,8 +102,13 @@ func (s *Service) Status(ctx context.Context, trackerID string) (api.TrackerAuth
 	return s.statusForSpec(ctx, spec)
 }
 
-// ImportCookies parses supplied cookie content, saves it for trackerID, and returns the updated auth status.
+// ImportCookies parses supplied cookie content, saves it for trackerID, and
+// returns refreshed auth status from persisted cookie/auth state. Parser errors
+// leave existing stored cookies unchanged.
 func (s *Service) ImportCookies(ctx context.Context, trackerID string, fileName string, content string) (api.TrackerAuthStatus, error) {
+	if err := s.validateTrackerConfigIDs(); err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
 	spec, err := s.specFor(trackerID)
 	if err != nil {
 		return api.TrackerAuthStatus{}, err
@@ -108,13 +128,17 @@ func (s *Service) ImportCookies(ctx context.Context, trackerID string, fileName 
 		return api.TrackerAuthStatus{}, err
 	}
 	status.State = StateHasCookies
-	status.CookieCount = len(values)
 	status.Message = "cookies imported"
 	return status, nil
 }
 
-// Validate returns tracker auth status after a remote validation check when the tracker has an adapter.
+// Validate returns tracker auth status after a remote validation check when the
+// tracker has an adapter. Confirmed-invalid stored sessions are deleted and
+// reported as login-required status without returning an error.
 func (s *Service) Validate(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error) {
+	if err := s.validateTrackerConfigIDs(); err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
 	spec, err := s.specFor(trackerID)
 	if err != nil {
 		return api.TrackerAuthStatus{}, err
@@ -148,6 +172,9 @@ func (s *Service) Validate(ctx context.Context, trackerID string) (api.TrackerAu
 
 // Login runs credential-based tracker auth when supported and returns status for missing credentials, unsupported remote login, or 2FA.
 func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAuthLoginRequest) (api.TrackerAuthStatus, error) {
+	if err := s.validateTrackerConfigIDs(); err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
 	spec, err := s.specFor(trackerID)
 	if err != nil {
 		return api.TrackerAuthStatus{}, err
@@ -200,6 +227,13 @@ func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string
 	if !ok {
 		return api.TrackerAuthStatus{}, errors.New("tracker auth: no active manual 2FA challenge")
 	}
+	ownerKey, err := s.challengeOwnerKey(challenge.TrackerID)
+	if err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
+	if !challengeOwnerMatches(challenge, ownerKey) {
+		return api.TrackerAuthStatus{}, errors.New("tracker auth: stale manual 2FA challenge")
+	}
 	adapter, ok := s.adapterFor(challenge.TrackerID)
 	if !ok {
 		return api.TrackerAuthStatus{}, newUnknownTrackerError(challenge.TrackerID)
@@ -214,7 +248,7 @@ func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string
 		status.ChallengeID = challengeID
 		return status, nil
 	}
-	if _, err := challenges.Consume(challengeID, challenge.TrackerID); err != nil {
+	if _, err := challenges.Consume(challengeID, challenge.TrackerID, ownerKey); err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
 	status, err := s.Status(ctx, challenge.TrackerID)
@@ -237,19 +271,42 @@ func (s *Service) challengeManager() *ChallengeManager {
 	return s.challenges
 }
 
-// Delete removes stored tracker auth material and returns the refreshed local auth status.
+// Delete removes tracker-specific auth state and generic cookies, then returns
+// the refreshed local auth status. AR auth-state and cookie cleanup failures
+// restore the previous AR auth state before returning the error even when the
+// caller's context has been canceled.
 func (s *Service) Delete(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error) {
+	if err := s.validateTrackerConfigIDs(); err != nil {
+		return api.TrackerAuthStatus{}, err
+	}
 	spec, err := s.specFor(trackerID)
 	if err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
-	if err := cookies.DeleteTrackerCookies(ctx, s.cfg.MainSettings.DBPath, spec.id); err != nil {
-		return api.TrackerAuthStatus{}, fmt.Errorf("tracker auth: delete %s cookies: %w", spec.id, err)
-	}
-	if err := deleteTrackerAuthState(ctx, s.cfg.MainSettings.DBPath, spec.id); err != nil {
+	authSnapshot, err := snapshotTrackerAuthState(ctx, s.cfg.MainSettings.DBPath, spec.id)
+	if err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
-	status, err := s.statusForSpec(ctx, spec)
+	if err := deleteTrackerAuthState(ctx, s.cfg.MainSettings.DBPath, spec.id); err != nil {
+		restoreErr := authSnapshot.restore(ctx)
+		deleteErr := fmt.Errorf("tracker auth: delete %s auth state: %w", spec.id, err)
+		if restoreErr != nil {
+			return api.TrackerAuthStatus{}, errors.Join(deleteErr, restoreErr)
+		}
+		return api.TrackerAuthStatus{}, deleteErr
+	}
+	if err := cookies.DeleteTrackerCookies(ctx, s.cfg.MainSettings.DBPath, spec.id); err != nil {
+		restoreErr := authSnapshot.restore(ctx)
+		deleteErr := fmt.Errorf("tracker auth: delete %s cookies: %w", spec.id, err)
+		if restoreErr != nil {
+			return api.TrackerAuthStatus{}, errors.Join(deleteErr, restoreErr)
+		}
+		return api.TrackerAuthStatus{}, deleteErr
+	}
+	if s.afterDeleteCleanup != nil {
+		s.afterDeleteCleanup()
+	}
+	status, err := s.statusForSpec(contextWithoutCancel(ctx), spec)
 	if err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
@@ -258,6 +315,9 @@ func (s *Service) Delete(ctx context.Context, trackerID string) (api.TrackerAuth
 	return status, nil
 }
 
+// statusForSpec reports configured auth material without hiding encrypted
+// storage availability; cookie-only trackers still surface unavailable storage
+// as the state when no stronger auth material is configured.
 func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) (api.TrackerAuthStatus, error) {
 	encryptedStorage := s.encryptedStorageAvailable()
 	status := api.TrackerAuthStatus{
@@ -269,6 +329,8 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) (api.Trac
 	}
 
 	cfg, hasCfg := trackerConfig(s.cfg, spec.id)
+	hasAPIKey := spec.apiKey && configAPIKey(cfg) != ""
+	hasCredentials := spec.login && hasCfg && hasUsableLoginConfig(spec, cfg)
 	if spec.cookies {
 		values, err := cookies.LoadTrackerCookieMap(ctx, s.cfg.MainSettings.DBPath, spec.id)
 		if err == nil && len(values) > 0 {
@@ -279,14 +341,13 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) (api.Trac
 		}
 	}
 
-	if spec.apiKey && configAPIKey(cfg) != "" {
+	if hasAPIKey && (!isMTVSpec(spec) || status.CookieCount > 0 || hasCredentials) {
 		status.State = StateConfigured
 	}
 	if spec.passkey && strings.TrimSpace(cfg.Passkey) != "" {
 		status.State = StateConfigured
 	}
 	if spec.login {
-		hasCredentials := hasCfg && strings.TrimSpace(cfg.Username) != "" && strings.TrimSpace(cfg.Password) != ""
 		if hasCredentials {
 			if status.State == StateNotConfigured {
 				status.State = StateConfigured
@@ -298,11 +359,31 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) (api.Trac
 			status.State = StateLoginRequired
 		}
 	}
-	if spec.cookies && status.CookieCount == 0 && !encryptedStorage {
+	if spec.cookies && status.CookieCount == 0 && !encryptedStorage && authStatusRequiresEncryptedStorage(spec, hasCredentials, hasAPIKey, strings.TrimSpace(cfg.Passkey) != "") {
 		status.State = StateEncryptedStorageUnavailable
 	}
 	status.Message = validationMessage(spec, status)
+	if isMTVSpec(spec) && hasAPIKey && status.CookieCount == 0 && !hasCredentials {
+		status.Message = "API key covers Torznab/search; imported cookies or login credentials required for upload auth"
+	}
 	return status, nil
+}
+
+func isMTVSpec(spec trackerSpec) bool {
+	return strings.EqualFold(spec.id, "MTV")
+}
+
+// hasUsableLoginConfig reports whether credential login has every config value
+// required by the tracker implementation. PTP also needs announce_url because
+// login derives the passkey from it.
+func hasUsableLoginConfig(spec trackerSpec, cfg config.TrackerConfig) bool {
+	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
+		return false
+	}
+	if strings.EqualFold(spec.id, "PTP") && strings.TrimSpace(cfg.AnnounceURL) == "" {
+		return false
+	}
+	return true
 }
 
 func (s *Service) encryptedStorageAvailable() bool {
@@ -313,19 +394,49 @@ func (s *Service) encryptedStorageAvailable() bool {
 	return err == nil
 }
 
+func authStatusRequiresEncryptedStorage(spec trackerSpec, hasCredentials bool, hasAPIKey bool, hasPasskey bool) bool {
+	if spec.passkey && hasPasskey {
+		return false
+	}
+	if spec.apiKey && hasAPIKey && !isMTVSpec(spec) {
+		return false
+	}
+	return !hasAPIKey || isMTVSpec(spec) || hasCredentials
+}
+
+// specFor resolves built-in and configured tracker IDs through normalizeTrackerID
+// so ASCII case differences match while non-ASCII runes keep their original case.
 func (s *Service) specFor(trackerID string) (trackerSpec, error) {
-	needle := strings.TrimSpace(trackerID)
+	needle := normalizeTrackerID(trackerID)
 	if needle == "" {
 		return trackerSpec{}, errors.New("tracker auth: tracker id is required")
 	}
 	for _, spec := range s.specs() {
-		if strings.EqualFold(spec.id, needle) {
+		if spec.id == needle {
 			return spec, nil
 		}
 	}
 	return trackerSpec{}, fmt.Errorf("tracker auth: unknown tracker %s", needle)
 }
 
+func (s *Service) validateTrackerConfigIDs() error {
+	seen := map[string]string{}
+	for id := range s.cfg.Trackers.Trackers {
+		trimmedID := strings.TrimSpace(id)
+		if trimmedID == "" {
+			continue
+		}
+		normalizedID := normalizeTrackerID(trimmedID)
+		if previous, ok := seen[normalizedID]; ok && previous != trimmedID {
+			return fmt.Errorf("tracker auth: duplicate tracker config id %q conflicts with %q", trimmedID, previous)
+		}
+		seen[normalizedID] = trimmedID
+	}
+	return nil
+}
+
+// specs returns built-ins plus configured trackers indexed by the same
+// canonical ID used by lookup and duplicate-config validation.
 func (s *Service) specs() []trackerSpec {
 	index := map[string]trackerSpec{}
 	for _, spec := range builtInSpecs() {
@@ -336,10 +447,10 @@ func (s *Service) specs() []trackerSpec {
 		if trimmedID == "" {
 			continue
 		}
-		upperID := strings.ToUpper(trimmedID)
-		spec, ok := index[upperID]
+		normalizedID := normalizeTrackerID(trimmedID)
+		spec, ok := index[normalizedID]
 		if !ok {
-			spec = trackerSpec{id: upperID, authKind: "config"}
+			spec = trackerSpec{id: normalizedID, authKind: "config"}
 		}
 		if configAPIKey(cfg) != "" {
 			spec.apiKey = true
@@ -360,7 +471,7 @@ func (s *Service) specs() []trackerSpec {
 				spec.authKind = "credential_login"
 			}
 		}
-		index[upperID] = spec
+		index[normalizedID] = spec
 	}
 
 	out := make([]trackerSpec, 0, len(index))
@@ -412,9 +523,41 @@ func capabilityFromSpec(spec trackerSpec) api.TrackerAuthCapability {
 	}
 }
 
+// capabilityForSpec exposes remote login, auto-login, and 2FA actions only
+// when this service has an adapter that can execute them.
+func (s *Service) capabilityForSpec(spec trackerSpec) api.TrackerAuthCapability {
+	capability := capabilityFromSpec(spec)
+	if _, ok := s.adapterFor(spec.id); ok {
+		return capability
+	}
+	capability.SupportsLogin = false
+	capability.SupportsAutoLogin = false
+	capability.SupportsTOTP = false
+	capability.SupportsManual2FA = false
+	return capability
+}
+
+func (s *Service) challengeOwnerKey(trackerID string) (string, error) {
+	if err := s.validateTrackerConfigIDs(); err != nil {
+		return "", err
+	}
+	cfg, ok := trackerConfig(s.cfg, trackerID)
+	if !ok {
+		cfg = config.TrackerConfig{}
+	}
+	// #nosec G117 -- payload is only hashed for a local challenge owner key.
+	payload, err := json.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("tracker auth: encode challenge owner: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	return normalizeTrackerID(trackerID) + ":" + hex.EncodeToString(sum[:]), nil
+}
+
 func trackerConfig(cfg config.Config, trackerID string) (config.TrackerConfig, bool) {
+	normalizedTrackerID := normalizeTrackerID(trackerID)
 	for key, value := range cfg.Trackers.Trackers {
-		if strings.EqualFold(strings.TrimSpace(key), strings.TrimSpace(trackerID)) {
+		if normalizeTrackerID(key) == normalizedTrackerID {
 			return value, true
 		}
 	}
@@ -433,6 +576,9 @@ func validationMessage(spec trackerSpec, status api.TrackerAuthStatus) string {
 	case StateHasCookies:
 		return fmt.Sprintf("%d stored cookie(s); tracker upload/search will validate remotely when used", status.CookieCount)
 	case StateConfigured:
+		if status.CookieCount > 0 {
+			return fmt.Sprintf("required config auth material is present; %d stored cookie(s)", status.CookieCount)
+		}
 		return "required config auth material is present"
 	case StateLoginRequired:
 		return "login credentials or imported cookies required"
@@ -446,19 +592,37 @@ func validationMessage(spec trackerSpec, status api.TrackerAuthStatus) string {
 	}
 }
 
-// ParseCookieContent parses JSON cookie exports or Netscape cookie files into a name/value map.
+// ParseCookieContent parses JSON cookie exports or Netscape cookie files into
+// a non-empty name/value map. Raw content above [MaxCookieImportContentBytes],
+// malformed JSON-looking payloads, JSON array entries without name and value,
+// and duplicate trimmed cookie names are rejected; cookie values are preserved
+// byte-for-byte after decoding.
 func ParseCookieContent(fileName string, content string) (map[string]string, error) {
+	if len(content) > MaxCookieImportContentBytes {
+		return nil, fmt.Errorf("tracker auth: cookie file content exceeds %d byte limit", MaxCookieImportContentBytes)
+	}
 	trimmed := strings.TrimSpace(content)
 	if trimmed == "" {
 		return nil, errors.New("tracker auth: cookie file content is required")
 	}
-	if strings.EqualFold(filepath.Ext(strings.TrimSpace(fileName)), ".json") || strings.HasPrefix(trimmed, "{") {
+	if shouldParseJSONCookies(fileName, trimmed) {
 		return parseJSONCookieContent([]byte(trimmed))
 	}
-	return parseNetscapeCookieContent(trimmed)
+	return parseNetscapeCookieContent(content)
+}
+
+// shouldParseJSONCookies accepts JSON by extension, leading object, or a valid
+// leading array so exported array payloads are not filename-dependent.
+func shouldParseJSONCookies(fileName string, trimmed string) bool {
+	return strings.EqualFold(filepath.Ext(strings.TrimSpace(fileName)), ".json") ||
+		strings.HasPrefix(trimmed, "{") ||
+		strings.HasPrefix(trimmed, "[")
 }
 
 func parseJSONCookieContent(payload []byte) (map[string]string, error) {
+	if err := rejectDuplicateJSONCookieNames(payload); err != nil {
+		return nil, err
+	}
 	var decoded any
 	if err := json.Unmarshal(payload, &decoded); err != nil {
 		return nil, fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
@@ -466,14 +630,18 @@ func parseJSONCookieContent(payload []byte) (map[string]string, error) {
 	out := make(map[string]string)
 	switch typed := decoded.(type) {
 	case map[string]any:
-		addJSONCookieObject(out, typed)
+		if err := addJSONCookieObject(out, typed); err != nil {
+			return nil, err
+		}
 	case []any:
 		for _, item := range typed {
 			entry, ok := item.(map[string]any)
 			if !ok {
-				continue
+				return nil, errors.New("tracker auth: JSON cookie array entries must be objects")
 			}
-			addJSONCookieArrayEntry(out, entry)
+			if err := addJSONCookieArrayEntry(out, entry); err != nil {
+				return nil, err
+			}
 		}
 	default:
 		return nil, errors.New("tracker auth: JSON cookie content must be an object or array")
@@ -484,7 +652,155 @@ func parseJSONCookieContent(payload []byte) (map[string]string, error) {
 	return out, nil
 }
 
-func addJSONCookieObject(out map[string]string, decoded map[string]any) {
+// rejectDuplicateJSONCookieNames rejects duplicates only where JSON fields
+// become effective cookie names or values before json.Unmarshal can collapse
+// them into a map.
+func rejectDuplicateJSONCookieNames(payload []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	token, err := decoder.Token()
+	if err != nil {
+		return fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		return rejectDuplicateJSONRootCookieNames(decoder)
+	case '[':
+		return rejectDuplicateJSONArrayCookieFields(decoder)
+	default:
+		return nil
+	}
+}
+
+func rejectDuplicateJSONRootCookieNames(decoder *json.Decoder) error {
+	seen := map[string]struct{}{}
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+		}
+		key, ok := token.(string)
+		if !ok {
+			return errors.New("tracker auth: JSON cookie object has non-string key")
+		}
+		name := strings.TrimSpace(key)
+		if name != "" {
+			if _, ok := seen[name]; ok {
+				return fmt.Errorf("tracker auth: duplicate cookie name %q", name)
+			}
+			seen[name] = struct{}{}
+		}
+		valueToken, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+		}
+		if err := rejectDuplicateJSONObjectCookieFields(decoder, valueToken, map[string]struct{}{"value": {}}); err != nil {
+			return err
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+	}
+	return nil
+}
+
+func rejectDuplicateJSONArrayCookieFields(decoder *json.Decoder) error {
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+		}
+		if err := rejectDuplicateJSONObjectCookieFields(decoder, token, map[string]struct{}{"name": {}, "value": {}}); err != nil {
+			return err
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+	}
+	return nil
+}
+
+func rejectDuplicateJSONObjectCookieFields(decoder *json.Decoder, token json.Token, fields map[string]struct{}) error {
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	if delim != '{' {
+		return discardJSONValue(decoder, token)
+	}
+	seen := map[string]struct{}{}
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return errors.New("tracker auth: JSON cookie object has non-string key")
+		}
+		name := strings.TrimSpace(key)
+		if _, relevant := fields[name]; relevant {
+			if _, ok := seen[name]; ok {
+				return fmt.Errorf("tracker auth: duplicate cookie name %q", name)
+			}
+			seen[name] = struct{}{}
+		}
+		valueToken, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+		}
+		if err := discardJSONValue(decoder, valueToken); err != nil {
+			return err
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+	}
+	return nil
+}
+
+func discardJSONValue(decoder *json.Decoder, token json.Token) error {
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		for decoder.More() {
+			if _, err := decoder.Token(); err != nil {
+				return fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+			}
+			valueToken, err := decoder.Token()
+			if err != nil {
+				return fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+			}
+			if err := discardJSONValue(decoder, valueToken); err != nil {
+				return err
+			}
+		}
+	case '[':
+		for decoder.More() {
+			valueToken, err := decoder.Token()
+			if err != nil {
+				return fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+			}
+			if err := discardJSONValue(decoder, valueToken); err != nil {
+				return err
+			}
+		}
+	default:
+		return nil
+	}
+	if _, err := decoder.Token(); err != nil {
+		return fmt.Errorf("tracker auth: parse JSON cookies: %w", err)
+	}
+	return nil
+}
+
+func addJSONCookieObject(out map[string]string, decoded map[string]any) error {
 	for key, value := range decoded {
 		name := strings.TrimSpace(key)
 		if name == "" {
@@ -492,25 +808,30 @@ func addJSONCookieObject(out map[string]string, decoded map[string]any) {
 		}
 		switch typed := value.(type) {
 		case string:
-			addCookieValue(out, name, typed)
+			if err := addCookieValue(out, name, typed); err != nil {
+				return err
+			}
 		case map[string]any:
 			if raw, ok := typed["value"]; ok && raw != nil {
-				addCookieValue(out, name, fmt.Sprint(raw))
+				if err := addCookieValue(out, name, fmt.Sprint(raw)); err != nil {
+					return err
+				}
 			}
 		}
 	}
+	return nil
 }
 
-func addJSONCookieArrayEntry(out map[string]string, entry map[string]any) {
-	name, hasName := jsonCookieField(entry, "name")
-	value, hasValue := jsonCookieField(entry, "value")
+func addJSONCookieArrayEntry(out map[string]string, entry map[string]any) error {
+	name, hasName := jsonCookieNameField(entry, "name")
+	value, hasValue := jsonCookieValueField(entry, "value")
 	if !hasName || !hasValue {
-		return
+		return errors.New("tracker auth: JSON cookie array entries require name and value")
 	}
-	addCookieValue(out, name, value)
+	return addCookieValue(out, name, value)
 }
 
-func jsonCookieField(entry map[string]any, key string) (string, bool) {
+func jsonCookieNameField(entry map[string]any, key string) (string, bool) {
 	raw, ok := entry[key]
 	if !ok || raw == nil {
 		return "", false
@@ -518,25 +839,39 @@ func jsonCookieField(entry map[string]any, key string) (string, bool) {
 	return strings.TrimSpace(fmt.Sprint(raw)), true
 }
 
-func addCookieValue(out map[string]string, name string, value string) {
-	name = strings.TrimSpace(name)
-	value = strings.TrimSpace(value)
-	if name != "" && value != "" {
-		out[name] = value
+func jsonCookieValueField(entry map[string]any, key string) (string, bool) {
+	raw, ok := entry[key]
+	if !ok || raw == nil {
+		return "", false
 	}
+	return fmt.Sprint(raw), true
 }
 
+func addCookieValue(out map[string]string, name string, value string) error {
+	name = strings.TrimSpace(name)
+	if name != "" && value != "" {
+		if _, ok := out[name]; ok {
+			return fmt.Errorf("tracker auth: duplicate cookie name %q", name)
+		}
+		out[name] = value
+	}
+	return nil
+}
+
+// parseNetscapeCookieContent extracts cookie name/value pairs from Netscape
+// cookie lines without scanner token-size limits. Names are trimmed; values are
+// preserved after the value column, including surrounding spaces and tabs.
 func parseNetscapeCookieContent(content string) (map[string]string, error) {
 	out := make(map[string]string)
-	scanner := bufio.NewScanner(strings.NewReader(content))
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
+	for rawLine := range strings.SplitSeq(content, "\n") {
+		line := strings.TrimSuffix(rawLine, "\r")
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == "" {
 			continue
 		}
-		if trimmedLine, ok := strings.CutPrefix(line, "#HttpOnly_"); ok {
-			line = trimmedLine
-		} else if strings.HasPrefix(line, "#") {
+		if httpOnlyLine, ok := strings.CutPrefix(trimmedLine, "#HttpOnly_"); ok {
+			line = httpOnlyLine
+		} else if strings.HasPrefix(trimmedLine, "#") {
 			continue
 		}
 		fields := strings.Split(line, "\t")
@@ -544,13 +879,13 @@ func parseNetscapeCookieContent(content string) (map[string]string, error) {
 			continue
 		}
 		name := strings.TrimSpace(fields[5])
-		value := strings.TrimSpace(strings.Join(fields[6:], "\t"))
+		value := strings.Join(fields[6:], "\t")
 		if name != "" && value != "" {
+			if _, ok := out[name]; ok {
+				return nil, fmt.Errorf("tracker auth: duplicate cookie name %q", name)
+			}
 			out[name] = value
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("tracker auth: scan Netscape cookies: %w", err)
 	}
 	if len(out) == 0 {
 		return nil, errors.New("tracker auth: cookie content has no entries")
@@ -558,8 +893,23 @@ func parseNetscapeCookieContent(content string) (map[string]string, error) {
 	return out, nil
 }
 
+var statusURLRe = regexp.MustCompile(`https?://[^\s"'>)]+`)
+
 func redact(value string) string {
-	return strings.TrimSpace(redaction.RedactValue(value, nil))
+	redacted := redaction.RedactValue(value, nil)
+	redacted = statusURLRe.ReplaceAllStringFunc(redacted, func(raw string) string {
+		trimmed := strings.TrimRight(raw, ".,;:")
+		suffix := strings.TrimPrefix(raw, trimmed)
+		parsed, err := url.Parse(trimmed)
+		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+			return raw
+		}
+		if parsed.EscapedPath() == "" && parsed.RawQuery == "" {
+			return raw
+		}
+		return parsed.Scheme + "://" + parsed.Host + "/[REDACTED]" + suffix
+	})
+	return strings.TrimSpace(redacted)
 }
 
 func mustTrackerConfig(cfg config.Config, trackerID string) config.TrackerConfig {
@@ -567,6 +917,8 @@ func mustTrackerConfig(cfg config.Config, trackerID string) config.TrackerConfig
 	return trackerCfg
 }
 
+// applyEnsureErrorToStatus maps typed ensure errors onto API status without
+// exposing an unactionable 2FA state when no challenge id exists.
 func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
 	status.LastError = redact(err.Error())
 	status.Message = "remote auth test failed"
@@ -574,14 +926,27 @@ func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
 	var authRequired *AuthRequiredError
 	if errors.As(err, &authRequired) {
 		status.State = StateLoginRequired
-		status.Message = "login credentials or imported cookies required"
+		if validation, ok := asValidationError(err); ok && validation.ConfirmedInvalid {
+			status.CookieCount = 0
+			status.Message = "stored session expired or invalid"
+		} else {
+			status.Message = "login credentials or imported cookies required"
+		}
 		return
 	}
 
 	var needs2FA *Needs2FAError
 	if errors.As(err, &needs2FA) {
+		challengeID := strings.TrimSpace(needs2FA.ChallengeID)
+		if challengeID == "" {
+			status.State = StateLoginRequired
+			status.Needs2FA = false
+			status.ChallengeID = ""
+			status.Message = "2FA required but no manual challenge is available"
+			return
+		}
 		status.Needs2FA = true
-		status.ChallengeID = strings.TrimSpace(needs2FA.ChallengeID)
+		status.ChallengeID = challengeID
 		status.State = StateLoginRequired
 		status.Message = "2FA required"
 		return
@@ -601,7 +966,8 @@ func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
 	}
 }
 
-// CookiesToMap converts HTTP cookies to a non-empty name/value map, ignoring nil cookies and blank names or values.
+// CookiesToMap converts HTTP cookies to a name/value map, ignoring nil cookies
+// and blank names or values while preserving cookie value bytes.
 func CookiesToMap(values []*http.Cookie) map[string]string {
 	out := make(map[string]string)
 	for _, cookie := range values {
@@ -609,7 +975,7 @@ func CookiesToMap(values []*http.Cookie) map[string]string {
 			continue
 		}
 		name := strings.TrimSpace(cookie.Name)
-		value := strings.TrimSpace(cookie.Value)
+		value := cookie.Value
 		if name != "" && value != "" {
 			out[name] = value
 		}
@@ -617,19 +983,116 @@ func CookiesToMap(values []*http.Cookie) map[string]string {
 	return out
 }
 
+// ReadCookieImportContent reads at most [MaxCookieImportContentBytes] from r and
+// returns the shared parser cap error before allocating a larger payload.
+func ReadCookieImportContent(r io.Reader) (string, error) {
+	if r == nil {
+		return "", errors.New("tracker auth: cookie file content is required")
+	}
+	limited := io.LimitReader(r, MaxCookieImportContentBytes+1)
+	payload, err := io.ReadAll(limited)
+	if err != nil {
+		return "", fmt.Errorf("tracker auth: read cookie file content: %w", err)
+	}
+	if len(payload) > MaxCookieImportContentBytes {
+		return "", fmt.Errorf("tracker auth: cookie file content exceeds %d byte limit", MaxCookieImportContentBytes)
+	}
+	return string(payload), nil
+}
+
+// trackerAuthStateSnapshot keeps the AR auth material needed to roll back a
+// partial delete after tracker cookie cleanup reports failure.
+type trackerAuthStateSnapshot struct {
+	dbPath          string
+	trackerID       string
+	authKeyValue    string
+	hadAuthKey      bool
+	legacyAuthPath  string
+	legacyAuthValue []byte
+	hadLegacyAuth   bool
+}
+
+// snapshotTrackerAuthState captures AR encrypted and legacy auth keys before a
+// destructive delete; non-AR trackers have no tracker-specific auth state here.
+func snapshotTrackerAuthState(ctx context.Context, dbPath string, trackerID string) (trackerAuthStateSnapshot, error) {
+	snapshot := trackerAuthStateSnapshot{dbPath: dbPath, trackerID: trackerID}
+	if !strings.EqualFold(strings.TrimSpace(trackerID), "AR") {
+		return snapshot, nil
+	}
+	authKey, err := LoadAuthState(ctx, dbPath, "AR", "auth_key")
+	if err == nil {
+		snapshot.authKeyValue = authKey
+		snapshot.hadAuthKey = true
+	} else if !errors.Is(err, ErrAuthStateNotFound) && encryptedAuthStateMayExist(dbPath) {
+		return snapshot, fmt.Errorf("tracker auth: snapshot AR auth state: %w", err)
+	}
+	if legacyPath, err := servicedb.CookiePath(dbPath, "AR_auth.txt"); err == nil {
+		snapshot.legacyAuthPath = legacyPath
+		legacyValue, readErr := os.ReadFile(legacyPath)
+		if readErr == nil {
+			snapshot.legacyAuthValue = legacyValue
+			snapshot.hadLegacyAuth = true
+		} else if !os.IsNotExist(readErr) {
+			return snapshot, fmt.Errorf("tracker auth: snapshot AR legacy auth key: %w", readErr)
+		}
+	}
+	return snapshot, nil
+}
+
+// restore writes captured AR auth material back using a rollback context so a
+// canceled request cannot prevent best-effort restoration.
+func (s trackerAuthStateSnapshot) restore(ctx context.Context) error {
+	if !strings.EqualFold(strings.TrimSpace(s.trackerID), "AR") {
+		return nil
+	}
+	rollbackCtx := contextWithoutCancel(ctx)
+	var errs []error
+	if s.hadAuthKey {
+		if err := SaveAuthState(rollbackCtx, s.dbPath, "AR", "auth_key", s.authKeyValue); err != nil {
+			errs = append(errs, fmt.Errorf("tracker auth: restore AR auth state: %w", err))
+		}
+	}
+	if s.hadLegacyAuth && s.legacyAuthPath != "" {
+		if err := os.MkdirAll(filepath.Dir(s.legacyAuthPath), 0o700); err != nil {
+			errs = append(errs, fmt.Errorf("tracker auth: restore AR legacy auth key dir: %w", err))
+		} else if err := os.WriteFile(s.legacyAuthPath, s.legacyAuthValue, 0o600); err != nil {
+			errs = append(errs, fmt.Errorf("tracker auth: restore AR legacy auth key: %w", err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// contextWithoutCancel preserves context values for rollback work while
+// detaching cancellation and deadline state.
+func contextWithoutCancel(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return context.WithoutCancel(ctx)
+}
+
+// deleteTrackerAuthState removes tracker-specific encrypted state in addition
+// to generic cookie storage. AR also has a legacy plaintext auth key path, so
+// deletion reports uncertain encrypted cleanup instead of silently leaving stale
+// auth material when helper state cannot prove absence.
 func deleteTrackerAuthState(ctx context.Context, dbPath string, trackerID string) error {
 	if !strings.EqualFold(strings.TrimSpace(trackerID), "AR") {
 		return nil
 	}
+	var errs []error
 	if err := DeleteAuthState(ctx, dbPath, "AR", "auth_key"); err != nil && encryptedAuthStateMayExist(dbPath) {
-		return fmt.Errorf("tracker auth: delete AR auth state: %w", err)
+		errs = append(errs, fmt.Errorf("tracker auth: delete AR auth state: %w", err))
+	} else if err != nil && !errors.Is(err, ErrAuthStateNotFound) {
+		errs = append(errs, fmt.Errorf("tracker auth: delete AR auth state uncertain: %w", err))
 	}
 	if legacyPath, err := servicedb.CookiePath(dbPath, "AR_auth.txt"); err == nil {
 		if err := os.Remove(legacyPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("tracker auth: delete AR legacy auth key: %w", err)
+			errs = append(errs, fmt.Errorf("tracker auth: delete AR legacy auth key: %w", err))
 		}
+	} else {
+		errs = append(errs, fmt.Errorf("tracker auth: resolve AR legacy auth key path: %w", err))
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func encryptedAuthStateMayExist(dbPath string) bool {

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackerauth
+
+import "testing"
+
+func TestParseCookieContentJSONMap(t *testing.T) {
+	got, err := ParseCookieContent("MTV.json", `{"session":"abc","nested":{"value":"def"}}`)
+	if err != nil {
+		t.Fatalf("ParseCookieContent: %v", err)
+	}
+	if got["session"] != "abc" || got["nested"] != "def" {
+		t.Fatalf("unexpected cookies: %#v", got)
+	}
+}
+
+func TestParseCookieContentNetscape(t *testing.T) {
+	got, err := ParseCookieContent("PTP.txt", ".example.test\tTRUE\t/\tTRUE\t0\tsession\tabc\n")
+	if err != nil {
+		t.Fatalf("ParseCookieContent: %v", err)
+	}
+	if got["session"] != "abc" {
+		t.Fatalf("unexpected cookies: %#v", got)
+	}
+}

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -6,6 +6,7 @@ package trackerauth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,6 +20,20 @@ import (
 	servicedb "github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
+
+type trackerAuthRecordingLogger struct {
+	api.NopLogger
+	info []string
+	warn []string
+}
+
+func (l *trackerAuthRecordingLogger) Infof(format string, args ...any) {
+	l.info = append(l.info, fmt.Sprintf(format, args...))
+}
+
+func (l *trackerAuthRecordingLogger) Warnf(format string, args ...any) {
+	l.warn = append(l.warn, fmt.Sprintf(format, args...))
+}
 
 func TestLoginCreatesManual2FAChallengeBeforeReturning(t *testing.T) {
 	cfg := config.Config{
@@ -184,16 +199,13 @@ func TestStatusConfiguredOTPURIAvoidsManualChallenge(t *testing.T) {
 			},
 		},
 	})
-	status, err := service.statusForSpec(context.Background(), trackerSpec{
+	status := service.statusForSpec(context.Background(), trackerSpec{
 		id:               "PTP",
 		login:            true,
 		totp:             true,
 		manual2FA:        true,
 		needsCredentials: true,
 	})
-	if err != nil {
-		t.Fatalf("statusForSpec: %v", err)
-	}
 	if status.State != StateConfigured {
 		t.Fatalf("expected configured status, got %#v", status)
 	}
@@ -315,10 +327,7 @@ func TestStatusConfiguredAuthReportsEncryptedStorageUnavailableWhenPersistenceRe
 					Trackers: map[string]config.TrackerConfig{tt.spec.id: tt.cfg},
 				},
 			})
-			status, err := service.statusForSpec(context.Background(), tt.spec)
-			if err != nil {
-				t.Fatalf("statusForSpec: %v", err)
-			}
+			status := service.statusForSpec(context.Background(), tt.spec)
 			if status.State != tt.wantState {
 				t.Fatalf("expected %s state, got %#v", tt.wantState, status)
 			}
@@ -418,13 +427,10 @@ func TestStatusCookiesOnlyReportsEncryptedStorageUnavailable(t *testing.T) {
 	service := NewService(config.Config{
 		MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(t.TempDir(), "upbrr.db")},
 	})
-	status, err := service.statusForSpec(context.Background(), trackerSpec{
+	status := service.statusForSpec(context.Background(), trackerSpec{
 		id:      "ASC",
 		cookies: true,
 	})
-	if err != nil {
-		t.Fatalf("statusForSpec: %v", err)
-	}
 	if status.State != StateEncryptedStorageUnavailable {
 		t.Fatalf("expected encrypted storage unavailable, got %#v", status)
 	}
@@ -899,6 +905,45 @@ func TestCapabilitiesDoNotAdvertiseUnsupportedMTVPTPManual2FA(t *testing.T) {
 			if cap.SupportsLogin || cap.SupportsAutoLogin || cap.SupportsManual2FA {
 				t.Fatalf("%s must not advertise unsupported login actions: %#v", cap.TrackerID, cap)
 			}
+		}
+	}
+}
+
+func TestTrackerAuthLogsOperationResultsWithoutSecrets(t *testing.T) {
+	t.Parallel()
+
+	logger := &trackerAuthRecordingLogger{}
+	service := NewServiceWithLogger(config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"MTV": {APIKey: "secret-api-key", Username: "secret-user", Password: "secret-password"},
+			},
+		},
+	}, logger)
+
+	status, err := service.Status(context.Background(), "MTV")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.TrackerID != "MTV" {
+		t.Fatalf("expected MTV status, got %#v", status)
+	}
+	if _, err := service.ImportCookies(context.Background(), "AR", "cookies.json", "{bad"); err == nil {
+		t.Fatal("expected invalid cookie import to fail")
+	}
+
+	infoLog := strings.Join(logger.info, "\n")
+	warnLog := strings.Join(logger.warn, "\n")
+	allLogs := infoLog + "\n" + warnLog
+	if !strings.Contains(infoLog, "tracker auth: status checked tracker=MTV") {
+		t.Fatalf("expected status info log, got info=%q warn=%q", infoLog, warnLog)
+	}
+	if !strings.Contains(warnLog, "tracker auth: cookie import failed tracker=AR bytes=4") {
+		t.Fatalf("expected import warning log, got info=%q warn=%q", infoLog, warnLog)
+	}
+	for _, secret := range []string{"secret-api-key", "secret-user", "secret-password", "{bad"} {
+		if strings.Contains(allLogs, secret) {
+			t.Fatalf("tracker auth log leaked %q: %s", secret, allLogs)
 		}
 	}
 }

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -274,6 +274,9 @@ func TestValidateFFLoginPersistsCookies(t *testing.T) {
 
 	ctx := context.Background()
 	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "FF", map[string]string{"session": "expired"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/upload.php":
@@ -326,6 +329,9 @@ func TestValidateFLLoginPersistsCookies(t *testing.T) {
 
 	ctx := context.Background()
 	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "FL", map[string]string{"session": "expired"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/login.php":
@@ -596,6 +602,52 @@ func TestSubmit2FAPreCodeLoginFailureDoesNotExposeRetryChallenge(t *testing.T) {
 	}
 	if !strings.Contains(status.LastError, "login failed") {
 		t.Fatalf("expected login failure in status, got %#v", status)
+	}
+}
+
+func TestSubmit2FAConfirmedInvalidFailureDoesNotExposeRetryChallenge(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"PTP": {
+					Username:    "user",
+					Password:    "pass",
+					AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+				},
+			},
+		},
+	}
+	service := NewService(cfg)
+	service.challenges = NewChallengeManager(defaultChallengeTTL)
+	service.adapters = map[string]Adapter{
+		"PTP": trackerAdapter{
+			capability: api.TrackerAuthCapability{
+				TrackerID:         "PTP",
+				SupportsLogin:     true,
+				SupportsManual2FA: true,
+			},
+			resolve: func(_ context.Context, _ config.TrackerConfig, _ string, login api.TrackerAuthLoginRequest) error {
+				if login.Code != "000000" {
+					t.Fatalf("expected submitted code, got %q", login.Code)
+				}
+				return &ValidationError{TrackerID: "PTP", ConfirmedInvalid: true, Submitted2FARejected: true, Err: errors.New("login failed")}
+			},
+		},
+	}
+	ownerKey, err := service.challengeOwnerKey("PTP")
+	if err != nil {
+		t.Fatalf("challengeOwnerKey: %v", err)
+	}
+	challengeID := service.challenges.Create(context.Background(), "PTP", ownerKey)
+
+	status, err := service.Submit2FA(context.Background(), challengeID, "000000")
+	if err != nil {
+		t.Fatalf("Submit2FA: %v", err)
+	}
+	if status.Needs2FA || strings.TrimSpace(status.ChallengeID) != "" {
+		t.Fatalf("confirmed-invalid failure must not expose retry challenge: %#v", status)
 	}
 }
 
@@ -1340,6 +1392,10 @@ func TestParseCookieContentPreservesCookieValueWhitespace(t *testing.T) {
 			fileName: "cookies.txt",
 			content:  ".example.test\tTRUE\t/\tTRUE\t0\tsession\t abc ",
 		},
+		"Netscape HttpOnly": {
+			fileName: "cookies.txt",
+			content:  "#HttpOnly_.example.test\tTRUE\t/\tTRUE\t0\tsession\t abc ",
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -1908,7 +1964,7 @@ func TestDeleteARAuthLegacyPathFailureReturnsError(t *testing.T) {
 	}
 }
 
-func TestDeleteARAuthFailureLeavesCookiesUntouched(t *testing.T) {
+func TestDeleteARAuthWithoutWebAuthMaterialDeletesStaleAuth(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -1942,21 +1998,14 @@ func TestDeleteARAuthFailureLeavesCookiesUntouched(t *testing.T) {
 	service := NewService(config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}})
 
 	_, err = service.Delete(ctx, "AR")
-	if err == nil {
-		t.Fatal("expected encrypted auth deletion uncertainty")
-	}
-	if !strings.Contains(err.Error(), "delete AR auth state uncertain") {
-		t.Fatalf("expected encrypted state uncertainty, got %v", err)
-	}
-	legacyAuth, err := os.ReadFile(legacyPath)
 	if err != nil {
-		t.Fatalf("expected legacy AR auth to be restored after uncertainty: %v", err)
+		t.Fatalf("Delete: %v", err)
 	}
-	if string(legacyAuth) != "legacy-auth-key" {
-		t.Fatalf("unexpected restored legacy auth")
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy AR auth deleted, got %v", err)
 	}
-	if _, err := os.Stat(cookiePath); err != nil {
-		t.Fatalf("expected cookies to remain after auth-state delete failure, got %v", err)
+	if _, err := os.Stat(cookiePath); !os.IsNotExist(err) {
+		t.Fatalf("expected cookies deleted, got %v", err)
 	}
 }
 

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/cookies"
 	servicedb "github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/internal/trackers/impl/mtv"
+	"github.com/autobrr/upbrr/internal/trackers/impl/ptp"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -72,6 +74,356 @@ func TestLoginCreatesManual2FAChallengeBeforeReturning(t *testing.T) {
 	}
 	if status.Needs2FA || status.ChallengeID != "" || status.Message != "2FA auth completed" {
 		t.Fatalf("unexpected submit status: %#v", status)
+	}
+}
+
+func TestDefaultAdaptersExposeMTVPTPManual2FAChallenge(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		cfg    func(string) config.TrackerConfig
+		server func(*testing.T) *httptest.Server
+	}{
+		"MTV": {
+			cfg: func(serverURL string) config.TrackerConfig {
+				return config.TrackerConfig{URL: serverURL, Username: "user", Password: "pass"}
+			},
+			server: newMTVManual2FAServer,
+		},
+		"PTP": {
+			cfg: func(serverURL string) config.TrackerConfig {
+				return config.TrackerConfig{
+					URL:         serverURL,
+					Username:    "user",
+					Password:    "pass",
+					AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+				}
+			},
+			server: newPTPManual2FAServer,
+		},
+	}
+	for trackerID, tt := range tests {
+		t.Run(trackerID, func(t *testing.T) {
+			t.Parallel()
+
+			server := tt.server(t)
+			dbPath := newTrackerAuthTestDB(t)
+			cfg := config.Config{
+				MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+				Trackers: config.TrackersConfig{
+					Trackers: map[string]config.TrackerConfig{
+						trackerID: tt.cfg(server.URL),
+					},
+				},
+			}
+
+			for name, action := range map[string]func(*Service) (api.TrackerAuthStatus, error){
+				"Login": func(service *Service) (api.TrackerAuthStatus, error) {
+					return service.Login(context.Background(), trackerID, api.TrackerAuthLoginRequest{})
+				},
+				"Validate": func(service *Service) (api.TrackerAuthStatus, error) {
+					return service.Validate(context.Background(), trackerID)
+				},
+			} {
+				t.Run(name, func(t *testing.T) {
+					service := NewService(cfg)
+					service.challenges = NewChallengeManager(defaultChallengeTTL)
+
+					status, err := action(service)
+					if err != nil {
+						t.Fatalf("%s: %v", name, err)
+					}
+					if !status.Needs2FA || strings.TrimSpace(status.ChallengeID) == "" {
+						t.Fatalf("%s should expose an active manual 2FA challenge, got %#v", name, status)
+					}
+					if status.State != StateLoginRequired || status.Message != "2FA required" {
+						t.Fatalf("%s returned unexpected status: %#v", name, status)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestSubmit2FARetriesAdapterLoginWithCurrentConfigAndCode(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newTrackerAuthTestDB(t)
+	cfg := config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"PTP": {
+					Username:    "user",
+					Password:    "pass",
+					AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+				},
+			},
+		},
+	}
+	var gotCode, gotDBPath, gotUsername string
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{
+			TrackerID:         "PTP",
+			SupportsLogin:     true,
+			SupportsManual2FA: true,
+		},
+		validate: func() (Session, error) {
+			return Session{}, &Needs2FAError{TrackerID: "PTP"}
+		},
+		submit: func(_ context.Context, cfg config.TrackerConfig, dbPath string, req api.TrackerAuthLoginRequest) (Session, error) {
+			gotCode = req.Code
+			gotDBPath = dbPath
+			gotUsername = cfg.Username
+			return Session{TrackerID: "PTP", State: SessionStateReady}, nil
+		},
+	}
+	service := NewService(cfg)
+	service.adapters = map[string]Adapter{"PTP": adapter}
+
+	status, err := service.Login(context.Background(), "PTP", api.TrackerAuthLoginRequest{})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if strings.TrimSpace(status.ChallengeID) == "" {
+		t.Fatalf("expected challenge: %#v", status)
+	}
+	if _, err := service.Submit2FA(context.Background(), status.ChallengeID, "654321"); err != nil {
+		t.Fatalf("Submit2FA: %v", err)
+	}
+	if gotCode != "654321" || gotDBPath != dbPath || gotUsername != "user" {
+		t.Fatalf("unexpected adapter retry args code=%q db=%q username=%q", gotCode, gotDBPath, gotUsername)
+	}
+}
+
+func TestSubmit2FAFailureKeepsChallengeRetryVisible(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"PTP": {
+					Username:    "user",
+					Password:    "pass",
+					AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+				},
+			},
+		},
+	}
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{
+			TrackerID:         "PTP",
+			SupportsLogin:     true,
+			SupportsManual2FA: true,
+		},
+		validate: func() (Session, error) {
+			return Session{}, &Needs2FAError{TrackerID: "PTP"}
+		},
+		submit: func(context.Context, config.TrackerConfig, string, api.TrackerAuthLoginRequest) (Session, error) {
+			return Session{}, &ValidationError{TrackerID: "PTP", Transient: true, Submitted2FARejected: true, Err: errors.New("login failed")}
+		},
+	}
+	service := NewService(cfg)
+	service.adapters = map[string]Adapter{"PTP": adapter}
+
+	status, err := service.Login(context.Background(), "PTP", api.TrackerAuthLoginRequest{})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	status, err = service.Submit2FA(context.Background(), status.ChallengeID, "000000")
+	if err != nil {
+		t.Fatalf("Submit2FA: %v", err)
+	}
+	if !status.Needs2FA || strings.TrimSpace(status.ChallengeID) == "" {
+		t.Fatalf("expected retry-visible challenge after failed code, got %#v", status)
+	}
+}
+
+func TestSubmit2FATransientSubmittedCodeFailureKeepsChallengeRetryVisible(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"PTP": {
+					Username:    "user",
+					Password:    "pass",
+					AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+				},
+			},
+		},
+	}
+	service := NewService(cfg)
+	service.challenges = NewChallengeManager(defaultChallengeTTL)
+	service.adapters = map[string]Adapter{
+		"PTP": trackerAdapter{
+			capability: api.TrackerAuthCapability{
+				TrackerID:         "PTP",
+				SupportsLogin:     true,
+				SupportsManual2FA: true,
+			},
+			resolve: func(_ context.Context, _ config.TrackerConfig, _ string, login api.TrackerAuthLoginRequest) error {
+				if login.Code != "000000" {
+					t.Fatalf("expected submitted code, got %q", login.Code)
+				}
+				return fmt.Errorf("trackers: PTP login failed: %w", ptp.ErrSubmitted2FARejected)
+			},
+		},
+	}
+	ownerKey, err := service.challengeOwnerKey("PTP")
+	if err != nil {
+		t.Fatalf("challengeOwnerKey: %v", err)
+	}
+	challengeID := service.challenges.Create(context.Background(), "PTP", ownerKey)
+
+	status, err := service.Submit2FA(context.Background(), challengeID, "000000")
+	if err != nil {
+		t.Fatalf("Submit2FA: %v", err)
+	}
+	if !status.Needs2FA || status.ChallengeID != challengeID {
+		t.Fatalf("expected retry-visible challenge after classified failed code, got %#v", status)
+	}
+	if _, ok := service.challenges.Get(challengeID); !ok {
+		t.Fatal("failed submitted code consumed challenge")
+	}
+}
+
+func TestSubmit2FAPreCodeLoginFailureDoesNotExposeRetryChallenge(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"PTP": {
+					Username:    "user",
+					Password:    "pass",
+					AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+				},
+			},
+		},
+	}
+	service := NewService(cfg)
+	service.challenges = NewChallengeManager(defaultChallengeTTL)
+	service.adapters = map[string]Adapter{
+		"PTP": trackerAdapter{
+			capability: api.TrackerAuthCapability{
+				TrackerID:         "PTP",
+				SupportsLogin:     true,
+				SupportsManual2FA: true,
+			},
+			resolve: func(_ context.Context, _ config.TrackerConfig, _ string, login api.TrackerAuthLoginRequest) error {
+				if login.Code != "000000" {
+					t.Fatalf("expected submitted code, got %q", login.Code)
+				}
+				return errors.New("trackers: PTP login failed")
+			},
+		},
+	}
+	ownerKey, err := service.challengeOwnerKey("PTP")
+	if err != nil {
+		t.Fatalf("challengeOwnerKey: %v", err)
+	}
+	challengeID := service.challenges.Create(context.Background(), "PTP", ownerKey)
+
+	status, err := service.Submit2FA(context.Background(), challengeID, "000000")
+	if err != nil {
+		t.Fatalf("Submit2FA: %v", err)
+	}
+	if status.Needs2FA || strings.TrimSpace(status.ChallengeID) != "" {
+		t.Fatalf("pre-code login failure must not expose retry challenge: %#v", status)
+	}
+	if !strings.Contains(status.LastError, "login failed") {
+		t.Fatalf("expected login failure in status, got %#v", status)
+	}
+}
+
+func TestSubmit2FAMTVSubmittedCodeAuthKeyFailureKeepsChallengeRetryVisible(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"MTV": {
+					Username: "user",
+					Password: "pass",
+				},
+			},
+		},
+	}
+	service := NewService(cfg)
+	service.challenges = NewChallengeManager(defaultChallengeTTL)
+	service.adapters = map[string]Adapter{
+		"MTV": trackerAdapter{
+			capability: api.TrackerAuthCapability{
+				TrackerID:         "MTV",
+				SupportsLogin:     true,
+				SupportsManual2FA: true,
+			},
+			resolve: func(_ context.Context, _ config.TrackerConfig, _ string, login api.TrackerAuthLoginRequest) error {
+				if login.Code != "000000" {
+					t.Fatalf("expected submitted code, got %q", login.Code)
+				}
+				return fmt.Errorf("trackers: MTV auth key not found: %w", mtv.ErrSubmitted2FARejected)
+			},
+		},
+	}
+	ownerKey, err := service.challengeOwnerKey("MTV")
+	if err != nil {
+		t.Fatalf("challengeOwnerKey: %v", err)
+	}
+	challengeID := service.challenges.Create(context.Background(), "MTV", ownerKey)
+
+	status, err := service.Submit2FA(context.Background(), challengeID, "000000")
+	if err != nil {
+		t.Fatalf("Submit2FA: %v", err)
+	}
+	if !status.Needs2FA || status.ChallengeID != challengeID {
+		t.Fatalf("expected retry-visible MTV challenge after auth-key miss, got %#v", status)
+	}
+	if _, ok := service.challenges.Get(challengeID); !ok {
+		t.Fatal("failed MTV submitted code consumed challenge")
+	}
+}
+
+func TestSubmit2FATransientParserFailureDoesNotExposeRetryChallenge(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"MTV": {Username: "user", Password: "pass"},
+			},
+		},
+	}
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{
+			TrackerID:         "MTV",
+			SupportsLogin:     true,
+			SupportsManual2FA: true,
+		},
+		validate: func() (Session, error) {
+			return Session{}, &Needs2FAError{TrackerID: "MTV"}
+		},
+		submit: func(context.Context, config.TrackerConfig, string, api.TrackerAuthLoginRequest) (Session, error) {
+			return Session{}, classifyAdapterError("MTV", errors.New("trackers: MTV 2FA token not found"))
+		},
+	}
+	service := NewService(cfg)
+	service.adapters = map[string]Adapter{"MTV": adapter}
+
+	status, err := service.Login(context.Background(), "MTV", api.TrackerAuthLoginRequest{})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	status, err = service.Submit2FA(context.Background(), status.ChallengeID, "000000")
+	if err != nil {
+		t.Fatalf("Submit2FA: %v", err)
+	}
+	if status.Needs2FA || strings.TrimSpace(status.ChallengeID) != "" {
+		t.Fatalf("transient parser failure must not expose retry challenge: %#v", status)
+	}
+	if !strings.Contains(status.LastError, "2FA token not found") {
+		t.Fatalf("expected parser failure in status, got %#v", status)
 	}
 }
 
@@ -138,7 +490,7 @@ func TestSubmit2FAUsesCanceledContextWithoutConsumingChallenge(t *testing.T) {
 			SupportsLogin:     true,
 			SupportsManual2FA: true,
 		},
-		submit: func(ctx context.Context, _ string, _ string) (Session, error) {
+		submit: func(ctx context.Context, _ config.TrackerConfig, _ string, _ api.TrackerAuthLoginRequest) (Session, error) {
 			return Session{}, ctx.Err()
 		},
 	}
@@ -187,30 +539,44 @@ func TestLoginMissingCredentialsReturnsLoginRequiredWithoutChallenge(t *testing.
 func TestStatusConfiguredOTPURIAvoidsManualChallenge(t *testing.T) {
 	t.Parallel()
 
-	service := NewService(config.Config{
-		Trackers: config.TrackersConfig{
-			Trackers: map[string]config.TrackerConfig{
-				"PTP": {
-					Username:    "user",
-					Password:    "pass",
-					AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
-					OTPURI:      "otpauth://totp/PTP:user?secret=ABC",
-				},
-			},
+	tests := map[string]config.TrackerConfig{
+		"configured otp uri": {
+			Username:    "user",
+			Password:    "pass",
+			AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+			OTPURI:      "otpauth://totp/PTP:user?secret=ABC",
 		},
-	})
-	status := service.statusForSpec(context.Background(), trackerSpec{
-		id:               "PTP",
-		login:            true,
-		totp:             true,
-		manual2FA:        true,
-		needsCredentials: true,
-	})
-	if status.State != StateConfigured {
-		t.Fatalf("expected configured status, got %#v", status)
+		"missing otp uri": {
+			Username:    "user",
+			Password:    "pass",
+			AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+		},
 	}
-	if status.Needs2FA || strings.TrimSpace(status.ChallengeID) != "" {
-		t.Fatalf("configured OTPURI must avoid manual challenge path: %#v", status)
+	for name, trackerCfg := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			service := NewService(config.Config{
+				Trackers: config.TrackersConfig{
+					Trackers: map[string]config.TrackerConfig{
+						"PTP": trackerCfg,
+					},
+				},
+			})
+			status := service.statusForSpec(context.Background(), trackerSpec{
+				id:               "PTP",
+				login:            true,
+				totp:             true,
+				manual2FA:        true,
+				needsCredentials: true,
+			})
+			if status.State != StateConfigured {
+				t.Fatalf("expected configured status, got %#v", status)
+			}
+			if status.Needs2FA || strings.TrimSpace(status.ChallengeID) != "" {
+				t.Fatalf("status-only config must not expose manual challenge path: %#v", status)
+			}
+		})
 	}
 }
 
@@ -877,7 +1243,7 @@ func TestImportCookiesReportsMergedCookieCount(t *testing.T) {
 	}
 }
 
-func TestCapabilitiesDoNotAdvertiseUnsupportedMTVPTPManual2FA(t *testing.T) {
+func TestCapabilitiesAdvertiseOnlySupportedManual2FA(t *testing.T) {
 	t.Parallel()
 
 	service := NewService(config.Config{})
@@ -888,8 +1254,8 @@ func TestCapabilitiesDoNotAdvertiseUnsupportedMTVPTPManual2FA(t *testing.T) {
 	for _, cap := range caps {
 		switch cap.TrackerID {
 		case "MTV", "PTP":
-			if cap.SupportsManual2FA {
-				t.Fatalf("%s must not advertise unsupported manual 2FA", cap.TrackerID)
+			if !cap.SupportsManual2FA {
+				t.Fatalf("%s must advertise supported manual 2FA", cap.TrackerID)
 			}
 			if !cap.SupportsTOTP {
 				t.Fatalf("%s TOTP auto-login capability must be preserved", cap.TrackerID)
@@ -1417,4 +1783,41 @@ func newTrackerAuthTestDB(t *testing.T) string {
 	}
 	_ = repo.Close()
 	return dbPath
+}
+
+func newMTVManual2FAServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/index.php":
+			_, _ = w.Write([]byte("<html>logged out</html>"))
+		case "/login":
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
+				return
+			}
+			http.Redirect(w, r, "/twofactor/login", http.StatusFound)
+		case "/twofactor/login":
+			_, _ = w.Write([]byte(`<input name="token" value="ponmlkjihgfedcba">`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newPTPManual2FAServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ajax.php" || r.URL.RawQuery != "action=login" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"Result":"TfaRequired"}`))
+	}))
+	t.Cleanup(server.Close)
+	return server
 }

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/cookies"
 	servicedb "github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/internal/trackers/impl/mtv"
 	"github.com/autobrr/upbrr/internal/trackers/impl/ptp"
 	"github.com/autobrr/upbrr/pkg/api"
@@ -265,6 +266,144 @@ func TestValidateHDBInvalidCookiesDeletesSession(t *testing.T) {
 	}
 	if _, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "HDB"); err == nil {
 		t.Fatal("expected invalid HDB cookies to be deleted")
+	}
+}
+
+func TestValidateFFLoginPersistsCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/upload.php":
+			if cookie, err := r.Cookie("session"); err == nil && cookie.Value == "valid" {
+				_, _ = w.Write([]byte(`<a href="friends.php">Friends</a>`))
+				return
+			}
+			_, _ = w.Write([]byte(`<input name="username">`))
+		case "/takelogin.php":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			if r.FormValue("username") != "user" || r.FormValue("password") != "pass" {
+				t.Fatalf("unexpected FF login form: %v", r.Form)
+			}
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "valid", Path: "/"})
+			w.Header().Set("Location", "/index.php")
+			w.WriteHeader(http.StatusFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	status, err := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"FF": {URL: server.URL, Username: "user", Password: "pass"},
+			},
+		},
+	}).Validate(ctx, "FF")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.State != StateConfigured {
+		t.Fatalf("expected FF configured after login, got %#v", status)
+	}
+	values, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "FF")
+	if err != nil {
+		t.Fatalf("LoadTrackerCookieMap: %v", err)
+	}
+	if values["session"] != "valid" {
+		t.Fatalf("expected saved FF login cookies, got %#v", values)
+	}
+}
+
+func TestValidateFLLoginPersistsCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login.php":
+			_, _ = w.Write([]byte(`<input name="validator" value="token">`))
+		case "/takelogin.php":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			if r.FormValue("validator") != "token" || r.FormValue("username") != "user" || r.FormValue("password") != "pass" {
+				t.Fatalf("unexpected FL login form: %v", r.Form)
+			}
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "valid", Path: "/"})
+			_, _ = w.Write([]byte("Logout"))
+		case "/index.php":
+			if cookie, err := r.Cookie("session"); err == nil && cookie.Value == "valid" {
+				_, _ = w.Write([]byte("Logout"))
+				return
+			}
+			_, _ = w.Write([]byte(`<input name="username">`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	status, err := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"FL": {URL: server.URL, Username: "user", Password: "pass"},
+			},
+		},
+	}).Validate(ctx, "FL")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.State != StateConfigured {
+		t.Fatalf("expected FL configured after login, got %#v", status)
+	}
+	values, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "FL")
+	if err != nil {
+		t.Fatalf("LoadTrackerCookieMap: %v", err)
+	}
+	if values["session"] != "valid" {
+		t.Fatalf("expected saved FL login cookies, got %#v", values)
+	}
+}
+
+func TestValidateTHRChecksCredentialLogin(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/takelogin.php" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if r.FormValue("username") != "user" || r.FormValue("password") != "pass" || r.FormValue("ssl") != "yes" {
+			t.Fatalf("unexpected THR login form: %v", r.Form)
+		}
+		_, _ = w.Write([]byte(`<a href="logout.php">Logout</a>`))
+	}))
+	t.Cleanup(server.Close)
+
+	status, err := NewService(config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"THR": {URL: server.URL, Username: "user", Password: "pass"},
+			},
+		},
+	}).Validate(context.Background(), "THR")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.State != StateConfigured {
+		t.Fatalf("expected THR configured after login check, got %#v", status)
 	}
 }
 
@@ -948,34 +1087,6 @@ func TestStatusCookiesOnlyReportsEncryptedStorageUnavailable(t *testing.T) {
 	}
 }
 
-func TestLoginWithoutAdapterDoesNotReportRemoteSuccess(t *testing.T) {
-	for _, trackerID := range []string{"FF", "FL", "THR"} {
-		t.Run(trackerID, func(t *testing.T) {
-			cfg := config.Config{
-				Trackers: config.TrackersConfig{
-					Trackers: map[string]config.TrackerConfig{
-						trackerID: {Username: "user", Password: "pass"},
-					},
-				},
-			}
-			status, err := NewService(cfg).Login(
-				context.Background(),
-				trackerID,
-				api.TrackerAuthLoginRequest{},
-			)
-			if err != nil {
-				t.Fatalf("Login: %v", err)
-			}
-			if strings.Contains(status.Message, "succeeded") {
-				t.Fatalf("unexpected remote success message for %s: %#v", trackerID, status)
-			}
-			if !strings.Contains(status.Message, "not supported") {
-				t.Fatalf("expected unsupported remote login message for %s, got %#v", trackerID, status)
-			}
-		})
-	}
-}
-
 func TestRTFStatusTreatsCredentialsAsRefreshAuth(t *testing.T) {
 	t.Parallel()
 
@@ -1016,7 +1127,7 @@ func TestTHRDoesNotAdvertiseCookieImport(t *testing.T) {
 	t.Fatal("THR capability not found")
 }
 
-func TestFFAdvertisesCookieImportWithoutRemoteLoginAction(t *testing.T) {
+func TestFFAdvertisesCookieImportWithRemoteLoginAction(t *testing.T) {
 	t.Parallel()
 
 	service := NewService(config.Config{})
@@ -1031,8 +1142,8 @@ func TestFFAdvertisesCookieImportWithoutRemoteLoginAction(t *testing.T) {
 		if !cap.SupportsCookieFile {
 			t.Fatalf("FF upload can use DB cookies and must advertise cookie import: %#v", cap)
 		}
-		if cap.SupportsLogin || cap.SupportsAutoLogin {
-			t.Fatalf("FF has no tracker-auth remote adapter and must not advertise login actions: %#v", cap)
+		if !cap.SupportsLogin || !cap.SupportsAutoLogin {
+			t.Fatalf("FF tracker-auth adapter must advertise login actions: %#v", cap)
 		}
 		return
 	}
@@ -1043,11 +1154,11 @@ func TestValidateWithoutAdapterReportsUnsupportedRemoteValidation(t *testing.T) 
 	cfg := config.Config{
 		Trackers: config.TrackersConfig{
 			Trackers: map[string]config.TrackerConfig{
-				"FF": {Username: "user", Password: "pass"},
+				"ASC": {},
 			},
 		},
 	}
-	status, err := NewService(cfg).Validate(context.Background(), "FF")
+	status, err := NewService(cfg).Validate(context.Background(), "ASC")
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
@@ -1490,14 +1601,34 @@ func TestCapabilitiesAdvertiseOnlySupportedManual2FA(t *testing.T) {
 			if !cap.SupportsCookieFile || !cap.RequiresPasskey {
 				t.Fatalf("%s must keep cookie/passkey capability: %#v", cap.TrackerID, cap)
 			}
-		case "FF", "FL", "THR":
+		case "FF", "FL":
+			if !cap.SupportsLogin || !cap.SupportsAutoLogin {
+				t.Fatalf("%s adapter-backed login capability must be preserved: %#v", cap.TrackerID, cap)
+			}
+			if !cap.SupportsCookieFile || cap.SupportsManual2FA {
+				t.Fatalf("%s must advertise cookie import without manual 2FA: %#v", cap.TrackerID, cap)
+			}
+		case "THR":
+			if !cap.SupportsLogin || !cap.SupportsAutoLogin {
+				t.Fatalf("%s adapter-backed login capability must be preserved: %#v", cap.TrackerID, cap)
+			}
+			if cap.SupportsCookieFile || cap.SupportsManual2FA {
+				t.Fatalf("%s must advertise stateless login without cookie import or 2FA: %#v", cap.TrackerID, cap)
+			}
+		case "ASC":
 			if cap.SupportsLogin || cap.SupportsAutoLogin || cap.SupportsManual2FA {
 				t.Fatalf("%s must not advertise unsupported login actions: %#v", cap.TrackerID, cap)
 			}
-		case "TTG":
-			if cap.SupportsLogin || cap.SupportsAutoLogin || cap.SupportsManual2FA {
-				t.Fatalf("%s must not advertise unsupported login actions: %#v", cap.TrackerID, cap)
-			}
+		}
+	}
+}
+
+func TestBuiltInSpecsOnlyReferenceKnownTrackers(t *testing.T) {
+	t.Parallel()
+
+	for _, spec := range builtInSpecs() {
+		if !trackers.IsKnownTracker(spec.id) {
+			t.Fatalf("built-in tracker auth spec references unknown tracker %s", spec.id)
 		}
 	}
 }

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -675,7 +675,7 @@ func TestStatusConfiguredAuthReportsEncryptedStorageUnavailableWhenPersistenceRe
 		},
 		"passkey": {
 			cfg:       config.TrackerConfig{Passkey: "passkey"},
-			wantState: StateConfigured,
+			wantState: StateEncryptedStorageUnavailable,
 			spec: trackerSpec{
 				id:      "HDB",
 				cookies: true,
@@ -712,7 +712,7 @@ func TestStatusConfiguredAuthReportsCoexistingCookies(t *testing.T) {
 		cfg       config.TrackerConfig
 	}{
 		"api key": {trackerID: "MTV", cfg: config.TrackerConfig{APIKey: "api-key"}},
-		"passkey": {trackerID: "HDB", cfg: config.TrackerConfig{Passkey: "passkey"}},
+		"passkey": {trackerID: "HDB", cfg: config.TrackerConfig{Username: "user", Passkey: "passkey"}},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -741,6 +741,26 @@ func TestStatusConfiguredAuthReportsCoexistingCookies(t *testing.T) {
 				t.Fatalf("expected message to preserve cookie presence, got %#v", status)
 			}
 		})
+	}
+}
+
+func TestStatusHDBPasskeyWithoutCookiesIsNotUploadReady(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newTrackerAuthTestDB(t)
+	service := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{"HDB": {Username: "user", Passkey: "passkey"}},
+		},
+	})
+
+	status, err := service.Status(context.Background(), "HDB")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.State != StateLoginRequired {
+		t.Fatalf("expected HDB cookie import requirement, got %#v", status)
 	}
 }
 
@@ -806,7 +826,7 @@ func TestStatusCookiesOnlyReportsEncryptedStorageUnavailable(t *testing.T) {
 }
 
 func TestLoginWithoutAdapterDoesNotReportRemoteSuccess(t *testing.T) {
-	for _, trackerID := range []string{"AR", "FL", "THR", "RTF"} {
+	for _, trackerID := range []string{"AR", "FF", "FL", "RTF", "THR"} {
 		t.Run(trackerID, func(t *testing.T) {
 			cfg := config.Config{
 				Trackers: config.TrackersConfig{
@@ -831,6 +851,69 @@ func TestLoginWithoutAdapterDoesNotReportRemoteSuccess(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRTFStatusTreatsCredentialsAsRefreshAuth(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"RTF": {Username: "user", Password: "pass"},
+			},
+		},
+	})
+
+	status, err := service.Status(context.Background(), "RTF")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.State != StateConfigured {
+		t.Fatalf("RTF credentials should report refresh auth configured without api_key: %#v", status)
+	}
+}
+
+func TestTHRDoesNotAdvertiseCookieImport(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(config.Config{})
+	caps, err := service.Capabilities(context.Background())
+	if err != nil {
+		t.Fatalf("Capabilities: %v", err)
+	}
+	for _, cap := range caps {
+		if cap.TrackerID != "THR" {
+			continue
+		}
+		if cap.SupportsCookieFile {
+			t.Fatalf("THR upload logs in per request and must not advertise DB cookie import: %#v", cap)
+		}
+		return
+	}
+	t.Fatal("THR capability not found")
+}
+
+func TestFFAdvertisesCookieImportWithoutRemoteLoginAction(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(config.Config{})
+	caps, err := service.Capabilities(context.Background())
+	if err != nil {
+		t.Fatalf("Capabilities: %v", err)
+	}
+	for _, cap := range caps {
+		if cap.TrackerID != "FF" {
+			continue
+		}
+		if !cap.SupportsCookieFile {
+			t.Fatalf("FF upload can use DB cookies and must advertise cookie import: %#v", cap)
+		}
+		if cap.SupportsLogin || cap.SupportsAutoLogin {
+			t.Fatalf("FF has no tracker-auth remote adapter and must not advertise login actions: %#v", cap)
+		}
+		return
+	}
+	t.Fatal("FF capability not found")
 }
 
 func TestValidateWithoutAdapterReportsUnsupportedRemoteValidation(t *testing.T) {
@@ -1263,7 +1346,7 @@ func TestCapabilitiesAdvertiseOnlySupportedManual2FA(t *testing.T) {
 			if !cap.SupportsLogin || !cap.SupportsAutoLogin {
 				t.Fatalf("%s adapter-backed login capability must be preserved: %#v", cap.TrackerID, cap)
 			}
-		case "AR", "FL", "RTF", "THR":
+		case "AR", "FF", "FL", "RTF", "THR":
 			if cap.SupportsLogin || cap.SupportsAutoLogin || cap.SupportsManual2FA {
 				t.Fatalf("%s must not advertise unsupported login actions: %#v", cap.TrackerID, cap)
 			}
@@ -1280,6 +1363,7 @@ func TestTrackerAuthLogsOperationResultsWithoutSecrets(t *testing.T) {
 
 	logger := &trackerAuthRecordingLogger{}
 	service := NewServiceWithLogger(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: newTrackerAuthTestDB(t)},
 		Trackers: config.TrackersConfig{
 			Trackers: map[string]config.TrackerConfig{
 				"MTV": {APIKey: "secret-api-key", Username: "secret-user", Password: "secret-password"},
@@ -1311,6 +1395,27 @@ func TestTrackerAuthLogsOperationResultsWithoutSecrets(t *testing.T) {
 		if strings.Contains(allLogs, secret) {
 			t.Fatalf("tracker auth log leaked %q: %s", secret, allLogs)
 		}
+	}
+}
+
+func TestTrackerAuthWarningStatusDoesNotLogSuccess(t *testing.T) {
+	t.Parallel()
+
+	logger := &trackerAuthRecordingLogger{}
+	service := NewServiceWithLogger(config.Config{}, logger)
+	service.logStatus("login completed", api.TrackerAuthStatus{
+		TrackerID: "MTV",
+		State:     StateConfigured,
+		LastError: "tracker auth: MTV: validation failed",
+	})
+
+	infoLog := strings.Join(logger.info, "\n")
+	warnLog := strings.Join(logger.warn, "\n")
+	if strings.Contains(infoLog, "tracker auth: login completed") {
+		t.Fatalf("warning status logged success info: info=%q warn=%q", infoLog, warnLog)
+	}
+	if !strings.Contains(warnLog, "tracker auth: login completed warning tracker=MTV") {
+		t.Fatalf("expected warning log, got info=%q warn=%q", infoLog, warnLog)
 	}
 }
 

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -60,6 +60,96 @@ func TestLoginCreatesManual2FAChallengeBeforeReturning(t *testing.T) {
 	}
 }
 
+func TestSubmit2FARejectsChallengeAfterTrackerConfigReplacement(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"PTP": {Username: "user", Password: "pass"},
+			},
+		},
+	}
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{
+			TrackerID:         "PTP",
+			SupportsLogin:     true,
+			SupportsManual2FA: true,
+		},
+		validate: func() (Session, error) {
+			return Session{}, &Needs2FAError{TrackerID: "PTP"}
+		},
+	}
+	loginService := NewService(cfg)
+	loginService.adapters = map[string]Adapter{"PTP": adapter}
+
+	status, err := loginService.Login(context.Background(), "PTP", api.TrackerAuthLoginRequest{})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	replacedCfg := config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"PTP": {Username: "other", Password: "pass"},
+			},
+		},
+	}
+	submitService := NewService(replacedCfg)
+	submitService.adapters = map[string]Adapter{"PTP": adapter}
+	_, err = submitService.Submit2FA(context.Background(), status.ChallengeID, "123456")
+	if err == nil {
+		t.Fatal("expected stale challenge error")
+	}
+	if !strings.Contains(err.Error(), "stale manual 2FA challenge") {
+		t.Fatalf("expected stale challenge error, got %v", err)
+	}
+}
+
+func TestSubmit2FAUsesCanceledContextWithoutConsumingChallenge(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"PTP": {Username: "user", Password: "pass"},
+			},
+		},
+	}
+	challenges := NewChallengeManager(defaultChallengeTTL)
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{
+			TrackerID:         "PTP",
+			SupportsLogin:     true,
+			SupportsManual2FA: true,
+		},
+		submit: func(ctx context.Context, _ string, _ string) (Session, error) {
+			return Session{}, ctx.Err()
+		},
+	}
+	service := NewService(cfg)
+	service.adapters = map[string]Adapter{"PTP": adapter}
+	service.challenges = challenges
+	ownerKey, err := service.challengeOwnerKey("PTP")
+	if err != nil {
+		t.Fatalf("challengeOwnerKey: %v", err)
+	}
+	challengeID := challenges.Create(context.Background(), "PTP", ownerKey)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	status, err := service.Submit2FA(ctx, challengeID, "123456")
+	if err != nil {
+		t.Fatalf("Submit2FA: %v", err)
+	}
+	if !strings.Contains(status.LastError, "context canceled") {
+		t.Fatalf("expected context canceled status, got %#v", status)
+	}
+	if _, ok := challenges.Get(challengeID); !ok {
+		t.Fatal("canceled 2FA submit consumed the challenge")
+	}
+}
+
 func TestLoginMissingCredentialsReturnsLoginRequiredWithoutChallenge(t *testing.T) {
 	t.Parallel()
 
@@ -85,7 +175,12 @@ func TestStatusConfiguredOTPURIAvoidsManualChallenge(t *testing.T) {
 	service := NewService(config.Config{
 		Trackers: config.TrackersConfig{
 			Trackers: map[string]config.TrackerConfig{
-				"PTP": {Username: "user", Password: "pass", OTPURI: "otpauth://totp/PTP:user?secret=ABC"},
+				"PTP": {
+					Username:    "user",
+					Password:    "pass",
+					AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+					OTPURI:      "otpauth://totp/PTP:user?secret=ABC",
+				},
 			},
 		},
 	})
@@ -104,6 +199,237 @@ func TestStatusConfiguredOTPURIAvoidsManualChallenge(t *testing.T) {
 	}
 	if status.Needs2FA || strings.TrimSpace(status.ChallengeID) != "" {
 		t.Fatalf("configured OTPURI must avoid manual challenge path: %#v", status)
+	}
+}
+
+func TestStatusPTPRequiresAnnounceURLForConfiguredLogin(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		cfg       config.TrackerConfig
+		wantState string
+	}{
+		"missing announce": {
+			cfg:       config.TrackerConfig{Username: "user", Password: "pass"},
+			wantState: StateLoginRequired,
+		},
+		"blank announce": {
+			cfg:       config.TrackerConfig{Username: "user", Password: "pass", AnnounceURL: " \t\n "},
+			wantState: StateLoginRequired,
+		},
+		"complete login config": {
+			cfg:       config.TrackerConfig{Username: "user", Password: "pass", AnnounceURL: "https://please.passthepopcorn.me/passkey/announce"},
+			wantState: StateConfigured,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			service := NewService(config.Config{
+				MainSettings: config.MainSettingsConfig{DBPath: newTrackerAuthTestDB(t)},
+				Trackers: config.TrackersConfig{
+					Trackers: map[string]config.TrackerConfig{"PTP": tt.cfg},
+				},
+			})
+			status, err := service.Status(context.Background(), "PTP")
+			if err != nil {
+				t.Fatalf("Status: %v", err)
+			}
+			if status.State != tt.wantState {
+				t.Fatalf("expected %s state, got %#v", tt.wantState, status)
+			}
+		})
+	}
+}
+
+func TestStatusPTPCookiesRemainConfiguredWithoutAnnounceURL(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "PTP", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	service := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{"PTP": {Username: "user", Password: "pass"}},
+		},
+	})
+
+	status, err := service.Status(ctx, "PTP")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.State != StateHasCookies || status.CookieCount != 1 {
+		t.Fatalf("expected stored PTP cookies to remain usable without announce URL, got %#v", status)
+	}
+}
+
+func TestStatusConfiguredAuthReportsEncryptedStorageUnavailableWhenPersistenceRequired(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		cfg       config.TrackerConfig
+		spec      trackerSpec
+		wantState string
+	}{
+		"MTV api key only": {
+			cfg:       config.TrackerConfig{APIKey: "api-key"},
+			wantState: StateEncryptedStorageUnavailable,
+			spec: trackerSpec{
+				id:               "MTV",
+				cookies:          true,
+				apiKey:           true,
+				needsCredentials: true,
+			},
+		},
+		"credentials": {
+			cfg:       config.TrackerConfig{Username: "user", Password: "pass"},
+			wantState: StateEncryptedStorageUnavailable,
+			spec: trackerSpec{
+				id:               "AR",
+				cookies:          true,
+				login:            true,
+				needsCredentials: true,
+			},
+		},
+		"passkey": {
+			cfg:       config.TrackerConfig{Passkey: "passkey"},
+			wantState: StateConfigured,
+			spec: trackerSpec{
+				id:      "HDB",
+				cookies: true,
+				passkey: true,
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			service := NewService(config.Config{
+				MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(t.TempDir(), "upbrr.db")},
+				Trackers: config.TrackersConfig{
+					Trackers: map[string]config.TrackerConfig{tt.spec.id: tt.cfg},
+				},
+			})
+			status, err := service.statusForSpec(context.Background(), tt.spec)
+			if err != nil {
+				t.Fatalf("statusForSpec: %v", err)
+			}
+			if status.State != tt.wantState {
+				t.Fatalf("expected %s state, got %#v", tt.wantState, status)
+			}
+			if status.EncryptedStorage {
+				t.Fatalf("expected storage availability to remain visible as false: %#v", status)
+			}
+		})
+	}
+}
+
+func TestStatusConfiguredAuthReportsCoexistingCookies(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		trackerID string
+		cfg       config.TrackerConfig
+	}{
+		"api key": {trackerID: "MTV", cfg: config.TrackerConfig{APIKey: "api-key"}},
+		"passkey": {trackerID: "HDB", cfg: config.TrackerConfig{Passkey: "passkey"}},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			dbPath := newTrackerAuthTestDB(t)
+			if err := cookies.SaveTrackerCookieMap(ctx, dbPath, tt.trackerID, map[string]string{"session": "abc"}); err != nil {
+				t.Fatalf("SaveTrackerCookieMap: %v", err)
+			}
+			service := NewService(config.Config{
+				MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+				Trackers: config.TrackersConfig{
+					Trackers: map[string]config.TrackerConfig{tt.trackerID: tt.cfg},
+				},
+			})
+
+			status, err := service.Status(ctx, tt.trackerID)
+			if err != nil {
+				t.Fatalf("Status: %v", err)
+			}
+			if status.State != StateConfigured || status.CookieCount != 1 {
+				t.Fatalf("expected configured state with cookie count, got %#v", status)
+			}
+			if !strings.Contains(status.Message, "stored cookie") {
+				t.Fatalf("expected message to preserve cookie presence, got %#v", status)
+			}
+		})
+	}
+}
+
+func TestStatusMTVAPIKeyOnlyReportsUploadNotReady(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newTrackerAuthTestDB(t)
+	service := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{"MTV": {APIKey: "api-key"}},
+		},
+	})
+
+	status, err := service.Status(context.Background(), "MTV")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.State != StateLoginRequired {
+		t.Fatalf("expected upload auth to be login-required, got %#v", status)
+	}
+	if !strings.Contains(status.Message, "API key covers Torznab/search") || !strings.Contains(status.Message, "required for upload auth") {
+		t.Fatalf("expected split search/upload message, got %#v", status)
+	}
+}
+
+func TestStatusMTVCredentialsWithoutAPIKeyRemainUploadReady(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newTrackerAuthTestDB(t)
+	service := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{"MTV": {Username: "user", Password: "pass"}},
+		},
+	})
+
+	status, err := service.Status(context.Background(), "MTV")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.State != StateConfigured {
+		t.Fatalf("expected MTV credentials to remain upload-ready, got %#v", status)
+	}
+}
+
+func TestStatusCookiesOnlyReportsEncryptedStorageUnavailable(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(t.TempDir(), "upbrr.db")},
+	})
+	status, err := service.statusForSpec(context.Background(), trackerSpec{
+		id:      "ASC",
+		cookies: true,
+	})
+	if err != nil {
+		t.Fatalf("statusForSpec: %v", err)
+	}
+	if status.State != StateEncryptedStorageUnavailable {
+		t.Fatalf("expected encrypted storage unavailable, got %#v", status)
+	}
+	if status.EncryptedStorage {
+		t.Fatalf("expected storage availability to remain visible as false: %#v", status)
 	}
 }
 
@@ -168,18 +494,30 @@ func TestParseCookieContentJSONMap(t *testing.T) {
 func TestParseCookieContentJSONArray(t *testing.T) {
 	got, err := ParseCookieContent("PTP.json", `[
 		{"domain":".example.test","name":"session","value":"abc"},
-		{"name":"session","value":"latest"},
+		{"name":"token","value":"latest"},
 		{"name":"empty","value":""},
 		{"name":"","value":"ignored"}
 	]`)
 	if err != nil {
 		t.Fatalf("ParseCookieContent: %v", err)
 	}
-	if got["session"] != "latest" {
-		t.Fatalf("expected deterministic last array value, got %#v", got)
+	if got["session"] != "abc" || got["token"] != "latest" {
+		t.Fatalf("unexpected cookies: %#v", got)
 	}
 	if _, ok := got["empty"]; ok {
 		t.Fatalf("empty cookie value should be ignored: %#v", got)
+	}
+}
+
+func TestParseCookieContentJSONArrayWithoutJSONExtension(t *testing.T) {
+	got, err := ParseCookieContent("PTP.txt", `[
+		{"domain":".example.test","name":"session","value":"abc"}
+	]`)
+	if err != nil {
+		t.Fatalf("ParseCookieContent: %v", err)
+	}
+	if got["session"] != "abc" {
+		t.Fatalf("unexpected cookies: %#v", got)
 	}
 }
 
@@ -193,10 +531,251 @@ func TestParseCookieContentNetscape(t *testing.T) {
 	}
 }
 
+func TestParseCookieContentRejectsTrimmedObjectKeyCollision(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseCookieContent("cookies.json", `{"session":"abc"," session ":"def"}`)
+	if err == nil {
+		t.Fatal("expected trimmed key collision error")
+	}
+	if !strings.Contains(err.Error(), "duplicate cookie name") {
+		t.Fatalf("expected duplicate cookie name error, got %v", err)
+	}
+}
+
+func TestParseCookieContentRejectsDuplicateJSONObjectNamesBeforeMapCollapse(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"root exact":           `{"session":"abc","session":"def"}`,
+		"root escaped":         `{"session":"abc","\u0073ession":"def"}`,
+		"nested value exact":   `{"session":{"value":"abc","value":"def"}}`,
+		"nested value escaped": `{"session":{"value":"abc","\u0076alue":"def"}}`,
+		"array name exact":     `[{"name":"session","name":"token","value":"abc"}]`,
+		"array value escaped":  `[{"name":"session","value":"abc","\u0076alue":"def"}]`,
+	}
+	for name, content := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseCookieContent("cookies.json", content)
+			if err == nil {
+				t.Fatal("expected duplicate error")
+			}
+			if !strings.Contains(err.Error(), "duplicate cookie name") {
+				t.Fatalf("expected duplicate cookie name error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestParseCookieContentAllowsNestedNonCookieDuplicateJSONKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"object metadata": `{"session":{"value":"abc","metadata":{"same":"first","same":"second"}}}`,
+		"array metadata":  `[{"name":"session","value":"abc","metadata":{"same":"first","same":"second"}}]`,
+	}
+	for name, content := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseCookieContent("cookies.json", content)
+			if err != nil {
+				t.Fatalf("ParseCookieContent: %v", err)
+			}
+			if got["session"] != "abc" {
+				t.Fatalf("unexpected cookies: %#v", got)
+			}
+		})
+	}
+}
+
+func TestParseCookieContentValidJSONModesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		fileName string
+		content  string
+		want     map[string]string
+	}{
+		"root map": {
+			fileName: "cookies.json",
+			content:  `{"session":"abc","nested":{"value":"def"}}`,
+			want:     map[string]string{"session": "abc", "nested": "def"},
+		},
+		"array": {
+			fileName: "cookies.json",
+			content:  `[{"name":"session","value":"abc"},{"name":"token","value":"def"}]`,
+			want:     map[string]string{"session": "abc", "token": "def"},
+		},
+		"txt array": {
+			fileName: "cookies.txt",
+			content:  `[{"name":"session","value":"abc"}]`,
+			want:     map[string]string{"session": "abc"},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseCookieContent(tt.fileName, tt.content)
+			if err != nil {
+				t.Fatalf("ParseCookieContent: %v", err)
+			}
+			for key, want := range tt.want {
+				if got[key] != want {
+					t.Fatalf("unexpected cookie %s: got %#v want %q", key, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseCookieContentPreservesCookieValueWhitespace(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		fileName string
+		content  string
+	}{
+		"JSON object": {
+			fileName: "cookies.json",
+			content:  `{"session":" abc "}`,
+		},
+		"JSON array": {
+			fileName: "cookies.json",
+			content:  `[{"name":"session","value":" abc "}]`,
+		},
+		"Netscape": {
+			fileName: "cookies.txt",
+			content:  ".example.test\tTRUE\t/\tTRUE\t0\tsession\t abc ",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseCookieContent(tt.fileName, tt.content)
+			if err != nil {
+				t.Fatalf("ParseCookieContent: %v", err)
+			}
+			if got["session"] != " abc " {
+				t.Fatalf("cookie value was normalized: %#v", got)
+			}
+		})
+	}
+}
+
+func TestApplyEnsureErrorToStatusDoesNotExposeEmpty2FAChallenge(t *testing.T) {
+	t.Parallel()
+
+	status := api.TrackerAuthStatus{TrackerID: "PTP", State: StateConfigured}
+	applyEnsureErrorToStatus(&status, &Needs2FAError{TrackerID: "PTP", Reason: "2FA required"})
+
+	if status.Needs2FA {
+		t.Fatalf("empty challenge must not enable 2FA submission: %#v", status)
+	}
+	if status.ChallengeID != "" {
+		t.Fatalf("empty challenge must not set challenge id: %#v", status)
+	}
+	if status.State != StateLoginRequired {
+		t.Fatalf("expected login required state, got %#v", status)
+	}
+}
+
+func TestApplyEnsureErrorToStatusRedactsURLPath(t *testing.T) {
+	t.Parallel()
+
+	status := api.TrackerAuthStatus{TrackerID: "MTV", State: StateConfigured}
+	applyEnsureErrorToStatus(&status, errors.New(`Get "https://www.morethantv.me/secret-login-token?passkey=abc": auth key not found`))
+
+	if strings.Contains(status.LastError, "secret-login-token") || strings.Contains(status.LastError, "abc") {
+		t.Fatalf("LastError leaked URL secret: %#v", status)
+	}
+	if !strings.Contains(status.LastError, "https://www.morethantv.me/[REDACTED]") {
+		t.Fatalf("LastError lost useful URL host context: %#v", status)
+	}
+}
+
+func TestCookiesToMapPreservesCookieValueWhitespace(t *testing.T) {
+	t.Parallel()
+
+	got := CookiesToMap([]*http.Cookie{{Name: " session ", Value: " abc "}})
+	if got["session"] != " abc " {
+		t.Fatalf("cookie value was normalized: %#v", got)
+	}
+}
+
+func TestParseCookieContentInvalidLeadingArrayReportsJSONError(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseCookieContent("PTP.txt", `[{"name":"session","value":"abc"}`)
+	if err == nil {
+		t.Fatal("expected invalid JSON error")
+	}
+	if !strings.Contains(err.Error(), "parse JSON cookies") {
+		t.Fatalf("expected JSON parse error, got %v", err)
+	}
+}
+
+func TestParseCookieContentRejectsDuplicateNames(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		fileName string
+		content  string
+	}{
+		"JSON array": {
+			fileName: "cookies.json",
+			content:  `[{"name":"session","value":"abc"},{"name":"session","value":"def"}]`,
+		},
+		"Netscape": {
+			fileName: "cookies.txt",
+			content:  ".example.test\tTRUE\t/\tTRUE\t0\tsession\tabc\n.example.test\tTRUE\t/\tTRUE\t0\tsession\tdef\n",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseCookieContent(tt.fileName, tt.content)
+			if err == nil {
+				t.Fatal("expected duplicate error")
+			}
+			if !strings.Contains(err.Error(), "duplicate cookie name") {
+				t.Fatalf("expected duplicate error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestParseCookieContentNetscapeOversizedValidLine(t *testing.T) {
+	value := strings.Repeat("a", 70*1024)
+	got, err := ParseCookieContent("PTP.txt", ".example.test\tTRUE\t/\tTRUE\t0\tsession\t"+value)
+	if err != nil {
+		t.Fatalf("ParseCookieContent: %v", err)
+	}
+	if got["session"] != value {
+		t.Fatalf("unexpected oversized cookie value length: got %d want %d", len(got["session"]), len(value))
+	}
+}
+
+func TestParseCookieContentNetscapeOversizedMalformedLineHasNoEntries(t *testing.T) {
+	_, err := ParseCookieContent("PTP.txt", strings.Repeat("x", 70*1024))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no entries") {
+		t.Fatalf("expected no entries error, got %v", err)
+	}
+}
+
 func TestParseCookieContentJSONRejectsInvalidShapes(t *testing.T) {
 	tests := map[string]string{
 		"empty":         "",
 		"invalid json":  "{",
+		"non-object":    `[{"name":"session","value":"abc"},"bad"]`,
 		"missing name":  `[{"value":"abc"}]`,
 		"missing value": `[{"name":"session"}]`,
 	}
@@ -206,6 +785,89 @@ func TestParseCookieContentJSONRejectsInvalidShapes(t *testing.T) {
 				t.Fatal("expected error")
 			}
 		})
+	}
+}
+
+func TestImportCookiesRejectsMalformedArrayEntryWithoutReplacingCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "AR", map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	service := NewService(config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}})
+
+	_, err := service.ImportCookies(ctx, "AR", "cookies.json", `[
+		{"name":"session","value":"replacement"},
+		{"name":"token"}
+	]`)
+	if err == nil {
+		t.Fatal("expected malformed array entry error")
+	}
+	if !strings.Contains(err.Error(), "require name and value") {
+		t.Fatalf("expected missing value error, got %v", err)
+	}
+
+	values, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "AR")
+	if err != nil {
+		t.Fatalf("LoadTrackerCookieMap: %v", err)
+	}
+	if values["session"] != "existing" {
+		t.Fatalf("existing cookies changed after failed import: %#v", values)
+	}
+}
+
+func TestImportCookiesRejectsOverCapWithoutReplacingCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "AR", map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	service := NewService(config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}})
+
+	_, err := service.ImportCookies(ctx, "AR", "cookies.txt", strings.Repeat("x", MaxCookieImportContentBytes+1))
+	if err == nil {
+		t.Fatal("expected over-cap import error")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected size error, got %v", err)
+	}
+
+	values, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "AR")
+	if err != nil {
+		t.Fatalf("LoadTrackerCookieMap: %v", err)
+	}
+	if values["session"] != "existing" {
+		t.Fatalf("existing cookies changed after failed import: %#v", values)
+	}
+}
+
+func TestImportCookiesReportsMergedCookieCount(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	legacyPath, err := servicedb.CookiePath(dbPath, "AR.txt")
+	if err != nil {
+		t.Fatalf("CookiePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o700); err != nil {
+		t.Fatalf("mkdir legacy dir: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte(".example.test\tTRUE\t/\tTRUE\t0\tlegacy\tfrom-file\n"), 0o600); err != nil {
+		t.Fatalf("write legacy cookies: %v", err)
+	}
+	service := NewService(config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}})
+
+	status, err := service.ImportCookies(ctx, "AR", "cookies.json", `{"session":"from-db"}`)
+	if err != nil {
+		t.Fatalf("ImportCookies: %v", err)
+	}
+	if status.CookieCount != 2 {
+		t.Fatalf("expected merged cookie count, got %#v", status)
 	}
 }
 
@@ -226,7 +888,128 @@ func TestCapabilitiesDoNotAdvertiseUnsupportedMTVPTPManual2FA(t *testing.T) {
 			if !cap.SupportsTOTP {
 				t.Fatalf("%s TOTP auto-login capability must be preserved", cap.TrackerID)
 			}
+			if !cap.SupportsLogin || !cap.SupportsAutoLogin {
+				t.Fatalf("%s adapter-backed login capability must be preserved: %#v", cap.TrackerID, cap)
+			}
+		case "AR", "FL", "RTF", "THR":
+			if cap.SupportsLogin || cap.SupportsAutoLogin || cap.SupportsManual2FA {
+				t.Fatalf("%s must not advertise unsupported login actions: %#v", cap.TrackerID, cap)
+			}
+		case "TTG":
+			if cap.SupportsLogin || cap.SupportsAutoLogin || cap.SupportsManual2FA {
+				t.Fatalf("%s must not advertise unsupported login actions: %#v", cap.TrackerID, cap)
+			}
 		}
+	}
+}
+
+func TestTrackerAuthRejectsCaseCollidingConfigIDs(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"ar": {Username: "user", Password: "pass"},
+				"AR": {APIKey: "api-key"},
+			},
+		},
+	})
+
+	if _, err := service.Capabilities(context.Background()); err == nil {
+		t.Fatal("expected capabilities to reject duplicate tracker ids")
+	} else if !strings.Contains(err.Error(), "duplicate tracker config id") {
+		t.Fatalf("expected duplicate tracker id error, got %v", err)
+	}
+	if _, err := service.Status(context.Background(), "AR"); err == nil {
+		t.Fatal("expected status to reject duplicate tracker ids")
+	} else if !strings.Contains(err.Error(), "duplicate tracker config id") {
+		t.Fatalf("expected duplicate tracker id error, got %v", err)
+	}
+	if _, err := service.Delete(context.Background(), "AR"); err == nil {
+		t.Fatal("expected delete to reject duplicate tracker ids")
+	} else if !strings.Contains(err.Error(), "duplicate tracker config id") {
+		t.Fatalf("expected duplicate tracker id error, got %v", err)
+	}
+}
+
+func TestTrackerAuthKeepsCaseInsensitiveSingleConfigLookup(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"ar": {Username: "user", Password: "pass"},
+			},
+		},
+	})
+
+	status, err := service.Status(context.Background(), "AR")
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.State != StateEncryptedStorageUnavailable {
+		t.Fatalf("expected single case variant to preserve storage readiness, got %#v", status)
+	}
+}
+
+func TestTrackerAuthKeepsCustomUnicodeConfigLookupCanonical(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"åar": {Username: "user", Password: "pass"},
+			},
+		},
+	})
+
+	status, err := service.Status(context.Background(), "åar")
+	if err != nil {
+		t.Fatalf("Status lowercase Unicode tracker: %v", err)
+	}
+	if status.State != StateConfigured {
+		t.Fatalf("expected custom Unicode tracker to remain configured, got %#v", status)
+	}
+	if _, err := service.Status(context.Background(), "Åar"); err == nil {
+		t.Fatal("expected Unicode-folded tracker id to remain unknown")
+	}
+}
+
+func TestTrackerAuthRejectsASCIICollidingUnicodeConfigIDs(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"åar": {Username: "user", Password: "pass"},
+				"åAR": {APIKey: "api-key"},
+			},
+		},
+	})
+
+	if _, err := service.Capabilities(context.Background()); err == nil {
+		t.Fatal("expected capabilities to reject duplicate custom Unicode tracker ids")
+	} else if !strings.Contains(err.Error(), "duplicate tracker config id") {
+		t.Fatalf("expected duplicate tracker id error, got %v", err)
+	}
+}
+
+func TestTrackerAuthDoesNotFoldUnicodeLookalikeTrackerIDs(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"K": {Username: "user", Password: "pass"},
+			},
+		},
+	})
+
+	if _, err := service.Status(context.Background(), "K"); err != nil {
+		t.Fatalf("Status ASCII tracker: %v", err)
+	}
+	if _, err := service.Status(context.Background(), "\u212a"); err == nil {
+		t.Fatal("expected Unicode lookalike tracker id to be unknown")
 	}
 }
 
@@ -274,12 +1057,222 @@ func TestDeleteARAuthClearsCookiesAuthStateAndLegacyAuth(t *testing.T) {
 	}
 }
 
-func TestEnsureSessionDeletesConfirmedInvalidMTVPTPCookies(t *testing.T) {
+func TestDeleteARAuthStatusRefreshIgnoresCancellationAfterMutation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "AR", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	deleteCtx, cancel := context.WithCancel(context.Background())
+	service := NewService(config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}})
+	service.afterDeleteCleanup = cancel
+
+	status, err := service.Delete(deleteCtx, "AR")
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if deleteCtx.Err() == nil {
+		t.Fatal("expected delete context to be canceled before status refresh")
+	}
+	if status.CookieCount != 0 || status.Message != "stored auth deleted" {
+		t.Fatalf("expected truthful delete status after cancellation, got %#v", status)
+	}
+	if _, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "AR"); err == nil {
+		t.Fatal("expected AR cookies to be deleted")
+	}
+}
+
+func TestDeleteARAuthLegacyPathFailureReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := SaveAuthState(ctx, dbPath, "AR", "auth_key", "secret-auth-key"); err != nil {
+		t.Fatalf("SaveAuthState: %v", err)
+	}
+	cookiesDir := filepath.Join(filepath.Dir(dbPath), "cookies")
+	if err := os.WriteFile(cookiesDir, []byte("blocks cookie path"), 0o600); err != nil {
+		t.Fatalf("write cookie path blocker: %v", err)
+	}
+	service := NewService(config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}})
+
+	_, err := service.Delete(ctx, "AR")
+	if err == nil {
+		t.Fatal("expected legacy auth path resolution error")
+	}
+	if !strings.Contains(err.Error(), "resolve AR legacy auth key path") {
+		t.Fatalf("expected legacy path resolution error, got %v", err)
+	}
+	authKey, err := LoadAuthState(ctx, dbPath, "AR", "auth_key")
+	if err != nil {
+		t.Fatalf("expected AR auth state to be restored: %v", err)
+	}
+	if authKey != "secret-auth-key" {
+		t.Fatalf("unexpected restored auth state")
+	}
+}
+
+func TestDeleteARAuthFailureLeavesCookiesUntouched(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	repo, err := servicedb.OpenWithLoggerContext(ctx, dbPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("OpenWithLoggerContext: %v", err)
+	}
+	if err := repo.MigrateContext(ctx); err != nil {
+		_ = repo.Close()
+		t.Fatalf("MigrateContext: %v", err)
+	}
+	_ = repo.Close()
+	legacyPath, err := servicedb.CookiePath(dbPath, "AR_auth.txt")
+	if err != nil {
+		t.Fatalf("CookiePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o700); err != nil {
+		t.Fatalf("mkdir legacy dir: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("legacy-auth-key"), 0o600); err != nil {
+		t.Fatalf("write legacy auth: %v", err)
+	}
+	cookiePath, err := servicedb.CookiePath(dbPath, "AR.txt")
+	if err != nil {
+		t.Fatalf("CookiePath: %v", err)
+	}
+	if err := os.WriteFile(cookiePath, []byte(".alpharatio.cc\tTRUE\t/\tTRUE\t0\tsession\tabc\n"), 0o600); err != nil {
+		t.Fatalf("write legacy cookies: %v", err)
+	}
+	service := NewService(config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}})
+
+	_, err = service.Delete(ctx, "AR")
+	if err == nil {
+		t.Fatal("expected encrypted auth deletion uncertainty")
+	}
+	if !strings.Contains(err.Error(), "delete AR auth state uncertain") {
+		t.Fatalf("expected encrypted state uncertainty, got %v", err)
+	}
+	legacyAuth, err := os.ReadFile(legacyPath)
+	if err != nil {
+		t.Fatalf("expected legacy AR auth to be restored after uncertainty: %v", err)
+	}
+	if string(legacyAuth) != "legacy-auth-key" {
+		t.Fatalf("unexpected restored legacy auth")
+	}
+	if _, err := os.Stat(cookiePath); err != nil {
+		t.Fatalf("expected cookies to remain after auth-state delete failure, got %v", err)
+	}
+}
+
+func TestDeleteARCookieFailureRestoresAuthState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := SaveAuthState(ctx, dbPath, "AR", "auth_key", "secret-auth-key"); err != nil {
+		t.Fatalf("SaveAuthState: %v", err)
+	}
+	legacyAuthPath, err := servicedb.CookiePath(dbPath, "AR_auth.txt")
+	if err != nil {
+		t.Fatalf("CookiePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(legacyAuthPath), 0o700); err != nil {
+		t.Fatalf("mkdir legacy auth dir: %v", err)
+	}
+	if err := os.WriteFile(legacyAuthPath, []byte("legacy-auth-key"), 0o600); err != nil {
+		t.Fatalf("write legacy auth: %v", err)
+	}
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "AR", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	legacyCookiePath, err := servicedb.CookiePath(dbPath, "AR.txt")
+	if err != nil {
+		t.Fatalf("CookiePath: %v", err)
+	}
+	if err := os.MkdirAll(legacyCookiePath, 0o700); err != nil {
+		t.Fatalf("mkdir legacy cookie path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyCookiePath, "child"), []byte("blocks remove"), 0o600); err != nil {
+		t.Fatalf("write legacy cookie child: %v", err)
+	}
+	service := NewService(config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}})
+
+	_, err = service.Delete(ctx, "AR")
+	if err == nil {
+		t.Fatal("expected cookie delete error")
+	}
+	if !strings.Contains(err.Error(), "delete AR cookies") {
+		t.Fatalf("expected cookie delete error, got %v", err)
+	}
+	authKey, err := LoadAuthState(ctx, dbPath, "AR", "auth_key")
+	if err != nil {
+		t.Fatalf("expected AR auth state to be restored: %v", err)
+	}
+	if authKey != "secret-auth-key" {
+		t.Fatalf("unexpected restored auth state")
+	}
+	legacyAuth, err := os.ReadFile(legacyAuthPath)
+	if err != nil {
+		t.Fatalf("expected legacy AR auth to be restored: %v", err)
+	}
+	if string(legacyAuth) != "legacy-auth-key" {
+		t.Fatalf("unexpected restored legacy AR auth")
+	}
+	cookieValues, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "AR")
+	if err != nil {
+		t.Fatalf("expected AR cookies to be restored: %v", err)
+	}
+	if cookieValues["session"] != "abc" {
+		t.Fatalf("unexpected restored AR cookies: %#v", cookieValues)
+	}
+}
+
+func TestTrackerAuthSnapshotRestoreIgnoresCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := SaveAuthState(ctx, dbPath, "AR", "auth_key", "secret-auth-key"); err != nil {
+		t.Fatalf("SaveAuthState: %v", err)
+	}
+	snapshot, err := snapshotTrackerAuthState(ctx, dbPath, "AR")
+	if err != nil {
+		t.Fatalf("snapshotTrackerAuthState: %v", err)
+	}
+	if err := deleteTrackerAuthState(ctx, dbPath, "AR"); err != nil {
+		t.Fatalf("deleteTrackerAuthState: %v", err)
+	}
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := snapshot.restore(cancelledCtx); err != nil {
+		t.Fatalf("restore with canceled context: %v", err)
+	}
+	authKey, err := LoadAuthState(ctx, dbPath, "AR", "auth_key")
+	if err != nil {
+		t.Fatalf("expected AR auth state to be restored: %v", err)
+	}
+	if authKey != "secret-auth-key" {
+		t.Fatalf("unexpected restored auth state")
+	}
+}
+
+func TestEnsureSessionPreservesMTVCookiesOnInvalidLookingAdapterText(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]string{
 		"MTV": "session",
-		"PTP": "session",
 	}
 	for trackerID, cookieName := range tests {
 		t.Run(trackerID, func(t *testing.T) {
@@ -304,12 +1297,60 @@ func TestEnsureSessionDeletesConfirmedInvalidMTVPTPCookies(t *testing.T) {
 				AutoLogin: true,
 			})
 			if err == nil {
-				t.Fatal("expected auth required error")
+				t.Fatal("expected validation error")
 			}
-			if _, err := cookies.LoadTrackerCookieMap(ctx, dbPath, trackerID); err == nil {
-				t.Fatal("expected confirmed-invalid cookies to be deleted")
+			values, err := cookies.LoadTrackerCookieMap(ctx, dbPath, trackerID)
+			if err != nil {
+				t.Fatalf("LoadTrackerCookieMap: %v", err)
+			}
+			if values[cookieName] != "abc" {
+				t.Fatalf("expected invalid-looking adapter text to preserve cookies, got %#v", values)
 			}
 		})
+	}
+}
+
+func TestValidateTransientAdapterFailurePreservesCookieCount(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "MTV", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html>logged out</html>"))
+	}))
+	t.Cleanup(server.Close)
+
+	service := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"MTV": {URL: server.URL},
+			},
+		},
+	})
+	status, err := service.Validate(ctx, "MTV")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.State != StateHasCookies {
+		t.Fatalf("expected cookies to remain configured after transient adapter failure, got %#v", status)
+	}
+	if status.CookieCount != 1 {
+		t.Fatalf("expected existing cookies to be preserved, got %#v", status)
+	}
+	if !strings.Contains(status.LastError, "auth key not found") {
+		t.Fatalf("expected adapter failure in status, got %#v", status)
+	}
+	values, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "MTV")
+	if err != nil {
+		t.Fatalf("LoadTrackerCookieMap: %v", err)
+	}
+	if values["session"] != "abc" {
+		t.Fatalf("expected transient adapter failure to preserve cookies, got %#v", values)
 	}
 }
 

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -145,6 +145,129 @@ func TestDefaultAdaptersExposeMTVPTPManual2FAChallenge(t *testing.T) {
 	}
 }
 
+func TestValidateRTFRefreshesExpiredAPIKey(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newTrackerAuthTestDB(t)
+	cfg := config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"RTF": {APIKey: "old-token", Username: "user", Password: "pass"},
+			},
+		},
+	}
+	saveTrackerAuthTestConfig(t, dbPath, cfg)
+
+	var testedToken string
+	var loginCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/test":
+			testedToken = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusUnauthorized)
+		case "/api/login":
+			loginCalled = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"new-token"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	cfg.Trackers.Trackers["RTF"] = config.TrackerConfig{
+		URL:      server.URL,
+		APIKey:   "old-token",
+		Username: "user",
+		Password: "pass",
+	}
+
+	status, err := NewService(cfg).Validate(context.Background(), "RTF")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.State != StateConfigured || status.Message != "remote auth check succeeded" {
+		t.Fatalf("expected successful RTF auth validation, got %#v", status)
+	}
+	if testedToken != "old-token" {
+		t.Fatalf("expected old token validation, got %q", testedToken)
+	}
+	if !loginCalled {
+		t.Fatal("expected expired API key to trigger RTF login")
+	}
+	if got := loadStoredTrackerConfig(t, dbPath).Trackers.Trackers["RTF"].APIKey; got != "new-token" {
+		t.Fatalf("expected refreshed token persisted, got %q", got)
+	}
+}
+
+func TestValidateARStoredCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "AR", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/torrents.php" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=abc") {
+			t.Fatalf("expected AR session cookie, got %q", got)
+		}
+		_, _ = w.Write([]byte(`<a href="/torrents.php?action=download&id=1&auth=session-key">Download</a>`))
+	}))
+	t.Cleanup(server.Close)
+
+	status, err := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"AR": {URL: server.URL},
+		}},
+	}).Validate(ctx, "AR")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.State != StateConfigured || status.Message != "remote auth check succeeded" {
+		t.Fatalf("expected successful AR auth validation, got %#v", status)
+	}
+}
+
+func TestValidateHDBInvalidCookiesDeletesSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "HDB", map[string]string{"session": "expired"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/upload/upload" {
+			http.NotFound(w, r)
+			return
+		}
+		http.Redirect(w, r, "/login.php", http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+
+	status, err := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"HDB": {URL: server.URL, Username: "user", Passkey: "passkey"},
+		}},
+	}).Validate(ctx, "HDB")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.State != StateLoginRequired || status.CookieCount != 0 || status.Message != "stored session expired or invalid" {
+		t.Fatalf("expected HDB login-required expired-session status, got %#v", status)
+	}
+	if _, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "HDB"); err == nil {
+		t.Fatal("expected invalid HDB cookies to be deleted")
+	}
+}
+
 func TestSubmit2FARetriesAdapterLoginWithCurrentConfigAndCode(t *testing.T) {
 	t.Parallel()
 
@@ -826,7 +949,7 @@ func TestStatusCookiesOnlyReportsEncryptedStorageUnavailable(t *testing.T) {
 }
 
 func TestLoginWithoutAdapterDoesNotReportRemoteSuccess(t *testing.T) {
-	for _, trackerID := range []string{"AR", "FF", "FL", "RTF", "THR"} {
+	for _, trackerID := range []string{"FF", "FL", "THR"} {
 		t.Run(trackerID, func(t *testing.T) {
 			cfg := config.Config{
 				Trackers: config.TrackersConfig{
@@ -920,11 +1043,11 @@ func TestValidateWithoutAdapterReportsUnsupportedRemoteValidation(t *testing.T) 
 	cfg := config.Config{
 		Trackers: config.TrackersConfig{
 			Trackers: map[string]config.TrackerConfig{
-				"AR": {Username: "user", Password: "pass"},
+				"FF": {Username: "user", Password: "pass"},
 			},
 		},
 	}
-	status, err := NewService(cfg).Validate(context.Background(), "AR")
+	status, err := NewService(cfg).Validate(context.Background(), "FF")
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
@@ -1346,7 +1469,28 @@ func TestCapabilitiesAdvertiseOnlySupportedManual2FA(t *testing.T) {
 			if !cap.SupportsLogin || !cap.SupportsAutoLogin {
 				t.Fatalf("%s adapter-backed login capability must be preserved: %#v", cap.TrackerID, cap)
 			}
-		case "AR", "FF", "FL", "RTF", "THR":
+		case "RTF":
+			if !cap.SupportsLogin || !cap.SupportsAutoLogin {
+				t.Fatalf("%s API refresh capability must be preserved: %#v", cap.TrackerID, cap)
+			}
+			if cap.SupportsManual2FA || cap.SupportsTOTP {
+				t.Fatalf("%s must not advertise 2FA actions: %#v", cap.TrackerID, cap)
+			}
+		case "AR":
+			if cap.SupportsLogin || cap.SupportsAutoLogin || cap.SupportsManual2FA {
+				t.Fatalf("%s auth check is validation-only in tracker-auth UI: %#v", cap.TrackerID, cap)
+			}
+			if !cap.SupportsCookieFile {
+				t.Fatalf("%s must keep cookie import capability: %#v", cap.TrackerID, cap)
+			}
+		case "HDB":
+			if cap.SupportsLogin || cap.SupportsAutoLogin || cap.SupportsManual2FA {
+				t.Fatalf("%s auth check is validation-only in tracker-auth UI: %#v", cap.TrackerID, cap)
+			}
+			if !cap.SupportsCookieFile || !cap.RequiresPasskey {
+				t.Fatalf("%s must keep cookie/passkey capability: %#v", cap.TrackerID, cap)
+			}
+		case "FF", "FL", "THR":
 			if cap.SupportsLogin || cap.SupportsAutoLogin || cap.SupportsManual2FA {
 				t.Fatalf("%s must not advertise unsupported login actions: %#v", cap.TrackerID, cap)
 			}
@@ -1888,6 +2032,34 @@ func newTrackerAuthTestDB(t *testing.T) string {
 	}
 	_ = repo.Close()
 	return dbPath
+}
+
+func saveTrackerAuthTestConfig(t *testing.T, dbPath string, cfg config.Config) {
+	t.Helper()
+
+	repo, err := servicedb.OpenWithLoggerContext(context.Background(), dbPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("OpenWithLoggerContext: %v", err)
+	}
+	defer repo.Close()
+	if err := config.SaveToDatabase(context.Background(), &cfg, repo); err != nil {
+		t.Fatalf("SaveToDatabase: %v", err)
+	}
+}
+
+func loadStoredTrackerConfig(t *testing.T, dbPath string) config.Config {
+	t.Helper()
+
+	repo, err := servicedb.OpenWithLoggerContext(context.Background(), dbPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("OpenWithLoggerContext: %v", err)
+	}
+	defer repo.Close()
+	cfg, err := config.LoadFromDatabase(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("LoadFromDatabase: %v", err)
+	}
+	return *cfg
 }
 
 func newMTVManual2FAServer(t *testing.T) *httptest.Server {

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -3,7 +3,157 @@
 
 package trackerauth
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/authmaterial"
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/cookies"
+	servicedb "github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestLoginCreatesManual2FAChallengeBeforeReturning(t *testing.T) {
+	cfg := config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"PTP": {Username: "user", Password: "pass"},
+			},
+		},
+	}
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{
+			TrackerID:         "PTP",
+			SupportsLogin:     true,
+			SupportsManual2FA: true,
+		},
+		validate: func() (Session, error) {
+			return Session{}, &Needs2FAError{TrackerID: "PTP"}
+		},
+	}
+	loginService := NewService(cfg)
+	loginService.adapters = map[string]Adapter{"PTP": adapter}
+
+	status, err := loginService.Login(context.Background(), "PTP", api.TrackerAuthLoginRequest{})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if !status.Needs2FA || strings.TrimSpace(status.ChallengeID) == "" {
+		t.Fatalf("expected active 2FA challenge, got %#v", status)
+	}
+
+	submitService := NewService(cfg)
+	submitService.adapters = map[string]Adapter{"PTP": adapter}
+	status, err = submitService.Submit2FA(context.Background(), status.ChallengeID, "123456")
+	if err != nil {
+		t.Fatalf("Submit2FA with challenge from separate service: %v", err)
+	}
+	if status.Needs2FA || status.ChallengeID != "" || status.Message != "2FA auth completed" {
+		t.Fatalf("unexpected submit status: %#v", status)
+	}
+}
+
+func TestLoginMissingCredentialsReturnsLoginRequiredWithoutChallenge(t *testing.T) {
+	t.Parallel()
+
+	status, err := NewService(config.Config{}).Login(
+		context.Background(),
+		"PTP",
+		api.TrackerAuthLoginRequest{},
+	)
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if status.State != StateLoginRequired {
+		t.Fatalf("expected login required status, got %#v", status)
+	}
+	if status.Needs2FA || strings.TrimSpace(status.ChallengeID) != "" {
+		t.Fatalf("missing credentials must not create manual 2FA challenge: %#v", status)
+	}
+}
+
+func TestStatusConfiguredOTPURIAvoidsManualChallenge(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"PTP": {Username: "user", Password: "pass", OTPURI: "otpauth://totp/PTP:user?secret=ABC"},
+			},
+		},
+	})
+	status, err := service.statusForSpec(context.Background(), trackerSpec{
+		id:               "PTP",
+		login:            true,
+		totp:             true,
+		manual2FA:        true,
+		needsCredentials: true,
+	})
+	if err != nil {
+		t.Fatalf("statusForSpec: %v", err)
+	}
+	if status.State != StateConfigured {
+		t.Fatalf("expected configured status, got %#v", status)
+	}
+	if status.Needs2FA || strings.TrimSpace(status.ChallengeID) != "" {
+		t.Fatalf("configured OTPURI must avoid manual challenge path: %#v", status)
+	}
+}
+
+func TestLoginWithoutAdapterDoesNotReportRemoteSuccess(t *testing.T) {
+	for _, trackerID := range []string{"AR", "FL", "THR", "RTF"} {
+		t.Run(trackerID, func(t *testing.T) {
+			cfg := config.Config{
+				Trackers: config.TrackersConfig{
+					Trackers: map[string]config.TrackerConfig{
+						trackerID: {Username: "user", Password: "pass"},
+					},
+				},
+			}
+			status, err := NewService(cfg).Login(
+				context.Background(),
+				trackerID,
+				api.TrackerAuthLoginRequest{},
+			)
+			if err != nil {
+				t.Fatalf("Login: %v", err)
+			}
+			if strings.Contains(status.Message, "succeeded") {
+				t.Fatalf("unexpected remote success message for %s: %#v", trackerID, status)
+			}
+			if !strings.Contains(status.Message, "not supported") {
+				t.Fatalf("expected unsupported remote login message for %s, got %#v", trackerID, status)
+			}
+		})
+	}
+}
+
+func TestValidateWithoutAdapterReportsUnsupportedRemoteValidation(t *testing.T) {
+	cfg := config.Config{
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"AR": {Username: "user", Password: "pass"},
+			},
+		},
+	}
+	status, err := NewService(cfg).Validate(context.Background(), "AR")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if strings.Contains(status.Message, "succeeded") {
+		t.Fatalf("unexpected remote success message: %#v", status)
+	}
+	if !strings.Contains(status.Message, "not supported") {
+		t.Fatalf("expected unsupported remote validation message, got %#v", status)
+	}
+}
 
 func TestParseCookieContentJSONMap(t *testing.T) {
 	got, err := ParseCookieContent("MTV.json", `{"session":"abc","nested":{"value":"def"}}`)
@@ -15,6 +165,24 @@ func TestParseCookieContentJSONMap(t *testing.T) {
 	}
 }
 
+func TestParseCookieContentJSONArray(t *testing.T) {
+	got, err := ParseCookieContent("PTP.json", `[
+		{"domain":".example.test","name":"session","value":"abc"},
+		{"name":"session","value":"latest"},
+		{"name":"empty","value":""},
+		{"name":"","value":"ignored"}
+	]`)
+	if err != nil {
+		t.Fatalf("ParseCookieContent: %v", err)
+	}
+	if got["session"] != "latest" {
+		t.Fatalf("expected deterministic last array value, got %#v", got)
+	}
+	if _, ok := got["empty"]; ok {
+		t.Fatalf("empty cookie value should be ignored: %#v", got)
+	}
+}
+
 func TestParseCookieContentNetscape(t *testing.T) {
 	got, err := ParseCookieContent("PTP.txt", ".example.test\tTRUE\t/\tTRUE\t0\tsession\tabc\n")
 	if err != nil {
@@ -23,4 +191,144 @@ func TestParseCookieContentNetscape(t *testing.T) {
 	if got["session"] != "abc" {
 		t.Fatalf("unexpected cookies: %#v", got)
 	}
+}
+
+func TestParseCookieContentJSONRejectsInvalidShapes(t *testing.T) {
+	tests := map[string]string{
+		"empty":         "",
+		"invalid json":  "{",
+		"missing name":  `[{"value":"abc"}]`,
+		"missing value": `[{"name":"session"}]`,
+	}
+	for name, payload := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseCookieContent("cookies.json", payload); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestCapabilitiesDoNotAdvertiseUnsupportedMTVPTPManual2FA(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(config.Config{})
+	caps, err := service.Capabilities(context.Background())
+	if err != nil {
+		t.Fatalf("Capabilities: %v", err)
+	}
+	for _, cap := range caps {
+		switch cap.TrackerID {
+		case "MTV", "PTP":
+			if cap.SupportsManual2FA {
+				t.Fatalf("%s must not advertise unsupported manual 2FA", cap.TrackerID)
+			}
+			if !cap.SupportsTOTP {
+				t.Fatalf("%s TOTP auto-login capability must be preserved", cap.TrackerID)
+			}
+		}
+	}
+}
+
+func TestDeleteARAuthClearsCookiesAuthStateAndLegacyAuth(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := SaveAuthState(ctx, dbPath, "AR", "auth_key", "secret-auth-key"); err != nil {
+		t.Fatalf("SaveAuthState: %v", err)
+	}
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "AR", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	legacyPath, err := servicedb.CookiePath(dbPath, "AR_auth.txt")
+	if err != nil {
+		t.Fatalf("CookiePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o700); err != nil {
+		t.Fatalf("mkdir legacy dir: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("legacy-auth-key"), 0o600); err != nil {
+		t.Fatalf("write legacy auth: %v", err)
+	}
+
+	service := NewService(config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}})
+	status, err := service.Delete(ctx, "AR")
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if status.CookieCount != 0 {
+		t.Fatalf("expected zero cookies after delete, got %#v", status)
+	}
+	if _, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "AR"); err == nil {
+		t.Fatal("expected AR cookies to be deleted")
+	}
+	if _, err := LoadAuthState(ctx, dbPath, "AR", "auth_key"); !errors.Is(err, ErrAuthStateNotFound) {
+		t.Fatalf("expected AR auth state to be deleted, got %v", err)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy AR auth to be deleted, got %v", err)
+	}
+}
+
+func TestEnsureSessionDeletesConfirmedInvalidMTVPTPCookies(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"MTV": "session",
+		"PTP": "session",
+	}
+	for trackerID, cookieName := range tests {
+		t.Run(trackerID, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			dbPath := newTrackerAuthTestDB(t)
+			if err := cookies.SaveTrackerCookieMap(ctx, dbPath, trackerID, map[string]string{cookieName: "abc"}); err != nil {
+				t.Fatalf("SaveTrackerCookieMap: %v", err)
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("<html>logged out</html>"))
+			}))
+			t.Cleanup(server.Close)
+
+			service := NewService(config.Config{})
+			_, err := service.EnsureSession(ctx, EnsureRequest{
+				TrackerID: trackerID,
+				Config:    config.TrackerConfig{URL: server.URL},
+				DBPath:    dbPath,
+				AutoLogin: true,
+			})
+			if err == nil {
+				t.Fatal("expected auth required error")
+			}
+			if _, err := cookies.LoadTrackerCookieMap(ctx, dbPath, trackerID); err == nil {
+				t.Fatal("expected confirmed-invalid cookies to be deleted")
+			}
+		})
+	}
+}
+
+func newTrackerAuthTestDB(t *testing.T) string {
+	t.Helper()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	repo, err := servicedb.OpenWithLoggerContext(ctx, dbPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("OpenWithLoggerContext: %v", err)
+	}
+	if err := repo.MigrateContext(ctx); err != nil {
+		_ = repo.Close()
+		t.Fatalf("MigrateContext: %v", err)
+	}
+	_ = repo.Close()
+	return dbPath
 }

--- a/internal/trackerauth/site_validators.go
+++ b/internal/trackerauth/site_validators.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -22,9 +24,21 @@ import (
 const (
 	arDefaultBaseURL  = "https://alpharatio.cc"
 	arBrowsePath      = "/torrents.php"
+	ffDefaultBaseURL  = "https://www.funfile.org"
+	ffLoginPath       = "/takelogin.php"
+	ffUploadPath      = "/upload.php"
+	flDefaultBaseURL  = "https://filelist.io"
+	flIndexPath       = "/index.php"
+	flLoginPagePath   = "/login.php"
+	flLoginPath       = "/takelogin.php"
 	hdbDefaultBaseURL = "https://hdbits.org"
 	hdbUploadPath     = "/upload/upload"
+	thrDefaultBaseURL = "https://www.torrenthr.org"
+	thrLoginPath      = "/takelogin.php"
 )
+
+// flValidatorPattern extracts the anti-CSRF validator required by FL login.
+var flValidatorPattern = regexp.MustCompile(`name="validator"\s+value="([^"]+)"`)
 
 // resolveARStoredSessionForTrackerAuth verifies imported AR cookies against
 // the browse page. Missing cookies require user auth material, login redirects
@@ -53,6 +67,180 @@ func resolveARStoredSessionForTrackerAuth(ctx context.Context, cfg config.Tracke
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return &ValidationError{TrackerID: "AR", Transient: true, Reason: "remote validation failed", Err: fmt.Errorf("trackers: AR session validation failed status=%d", resp.StatusCode)}
+	}
+	return nil
+}
+
+// resolveFFSessionForTrackerAuth verifies stored FF cookies against the upload
+// page, or logs in with configured credentials and persists returned cookies.
+func resolveFFSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string, _ api.TrackerAuthLoginRequest) error {
+	baseURL := resolveAuthBaseURL(cfg, ffDefaultBaseURL)
+	values, err := cookies.LoadTrackerHTTPCookies(ctx, dbPath, "FF", "www.funfile.org")
+	if err == nil && len(values) > 0 {
+		validationErr := validateFFStoredCookies(ctx, baseURL, values)
+		if validationErr == nil {
+			return nil
+		}
+		return validationErr
+	}
+	if !hasLoginCredentials(cfg) {
+		return &AuthRequiredError{TrackerID: "FF", Reason: "cookies or username/password missing", Err: cookieLoadError("FF", err)}
+	}
+	return loginFFForTrackerAuth(ctx, cfg, dbPath, baseURL)
+}
+
+// validateFFStoredCookies checks imported FF cookies without mutating storage.
+// Login pages and missing logged-in markers are confirmed invalid; transport
+// and unexpected HTTP failures are transient.
+func validateFFStoredCookies(ctx context.Context, baseURL string, values []*http.Cookie) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, joinAuthURL(baseURL, ffUploadPath), nil)
+	if err != nil {
+		return fmt.Errorf("trackers: FF session validation request build: %w", err)
+	}
+	req.Header.Set("User-Agent", "upbrr")
+	commonhttp.ApplyCookies(req, values)
+
+	resp, err := noRedirectHTTPClient().Do(req)
+	if err != nil {
+		return &ValidationError{TrackerID: "FF", Transient: true, Reason: "remote validation unavailable", Err: fmt.Errorf("trackers: FF session validation request: %w", err)}
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if isLoginRedirect(resp) || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || ffLooksLoggedOut(string(body)) {
+		return &ValidationError{TrackerID: "FF", ConfirmedInvalid: true, Reason: "stored session expired", Err: fmt.Errorf("trackers: FF session validation failed status=%d", resp.StatusCode)}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &ValidationError{TrackerID: "FF", Transient: true, Reason: "remote validation failed", Err: fmt.Errorf("trackers: FF session validation failed status=%d", resp.StatusCode)}
+	}
+	if !ffLooksLoggedIn(string(body)) {
+		return &ValidationError{TrackerID: "FF", ConfirmedInvalid: true, Reason: "stored session expired", Err: errors.New("trackers: FF login marker not found")}
+	}
+	return nil
+}
+
+// loginFFForTrackerAuth performs the FF credential login flow and persists the
+// cookies returned by a successful redirect response.
+func loginFFForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string, baseURL string) error {
+	data := url.Values{}
+	data.Set("returnto", "/index.php")
+	data.Set("username", strings.TrimSpace(cfg.Username))
+	data.Set("password", strings.TrimSpace(cfg.Password))
+	data.Set("login", "Login")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, joinAuthURL(baseURL, ffLoginPath), strings.NewReader(data.Encode()))
+	if err != nil {
+		return fmt.Errorf("trackers: FF login request build: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "upbrr")
+	resp, err := noRedirectHTTPClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("trackers: FF login request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		return &ValidationError{TrackerID: "FF", ConfirmedInvalid: true, Reason: "login failed", Err: fmt.Errorf("trackers: FF login failed status=%d", resp.StatusCode)}
+	}
+	if err := persistHTTPCookies(ctx, dbPath, "FF", resp.Cookies()); err != nil {
+		return fmt.Errorf("trackers: FF persist login cookies: %w", err)
+	}
+	return nil
+}
+
+// resolveFLSessionForTrackerAuth verifies stored FL cookies against the index
+// page, or logs in with configured credentials and persists returned cookies.
+func resolveFLSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string, _ api.TrackerAuthLoginRequest) error {
+	baseURL := resolveAuthBaseURL(cfg, flDefaultBaseURL)
+	values, err := cookies.LoadTrackerHTTPCookies(ctx, dbPath, "FL", ".filelist.io")
+	if err == nil && len(values) > 0 {
+		validationErr := validateFLStoredCookies(ctx, baseURL, values)
+		if validationErr == nil {
+			return nil
+		}
+		return validationErr
+	}
+	if !hasLoginCredentials(cfg) {
+		return &AuthRequiredError{TrackerID: "FL", Reason: "cookies or username/password missing", Err: cookieLoadError("FL", err)}
+	}
+	return loginFLForTrackerAuth(ctx, cfg, dbPath, baseURL)
+}
+
+// validateFLStoredCookies checks imported FL cookies against the index page
+// without mutating storage. Logout text is treated as the logged-in marker.
+func validateFLStoredCookies(ctx context.Context, baseURL string, values []*http.Cookie) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, joinAuthURL(baseURL, flIndexPath), nil)
+	if err != nil {
+		return fmt.Errorf("trackers: FL session validation request build: %w", err)
+	}
+	req.Header.Set("User-Agent", "upbrr")
+	commonhttp.ApplyCookies(req, values)
+
+	resp, err := noRedirectHTTPClient().Do(req)
+	if err != nil {
+		return &ValidationError{TrackerID: "FL", Transient: true, Reason: "remote validation unavailable", Err: fmt.Errorf("trackers: FL session validation request: %w", err)}
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if isLoginRedirect(resp) || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || flLooksLoggedOut(string(body)) {
+		return &ValidationError{TrackerID: "FL", ConfirmedInvalid: true, Reason: "stored session expired", Err: fmt.Errorf("trackers: FL session validation failed status=%d", resp.StatusCode)}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &ValidationError{TrackerID: "FL", Transient: true, Reason: "remote validation failed", Err: fmt.Errorf("trackers: FL session validation failed status=%d", resp.StatusCode)}
+	}
+	if !flLooksLoggedIn(string(body)) {
+		return &ValidationError{TrackerID: "FL", ConfirmedInvalid: true, Reason: "stored session expired", Err: errors.New("trackers: FL logout marker not found")}
+	}
+	return nil
+}
+
+// loginFLForTrackerAuth fetches FL's login validator, submits credentials, and
+// persists the resulting cookie jar when login succeeds.
+func loginFLForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string, baseURL string) error {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return fmt.Errorf("trackers: FL create login cookie jar: %w", err)
+	}
+	client := &http.Client{Timeout: 30 * time.Second, Jar: jar}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, joinAuthURL(baseURL, flLoginPagePath), nil)
+	if err != nil {
+		return fmt.Errorf("trackers: FL login page request build: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("trackers: FL login page request: %w", err)
+	}
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	resp.Body.Close()
+	if readErr != nil {
+		return fmt.Errorf("trackers: FL read login page response: %w", readErr)
+	}
+	match := flValidatorPattern.FindStringSubmatch(string(body))
+	if len(match) < 2 {
+		return errors.New("trackers: FL validator token not found")
+	}
+	data := url.Values{}
+	data.Set("validator", match[1])
+	data.Set("username", strings.TrimSpace(cfg.Username))
+	data.Set("password", strings.TrimSpace(cfg.Password))
+	data.Set("unlock", "1")
+	loginReq, err := http.NewRequestWithContext(ctx, http.MethodPost, joinAuthURL(baseURL, flLoginPath), strings.NewReader(data.Encode()))
+	if err != nil {
+		return fmt.Errorf("trackers: FL login request build: %w", err)
+	}
+	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	loginResp, err := client.Do(loginReq)
+	if err != nil {
+		return fmt.Errorf("trackers: FL login request: %w", err)
+	}
+	defer loginResp.Body.Close()
+	if loginResp.StatusCode < 200 || loginResp.StatusCode >= 400 {
+		return &ValidationError{TrackerID: "FL", ConfirmedInvalid: true, Reason: "login failed", Err: fmt.Errorf("trackers: FL login failed status=%d", loginResp.StatusCode)}
+	}
+	base, err := url.Parse(strings.TrimRight(baseURL, "/") + "/")
+	if err != nil {
+		return fmt.Errorf("trackers: FL parse base URL: %w", err)
+	}
+	if err := persistHTTPCookies(ctx, dbPath, "FL", jar.Cookies(base)); err != nil {
+		return fmt.Errorf("trackers: FL persist login cookies: %w", err)
 	}
 	return nil
 }
@@ -87,6 +275,58 @@ func resolveHDBStoredSessionForTrackerAuth(ctx context.Context, cfg config.Track
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return &ValidationError{TrackerID: "HDB", Transient: true, Reason: "remote validation failed", Err: fmt.Errorf("trackers: HDB session validation failed status=%d", resp.StatusCode)}
+	}
+	return nil
+}
+
+// resolveTHRSessionForTrackerAuth validates THR credentials by performing a
+// login check. THR uploads log in per request and do not use stored cookies.
+func resolveTHRSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, _ string, _ api.TrackerAuthLoginRequest) error {
+	if !hasLoginCredentials(cfg) {
+		return &AuthRequiredError{TrackerID: "THR", Reason: "username/password missing", Err: errors.New("trackers: THR missing username/password")}
+	}
+	baseURL := resolveAuthBaseURL(cfg, thrDefaultBaseURL)
+	data := url.Values{}
+	data.Set("username", strings.TrimSpace(cfg.Username))
+	data.Set("password", strings.TrimSpace(cfg.Password))
+	data.Set("ssl", "yes")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, joinAuthURL(baseURL, thrLoginPath), strings.NewReader(data.Encode()))
+	if err != nil {
+		return fmt.Errorf("trackers: THR login request build: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "upbrr")
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("trackers: THR login request: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return &ValidationError{TrackerID: "THR", ConfirmedInvalid: true, Reason: "login failed", Err: fmt.Errorf("trackers: THR login failed status=%d", resp.StatusCode)}
+	}
+	if !thrLooksLoggedIn(string(body), resp) {
+		return &ValidationError{TrackerID: "THR", ConfirmedInvalid: true, Reason: "login failed", Err: errors.New("trackers: THR login marker not found")}
+	}
+	return nil
+}
+
+// persistHTTPCookies saves non-empty login cookies and rejects empty login
+// responses so tracker auth never reports success without durable auth material.
+func persistHTTPCookies(ctx context.Context, dbPath string, trackerID string, values []*http.Cookie) error {
+	valid := make([]*http.Cookie, 0, len(values))
+	for _, cookie := range values {
+		if cookie == nil || strings.TrimSpace(cookie.Name) == "" || strings.TrimSpace(cookie.Value) == "" {
+			continue
+		}
+		valid = append(valid, cookie)
+	}
+	if len(valid) == 0 {
+		return fmt.Errorf("trackers: %s login returned no usable cookies", trackerID)
+	}
+	if err := cookies.SaveTrackerHTTPCookies(ctx, dbPath, trackerID, valid); err != nil {
+		return fmt.Errorf("trackers: %s save cookies: %w", trackerID, err)
 	}
 	return nil
 }
@@ -153,4 +393,40 @@ func arLooksLoggedOut(body string) bool {
 func hdbLooksLoggedOut(body string) bool {
 	lower := strings.ToLower(body)
 	return strings.Contains(lower, "login.php") || strings.Contains(lower, "name=\"username\"") || strings.Contains(lower, "name=\"password\"")
+}
+
+// ffLooksLoggedIn recognizes the FF upload-page marker used by Upload Assistant.
+func ffLooksLoggedIn(body string) bool {
+	return strings.Contains(strings.ToLower(body), "friends.php")
+}
+
+// ffLooksLoggedOut recognizes FF login form markers in validation responses.
+func ffLooksLoggedOut(body string) bool {
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "takelogin.php") || strings.Contains(lower, "name=\"username\"") || strings.Contains(lower, "name=\"password\"")
+}
+
+// flLooksLoggedIn recognizes FL's logout marker on authenticated pages.
+func flLooksLoggedIn(body string) bool {
+	return strings.Contains(strings.ToLower(body), "logout")
+}
+
+// flLooksLoggedOut recognizes FL login form markers in validation responses.
+func flLooksLoggedOut(body string) bool {
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "login.php") || strings.Contains(lower, "name=\"username\"") || strings.Contains(lower, "name=\"password\"")
+}
+
+// thrLooksLoggedIn recognizes THR credential-login success by response body or
+// final URL because THR uploads use per-request login instead of stored cookies.
+func thrLooksLoggedIn(body string, resp *http.Response) bool {
+	lower := strings.ToLower(body)
+	if strings.Contains(lower, "logout.php") {
+		return true
+	}
+	if resp != nil && resp.Request != nil && resp.Request.URL != nil {
+		path := strings.ToLower(resp.Request.URL.Path)
+		return strings.Contains(path, "index.php")
+	}
+	return false
 }

--- a/internal/trackerauth/site_validators.go
+++ b/internal/trackerauth/site_validators.go
@@ -81,7 +81,9 @@ func resolveFFSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfi
 		if validationErr == nil {
 			return nil
 		}
-		return validationErr
+		if !shouldRefreshStoredCookiesWithCredentials(validationErr) || !hasLoginCredentials(cfg) {
+			return validationErr
+		}
 	}
 	if !hasLoginCredentials(cfg) {
 		return &AuthRequiredError{TrackerID: "FF", Reason: "cookies or username/password missing", Err: cookieLoadError("FF", err)}
@@ -156,7 +158,9 @@ func resolveFLSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfi
 		if validationErr == nil {
 			return nil
 		}
-		return validationErr
+		if !shouldRefreshStoredCookiesWithCredentials(validationErr) || !hasLoginCredentials(cfg) {
+			return validationErr
+		}
 	}
 	if !hasLoginCredentials(cfg) {
 		return &AuthRequiredError{TrackerID: "FL", Reason: "cookies or username/password missing", Err: cookieLoadError("FL", err)}
@@ -310,6 +314,13 @@ func resolveTHRSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConf
 		return &ValidationError{TrackerID: "THR", ConfirmedInvalid: true, Reason: "login failed", Err: errors.New("trackers: THR login marker not found")}
 	}
 	return nil
+}
+
+// shouldRefreshStoredCookiesWithCredentials reports whether stored cookies were
+// proven expired, allowing credential login to refresh them.
+func shouldRefreshStoredCookiesWithCredentials(err error) bool {
+	validation, ok := asValidationError(err)
+	return ok && validation.ConfirmedInvalid && !validation.Transient
 }
 
 // persistHTTPCookies saves non-empty login cookies and rejects empty login

--- a/internal/trackerauth/site_validators.go
+++ b/internal/trackerauth/site_validators.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackerauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/cookies"
+	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+const (
+	arDefaultBaseURL  = "https://alpharatio.cc"
+	arBrowsePath      = "/torrents.php"
+	hdbDefaultBaseURL = "https://hdbits.org"
+	hdbUploadPath     = "/upload/upload"
+)
+
+// resolveARStoredSessionForTrackerAuth verifies imported AR cookies against
+// the browse page. Missing cookies require user auth material, login redirects
+// or logged-out page markers invalidate stored cookies, and transport or
+// unexpected HTTP failures preserve stored cookies as transient failures.
+func resolveARStoredSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string, _ api.TrackerAuthLoginRequest) error {
+	values, err := cookies.LoadTrackerHTTPCookies(ctx, dbPath, "AR", "alpharatio.cc")
+	if err != nil || len(values) == 0 {
+		return &AuthRequiredError{TrackerID: "AR", Reason: "cookies missing", Err: cookieLoadError("AR", err)}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, joinAuthURL(resolveAuthBaseURL(cfg, arDefaultBaseURL), arBrowsePath), nil)
+	if err != nil {
+		return fmt.Errorf("trackers: AR session validation request build: %w", err)
+	}
+	req.Header.Set("User-Agent", "upbrr")
+	commonhttp.ApplyCookies(req, values)
+
+	resp, err := noRedirectHTTPClient().Do(req)
+	if err != nil {
+		return &ValidationError{TrackerID: "AR", Transient: true, Reason: "remote validation unavailable", Err: fmt.Errorf("trackers: AR session validation request: %w", err)}
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if isLoginRedirect(resp) || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || arLooksLoggedOut(string(body)) {
+		return &ValidationError{TrackerID: "AR", ConfirmedInvalid: true, Reason: "stored session expired", Err: fmt.Errorf("trackers: AR session validation failed status=%d", resp.StatusCode)}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &ValidationError{TrackerID: "AR", Transient: true, Reason: "remote validation failed", Err: fmt.Errorf("trackers: AR session validation failed status=%d", resp.StatusCode)}
+	}
+	return nil
+}
+
+// resolveHDBStoredSessionForTrackerAuth verifies the HDB upload prerequisites:
+// username/passkey config plus imported cookies that can reach the upload page.
+// Confirmed login responses invalidate stored cookies; remote failures remain
+// transient so a temporary tracker outage does not discard auth material.
+func resolveHDBStoredSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string, _ api.TrackerAuthLoginRequest) error {
+	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Passkey) == "" {
+		return &AuthRequiredError{TrackerID: "HDB", Reason: "username/passkey missing", Err: errors.New("trackers: HDB missing username/passkey")}
+	}
+	values, err := cookies.LoadTrackerHTTPCookies(ctx, dbPath, "HDB", "hdbits.org")
+	if err != nil || len(values) == 0 {
+		return &AuthRequiredError{TrackerID: "HDB", Reason: "cookies missing", Err: cookieLoadError("HDB", err)}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, joinAuthURL(resolveAuthBaseURL(cfg, hdbDefaultBaseURL), hdbUploadPath), nil)
+	if err != nil {
+		return fmt.Errorf("trackers: HDB session validation request build: %w", err)
+	}
+	req.Header.Set("User-Agent", "upbrr")
+	commonhttp.ApplyCookies(req, values)
+
+	resp, err := noRedirectHTTPClient().Do(req)
+	if err != nil {
+		return &ValidationError{TrackerID: "HDB", Transient: true, Reason: "remote validation unavailable", Err: fmt.Errorf("trackers: HDB session validation request: %w", err)}
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if isLoginRedirect(resp) || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || hdbLooksLoggedOut(string(body)) {
+		return &ValidationError{TrackerID: "HDB", ConfirmedInvalid: true, Reason: "stored session expired", Err: fmt.Errorf("trackers: HDB session validation failed status=%d", resp.StatusCode)}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &ValidationError{TrackerID: "HDB", Transient: true, Reason: "remote validation failed", Err: fmt.Errorf("trackers: HDB session validation failed status=%d", resp.StatusCode)}
+	}
+	return nil
+}
+
+// cookieLoadError preserves the underlying cookie load failure when available
+// while providing a stable tracker-specific error for empty cookie storage.
+func cookieLoadError(trackerID string, err error) error {
+	if err != nil {
+		return fmt.Errorf("trackers: %s load cookies: %w", trackerID, err)
+	}
+	return fmt.Errorf("trackers: %s cookies not found", trackerID)
+}
+
+// noRedirectHTTPClient exposes login redirects as validation evidence instead
+// of following them and classifying the login page as a successful response.
+func noRedirectHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// resolveAuthBaseURL applies a tracker override when configured and otherwise
+// falls back to the site's production base URL.
+func resolveAuthBaseURL(cfg config.TrackerConfig, fallback string) string {
+	if value := strings.TrimRight(strings.TrimSpace(cfg.URL), "/"); value != "" {
+		return value
+	}
+	return fallback
+}
+
+// joinAuthURL resolves site-relative validation paths against tracker base URLs
+// without using path joins that would corrupt URL semantics.
+func joinAuthURL(baseURL string, urlPath string) string {
+	parsed, err := url.Parse(strings.TrimRight(baseURL, "/") + "/")
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return strings.TrimRight(baseURL, "/") + urlPath
+	}
+	ref, err := url.Parse(strings.TrimLeft(urlPath, "/"))
+	if err != nil {
+		return strings.TrimRight(baseURL, "/") + urlPath
+	}
+	return parsed.ResolveReference(ref).String()
+}
+
+// isLoginRedirect reports redirects whose target path indicates an unauthenticated session.
+func isLoginRedirect(resp *http.Response) bool {
+	if resp == nil || resp.StatusCode < 300 || resp.StatusCode >= 400 {
+		return false
+	}
+	location := strings.ToLower(strings.TrimSpace(resp.Header.Get("Location")))
+	return strings.Contains(location, "login")
+}
+
+// arLooksLoggedOut recognizes AR login/recovery page markers in validation responses.
+func arLooksLoggedOut(body string) bool {
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "forgot your password") || strings.Contains(lower, "login.php?act=recover")
+}
+
+// hdbLooksLoggedOut recognizes HDB login form markers in validation responses.
+func hdbLooksLoggedOut(body string) bool {
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "login.php") || strings.Contains(lower, "name=\"username\"") || strings.Contains(lower, "name=\"password\"")
+}

--- a/internal/trackerauth/state_store.go
+++ b/internal/trackerauth/state_store.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackerauth
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	cookiepkg "github.com/autobrr/upbrr/internal/cookies"
+	servicedb "github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+var ErrAuthStateNotFound = errors.New("tracker auth state not found")
+
+type AuthStateStore struct {
+	db *sql.DB
+}
+
+func SaveAuthState(ctx context.Context, dbPath string, trackerID string, stateKey string, value string) error {
+	store, encKey, repo, err := openAuthStateStore(ctx, dbPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = repo.Close()
+	}()
+	return store.Save(ctx, trackerID, stateKey, value, encKey)
+}
+
+func LoadAuthState(ctx context.Context, dbPath string, trackerID string, stateKey string) (string, error) {
+	store, encKey, repo, err := openAuthStateStore(ctx, dbPath)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = repo.Close()
+	}()
+	return store.Load(ctx, trackerID, stateKey, encKey)
+}
+
+func DeleteAuthState(ctx context.Context, dbPath string, trackerID string, stateKey string) error {
+	store, _, repo, err := openAuthStateStore(ctx, dbPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = repo.Close()
+	}()
+	return store.Delete(ctx, trackerID, stateKey)
+}
+
+func NewAuthStateStore(db *sql.DB) (*AuthStateStore, error) {
+	if db == nil {
+		return nil, errors.New("tracker auth state: nil database connection")
+	}
+	return &AuthStateStore{db: db}, nil
+}
+
+func (s *AuthStateStore) Save(ctx context.Context, trackerID string, stateKey string, value string, encKey []byte) error {
+	if ctx == nil {
+		return errors.New("tracker auth state: context is required")
+	}
+	if err := validateStateInputs("Save", trackerID, stateKey); err != nil {
+		return err
+	}
+	if len(encKey) != 32 {
+		return errors.New("Save: invalid encryption key")
+	}
+	encrypted, err := cookiepkg.EncryptCookieValue(value, encKey)
+	if err != nil {
+		return fmt.Errorf("tracker auth state: encrypt: %w", err)
+	}
+	encoded := encrypted.EncodeForStorage()
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO tracker_auth_state (tracker_id, state_key, encrypted_value, nonce, auth_tag, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		ON CONFLICT(tracker_id, state_key) DO UPDATE SET
+			encrypted_value = excluded.encrypted_value,
+			nonce = excluded.nonce,
+			auth_tag = excluded.auth_tag,
+			updated_at = CURRENT_TIMESTAMP
+	`, normalizeTrackerID(trackerID), strings.TrimSpace(stateKey), encoded.CiphertextB64, encoded.NonceB64, encoded.AuthTagB64)
+	if err != nil {
+		return fmt.Errorf("tracker auth state: save: %w", err)
+	}
+	return nil
+}
+
+func (s *AuthStateStore) Load(ctx context.Context, trackerID string, stateKey string, encKey []byte) (string, error) {
+	if ctx == nil {
+		return "", errors.New("tracker auth state: context is required")
+	}
+	if err := validateStateInputs("Load", trackerID, stateKey); err != nil {
+		return "", err
+	}
+	if len(encKey) != 32 {
+		return "", errors.New("Load: invalid encryption key")
+	}
+	var encoded cookiepkg.EncodedEncryptedCookie
+	err := s.db.QueryRowContext(ctx, `
+		SELECT encrypted_value, nonce, auth_tag
+		FROM tracker_auth_state
+		WHERE tracker_id = ? AND state_key = ?
+	`, normalizeTrackerID(trackerID), strings.TrimSpace(stateKey)).Scan(&encoded.CiphertextB64, &encoded.NonceB64, &encoded.AuthTagB64)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrAuthStateNotFound
+	}
+	if err != nil {
+		return "", fmt.Errorf("tracker auth state: load: %w", err)
+	}
+	encrypted, err := cookiepkg.DecodeFromStorage(encoded)
+	if err != nil {
+		return "", fmt.Errorf("tracker auth state: decode: %w", err)
+	}
+	value, err := cookiepkg.DecryptCookieValue(encrypted, encKey)
+	if err != nil {
+		return "", fmt.Errorf("tracker auth state: decrypt: %w", err)
+	}
+	return value, nil
+}
+
+func (s *AuthStateStore) Delete(ctx context.Context, trackerID string, stateKey string) error {
+	if ctx == nil {
+		return errors.New("tracker auth state: context is required")
+	}
+	if err := validateStateInputs("Delete", trackerID, stateKey); err != nil {
+		return err
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM tracker_auth_state WHERE tracker_id = ? AND state_key = ?`, normalizeTrackerID(trackerID), strings.TrimSpace(stateKey))
+	if err != nil {
+		return fmt.Errorf("tracker auth state: delete: %w", err)
+	}
+	return nil
+}
+
+func openAuthStateStore(ctx context.Context, dbPath string) (*AuthStateStore, []byte, *servicedb.SQLiteRepository, error) {
+	repo, err := servicedb.OpenWithLoggerContext(ctx, dbPath, api.NopLogger{})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("tracker auth state: open db: %w", err)
+	}
+	if err := repo.MigrateContext(ctx); err != nil {
+		_ = repo.Close()
+		return nil, nil, nil, fmt.Errorf("tracker auth state: migrate db: %w", err)
+	}
+	store, err := NewAuthStateStore(repo.RawDB())
+	if err != nil {
+		_ = repo.Close()
+		return nil, nil, nil, err
+	}
+	encKey, err := cookiepkg.NewKeyManager(repo.RawDB()).InitializeEncryptionKey(ctx, dbPath)
+	if err != nil {
+		_ = repo.Close()
+		return nil, nil, nil, fmt.Errorf("tracker auth state: initialize encryption key: %w", err)
+	}
+	return store, encKey, repo, nil
+}
+
+func validateStateInputs(operation string, trackerID string, stateKey string) error {
+	if strings.TrimSpace(trackerID) == "" || strings.TrimSpace(stateKey) == "" {
+		return fmt.Errorf("%s: trackerID and stateKey must be non-empty", operation)
+	}
+	return nil
+}

--- a/internal/trackerauth/state_store.go
+++ b/internal/trackerauth/state_store.go
@@ -6,6 +6,7 @@ package trackerauth
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -21,6 +22,13 @@ var ErrAuthStateNotFound = errors.New("tracker auth state not found")
 // AuthStateStore persists encrypted tracker auth state in the shared SQLite database.
 type AuthStateStore struct {
 	db *sql.DB
+}
+
+// authStatePayload binds encrypted auth state to the row identity used to load it.
+type authStatePayload struct {
+	TrackerID string `json:"tracker_id"`
+	StateKey  string `json:"state_key"`
+	Value     string `json:"value"`
 }
 
 // SaveAuthState opens dbPath, initializes encrypted auth storage, and upserts value for trackerID/stateKey.
@@ -50,7 +58,7 @@ func LoadAuthState(ctx context.Context, dbPath string, trackerID string, stateKe
 
 // DeleteAuthState opens dbPath and deletes value for trackerID/stateKey.
 func DeleteAuthState(ctx context.Context, dbPath string, trackerID string, stateKey string) error {
-	store, _, repo, err := openAuthStateStore(ctx, dbPath)
+	store, repo, err := openAuthStateStoreWithoutKey(ctx, dbPath)
 	if err != nil {
 		return err
 	}
@@ -80,7 +88,9 @@ func (s *AuthStateStore) Save(ctx context.Context, trackerID string, stateKey st
 	if len(encKey) != 32 {
 		return errors.New("Save: invalid encryption key")
 	}
-	encrypted, err := cookiepkg.EncryptCookieValue(value, encKey)
+	normalizedTrackerID := normalizeTrackerID(trackerID)
+	normalizedStateKey := strings.TrimSpace(stateKey)
+	encrypted, err := encryptAuthStateValue(value, encKey, normalizedTrackerID, normalizedStateKey)
 	if err != nil {
 		return fmt.Errorf("tracker auth state: encrypt: %w", err)
 	}
@@ -93,7 +103,7 @@ func (s *AuthStateStore) Save(ctx context.Context, trackerID string, stateKey st
 			nonce = excluded.nonce,
 			auth_tag = excluded.auth_tag,
 			updated_at = CURRENT_TIMESTAMP
-	`, normalizeTrackerID(trackerID), strings.TrimSpace(stateKey), encoded.CiphertextB64, encoded.NonceB64, encoded.AuthTagB64)
+	`, normalizedTrackerID, normalizedStateKey, encoded.CiphertextB64, encoded.NonceB64, encoded.AuthTagB64)
 	if err != nil {
 		return fmt.Errorf("tracker auth state: save: %w", err)
 	}
@@ -112,12 +122,14 @@ func (s *AuthStateStore) Load(ctx context.Context, trackerID string, stateKey st
 	if len(encKey) != 32 {
 		return "", errors.New("Load: invalid encryption key")
 	}
+	normalizedTrackerID := normalizeTrackerID(trackerID)
+	normalizedStateKey := strings.TrimSpace(stateKey)
 	var encoded cookiepkg.EncodedEncryptedCookie
 	err := s.db.QueryRowContext(ctx, `
 		SELECT encrypted_value, nonce, auth_tag
 		FROM tracker_auth_state
 		WHERE tracker_id = ? AND state_key = ?
-	`, normalizeTrackerID(trackerID), strings.TrimSpace(stateKey)).Scan(&encoded.CiphertextB64, &encoded.NonceB64, &encoded.AuthTagB64)
+	`, normalizedTrackerID, normalizedStateKey).Scan(&encoded.CiphertextB64, &encoded.NonceB64, &encoded.AuthTagB64)
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", ErrAuthStateNotFound
 	}
@@ -128,7 +140,7 @@ func (s *AuthStateStore) Load(ctx context.Context, trackerID string, stateKey st
 	if err != nil {
 		return "", fmt.Errorf("tracker auth state: decode: %w", err)
 	}
-	value, err := cookiepkg.DecryptCookieValue(encrypted, encKey)
+	value, err := decryptAuthStateValue(encrypted, encKey, normalizedTrackerID, normalizedStateKey)
 	if err != nil {
 		return "", fmt.Errorf("tracker auth state: decrypt: %w", err)
 	}
@@ -150,18 +162,42 @@ func (s *AuthStateStore) Delete(ctx context.Context, trackerID string, stateKey 
 	return nil
 }
 
+// encryptAuthStateValue stores value with its normalized tracker/state identity so ciphertext cannot be replayed under another row key.
+func encryptAuthStateValue(value string, encKey []byte, trackerID string, stateKey string) (*cookiepkg.EncryptedCookie, error) {
+	payload, err := json.Marshal(authStatePayload{
+		TrackerID: trackerID,
+		StateKey:  stateKey,
+		Value:     value,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode bound payload: %w", err)
+	}
+	encrypted, err := cookiepkg.EncryptCookieValue(string(payload), encKey)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt bound payload: %w", err)
+	}
+	return encrypted, nil
+}
+
+// decryptAuthStateValue verifies the encrypted payload identity before returning the stored value.
+func decryptAuthStateValue(encrypted *cookiepkg.EncryptedCookie, encKey []byte, trackerID string, stateKey string) (string, error) {
+	plaintext, err := cookiepkg.DecryptCookieValue(encrypted, encKey)
+	if err != nil {
+		return "", fmt.Errorf("decrypt bound payload: %w", err)
+	}
+	var payload authStatePayload
+	if err := json.Unmarshal([]byte(plaintext), &payload); err != nil {
+		return "", fmt.Errorf("decode bound payload: %w", err)
+	}
+	if payload.TrackerID != trackerID || payload.StateKey != stateKey {
+		return "", errors.New("encrypted payload identity mismatch")
+	}
+	return payload.Value, nil
+}
+
 func openAuthStateStore(ctx context.Context, dbPath string) (*AuthStateStore, []byte, *servicedb.SQLiteRepository, error) {
-	repo, err := servicedb.OpenWithLoggerContext(ctx, dbPath, api.NopLogger{})
+	store, repo, err := openAuthStateStoreWithoutKey(ctx, dbPath)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("tracker auth state: open db: %w", err)
-	}
-	if err := repo.MigrateContext(ctx); err != nil {
-		_ = repo.Close()
-		return nil, nil, nil, fmt.Errorf("tracker auth state: migrate db: %w", err)
-	}
-	store, err := NewAuthStateStore(repo.RawDB())
-	if err != nil {
-		_ = repo.Close()
 		return nil, nil, nil, err
 	}
 	encKey, err := cookiepkg.NewKeyManager(repo.RawDB()).InitializeEncryptionKey(ctx, dbPath)
@@ -170,6 +206,24 @@ func openAuthStateStore(ctx context.Context, dbPath string) (*AuthStateStore, []
 		return nil, nil, nil, fmt.Errorf("tracker auth state: initialize encryption key: %w", err)
 	}
 	return store, encKey, repo, nil
+}
+
+// openAuthStateStoreWithoutKey opens and migrates auth-state storage without loading encryption material for delete-only cleanup paths.
+func openAuthStateStoreWithoutKey(ctx context.Context, dbPath string) (*AuthStateStore, *servicedb.SQLiteRepository, error) {
+	repo, err := servicedb.OpenWithLoggerContext(ctx, dbPath, api.NopLogger{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("tracker auth state: open db: %w", err)
+	}
+	if err := repo.MigrateContext(ctx); err != nil {
+		_ = repo.Close()
+		return nil, nil, fmt.Errorf("tracker auth state: migrate db: %w", err)
+	}
+	store, err := NewAuthStateStore(repo.RawDB())
+	if err != nil {
+		_ = repo.Close()
+		return nil, nil, err
+	}
+	return store, repo, nil
 }
 
 func validateStateInputs(operation string, trackerID string, stateKey string) error {

--- a/internal/trackerauth/state_store.go
+++ b/internal/trackerauth/state_store.go
@@ -15,12 +15,15 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+// ErrAuthStateNotFound is returned when no encrypted tracker auth state exists for a tracker/key pair.
 var ErrAuthStateNotFound = errors.New("tracker auth state not found")
 
+// AuthStateStore persists encrypted tracker auth state in the shared SQLite database.
 type AuthStateStore struct {
 	db *sql.DB
 }
 
+// SaveAuthState opens dbPath, initializes encrypted auth storage, and upserts value for trackerID/stateKey.
 func SaveAuthState(ctx context.Context, dbPath string, trackerID string, stateKey string, value string) error {
 	store, encKey, repo, err := openAuthStateStore(ctx, dbPath)
 	if err != nil {
@@ -32,6 +35,8 @@ func SaveAuthState(ctx context.Context, dbPath string, trackerID string, stateKe
 	return store.Save(ctx, trackerID, stateKey, value, encKey)
 }
 
+// LoadAuthState opens dbPath and decrypts value for trackerID/stateKey.
+// It returns [ErrAuthStateNotFound] when the key has not been saved.
 func LoadAuthState(ctx context.Context, dbPath string, trackerID string, stateKey string) (string, error) {
 	store, encKey, repo, err := openAuthStateStore(ctx, dbPath)
 	if err != nil {
@@ -43,6 +48,7 @@ func LoadAuthState(ctx context.Context, dbPath string, trackerID string, stateKe
 	return store.Load(ctx, trackerID, stateKey, encKey)
 }
 
+// DeleteAuthState opens dbPath and deletes value for trackerID/stateKey.
 func DeleteAuthState(ctx context.Context, dbPath string, trackerID string, stateKey string) error {
 	store, _, repo, err := openAuthStateStore(ctx, dbPath)
 	if err != nil {
@@ -54,6 +60,7 @@ func DeleteAuthState(ctx context.Context, dbPath string, trackerID string, state
 	return store.Delete(ctx, trackerID, stateKey)
 }
 
+// NewAuthStateStore wraps db for encrypted tracker auth state operations.
 func NewAuthStateStore(db *sql.DB) (*AuthStateStore, error) {
 	if db == nil {
 		return nil, errors.New("tracker auth state: nil database connection")
@@ -61,6 +68,8 @@ func NewAuthStateStore(db *sql.DB) (*AuthStateStore, error) {
 	return &AuthStateStore{db: db}, nil
 }
 
+// Save encrypts value with encKey and upserts it for trackerID/stateKey.
+// encKey must be a 32-byte key from cookie encryption storage.
 func (s *AuthStateStore) Save(ctx context.Context, trackerID string, stateKey string, value string, encKey []byte) error {
 	if ctx == nil {
 		return errors.New("tracker auth state: context is required")
@@ -91,6 +100,8 @@ func (s *AuthStateStore) Save(ctx context.Context, trackerID string, stateKey st
 	return nil
 }
 
+// Load decrypts value for trackerID/stateKey with encKey.
+// It returns [ErrAuthStateNotFound] when the key has not been saved.
 func (s *AuthStateStore) Load(ctx context.Context, trackerID string, stateKey string, encKey []byte) (string, error) {
 	if ctx == nil {
 		return "", errors.New("tracker auth state: context is required")
@@ -124,6 +135,7 @@ func (s *AuthStateStore) Load(ctx context.Context, trackerID string, stateKey st
 	return value, nil
 }
 
+// Delete removes encrypted value for trackerID/stateKey.
 func (s *AuthStateStore) Delete(ctx context.Context, trackerID string, stateKey string) error {
 	if ctx == nil {
 		return errors.New("tracker auth state: context is required")

--- a/internal/trackerauth/state_store_test.go
+++ b/internal/trackerauth/state_store_test.go
@@ -6,11 +6,13 @@ package trackerauth
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/authmaterial"
+	servicedb "github.com/autobrr/upbrr/internal/services/db"
 )
 
 func TestAuthStateRoundTripEncrypted(t *testing.T) {
@@ -41,6 +43,37 @@ func TestAuthStateRoundTripEncrypted(t *testing.T) {
 	}
 }
 
+func TestAuthStateRejectsMovedEncryptedPayload(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := SaveAuthState(ctx, dbPath, "AR", "auth_key", "secret-auth-key"); err != nil {
+		t.Fatalf("SaveAuthState: %v", err)
+	}
+	repo, err := servicedb.OpenWithLoggerContext(ctx, dbPath, nil)
+	if err != nil {
+		t.Fatalf("OpenWithLoggerContext: %v", err)
+	}
+	if _, err := repo.RawDB().ExecContext(ctx, `UPDATE tracker_auth_state SET tracker_id = ? WHERE tracker_id = ? AND state_key = ?`, "PTP", "AR", "auth_key"); err != nil {
+		_ = repo.Close()
+		t.Fatalf("move auth state row: %v", err)
+	}
+	if err := repo.Close(); err != nil {
+		t.Fatalf("close repo: %v", err)
+	}
+
+	if _, err := LoadAuthState(ctx, dbPath, "PTP", "auth_key"); err == nil || !strings.Contains(err.Error(), "identity mismatch") {
+		t.Fatalf("expected moved payload identity mismatch, got %v", err)
+	}
+	if _, err := LoadAuthState(ctx, dbPath, "AR", "auth_key"); !errors.Is(err, ErrAuthStateNotFound) {
+		t.Fatalf("expected original key to be missing, got %v", err)
+	}
+}
+
 func TestAuthStateWriteRequiresWebAuthMaterial(t *testing.T) {
 	t.Parallel()
 
@@ -50,5 +83,48 @@ func TestAuthStateWriteRequiresWebAuthMaterial(t *testing.T) {
 	}
 	if !strings.Contains(strings.ToLower(err.Error()), "auth") {
 		t.Fatalf("expected auth material error, got %v", err)
+	}
+}
+
+func TestDeleteAuthStateDoesNotRequireWebAuthMaterial(t *testing.T) {
+	t.Parallel()
+
+	err := DeleteAuthState(context.Background(), filepath.Join(t.TempDir(), "upbrr.db"), "AR", "auth_key")
+	if err != nil {
+		t.Fatalf("DeleteAuthState: %v", err)
+	}
+}
+
+func TestDeleteAuthStateRemovesRowsWhenWebAuthMaterialMissing(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := SaveAuthState(ctx, dbPath, "AR", "auth_key", "secret-auth-key"); err != nil {
+		t.Fatalf("SaveAuthState: %v", err)
+	}
+	if err := os.Remove(filepath.Join(filepath.Dir(dbPath), authmaterial.WebAuthFileName)); err != nil {
+		t.Fatalf("Remove web auth: %v", err)
+	}
+
+	if err := DeleteAuthState(ctx, dbPath, "AR", "auth_key"); err != nil {
+		t.Fatalf("DeleteAuthState: %v", err)
+	}
+	repo, err := servicedb.OpenWithLoggerContext(ctx, dbPath, nil)
+	if err != nil {
+		t.Fatalf("OpenWithLoggerContext: %v", err)
+	}
+	defer func() {
+		_ = repo.Close()
+	}()
+	var count int
+	if err := repo.RawDB().QueryRowContext(ctx, `SELECT COUNT(*) FROM tracker_auth_state WHERE tracker_id = ? AND state_key = ?`, "AR", "auth_key").Scan(&count); err != nil {
+		t.Fatalf("count tracker auth state: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected auth state row deleted, got %d", count)
 	}
 }

--- a/internal/trackerauth/state_store_test.go
+++ b/internal/trackerauth/state_store_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackerauth
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/authmaterial"
+)
+
+func TestAuthStateRoundTripEncrypted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+
+	if err := SaveAuthState(ctx, dbPath, "ar", "auth_key", "secret-auth-key"); err != nil {
+		t.Fatalf("SaveAuthState: %v", err)
+	}
+	got, err := LoadAuthState(ctx, dbPath, "AR", "auth_key")
+	if err != nil {
+		t.Fatalf("LoadAuthState: %v", err)
+	}
+	if got != "secret-auth-key" {
+		t.Fatalf("state value: got %q", got)
+	}
+
+	if err := DeleteAuthState(ctx, dbPath, "AR", "auth_key"); err != nil {
+		t.Fatalf("DeleteAuthState: %v", err)
+	}
+	if _, err := LoadAuthState(ctx, dbPath, "AR", "auth_key"); !errors.Is(err, ErrAuthStateNotFound) {
+		t.Fatalf("expected ErrAuthStateNotFound, got %v", err)
+	}
+}
+
+func TestAuthStateWriteRequiresWebAuthMaterial(t *testing.T) {
+	t.Parallel()
+
+	err := SaveAuthState(context.Background(), filepath.Join(t.TempDir(), "upbrr.db"), "AR", "auth_key", "secret")
+	if err == nil {
+		t.Fatal("expected missing web auth material error")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "auth") {
+		t.Fatalf("expected auth material error, got %v", err)
+	}
+}

--- a/internal/trackerauth/types.go
+++ b/internal/trackerauth/types.go
@@ -66,8 +66,8 @@ type Adapter interface {
 	Validate(ctx context.Context, cfg config.TrackerConfig, dbPath string) (Session, error)
 	// Login attempts credential-based auth and may persist refreshed auth material.
 	Login(ctx context.Context, cfg config.TrackerConfig, dbPath string, req api.TrackerAuthLoginRequest) (Session, error)
-	// Submit2FA continues a manual 2FA challenge previously returned by Validate or Login.
-	Submit2FA(ctx context.Context, challengeID string, code string) (Session, error)
+	// Submit2FA retries auth with manual 2FA input for a service-verified challenge.
+	Submit2FA(ctx context.Context, cfg config.TrackerConfig, dbPath string, req api.TrackerAuthLoginRequest) (Session, error)
 	// Delete removes persisted auth material owned by the adapter.
 	Delete(ctx context.Context, dbPath string) error
 }
@@ -126,8 +126,10 @@ type ValidationError struct {
 	ConfirmedInvalid bool
 	// Transient means stored auth material should be preserved because the failure may be temporary.
 	Transient bool
-	Reason    string
-	Err       error
+	// Submitted2FARejected means an adapter proved a submitted manual 2FA code reached the tracker and was rejected.
+	Submitted2FARejected bool
+	Reason               string
+	Err                  error
 }
 
 func (e *ValidationError) Error() string {

--- a/internal/trackerauth/types.go
+++ b/internal/trackerauth/types.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackerauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+const (
+	SessionStateReady        = "ready"
+	SessionStateAuthRequired = "auth_required"
+	SessionStateNeeds2FA     = "needs_2fa"
+	SessionStateUnsupported  = "unsupported"
+)
+
+type EnsureRequest struct {
+	TrackerID string
+	Config    config.TrackerConfig
+	DBPath    string
+	AutoLogin bool
+	Login     api.TrackerAuthLoginRequest
+}
+
+type Session struct {
+	TrackerID   string
+	State       string
+	Cookies     map[string]string
+	Token       string
+	ChallengeID string
+	Message     string
+}
+
+type Adapter interface {
+	Capability() api.TrackerAuthCapability
+	Status(ctx context.Context, cfg config.TrackerConfig, dbPath string) (api.TrackerAuthStatus, error)
+	Validate(ctx context.Context, cfg config.TrackerConfig, dbPath string) (Session, error)
+	Login(ctx context.Context, cfg config.TrackerConfig, dbPath string, req api.TrackerAuthLoginRequest) (Session, error)
+	Submit2FA(ctx context.Context, challengeID string, code string) (Session, error)
+	Delete(ctx context.Context, dbPath string) error
+}
+
+type AuthRequiredError struct {
+	TrackerID string
+	Reason    string
+	Err       error
+}
+
+func (e *AuthRequiredError) Error() string {
+	return trackerAuthError("auth required", e.TrackerID, e.Reason, e.Err)
+}
+
+func (e *AuthRequiredError) Unwrap() error {
+	return e.Err
+}
+
+type Needs2FAError struct {
+	TrackerID   string
+	ChallengeID string
+	Reason      string
+	Err         error
+}
+
+func (e *Needs2FAError) Error() string {
+	return trackerAuthError("2FA required", e.TrackerID, e.Reason, e.Err)
+}
+
+func (e *Needs2FAError) Unwrap() error {
+	return e.Err
+}
+
+type UnsupportedAuthError struct {
+	TrackerID string
+	Reason    string
+	Err       error
+}
+
+func (e *UnsupportedAuthError) Error() string {
+	return trackerAuthError("unsupported auth", e.TrackerID, e.Reason, e.Err)
+}
+
+func (e *UnsupportedAuthError) Unwrap() error {
+	return e.Err
+}
+
+type ValidationError struct {
+	TrackerID        string
+	ConfirmedInvalid bool
+	Transient        bool
+	Reason           string
+	Err              error
+}
+
+func (e *ValidationError) Error() string {
+	return trackerAuthError("validation failed", e.TrackerID, e.Reason, e.Err)
+}
+
+func (e *ValidationError) Unwrap() error {
+	return e.Err
+}
+
+func trackerAuthError(kind string, trackerID string, reason string, err error) string {
+	parts := []string{"tracker auth"}
+	if trimmed := strings.TrimSpace(trackerID); trimmed != "" {
+		parts = append(parts, strings.ToUpper(trimmed))
+	}
+	parts = append(parts, kind)
+	if trimmed := strings.TrimSpace(reason); trimmed != "" {
+		parts = append(parts, trimmed)
+	}
+	msg := strings.Join(parts, ": ")
+	if err != nil {
+		msg += ": " + err.Error()
+	}
+	return msg
+}
+
+func asValidationError(err error) (*ValidationError, bool) {
+	var validationErr *ValidationError
+	if errors.As(err, &validationErr) {
+		return validationErr, true
+	}
+	return nil, false
+}
+
+func hasLoginCredentials(cfg config.TrackerConfig) bool {
+	return strings.TrimSpace(cfg.Username) != "" && strings.TrimSpace(cfg.Password) != ""
+}
+
+func normalizeTrackerID(trackerID string) string {
+	return strings.ToUpper(strings.TrimSpace(trackerID))
+}
+
+func newUnknownTrackerError(trackerID string) error {
+	return fmt.Errorf("tracker auth: unknown tracker %s", strings.TrimSpace(trackerID))
+}

--- a/internal/trackerauth/types.go
+++ b/internal/trackerauth/types.go
@@ -52,7 +52,8 @@ type Session struct {
 	Token string
 	// ChallengeID identifies a pending manual 2FA continuation.
 	ChallengeID string
-	Message     string
+	// Message contains caller-visible detail about the current auth state.
+	Message string
 }
 
 // Adapter validates and mutates tracker-specific auth material.
@@ -166,7 +167,16 @@ func hasLoginCredentials(cfg config.TrackerConfig) bool {
 }
 
 func normalizeTrackerID(trackerID string) string {
-	return strings.ToUpper(strings.TrimSpace(trackerID))
+	trimmed := strings.TrimSpace(trackerID)
+	var builder strings.Builder
+	builder.Grow(len(trimmed))
+	for _, r := range trimmed {
+		if r >= 'a' && r <= 'z' {
+			r -= 'a' - 'A'
+		}
+		builder.WriteRune(r)
+	}
+	return builder.String()
 }
 
 func newUnknownTrackerError(trackerID string) error {

--- a/internal/trackerauth/types.go
+++ b/internal/trackerauth/types.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2025-2026, Audionut and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+// Package trackerauth manages tracker login, cookie import, session validation,
+// and encrypted auxiliary auth state for tracker implementations.
 package trackerauth
 
 import (
@@ -14,38 +16,62 @@ import (
 )
 
 const (
-	SessionStateReady        = "ready"
+	// SessionStateReady means an adapter returned auth material ready for tracker requests.
+	SessionStateReady = "ready"
+	// SessionStateAuthRequired means no usable session is available without user auth material.
 	SessionStateAuthRequired = "auth_required"
-	SessionStateNeeds2FA     = "needs_2fa"
-	SessionStateUnsupported  = "unsupported"
+	// SessionStateNeeds2FA means the auth flow is paused until a manual 2FA code is submitted.
+	SessionStateNeeds2FA = "needs_2fa"
+	// SessionStateUnsupported means the tracker has no supported auth operation for the requested flow.
+	SessionStateUnsupported = "unsupported"
 )
 
+// EnsureRequest describes one tracker auth validation or login attempt.
 type EnsureRequest struct {
+	// TrackerID is the tracker code to validate; comparisons are case-insensitive.
 	TrackerID string
-	Config    config.TrackerConfig
-	DBPath    string
+	// Config supplies credentials, URLs, passkeys, and OTP settings for the tracker.
+	Config config.TrackerConfig
+	// DBPath points at the application database used for encrypted cookie and state storage.
+	DBPath string
+	// AutoLogin allows EnsureSession to attempt credential login after a confirmed invalid stored session.
 	AutoLogin bool
-	Login     api.TrackerAuthLoginRequest
+	// Login carries optional adapter-specific login input, such as a one-time 2FA code.
+	Login api.TrackerAuthLoginRequest
 }
 
+// Session is the normalized result returned by a tracker auth adapter.
 type Session struct {
-	TrackerID   string
-	State       string
-	Cookies     map[string]string
-	Token       string
+	// TrackerID is the normalized tracker code that produced the session.
+	TrackerID string
+	// State reports whether the session is ready, blocked by auth, paused for 2FA, or unsupported.
+	State string
+	// Cookies contains session cookies returned by adapters that expose cookie maps.
+	Cookies map[string]string
+	// Token contains tracker-specific CSRF/auth tokens when an adapter exposes one.
+	Token string
+	// ChallengeID identifies a pending manual 2FA continuation.
 	ChallengeID string
 	Message     string
 }
 
+// Adapter validates and mutates tracker-specific auth material.
 type Adapter interface {
+	// Capability returns static auth support metadata for the tracker.
 	Capability() api.TrackerAuthCapability
+	// Status returns local auth state without forcing a remote login.
 	Status(ctx context.Context, cfg config.TrackerConfig, dbPath string) (api.TrackerAuthStatus, error)
+	// Validate checks whether stored auth material can be used for tracker requests.
 	Validate(ctx context.Context, cfg config.TrackerConfig, dbPath string) (Session, error)
+	// Login attempts credential-based auth and may persist refreshed auth material.
 	Login(ctx context.Context, cfg config.TrackerConfig, dbPath string, req api.TrackerAuthLoginRequest) (Session, error)
+	// Submit2FA continues a manual 2FA challenge previously returned by Validate or Login.
 	Submit2FA(ctx context.Context, challengeID string, code string) (Session, error)
+	// Delete removes persisted auth material owned by the adapter.
 	Delete(ctx context.Context, dbPath string) error
 }
 
+// AuthRequiredError reports that no usable session is available and caller-supplied auth material is required.
 type AuthRequiredError struct {
 	TrackerID string
 	Reason    string
@@ -60,8 +86,10 @@ func (e *AuthRequiredError) Unwrap() error {
 	return e.Err
 }
 
+// Needs2FAError reports that a manual 2FA code is required before auth can continue.
 type Needs2FAError struct {
-	TrackerID   string
+	TrackerID string
+	// ChallengeID is set when the caller can continue the flow with Submit2FA.
 	ChallengeID string
 	Reason      string
 	Err         error
@@ -75,6 +103,7 @@ func (e *Needs2FAError) Unwrap() error {
 	return e.Err
 }
 
+// UnsupportedAuthError reports that the requested auth operation is not implemented for the tracker.
 type UnsupportedAuthError struct {
 	TrackerID string
 	Reason    string
@@ -89,12 +118,15 @@ func (e *UnsupportedAuthError) Unwrap() error {
 	return e.Err
 }
 
+// ValidationError reports a failed remote or local validation check.
 type ValidationError struct {
-	TrackerID        string
+	TrackerID string
+	// ConfirmedInvalid means stored auth material is known bad and may be deleted.
 	ConfirmedInvalid bool
-	Transient        bool
-	Reason           string
-	Err              error
+	// Transient means stored auth material should be preserved because the failure may be temporary.
+	Transient bool
+	Reason    string
+	Err       error
 }
 
 func (e *ValidationError) Error() string {

--- a/internal/trackers/impl/ar/upload.go
+++ b/internal/trackers/impl/ar/upload.go
@@ -28,6 +28,7 @@ import (
 	"github.com/autobrr/upbrr/internal/paths"
 	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/internal/trackerauth"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
 	"github.com/autobrr/upbrr/pkg/api"
@@ -39,6 +40,7 @@ const (
 	arLoginURL   = arBaseURL + "/login.php"
 	arBrowseURL  = arBaseURL + "/torrents.php"
 	arAuthFile   = "AR_auth.txt"
+	arAuthKeyKey = "auth_key"
 	arUserAgent  = "upbrr"
 	arSourceFlag = "AlphaRatio"
 )
@@ -532,8 +534,8 @@ func resolveSession(ctx context.Context, cfg config.TrackerConfig, dbPath string
 	if err := persistLoginCookies(ctx, dbPath, logger, jar.Cookies(base)); err != nil {
 		return nil, "", err
 	}
-	if err := os.WriteFile(authPath(dbPath), []byte(authKey), 0o600); err != nil {
-		return nil, "", fmt.Errorf("trackers: AR write auth key: %w", err)
+	if err := writeAuthKey(ctx, dbPath, authKey); err != nil {
+		return nil, "", err
 	}
 	return client, authKey, nil
 }
@@ -571,15 +573,15 @@ func validateSession(ctx context.Context, client *http.Client, dbPath string) (s
 	if resp.StatusCode != http.StatusOK || arLoginFailurePattern.MatchString(body) {
 		return "", false, nil
 	}
-	if authKey := readAuthKey(dbPath); authKey != "" {
+	if authKey := readAuthKey(ctx, dbPath); authKey != "" {
 		return authKey, true, nil
 	}
 	authKey := extractAuthKey(body)
 	if authKey == "" {
 		return "", false, nil
 	}
-	if err := os.WriteFile(authPath(dbPath), []byte(authKey), 0o600); err != nil {
-		return "", false, fmt.Errorf("trackers: AR write auth key: %w", err)
+	if err := writeAuthKey(ctx, dbPath, authKey); err != nil {
+		return "", false, err
 	}
 	return authKey, true, nil
 }
@@ -717,12 +719,34 @@ func authPath(dbPath string) string {
 	return path
 }
 
-func readAuthKey(dbPath string) string {
+func readAuthKey(ctx context.Context, dbPath string) string {
+	if authKey, err := trackerauth.LoadAuthState(ctx, dbPath, "AR", arAuthKeyKey); err == nil && strings.TrimSpace(authKey) != "" {
+		return strings.TrimSpace(authKey)
+	}
 	payload, err := os.ReadFile(authPath(dbPath))
 	if err != nil {
 		return ""
 	}
 	return strings.TrimSpace(string(payload))
+}
+
+func writeAuthKey(ctx context.Context, dbPath string, authKey string) error {
+	authKey = strings.TrimSpace(authKey)
+	if authKey == "" {
+		return nil
+	}
+	if err := trackerauth.SaveAuthState(ctx, dbPath, "AR", arAuthKeyKey, authKey); err != nil {
+		if errors.Is(err, cookiepkg.ErrAuthHelperUnavailable) {
+			return nil
+		}
+		return fmt.Errorf("trackers: AR write encrypted auth key: %w", err)
+	}
+	if legacyPath := authPath(dbPath); legacyPath != "" {
+		if err := os.Remove(legacyPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("trackers: AR delete legacy auth key: %w", err)
+		}
+	}
+	return nil
 }
 
 func loadCookies(ctx context.Context, dbPath string) ([]*http.Cookie, error) {

--- a/internal/trackers/impl/ar/upload.go
+++ b/internal/trackers/impl/ar/upload.go
@@ -647,11 +647,11 @@ func validateSessionWithAuthKeyPersistence(ctx context.Context, client *http.Cli
 	if resp.StatusCode != http.StatusOK || arLoginFailurePattern.MatchString(body) {
 		return "", false, nil
 	}
-	if authKey := readAuthKey(ctx, dbPath); authKey != "" {
-		return authKey, true, nil
-	}
 	authKey := extractAuthKey(body)
 	if authKey == "" {
+		if authKey := readAuthKey(ctx, dbPath); authKey != "" {
+			return authKey, true, nil
+		}
 		return "", false, nil
 	}
 	if !persistAuthKey {

--- a/internal/trackers/impl/ar/upload.go
+++ b/internal/trackers/impl/ar/upload.go
@@ -22,6 +22,7 @@ import (
 
 	"golang.org/x/net/html"
 
+	"github.com/autobrr/upbrr/internal/authmaterial"
 	"github.com/autobrr/upbrr/internal/config"
 	cookiepkg "github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
@@ -411,8 +412,8 @@ func resolveTags(meta api.PreparedMetadata) string {
 	if meta.ExternalIDs.IMDBID > 0 {
 		values = append(values, "tt"+strconv.Itoa(meta.ExternalIDs.IMDBID))
 	}
-	for _, value := range strings.Split(resolveGenres(meta), ",") {
-		for _, sub := range strings.Split(value, "&") {
+	for value := range strings.SplitSeq(resolveGenres(meta), ",") {
+		for sub := range strings.SplitSeq(value, "&") {
 			tag := strings.TrimSpace(collapseDots(sub))
 			if tag == "" {
 				continue
@@ -506,6 +507,8 @@ func dryRunAuthProblem(ctx context.Context, cfg config.TrackerConfig, dbPath str
 	return "missing valid AR cookies/auth and username/password are not configured"
 }
 
+// resolveSession returns an authenticated AR client and auth key from stored
+// cookies/auth state or by logging in with configured credentials.
 func resolveSession(ctx context.Context, cfg config.TrackerConfig, dbPath string, logger api.Logger) (*http.Client, string, error) {
 	if logger == nil {
 		logger = api.NopLogger{}
@@ -527,34 +530,105 @@ func resolveSession(ctx context.Context, cfg config.TrackerConfig, dbPath string
 	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
 		return nil, "", errors.New("trackers: AR cookie invalid/missing and username/password not configured")
 	}
+	if err := ensureLoginPersistenceAvailable(dbPath); err != nil {
+		return nil, "", err
+	}
 	authKey, err := login(ctx, client, cfg, dbPath)
 	if err != nil {
 		return nil, "", err
 	}
-	if err := persistLoginCookies(ctx, dbPath, logger, jar.Cookies(base)); err != nil {
-		return nil, "", err
-	}
-	if err := writeAuthKey(ctx, dbPath, authKey); err != nil {
+	if err := persistLoginAuth(ctx, dbPath, logger, jar.Cookies(base), authKey); err != nil {
 		return nil, "", err
 	}
 	return client, authKey, nil
 }
 
-func persistLoginCookies(ctx context.Context, dbPath string, logger api.Logger, values []*http.Cookie) error {
-	if err := saveCookies(ctx, dbPath, values); err != nil {
-		if errors.Is(err, cookiepkg.ErrAuthHelperUnavailable) {
-			if logger == nil {
-				logger = api.NopLogger{}
-			}
-			logger.Warnf("trackers: AR failed to persist cookies; continuing with plaintext fallback: %v", err)
-			return nil
+func persistLoginAuth(ctx context.Context, dbPath string, logger api.Logger, values []*http.Cookie, authKey string) error {
+	return persistLoginAuthWithWriter(ctx, dbPath, logger, values, authKey, writeAuthKey)
+}
+
+// persistLoginAuthWithWriter persists login cookies before the encrypted AR
+// auth key so cookie persistence failures cannot commit a new key alone. If
+// auth key persistence fails after cookies were saved, it restores the previous
+// cookie state before returning the auth key error.
+func persistLoginAuthWithWriter(
+	ctx context.Context,
+	dbPath string,
+	logger api.Logger,
+	values []*http.Cookie,
+	authKey string,
+	write func(context.Context, string, string) error,
+) error {
+	previous, hadPrevious, err := snapshotLoginCookies(ctx, dbPath)
+	if err != nil {
+		return err
+	}
+	if err := persistLoginCookies(ctx, dbPath, logger, values); err != nil {
+		return err
+	}
+	if err := write(ctx, dbPath, authKey); err != nil {
+		if rollbackErr := restoreLoginCookies(context.WithoutCancel(ctx), dbPath, previous, hadPrevious); rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("trackers: AR rollback login cookies: %w", rollbackErr))
 		}
 		return err
 	}
 	return nil
 }
 
+func snapshotLoginCookies(ctx context.Context, dbPath string) ([]*http.Cookie, bool, error) {
+	values, err := loadCookies(ctx, dbPath)
+	if err == nil {
+		return values, len(values) > 0, nil
+	}
+	if errors.Is(err, cookiepkg.ErrAuthHelperUnavailable) || strings.Contains(strings.ToLower(err.Error()), "no cookies found") {
+		return nil, false, nil
+	}
+	return nil, false, err
+}
+
+func restoreLoginCookies(ctx context.Context, dbPath string, previous []*http.Cookie, hadPrevious bool) error {
+	if hadPrevious {
+		return saveCookies(ctx, dbPath, previous)
+	}
+	return wrapTrackerError(cookiepkg.DeleteTrackerCookies(ctx, dbPath, "AR"))
+}
+
+// persistLoginCookies saves encrypted cookies after login; persistence failures
+// are returned so callers do not report login success without durable cookies.
+func persistLoginCookies(ctx context.Context, dbPath string, logger api.Logger, values []*http.Cookie) error {
+	_ = logger
+	if len(usableHTTPCookies(values)) == 0 {
+		return errors.New("trackers: AR login returned no usable cookies")
+	}
+	if err := saveCookies(ctx, dbPath, values); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ensureLoginPersistenceAvailable(dbPath string) error {
+	if _, err := authmaterial.LoadFromDBPath(dbPath); err != nil {
+		if errors.Is(err, authmaterial.ErrUnavailable) {
+			return fmt.Errorf("trackers: AR encrypted auth storage unavailable before credential login: %w", cookiepkg.ErrAuthHelperUnavailable)
+		}
+		return fmt.Errorf("trackers: AR check encrypted auth storage before credential login: %w", err)
+	}
+	return nil
+}
+
+// validateSession checks the current AR session and refreshes encrypted auth
+// state when the response exposes an auth key.
 func validateSession(ctx context.Context, client *http.Client, dbPath string) (string, bool, error) {
+	return validateSessionWithAuthKeyPersistence(ctx, client, dbPath, true)
+}
+
+// validateSessionAfterLogin checks the just-authenticated AR session without
+// persisting the auth key before login cookies are durably saved.
+func validateSessionAfterLogin(ctx context.Context, client *http.Client, dbPath string) (string, bool, error) {
+	return validateSessionWithAuthKeyPersistence(ctx, client, dbPath, false)
+}
+
+func validateSessionWithAuthKeyPersistence(ctx context.Context, client *http.Client, dbPath string, persistAuthKey bool) (string, bool, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, arBrowseURL, nil)
 	if err != nil {
 		return "", false, fmt.Errorf("trackers: AR session validation request build: %w", err)
@@ -579,6 +653,9 @@ func validateSession(ctx context.Context, client *http.Client, dbPath string) (s
 	authKey := extractAuthKey(body)
 	if authKey == "" {
 		return "", false, nil
+	}
+	if !persistAuthKey {
+		return authKey, true, nil
 	}
 	if err := writeAuthKey(ctx, dbPath, authKey); err != nil {
 		return "", false, err
@@ -616,7 +693,7 @@ func login(ctx context.Context, client *http.Client, cfg config.TrackerConfig, d
 	if authKey != "" {
 		return authKey, nil
 	}
-	authKey, valid, err := validateSession(ctx, client, dbPath)
+	authKey, valid, err := validateSessionAfterLogin(ctx, client, dbPath)
 	if err != nil {
 		return "", err
 	}
@@ -719,6 +796,8 @@ func authPath(dbPath string) string {
 	return path
 }
 
+// readAuthKey prefers encrypted AR auth state and falls back to the legacy
+// plaintext auth key file.
 func readAuthKey(ctx context.Context, dbPath string) string {
 	if authKey, err := trackerauth.LoadAuthState(ctx, dbPath, "AR", arAuthKeyKey); err == nil && strings.TrimSpace(authKey) != "" {
 		return strings.TrimSpace(authKey)
@@ -730,21 +809,91 @@ func readAuthKey(ctx context.Context, dbPath string) string {
 	return strings.TrimSpace(string(payload))
 }
 
+// writeAuthKey persists AR auth keys only to encrypted tracker auth state and
+// deletes any legacy plaintext key after a successful write. If legacy cleanup
+// fails, the encrypted write is rolled back so callers never commit split auth
+// state. Existing legacy installs without web auth keep using the legacy path.
 func writeAuthKey(ctx context.Context, dbPath string, authKey string) error {
 	authKey = strings.TrimSpace(authKey)
 	if authKey == "" {
 		return nil
 	}
+	previous, err := snapshotEncryptedAuthKey(ctx, dbPath)
+	if err != nil {
+		return err
+	}
+	if !previous.available {
+		return writeLegacyAuthKeyIfPresent(dbPath, authKey, previous.err)
+	}
 	if err := trackerauth.SaveAuthState(ctx, dbPath, "AR", arAuthKeyKey, authKey); err != nil {
-		if errors.Is(err, cookiepkg.ErrAuthHelperUnavailable) {
-			return nil
-		}
 		return fmt.Errorf("trackers: AR write encrypted auth key: %w", err)
 	}
 	if legacyPath := authPath(dbPath); legacyPath != "" {
-		if err := os.Remove(legacyPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("trackers: AR delete legacy auth key: %w", err)
+		if err := os.Remove(legacyPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			if rollbackErr := restoreEncryptedAuthKey(context.WithoutCancel(ctx), dbPath, previous); rollbackErr != nil {
+				return errors.Join(fmt.Errorf("trackers: AR remove legacy auth key: %w", err), fmt.Errorf("trackers: AR rollback encrypted auth key: %w", rollbackErr))
+			}
+			return fmt.Errorf("trackers: AR remove legacy auth key: %w", err)
 		}
+	}
+	return nil
+}
+
+type encryptedAuthKeySnapshot struct {
+	value     string
+	existed   bool
+	available bool
+	err       error
+}
+
+func snapshotEncryptedAuthKey(ctx context.Context, dbPath string) (encryptedAuthKeySnapshot, error) {
+	value, err := trackerauth.LoadAuthState(ctx, dbPath, "AR", arAuthKeyKey)
+	if err == nil {
+		return encryptedAuthKeySnapshot{value: value, existed: true, available: true}, nil
+	}
+	if errors.Is(err, trackerauth.ErrAuthStateNotFound) {
+		return encryptedAuthKeySnapshot{available: true}, nil
+	}
+	if errors.Is(err, cookiepkg.ErrAuthHelperUnavailable) {
+		return encryptedAuthKeySnapshot{available: false, err: err}, nil
+	}
+	return encryptedAuthKeySnapshot{}, fmt.Errorf("trackers: AR snapshot encrypted auth key: %w", err)
+}
+
+func restoreEncryptedAuthKey(ctx context.Context, dbPath string, previous encryptedAuthKeySnapshot) error {
+	if previous.existed {
+		if err := trackerauth.SaveAuthState(ctx, dbPath, "AR", arAuthKeyKey, previous.value); err != nil {
+			return fmt.Errorf("trackers: AR restore encrypted auth key: %w", err)
+		}
+		return nil
+	}
+	err := trackerauth.DeleteAuthState(ctx, dbPath, "AR", arAuthKeyKey)
+	if errors.Is(err, trackerauth.ErrAuthStateNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("trackers: AR remove restored encrypted auth key: %w", err)
+	}
+	return nil
+}
+
+func writeLegacyAuthKeyIfPresent(dbPath string, authKey string, encryptedErr error) error {
+	legacyPath := authPath(dbPath)
+	if legacyPath == "" {
+		return fmt.Errorf("trackers: AR write encrypted auth key: %w", encryptedErr)
+	}
+	info, statErr := os.Stat(legacyPath)
+	if statErr != nil {
+		if errors.Is(statErr, os.ErrNotExist) {
+			return fmt.Errorf("trackers: AR write encrypted auth key: %w", encryptedErr)
+		}
+		return fmt.Errorf("trackers: AR stat legacy auth key: %w", statErr)
+	}
+	if info.IsDir() {
+		return errors.New("trackers: AR legacy auth key path is a directory")
+	}
+	if err := os.WriteFile(legacyPath, []byte(authKey), 0o600); err != nil {
+		return fmt.Errorf("trackers: AR write legacy auth key: %w", err)
 	}
 	return nil
 }
@@ -754,7 +903,22 @@ func loadCookies(ctx context.Context, dbPath string) ([]*http.Cookie, error) {
 }
 
 func saveCookies(ctx context.Context, dbPath string, values []*http.Cookie) error {
-	return wrapTrackerError(cookiepkg.SaveTrackerHTTPCookies(ctx, dbPath, "AR", values))
+	valid := usableHTTPCookies(values)
+	if len(valid) == 0 {
+		return errors.New("trackers: AR login returned no usable cookies")
+	}
+	return wrapTrackerError(cookiepkg.SaveTrackerHTTPCookies(ctx, dbPath, "AR", valid))
+}
+
+func usableHTTPCookies(values []*http.Cookie) []*http.Cookie {
+	out := make([]*http.Cookie, 0, len(values))
+	for _, cookie := range values {
+		if cookie == nil || strings.TrimSpace(cookie.Name) == "" || strings.TrimSpace(cookie.Value) == "" {
+			continue
+		}
+		out = append(out, cookie)
+	}
+	return out
 }
 
 func extractAuthKey(body string) string {

--- a/internal/trackers/impl/ar/upload_test.go
+++ b/internal/trackers/impl/ar/upload_test.go
@@ -361,7 +361,7 @@ func TestLoginFallbackDoesNotPersistAuthKeyBeforeCookies(t *testing.T) {
 	}
 }
 
-func TestLoginFallbackCookieFailurePreservesPreviousAuthKey(t *testing.T) {
+func TestLoginFallbackPrefersCurrentResponseKeyAndPreservesPreviousAuthKeyOnCookieFailure(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -395,8 +395,8 @@ func TestLoginFallbackCookieFailurePreservesPreviousAuthKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("login: %v", err)
 	}
-	if authKey != "previous-key" {
-		t.Fatalf("expected existing auth key precedence to remain unchanged, got %q", authKey)
+	if authKey != "new-key" {
+		t.Fatalf("expected current response auth key, got %q", authKey)
 	}
 	if err := persistLoginAuth(ctx, dbPath, api.NopLogger{}, nil, authKey); err == nil || !strings.Contains(err.Error(), "no usable cookies") {
 		t.Fatalf("expected cookie persistence failure, got %v", err)

--- a/internal/trackers/impl/ar/upload_test.go
+++ b/internal/trackers/impl/ar/upload_test.go
@@ -5,12 +5,20 @@ package ar
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/authmaterial"
+	"github.com/autobrr/upbrr/internal/config"
+	cookiepkg "github.com/autobrr/upbrr/internal/cookies"
+	servicedb "github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/internal/trackerauth"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -51,19 +59,65 @@ func (l *captureLogger) Warnf(format string, _ ...any) {
 	l.warnings = append(l.warnings, strings.TrimSpace(format))
 }
 
-func TestPersistLoginCookiesAllowsPlaintextFallbackWhenAuthHelperUnavailable(t *testing.T) {
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func arTestResponse(req *http.Request, body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}
+
+func TestPersistLoginCookiesReturnsAuthHelperUnavailable(t *testing.T) {
 	t.Parallel()
 
 	logger := &captureLogger{}
-	err := persistLoginCookies(context.Background(), filepath.Join(t.TempDir(), "upbrr.db"), logger, nil)
+	err := persistLoginCookies(context.Background(), filepath.Join(t.TempDir(), "upbrr.db"), logger, []*http.Cookie{{Name: "session", Value: "abc"}})
+	if !errors.Is(err, cookiepkg.ErrAuthHelperUnavailable) {
+		t.Fatalf("expected auth helper unavailable error, got %v", err)
+	}
+	if len(logger.warnings) != 0 {
+		t.Fatalf("unexpected warning after hard persistence failure: %v", logger.warnings)
+	}
+}
+
+func TestPersistLoginCookiesRejectsEmptyJarWithoutReplacingCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newARAuthTestDB(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "AR", map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+
+	err := persistLoginCookies(ctx, dbPath, api.NopLogger{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "no usable cookies") {
+		t.Fatalf("expected empty login cookie error, got %v", err)
+	}
+	values, err := cookiepkg.LoadTrackerCookieMap(ctx, dbPath, "AR")
 	if err != nil {
-		t.Fatalf("expected plaintext fallback, got %v", err)
+		t.Fatalf("LoadTrackerCookieMap: %v", err)
 	}
-	if len(logger.warnings) != 1 {
-		t.Fatalf("expected one warning, got %d", len(logger.warnings))
+	if values["session"] != "existing" {
+		t.Fatalf("empty jar must preserve previous cookies, got %#v", values)
 	}
-	if !strings.Contains(logger.warnings[0], "plaintext fallback") {
-		t.Fatalf("expected plaintext fallback warning, got %q", logger.warnings[0])
+}
+
+func TestEnsureLoginPersistenceAvailableRequiresWebAuth(t *testing.T) {
+	t.Parallel()
+
+	err := ensureLoginPersistenceAvailable(filepath.Join(t.TempDir(), "upbrr.db"))
+	if !errors.Is(err, cookiepkg.ErrAuthHelperUnavailable) {
+		t.Fatalf("expected auth helper unavailable preflight, got %v", err)
 	}
 }
 
@@ -93,16 +147,285 @@ func TestWriteAuthKeyUsesEncryptedStateAndDeletesLegacyFile(t *testing.T) {
 	}
 }
 
-func TestWriteAuthKeyWithoutWebAuthDoesNotCreatePlaintextFile(t *testing.T) {
+func TestWriteAuthKeyRollsBackEncryptedStateOnLegacyDeleteFailure(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
-	if err := writeAuthKey(context.Background(), dbPath, "session-key"); err != nil {
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	legacyPath := authPath(dbPath)
+	if err := os.MkdirAll(filepath.Join(legacyPath, "blocked"), 0o755); err != nil {
+		t.Fatalf("seed legacy auth path as non-empty dir: %v", err)
+	}
+
+	if err := writeAuthKey(context.Background(), dbPath, "encrypted-key"); err == nil {
+		t.Fatal("expected legacy cleanup failure")
+	} else if !strings.Contains(err.Error(), "remove legacy auth key") {
+		t.Fatalf("expected legacy cleanup error, got %v", err)
+	}
+	if _, err := trackerauth.LoadAuthState(context.Background(), dbPath, "AR", arAuthKeyKey); !errors.Is(err, trackerauth.ErrAuthStateNotFound) {
+		t.Fatalf("expected encrypted auth key rollback, got %v", err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("expected failed legacy cleanup path to remain, stat err=%v", err)
+	}
+}
+
+func TestWriteAuthKeyFallsBackToExistingLegacyFileWhenWebAuthUnavailable(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	legacyPath := authPath(dbPath)
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatalf("mkdir legacy dir: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("legacy-key"), 0o600); err != nil {
+		t.Fatalf("seed legacy auth key: %v", err)
+	}
+
+	if err := writeAuthKey(context.Background(), dbPath, "updated-legacy-key"); err != nil {
 		t.Fatalf("writeAuthKey: %v", err)
+	}
+	if got := readAuthKey(context.Background(), dbPath); got != "updated-legacy-key" {
+		t.Fatalf("readAuthKey: got %q", got)
+	}
+}
+
+func TestWriteAuthKeySucceedsWhenLegacyFileAbsent(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+
+	if err := writeAuthKey(context.Background(), dbPath, "encrypted-key"); err != nil {
+		t.Fatalf("writeAuthKey: %v", err)
+	}
+	if got := readAuthKey(context.Background(), dbPath); got != "encrypted-key" {
+		t.Fatalf("readAuthKey: got %q", got)
+	}
+}
+
+func TestWriteAuthKeyWithoutWebAuthReturnsPersistenceFailure(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := writeAuthKey(context.Background(), dbPath, "session-key"); !errors.Is(err, cookiepkg.ErrAuthHelperUnavailable) {
+		t.Fatalf("expected auth helper unavailable error, got %v", err)
 	}
 	if _, err := os.Stat(authPath(dbPath)); !os.IsNotExist(err) {
 		t.Fatalf("expected no plaintext auth key, stat err=%v", err)
 	}
+}
+
+func TestPersistLoginAuthRestoresPreviousCookiesWhenAuthKeyWriteFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newARAuthTestDB(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "AR", map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	forcedErr := errors.New("forced auth key failure")
+
+	err := persistLoginAuthWithWriter(
+		ctx,
+		dbPath,
+		api.NopLogger{},
+		[]*http.Cookie{{Name: "session", Value: "new"}},
+		"new-auth-key",
+		func(context.Context, string, string) error { return forcedErr },
+	)
+	if !errors.Is(err, forcedErr) {
+		t.Fatalf("expected forced auth key failure, got %v", err)
+	}
+	values, err := cookiepkg.LoadTrackerCookieMap(ctx, dbPath, "AR")
+	if err != nil {
+		t.Fatalf("LoadTrackerCookieMap: %v", err)
+	}
+	if values["session"] != "existing" {
+		t.Fatalf("expected previous cookies restored, got %#v", values)
+	}
+}
+
+func TestPersistLoginAuthRestoresPreviousCookiesWhenCallerContextCanceledDuringWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	dbPath := newARAuthTestDB(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := cookiepkg.SaveTrackerCookieMap(context.Background(), dbPath, "AR", map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	forcedErr := errors.New("forced auth key failure")
+
+	err := persistLoginAuthWithWriter(
+		ctx,
+		dbPath,
+		api.NopLogger{},
+		[]*http.Cookie{{Name: "session", Value: "new"}},
+		"new-auth-key",
+		func(context.Context, string, string) error {
+			cancel()
+			return forcedErr
+		},
+	)
+	if !errors.Is(err, forcedErr) {
+		t.Fatalf("expected forced auth key failure, got %v", err)
+	}
+	values, err := cookiepkg.LoadTrackerCookieMap(context.Background(), dbPath, "AR")
+	if err != nil {
+		t.Fatalf("LoadTrackerCookieMap: %v", err)
+	}
+	if values["session"] != "existing" {
+		t.Fatalf("expected previous cookies restored after cancellation, got %#v", values)
+	}
+}
+
+func TestPersistLoginAuthRemovesNewCookiesWhenAuthKeyWriteFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newARAuthTestDB(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	forcedErr := errors.New("forced auth key failure")
+
+	err := persistLoginAuthWithWriter(
+		ctx,
+		dbPath,
+		api.NopLogger{},
+		[]*http.Cookie{{Name: "session", Value: "new"}},
+		"new-auth-key",
+		func(context.Context, string, string) error { return forcedErr },
+	)
+	if !errors.Is(err, forcedErr) {
+		t.Fatalf("expected forced auth key failure, got %v", err)
+	}
+	if _, err := cookiepkg.LoadTrackerCookieMap(ctx, dbPath, "AR"); err == nil {
+		t.Fatal("expected rollback to remove newly persisted cookies")
+	}
+}
+
+func TestLoginFallbackDoesNotPersistAuthKeyBeforeCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newARAuthTestDB(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := &http.Client{
+		Jar: jar,
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case arLoginURL:
+				return arTestResponse(req, "<html>logged in without inline auth</html>"), nil
+			case arBrowseURL:
+				return arTestResponse(req, `<a href="/torrents.php?action=download&id=1&auth=session-key">Download</a>`), nil
+			default:
+				t.Fatalf("unexpected request URL %s", req.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+
+	authKey, err := login(ctx, client, config.TrackerConfig{Username: "user", Password: "pass"}, dbPath)
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if authKey != "session-key" {
+		t.Fatalf("expected auth key from validation page, got %q", authKey)
+	}
+	if _, err := trackerauth.LoadAuthState(ctx, dbPath, "AR", arAuthKeyKey); !errors.Is(err, trackerauth.ErrAuthStateNotFound) {
+		t.Fatalf("login fallback must not persist auth key before cookie save, got %v", err)
+	}
+
+	if err := persistLoginAuth(ctx, dbPath, api.NopLogger{}, nil, authKey); err == nil || !strings.Contains(err.Error(), "no usable cookies") {
+		t.Fatalf("expected cookie persistence failure, got %v", err)
+	}
+	if _, err := trackerauth.LoadAuthState(ctx, dbPath, "AR", arAuthKeyKey); !errors.Is(err, trackerauth.ErrAuthStateNotFound) {
+		t.Fatalf("cookie persistence failure must leave no new auth key, got %v", err)
+	}
+}
+
+func TestLoginFallbackCookieFailurePreservesPreviousAuthKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newARAuthTestDB(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := trackerauth.SaveAuthState(ctx, dbPath, "AR", arAuthKeyKey, "previous-key"); err != nil {
+		t.Fatalf("SaveAuthState: %v", err)
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := &http.Client{
+		Jar: jar,
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case arLoginURL:
+				return arTestResponse(req, "<html>logged in without inline auth</html>"), nil
+			case arBrowseURL:
+				return arTestResponse(req, `<a href="/torrents.php?action=download&id=1&auth=new-key">Download</a>`), nil
+			default:
+				t.Fatalf("unexpected request URL %s", req.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+
+	authKey, err := login(ctx, client, config.TrackerConfig{Username: "user", Password: "pass"}, dbPath)
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if authKey != "previous-key" {
+		t.Fatalf("expected existing auth key precedence to remain unchanged, got %q", authKey)
+	}
+	if err := persistLoginAuth(ctx, dbPath, api.NopLogger{}, nil, authKey); err == nil || !strings.Contains(err.Error(), "no usable cookies") {
+		t.Fatalf("expected cookie persistence failure, got %v", err)
+	}
+	got, err := trackerauth.LoadAuthState(ctx, dbPath, "AR", arAuthKeyKey)
+	if err != nil {
+		t.Fatalf("LoadAuthState: %v", err)
+	}
+	if got != "previous-key" {
+		t.Fatal("cookie persistence failure changed previous auth key")
+	}
+}
+
+func newARAuthTestDB(t *testing.T) string {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	repo, err := servicedb.OpenWithLogger(dbPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	if err := repo.Migrate(); err != nil {
+		_ = repo.Close()
+		t.Fatalf("migrate repo: %v", err)
+	}
+	if err := repo.Close(); err != nil {
+		t.Fatalf("close repo: %v", err)
+	}
+	return dbPath
 }
 
 func TestBuildDatabaseLinksSkipsTVDBForMovie(t *testing.T) {

--- a/internal/trackers/impl/ar/upload_test.go
+++ b/internal/trackers/impl/ar/upload_test.go
@@ -5,10 +5,12 @@ package ar
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/autobrr/upbrr/internal/authmaterial"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -62,6 +64,44 @@ func TestPersistLoginCookiesAllowsPlaintextFallbackWhenAuthHelperUnavailable(t *
 	}
 	if !strings.Contains(logger.warnings[0], "plaintext fallback") {
 		t.Fatalf("expected plaintext fallback warning, got %q", logger.warnings[0])
+	}
+}
+
+func TestWriteAuthKeyUsesEncryptedStateAndDeletesLegacyFile(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	legacyPath := authPath(dbPath)
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatalf("mkdir legacy dir: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("legacy-key"), 0o600); err != nil {
+		t.Fatalf("seed legacy auth key: %v", err)
+	}
+
+	if err := writeAuthKey(context.Background(), dbPath, "encrypted-key"); err != nil {
+		t.Fatalf("writeAuthKey: %v", err)
+	}
+	if got := readAuthKey(context.Background(), dbPath); got != "encrypted-key" {
+		t.Fatalf("readAuthKey: got %q", got)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy auth key removed, stat err=%v", err)
+	}
+}
+
+func TestWriteAuthKeyWithoutWebAuthDoesNotCreatePlaintextFile(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := writeAuthKey(context.Background(), dbPath, "session-key"); err != nil {
+		t.Fatalf("writeAuthKey: %v", err)
+	}
+	if _, err := os.Stat(authPath(dbPath)); !os.IsNotExist(err) {
+		t.Fatalf("expected no plaintext auth key, stat err=%v", err)
 	}
 }
 

--- a/internal/trackers/impl/commonhttp/commonhttp.go
+++ b/internal/trackers/impl/commonhttp/commonhttp.go
@@ -150,8 +150,8 @@ func LoadNetscapeCookies(path string, expectedDomain string) ([]*http.Cookie, er
 		if trimmedLine == "" {
 			continue
 		}
-		if httpOnlyLine, ok := strings.CutPrefix(trimmedLine, "#HttpOnly_"); ok {
-			line = httpOnlyLine
+		if strings.HasPrefix(trimmedLine, "#HttpOnly_") {
+			line = line[strings.Index(line, "#HttpOnly_")+len("#HttpOnly_"):]
 		} else if strings.HasPrefix(trimmedLine, "#") {
 			continue
 		}

--- a/internal/trackers/impl/commonhttp/commonhttp.go
+++ b/internal/trackers/impl/commonhttp/commonhttp.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -34,6 +35,11 @@ const maxHTTPErrorDetailDepth = 10
 
 var htmlTagPattern = regexp.MustCompile(`<[^>]+>`)
 
+// FileField describes one file part in a tracker multipart upload. FieldName is
+// the form field; Content is used when present; otherwise Path is read from disk
+// and FileName overrides the filename sent in the part. ContentType is carried
+// for callers that need to retain media-type metadata, but the current builders
+// use Go's default multipart file-part headers.
 type FileField struct {
 	FieldName   string
 	FileName    string
@@ -42,6 +48,8 @@ type FileField struct {
 	Content     []byte
 }
 
+// CookiePathCandidates returns cleaned legacy cookie file paths beside dbPath
+// for the supplied tracker name and extensions.
 func CookiePathCandidates(dbPath string, name string, exts ...string) []string {
 	candidates := make([]string, 0, len(exts))
 	baseName := strings.TrimSpace(name)
@@ -65,9 +73,8 @@ type CookieStore interface {
 }
 
 // LoadCookiesForTracker loads cookies for a tracker from startup cookie files and the
-// database. When both sources are available, startup file cookies win on conflicts so
-// a fresh startup bootstrap can override stale persisted values while still preserving
-// DB-only cookies.
+// database. When both sources are available, database cookies win on conflicts while
+// preserving legacy-file-only cookies.
 // Callers must pass an explicit request-scoped context so cancellation and
 // deadlines are preserved through database cookie reads.
 func LoadCookiesForTracker(ctx context.Context, dbPath string, trackerID string, cookieStore CookieStore, encryptionKey []byte) (map[string]string, error) {
@@ -77,7 +84,7 @@ func LoadCookiesForTracker(ctx context.Context, dbPath string, trackerID string,
 
 	var storeCookies map[string]string
 
-	// Load database cookies first so startup cookie files can overwrite stale entries.
+	// Load database cookies first so store errors are reported before legacy fallback.
 	if cookieStore != nil && len(encryptionKey) > 0 {
 		cookies, err := cookieStore.GetAllTrackerCookies(ctx, trackerID, encryptionKey)
 		if err != nil {
@@ -88,19 +95,18 @@ func LoadCookiesForTracker(ctx context.Context, dbPath string, trackerID string,
 		}
 	}
 
-	// Load startup file cookies and let them override any persisted DB values.
+	// Load startup file cookies as fallback/compatibility input, then let persisted
+	// DB values win same-name conflicts.
 	candidates := CookiePathCandidates(dbPath, trackerID, ".txt", ".json")
 	for _, path := range candidates {
 		switch filepath.Ext(path) {
 		case ".txt":
 			if cookies, err := LoadNetscapeCookies(path, ""); err == nil && len(cookies) > 0 {
 				result := make(map[string]string, len(storeCookies)+len(cookies))
-				for name, value := range storeCookies {
-					result[name] = value
-				}
 				for _, c := range cookies {
 					result[c.Name] = c.Value
 				}
+				maps.Copy(result, storeCookies)
 				return result, nil
 			}
 		case ".json":
@@ -110,12 +116,8 @@ func LoadCookiesForTracker(ctx context.Context, dbPath string, trackerID string,
 				}
 
 				result := make(map[string]string, len(storeCookies)+len(cookies))
-				for name, value := range storeCookies {
-					result[name] = value
-				}
-				for name, value := range cookies {
-					result[name] = value
-				}
+				maps.Copy(result, cookies)
+				maps.Copy(result, storeCookies)
 				return result, nil
 			}
 		}
@@ -128,6 +130,10 @@ func LoadCookiesForTracker(ctx context.Context, dbPath string, trackerID string,
 	return nil, errors.New("no cookies found for tracker: " + trackerID)
 }
 
+// LoadNetscapeCookies reads Netscape-format cookies from path, optionally
+// filtering by expectedDomain. It trims names and domains, preserves cookie
+// values after the value column, and returns an error when no valid cookies
+// match.
 func LoadNetscapeCookies(path string, expectedDomain string) ([]*http.Cookie, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -139,13 +145,14 @@ func LoadNetscapeCookies(path string, expectedDomain string) ([]*http.Cookie, er
 	scanner := bufio.NewScanner(file)
 	cookies := make([]*http.Cookie, 0, 4)
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
+		line := strings.TrimSuffix(scanner.Text(), "\r")
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "#HttpOnly_") {
-			line = strings.TrimPrefix(line, "#HttpOnly_")
-		} else if strings.HasPrefix(line, "#") {
+		if httpOnlyLine, ok := strings.CutPrefix(trimmedLine, "#HttpOnly_"); ok {
+			line = httpOnlyLine
+		} else if strings.HasPrefix(trimmedLine, "#") {
 			continue
 		}
 		fields := strings.Split(line, "\t")
@@ -160,7 +167,7 @@ func LoadNetscapeCookies(path string, expectedDomain string) ([]*http.Cookie, er
 			continue
 		}
 		name := strings.TrimSpace(fields[5])
-		value := strings.TrimSpace(strings.Join(fields[6:], "\t"))
+		value := strings.Join(fields[6:], "\t")
 		if name == "" || value == "" {
 			continue
 		}
@@ -182,6 +189,8 @@ func LoadNetscapeCookies(path string, expectedDomain string) ([]*http.Cookie, er
 	return cookies, nil
 }
 
+// LoadJSONCookieMap reads a JSON cookie map from path and returns non-empty
+// trimmed names with non-empty values.
 func LoadJSONCookieMap(path string) (map[string]string, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
@@ -216,6 +225,8 @@ func LoadJSONCookieMap(path string) (map[string]string, error) {
 	return result, nil
 }
 
+// BuildMultipartPayload encodes single-value fields and files as multipart
+// form data and returns the payload with its Content-Type header value.
 func BuildMultipartPayload(fields map[string]string, files []FileField) ([]byte, string, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
@@ -254,6 +265,9 @@ func BuildMultipartPayload(fields map[string]string, files []FileField) ([]byte,
 	return body.Bytes(), writer.FormDataContentType(), nil
 }
 
+// BuildMultipartPayloadMulti encodes repeated field values and files as
+// multipart form data and returns the payload with its Content-Type header
+// value.
 func BuildMultipartPayloadMulti(fields map[string][]string, files []FileField) ([]byte, string, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
@@ -299,6 +313,8 @@ func BuildMultipartPayloadMulti(fields map[string][]string, files []FileField) (
 	return body.Bytes(), writer.FormDataContentType(), nil
 }
 
+// ApplyCookies adds non-empty cookies to req and ignores nil cookies or blank
+// names and values.
 func ApplyCookies(req *http.Request, cookies []*http.Cookie) {
 	for _, cookie := range cookies {
 		if cookie == nil || strings.TrimSpace(cookie.Name) == "" || strings.TrimSpace(cookie.Value) == "" {
@@ -308,6 +324,9 @@ func ApplyCookies(req *http.Request, cookies []*http.Cookie) {
 	}
 }
 
+// WriteFailureArtifact stores a tracker failure response under the release temp
+// directory and returns the written path. It returns an empty path when dbPath or
+// the source path is unavailable.
 func WriteFailureArtifact(meta api.PreparedMetadata, dbPath string, tracker string, name string, body []byte, ext string) (string, error) {
 	if strings.TrimSpace(dbPath) == "" || strings.TrimSpace(meta.SourcePath) == "" {
 		return "", nil
@@ -338,6 +357,8 @@ func WriteFailureArtifact(meta api.PreparedMetadata, dbPath string, tracker stri
 	return path, nil
 }
 
+// ReadOptionalFile returns file contents for a non-empty path or an empty string
+// when the path is blank or unreadable.
 func ReadOptionalFile(path string) string {
 	trimmed := strings.TrimSpace(path)
 	if trimmed == "" {
@@ -350,6 +371,8 @@ func ReadOptionalFile(path string) string {
 	return string(payload)
 }
 
+// ReadFirstMatching returns the first readable non-directory file matched by the
+// supplied glob patterns.
 func ReadFirstMatching(dir string, patterns ...string) ([]byte, string, error) {
 	for _, pattern := range patterns {
 		matches, err := filepath.Glob(filepath.Join(dir, pattern))
@@ -371,6 +394,8 @@ func ReadFirstMatching(dir string, patterns ...string) ([]byte, string, error) {
 	return nil, "", errors.New("matching file not found")
 }
 
+// FileBytes reads the entire file at path and wraps open/read failures with the
+// trimmed path.
 func FileBytes(path string) ([]byte, error) {
 	file, err := os.Open(strings.TrimSpace(path))
 	if err != nil {
@@ -389,10 +414,13 @@ type HTTPError struct {
 	message string
 }
 
+// Error returns the formatted, redacted tracker upload failure message.
 func (e HTTPError) Error() string {
 	return e.message
 }
 
+// UploadHTTPError formats a tracker upload HTTP failure with redacted response
+// detail extracted from body.
 func UploadHTTPError(tracker string, status int, body []byte) HTTPError {
 	detail := ExtractHTTPErrorDetail(body)
 	tracker = strings.ToUpper(RedactErrorDetail(tracker))
@@ -402,6 +430,8 @@ func UploadHTTPError(tracker string, status int, body []byte) HTTPError {
 	return HTTPError{message: fmt.Sprintf("trackers: %s upload failed status=%d: %s", tracker, status, detail)}
 }
 
+// UploadHTTPErrorWithURL formats a tracker upload HTTP failure with the
+// redacted final URL and response detail.
 func UploadHTTPErrorWithURL(tracker string, status int, url string, body []byte) HTTPError {
 	detail := ExtractHTTPErrorDetail(body)
 	tracker = strings.ToUpper(RedactErrorDetail(tracker))
@@ -412,10 +442,13 @@ func UploadHTTPErrorWithURL(tracker string, status int, url string, body []byte)
 	return HTTPError{message: fmt.Sprintf("trackers: %s upload failed status=%d url=%s: %s", tracker, status, url, detail)}
 }
 
+// RedactErrorDetail trims value after applying the repository secret redactor.
 func RedactErrorDetail(value string) string {
 	return strings.TrimSpace(redaction.RedactValue(value, nil))
 }
 
+// ExtractHTTPErrorDetail returns a compact, redacted error detail from plain
+// text, HTML, or JSON response bodies.
 func ExtractHTTPErrorDetail(body []byte) string {
 	text := RedactErrorDetail(string(body))
 	if text == "" {

--- a/internal/trackers/impl/commonhttp/commonhttp_test.go
+++ b/internal/trackers/impl/commonhttp/commonhttp_test.go
@@ -42,7 +42,7 @@ func TestLoadCookiesForTrackerUsesCookieStoreWhenNoStartupCookieExists(t *testin
 	}
 }
 
-func TestLoadCookiesForTrackerStartupCookieOverridesCookieStore(t *testing.T) {
+func TestLoadCookiesForTrackerCookieStoreOverridesStartupCookie(t *testing.T) {
 	t.Parallel()
 
 	dbPath := filepath.Join(t.TempDir(), "state", "upbrr.db")
@@ -75,8 +75,8 @@ func TestLoadCookiesForTrackerStartupCookieOverridesCookieStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadCookiesForTracker: %v", err)
 	}
-	if got["session"] != "from-startup" {
-		t.Fatalf("expected startup cookie to override store value, got %#v", got)
+	if got["session"] != "from-db" {
+		t.Fatalf("expected store cookie to override startup value, got %#v", got)
 	}
 	if got["persisted"] != "keep-me" {
 		t.Fatalf("expected db-only cookie to be preserved, got %#v", got)
@@ -150,7 +150,7 @@ func TestLoadCookiesForTrackerFallsBackToNetscapeFileWithoutDomainFilter(t *test
 		t.Fatalf("MkdirAll: %v", err)
 	}
 
-	netscape := ".example.org\tTRUE\t/\tFALSE\t0\tsession\tfrom-txt\n"
+	netscape := ".example.org\tTRUE\t/\tFALSE\t0\tsession\t from-txt \n"
 	if err := os.WriteFile(txtPath, []byte(netscape), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
@@ -165,8 +165,34 @@ func TestLoadCookiesForTrackerFallsBackToNetscapeFileWithoutDomainFilter(t *test
 	if err != nil {
 		t.Fatalf("LoadCookiesForTracker: %v", err)
 	}
-	if got["session"] != "from-txt" {
+	if got["session"] != " from-txt " {
 		t.Fatalf("expected Netscape fallback cookie, got %#v", got)
+	}
+}
+
+func TestLoadNetscapeCookiesPreservesValueWhitespaceAndSkipsEmptyNameOrValue(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "cookies.txt")
+	content := strings.Join([]string{
+		".example.org\tTRUE\t/\tFALSE\t0\t\tmissing-name",
+		".example.org\tTRUE\t/\tFALSE\t0\tempty\t",
+		".example.org\tTRUE\t/\tFALSE\t0\tsession\t padded ",
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := LoadNetscapeCookies(path, "example.org")
+	if err != nil {
+		t.Fatalf("LoadNetscapeCookies: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one valid cookie, got %#v", got)
+	}
+	if got[0].Name != "session" || got[0].Value != " padded " {
+		t.Fatalf("expected padded Netscape value to be preserved, got %#v", got[0])
 	}
 }
 

--- a/internal/trackers/impl/commonhttp/commonhttp_test.go
+++ b/internal/trackers/impl/commonhttp/commonhttp_test.go
@@ -178,6 +178,7 @@ func TestLoadNetscapeCookiesPreservesValueWhitespaceAndSkipsEmptyNameOrValue(t *
 		".example.org\tTRUE\t/\tFALSE\t0\t\tmissing-name",
 		".example.org\tTRUE\t/\tFALSE\t0\tempty\t",
 		".example.org\tTRUE\t/\tFALSE\t0\tsession\t padded ",
+		"#HttpOnly_.example.org\tTRUE\t/\tFALSE\t0\thttp_only\t padded http ",
 		"",
 	}, "\n")
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
@@ -188,11 +189,14 @@ func TestLoadNetscapeCookiesPreservesValueWhitespaceAndSkipsEmptyNameOrValue(t *
 	if err != nil {
 		t.Fatalf("LoadNetscapeCookies: %v", err)
 	}
-	if len(got) != 1 {
+	if len(got) != 2 {
 		t.Fatalf("expected one valid cookie, got %#v", got)
 	}
 	if got[0].Name != "session" || got[0].Value != " padded " {
 		t.Fatalf("expected padded Netscape value to be preserved, got %#v", got[0])
+	}
+	if got[1].Name != "http_only" || got[1].Value != " padded http " {
+		t.Fatalf("expected padded HttpOnly Netscape value to be preserved, got %#v", got[1])
 	}
 }
 

--- a/internal/trackers/impl/fl/upload.go
+++ b/internal/trackers/impl/fl/upload.go
@@ -242,7 +242,11 @@ func resolveCookies(ctx context.Context, logger api.Logger, cfg config.TrackerCo
 	if loginResp.StatusCode < 200 || loginResp.StatusCode >= 400 {
 		return nil, fmt.Errorf("trackers: FL login failed status=%d", loginResp.StatusCode)
 	}
-	return loginResp.Cookies(), nil
+	loginCookies := loginResp.Cookies()
+	if err := cookies.SaveTrackerHTTPCookies(ctx, dbPath, "FL", loginCookies); err != nil && logger != nil {
+		logger.Warnf("trackers: FL failed to persist login cookies: %v", err)
+	}
+	return loginCookies, nil
 }
 
 func validFLCookies(values []*http.Cookie) []*http.Cookie {

--- a/internal/trackers/impl/fl/upload.go
+++ b/internal/trackers/impl/fl/upload.go
@@ -218,11 +218,17 @@ func resolveCookies(ctx context.Context, logger api.Logger, cfg config.TrackerCo
 	if err := ensureLoginCookieStorageAvailable(dbPath); err != nil {
 		return nil, err
 	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("trackers: FL create login cookie jar: %w", err)
+	}
+	client := newHTTPClient(httpclient.DefaultTimeout)
+	client.Jar = jar
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, loginPageURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("trackers: FL login page request build: %w", err)
 	}
-	resp, err := newHTTPClient(httpclient.DefaultTimeout).Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("trackers: FL login page request: %w", err)
 	}
@@ -245,7 +251,6 @@ func resolveCookies(ctx context.Context, logger api.Logger, cfg config.TrackerCo
 		return nil, fmt.Errorf("trackers: FL login request build: %w", err)
 	}
 	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	client := newHTTPClient(httpclient.DefaultTimeout)
 	loginResp, err := client.Do(loginReq)
 	if err != nil {
 		return nil, fmt.Errorf("trackers: FL login request: %w", err)
@@ -254,7 +259,8 @@ func resolveCookies(ctx context.Context, logger api.Logger, cfg config.TrackerCo
 	if loginResp.StatusCode < 200 || loginResp.StatusCode >= 400 {
 		return nil, fmt.Errorf("trackers: FL login failed status=%d", loginResp.StatusCode)
 	}
-	loginCookies := loginResp.Cookies()
+	base, _ := url.Parse(baseURL)
+	loginCookies := client.Jar.Cookies(base)
 	if err := persistLoginCookies(ctx, dbPath, loginCookies); err != nil {
 		return nil, err
 	}

--- a/internal/trackers/impl/fl/upload.go
+++ b/internal/trackers/impl/fl/upload.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -19,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/autobrr/upbrr/internal/authmaterial"
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/httpclient"
@@ -40,6 +42,7 @@ const (
 var (
 	validatorPattern = regexp.MustCompile(`name="validator"\s+value="([^"]+)"`)
 	successPattern   = regexp.MustCompile(`details\.php\?id=(\d+)&uploaded=`)
+	newHTTPClient    = httpclient.New
 )
 
 type uploadState struct {
@@ -188,6 +191,9 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest, dryRun 
 	return state, cookies, nil
 }
 
+// resolveCookies returns usable stored FL cookies or performs credential login.
+// Login-page read errors are reported before token parsing, and successful
+// credential login requires durable cookie persistence.
 func resolveCookies(ctx context.Context, logger api.Logger, cfg config.TrackerConfig, dbPath string, dryRun bool) ([]*http.Cookie, error) {
 	loaded, err := cookies.LoadTrackerHTTPCookies(ctx, dbPath, "FL", ".filelist.io")
 	if err != nil {
@@ -209,16 +215,22 @@ func resolveCookies(ctx context.Context, logger api.Logger, cfg config.TrackerCo
 	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
 		return nil, errors.New("trackers: FL cookie invalid/missing and username/password not configured")
 	}
+	if err := ensureLoginCookieStorageAvailable(dbPath); err != nil {
+		return nil, err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, loginPageURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("trackers: FL login page request build: %w", err)
 	}
-	resp, err := httpclient.New(httpclient.DefaultTimeout).Do(req)
+	resp, err := newHTTPClient(httpclient.DefaultTimeout).Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("trackers: FL login page request: %w", err)
 	}
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("trackers: FL read login page response: %w", err)
+	}
 	match := validatorPattern.FindStringSubmatch(string(body))
 	if len(match) < 2 {
 		return nil, errors.New("trackers: FL validator token not found")
@@ -233,7 +245,7 @@ func resolveCookies(ctx context.Context, logger api.Logger, cfg config.TrackerCo
 		return nil, fmt.Errorf("trackers: FL login request build: %w", err)
 	}
 	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	client := httpclient.New(httpclient.DefaultTimeout)
+	client := newHTTPClient(httpclient.DefaultTimeout)
 	loginResp, err := client.Do(loginReq)
 	if err != nil {
 		return nil, fmt.Errorf("trackers: FL login request: %w", err)
@@ -243,10 +255,33 @@ func resolveCookies(ctx context.Context, logger api.Logger, cfg config.TrackerCo
 		return nil, fmt.Errorf("trackers: FL login failed status=%d", loginResp.StatusCode)
 	}
 	loginCookies := loginResp.Cookies()
-	if err := cookies.SaveTrackerHTTPCookies(ctx, dbPath, "FL", loginCookies); err != nil && logger != nil {
-		logger.Warnf("trackers: FL failed to persist login cookies: %v", err)
+	if err := persistLoginCookies(ctx, dbPath, loginCookies); err != nil {
+		return nil, err
 	}
 	return loginCookies, nil
+}
+
+// persistLoginCookies saves FL login cookies and returns any persistence error
+// so callers do not report login success without durable cookie storage.
+func persistLoginCookies(ctx context.Context, dbPath string, values []*http.Cookie) error {
+	valid := validFLCookies(values)
+	if len(valid) == 0 {
+		return errors.New("trackers: FL login returned no usable cookies")
+	}
+	if err := cookies.SaveTrackerHTTPCookies(ctx, dbPath, "FL", valid); err != nil {
+		return fmt.Errorf("trackers: FL persist login cookies: %w", err)
+	}
+	return nil
+}
+
+func ensureLoginCookieStorageAvailable(dbPath string) error {
+	if _, err := authmaterial.LoadFromDBPath(dbPath); err != nil {
+		if errors.Is(err, authmaterial.ErrUnavailable) {
+			return fmt.Errorf("trackers: FL encrypted cookie storage unavailable before credential login: %w", cookies.ErrAuthHelperUnavailable)
+		}
+		return fmt.Errorf("trackers: FL check encrypted cookie storage before credential login: %w", err)
+	}
+	return nil
 }
 
 func validFLCookies(values []*http.Cookie) []*http.Cookie {
@@ -420,8 +455,6 @@ func isSD(meta api.PreparedMetadata) bool {
 
 func cloneFields(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 	return out
 }

--- a/internal/trackers/impl/fl/upload_test.go
+++ b/internal/trackers/impl/fl/upload_test.go
@@ -97,7 +97,9 @@ func TestResolveCookiesPostsFirstValidatorMatch(t *testing.T) {
 		requests++
 		switch {
 		case req.Method == http.MethodGet && req.URL.String() == loginPageURL:
-			return textResponse(req, `<input name="validator" value="first"><input name="validator" value="second">`), nil
+			resp := textResponse(req, `<input name="validator" value="first"><input name="validator" value="second">`)
+			resp.Header.Add("Set-Cookie", "validator_cookie=from-page; Path=/")
+			return resp, nil
 		case req.Method == http.MethodPost && req.URL.String() == loginURL:
 			if err := req.ParseForm(); err != nil {
 				t.Fatalf("ParseForm: %v", err)
@@ -128,7 +130,11 @@ func TestResolveCookiesPostsFirstValidatorMatch(t *testing.T) {
 	if postedValidator != "first" {
 		t.Fatalf("validator = %q, want first", postedValidator)
 	}
-	if len(values) != 1 || values[0].Name != "session" || values[0].Value != "abc" {
+	cookieValues := make(map[string]string, len(values))
+	for _, cookie := range values {
+		cookieValues[cookie.Name] = cookie.Value
+	}
+	if cookieValues["validator_cookie"] != "from-page" || cookieValues["session"] != "abc" {
 		t.Fatalf("unexpected cookies: %#v", values)
 	}
 	if requests != 2 {

--- a/internal/trackers/impl/fl/upload_test.go
+++ b/internal/trackers/impl/fl/upload_test.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package fl
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/authmaterial"
+	"github.com/autobrr/upbrr/internal/config"
+	cookiepkg "github.com/autobrr/upbrr/internal/cookies"
+	servicedb "github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestResolveCookiesReturnsLoginPageReadError(t *testing.T) {
+	ctx := context.Background()
+	dbPath := newFLAuthTestDB(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+
+	requests := 0
+	withFLHTTPClient(t, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet || req.URL.String() != loginPageURL {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       &failingReadCloser{data: `<input name="validator" value="partial">`},
+			Request:    req,
+		}, nil
+	})})
+
+	_, err := resolveCookies(ctx, api.NopLogger{}, configWithCredentials(), dbPath, false)
+	if err == nil {
+		t.Fatal("expected login page read error")
+	}
+	if !strings.Contains(err.Error(), "read login page response") {
+		t.Fatalf("expected read error context, got %v", err)
+	}
+	if strings.Contains(err.Error(), "validator token not found") {
+		t.Fatalf("read error must not be replaced by validator parse error: %v", err)
+	}
+	if strings.Contains(err.Error(), "user") || strings.Contains(err.Error(), "pass") {
+		t.Fatalf("read error must not expose credentials: %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("read failure must stop before login POST, got %d requests", requests)
+	}
+}
+
+func TestResolveCookiesMissingValidatorStillFailsBeforePost(t *testing.T) {
+	ctx := context.Background()
+	dbPath := newFLAuthTestDB(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+
+	requests := 0
+	withFLHTTPClient(t, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet || req.URL.String() != loginPageURL {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		return textResponse(req, "no validator here"), nil
+	})})
+
+	_, err := resolveCookies(ctx, api.NopLogger{}, configWithCredentials(), dbPath, false)
+	if err == nil || !strings.Contains(err.Error(), "validator token not found") {
+		t.Fatalf("expected missing validator error, got %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("missing validator must stop before login POST, got %d requests", requests)
+	}
+}
+
+func TestResolveCookiesPostsFirstValidatorMatch(t *testing.T) {
+	ctx := context.Background()
+	dbPath := newFLAuthTestDB(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+
+	var postedValidator string
+	requests := 0
+	withFLHTTPClient(t, &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		switch {
+		case req.Method == http.MethodGet && req.URL.String() == loginPageURL:
+			return textResponse(req, `<input name="validator" value="first"><input name="validator" value="second">`), nil
+		case req.Method == http.MethodPost && req.URL.String() == loginURL:
+			if err := req.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			postedValidator = req.Form.Get("validator")
+			if got := req.Form.Get("username"); got != "user" {
+				t.Fatalf("username = %q", got)
+			}
+			if got := req.Form.Get("password"); got != "pass" {
+				t.Fatalf("password = %q", got)
+			}
+			if got := req.Form.Get("unlock"); got != "1" {
+				t.Fatalf("unlock = %q", got)
+			}
+			resp := textResponse(req, "ok")
+			resp.Header.Add("Set-Cookie", "session=abc; Path=/")
+			return resp, nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			return nil, nil
+		}
+	})})
+
+	values, err := resolveCookies(ctx, api.NopLogger{}, configWithCredentials(), dbPath, false)
+	if err != nil {
+		t.Fatalf("resolveCookies: %v", err)
+	}
+	if postedValidator != "first" {
+		t.Fatalf("validator = %q, want first", postedValidator)
+	}
+	if len(values) != 1 || values[0].Name != "session" || values[0].Value != "abc" {
+		t.Fatalf("unexpected cookies: %#v", values)
+	}
+	if requests != 2 {
+		t.Fatalf("successful login should GET then POST, got %d requests", requests)
+	}
+}
+
+func TestPersistLoginCookiesReturnsSaveFailure(t *testing.T) {
+	t.Parallel()
+
+	err := persistLoginCookies(
+		context.Background(),
+		filepath.Join(t.TempDir(), "upbrr.db"),
+		[]*http.Cookie{{Name: "session", Value: "abc"}},
+	)
+	if !errors.Is(err, cookiepkg.ErrAuthHelperUnavailable) {
+		t.Fatalf("expected auth helper save failure, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "persist login cookies") {
+		t.Fatalf("expected persistence context, got %v", err)
+	}
+}
+
+func TestPersistLoginCookiesRejectsEmptyResponseWithoutReplacingCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newFLAuthTestDB(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "FL", map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+
+	err := persistLoginCookies(ctx, dbPath, nil)
+	if err == nil || !strings.Contains(err.Error(), "no usable cookies") {
+		t.Fatalf("expected empty login cookie error, got %v", err)
+	}
+	values, err := cookiepkg.LoadTrackerCookieMap(ctx, dbPath, "FL")
+	if err != nil {
+		t.Fatalf("LoadTrackerCookieMap: %v", err)
+	}
+	if values["session"] != "existing" {
+		t.Fatalf("empty response must preserve previous cookies, got %#v", values)
+	}
+}
+
+func TestEnsureLoginCookieStorageAvailableRequiresWebAuth(t *testing.T) {
+	t.Parallel()
+
+	err := ensureLoginCookieStorageAvailable(filepath.Join(t.TempDir(), "upbrr.db"))
+	if !errors.Is(err, cookiepkg.ErrAuthHelperUnavailable) {
+		t.Fatalf("expected auth helper unavailable preflight, got %v", err)
+	}
+}
+
+func newFLAuthTestDB(t *testing.T) string {
+	t.Helper()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	repo, err := servicedb.OpenWithLoggerContext(ctx, dbPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("OpenWithLoggerContext: %v", err)
+	}
+	if err := repo.MigrateContext(ctx); err != nil {
+		_ = repo.Close()
+		t.Fatalf("MigrateContext: %v", err)
+	}
+	_ = repo.Close()
+	return dbPath
+}
+
+func configWithCredentials() config.TrackerConfig {
+	return config.TrackerConfig{Username: "user", Password: "pass"}
+}
+
+func withFLHTTPClient(t *testing.T, client *http.Client) {
+	t.Helper()
+
+	original := newHTTPClient
+	newHTTPClient = func(time.Duration) *http.Client {
+		return client
+	}
+	t.Cleanup(func() {
+		newHTTPClient = original
+	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+type failingReadCloser struct {
+	data string
+	done bool
+}
+
+func (body *failingReadCloser) Read(p []byte) (int, error) {
+	if body.done {
+		return 0, io.EOF
+	}
+	body.done = true
+	return copy(p, body.data), errors.New("simulated read failure")
+}
+
+func (body *failingReadCloser) Close() error {
+	return nil
+}
+
+func textResponse(req *http.Request, body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}

--- a/internal/trackers/impl/mtv/upload.go
+++ b/internal/trackers/impl/mtv/upload.go
@@ -274,7 +274,8 @@ func ResolveSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig,
 // falling back to the configured OTP URI; if neither yields a code, the error
 // is returned before stored cookies are replaced. A rejected submitted code can
 // return [ErrSubmitted2FARejected] with the auth-key lookup failure before
-// refreshed cookies are persisted.
+// refreshed cookies are persisted. Response read errors are returned directly
+// and are not classified as submitted-code rejections.
 func ResolveSessionForTrackerAuthLogin(ctx context.Context, cfg config.TrackerConfig, dbPath string, login api.TrackerAuthLoginRequest) error {
 	baseURL := strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
 	if baseURL == "" {
@@ -328,8 +329,11 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 	if err != nil {
 		return "", nil, nil, "", fmt.Errorf("trackers: MTV login page request: %w", err)
 	}
-	loginBody, _ := io.ReadAll(loginResp.Body)
+	loginBody, err := io.ReadAll(loginResp.Body)
 	_ = loginResp.Body.Close()
+	if err != nil {
+		return "", nil, nil, "", fmt.Errorf("trackers: MTV read login page response: %w", err)
+	}
 	effectiveBaseURL := mtvEffectiveBaseURL(baseURL, loginResp)
 	effectiveLoginURL := strings.TrimRight(effectiveBaseURL, "/") + "/login"
 	match := mtvTokenPattern.FindStringSubmatch(string(loginBody))
@@ -357,8 +361,11 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 	if err != nil {
 		return "", nil, nil, "", fmt.Errorf("trackers: MTV login request: %w", err)
 	}
-	body, _ := io.ReadAll(postResp.Body)
+	body, err := io.ReadAll(postResp.Body)
 	_ = postResp.Body.Close()
+	if err != nil {
+		return "", nil, nil, "", fmt.Errorf("trackers: MTV read login response: %w", err)
+	}
 	finalAuthBody := string(body)
 	finalAuthTrace := mtvResponseTrace(postResp)
 
@@ -386,8 +393,11 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 		if err != nil {
 			return "", nil, nil, "", fmt.Errorf("trackers: MTV 2FA login request: %w", err)
 		}
-		twoFactorBody, _ := io.ReadAll(twoResp.Body)
+		twoFactorBody, err := io.ReadAll(twoResp.Body)
 		_ = twoResp.Body.Close()
+		if err != nil {
+			return "", nil, nil, "", fmt.Errorf("trackers: MTV read 2FA login response: %w", err)
+		}
 		finalAuthBody = string(twoFactorBody)
 		finalAuthTrace = mtvResponseTrace(twoResp)
 		submittedManualCode = strings.TrimSpace(login.Code) != ""

--- a/internal/trackers/impl/mtv/upload.go
+++ b/internal/trackers/impl/mtv/upload.go
@@ -252,6 +252,7 @@ func saveMTVCookies(ctx context.Context, dbPath string, values map[string]string
 	return wrapTrackerError(cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "MTV", values))
 }
 
+// ResolveSessionForTrackerAuth validates MTV stored cookies or logs in with configured credentials and saves refreshed cookies.
 func ResolveSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string) error {
 	baseURL := strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
 	if baseURL == "" {
@@ -261,8 +262,9 @@ func ResolveSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig,
 	if err == nil && len(cookies) > 0 {
 		if _, _, err := resolveAuthKey(ctx, baseURL, cookies); err == nil {
 			return nil
+		} else if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
+			return err
 		}
-		_ = cookiepkg.DeleteTrackerCookies(ctx, dbPath, "MTV")
 	}
 	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
 		return errors.New("trackers: MTV cookie invalid/missing and username/password not configured")

--- a/internal/trackers/impl/mtv/upload.go
+++ b/internal/trackers/impl/mtv/upload.go
@@ -252,7 +252,9 @@ func saveMTVCookies(ctx context.Context, dbPath string, values map[string]string
 	return wrapTrackerError(cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "MTV", values))
 }
 
-// ResolveSessionForTrackerAuth validates MTV stored cookies or logs in with configured credentials and saves refreshed cookies.
+// ResolveSessionForTrackerAuth validates MTV stored cookies or logs in with
+// configured credentials. After a successful login, cookie persistence failures
+// are returned distinctly from remote authentication failures.
 func ResolveSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string) error {
 	baseURL := strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
 	if baseURL == "" {
@@ -273,9 +275,17 @@ func ResolveSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig,
 	if err != nil {
 		return err
 	}
-	return saveMTVCookies(ctx, dbPath, values)
+	if len(values) == 0 {
+		return errors.New("trackers: MTV login returned no usable cookies")
+	}
+	if err := saveMTVCookies(ctx, dbPath, values); err != nil {
+		return fmt.Errorf("trackers: MTV persist cookies after successful login: %w", err)
+	}
+	return nil
 }
 
+// loginAndResolveAuthKey performs MTV login, optional TOTP submission, and auth
+// key discovery, returning cookies captured from the authenticated jar.
 func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseURL string) (string, *http.Client, map[string]string, error) {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
@@ -391,10 +401,10 @@ func cookiesFromJar(baseURL string, jar http.CookieJar) map[string]string {
 	}
 	out := make(map[string]string)
 	for _, cookie := range jar.Cookies(parsed) {
-		if cookie == nil || strings.TrimSpace(cookie.Name) == "" {
+		if cookie == nil || strings.TrimSpace(cookie.Name) == "" || strings.TrimSpace(cookie.Value) == "" {
 			continue
 		}
-		out[strings.TrimSpace(cookie.Name)] = strings.TrimSpace(cookie.Value)
+		out[strings.TrimSpace(cookie.Name)] = cookie.Value
 	}
 	return out
 }

--- a/internal/trackers/impl/mtv/upload.go
+++ b/internal/trackers/impl/mtv/upload.go
@@ -45,6 +45,12 @@ const (
 var mtvAuthKeyPattern = regexp.MustCompile(`authkey=([a-zA-Z0-9]{32})`)
 var mtvTokenPattern = regexp.MustCompile(`name="token"\s+value="([^"]{16,128})"`)
 
+// ErrSubmitted2FARejected marks an MTV failure after a submitted manual 2FA code
+// reached the tracker and was rejected.
+var ErrSubmitted2FARejected = errors.New("trackers: MTV submitted 2FA rejected")
+
+var errMTVAuthKeyNotFound = errors.New("trackers: MTV auth key not found")
+
 func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary, error) {
 	select {
 	case <-ctx.Done():
@@ -70,7 +76,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 			}
 			return api.UploadSummary{}, err
 		}
-		auth, client, cookies, err = loginAndResolveAuthKey(ctx, req.TrackerConfig, baseURL)
+		auth, client, cookies, err = loginAndResolveAuthKey(ctx, req.TrackerConfig, baseURL, api.TrackerAuthLoginRequest{})
 		if err != nil {
 			return api.UploadSummary{}, err
 		}
@@ -239,7 +245,7 @@ func resolveAuthKey(ctx context.Context, baseURL string, cookies map[string]stri
 	}
 	match := mtvAuthKeyPattern.FindStringSubmatch(string(body))
 	if len(match) < 2 {
-		return "", nil, errors.New("trackers: MTV auth key not found")
+		return "", nil, errMTVAuthKeyNotFound
 	}
 	return strings.TrimSpace(match[1]), client, nil
 }
@@ -256,6 +262,16 @@ func saveMTVCookies(ctx context.Context, dbPath string, values map[string]string
 // configured credentials. After a successful login, cookie persistence failures
 // are returned distinctly from remote authentication failures.
 func ResolveSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string) error {
+	return ResolveSessionForTrackerAuthLogin(ctx, cfg, dbPath, api.TrackerAuthLoginRequest{})
+}
+
+// ResolveSessionForTrackerAuthLogin validates MTV stored cookies or logs in
+// with configured credentials. When MTV requires 2FA, login.Code is used before
+// falling back to the configured OTP URI; if neither yields a code, the error
+// is returned before stored cookies are replaced. A rejected submitted code can
+// return [ErrSubmitted2FARejected] with the auth-key lookup failure before
+// refreshed cookies are persisted.
+func ResolveSessionForTrackerAuthLogin(ctx context.Context, cfg config.TrackerConfig, dbPath string, login api.TrackerAuthLoginRequest) error {
 	baseURL := strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
 	if baseURL == "" {
 		baseURL = mtvBaseURL
@@ -271,7 +287,7 @@ func ResolveSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig,
 	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
 		return errors.New("trackers: MTV cookie invalid/missing and username/password not configured")
 	}
-	_, _, values, err := loginAndResolveAuthKey(ctx, cfg, baseURL)
+	_, _, values, err := loginAndResolveAuthKey(ctx, cfg, baseURL, login)
 	if err != nil {
 		return err
 	}
@@ -285,8 +301,10 @@ func ResolveSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig,
 }
 
 // loginAndResolveAuthKey performs MTV login, optional TOTP submission, and auth
-// key discovery, returning cookies captured from the authenticated jar.
-func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseURL string) (string, *http.Client, map[string]string, error) {
+// key discovery. Missing form tokens and auth-key parser failures remain
+// ordinary errors unless an auth-key miss follows a submitted manual code;
+// authenticated cookies are returned only after auth-key discovery.
+func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseURL string, login api.TrackerAuthLoginRequest) (string, *http.Client, map[string]string, error) {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("trackers: MTV create login cookie jar: %w", err)
@@ -333,14 +351,15 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 	body, _ := io.ReadAll(postResp.Body)
 	_ = postResp.Body.Close()
 
+	submittedManualCode := false
 	if postResp.Request != nil && postResp.Request.URL != nil && strings.Contains(postResp.Request.URL.Path, "/twofactor/login") {
 		twoFactorTokenMatch := mtvTokenPattern.FindStringSubmatch(string(body))
 		if len(twoFactorTokenMatch) < 2 {
 			return "", nil, nil, errors.New("trackers: MTV 2FA token not found")
 		}
-		code, err := totpFromOTPURI(strings.TrimSpace(cfg.OTPURI), time.Now())
+		code, err := resolveMTV2FACode(cfg, login)
 		if err != nil {
-			return "", nil, nil, fmt.Errorf("trackers: MTV 2FA required but otp_uri invalid: %w", err)
+			return "", nil, nil, err
 		}
 		twoFactorForm := url.Values{}
 		twoFactorForm.Set("token", twoFactorTokenMatch[1])
@@ -358,14 +377,31 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 		}
 		_, _ = io.ReadAll(twoResp.Body)
 		_ = twoResp.Body.Close()
+		submittedManualCode = strings.TrimSpace(login.Code) != ""
 	}
 
 	auth, authedClient, err := resolveAuthKeyFromClient(ctx, baseURL, client)
 	if err != nil {
+		if submittedManualCode && errors.Is(err, errMTVAuthKeyNotFound) {
+			return "", nil, nil, fmt.Errorf("%w: %w", err, ErrSubmitted2FARejected)
+		}
 		return "", nil, nil, err
 	}
 	cookieMap := cookiesFromJar(baseURL, authedClient.Jar)
 	return auth, authedClient, cookieMap, nil
+}
+
+// resolveMTV2FACode prefers a submitted manual code so users can continue a
+// browser-visible challenge when no reusable OTP URI is configured.
+func resolveMTV2FACode(cfg config.TrackerConfig, login api.TrackerAuthLoginRequest) (string, error) {
+	if code := strings.TrimSpace(login.Code); code != "" {
+		return code, nil
+	}
+	code, err := totpFromOTPURI(strings.TrimSpace(cfg.OTPURI), time.Now())
+	if err != nil {
+		return "", fmt.Errorf("trackers: MTV 2FA required but otp_uri invalid: %w", err)
+	}
+	return code, nil
 }
 
 func resolveAuthKeyFromClient(ctx context.Context, baseURL string, client *http.Client) (string, *http.Client, error) {
@@ -386,7 +422,7 @@ func resolveAuthKeyFromClient(ctx context.Context, baseURL string, client *http.
 	}
 	match := mtvAuthKeyPattern.FindStringSubmatch(string(body))
 	if len(match) < 2 {
-		return "", nil, errors.New("trackers: MTV auth key not found")
+		return "", nil, errMTVAuthKeyNotFound
 	}
 	return strings.TrimSpace(match[1]), client, nil
 }

--- a/internal/trackers/impl/mtv/upload.go
+++ b/internal/trackers/impl/mtv/upload.go
@@ -42,7 +42,6 @@ const (
 	mtvUserAgentWeb = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
 )
 
-var mtvAuthKeyPattern = regexp.MustCompile(`authkey=([a-zA-Z0-9]{32})`)
 var mtvTokenPattern = regexp.MustCompile(`name="token"\s+value="([^"]{16,128})"`)
 
 // ErrSubmitted2FARejected marks an MTV failure after a submitted manual 2FA code
@@ -237,17 +236,17 @@ func resolveAuthKey(ctx context.Context, baseURL string, cookies map[string]stri
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", nil, fmt.Errorf("trackers: MTV auth status %d", resp.StatusCode)
+		return "", nil, fmt.Errorf("trackers: MTV auth key lookup failed %s: auth status %d", mtvResponseTrace(resp), resp.StatusCode)
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", nil, fmt.Errorf("trackers: MTV read auth response: %w", err)
 	}
-	match := mtvAuthKeyPattern.FindStringSubmatch(string(body))
-	if len(match) < 2 {
-		return "", nil, errMTVAuthKeyNotFound
+	auth := extractMTVAuthKey(string(body))
+	if auth == "" {
+		return "", nil, fmt.Errorf("%w: %s", errMTVAuthKeyNotFound, mtvResponseTrace(resp))
 	}
-	return strings.TrimSpace(match[1]), client, nil
+	return auth, client, nil
 }
 
 func loadMTVCookies(ctx context.Context, dbPath string) (map[string]string, error) {
@@ -301,9 +300,11 @@ func ResolveSessionForTrackerAuthLogin(ctx context.Context, cfg config.TrackerCo
 }
 
 // loginAndResolveAuthKey performs MTV login, optional TOTP submission, and auth
-// key discovery. Missing form tokens and auth-key parser failures remain
-// ordinary errors unless an auth-key miss follows a submitted manual code;
-// authenticated cookies are returned only after auth-key discovery.
+// key discovery. MTV can return authkey in the final login response, so that
+// body is checked before falling back to the index page. Missing form tokens
+// and auth-key parser failures remain ordinary errors unless an auth-key miss
+// follows a submitted manual code; authenticated cookies are returned only
+// after auth-key discovery.
 func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseURL string, login api.TrackerAuthLoginRequest) (string, *http.Client, map[string]string, error) {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
@@ -323,6 +324,8 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 	}
 	loginBody, _ := io.ReadAll(loginResp.Body)
 	_ = loginResp.Body.Close()
+	effectiveBaseURL := mtvEffectiveBaseURL(baseURL, loginResp)
+	effectiveLoginURL := strings.TrimRight(effectiveBaseURL, "/") + "/login"
 	match := mtvTokenPattern.FindStringSubmatch(string(loginBody))
 	if len(match) < 2 {
 		return "", nil, nil, errors.New("trackers: MTV login token not found")
@@ -338,7 +341,7 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 	form.Set("iplocked", "1")
 	form.Set("token", token)
 
-	postReq, err := http.NewRequestWithContext(ctx, http.MethodPost, loginURL, strings.NewReader(form.Encode()))
+	postReq, err := http.NewRequestWithContext(ctx, http.MethodPost, effectiveLoginURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("trackers: MTV build login request: %w", err)
 	}
@@ -350,6 +353,8 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 	}
 	body, _ := io.ReadAll(postResp.Body)
 	_ = postResp.Body.Close()
+	finalAuthBody := string(body)
+	finalAuthTrace := mtvResponseTrace(postResp)
 
 	submittedManualCode := false
 	if postResp.Request != nil && postResp.Request.URL != nil && strings.Contains(postResp.Request.URL.Path, "/twofactor/login") {
@@ -365,7 +370,7 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 		twoFactorForm.Set("token", twoFactorTokenMatch[1])
 		twoFactorForm.Set("code", code)
 		twoFactorForm.Set("submit", "login")
-		twoReq, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(baseURL, "/")+"/twofactor/login", strings.NewReader(twoFactorForm.Encode()))
+		twoReq, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(effectiveBaseURL, "/")+"/twofactor/login", strings.NewReader(twoFactorForm.Encode()))
 		if err != nil {
 			return "", nil, nil, fmt.Errorf("trackers: MTV build 2FA login request: %w", err)
 		}
@@ -375,20 +380,67 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 		if err != nil {
 			return "", nil, nil, fmt.Errorf("trackers: MTV 2FA login request: %w", err)
 		}
-		_, _ = io.ReadAll(twoResp.Body)
+		twoFactorBody, _ := io.ReadAll(twoResp.Body)
 		_ = twoResp.Body.Close()
+		finalAuthBody = string(twoFactorBody)
+		finalAuthTrace = mtvResponseTrace(twoResp)
 		submittedManualCode = strings.TrimSpace(login.Code) != ""
 	}
 
-	auth, authedClient, err := resolveAuthKeyFromClient(ctx, baseURL, client)
+	if auth := extractMTVAuthKey(finalAuthBody); auth != "" {
+		cookieMap := cookiesFromJar(effectiveBaseURL, client.Jar)
+		return auth, client, cookieMap, nil
+	}
+	auth, authedClient, err := resolveAuthKeyFromClient(ctx, effectiveBaseURL, client)
 	if err != nil {
 		if submittedManualCode && errors.Is(err, errMTVAuthKeyNotFound) {
-			return "", nil, nil, fmt.Errorf("%w: %w", err, ErrSubmitted2FARejected)
+			return "", nil, nil, fmt.Errorf("trackers: MTV auth key not found after submitted 2FA final_%s: %w: %w", finalAuthTrace, err, ErrSubmitted2FARejected)
 		}
-		return "", nil, nil, err
+		if errors.Is(err, errMTVAuthKeyNotFound) {
+			return "", nil, nil, fmt.Errorf("trackers: MTV auth key not found after login final_%s: %w", finalAuthTrace, err)
+		}
+		return "", nil, nil, fmt.Errorf("trackers: MTV auth key lookup after login final_%s: %w", finalAuthTrace, err)
 	}
-	cookieMap := cookiesFromJar(baseURL, authedClient.Jar)
+	cookieMap := cookiesFromJar(effectiveBaseURL, authedClient.Jar)
 	return auth, authedClient, cookieMap, nil
+}
+
+func mtvEffectiveBaseURL(fallback string, resp *http.Response) string {
+	if resp == nil || resp.Request == nil || resp.Request.URL == nil {
+		return strings.TrimRight(fallback, "/")
+	}
+	u := resp.Request.URL
+	if strings.TrimSpace(u.Scheme) == "" || strings.TrimSpace(u.Host) == "" {
+		return strings.TrimRight(fallback, "/")
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+func mtvResponseTrace(resp *http.Response) string {
+	if resp == nil {
+		return "path=unknown status=0"
+	}
+	path := "unknown"
+	if resp.Request != nil && resp.Request.URL != nil {
+		path = resp.Request.URL.EscapedPath()
+		if strings.TrimSpace(path) == "" {
+			path = "/"
+		}
+	}
+	return fmt.Sprintf("path=%s status=%d", path, resp.StatusCode)
+}
+
+func extractMTVAuthKey(body string) string {
+	const marker = "authkey="
+	idx := strings.LastIndex(body, marker)
+	if idx < 0 {
+		return ""
+	}
+	raw := strings.TrimSpace(body[idx+len(marker):])
+	if len(raw) < 32 {
+		return ""
+	}
+	return raw[:32]
 }
 
 // resolveMTV2FACode prefers a submitted manual code so users can continue a
@@ -416,15 +468,18 @@ func resolveAuthKeyFromClient(ctx context.Context, baseURL string, client *http.
 		return "", nil, fmt.Errorf("trackers: MTV auth request: %w", err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", nil, fmt.Errorf("trackers: MTV auth key lookup failed %s: auth status %d", mtvResponseTrace(resp), resp.StatusCode)
+	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", nil, fmt.Errorf("trackers: MTV read auth response: %w", err)
 	}
-	match := mtvAuthKeyPattern.FindStringSubmatch(string(body))
-	if len(match) < 2 {
-		return "", nil, errMTVAuthKeyNotFound
+	auth := extractMTVAuthKey(string(body))
+	if auth == "" {
+		return "", nil, fmt.Errorf("%w: %s", errMTVAuthKeyNotFound, mtvResponseTrace(resp))
 	}
-	return strings.TrimSpace(match[1]), client, nil
+	return auth, client, nil
 }
 
 func cookiesFromJar(baseURL string, jar http.CookieJar) map[string]string {

--- a/internal/trackers/impl/mtv/upload.go
+++ b/internal/trackers/impl/mtv/upload.go
@@ -75,9 +75,14 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 			}
 			return api.UploadSummary{}, err
 		}
-		auth, client, cookies, err = loginAndResolveAuthKey(ctx, req.TrackerConfig, baseURL, api.TrackerAuthLoginRequest{})
+		var effectiveBaseURL string
+		auth, client, cookies, effectiveBaseURL, err = loginAndResolveAuthKey(ctx, req.TrackerConfig, baseURL, api.TrackerAuthLoginRequest{})
 		if err != nil {
 			return api.UploadSummary{}, err
+		}
+		if strings.TrimSpace(effectiveBaseURL) != "" && !strings.EqualFold(effectiveBaseURL, baseURL) {
+			baseURL = effectiveBaseURL
+			uploadURL = baseURL + mtvUploadPath
 		}
 		if persistErr := saveMTVCookies(ctx, req.AppConfig.MainSettings.DBPath, cookies); persistErr != nil && req.Logger != nil {
 			req.Logger.Warnf("trackers: MTV failed to persist cookies: %v", persistErr)
@@ -286,7 +291,7 @@ func ResolveSessionForTrackerAuthLogin(ctx context.Context, cfg config.TrackerCo
 	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
 		return errors.New("trackers: MTV cookie invalid/missing and username/password not configured")
 	}
-	_, _, values, err := loginAndResolveAuthKey(ctx, cfg, baseURL, login)
+	_, _, values, _, err := loginAndResolveAuthKey(ctx, cfg, baseURL, login)
 	if err != nil {
 		return err
 	}
@@ -303,24 +308,25 @@ func ResolveSessionForTrackerAuthLogin(ctx context.Context, cfg config.TrackerCo
 // key discovery. MTV can return authkey in the final login response, so that
 // body is checked before falling back to the index page. Missing form tokens
 // and auth-key parser failures remain ordinary errors unless an auth-key miss
-// follows a submitted manual code; authenticated cookies are returned only
-// after auth-key discovery.
-func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseURL string, login api.TrackerAuthLoginRequest) (string, *http.Client, map[string]string, error) {
+// follows a submitted manual code. Authenticated cookies and the effective base
+// URL are returned only after auth-key discovery so upload can reuse any
+// canonical host reached during login redirects.
+func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseURL string, login api.TrackerAuthLoginRequest) (string, *http.Client, map[string]string, string, error) {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("trackers: MTV create login cookie jar: %w", err)
+		return "", nil, nil, "", fmt.Errorf("trackers: MTV create login cookie jar: %w", err)
 	}
 	client := &http.Client{Timeout: 25 * time.Second, Jar: jar}
 
 	loginURL := strings.TrimRight(baseURL, "/") + "/login"
 	loginReq, err := http.NewRequestWithContext(ctx, http.MethodGet, loginURL, nil)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("trackers: MTV build login page request: %w", err)
+		return "", nil, nil, "", fmt.Errorf("trackers: MTV build login page request: %w", err)
 	}
 	loginReq.Header.Set("User-Agent", mtvUserAgentWeb)
 	loginResp, err := client.Do(loginReq)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("trackers: MTV login page request: %w", err)
+		return "", nil, nil, "", fmt.Errorf("trackers: MTV login page request: %w", err)
 	}
 	loginBody, _ := io.ReadAll(loginResp.Body)
 	_ = loginResp.Body.Close()
@@ -328,7 +334,7 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 	effectiveLoginURL := strings.TrimRight(effectiveBaseURL, "/") + "/login"
 	match := mtvTokenPattern.FindStringSubmatch(string(loginBody))
 	if len(match) < 2 {
-		return "", nil, nil, errors.New("trackers: MTV login token not found")
+		return "", nil, nil, "", errors.New("trackers: MTV login token not found")
 	}
 	token := strings.TrimSpace(match[1])
 
@@ -343,13 +349,13 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 
 	postReq, err := http.NewRequestWithContext(ctx, http.MethodPost, effectiveLoginURL, strings.NewReader(form.Encode()))
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("trackers: MTV build login request: %w", err)
+		return "", nil, nil, "", fmt.Errorf("trackers: MTV build login request: %w", err)
 	}
 	postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	postReq.Header.Set("User-Agent", mtvUserAgentWeb)
 	postResp, err := client.Do(postReq)
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("trackers: MTV login request: %w", err)
+		return "", nil, nil, "", fmt.Errorf("trackers: MTV login request: %w", err)
 	}
 	body, _ := io.ReadAll(postResp.Body)
 	_ = postResp.Body.Close()
@@ -360,11 +366,11 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 	if postResp.Request != nil && postResp.Request.URL != nil && strings.Contains(postResp.Request.URL.Path, "/twofactor/login") {
 		twoFactorTokenMatch := mtvTokenPattern.FindStringSubmatch(string(body))
 		if len(twoFactorTokenMatch) < 2 {
-			return "", nil, nil, errors.New("trackers: MTV 2FA token not found")
+			return "", nil, nil, "", errors.New("trackers: MTV 2FA token not found")
 		}
 		code, err := resolveMTV2FACode(cfg, login)
 		if err != nil {
-			return "", nil, nil, err
+			return "", nil, nil, "", err
 		}
 		twoFactorForm := url.Values{}
 		twoFactorForm.Set("token", twoFactorTokenMatch[1])
@@ -372,13 +378,13 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 		twoFactorForm.Set("submit", "login")
 		twoReq, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(effectiveBaseURL, "/")+"/twofactor/login", strings.NewReader(twoFactorForm.Encode()))
 		if err != nil {
-			return "", nil, nil, fmt.Errorf("trackers: MTV build 2FA login request: %w", err)
+			return "", nil, nil, "", fmt.Errorf("trackers: MTV build 2FA login request: %w", err)
 		}
 		twoReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		twoReq.Header.Set("User-Agent", mtvUserAgentWeb)
 		twoResp, err := client.Do(twoReq)
 		if err != nil {
-			return "", nil, nil, fmt.Errorf("trackers: MTV 2FA login request: %w", err)
+			return "", nil, nil, "", fmt.Errorf("trackers: MTV 2FA login request: %w", err)
 		}
 		twoFactorBody, _ := io.ReadAll(twoResp.Body)
 		_ = twoResp.Body.Close()
@@ -389,20 +395,20 @@ func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseU
 
 	if auth := extractMTVAuthKey(finalAuthBody); auth != "" {
 		cookieMap := cookiesFromJar(effectiveBaseURL, client.Jar)
-		return auth, client, cookieMap, nil
+		return auth, client, cookieMap, effectiveBaseURL, nil
 	}
 	auth, authedClient, err := resolveAuthKeyFromClient(ctx, effectiveBaseURL, client)
 	if err != nil {
 		if submittedManualCode && errors.Is(err, errMTVAuthKeyNotFound) {
-			return "", nil, nil, fmt.Errorf("trackers: MTV auth key not found after submitted 2FA final_%s: %w: %w", finalAuthTrace, err, ErrSubmitted2FARejected)
+			return "", nil, nil, "", fmt.Errorf("trackers: MTV auth key not found after submitted 2FA final_%s: %w: %w", finalAuthTrace, err, ErrSubmitted2FARejected)
 		}
 		if errors.Is(err, errMTVAuthKeyNotFound) {
-			return "", nil, nil, fmt.Errorf("trackers: MTV auth key not found after login final_%s: %w", finalAuthTrace, err)
+			return "", nil, nil, "", fmt.Errorf("trackers: MTV auth key not found after login final_%s: %w", finalAuthTrace, err)
 		}
-		return "", nil, nil, fmt.Errorf("trackers: MTV auth key lookup after login final_%s: %w", finalAuthTrace, err)
+		return "", nil, nil, "", fmt.Errorf("trackers: MTV auth key lookup after login final_%s: %w", finalAuthTrace, err)
 	}
 	cookieMap := cookiesFromJar(effectiveBaseURL, authedClient.Jar)
-	return auth, authedClient, cookieMap, nil
+	return auth, authedClient, cookieMap, effectiveBaseURL, nil
 }
 
 func mtvEffectiveBaseURL(fallback string, resp *http.Response) string {

--- a/internal/trackers/impl/mtv/upload.go
+++ b/internal/trackers/impl/mtv/upload.go
@@ -252,6 +252,28 @@ func saveMTVCookies(ctx context.Context, dbPath string, values map[string]string
 	return wrapTrackerError(cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "MTV", values))
 }
 
+func ResolveSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string) error {
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
+	if baseURL == "" {
+		baseURL = mtvBaseURL
+	}
+	cookies, err := loadMTVCookies(ctx, dbPath)
+	if err == nil && len(cookies) > 0 {
+		if _, _, err := resolveAuthKey(ctx, baseURL, cookies); err == nil {
+			return nil
+		}
+		_ = cookiepkg.DeleteTrackerCookies(ctx, dbPath, "MTV")
+	}
+	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
+		return errors.New("trackers: MTV cookie invalid/missing and username/password not configured")
+	}
+	_, _, values, err := loginAndResolveAuthKey(ctx, cfg, baseURL)
+	if err != nil {
+		return err
+	}
+	return saveMTVCookies(ctx, dbPath, values)
+}
+
 func loginAndResolveAuthKey(ctx context.Context, cfg config.TrackerConfig, baseURL string) (string, *http.Client, map[string]string, error) {
 	jar, err := cookiejar.New(nil)
 	if err != nil {

--- a/internal/trackers/impl/mtv/upload_test.go
+++ b/internal/trackers/impl/mtv/upload_test.go
@@ -143,6 +143,155 @@ func TestResolveSessionForTrackerAuthRejectsEmptyLoginCookiesWithoutReplacingSto
 	}
 }
 
+func TestResolveSessionForTrackerAuthLoginUsesManual2FACode(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newMTVAuthDB(t)
+	var gotCode string
+	twoFACompleted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/index.php":
+			if !twoFACompleted {
+				_, _ = w.Write([]byte(`<html>logged out</html>`))
+				return
+			}
+			_, _ = w.Write([]byte(`authkey=abcdefghijklmnopqrstuvwxyzABCDEF`))
+		case "/login":
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
+				return
+			}
+			http.Redirect(w, r, "/twofactor/login", http.StatusFound)
+		case "/twofactor/login":
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte(`<input name="token" value="ponmlkjihgfedcba">`))
+				return
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			gotCode = r.FormValue("code")
+			twoFACompleted = true
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
+			_, _ = w.Write([]byte(`<html>ok</html>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuthLogin(ctx, config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath, api.TrackerAuthLoginRequest{Code: "654321"})
+	if err != nil {
+		t.Fatalf("ResolveSessionForTrackerAuthLogin: %v", err)
+	}
+	if gotCode != "654321" {
+		t.Fatalf("expected manual 2FA code, got %q", gotCode)
+	}
+	got, err := loadMTVCookies(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("loadMTVCookies: %v", err)
+	}
+	if got["session"] != "new" {
+		t.Fatalf("expected saved 2FA login cookies, got %#v", got)
+	}
+}
+
+func TestResolveSessionForTrackerAuthLoginMarksSubmitted2FAAuthKeyMiss(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newMTVAuthDB(t)
+	if err := saveMTVCookies(ctx, dbPath, map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("saveMTVCookies: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/index.php":
+			_, _ = w.Write([]byte(`<html>logged out</html>`))
+		case "/login":
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
+				return
+			}
+			http.Redirect(w, r, "/twofactor/login", http.StatusFound)
+		case "/twofactor/login":
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte(`<input name="token" value="ponmlkjihgfedcba">`))
+				return
+			}
+			_, _ = w.Write([]byte(`<html>invalid code</html>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuthLogin(ctx, config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath, api.TrackerAuthLoginRequest{Code: "000000"})
+	if !errors.Is(err, ErrSubmitted2FARejected) {
+		t.Fatalf("expected submitted 2FA rejection marker, got %v", err)
+	}
+	got, loadErr := loadMTVCookies(ctx, dbPath)
+	if loadErr != nil {
+		t.Fatalf("loadMTVCookies: %v", loadErr)
+	}
+	if got["session"] != "existing" {
+		t.Fatalf("submitted 2FA rejection must preserve stored cookies, got %#v", got)
+	}
+}
+
+func TestResolveSessionForTrackerAuthLoginMissing2FACodePreservesCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newMTVAuthDB(t)
+	if err := saveMTVCookies(ctx, dbPath, map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("saveMTVCookies: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/index.php":
+			_, _ = w.Write([]byte(`<html>logged out</html>`))
+		case "/login":
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
+				return
+			}
+			http.Redirect(w, r, "/twofactor/login", http.StatusFound)
+		case "/twofactor/login":
+			_, _ = w.Write([]byte(`<input name="token" value="ponmlkjihgfedcba">`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuthLogin(ctx, config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath, api.TrackerAuthLoginRequest{})
+	if err == nil || !strings.Contains(err.Error(), "2FA required") {
+		t.Fatalf("expected missing 2FA error, got %v", err)
+	}
+	got, loadErr := loadMTVCookies(ctx, dbPath)
+	if loadErr != nil {
+		t.Fatalf("loadMTVCookies: %v", loadErr)
+	}
+	if got["session"] != "existing" {
+		t.Fatalf("missing 2FA code must preserve stored cookies, got %#v", got)
+	}
+}
+
 func newMTVAuthDB(t *testing.T) string {
 	t.Helper()
 

--- a/internal/trackers/impl/mtv/upload_test.go
+++ b/internal/trackers/impl/mtv/upload_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	cookiepkg "github.com/autobrr/upbrr/internal/cookies"
 	servicedb "github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -204,6 +206,69 @@ func TestResolveSessionForTrackerAuthPostsLoginToRedirectedHost(t *testing.T) {
 	}
 	if got["session"] != "fresh" {
 		t.Fatalf("expected saved redirected-login cookies, got %#v", got)
+	}
+}
+
+func TestUploadPostsToRedirectedLoginHost(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	torrentPath := filepath.Join(t.TempDir(), "release.torrent")
+	if err := os.WriteFile(torrentPath, []byte("torrent"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+	var canonicalURL string
+	postedCanonicalUpload := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/login" && r.Method == http.MethodGet && strings.HasPrefix(r.Host, "localhost:"):
+			http.Redirect(w, r, canonicalURL+"/login", http.StatusFound)
+		case r.URL.Path == "/login" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
+		case r.URL.Path == "/login" && r.Method == http.MethodPost:
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "fresh", Path: "/"})
+			_, _ = w.Write([]byte(`authkey=abcdefghijklmnopqrstuvwxyzABCDEF`))
+		case r.URL.Path == mtvUploadPath && r.Method == http.MethodPost && strings.HasPrefix(r.Host, "localhost:"):
+			t.Fatalf("upload POST used original host")
+		case r.URL.Path == mtvUploadPath && r.Method == http.MethodPost:
+			postedCanonicalUpload = true
+			if _, err := r.Cookie("session"); err != nil {
+				t.Fatalf("expected session cookie on canonical upload: %v", err)
+			}
+			http.Redirect(w, r, canonicalURL+"/torrents.php?id=1", http.StatusFound)
+		case r.URL.Path == "/torrents.php":
+			_, _ = w.Write([]byte("ok"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	canonicalURL = server.URL
+	sourceURL := strings.Replace(server.URL, "127.0.0.1", "localhost", 1)
+
+	summary, err := upload(ctx, trackers.UploadRequest{
+		Tracker: "MTV",
+		Meta: api.PreparedMetadata{
+			TorrentPath: torrentPath,
+			ReleaseName: "Release",
+		},
+		TrackerConfig: config.TrackerConfig{
+			URL:      sourceURL,
+			Username: "user",
+			Password: "pass",
+		},
+		AppConfig: config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}},
+		Assets:    &trackers.DescriptionAssets{Final: true, Description: "desc"},
+	})
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if summary.Uploaded != 1 {
+		t.Fatalf("expected upload success, got %#v", summary)
+	}
+	if !postedCanonicalUpload {
+		t.Fatal("expected upload POST on redirected host")
 	}
 }
 

--- a/internal/trackers/impl/mtv/upload_test.go
+++ b/internal/trackers/impl/mtv/upload_test.go
@@ -6,6 +6,7 @@ package mtv
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -165,12 +166,16 @@ func TestResolveSessionForTrackerAuthSavesCookiesWhenLoginResponseContainsAuthKe
 func TestLoginAndResolveAuthKeyReturnsLoginPageReadError(t *testing.T) {
 	t.Parallel()
 
+	handlerErrs := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/login" && r.Method == http.MethodGet:
-			writeMalformedChunkedResponse(t, w)
+			if err := writeMalformedChunkedResponse(w); err != nil {
+				recordHandlerError(handlerErrs, "write malformed chunked response: %v", err)
+			}
 		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			recordHandlerError(handlerErrs, "unexpected request %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
 		}
 	}))
 	t.Cleanup(server.Close)
@@ -179,6 +184,7 @@ func TestLoginAndResolveAuthKeyReturnsLoginPageReadError(t *testing.T) {
 		Username: "user",
 		Password: "pass",
 	}, server.URL, api.TrackerAuthLoginRequest{})
+	assertNoHandlerError(t, handlerErrs)
 	if err == nil {
 		t.Fatal("expected login page read error")
 	}
@@ -190,14 +196,18 @@ func TestLoginAndResolveAuthKeyReturnsLoginPageReadError(t *testing.T) {
 func TestLoginAndResolveAuthKeyReturnsLoginPostReadError(t *testing.T) {
 	t.Parallel()
 
+	handlerErrs := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/login" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
 		case r.URL.Path == "/login" && r.Method == http.MethodPost:
-			writeMalformedChunkedResponse(t, w)
+			if err := writeMalformedChunkedResponse(w); err != nil {
+				recordHandlerError(handlerErrs, "write malformed chunked response: %v", err)
+			}
 		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			recordHandlerError(handlerErrs, "unexpected request %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
 		}
 	}))
 	t.Cleanup(server.Close)
@@ -206,6 +216,7 @@ func TestLoginAndResolveAuthKeyReturnsLoginPostReadError(t *testing.T) {
 		Username: "user",
 		Password: "pass",
 	}, server.URL, api.TrackerAuthLoginRequest{})
+	assertNoHandlerError(t, handlerErrs)
 	if err == nil {
 		t.Fatal("expected login response read error")
 	}
@@ -487,6 +498,7 @@ func TestResolveSessionForTrackerAuthLoginReturns2FAReadError(t *testing.T) {
 	if err := saveMTVCookies(ctx, dbPath, map[string]string{"session": "existing"}); err != nil {
 		t.Fatalf("saveMTVCookies: %v", err)
 	}
+	handlerErrs := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/index.php":
@@ -502,7 +514,9 @@ func TestResolveSessionForTrackerAuthLoginReturns2FAReadError(t *testing.T) {
 				_, _ = w.Write([]byte(`<input name="token" value="ponmlkjihgfedcba">`))
 				return
 			}
-			writeMalformedChunkedResponse(t, w)
+			if err := writeMalformedChunkedResponse(w); err != nil {
+				recordHandlerError(handlerErrs, "write malformed chunked response: %v", err)
+			}
 		default:
 			http.NotFound(w, r)
 		}
@@ -514,6 +528,7 @@ func TestResolveSessionForTrackerAuthLoginReturns2FAReadError(t *testing.T) {
 		Username: "user",
 		Password: "pass",
 	}, dbPath, api.TrackerAuthLoginRequest{Code: "123456"})
+	assertNoHandlerError(t, handlerErrs)
 	if err == nil {
 		t.Fatal("expected 2FA response read error")
 	}
@@ -635,24 +650,46 @@ func newMTVAuthDB(t *testing.T) string {
 	return dbPath
 }
 
-func writeMalformedChunkedResponse(t *testing.T, w http.ResponseWriter) {
+// recordHandlerError preserves handler failures for assertion from the test
+// goroutine, where testing.T failures are safe to report.
+func recordHandlerError(errs chan<- string, format string, args ...any) {
+	select {
+	case errs <- fmt.Sprintf(format, args...):
+	default:
+	}
+}
+
+// assertNoHandlerError fails the test if the server handler recorded a setup or
+// routing error while servicing the request under test.
+func assertNoHandlerError(t *testing.T, errs <-chan string) {
 	t.Helper()
 
+	select {
+	case err := <-errs:
+		t.Fatal(err)
+	default:
+	}
+}
+
+// writeMalformedChunkedResponse sends an intentionally truncated chunked body so
+// callers exercise response-body read errors after headers are received.
+func writeMalformedChunkedResponse(w http.ResponseWriter) error {
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
-		t.Fatal("response writer does not support hijacking")
+		return errors.New("response writer does not support hijacking")
 	}
 	conn, rw, err := hijacker.Hijack()
 	if err != nil {
-		t.Fatalf("hijack response: %v", err)
+		return fmt.Errorf("hijack response: %w", err)
 	}
 	if _, err := rw.WriteString("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nTransfer-Encoding: chunked\r\n\r\n20\r\npartial"); err != nil {
 		_ = conn.Close()
-		t.Fatalf("write malformed chunked response: %v", err)
+		return fmt.Errorf("write response: %w", err)
 	}
 	if err := rw.Flush(); err != nil {
 		_ = conn.Close()
-		t.Fatalf("flush malformed chunked response: %v", err)
+		return fmt.Errorf("flush response: %w", err)
 	}
 	_ = conn.Close()
+	return nil
 }

--- a/internal/trackers/impl/mtv/upload_test.go
+++ b/internal/trackers/impl/mtv/upload_test.go
@@ -5,6 +5,7 @@ package mtv
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/autobrr/upbrr/internal/authmaterial"
 	"github.com/autobrr/upbrr/internal/config"
+	cookiepkg "github.com/autobrr/upbrr/internal/cookies"
 	servicedb "github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -62,6 +64,82 @@ func TestResolveSessionForTrackerAuthPreservesCookiesOnTransientAuthFetch(t *tes
 	}
 	if got["session"] != "abc" {
 		t.Fatalf("expected transient failure to preserve cookies, got %#v", got)
+	}
+}
+
+func TestResolveSessionForTrackerAuthReportsPostLoginCookiePersistenceFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "abc", Path: "/"})
+			_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
+		case "/index.php":
+			_, _ = w.Write([]byte(`authkey=abcdefghijklmnopqrstuvwxyzABCDEF`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuth(context.Background(), config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, filepath.Join(t.TempDir(), "upbrr.db"))
+	if !errors.Is(err, cookiepkg.ErrAuthHelperUnavailable) {
+		t.Fatalf("expected auth helper unavailable error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "persist cookies after successful login") {
+		t.Fatalf("expected distinct persistence failure, got %v", err)
+	}
+}
+
+func TestResolveSessionForTrackerAuthRejectsEmptyLoginCookiesWithoutReplacingStoredCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newMTVAuthDB(t)
+	if err := saveMTVCookies(ctx, dbPath, map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("saveMTVCookies: %v", err)
+	}
+	indexRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
+				return
+			}
+			_, _ = w.Write([]byte(`<html>ok</html>`))
+		case "/index.php":
+			indexRequests++
+			if indexRequests == 1 {
+				_, _ = w.Write([]byte(`<html>logged out</html>`))
+				return
+			}
+			_, _ = w.Write([]byte(`authkey=abcdefghijklmnopqrstuvwxyzABCDEF`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuth(ctx, config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath)
+	if err == nil || !strings.Contains(err.Error(), "no usable cookies") {
+		t.Fatalf("expected empty login cookie error, got %v", err)
+	}
+	got, loadErr := loadMTVCookies(ctx, dbPath)
+	if loadErr != nil {
+		t.Fatalf("loadMTVCookies after empty login cookies: %v", loadErr)
+	}
+	if got["session"] != "existing" {
+		t.Fatalf("expected empty login cookies to preserve stored cookies, got %#v", got)
 	}
 }
 

--- a/internal/trackers/impl/mtv/upload_test.go
+++ b/internal/trackers/impl/mtv/upload_test.go
@@ -38,6 +38,26 @@ func TestResolveGroupDescriptionIncludesTVDBForTV(t *testing.T) {
 	}
 }
 
+func TestExtractMTVAuthKeyMatchesUploadAssistantShape(t *testing.T) {
+	t.Parallel()
+
+	auth := "abcdefghijklmnopqrstuvwxyzABCDEF"
+	tests := map[string]string{
+		"plain":       "authkey=" + auth,
+		"query tail":  "https://example.test/upload?authkey=" + auth + "&x=1",
+		"last marker": "authkey=oldoldoldoldoldoldoldoldoldoldoldold authkey=" + auth + `">`,
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := extractMTVAuthKey(body); got != auth {
+				t.Fatalf("expected %q, got %q", auth, got)
+			}
+		})
+	}
+}
+
 func TestResolveSessionForTrackerAuthPreservesCookiesOnTransientAuthFetch(t *testing.T) {
 	t.Parallel()
 
@@ -96,6 +116,97 @@ func TestResolveSessionForTrackerAuthReportsPostLoginCookiePersistenceFailure(t 
 	}
 }
 
+func TestResolveSessionForTrackerAuthSavesCookiesWhenLoginResponseContainsAuthKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newMTVAuthDB(t)
+	indexRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
+				return
+			}
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "fresh", Path: "/"})
+			_, _ = w.Write([]byte(`authkey=abcdefghijklmnopqrstuvwxyzABCDEF`))
+		case "/index.php":
+			indexRequests++
+			_, _ = w.Write([]byte(`<html>logged out</html>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuth(ctx, config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath)
+	if err != nil {
+		t.Fatalf("ResolveSessionForTrackerAuth: %v", err)
+	}
+	if indexRequests != 0 {
+		t.Fatalf("expected login response authkey to avoid index lookup, got %d", indexRequests)
+	}
+	got, err := loadMTVCookies(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("loadMTVCookies: %v", err)
+	}
+	if got["session"] != "fresh" {
+		t.Fatalf("expected saved login cookies, got %#v", got)
+	}
+}
+
+func TestResolveSessionForTrackerAuthPostsLoginToRedirectedHost(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newMTVAuthDB(t)
+	var canonicalURL string
+	postedCanonicalLogin := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/login" && r.Method == http.MethodGet && strings.HasPrefix(r.Host, "localhost:"):
+			http.Redirect(w, r, canonicalURL+"/login", http.StatusFound)
+		case r.URL.Path == "/login" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
+		case r.URL.Path == "/login" && r.Method == http.MethodPost && strings.HasPrefix(r.Host, "localhost:"):
+			t.Fatalf("login POST used original host")
+		case r.URL.Path == "/login" && r.Method == http.MethodPost:
+			postedCanonicalLogin = true
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "fresh", Path: "/"})
+			_, _ = w.Write([]byte(`authkey=abcdefghijklmnopqrstuvwxyzABCDEF`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	canonicalURL = server.URL
+	sourceURL := strings.Replace(server.URL, "127.0.0.1", "localhost", 1)
+
+	err := ResolveSessionForTrackerAuth(ctx, config.TrackerConfig{
+		URL:      sourceURL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath)
+	if err != nil {
+		t.Fatalf("ResolveSessionForTrackerAuth: %v", err)
+	}
+	if !postedCanonicalLogin {
+		t.Fatal("expected login POST on redirected host")
+	}
+	got, err := loadMTVCookies(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("loadMTVCookies: %v", err)
+	}
+	if got["session"] != "fresh" {
+		t.Fatalf("expected saved redirected-login cookies, got %#v", got)
+	}
+}
+
 func TestResolveSessionForTrackerAuthRejectsEmptyLoginCookiesWithoutReplacingStoredCookies(t *testing.T) {
 	t.Parallel()
 
@@ -149,15 +260,12 @@ func TestResolveSessionForTrackerAuthLoginUsesManual2FACode(t *testing.T) {
 	ctx := context.Background()
 	dbPath := newMTVAuthDB(t)
 	var gotCode string
-	twoFACompleted := false
+	indexRequests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/index.php":
-			if !twoFACompleted {
-				_, _ = w.Write([]byte(`<html>logged out</html>`))
-				return
-			}
-			_, _ = w.Write([]byte(`authkey=abcdefghijklmnopqrstuvwxyzABCDEF`))
+			indexRequests++
+			_, _ = w.Write([]byte(`<html>logged out</html>`))
 		case "/login":
 			if r.Method == http.MethodGet {
 				_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
@@ -173,9 +281,8 @@ func TestResolveSessionForTrackerAuthLoginUsesManual2FACode(t *testing.T) {
 				t.Fatalf("ParseForm: %v", err)
 			}
 			gotCode = r.FormValue("code")
-			twoFACompleted = true
 			http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
-			_, _ = w.Write([]byte(`<html>ok</html>`))
+			_, _ = w.Write([]byte(`authkey=abcdefghijklmnopqrstuvwxyzABCDEF`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -192,6 +299,9 @@ func TestResolveSessionForTrackerAuthLoginUsesManual2FACode(t *testing.T) {
 	}
 	if gotCode != "654321" {
 		t.Fatalf("expected manual 2FA code, got %q", gotCode)
+	}
+	if indexRequests != 0 {
+		t.Fatalf("expected 2FA response authkey to avoid index lookup, got %d", indexRequests)
 	}
 	got, err := loadMTVCookies(ctx, dbPath)
 	if err != nil {
@@ -240,12 +350,55 @@ func TestResolveSessionForTrackerAuthLoginMarksSubmitted2FAAuthKeyMiss(t *testin
 	if !errors.Is(err, ErrSubmitted2FARejected) {
 		t.Fatalf("expected submitted 2FA rejection marker, got %v", err)
 	}
+	if !strings.Contains(err.Error(), "final_path=/twofactor/login status=200") || !strings.Contains(err.Error(), "path=/index.php status=200") {
+		t.Fatalf("expected safe path/status diagnostics, got %v", err)
+	}
 	got, loadErr := loadMTVCookies(ctx, dbPath)
 	if loadErr != nil {
 		t.Fatalf("loadMTVCookies: %v", loadErr)
 	}
 	if got["session"] != "existing" {
 		t.Fatalf("submitted 2FA rejection must preserve stored cookies, got %#v", got)
+	}
+}
+
+func TestResolveSessionForTrackerAuthLoginReportsSafeAuthKeyDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newMTVAuthDB(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
+				return
+			}
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
+			_, _ = w.Write([]byte(`<html>login accepted but no upload token secret-response-body</html>`))
+		case "/index.php":
+			_, _ = w.Write([]byte(`<html>logged in but no upload token other-secret-body</html>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuthLogin(ctx, config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath, api.TrackerAuthLoginRequest{})
+	if !errors.Is(err, errMTVAuthKeyNotFound) {
+		t.Fatalf("expected auth key miss, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "final_path=/login status=200") || !strings.Contains(err.Error(), "path=/index.php status=200") {
+		t.Fatalf("expected path/status diagnostics, got %v", err)
+	}
+	for _, secret := range []string{"secret-response-body", "other-secret-body"} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("diagnostic leaked response body %q: %v", secret, err)
+		}
 	}
 }
 

--- a/internal/trackers/impl/mtv/upload_test.go
+++ b/internal/trackers/impl/mtv/upload_test.go
@@ -162,6 +162,58 @@ func TestResolveSessionForTrackerAuthSavesCookiesWhenLoginResponseContainsAuthKe
 	}
 }
 
+func TestLoginAndResolveAuthKeyReturnsLoginPageReadError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/login" && r.Method == http.MethodGet:
+			writeMalformedChunkedResponse(t, w)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	_, _, _, _, err := loginAndResolveAuthKey(context.Background(), config.TrackerConfig{
+		Username: "user",
+		Password: "pass",
+	}, server.URL, api.TrackerAuthLoginRequest{})
+	if err == nil {
+		t.Fatal("expected login page read error")
+	}
+	if !strings.Contains(err.Error(), "read login page response") {
+		t.Fatalf("expected login page read-error context, got %v", err)
+	}
+}
+
+func TestLoginAndResolveAuthKeyReturnsLoginPostReadError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/login" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
+		case r.URL.Path == "/login" && r.Method == http.MethodPost:
+			writeMalformedChunkedResponse(t, w)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	_, _, _, _, err := loginAndResolveAuthKey(context.Background(), config.TrackerConfig{
+		Username: "user",
+		Password: "pass",
+	}, server.URL, api.TrackerAuthLoginRequest{})
+	if err == nil {
+		t.Fatal("expected login response read error")
+	}
+	if !strings.Contains(err.Error(), "read login response") {
+		t.Fatalf("expected login response read-error context, got %v", err)
+	}
+}
+
 func TestResolveSessionForTrackerAuthPostsLoginToRedirectedHost(t *testing.T) {
 	t.Parallel()
 
@@ -427,6 +479,59 @@ func TestResolveSessionForTrackerAuthLoginMarksSubmitted2FAAuthKeyMiss(t *testin
 	}
 }
 
+func TestResolveSessionForTrackerAuthLoginReturns2FAReadError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newMTVAuthDB(t)
+	if err := saveMTVCookies(ctx, dbPath, map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("saveMTVCookies: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/index.php":
+			_, _ = w.Write([]byte(`<html>logged out</html>`))
+		case "/login":
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
+				return
+			}
+			http.Redirect(w, r, "/twofactor/login", http.StatusFound)
+		case "/twofactor/login":
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte(`<input name="token" value="ponmlkjihgfedcba">`))
+				return
+			}
+			writeMalformedChunkedResponse(t, w)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuthLogin(ctx, config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath, api.TrackerAuthLoginRequest{Code: "123456"})
+	if err == nil {
+		t.Fatal("expected 2FA response read error")
+	}
+	if errors.Is(err, ErrSubmitted2FARejected) {
+		t.Fatalf("read error must not be classified as submitted 2FA rejection: %v", err)
+	}
+	if !strings.Contains(err.Error(), "read 2FA login response") {
+		t.Fatalf("expected read-error context, got %v", err)
+	}
+	got, loadErr := loadMTVCookies(ctx, dbPath)
+	if loadErr != nil {
+		t.Fatalf("loadMTVCookies: %v", loadErr)
+	}
+	if got["session"] != "existing" {
+		t.Fatalf("2FA read error must preserve stored cookies, got %#v", got)
+	}
+}
+
 func TestResolveSessionForTrackerAuthLoginReportsSafeAuthKeyDiagnostics(t *testing.T) {
 	t.Parallel()
 
@@ -528,4 +633,26 @@ func newMTVAuthDB(t *testing.T) string {
 	}
 	_ = repo.Close()
 	return dbPath
+}
+
+func writeMalformedChunkedResponse(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		t.Fatal("response writer does not support hijacking")
+	}
+	conn, rw, err := hijacker.Hijack()
+	if err != nil {
+		t.Fatalf("hijack response: %v", err)
+	}
+	if _, err := rw.WriteString("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nTransfer-Encoding: chunked\r\n\r\n20\r\npartial"); err != nil {
+		_ = conn.Close()
+		t.Fatalf("write malformed chunked response: %v", err)
+	}
+	if err := rw.Flush(); err != nil {
+		_ = conn.Close()
+		t.Fatalf("flush malformed chunked response: %v", err)
+	}
+	_ = conn.Close()
 }

--- a/internal/trackers/impl/ptp/definition_test.go
+++ b/internal/trackers/impl/ptp/definition_test.go
@@ -277,7 +277,7 @@ func TestResolveUploadTorrentPathReusesPreparedPTPArtifact(t *testing.T) {
 
 func TestDefinitionUploadSuccess(t *testing.T) {
 	tmp := t.TempDir()
-	dbPath := filepath.Join(tmp, "ua.db")
+	dbPath := newPTPAuthDB(t)
 	torrentPath := filepath.Join(tmp, "release.torrent")
 	createTestTorrent(t, filepath.Join(tmp, "source.bin"), torrentPath)
 	markTorrentWithPrivateMetadata(t, torrentPath)

--- a/internal/trackers/impl/ptp/definition_test.go
+++ b/internal/trackers/impl/ptp/definition_test.go
@@ -397,6 +397,61 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 	}
 }
 
+func TestLoginAndFetchAntiCsrfTokenHandles2FA(t *testing.T) {
+	secondLogin := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RequestURI() != ptpLoginPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse login: %v", err)
+		}
+		if r.FormValue("username") != "user" || r.FormValue("password") != "pass" || r.FormValue("passkey") != "passkey" || r.FormValue("keeplogged") != "1" {
+			t.Fatalf("unexpected login form: %v", r.Form)
+		}
+		if r.FormValue("TfaCode") == "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"Result": "TfaRequired"})
+			return
+		}
+		secondLogin = true
+		if r.FormValue("TfaType") != "normal" {
+			t.Fatalf("expected TfaType normal, got %q", r.FormValue("TfaType"))
+		}
+		code := r.FormValue("TfaCode")
+		if len(code) != 6 || strings.Trim(code, "0123456789") != "" {
+			t.Fatalf("expected six digit TfaCode, got %q", code)
+		}
+		http.SetCookie(w, &http.Cookie{Name: "session", Value: "cookievalue", Path: "/"})
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"Result":        "Ok",
+			"AntiCsrfToken": "csrf-token",
+		})
+	}))
+	defer server.Close()
+
+	dbPath := newPTPAuthDB(t)
+	client, token, err := loginAndFetchAntiCsrfToken(context.Background(), config.TrackerConfig{
+		Username:    "user",
+		Password:    "pass",
+		AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+		OTPURI:      "otpauth://totp/PTP:user?secret=JBSWY3DPEHPK3PXP&issuer=PTP",
+	}, dbPath, server.URL, api.NopLogger{}, api.TrackerAuthLoginRequest{})
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if token != "csrf-token" {
+		t.Fatalf("expected csrf token, got %q", token)
+	}
+	if client == nil {
+		t.Fatal("expected authenticated client")
+	}
+	if !secondLogin {
+		t.Fatal("expected second 2FA login request")
+	}
+}
+
 func TestRehostPosterToSelectedHostUploadsPoster(t *testing.T) {
 	tmp := t.TempDir()
 	dbPath := filepath.Join(tmp, "ua.db")

--- a/internal/trackers/impl/ptp/definition_test.go
+++ b/internal/trackers/impl/ptp/definition_test.go
@@ -20,6 +20,7 @@ import (
 	mkbrr "github.com/autobrr/mkbrr/torrent"
 
 	"github.com/autobrr/upbrr/internal/config"
+	servicedb "github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -392,7 +393,11 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 	if _, err := os.Stat(artifactPath); err != nil {
 		t.Fatalf("expected tracker torrent file: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(tmp, "cookies", ptpCookieFile)); !os.IsNotExist(err) {
+	legacyCookiePath, err := servicedb.CookiePath(dbPath, ptpCookieFile)
+	if err != nil {
+		t.Fatalf("resolve legacy PTP cookie path: %v", err)
+	}
+	if _, err := os.Stat(legacyCookiePath); !os.IsNotExist(err) {
 		t.Fatalf("expected no legacy PTP cookie file after upload, got err=%v", err)
 	}
 }

--- a/internal/trackers/impl/ptp/upload.go
+++ b/internal/trackers/impl/ptp/upload.go
@@ -684,11 +684,14 @@ func resolveSession(ctx context.Context, trackerConfig config.TrackerConfig, dbP
 		if tokenErr == nil {
 			return client, token, nil
 		}
-		_ = cookiepkg.DeleteTrackerCookies(ctx, dbPath, "PTP")
+		if strings.TrimSpace(trackerConfig.Username) == "" || strings.TrimSpace(trackerConfig.Password) == "" || strings.TrimSpace(normalizedAnnounceURL(trackerConfig.AnnounceURL)) == "" {
+			return nil, "", tokenErr
+		}
 	}
 	return loginAndFetchAntiCsrfToken(ctx, trackerConfig, dbPath, baseURL, logger)
 }
 
+// ResolveSessionForTrackerAuth validates PTP stored cookies or logs in with configured credentials and saves refreshed cookies.
 func ResolveSessionForTrackerAuth(ctx context.Context, trackerConfig config.TrackerConfig, dbPath string) error {
 	baseURL := strings.TrimRight(strings.TrimSpace(trackerConfig.URL), "/")
 	if baseURL == "" {
@@ -923,7 +926,10 @@ func resolveFailurePath(meta api.PreparedMetadata, dbPath string) (string, error
 
 func loadCookies(ctx context.Context, dbPath string) (map[string]string, error) {
 	values, err := cookiepkg.LoadTrackerCookieMap(ctx, dbPath, "PTP")
-	return values, fmt.Errorf("trackers: %w", err)
+	if err != nil {
+		return nil, fmt.Errorf("trackers: %w", err)
+	}
+	return values, nil
 }
 
 func saveCookies(ctx context.Context, dbPath string, client *http.Client, baseURL string) error {

--- a/internal/trackers/impl/ptp/upload.go
+++ b/internal/trackers/impl/ptp/upload.go
@@ -689,6 +689,15 @@ func resolveSession(ctx context.Context, trackerConfig config.TrackerConfig, dbP
 	return loginAndFetchAntiCsrfToken(ctx, trackerConfig, dbPath, baseURL, logger)
 }
 
+func ResolveSessionForTrackerAuth(ctx context.Context, trackerConfig config.TrackerConfig, dbPath string) error {
+	baseURL := strings.TrimRight(strings.TrimSpace(trackerConfig.URL), "/")
+	if baseURL == "" {
+		baseURL = ptpBaseURL
+	}
+	_, _, err := resolveSession(ctx, trackerConfig, dbPath, baseURL, api.NopLogger{})
+	return err
+}
+
 func fetchAntiCsrfToken(ctx context.Context, baseURL string, cookies map[string]string) (*http.Client, string, error) {
 	jar, err := cookiejar.New(nil)
 	if err != nil {

--- a/internal/trackers/impl/ptp/upload.go
+++ b/internal/trackers/impl/ptp/upload.go
@@ -70,6 +70,10 @@ var (
 	}
 )
 
+// ErrSubmitted2FARejected marks a PTP failure after a submitted manual 2FA code
+// reached the tracker and was rejected.
+var ErrSubmitted2FARejected = errors.New("trackers: PTP submitted 2FA rejected")
+
 type uploadState struct {
 	baseURL     string
 	uploadURL   string
@@ -674,6 +678,10 @@ func buildUploadFields(meta api.PreparedMetadata, description string, groupID st
 }
 
 func resolveSession(ctx context.Context, trackerConfig config.TrackerConfig, dbPath string, baseURL string, logger api.Logger) (*http.Client, string, error) {
+	return resolveSessionLogin(ctx, trackerConfig, dbPath, baseURL, logger, api.TrackerAuthLoginRequest{})
+}
+
+func resolveSessionLogin(ctx context.Context, trackerConfig config.TrackerConfig, dbPath string, baseURL string, logger api.Logger, login api.TrackerAuthLoginRequest) (*http.Client, string, error) {
 	if logger == nil {
 		logger = api.NopLogger{}
 	}
@@ -688,18 +696,28 @@ func resolveSession(ctx context.Context, trackerConfig config.TrackerConfig, dbP
 			return nil, "", tokenErr
 		}
 	}
-	return loginAndFetchAntiCsrfToken(ctx, trackerConfig, dbPath, baseURL, logger)
+	return loginAndFetchAntiCsrfToken(ctx, trackerConfig, dbPath, baseURL, logger, login)
 }
 
 // ResolveSessionForTrackerAuth validates PTP stored cookies or logs in with
 // configured credentials. Credential login must produce an anti-CSRF token
 // before refreshed cookies are persisted.
 func ResolveSessionForTrackerAuth(ctx context.Context, trackerConfig config.TrackerConfig, dbPath string) error {
+	return ResolveSessionForTrackerAuthLogin(ctx, trackerConfig, dbPath, api.TrackerAuthLoginRequest{})
+}
+
+// ResolveSessionForTrackerAuthLogin validates PTP stored cookies or logs in
+// with configured credentials. When PTP requires 2FA, login.Code is used before
+// falling back to the configured OTP URI; if neither yields a code, the error
+// is returned before stored cookies are replaced. A rejected submitted code
+// returns [ErrSubmitted2FARejected] with the login-failed error before refreshed
+// cookies are persisted.
+func ResolveSessionForTrackerAuthLogin(ctx context.Context, trackerConfig config.TrackerConfig, dbPath string, login api.TrackerAuthLoginRequest) error {
 	baseURL := strings.TrimRight(strings.TrimSpace(trackerConfig.URL), "/")
 	if baseURL == "" {
 		baseURL = ptpBaseURL
 	}
-	_, _, err := resolveSession(ctx, trackerConfig, dbPath, baseURL, api.NopLogger{})
+	_, _, err := resolveSessionLogin(ctx, trackerConfig, dbPath, baseURL, api.NopLogger{}, login)
 	return err
 }
 
@@ -729,7 +747,7 @@ func fetchAntiCsrfToken(ctx context.Context, baseURL string, cookies map[string]
 	return client, token, nil
 }
 
-func loginAndFetchAntiCsrfToken(ctx context.Context, trackerConfig config.TrackerConfig, dbPath string, baseURL string, _ api.Logger) (*http.Client, string, error) {
+func loginAndFetchAntiCsrfToken(ctx context.Context, trackerConfig config.TrackerConfig, dbPath string, baseURL string, _ api.Logger, login api.TrackerAuthLoginRequest) (*http.Client, string, error) {
 	username := strings.TrimSpace(trackerConfig.Username)
 	password := strings.TrimSpace(trackerConfig.Password)
 	announceURL := normalizedAnnounceURL(trackerConfig.AnnounceURL)
@@ -771,7 +789,7 @@ func loginAndFetchAntiCsrfToken(ctx context.Context, trackerConfig config.Tracke
 	switch strings.TrimSpace(stringFromAny(payload["Result"])) {
 	case "Ok":
 	case "TfaRequired":
-		code, codeErr := resolve2FACode(trackerConfig.OTPURI)
+		code, codeErr := resolvePTP2FACode(trackerConfig, login)
 		if codeErr != nil {
 			return nil, "", fmt.Errorf("trackers: PTP 2FA required: %w", codeErr)
 		}
@@ -793,7 +811,7 @@ func loginAndFetchAntiCsrfToken(ctx context.Context, trackerConfig config.Tracke
 			return nil, "", fmt.Errorf("trackers: PTP 2FA decode: %w", err)
 		}
 		if strings.TrimSpace(stringFromAny(payload["Result"])) != "Ok" {
-			return nil, "", errors.New("trackers: PTP login failed")
+			return nil, "", fmt.Errorf("trackers: PTP login failed: %w", ErrSubmitted2FARejected)
 		}
 	default:
 		return nil, "", errors.New("trackers: PTP login failed")
@@ -807,6 +825,15 @@ func loginAndFetchAntiCsrfToken(ctx context.Context, trackerConfig config.Tracke
 		return nil, "", fmt.Errorf("trackers: PTP persist login cookies: %w", err)
 	}
 	return client, token, nil
+}
+
+// resolvePTP2FACode prefers a submitted manual code so users can continue a
+// browser-visible challenge when no reusable OTP URI is configured.
+func resolvePTP2FACode(trackerConfig config.TrackerConfig, login api.TrackerAuthLoginRequest) (string, error) {
+	if code := strings.TrimSpace(login.Code); code != "" {
+		return code, nil
+	}
+	return resolve2FACode(trackerConfig.OTPURI)
 }
 
 func requestAntiCsrfToken(ctx context.Context, client *http.Client, baseURL string) (string, error) {

--- a/internal/trackers/impl/ptp/upload.go
+++ b/internal/trackers/impl/ptp/upload.go
@@ -691,7 +691,9 @@ func resolveSession(ctx context.Context, trackerConfig config.TrackerConfig, dbP
 	return loginAndFetchAntiCsrfToken(ctx, trackerConfig, dbPath, baseURL, logger)
 }
 
-// ResolveSessionForTrackerAuth validates PTP stored cookies or logs in with configured credentials and saves refreshed cookies.
+// ResolveSessionForTrackerAuth validates PTP stored cookies or logs in with
+// configured credentials. Credential login must produce an anti-CSRF token
+// before refreshed cookies are persisted.
 func ResolveSessionForTrackerAuth(ctx context.Context, trackerConfig config.TrackerConfig, dbPath string) error {
 	baseURL := strings.TrimRight(strings.TrimSpace(trackerConfig.URL), "/")
 	if baseURL == "" {
@@ -727,11 +729,7 @@ func fetchAntiCsrfToken(ctx context.Context, baseURL string, cookies map[string]
 	return client, token, nil
 }
 
-func loginAndFetchAntiCsrfToken(ctx context.Context, trackerConfig config.TrackerConfig, dbPath string, baseURL string, logger api.Logger) (*http.Client, string, error) {
-	if logger == nil {
-		logger = api.NopLogger{}
-	}
-
+func loginAndFetchAntiCsrfToken(ctx context.Context, trackerConfig config.TrackerConfig, dbPath string, baseURL string, _ api.Logger) (*http.Client, string, error) {
 	username := strings.TrimSpace(trackerConfig.Username)
 	password := strings.TrimSpace(trackerConfig.Password)
 	announceURL := normalizedAnnounceURL(trackerConfig.AnnounceURL)
@@ -801,12 +799,12 @@ func loginAndFetchAntiCsrfToken(ctx context.Context, trackerConfig config.Tracke
 		return nil, "", errors.New("trackers: PTP login failed")
 	}
 
-	if err := saveCookies(ctx, dbPath, client, baseURL); err != nil {
-		logger.Warnf("trackers: PTP failed to persist login cookies: %v", err)
-	}
 	token := strings.TrimSpace(stringFromAny(payload["AntiCsrfToken"]))
 	if token == "" {
 		return nil, "", errors.New("trackers: PTP login missing anti csrf token")
+	}
+	if err := saveCookies(ctx, dbPath, client, baseURL); err != nil {
+		return nil, "", fmt.Errorf("trackers: PTP persist login cookies: %w", err)
 	}
 	return client, token, nil
 }
@@ -934,7 +932,7 @@ func loadCookies(ctx context.Context, dbPath string) (map[string]string, error) 
 
 func saveCookies(ctx context.Context, dbPath string, client *http.Client, baseURL string) error {
 	if client == nil || client.Jar == nil {
-		return nil
+		return errors.New("trackers: PTP login returned no cookie jar")
 	}
 	parsed, err := url.Parse(baseURL)
 	if err != nil {
@@ -945,10 +943,13 @@ func saveCookies(ctx context.Context, dbPath string, client *http.Client, baseUR
 		if cookie == nil || strings.TrimSpace(cookie.Name) == "" {
 			continue
 		}
-		cookies[strings.TrimSpace(cookie.Name)] = strings.TrimSpace(cookie.Value)
+		if strings.TrimSpace(cookie.Value) == "" {
+			continue
+		}
+		cookies[strings.TrimSpace(cookie.Name)] = cookie.Value
 	}
 	if len(cookies) == 0 {
-		return nil
+		return errors.New("trackers: PTP login returned no usable cookies")
 	}
 	return wrapTrackerError(cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "PTP", cookies))
 }
@@ -1359,6 +1360,8 @@ func compactError(value string) string {
 
 func stringFromAny(value any) string {
 	switch typed := value.(type) {
+	case nil:
+		return ""
 	case string:
 		return strings.TrimSpace(typed)
 	case float64:

--- a/internal/trackers/impl/ptp/upload_test.go
+++ b/internal/trackers/impl/ptp/upload_test.go
@@ -1,71 +1,71 @@
 // Copyright (c) 2025-2026, Audionut and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-package mtv
+package ptp
 
 import (
 	"context"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/authmaterial"
 	"github.com/autobrr/upbrr/internal/config"
+	cookiepkg "github.com/autobrr/upbrr/internal/cookies"
 	servicedb "github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-func TestResolveGroupDescriptionSkipsTVDBForMovie(t *testing.T) {
-	got := resolveGroupDescription(api.PreparedMetadata{
-		MediaInfoCategory: "TV",
-		ExternalIDs:       api.ExternalIDs{Category: "MOVIE", TVDBID: 456},
-	})
-	if strings.Contains(got, "thetvdb.com") {
-		t.Fatalf("did not expect tvdb link for movie description, got %q", got)
-	}
-}
-
-func TestResolveGroupDescriptionIncludesTVDBForTV(t *testing.T) {
-	got := resolveGroupDescription(api.PreparedMetadata{
-		ExternalIDs: api.ExternalIDs{Category: "TV", TVDBID: 456},
-	})
-	if !strings.Contains(got, "thetvdb.com/?id=456") {
-		t.Fatalf("expected tvdb link for TV description, got %q", got)
-	}
-}
-
-func TestResolveSessionForTrackerAuthPreservesCookiesOnTransientAuthFetch(t *testing.T) {
+func TestLoadCookiesSuccessReturnsNilError(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	dbPath := newMTVAuthDB(t)
-	if err := saveMTVCookies(ctx, dbPath, map[string]string{"session": "abc"}); err != nil {
-		t.Fatalf("saveMTVCookies: %v", err)
+	dbPath := newPTPAuthDB(t)
+	if err := cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "PTP", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+
+	got, err := loadCookies(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("loadCookies: %v", err)
+	}
+	if got["session"] != "abc" {
+		t.Fatalf("unexpected cookies: %#v", got)
+	}
+}
+
+func TestResolveSessionForTrackerAuthPreservesCookiesOnTransientTokenFetch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newPTPAuthDB(t)
+	if err := cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "PTP", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	baseURL := server.URL
 	server.Close()
 
 	err := ResolveSessionForTrackerAuth(ctx, config.TrackerConfig{
-		URL:      baseURL,
-		Username: "user",
-		Password: "pass",
+		URL:         baseURL,
+		Username:    "user",
+		Password:    "pass",
+		AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
 	}, dbPath)
 	if err == nil {
-		t.Fatal("expected transient auth fetch error")
+		t.Fatal("expected transient token fetch error")
 	}
-	got, loadErr := loadMTVCookies(ctx, dbPath)
+	got, loadErr := loadCookies(ctx, dbPath)
 	if loadErr != nil {
-		t.Fatalf("loadMTVCookies after transient error: %v", loadErr)
+		t.Fatalf("loadCookies after transient error: %v", loadErr)
 	}
 	if got["session"] != "abc" {
 		t.Fatalf("expected transient failure to preserve cookies, got %#v", got)
 	}
 }
 
-func newMTVAuthDB(t *testing.T) string {
+func newPTPAuthDB(t *testing.T) string {
 	t.Helper()
 
 	ctx := context.Background()

--- a/internal/trackers/impl/ptp/upload_test.go
+++ b/internal/trackers/impl/ptp/upload_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/authmaterial"
@@ -62,6 +63,147 @@ func TestResolveSessionForTrackerAuthPreservesCookiesOnTransientTokenFetch(t *te
 	}
 	if got["session"] != "abc" {
 		t.Fatalf("expected transient failure to preserve cookies, got %#v", got)
+	}
+}
+
+func TestLoginAndFetchAntiCsrfTokenReturnsPersistenceError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ajax.php" || r.URL.RawQuery != "action=login" {
+			http.NotFound(w, r)
+			return
+		}
+		http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
+		_, _ = w.Write([]byte(`{"Result":"Ok","AntiCsrfToken":"token"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, _, err := resolveSession(context.Background(), config.TrackerConfig{
+		URL:         server.URL,
+		Username:    "user",
+		Password:    "pass",
+		AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+	}, filepath.Join(t.TempDir(), "upbrr.db"), server.URL, api.NopLogger{})
+	if err == nil {
+		t.Fatal("expected persistence error")
+	}
+	if !strings.Contains(err.Error(), "persist login cookies") {
+		t.Fatalf("expected persistence error, got %v", err)
+	}
+}
+
+func TestLoginAndFetchAntiCsrfTokenDoesNotOverwriteCookiesWhenTokenMissing(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newPTPAuthDB(t)
+	if err := cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "PTP", map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == ptpUploadPath {
+			_, _ = w.Write([]byte("<html>logged out</html>"))
+			return
+		}
+		if r.URL.Path != "/ajax.php" || r.URL.RawQuery != "action=login" {
+			http.NotFound(w, r)
+			return
+		}
+		http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
+		_, _ = w.Write([]byte(`{"Result":"Ok"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, _, err := resolveSession(ctx, config.TrackerConfig{
+		URL:         server.URL,
+		Username:    "user",
+		Password:    "pass",
+		AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+	}, dbPath, server.URL, api.NopLogger{})
+	if err == nil {
+		t.Fatal("expected missing token error")
+	}
+	values, err := loadCookies(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("loadCookies: %v", err)
+	}
+	if values["session"] != "existing" {
+		t.Fatalf("missing token must not overwrite stored cookies, got %#v", values)
+	}
+}
+
+func TestLoginAndFetchAntiCsrfTokenPersistsCookiesAfterTokenGate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newPTPAuthDB(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ajax.php" || r.URL.RawQuery != "action=login" {
+			http.NotFound(w, r)
+			return
+		}
+		http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
+		_, _ = w.Write([]byte(`{"Result":"Ok","AntiCsrfToken":"token"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, token, err := resolveSession(ctx, config.TrackerConfig{
+		URL:         server.URL,
+		Username:    "user",
+		Password:    "pass",
+		AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+	}, dbPath, server.URL, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("resolveSession: %v", err)
+	}
+	if token != "token" {
+		t.Fatalf("unexpected token %q", token)
+	}
+	values, err := loadCookies(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("loadCookies: %v", err)
+	}
+	if values["session"] != "new" {
+		t.Fatalf("expected saved login cookies, got %#v", values)
+	}
+}
+
+func TestLoginAndFetchAntiCsrfTokenRejectsEmptyJarWithoutReplacingCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newPTPAuthDB(t)
+	if err := cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "PTP", map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == ptpUploadPath:
+			_, _ = w.Write([]byte("<html>logged out</html>"))
+		case r.URL.Path == "/ajax.php" && r.URL.RawQuery == "action=login":
+			_, _ = w.Write([]byte(`{"Result":"Ok","AntiCsrfToken":"token"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	_, _, err := resolveSession(ctx, config.TrackerConfig{
+		URL:         server.URL,
+		Username:    "user",
+		Password:    "pass",
+		AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+	}, dbPath, server.URL, api.NopLogger{})
+	if err == nil || !strings.Contains(err.Error(), "no usable cookies") {
+		t.Fatalf("expected empty cookie jar error, got %v", err)
+	}
+	values, err := loadCookies(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("loadCookies: %v", err)
+	}
+	if values["session"] != "existing" {
+		t.Fatalf("empty login jar must preserve stored cookies, got %#v", values)
 	}
 }
 

--- a/internal/trackers/impl/ptp/upload_test.go
+++ b/internal/trackers/impl/ptp/upload_test.go
@@ -5,6 +5,7 @@ package ptp
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -204,6 +205,171 @@ func TestLoginAndFetchAntiCsrfTokenRejectsEmptyJarWithoutReplacingCookies(t *tes
 	}
 	if values["session"] != "existing" {
 		t.Fatalf("empty login jar must preserve stored cookies, got %#v", values)
+	}
+}
+
+func TestResolveSessionForTrackerAuthLoginUsesManual2FACode(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newPTPAuthDB(t)
+	var gotCode string
+	loginRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ajax.php" || r.URL.RawQuery != "action=login" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		loginRequests++
+		if loginRequests == 1 {
+			_, _ = w.Write([]byte(`{"Result":"TfaRequired"}`))
+			return
+		}
+		gotCode = r.FormValue("TfaCode")
+		http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
+		_, _ = w.Write([]byte(`{"Result":"Ok","AntiCsrfToken":"token"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuthLogin(ctx, config.TrackerConfig{
+		URL:         server.URL,
+		Username:    "user",
+		Password:    "pass",
+		AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+	}, dbPath, api.TrackerAuthLoginRequest{Code: "654321"})
+	if err != nil {
+		t.Fatalf("ResolveSessionForTrackerAuthLogin: %v", err)
+	}
+	if gotCode != "654321" {
+		t.Fatalf("expected manual 2FA code, got %q", gotCode)
+	}
+	values, err := loadCookies(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("loadCookies: %v", err)
+	}
+	if values["session"] != "new" {
+		t.Fatalf("expected saved 2FA login cookies, got %#v", values)
+	}
+}
+
+func TestResolveSessionForTrackerAuthLoginMarksSubmitted2FARejected(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newPTPAuthDB(t)
+	if err := cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "PTP", map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	loginRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ajax.php" || r.URL.RawQuery != "action=login" {
+			http.NotFound(w, r)
+			return
+		}
+		loginRequests++
+		if loginRequests == 1 {
+			_, _ = w.Write([]byte(`{"Result":"TfaRequired"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"Result":"Invalid"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuthLogin(ctx, config.TrackerConfig{
+		URL:         server.URL,
+		Username:    "user",
+		Password:    "pass",
+		AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+	}, dbPath, api.TrackerAuthLoginRequest{Code: "000000"})
+	if !errors.Is(err, ErrSubmitted2FARejected) {
+		t.Fatalf("expected submitted 2FA rejection marker, got %v", err)
+	}
+	values, err := loadCookies(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("loadCookies: %v", err)
+	}
+	if values["session"] != "existing" {
+		t.Fatalf("submitted 2FA rejection must preserve stored cookies, got %#v", values)
+	}
+}
+
+func TestResolveSessionForTrackerAuthLoginPreCodeFailureIsNotSubmitted2FARejected(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newPTPAuthDB(t)
+	if err := cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "PTP", map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ajax.php" || r.URL.RawQuery != "action=login" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"Result":"Invalid"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuthLogin(ctx, config.TrackerConfig{
+		URL:         server.URL,
+		Username:    "user",
+		Password:    "pass",
+		AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+	}, dbPath, api.TrackerAuthLoginRequest{Code: "000000"})
+	if err == nil || !strings.Contains(err.Error(), "login failed") {
+		t.Fatalf("expected pre-code login failed error, got %v", err)
+	}
+	if errors.Is(err, ErrSubmitted2FARejected) {
+		t.Fatalf("pre-code login failure must not carry submitted 2FA marker: %v", err)
+	}
+	values, err := loadCookies(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("loadCookies: %v", err)
+	}
+	if values["session"] != "existing" {
+		t.Fatalf("pre-code login failure must preserve stored cookies, got %#v", values)
+	}
+}
+
+func TestResolveSessionForTrackerAuthLoginMissing2FACodePreservesCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newPTPAuthDB(t)
+	if err := cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "PTP", map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == ptpUploadPath:
+			_, _ = w.Write([]byte("<html>logged out</html>"))
+		case r.URL.Path == "/ajax.php" && r.URL.RawQuery == "action=login":
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
+			_, _ = w.Write([]byte(`{"Result":"TfaRequired"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuthLogin(ctx, config.TrackerConfig{
+		URL:         server.URL,
+		Username:    "user",
+		Password:    "pass",
+		AnnounceURL: "https://please.passthepopcorn.me/passkey/announce",
+	}, dbPath, api.TrackerAuthLoginRequest{})
+	if err == nil || !strings.Contains(err.Error(), "2FA required") {
+		t.Fatalf("expected missing 2FA error, got %v", err)
+	}
+	values, err := loadCookies(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("loadCookies: %v", err)
+	}
+	if values["session"] != "existing" {
+		t.Fatalf("missing 2FA code must preserve stored cookies, got %#v", values)
 	}
 }
 

--- a/internal/trackers/impl/rtf/upload.go
+++ b/internal/trackers/impl/rtf/upload.go
@@ -11,21 +11,25 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
+	servicedb "github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
 const (
-	uploadURL  = "https://retroflix.club/api/upload"
-	browseURL  = "https://retroflix.club/browse/t/"
-	sourceFlag = "sunshine"
+	defaultBaseURL = "https://retroflix.club"
+	sourceFlag     = "sunshine"
 )
+
+var newHTTPClient = func() *http.Client { return &http.Client{Timeout: 40 * time.Second} }
 
 type uploadResponse struct {
 	Error   bool   `json:"error"`
@@ -44,6 +48,11 @@ type uploadState struct {
 }
 
 func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary, error) {
+	apiKey, err := resolveAPIKey(ctx, req)
+	if err != nil {
+		return api.UploadSummary{}, err
+	}
+
 	state, err := prepareUploadState(ctx, req)
 	if err != nil {
 		return api.UploadSummary{}, err
@@ -56,15 +65,16 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if err != nil {
 		return api.UploadSummary{}, fmt.Errorf("trackers: RTF marshal upload payload: %w", err)
 	}
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, strings.NewReader(string(body)))
+	baseURL := resolveBaseURL(req.TrackerConfig)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, joinURL(baseURL, "/api/upload"), strings.NewReader(string(body)))
 	if err != nil {
 		return api.UploadSummary{}, fmt.Errorf("trackers: RTF create upload request: %w", err)
 	}
 	httpReq.Header.Set("Accept", "application/json")
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", strings.TrimSpace(req.TrackerConfig.APIKey))
+	httpReq.Header.Set("Authorization", apiKey)
 
-	resp, err := (&http.Client{Timeout: 40 * time.Second}).Do(httpReq)
+	resp, err := newHTTPClient().Do(httpReq)
 	if err != nil {
 		return api.UploadSummary{}, fmt.Errorf("trackers: RTF upload request: %w", err)
 	}
@@ -78,7 +88,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		if id == "" {
 			return api.UploadSummary{}, errors.New("trackers: RTF upload succeeded but torrent id missing")
 		}
-		tURL := browseURL + id
+		tURL := joinURL(baseURL, "/browse/t/") + id
 		artifactPath := ""
 		if announce := strings.TrimSpace(req.TrackerConfig.AnnounceURL); announce != "" {
 			artifactPath, err = trackers.ResolveTrackerTorrentArtifactPath(req.Meta, req.AppConfig.MainSettings.DBPath, "RTF")
@@ -95,7 +105,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 				Tracker:     "RTF",
 				TorrentID:   id,
 				TorrentURL:  tURL,
-				DownloadURL: "https://retroflix.club/api/torrent/" + id + "/download",
+				DownloadURL: joinURL(baseURL, "/api/torrent/") + id + "/download",
 				TorrentPath: artifactPath,
 			}},
 		}, nil
@@ -127,15 +137,15 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 		ReleaseName:      state.releaseName,
 		DescriptionGroup: "rtf",
 		Description:      state.description,
-		Endpoint:         uploadURL,
+		Endpoint:         joinURL(resolveBaseURL(req.TrackerConfig), "/api/upload"),
 		Payload:          payload,
 		Files:            []api.TrackerDryRunFile{{Field: "file", Path: state.torrentPath, Present: strings.TrimSpace(state.torrentPath) != ""}},
 	}, nil
 }
 
 func prepareUploadState(ctx context.Context, req trackers.UploadRequest) (uploadState, error) {
-	if strings.TrimSpace(req.TrackerConfig.APIKey) == "" {
-		return uploadState{}, errors.New("trackers: RTF missing api_key")
+	if strings.TrimSpace(req.TrackerConfig.APIKey) == "" && (strings.TrimSpace(req.TrackerConfig.Username) == "" || strings.TrimSpace(req.TrackerConfig.Password) == "") {
+		return uploadState{}, errors.New("trackers: RTF missing api_key or username/password")
 	}
 	torrentPath, err := trackers.ResolveUploadTorrentPath(req.Meta, req.AppConfig.MainSettings.DBPath)
 	if err != nil {
@@ -177,6 +187,138 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest) (upload
 		payload:       payload,
 		blockedReason: validateEligibility(req.Meta),
 	}, nil
+}
+
+func resolveAPIKey(ctx context.Context, req trackers.UploadRequest) (string, error) {
+	apiKey := strings.TrimSpace(req.TrackerConfig.APIKey)
+	baseURL := resolveBaseURL(req.TrackerConfig)
+	if apiKey != "" {
+		valid, err := testAPIKey(ctx, baseURL, apiKey)
+		if err == nil && valid {
+			return apiKey, nil
+		}
+		if strings.TrimSpace(req.TrackerConfig.Username) == "" || strings.TrimSpace(req.TrackerConfig.Password) == "" {
+			if err != nil {
+				return "", fmt.Errorf("trackers: RTF API key validation failed and username/password not configured: %w", err)
+			}
+			return "", errors.New("trackers: RTF API key invalid and username/password not configured")
+		}
+	}
+	if strings.TrimSpace(req.TrackerConfig.Username) == "" || strings.TrimSpace(req.TrackerConfig.Password) == "" {
+		return "", errors.New("trackers: RTF missing api_key or username/password")
+	}
+	refreshed, err := refreshAPIKey(ctx, baseURL, req.TrackerConfig)
+	if err != nil {
+		return "", err
+	}
+	if err := persistRefreshedAPIKey(ctx, req.AppConfig.MainSettings.DBPath, refreshed); err != nil && req.Logger != nil {
+		req.Logger.Warnf("trackers: RTF failed to persist refreshed API key: %v", err)
+	}
+	return refreshed, nil
+}
+
+func testAPIKey(ctx context.Context, baseURL string, apiKey string) (bool, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, joinURL(baseURL, "/api/test"), nil)
+	if err != nil {
+		return false, fmt.Errorf("trackers: RTF create API test request: %w", err)
+	}
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("Authorization", strings.TrimSpace(apiKey))
+	resp, err := newHTTPClient().Do(httpReq)
+	if err != nil {
+		return false, fmt.Errorf("trackers: RTF API test request: %w", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK, nil
+}
+
+func refreshAPIKey(ctx context.Context, baseURL string, cfg config.TrackerConfig) (string, error) {
+	payload := map[string]string{
+		"username": strings.TrimSpace(cfg.Username),
+		"password": strings.TrimSpace(cfg.Password),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("trackers: RTF marshal API login payload: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, joinURL(baseURL, "/api/login"), strings.NewReader(string(body)))
+	if err != nil {
+		return "", fmt.Errorf("trackers: RTF create API login request: %w", err)
+	}
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := newHTTPClient().Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("trackers: RTF API login request: %w", err)
+	}
+	defer resp.Body.Close()
+	responseBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("trackers: RTF API login failed status=%d", resp.StatusCode)
+	}
+	var decoded struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(responseBody, &decoded); err != nil {
+		return "", fmt.Errorf("trackers: RTF decode API login response: %w", err)
+	}
+	token := strings.TrimSpace(decoded.Token)
+	if token == "" {
+		return "", errors.New("trackers: RTF API login response missing token")
+	}
+	return token, nil
+}
+
+func persistRefreshedAPIKey(ctx context.Context, dbPath string, token string) error {
+	dbPath = strings.TrimSpace(dbPath)
+	if dbPath == "" {
+		return errors.New("trackers: RTF persist refreshed API key: db path not configured")
+	}
+	repo, err := servicedb.OpenContext(ctx, dbPath)
+	if err != nil {
+		return fmt.Errorf("trackers: RTF persist refreshed API key open db: %w", err)
+	}
+	defer repo.Close()
+	cfg, err := config.LoadFromDatabase(ctx, repo)
+	if err != nil {
+		return fmt.Errorf("trackers: RTF persist refreshed API key load config: %w", err)
+	}
+	if cfg.Trackers.Trackers == nil {
+		cfg.Trackers.Trackers = map[string]config.TrackerConfig{}
+	}
+	trackerKey := "RTF"
+	for key := range cfg.Trackers.Trackers {
+		if strings.EqualFold(strings.TrimSpace(key), "RTF") {
+			trackerKey = key
+			break
+		}
+	}
+	trackerCfg := cfg.Trackers.Trackers[trackerKey]
+	trackerCfg.APIKey = strings.TrimSpace(token)
+	cfg.Trackers.Trackers[trackerKey] = trackerCfg
+	if err := config.SaveToDatabase(ctx, cfg, repo); err != nil {
+		return fmt.Errorf("trackers: RTF persist refreshed API key: %w", err)
+	}
+	return nil
+}
+
+func resolveBaseURL(cfg config.TrackerConfig) string {
+	if value := strings.TrimRight(strings.TrimSpace(cfg.URL), "/"); value != "" {
+		return value
+	}
+	return defaultBaseURL
+}
+
+func joinURL(baseURL string, path string) string {
+	parsed, err := url.Parse(strings.TrimRight(baseURL, "/") + "/")
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return strings.TrimRight(defaultBaseURL, "/") + path
+	}
+	ref, err := url.Parse(strings.TrimLeft(path, "/"))
+	if err != nil {
+		return strings.TrimRight(baseURL, "/") + path
+	}
+	return parsed.ResolveReference(ref).String()
 }
 
 func buildDescription(assets trackers.DescriptionAssets) string {

--- a/internal/trackers/impl/rtf/upload.go
+++ b/internal/trackers/impl/rtf/upload.go
@@ -48,7 +48,8 @@ type uploadState struct {
 }
 
 func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary, error) {
-	apiKey, err := resolveAPIKey(ctx, req)
+	baseURL := resolveBaseURL(req.TrackerConfig)
+	uploadURL, err := joinURL(baseURL, "/api/upload")
 	if err != nil {
 		return api.UploadSummary{}, err
 	}
@@ -61,14 +62,14 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: RTF %s", state.blockedReason)
 	}
 
+	apiKey, err := resolveAPIKey(ctx, req)
+	if err != nil {
+		return api.UploadSummary{}, err
+	}
+
 	body, err := json.Marshal(state.payload)
 	if err != nil {
 		return api.UploadSummary{}, fmt.Errorf("trackers: RTF marshal upload payload: %w", err)
-	}
-	baseURL := resolveBaseURL(req.TrackerConfig)
-	uploadURL, err := joinURL(baseURL, "/api/upload")
-	if err != nil {
-		return api.UploadSummary{}, err
 	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, strings.NewReader(string(body)))
 	if err != nil {
@@ -205,6 +206,8 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest) (upload
 	}, nil
 }
 
+// resolveAPIKey validates configured RTF API auth and persists a refreshed token when credentials are used.
+// Callers must complete no-upload eligibility gates before invoking it.
 func resolveAPIKey(ctx context.Context, req trackers.UploadRequest) (string, error) {
 	apiKey := strings.TrimSpace(req.TrackerConfig.APIKey)
 	baseURL := resolveBaseURL(req.TrackerConfig)
@@ -233,8 +236,8 @@ func resolveAPIKey(ctx context.Context, req trackers.UploadRequest) (string, err
 	return refreshed, nil
 }
 
-// ResolveSessionForTrackerAuthLogin validates RTF API auth or refreshes the API
-// key with configured credentials for tracker-auth checks.
+// ResolveSessionForTrackerAuthLogin validates RTF API auth or refreshes and
+// persists the API key with configured credentials for tracker-auth checks.
 func ResolveSessionForTrackerAuthLogin(ctx context.Context, cfg config.TrackerConfig, dbPath string, _ api.TrackerAuthLoginRequest) error {
 	apiKey := strings.TrimSpace(cfg.APIKey)
 	baseURL := resolveBaseURL(cfg)

--- a/internal/trackers/impl/rtf/upload.go
+++ b/internal/trackers/impl/rtf/upload.go
@@ -217,6 +217,36 @@ func resolveAPIKey(ctx context.Context, req trackers.UploadRequest) (string, err
 	return refreshed, nil
 }
 
+// ResolveSessionForTrackerAuthLogin validates RTF API auth or refreshes the API
+// key with configured credentials for tracker-auth checks.
+func ResolveSessionForTrackerAuthLogin(ctx context.Context, cfg config.TrackerConfig, dbPath string, _ api.TrackerAuthLoginRequest) error {
+	apiKey := strings.TrimSpace(cfg.APIKey)
+	baseURL := resolveBaseURL(cfg)
+	if apiKey != "" {
+		valid, err := testAPIKey(ctx, baseURL, apiKey)
+		if err == nil && valid {
+			return nil
+		}
+		if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
+			if err != nil {
+				return fmt.Errorf("trackers: RTF API key validation failed and username/password not configured: %w", err)
+			}
+			return errors.New("trackers: RTF API key invalid and username/password not configured")
+		}
+	}
+	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
+		return errors.New("trackers: RTF missing api_key or username/password")
+	}
+	refreshed, err := refreshAPIKey(ctx, baseURL, cfg)
+	if err != nil {
+		return err
+	}
+	if err := persistRefreshedAPIKey(ctx, dbPath, refreshed); err != nil {
+		return err
+	}
+	return nil
+}
+
 func testAPIKey(ctx context.Context, baseURL string, apiKey string) (bool, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, joinURL(baseURL, "/api/test"), nil)
 	if err != nil {

--- a/internal/trackers/impl/rtf/upload.go
+++ b/internal/trackers/impl/rtf/upload.go
@@ -66,7 +66,11 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: RTF marshal upload payload: %w", err)
 	}
 	baseURL := resolveBaseURL(req.TrackerConfig)
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, joinURL(baseURL, "/api/upload"), strings.NewReader(string(body)))
+	uploadURL, err := joinURL(baseURL, "/api/upload")
+	if err != nil {
+		return api.UploadSummary{}, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, strings.NewReader(string(body)))
 	if err != nil {
 		return api.UploadSummary{}, fmt.Errorf("trackers: RTF create upload request: %w", err)
 	}
@@ -88,7 +92,15 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		if id == "" {
 			return api.UploadSummary{}, errors.New("trackers: RTF upload succeeded but torrent id missing")
 		}
-		tURL := joinURL(baseURL, "/browse/t/") + id
+		torrentURL, err := joinURL(baseURL, "/browse/t/")
+		if err != nil {
+			return api.UploadSummary{}, err
+		}
+		downloadURL, err := joinURL(baseURL, "/api/torrent/")
+		if err != nil {
+			return api.UploadSummary{}, err
+		}
+		tURL := torrentURL + id
 		artifactPath := ""
 		if announce := strings.TrimSpace(req.TrackerConfig.AnnounceURL); announce != "" {
 			artifactPath, err = trackers.ResolveTrackerTorrentArtifactPath(req.Meta, req.AppConfig.MainSettings.DBPath, "RTF")
@@ -105,7 +117,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 				Tracker:     "RTF",
 				TorrentID:   id,
 				TorrentURL:  tURL,
-				DownloadURL: joinURL(baseURL, "/api/torrent/") + id + "/download",
+				DownloadURL: downloadURL + id + "/download",
 				TorrentPath: artifactPath,
 			}},
 		}, nil
@@ -130,6 +142,10 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 	for key, value := range state.payload {
 		payload[key] = strings.TrimSpace(fmt.Sprint(value))
 	}
+	endpoint, err := joinURL(resolveBaseURL(req.TrackerConfig), "/api/upload")
+	if err != nil {
+		return api.TrackerDryRunEntry{}, err
+	}
 	return api.TrackerDryRunEntry{
 		Tracker:          "RTF",
 		Status:           status,
@@ -137,7 +153,7 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 		ReleaseName:      state.releaseName,
 		DescriptionGroup: "rtf",
 		Description:      state.description,
-		Endpoint:         joinURL(resolveBaseURL(req.TrackerConfig), "/api/upload"),
+		Endpoint:         endpoint,
 		Payload:          payload,
 		Files:            []api.TrackerDryRunFile{{Field: "file", Path: state.torrentPath, Present: strings.TrimSpace(state.torrentPath) != ""}},
 	}, nil
@@ -248,7 +264,11 @@ func ResolveSessionForTrackerAuthLogin(ctx context.Context, cfg config.TrackerCo
 }
 
 func testAPIKey(ctx context.Context, baseURL string, apiKey string) (bool, error) {
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, joinURL(baseURL, "/api/test"), nil)
+	testURL, err := joinURL(baseURL, "/api/test")
+	if err != nil {
+		return false, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, testURL, nil)
 	if err != nil {
 		return false, fmt.Errorf("trackers: RTF create API test request: %w", err)
 	}
@@ -271,7 +291,11 @@ func refreshAPIKey(ctx context.Context, baseURL string, cfg config.TrackerConfig
 	if err != nil {
 		return "", fmt.Errorf("trackers: RTF marshal API login payload: %w", err)
 	}
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, joinURL(baseURL, "/api/login"), strings.NewReader(string(body)))
+	loginURL, err := joinURL(baseURL, "/api/login")
+	if err != nil {
+		return "", err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, loginURL, strings.NewReader(string(body)))
 	if err != nil {
 		return "", fmt.Errorf("trackers: RTF create API login request: %w", err)
 	}
@@ -339,16 +363,17 @@ func resolveBaseURL(cfg config.TrackerConfig) string {
 	return defaultBaseURL
 }
 
-func joinURL(baseURL string, path string) string {
+// joinURL resolves path against baseURL and rejects malformed configured URLs instead of falling back to the default tracker host.
+func joinURL(baseURL string, path string) (string, error) {
 	parsed, err := url.Parse(strings.TrimRight(baseURL, "/") + "/")
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return strings.TrimRight(defaultBaseURL, "/") + path
+		return "", fmt.Errorf("trackers: RTF invalid base URL %q", baseURL)
 	}
 	ref, err := url.Parse(strings.TrimLeft(path, "/"))
 	if err != nil {
-		return strings.TrimRight(baseURL, "/") + path
+		return "", fmt.Errorf("trackers: RTF invalid URL path %q: %w", path, err)
 	}
-	return parsed.ResolveReference(ref).String()
+	return parsed.ResolveReference(ref).String(), nil
 }
 
 func buildDescription(assets trackers.DescriptionAssets) string {

--- a/internal/trackers/impl/rtf/upload_test.go
+++ b/internal/trackers/impl/rtf/upload_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/config"
@@ -212,6 +213,19 @@ func TestUploadGeneratesMissingAPIKeyFromCredentials(t *testing.T) {
 	}
 	if got := loadStoredRTFAPIKey(t, dbPath); got != "generated-token" {
 		t.Fatalf("expected generated token persisted, got %q", got)
+	}
+}
+
+func TestUploadRejectsMalformedBaseURL(t *testing.T) {
+	_, err := upload(context.Background(), trackers.UploadRequest{
+		Tracker:       "RTF",
+		TrackerConfig: config.TrackerConfig{URL: "not a url", APIKey: "token"},
+	})
+	if err == nil {
+		t.Fatal("expected malformed base URL error")
+	}
+	if !strings.Contains(err.Error(), "invalid base URL") {
+		t.Fatalf("expected invalid base URL error, got %v", err)
 	}
 }
 

--- a/internal/trackers/impl/rtf/upload_test.go
+++ b/internal/trackers/impl/rtf/upload_test.go
@@ -113,6 +113,51 @@ func TestUploadRefreshesExpiredAPIKeyAndPersistsIt(t *testing.T) {
 	}
 }
 
+func TestUploadBlockedExpiredAPIKeyDoesNotRefreshOrPersist(t *testing.T) {
+	root := t.TempDir()
+	torrentPath := filepath.Join(root, "test.torrent")
+	if err := os.WriteFile(torrentPath, []byte("torrent-bytes"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+	dbPath := filepath.Join(root, "upbrr.db")
+	seedRTFConfig(t, dbPath, config.TrackerConfig{APIKey: "old-token", Username: "user", Password: "pass"})
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := upload(context.Background(), trackers.UploadRequest{
+		Tracker: "RTF",
+		Meta: api.PreparedMetadata{
+			TorrentPath: torrentPath,
+			ReleaseName: "Recent Release",
+			Release:     api.ReleaseInfo{Year: 9999},
+		},
+		TrackerConfig: config.TrackerConfig{
+			URL:      server.URL,
+			APIKey:   "old-token",
+			Username: "user",
+			Password: "pass",
+		},
+		AppConfig: config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}},
+	})
+	if err == nil {
+		t.Fatal("expected blocked upload error")
+	}
+	if !strings.Contains(err.Error(), "content must be at least 10 years old") {
+		t.Fatalf("expected eligibility error, got %v", err)
+	}
+	if requests != 0 {
+		t.Fatalf("blocked upload must not call RTF auth or upload endpoints, got %d requests", requests)
+	}
+	if got := loadStoredRTFAPIKey(t, dbPath); got != "old-token" {
+		t.Fatalf("blocked upload must leave stored token unchanged, got %q", got)
+	}
+}
+
 func TestUploadUsesValidAPIKeyWithoutRefresh(t *testing.T) {
 	root := t.TempDir()
 	torrentPath := filepath.Join(root, "test.torrent")

--- a/internal/trackers/impl/rtf/upload_test.go
+++ b/internal/trackers/impl/rtf/upload_test.go
@@ -5,11 +5,14 @@ package rtf
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/config"
+	servicedb "github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -42,4 +45,209 @@ func TestBuildUploadDryRunUsesDescriptionPayloadAndLeavesNFOEmpty(t *testing.T) 
 	if entry.Payload["nfo"] != "" {
 		t.Fatalf("expected empty nfo payload, got %#v", entry.Payload["nfo"])
 	}
+}
+
+func TestUploadRefreshesExpiredAPIKeyAndPersistsIt(t *testing.T) {
+	root := t.TempDir()
+	torrentPath := filepath.Join(root, "test.torrent")
+	if err := os.WriteFile(torrentPath, []byte("torrent-bytes"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+	dbPath := filepath.Join(root, "upbrr.db")
+	seedRTFConfig(t, dbPath, config.TrackerConfig{APIKey: "old-token", Username: "user", Password: "pass"})
+
+	var testedToken string
+	var loginCalled bool
+	var uploadToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/test":
+			testedToken = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusUnauthorized)
+		case "/api/login":
+			loginCalled = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"new-token"}`))
+		case "/api/upload":
+			uploadToken = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"error":false,"torrent":{"id":123}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	summary, err := upload(context.Background(), trackers.UploadRequest{
+		Tracker: "RTF",
+		Meta: api.PreparedMetadata{
+			TorrentPath: torrentPath,
+			ReleaseName: "Release",
+		},
+		TrackerConfig: config.TrackerConfig{
+			URL:      server.URL,
+			APIKey:   "old-token",
+			Username: "user",
+			Password: "pass",
+		},
+		AppConfig: config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}},
+	})
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if summary.Uploaded != 1 {
+		t.Fatalf("expected upload success, got %#v", summary)
+	}
+	if testedToken != "old-token" {
+		t.Fatalf("expected old token to be tested, got %q", testedToken)
+	}
+	if !loginCalled {
+		t.Fatal("expected expired token to trigger API login")
+	}
+	if uploadToken != "new-token" {
+		t.Fatalf("expected upload to use refreshed token, got %q", uploadToken)
+	}
+	if got := loadStoredRTFAPIKey(t, dbPath); got != "new-token" {
+		t.Fatalf("expected refreshed token persisted, got %q", got)
+	}
+}
+
+func TestUploadUsesValidAPIKeyWithoutRefresh(t *testing.T) {
+	root := t.TempDir()
+	torrentPath := filepath.Join(root, "test.torrent")
+	if err := os.WriteFile(torrentPath, []byte("torrent-bytes"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+
+	var loginCalled bool
+	var uploadToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/test":
+			w.WriteHeader(http.StatusOK)
+		case "/api/login":
+			loginCalled = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"new-token"}`))
+		case "/api/upload":
+			uploadToken = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"error":false,"torrent":{"id":123}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	if _, err := upload(context.Background(), trackers.UploadRequest{
+		Tracker: "RTF",
+		Meta: api.PreparedMetadata{
+			TorrentPath: torrentPath,
+			ReleaseName: "Release",
+		},
+		TrackerConfig: config.TrackerConfig{
+			URL:    server.URL,
+			APIKey: "valid-token",
+		},
+	}); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if loginCalled {
+		t.Fatal("valid token should not trigger API login")
+	}
+	if uploadToken != "valid-token" {
+		t.Fatalf("expected upload to use original token, got %q", uploadToken)
+	}
+}
+
+func TestUploadGeneratesMissingAPIKeyFromCredentials(t *testing.T) {
+	root := t.TempDir()
+	torrentPath := filepath.Join(root, "test.torrent")
+	if err := os.WriteFile(torrentPath, []byte("torrent-bytes"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+	dbPath := filepath.Join(root, "upbrr.db")
+	seedRTFConfig(t, dbPath, config.TrackerConfig{Username: "user", Password: "pass"})
+
+	var testCalled bool
+	var uploadToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/test":
+			testCalled = true
+			w.WriteHeader(http.StatusOK)
+		case "/api/login":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"generated-token"}`))
+		case "/api/upload":
+			uploadToken = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"error":false,"torrent":{"id":123}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	if _, err := upload(context.Background(), trackers.UploadRequest{
+		Tracker: "RTF",
+		Meta: api.PreparedMetadata{
+			TorrentPath: torrentPath,
+			ReleaseName: "Release",
+		},
+		TrackerConfig: config.TrackerConfig{
+			URL:      server.URL,
+			Username: "user",
+			Password: "pass",
+		},
+		AppConfig: config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}},
+	}); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if testCalled {
+		t.Fatal("missing token should refresh directly without API test")
+	}
+	if uploadToken != "generated-token" {
+		t.Fatalf("expected upload to use generated token, got %q", uploadToken)
+	}
+	if got := loadStoredRTFAPIKey(t, dbPath); got != "generated-token" {
+		t.Fatalf("expected generated token persisted, got %q", got)
+	}
+}
+
+func seedRTFConfig(t *testing.T, dbPath string, trackerCfg config.TrackerConfig) {
+	t.Helper()
+
+	repo, err := servicedb.OpenContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	defer repo.Close()
+	if err := repo.MigrateContext(context.Background()); err != nil {
+		t.Fatalf("MigrateContext: %v", err)
+	}
+	cfg := config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{"RTF": trackerCfg},
+		},
+	}
+	if err := config.SaveToDatabase(context.Background(), &cfg, repo); err != nil {
+		t.Fatalf("SaveToDatabase: %v", err)
+	}
+}
+
+func loadStoredRTFAPIKey(t *testing.T, dbPath string) string {
+	t.Helper()
+
+	repo, err := servicedb.OpenContext(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	defer repo.Close()
+	cfg, err := config.LoadFromDatabase(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("LoadFromDatabase: %v", err)
+	}
+	return cfg.Trackers.Trackers["RTF"].APIKey
 }

--- a/internal/webserver/app_routes.go
+++ b/internal/webserver/app_routes.go
@@ -14,8 +14,13 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/internal/services/trackericon"
+	"github.com/autobrr/upbrr/internal/trackerauth"
 	"github.com/autobrr/upbrr/pkg/api"
 )
+
+// cookieImportRequestEnvelopeMaxBytes leaves JSON envelope headroom while the
+// tracker auth importer enforces the shared raw cookie content limit.
+const cookieImportRequestEnvelopeMaxBytes = trackerauth.MaxCookieImportContentBytes*6 + 64*1024
 
 func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/app/ListTrackerAuthCapabilities", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
@@ -54,7 +59,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 			return
 		}
-		r.Body = http.MaxBytesReader(w, r.Body, 1024*1024)
+		r.Body = http.MaxBytesReader(w, r.Body, cookieImportRequestEnvelopeMaxBytes)
 		var req struct {
 			Tracker  string
 			FileName string
@@ -64,7 +69,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.ImportTrackerAuthCookieContent(req.Tracker, req.FileName, req.Content)
+		value, err := s.backend.ImportTrackerAuthCookieContent(r.Context(), req.Tracker, req.FileName, req.Content)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -82,7 +87,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.TestTrackerAuth(req.Tracker)
+		value, err := s.backend.TestTrackerAuth(r.Context(), req.Tracker)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -103,7 +108,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.LoginTrackerAuth(req.Tracker, req.Login)
+		value, err := s.backend.LoginTrackerAuth(r.Context(), req.Tracker, req.Login)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -124,7 +129,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.SubmitTrackerAuth2FA(req.ChallengeID, req.Code)
+		value, err := s.backend.SubmitTrackerAuth2FA(r.Context(), req.ChallengeID, req.Code)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -142,7 +147,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.DeleteTrackerAuth(req.Tracker)
+		value, err := s.backend.DeleteTrackerAuth(r.Context(), req.Tracker)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return

--- a/internal/webserver/app_routes.go
+++ b/internal/webserver/app_routes.go
@@ -18,6 +18,138 @@ import (
 )
 
 func (s *Server) registerAppRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/app/ListTrackerAuthCapabilities", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+		value, err := s.backend.ListTrackerAuthCapabilities()
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, value)
+	}))
+
+	mux.HandleFunc("/api/app/GetTrackerAuthStatus", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+		var req struct{ Tracker string }
+		if err := decodeJSON(r, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		value, err := s.backend.GetTrackerAuthStatus(req.Tracker)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, value)
+	}))
+
+	mux.HandleFunc("/api/app/ImportTrackerAuthCookieContent", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1024*1024)
+		var req struct {
+			Tracker  string
+			FileName string
+			Content  string
+		}
+		if err := decodeJSON(r, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		value, err := s.backend.ImportTrackerAuthCookieContent(req.Tracker, req.FileName, req.Content)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, value)
+	}))
+
+	mux.HandleFunc("/api/app/TestTrackerAuth", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+		var req struct{ Tracker string }
+		if err := decodeJSON(r, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		value, err := s.backend.TestTrackerAuth(req.Tracker)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, value)
+	}))
+
+	mux.HandleFunc("/api/app/LoginTrackerAuth", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+		var req struct {
+			Tracker string
+			Login   api.TrackerAuthLoginRequest
+		}
+		if err := decodeJSON(r, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		value, err := s.backend.LoginTrackerAuth(req.Tracker, req.Login)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, value)
+	}))
+
+	mux.HandleFunc("/api/app/SubmitTrackerAuth2FA", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+		var req struct {
+			ChallengeID string
+			Code        string
+		}
+		if err := decodeJSON(r, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		value, err := s.backend.SubmitTrackerAuth2FA(req.ChallengeID, req.Code)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, value)
+	}))
+
+	mux.HandleFunc("/api/app/DeleteTrackerAuth", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+		var req struct{ Tracker string }
+		if err := decodeJSON(r, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		value, err := s.backend.DeleteTrackerAuth(req.Tracker)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, value)
+	}))
+
 	mux.HandleFunc("/api/app/BrowseFile", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		if r.Method != http.MethodPost {
 			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -773,7 +773,8 @@ func (b *Backend) GetDefaultConfig() (string, error) {
 	return wrapWebResult(config.ExportToJSON(cfg))
 }
 
-// ListTrackerAuthCapabilities returns tracker auth support metadata through the embedded web API.
+// ListTrackerAuthCapabilities returns browser-visible tracker auth support from
+// the current runtime config.
 func (b *Backend) ListTrackerAuthCapabilities() ([]api.TrackerAuthCapability, error) {
 	if b == nil {
 		return nil, errors.New("backend not initialized")
@@ -781,7 +782,8 @@ func (b *Backend) ListTrackerAuthCapabilities() ([]api.TrackerAuthCapability, er
 	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Capabilities(context.Background()))
 }
 
-// GetTrackerAuthStatus returns the current local auth status for one tracker.
+// GetTrackerAuthStatus reports local auth state for tracker from the current
+// runtime config and persisted cookie/auth state.
 func (b *Backend) GetTrackerAuthStatus(tracker string) (api.TrackerAuthStatus, error) {
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
@@ -789,44 +791,49 @@ func (b *Backend) GetTrackerAuthStatus(tracker string) (api.TrackerAuthStatus, e
 	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Status(context.Background(), tracker))
 }
 
-// ImportTrackerAuthCookieContent imports browser-supplied cookie content for one tracker.
-func (b *Backend) ImportTrackerAuthCookieContent(tracker string, fileName string, content string) (api.TrackerAuthStatus, error) {
+// ImportTrackerAuthCookieContent imports browser-supplied cookie content with
+// the request context and the shared raw content size limit.
+func (b *Backend) ImportTrackerAuthCookieContent(ctx context.Context, tracker string, fileName string, content string) (api.TrackerAuthStatus, error) {
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
 	}
-	return wrapWebResult(trackerauth.NewService(b.currentConfig()).ImportCookies(context.Background(), tracker, fileName, content))
+	return wrapWebResult(trackerauth.NewService(b.currentConfig()).ImportCookies(ctx, tracker, fileName, content))
 }
 
-// TestTrackerAuth validates tracker auth remotely when supported and otherwise returns local status with an unsupported message.
-func (b *Backend) TestTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
+// TestTrackerAuth validates tracker auth with ctx so canceled web requests stop
+// remote validation and persistence work.
+func (b *Backend) TestTrackerAuth(ctx context.Context, tracker string) (api.TrackerAuthStatus, error) {
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
 	}
-	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Validate(context.Background(), tracker))
+	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Validate(ctx, tracker))
 }
 
-// LoginTrackerAuth attempts credential-based tracker auth and returns status for missing credentials, unsupported login, or 2FA.
-func (b *Backend) LoginTrackerAuth(tracker string, req api.TrackerAuthLoginRequest) (api.TrackerAuthStatus, error) {
+// LoginTrackerAuth attempts credential-based tracker auth with ctx and returns
+// status for missing credentials, unsupported login, or 2FA.
+func (b *Backend) LoginTrackerAuth(ctx context.Context, tracker string, req api.TrackerAuthLoginRequest) (api.TrackerAuthStatus, error) {
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
 	}
-	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Login(context.Background(), tracker, req))
+	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Login(ctx, tracker, req))
 }
 
-// SubmitTrackerAuth2FA submits a manual 2FA code for an active tracker auth challenge.
-func (b *Backend) SubmitTrackerAuth2FA(challengeID string, code string) (api.TrackerAuthStatus, error) {
+// SubmitTrackerAuth2FA completes an active manual 2FA challenge with ctx and
+// returns the refreshed tracker auth status.
+func (b *Backend) SubmitTrackerAuth2FA(ctx context.Context, challengeID string, code string) (api.TrackerAuthStatus, error) {
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
 	}
-	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Submit2FA(context.Background(), challengeID, code))
+	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Submit2FA(ctx, challengeID, code))
 }
 
-// DeleteTrackerAuth removes stored auth material for one tracker and returns refreshed local status.
-func (b *Backend) DeleteTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
+// DeleteTrackerAuth removes stored tracker cookies and tracker-specific auth
+// state with ctx, then returns the refreshed local status.
+func (b *Backend) DeleteTrackerAuth(ctx context.Context, tracker string) (api.TrackerAuthStatus, error) {
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
 	}
-	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Delete(context.Background(), tracker))
+	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Delete(ctx, tracker))
 }
 
 // exportableConfig returns the normalized config snapshot and the DB path that
@@ -909,8 +916,8 @@ func (b *Backend) allowUnencryptedExport(dbPath string) (bool, error) {
 }
 
 // SaveConfig validates encrypted browser settings, builds the replacement
-// runtime, persists the non-env config, then attempts shared cookie migration
-// before installing the runtime. Runtime build or save failures leave the
+// runtime, migrates shared cookies, then persists the non-env config before
+// installing the runtime. Runtime build, migration, or save failures leave the
 // persisted config and active runtime unchanged; env overrides apply only to
 // the installed runtime config.
 func (b *Backend) SaveConfig(payload string) error {
@@ -947,10 +954,10 @@ func (b *Backend) SaveConfig(payload string) error {
 const configImportMaxBytes = importer.MaxFileBytes
 
 // ImportConfig imports browser-uploaded config content, validates the saved and
-// env-applied runtime forms, builds the replacement runtime, persists the
-// non-env config, then attempts shared cookie migration before installing the
-// runtime. Runtime build or save failures leave the persisted config and active
-// runtime unchanged.
+// env-applied runtime forms, builds the replacement runtime, migrates shared
+// cookies, then persists the non-env config before installing the runtime.
+// Runtime build, migration, or save failures leave the persisted config and
+// active runtime unchanged.
 func (b *Backend) ImportConfig(fileName, fileContent string) (string, []string, error) {
 	if b.repo == nil {
 		return "", nil, errors.New("config repository not initialized")
@@ -992,9 +999,9 @@ func (b *Backend) ImportConfig(fileName, fileContent string) (string, []string, 
 }
 
 // saveAndApplyConfig builds the replacement runtime before any repository
-// writes, then persists cfg, attempts shared cookie migration, and installs the
-// runtime as one ordered transition. If persistence fails, the built runtime is
-// closed and the active runtime is left untouched.
+// writes, then migrates shared cookies, persists cfg, and installs the runtime
+// as one ordered transition. If migration or persistence fails, the built
+// runtime is closed and the active runtime is left untouched.
 func (b *Backend) saveAndApplyConfig(ctx context.Context, cfg *config.Config, runtimeCfg config.Config, dbPath string) error {
 	if err := validateCookieAuthMaterial(dbPath); err != nil {
 		if !errors.Is(err, cookies.ErrAuthHelperUnavailable) {
@@ -1006,13 +1013,13 @@ func (b *Backend) saveAndApplyConfig(ctx context.Context, cfg *config.Config, ru
 	if err != nil {
 		return err
 	}
-	if err := b.saveConfigToRepository(ctx, cfg, dbPath); err != nil {
-		closeBuiltRuntime(rt)
-		return err
-	}
 	if err := b.ensureSharedCookieMigrationForRuntime(ctx, dbPath, rt.Logger); err != nil {
 		closeBuiltRuntime(rt)
 		return fmt.Errorf("web: cookie migration failed: %w", err)
+	}
+	if err := b.saveConfigToRepository(ctx, cfg, dbPath); err != nil {
+		closeBuiltRuntime(rt)
+		return err
 	}
 	b.installConfigRuntime(runtimeCfg, rt)
 	return nil

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -779,7 +779,7 @@ func (b *Backend) ListTrackerAuthCapabilities() ([]api.TrackerAuthCapability, er
 	if b == nil {
 		return nil, errors.New("backend not initialized")
 	}
-	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Capabilities(context.Background()))
+	return wrapWebResult(trackerauth.NewServiceWithLogger(b.currentConfig(), b.currentLogger()).Capabilities(context.Background()))
 }
 
 // GetTrackerAuthStatus reports local auth state for tracker from the current
@@ -788,7 +788,7 @@ func (b *Backend) GetTrackerAuthStatus(tracker string) (api.TrackerAuthStatus, e
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
 	}
-	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Status(context.Background(), tracker))
+	return wrapWebResult(trackerauth.NewServiceWithLogger(b.currentConfig(), b.currentLogger()).Status(context.Background(), tracker))
 }
 
 // ImportTrackerAuthCookieContent imports browser-supplied cookie content with
@@ -797,7 +797,7 @@ func (b *Backend) ImportTrackerAuthCookieContent(ctx context.Context, tracker st
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
 	}
-	return wrapWebResult(trackerauth.NewService(b.currentConfig()).ImportCookies(ctx, tracker, fileName, content))
+	return wrapWebResult(trackerauth.NewServiceWithLogger(b.currentConfig(), b.currentLogger()).ImportCookies(ctx, tracker, fileName, content))
 }
 
 // TestTrackerAuth validates tracker auth with ctx so canceled web requests stop
@@ -806,7 +806,7 @@ func (b *Backend) TestTrackerAuth(ctx context.Context, tracker string) (api.Trac
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
 	}
-	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Validate(ctx, tracker))
+	return wrapWebResult(trackerauth.NewServiceWithLogger(b.currentConfig(), b.currentLogger()).Validate(ctx, tracker))
 }
 
 // LoginTrackerAuth attempts credential-based tracker auth with ctx and returns
@@ -815,7 +815,7 @@ func (b *Backend) LoginTrackerAuth(ctx context.Context, tracker string, req api.
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
 	}
-	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Login(ctx, tracker, req))
+	return wrapWebResult(trackerauth.NewServiceWithLogger(b.currentConfig(), b.currentLogger()).Login(ctx, tracker, req))
 }
 
 // SubmitTrackerAuth2FA completes an active manual 2FA challenge with ctx and
@@ -824,7 +824,7 @@ func (b *Backend) SubmitTrackerAuth2FA(ctx context.Context, challengeID string, 
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
 	}
-	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Submit2FA(ctx, challengeID, code))
+	return wrapWebResult(trackerauth.NewServiceWithLogger(b.currentConfig(), b.currentLogger()).Submit2FA(ctx, challengeID, code))
 }
 
 // DeleteTrackerAuth removes stored tracker cookies and tracker-specific auth
@@ -833,7 +833,7 @@ func (b *Backend) DeleteTrackerAuth(ctx context.Context, tracker string) (api.Tr
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
 	}
-	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Delete(ctx, tracker))
+	return wrapWebResult(trackerauth.NewServiceWithLogger(b.currentConfig(), b.currentLogger()).Delete(ctx, tracker))
 }
 
 // exportableConfig returns the normalized config snapshot and the DB path that

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -773,6 +773,7 @@ func (b *Backend) GetDefaultConfig() (string, error) {
 	return wrapWebResult(config.ExportToJSON(cfg))
 }
 
+// ListTrackerAuthCapabilities returns tracker auth support metadata through the embedded web API.
 func (b *Backend) ListTrackerAuthCapabilities() ([]api.TrackerAuthCapability, error) {
 	if b == nil {
 		return nil, errors.New("backend not initialized")
@@ -780,6 +781,7 @@ func (b *Backend) ListTrackerAuthCapabilities() ([]api.TrackerAuthCapability, er
 	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Capabilities(context.Background()))
 }
 
+// GetTrackerAuthStatus returns the current local auth status for one tracker.
 func (b *Backend) GetTrackerAuthStatus(tracker string) (api.TrackerAuthStatus, error) {
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
@@ -787,6 +789,7 @@ func (b *Backend) GetTrackerAuthStatus(tracker string) (api.TrackerAuthStatus, e
 	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Status(context.Background(), tracker))
 }
 
+// ImportTrackerAuthCookieContent imports browser-supplied cookie content for one tracker.
 func (b *Backend) ImportTrackerAuthCookieContent(tracker string, fileName string, content string) (api.TrackerAuthStatus, error) {
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
@@ -794,6 +797,7 @@ func (b *Backend) ImportTrackerAuthCookieContent(tracker string, fileName string
 	return wrapWebResult(trackerauth.NewService(b.currentConfig()).ImportCookies(context.Background(), tracker, fileName, content))
 }
 
+// TestTrackerAuth validates tracker auth remotely when supported and otherwise returns local status with an unsupported message.
 func (b *Backend) TestTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
@@ -801,6 +805,7 @@ func (b *Backend) TestTrackerAuth(tracker string) (api.TrackerAuthStatus, error)
 	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Validate(context.Background(), tracker))
 }
 
+// LoginTrackerAuth attempts credential-based tracker auth and returns status for missing credentials, unsupported login, or 2FA.
 func (b *Backend) LoginTrackerAuth(tracker string, req api.TrackerAuthLoginRequest) (api.TrackerAuthStatus, error) {
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
@@ -808,6 +813,7 @@ func (b *Backend) LoginTrackerAuth(tracker string, req api.TrackerAuthLoginReque
 	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Login(context.Background(), tracker, req))
 }
 
+// SubmitTrackerAuth2FA submits a manual 2FA code for an active tracker auth challenge.
 func (b *Backend) SubmitTrackerAuth2FA(challengeID string, code string) (api.TrackerAuthStatus, error) {
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
@@ -815,6 +821,7 @@ func (b *Backend) SubmitTrackerAuth2FA(challengeID string, code string) (api.Tra
 	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Submit2FA(context.Background(), challengeID, code))
 }
 
+// DeleteTrackerAuth removes stored auth material for one tracker and returns refreshed local status.
 func (b *Backend) DeleteTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
 	if b == nil {
 		return api.TrackerAuthStatus{}, errors.New("backend not initialized")

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -32,6 +32,7 @@ import (
 	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/internal/services/bdinfo"
 	"github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/internal/trackerauth"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -770,6 +771,55 @@ func (b *Backend) GetDefaultConfig() (string, error) {
 		return "", fmt.Errorf("web: %w", err)
 	}
 	return wrapWebResult(config.ExportToJSON(cfg))
+}
+
+func (b *Backend) ListTrackerAuthCapabilities() ([]api.TrackerAuthCapability, error) {
+	if b == nil {
+		return nil, errors.New("backend not initialized")
+	}
+	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Capabilities(context.Background()))
+}
+
+func (b *Backend) GetTrackerAuthStatus(tracker string) (api.TrackerAuthStatus, error) {
+	if b == nil {
+		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
+	}
+	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Status(context.Background(), tracker))
+}
+
+func (b *Backend) ImportTrackerAuthCookieContent(tracker string, fileName string, content string) (api.TrackerAuthStatus, error) {
+	if b == nil {
+		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
+	}
+	return wrapWebResult(trackerauth.NewService(b.currentConfig()).ImportCookies(context.Background(), tracker, fileName, content))
+}
+
+func (b *Backend) TestTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
+	if b == nil {
+		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
+	}
+	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Validate(context.Background(), tracker))
+}
+
+func (b *Backend) LoginTrackerAuth(tracker string, req api.TrackerAuthLoginRequest) (api.TrackerAuthStatus, error) {
+	if b == nil {
+		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
+	}
+	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Login(context.Background(), tracker, req))
+}
+
+func (b *Backend) SubmitTrackerAuth2FA(challengeID string, code string) (api.TrackerAuthStatus, error) {
+	if b == nil {
+		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
+	}
+	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Submit2FA(context.Background(), challengeID, code))
+}
+
+func (b *Backend) DeleteTrackerAuth(tracker string) (api.TrackerAuthStatus, error) {
+	if b == nil {
+		return api.TrackerAuthStatus{}, errors.New("backend not initialized")
+	}
+	return wrapWebResult(trackerauth.NewService(b.currentConfig()).Delete(context.Background(), tracker))
 }
 
 // exportableConfig returns the normalized config snapshot and the DB path that

--- a/internal/webserver/backend_repo_test.go
+++ b/internal/webserver/backend_repo_test.go
@@ -976,7 +976,7 @@ func TestBackendSaveConfigBuildRuntimeFailureDoesNotPersist(t *testing.T) {
 		t.Fatal("expected runtime build failure")
 	}
 
-	assertStoredSkipAutoTorrent(t, repo, false)
+	assertStoredSkipAutoTorrentUnset(t, repo)
 	if got := backend.currentConfig().Metadata.SkipAutoTorrent; got {
 		t.Fatal("expected runtime config to remain unchanged")
 	}
@@ -1012,7 +1012,7 @@ func TestBackendImportConfigBuildRuntimeFailureDoesNotPersist(t *testing.T) {
 		t.Fatal("expected runtime build failure")
 	}
 
-	assertStoredSkipAutoTorrent(t, repo, false)
+	assertStoredSkipAutoTorrentUnset(t, repo)
 	if got := backend.currentConfig().Metadata.SkipAutoTorrent; got {
 		t.Fatal("expected runtime config to remain unchanged")
 	}
@@ -1110,7 +1110,7 @@ func TestBackendSaveConfigSyncsUsableWebAuthBeforeSave(t *testing.T) {
 	assertCookieAuthStatePresent(t, repo)
 }
 
-func TestBackendSaveConfigCookieSyncRollsBackWhenConfigSaveFails(t *testing.T) {
+func TestBackendSaveConfigLeavesConfigUnchangedWhenRepositorySaveFailsAfterCookieSync(t *testing.T) {
 	t.Parallel()
 
 	repo, repoPath := openBackendConfigTestRepo(t, "backend-save-cookie-rollback.db")
@@ -1137,7 +1137,8 @@ func TestBackendSaveConfigCookieSyncRollsBackWhenConfigSaveFails(t *testing.T) {
 		t.Fatal("expected save config to fail")
 	}
 
-	assertFailedConfigSaveRowsAbsent(t, repo)
+	assertConfigRowsAbsent(t, repo)
+	assertCookieAuthStatePresent(t, repo)
 	if got := backend.currentConfig().Metadata.SkipAutoTorrent; got {
 		t.Fatal("expected runtime config not to be applied after failed config save")
 	}
@@ -1174,7 +1175,7 @@ func TestBackendSaveConfigHardCookieMigrationErrorDoesNotInstallRuntime(t *testi
 	if !strings.Contains(err.Error(), "forced migration failure") {
 		t.Fatalf("expected forced migration failure, got %v", err)
 	}
-	assertStoredSkipAutoTorrent(t, repo, true)
+	assertStoredSkipAutoTorrentUnset(t, repo)
 	if got := backend.currentConfig().Metadata.SkipAutoTorrent; got {
 		t.Fatal("expected runtime config not to be applied after hard migration failure")
 	}
@@ -1211,6 +1212,7 @@ func TestBackendImportConfigHardCookieMigrationErrorPropagates(t *testing.T) {
 	if !strings.Contains(err.Error(), "forced migration failure") {
 		t.Fatalf("expected forced migration failure, got %v", err)
 	}
+	assertStoredSkipAutoTorrentUnset(t, repo)
 	if got := backend.currentConfig().Metadata.SkipAutoTorrent; got {
 		t.Fatal("expected runtime config not to be applied after imported hard migration failure")
 	}
@@ -1319,6 +1321,19 @@ func assertFailedConfigSaveRowsAbsent(t *testing.T, repo *db.SQLiteRepository) {
 	}
 }
 
+func assertConfigRowsAbsent(t *testing.T, repo *db.SQLiteRepository) {
+	t.Helper()
+
+	var data string
+	err := repo.RawDB().QueryRowContext(context.Background(),
+		`SELECT data FROM config_settings WHERE section = ?`,
+		"MainSettings",
+	).Scan(&data)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected MainSettings to be absent after failed save, got row=%q err=%v", data, err)
+	}
+}
+
 func expectLogStreamMessage(t *testing.T, events <-chan serverEvent, streamID string, want string) {
 	t.Helper()
 
@@ -1359,15 +1374,15 @@ func drainLogStreamEvents(events <-chan serverEvent) {
 	}
 }
 
-func assertStoredSkipAutoTorrent(t *testing.T, repo *db.SQLiteRepository, want bool) {
+func assertStoredSkipAutoTorrentUnset(t *testing.T, repo *db.SQLiteRepository) {
 	t.Helper()
 
 	stored, err := config.LoadFromDatabase(context.Background(), repo)
 	if err != nil {
 		t.Fatalf("load stored config: %v", err)
 	}
-	if got := stored.Metadata.SkipAutoTorrent; got != want {
-		t.Fatalf("stored skip_auto_torrent: got %t want %t", got, want)
+	if stored.Metadata.SkipAutoTorrent {
+		t.Fatal("stored skip_auto_torrent changed unexpectedly")
 	}
 }
 

--- a/internal/webserver/backend_repo_test.go
+++ b/internal/webserver/backend_repo_test.go
@@ -1377,6 +1377,25 @@ func drainLogStreamEvents(events <-chan serverEvent) {
 func assertStoredSkipAutoTorrentUnset(t *testing.T, repo *db.SQLiteRepository) {
 	t.Helper()
 
+	var rawMetadata string
+	if err := repo.RawDB().QueryRowContext(context.Background(),
+		`SELECT data FROM config_settings WHERE section = ?`,
+		"Metadata",
+	).Scan(&rawMetadata); err != nil {
+		t.Fatalf("load raw metadata config section: %v", err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal([]byte(rawMetadata), &metadata); err != nil {
+		t.Fatalf("decode raw metadata config section: %v", err)
+	}
+	rawValue, ok := metadata["SkipAutoTorrent"].(bool)
+	if !ok {
+		t.Fatalf("raw metadata config section missing SkipAutoTorrent: %s", rawMetadata)
+	}
+	if rawValue {
+		t.Fatal("raw stored skip_auto_torrent changed unexpectedly")
+	}
+
 	stored, err := config.LoadFromDatabase(context.Background(), repo)
 	if err != nil {
 		t.Fatalf("load stored config: %v", err)

--- a/internal/webserver/routes_auth_test.go
+++ b/internal/webserver/routes_auth_test.go
@@ -12,10 +12,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/autobrr/upbrr/internal/authmaterial"
+	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/services/db"
 
@@ -761,6 +763,110 @@ func TestRetainedSessionCanAccessAppRouteAfterRestart(t *testing.T) {
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected retained session to access app route after restart, got %d: %s", recorder.Code, recorder.Body.String())
 	}
+}
+
+func TestTrackerAuthBackendUsesRequestContext(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	trackerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">authkey=abcdefghijklmnopqrstuvwxyzABCDEF`))
+	}))
+	t.Cleanup(trackerServer.Close)
+
+	backend := &Backend{
+		cfg: config.Config{
+			Trackers: config.TrackersConfig{
+				Trackers: map[string]config.TrackerConfig{
+					"MTV": {
+						URL:      trackerServer.URL,
+						Username: "user",
+						Password: "pass",
+					},
+				},
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	status, err := backend.TestTrackerAuth(ctx, "MTV")
+	if err != nil {
+		t.Fatalf("TestTrackerAuth: %v", err)
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("expected canceled context to prevent remote auth request, got %d request(s)", requests.Load())
+	}
+	if !strings.Contains(status.LastError, "context canceled") {
+		t.Fatalf("expected context canceled status, got %#v", status)
+	}
+}
+
+func TestTrackerAuthImportCanceledContextDoesNotPersistCookies(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newTrackerAuthWebTestDB(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	backend := &Backend{cfg: config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := backend.ImportTrackerAuthCookieContent(ctx, "AR", "cookies.txt", ".example.test\tTRUE\t/\tTRUE\t0\tsession\tabc\n")
+	if err == nil {
+		t.Fatal("expected canceled import error")
+	}
+	if _, loadErr := cookies.LoadTrackerCookieMap(context.Background(), dbPath, "AR"); loadErr == nil {
+		t.Fatal("canceled import persisted cookies")
+	}
+}
+
+func TestTrackerAuthDeleteCanceledContextDoesNotDeleteCookies(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newTrackerAuthWebTestDB(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := cookies.SaveTrackerCookieMap(context.Background(), dbPath, "AR", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	backend := &Backend{cfg: config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := backend.DeleteTrackerAuth(ctx, "AR")
+	if err == nil {
+		t.Fatal("expected canceled delete error")
+	}
+	values, loadErr := cookies.LoadTrackerCookieMap(context.Background(), dbPath, "AR")
+	if loadErr != nil {
+		t.Fatalf("LoadTrackerCookieMap: %v", loadErr)
+	}
+	if values["session"] != "abc" {
+		t.Fatalf("canceled delete changed cookies: %#v", values)
+	}
+}
+
+func newTrackerAuthWebTestDB(t *testing.T) string {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	repo, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	if err := repo.Migrate(); err != nil {
+		_ = repo.Close()
+		t.Fatalf("migrate repo: %v", err)
+	}
+	if err := repo.Close(); err != nil {
+		t.Fatalf("close repo: %v", err)
+	}
+	return dbPath
 }
 
 func TestRequestSessionTokenMustMatchCookieSession(t *testing.T) {

--- a/internal/webserver/tracker_auth_import_test.go
+++ b/internal/webserver/tracker_auth_import_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package webserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/authmaterial"
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackerauth"
+)
+
+func TestBackendImportTrackerAuthCookieContentRejectsOverCap(t *testing.T) {
+	t.Parallel()
+
+	_, err := (&Backend{}).ImportTrackerAuthCookieContent(
+		context.Background(),
+		"AR",
+		"cookies.txt",
+		strings.Repeat("x", trackerauth.MaxCookieImportContentBytes+1),
+	)
+	if err == nil {
+		t.Fatal("expected over-cap import error")
+	}
+	if !strings.Contains(err.Error(), "cookie file content exceeds") {
+		t.Fatalf("expected shared content cap error, got %v", err)
+	}
+}
+
+func TestRouteImportTrackerAuthCookieContentAcceptsEscapedEnvelopeAtRawCap(t *testing.T) {
+	t.Parallel()
+
+	repo, dbPath := openBrowseTestRepo(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	server := testServerWithBackend(t, repo, config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}})
+	prefix := ".example.test\tTRUE\t/\tTRUE\t0\tsession\t"
+	content := prefix + strings.Repeat("<", trackerauth.MaxCookieImportContentBytes-len(prefix))
+	body, err := json.Marshal(map[string]string{
+		"Tracker":  "AR",
+		"FileName": "cookies.txt",
+		"Content":  content,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if len(body) <= trackerauth.MaxCookieImportContentBytes+64*1024 {
+		t.Fatalf("test envelope did not exceed prior cap: got %d", len(body))
+	}
+
+	mux := http.NewServeMux()
+	server.registerAppRoutes(mux)
+	req := trackerAuthImportRouteRequest(body)
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected escaped envelope import to succeed, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestRouteImportTrackerAuthCookieContentRejectsEnvelopeOverRouteCap(t *testing.T) {
+	t.Parallel()
+
+	repo, dbPath := openBrowseTestRepo(t)
+	server := testServerWithBackend(t, repo, config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}})
+	mux := http.NewServeMux()
+	server.registerAppRoutes(mux)
+	req := trackerAuthImportRouteRequest([]byte(strings.Repeat(" ", cookieImportRequestEnvelopeMaxBytes+1) + "x"))
+	recorder := httptest.NewRecorder()
+
+	mux.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected route cap rejection, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "request body too large") {
+		t.Fatalf("expected body-too-large error, got %s", recorder.Body.String())
+	}
+}
+
+func trackerAuthImportRouteRequest(body []byte) *http.Request {
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/api/app/ImportTrackerAuthCookieContent",
+		strings.NewReader(string(body)),
+	)
+	req.Host = "127.0.0.1:8080"
+	req.RemoteAddr = "127.0.0.1:5050"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://127.0.0.1:8080")
+	req.Header.Set("X-Csrf-Token", "test-csrf")
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "test-session"})
+	return req
+}

--- a/pkg/api/preview.go
+++ b/pkg/api/preview.go
@@ -23,6 +23,9 @@ type MetadataPreview struct {
 	ExternalPreview      []ExternalPreview
 	Bluray               *BlurayMetadata
 	TrackerData          []TrackerPreview
+	// TrackerRuleFailures is keyed by normalized tracker code and contains
+	// upload rule failures known at preview time.
+	TrackerRuleFailures map[string][]RuleFailure
 }
 
 type DescriptionBuilderPreview struct {

--- a/pkg/api/tracker_auth.go
+++ b/pkg/api/tracker_auth.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package api
+
+type TrackerAuthCapability struct {
+	TrackerID          string   `json:"trackerID"`
+	DisplayName        string   `json:"displayName"`
+	AuthKind           string   `json:"authKind"`
+	SupportsCookieFile bool     `json:"supportsCookieFile"`
+	SupportsLogin      bool     `json:"supportsLogin"`
+	SupportsAutoLogin  bool     `json:"supportsAutoLogin"`
+	SupportsTOTP       bool     `json:"supportsTOTP"`
+	SupportsManual2FA  bool     `json:"supportsManual2FA"`
+	RequiresAPIKey     bool     `json:"requiresAPIKey"`
+	RequiresPasskey    bool     `json:"requiresPasskey"`
+	Notes              []string `json:"notes"`
+}
+
+type TrackerAuthStatus struct {
+	TrackerID        string `json:"trackerID"`
+	DisplayName      string `json:"displayName"`
+	State            string `json:"state"`
+	CookieCount      int    `json:"cookieCount"`
+	LastCheckedAt    string `json:"lastCheckedAt"`
+	LastError        string `json:"lastError"`
+	EncryptedStorage bool   `json:"encryptedStorage"`
+	Needs2FA         bool   `json:"needs2FA"`
+	ChallengeID      string `json:"challengeID"`
+	Message          string `json:"message"`
+}
+
+type TrackerAuthLoginRequest struct {
+	Code string `json:"code"`
+}

--- a/pkg/api/tracker_auth.go
+++ b/pkg/api/tracker_auth.go
@@ -3,9 +3,12 @@
 
 package api
 
+// TrackerAuthCapability describes the auth operations the UI can offer for one tracker.
 type TrackerAuthCapability struct {
-	TrackerID          string   `json:"trackerID"`
-	DisplayName        string   `json:"displayName"`
+	// TrackerID is the normalized tracker code used in bridge requests.
+	TrackerID   string `json:"trackerID"`
+	DisplayName string `json:"displayName"`
+	// AuthKind is a compact capability label such as "cookies", "credential_login", or "api_key_cookies_login".
 	AuthKind           string   `json:"authKind"`
 	SupportsCookieFile bool     `json:"supportsCookieFile"`
 	SupportsLogin      bool     `json:"supportsLogin"`
@@ -17,19 +20,26 @@ type TrackerAuthCapability struct {
 	Notes              []string `json:"notes"`
 }
 
+// TrackerAuthStatus reports the current local tracker auth state after a status, import, login, validation, 2FA, or delete action.
 type TrackerAuthStatus struct {
-	TrackerID        string `json:"trackerID"`
-	DisplayName      string `json:"displayName"`
-	State            string `json:"state"`
-	CookieCount      int    `json:"cookieCount"`
-	LastCheckedAt    string `json:"lastCheckedAt"`
+	TrackerID   string `json:"trackerID"`
+	DisplayName string `json:"displayName"`
+	// State is one of the tracker auth state strings returned by the backend, such as "configured", "has_cookies", or "login_required".
+	State       string `json:"state"`
+	CookieCount int    `json:"cookieCount"`
+	// LastCheckedAt is an RFC3339 UTC timestamp generated when the status is evaluated.
+	LastCheckedAt string `json:"lastCheckedAt"`
+	// LastError contains redacted failure text when a local or remote auth check failed.
 	LastError        string `json:"lastError"`
 	EncryptedStorage bool   `json:"encryptedStorage"`
 	Needs2FA         bool   `json:"needs2FA"`
-	ChallengeID      string `json:"challengeID"`
-	Message          string `json:"message"`
+	// ChallengeID is an opaque manual-2FA continuation token; it is empty unless Needs2FA is true.
+	ChallengeID string `json:"challengeID"`
+	Message     string `json:"message"`
 }
 
+// TrackerAuthLoginRequest carries optional login data for tracker auth flows.
 type TrackerAuthLoginRequest struct {
+	// Code is a one-time 2FA code for adapters that accept it during login.
 	Code string `json:"code"`
 }


### PR DESCRIPTION
## Summary

- Add shared tracker auth management across Wails and embedded web, including capability/status DTOs, cookie import/delete/test/login actions, and Settings UI controls.
- Add internal/trackerauth with adapter-backed session validation/login, typed auth failures, short-lived manual 2FA challenge state, and encrypted non-cookie auth state storage.
- Add tracker_auth_state migration and move AR auth key persistence to encrypted state with legacy plaintext fallback only.
- Wire existing MTV/PTP auth flows into the shared service path and persist FL cookies after credential login.

## Validation

- go test ./internal/trackerauth ./internal/services/db ./internal/guiapp ./internal/webserver ./pkg/api ./internal/trackers/impl/ar ./internal/trackers/impl/fl ./internal/trackers/impl/mtv ./internal/trackers/impl/ptp
- go test ./internal/trackers/impl
- pnpm --dir gui/frontend run typecheck
- pnpm --dir gui/frontend run test:unit -- src/pages/settings/index.test.tsx src/utils/runtime.test.ts
- make lint
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Tracker Auth** section in Settings to view per-tracker auth status and manage tracker login, including cookie import and **manual 2FA**.
  * Interactive uploads now validate tracker readiness up front and can prompt for 2FA when required.

* **Bug Fixes**
  * Cookie loading now prefers stored (DB) cookies over startup files, and preserves cookie value whitespace.
  * Tracker auth cookie imports enforce a size limit; failed/canceled actions no longer wipe existing tracker auth data.
  * Improved cookie deletion and auth-state update safety with rollback on failures.

* **Tests**
  * Expanded coverage for tracker auth UI, flows, limits, cancellation, and state races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->