### PR TITLE
fix: provided release name issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,10 @@ replace github.com/moistari/rls => github.com/autobrr/rls v0.8.1
 
 replace github.com/anacrolix/dht/v2 => github.com/anacrolix/dht/v2 v2.24.0
 
+replace github.com/autobrr/go-bdinfo => github.com/Audionut/go-bdinfo v0.2.1-0.20260628010705-5a98a8bb3c49
+
+replace github.com/autobrr/go-mediainfo => github.com/Audionut/go-mediainfo v0.2.2-0.20260628053221-f40c1afb1843
+
 require (
 	git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ crawshaw.io/iox v0.0.0-20181124134642-c51c3df30797/go.mod h1:sXBiorCo8c46JlQV3oX
 crawshaw.io/sqlite v0.3.2/go.mod h1:igAO5JulrQ1DbdZdtVq48mnZUBAPOeFzer7VhDWNtW4=
 git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 h1:N3IGoHHp9pb6mj1cbXbuaSXV/UMKwmbKLf53nQmtqMA=
 git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3/go.mod h1:QtOLZGz8olr4qH2vWK0QH0w0O4T9fEIjMuWpKUsH7nc=
+github.com/Audionut/go-bdinfo v0.2.1-0.20260628010705-5a98a8bb3c49 h1:ttgpoP4Fw1cpAf7zt60rsY2S/T0W3xPQo+ymiAXOk+Y=
+github.com/Audionut/go-bdinfo v0.2.1-0.20260628010705-5a98a8bb3c49/go.mod h1:LvWQ9miDSoeSvJ2vyttB1pYicDl5+eTZ5snvqH7OmZA=
+github.com/Audionut/go-mediainfo v0.2.2-0.20260628053221-f40c1afb1843 h1:PaKUDJN5XLe142huwL4K9KxKZXHuxMfBE812DNRB8Hc=
+github.com/Audionut/go-mediainfo v0.2.2-0.20260628053221-f40c1afb1843/go.mod h1:xVXgHDAYYpIeGQCQCdTBpoiY/O3tojJfflK+rrbzclQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
@@ -44,10 +48,6 @@ github.com/anacrolix/tagflag v1.1.0/go.mod h1:Scxs9CV10NQatSmbyjqmqmeQNwGzlNe0CM
 github.com/anacrolix/torrent v1.61.0 h1:vxo+B4SwnoP5AQWbhvnTYIaTgPSX+llYUVuQVsN4Jg8=
 github.com/anacrolix/torrent v1.61.0/go.mod h1:yKUKuZSSDdyOsCbuH+rDOpswl/g546gICapdrU7aUmQ=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/autobrr/go-bdinfo v0.3.1 h1:gO9n1lDspswOjvimV/ZERzU9znFBeWBA/kWl85zbi1Y=
-github.com/autobrr/go-bdinfo v0.3.1/go.mod h1:LvWQ9miDSoeSvJ2vyttB1pYicDl5+eTZ5snvqH7OmZA=
-github.com/autobrr/go-mediainfo v0.4.0 h1:S68enHlG067nE9UF61Yg7QoQBWfeXJTRYctyNxPf1UE=
-github.com/autobrr/go-mediainfo v0.4.0/go.mod h1:xVXgHDAYYpIeGQCQCdTBpoiY/O3tojJfflK+rrbzclQ=
 github.com/autobrr/go-qbittorrent v1.16.0 h1:H0zwzLOaCxvJTxJ3xe4+hV3rFSuxucsgKQxsGHydXCU=
 github.com/autobrr/go-qbittorrent v1.16.0/go.mod h1:s36a75VlatWPpHI+pNg4Ta6eB3fRxQvTZPfgMtOsQfY=
 github.com/autobrr/mkbrr v1.23.0 h1:g9RhZqT78u9726ifDt+KP8VhPNNm1pxmL8Y4L9wa2yk=

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -1290,8 +1290,9 @@ func uhdFromMeta(meta api.PreparedMetadata) string {
 	return ""
 }
 
-// hdrFromMedia prefers BDInfo and MediaInfo HDR evidence, then falls back to
-// normalized filename tokens from the current source path or parsed release.
+// hdrFromMedia prefers BDInfo and MediaInfo HDR evidence, normalizing bare PQ
+// transfer metadata to HDR for tracker naming, then falls back to normalized
+// filename tokens from the current source path or parsed release.
 func hdrFromMedia(doc mediaInfoDoc, bdinfo *discparse.BDInfo, meta api.PreparedMetadata) string {
 	if bdinfo != nil && len(bdinfo.Video) > 0 {
 		hdr := ""
@@ -1338,7 +1339,7 @@ func hdrFromMedia(doc mediaInfoDoc, bdinfo *discparse.BDInfo, meta api.PreparedM
 		}
 		transfer := trackString(track, "transfer_characteristics", "transfer_characteristics_Original")
 		if hdrFormat == "" && strings.Contains(strings.ToUpper(transfer), "PQ") {
-			hdr = "PQ10"
+			hdr = "HDR"
 		}
 		if strings.Contains(strings.ToUpper(transfer), "HLG") {
 			hdr = "HLG"

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -379,7 +379,7 @@ func audioFromMedia(meta api.PreparedMetadata, doc mediaInfoDoc, bdinfo *discpar
 	if len(audioTracks) == 0 {
 		return "", "", false
 	}
-	firstAudioTitle := strings.ToLower(trackString(audioTracks[0], "Title", "title"))
+	firstAudioTitle := strings.ToLower(audioTrackTitle(audioTracks[0]))
 	track := selectPrimaryAudioTrack(audioTracks)
 	format := normalizeAudioFormat(track)
 	additional := trackString(track, "Format_AdditionalFeatures", "Format_AdditionalFeatures_String", "Format_AdditionalFeatures_Original")
@@ -417,7 +417,7 @@ func audioFromMedia(meta api.PreparedMetadata, doc mediaInfoDoc, bdinfo *discpar
 	}
 	commentary := false
 	for _, audioTrack := range audioTracks {
-		title := strings.ToLower(trackString(audioTrack, "Title", "title"))
+		title := strings.ToLower(audioTrackTitle(audioTrack))
 		if strings.Contains(title, "commentary") {
 			commentary = true
 			break
@@ -441,10 +441,16 @@ func normalizeAudioFormatSettings(value string) string {
 	return ""
 }
 
+// audioTrackTitle returns the first MediaInfo title field used to identify
+// commentary or compatibility tracks before audio language classification.
+func audioTrackTitle(track map[string]any) string {
+	return trackString(track, "Title", "title", "Title_String", "Title_String2", "Title_String3")
+}
+
 func audioLanguagePrefix(meta api.PreparedMetadata, tracks []map[string]any) string {
 	filtered := make([]map[string]any, 0, len(tracks))
 	for _, track := range tracks {
-		if isCommentaryOrCompatibilityAudioValue(trackString(track, "Title", "title")) {
+		if isCommentaryOrCompatibilityAudioValue(audioTrackTitle(track)) {
 			continue
 		}
 		filtered = append(filtered, track)

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -357,6 +357,9 @@ func containerFromMeta(meta api.PreparedMetadata) string {
 	return strings.ToLower(ext)
 }
 
+// audioFromMedia derives the primary audio label, channel count, and
+// commentary presence from BDInfo or MediaInfo. Object-audio markers such as
+// Atmos are emitted after the channel count to match release-name ordering.
 func audioFromMedia(meta api.PreparedMetadata, doc mediaInfoDoc, bdinfo *discparse.BDInfo) (string, string, bool) {
 	if bdinfo != nil && len(bdinfo.Audio) > 0 {
 		track := bdinfo.Audio[0]
@@ -365,14 +368,15 @@ func audioFromMedia(meta api.PreparedMetadata, doc mediaInfoDoc, bdinfo *discpar
 			"Format":            track.Codec,
 		})
 		codec = strings.TrimSpace(codec)
-		if track.Atmos != "" && !strings.Contains(strings.ToLower(codec), "atmos") {
-			codec = strings.TrimSpace(codec + " Atmos")
-		}
 		channels := strings.TrimSpace(track.Channels)
 		if channels == "" {
 			channels = "Unknown"
 		}
-		return strings.TrimSpace(codec + " " + channels), channels, false
+		extra := ""
+		if track.Atmos != "" && !strings.Contains(strings.ToLower(codec), "atmos") {
+			extra = "Atmos"
+		}
+		return strings.Join(strings.Fields(strings.Join([]string{codec, channels, extra}, " ")), " "), channels, false
 	}
 
 	_, _, audioTracks := splitMediaInfoTracks(doc)
@@ -396,8 +400,9 @@ func audioFromMedia(meta api.PreparedMetadata, doc mediaInfoDoc, bdinfo *discpar
 	}
 
 	formatLower := strings.ToLower(format)
+	extra := ""
 	if isAtmosAudio(additional, formatLower, trackString(track, "ChannelLayout", "ChannelPositions")) && !strings.Contains(formatLower, "atmos") {
-		format = strings.TrimSpace(format + " Atmos")
+		extra = "Atmos"
 	}
 	if isDTSXAudio(additional, formatLower) && !strings.Contains(strings.ToLower(format), "dts:x") {
 		if strings.EqualFold(format, "DTS") {
@@ -412,8 +417,8 @@ func audioFromMedia(meta api.PreparedMetadata, doc mediaInfoDoc, bdinfo *discpar
 	if formatSettings == "EX" && channels != "5.1" {
 		formatSettings = ""
 	}
-	if !strings.Contains(strings.ToLower(format), "atmos") && strings.Contains(firstAudioTitle, "auro3d") {
-		format = strings.TrimSpace(format + " Auro3D")
+	if extra == "" && strings.Contains(firstAudioTitle, "auro3d") {
+		extra = "Auro3D"
 	}
 	commentary := false
 	for _, audioTrack := range audioTracks {
@@ -427,7 +432,7 @@ func audioFromMedia(meta api.PreparedMetadata, doc mediaInfoDoc, bdinfo *discpar
 	if strings.TrimSpace(meta.DiscType) == "" {
 		prefix = audioLanguagePrefix(meta, audioTracks)
 	}
-	return strings.Join(strings.Fields(strings.Join([]string{prefix, format, formatSettings, channels}, " ")), " "), channels, commentary
+	return strings.Join(strings.Fields(strings.Join([]string{prefix, format, formatSettings, channels, extra}, " ")), " "), channels, commentary
 }
 
 func normalizeAudioFormatSettings(value string) string {

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -362,6 +362,8 @@ func containerFromMeta(meta api.PreparedMetadata) string {
 // audioFromMedia derives the primary audio label, channel count, and
 // commentary presence from BDInfo or MediaInfo. Object-audio markers such as
 // Atmos are emitted after the channel count to match release-name ordering.
+// MediaInfo title-derived markers such as Auro3D come from the selected
+// primary audio track.
 func audioFromMedia(meta api.PreparedMetadata, doc mediaInfoDoc, bdinfo *discparse.BDInfo) (string, string, bool) {
 	if bdinfo != nil && len(bdinfo.Audio) > 0 {
 		track := bdinfo.Audio[0]
@@ -385,8 +387,8 @@ func audioFromMedia(meta api.PreparedMetadata, doc mediaInfoDoc, bdinfo *discpar
 	if len(audioTracks) == 0 {
 		return "", "", false
 	}
-	firstAudioTitle := strings.ToLower(audioTrackTitle(audioTracks[0]))
 	track := selectPrimaryAudioTrack(audioTracks)
+	primaryAudioTitle := strings.ToLower(audioTrackTitle(track))
 	format := normalizeAudioFormat(track)
 	additional := trackString(track, "Format_AdditionalFeatures", "Format_AdditionalFeatures_String", "Format_AdditionalFeatures_Original")
 	formatSettings := normalizeAudioFormatSettings(trackString(track, "Format_Settings"))
@@ -419,7 +421,7 @@ func audioFromMedia(meta api.PreparedMetadata, doc mediaInfoDoc, bdinfo *discpar
 	if formatSettings == "EX" && channels != "5.1" {
 		formatSettings = ""
 	}
-	if extra == "" && strings.Contains(firstAudioTitle, "auro3d") {
+	if extra == "" && strings.Contains(primaryAudioTitle, "auro3d") {
 		extra = "Auro3D"
 	}
 	commentary := false

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -20,6 +20,7 @@ import (
 	"github.com/autobrr/upbrr/internal/metadata/discparse"
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	"github.com/autobrr/upbrr/internal/paths"
+	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
@@ -1550,12 +1551,12 @@ func editionFromMeta(meta api.PreparedMetadata, doc mediaInfoDoc) (string, strin
 	return cleanEditionText(edition), strings.ToUpper(repack)
 }
 
-// repackFromMeta scans raw path and parsed release tokens so repack markers do
-// not depend on guessit/rls placing them in the edition field.
+// repackFromMeta scans source basenames and parsed release tokens so repack
+// markers do not depend on guessit/rls placing them in the edition field.
 func repackFromMeta(meta api.PreparedMetadata, edition string) string {
 	return repackFromText(
-		meta.SourcePath,
-		meta.VideoPath,
+		pathutil.Base(meta.SourcePath),
+		pathutil.Base(meta.VideoPath),
 		edition,
 		strings.Join(meta.Release.Edition, " "),
 		strings.Join(meta.Release.Other, " "),

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -26,7 +26,7 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-var repackPattern = regexp.MustCompile(`(?i)\b(?:REPACK\d?|RERIP|PROPER\d?)\b`)
+var repackPattern = regexp.MustCompile(`(?i)\b(?:REPACK\d?|RERIP|PROPER\d?|V[2-4])\b`)
 var editionWordPattern = regexp.MustCompile(`(?i)\bedition\b`)
 var editionBadTokenPattern = regexp.MustCompile(`(?i)\b(?:internal|limited|retail|version|remastered)\b`)
 var editionWhitespacePattern = regexp.MustCompile(`\s+`)

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -31,6 +31,7 @@ var editionBadTokenPattern = regexp.MustCompile(`(?i)\b(?:internal|limited|retai
 var editionWhitespacePattern = regexp.MustCompile(`\s+`)
 var durationTokenPattern = regexp.MustCompile(`(?i)(\d+(?:\.\d+)?)\s*(milliseconds?|msecs?|ms|hours?|hrs?|h|minutes?|mins?|min|seconds?|secs?|sec|s)\b`)
 var numericPattern = regexp.MustCompile(`\d+`)
+var releaseTokenSeparatorPattern = regexp.MustCompile(`[^A-Z0-9]+`)
 
 // ApplyMediaDetails enriches prepared metadata from MediaInfo, BDInfo, filename
 // tokens, overrides, and tracker policies, then rebuilds the release name.
@@ -1531,18 +1532,82 @@ func editionFromMeta(meta api.PreparedMetadata, doc mediaInfoDoc) (string, strin
 	if edition == "" && len(meta.Release.Edition) > 0 {
 		edition = strings.TrimSpace(strings.Join(meta.Release.Edition, " "))
 	}
+	repack := repackFromMeta(meta, edition)
 	if edition == "" {
-		return "", ""
+		return "", repack
 	}
-	repack := ""
 	if repackPattern.MatchString(edition) {
-		repack = repackPattern.FindString(edition)
+		if repack == "" {
+			repack = repackPattern.FindString(edition)
+		}
 		edition = strings.TrimSpace(repackPattern.ReplaceAllString(edition, ""))
 	}
 	if isIMDbEdition {
 		return cleanIMDbEditionText(edition), strings.ToUpper(repack)
 	}
 	return cleanEditionText(edition), strings.ToUpper(repack)
+}
+
+// repackFromMeta scans raw path and parsed release tokens so repack markers do
+// not depend on guessit/rls placing them in the edition field.
+func repackFromMeta(meta api.PreparedMetadata, edition string) string {
+	return repackFromText(
+		meta.SourcePath,
+		meta.VideoPath,
+		edition,
+		strings.Join(meta.Release.Edition, " "),
+		strings.Join(meta.Release.Other, " "),
+	)
+}
+
+// repackFromText returns the highest-priority repack/proper marker present in
+// release tokens, matching Upload Assistant's V2/V3/V4 repack aliases.
+func repackFromText(values ...string) string {
+	tokens := releaseTokens(values...)
+	repack := ""
+	if hasReleaseToken(tokens, "REPACK") || hasReleaseToken(tokens, "V2") {
+		repack = "REPACK"
+	}
+	if hasReleaseToken(tokens, "REPACK2") || hasReleaseToken(tokens, "V3") {
+		repack = "REPACK2"
+	}
+	if hasReleaseToken(tokens, "REPACK3") || hasReleaseToken(tokens, "V4") {
+		repack = "REPACK3"
+	}
+	if hasReleaseToken(tokens, "PROPER") {
+		repack = "PROPER"
+	}
+	if hasReleaseToken(tokens, "PROPER2") {
+		repack = "PROPER2"
+	}
+	if hasReleaseToken(tokens, "PROPER3") {
+		repack = "PROPER3"
+	}
+	if hasReleaseToken(tokens, "RERIP") {
+		repack = "RERIP"
+	}
+	return repack
+}
+
+// releaseTokens splits release-name text into uppercase tokens using
+// punctuation, whitespace, and path separators as boundaries.
+func releaseTokens(values ...string) map[string]struct{} {
+	tokens := make(map[string]struct{})
+	for _, value := range values {
+		for _, token := range releaseTokenSeparatorPattern.Split(strings.ToUpper(value), -1) {
+			if token == "" {
+				continue
+			}
+			tokens[token] = struct{}{}
+		}
+	}
+	return tokens
+}
+
+// hasReleaseToken reports whether a normalized token set contains value.
+func hasReleaseToken(tokens map[string]struct{}, value string) bool {
+	_, ok := tokens[value]
+	return ok
 }
 
 func resolveMultiPlaylistEdition(meta api.PreparedMetadata) string {

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -809,14 +809,15 @@ func audioBloatReason(languages []string, hardBlocked bool) string {
 	return fmt.Sprintf("audio languages %s may be considered bloated", parts)
 }
 
-// selectPrimaryAudioTrack filters out compatibility tracks before selection.
-// This intentionally diverges from the Python reference, which selects from
-// all tracks, to avoid fallback compatibility tracks representing the release.
+// selectPrimaryAudioTrack returns the track used to derive the release audio
+// label, excluding commentary and compatibility tracks when possible. This
+// intentionally diverges from the Python reference, which selects from all
+// tracks, to avoid fallback tracks representing the release.
 func selectPrimaryAudioTrack(tracks []map[string]any) map[string]any {
 	if len(tracks) == 0 {
 		return nil
 	}
-	filtered := filterCompatibilityTracks(tracks)
+	filtered := filterPrimaryAudioTracks(tracks)
 	if len(filtered) == 0 {
 		filtered = tracks
 	}
@@ -829,13 +830,13 @@ func selectPrimaryAudioTrack(tracks []map[string]any) map[string]any {
 	return filtered[0]
 }
 
-// filterCompatibilityTracks removes fallback audio tracks marked by any
-// MediaInfo title variant, leaving all-track fallback decisions to the caller.
-func filterCompatibilityTracks(tracks []map[string]any) []map[string]any {
+// filterPrimaryAudioTracks returns tracks eligible to represent primary release
+// audio by ignoring commentary and compatibility markers in any MediaInfo title
+// variant. It leaves all-track fallback decisions to the caller.
+func filterPrimaryAudioTracks(tracks []map[string]any) []map[string]any {
 	filtered := make([]map[string]any, 0, len(tracks))
 	for _, track := range tracks {
-		title := strings.ToLower(audioTrackTitle(track))
-		if strings.Contains(title, "compatibility") {
+		if isCommentaryOrCompatibilityAudioValue(audioTrackTitle(track)) {
 			continue
 		}
 		filtered = append(filtered, track)

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -828,10 +828,12 @@ func selectPrimaryAudioTrack(tracks []map[string]any) map[string]any {
 	return filtered[0]
 }
 
+// filterCompatibilityTracks removes fallback audio tracks marked by any
+// MediaInfo title variant, leaving all-track fallback decisions to the caller.
 func filterCompatibilityTracks(tracks []map[string]any) []map[string]any {
 	filtered := make([]map[string]any, 0, len(tracks))
 	for _, track := range tracks {
-		title := strings.ToLower(trackString(track, "Title", "title"))
+		title := strings.ToLower(audioTrackTitle(track))
 		if strings.Contains(title, "compatibility") {
 			continue
 		}

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -694,7 +694,7 @@ func TestAudioFromMediaSkipsCommentaryTitleVariantsForDualAudio(t *testing.T) {
 	}
 
 	audio, channels, commentary := audioFromMedia(meta, doc, nil)
-	if audio != "Dubbed TrueHD Atmos 7.1" {
+	if audio != "Dubbed TrueHD 7.1 Atmos" {
 		t.Fatalf("expected commentary track to be ignored for dual-audio prefix, got %q", audio)
 	}
 	if channels != "7.1" || !commentary {
@@ -1049,8 +1049,8 @@ func TestAudioFromMediaNormalizesBDInfoCodecWithAtmos(t *testing.T) {
 		}},
 	})
 
-	if audio != "TrueHD Atmos 7.1" {
-		t.Fatalf("expected normalized BDInfo audio to be TrueHD Atmos 7.1, got %q", audio)
+	if audio != "TrueHD 7.1 Atmos" {
+		t.Fatalf("expected normalized BDInfo audio to be TrueHD 7.1 Atmos, got %q", audio)
 	}
 	if channels != "7.1" || commentary {
 		t.Fatalf("expected channels=7.1 commentary=false, got channels=%q commentary=%t", channels, commentary)

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -277,6 +277,47 @@ func TestEditionFromMetaExtractsRepackAndCleansEdition(t *testing.T) {
 	}
 }
 
+func TestEditionFromMetaExtractsRepackFromSourcePath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "explicit repack2",
+			path: `C:\Movies\Melancholia.2011.REPACK2.1080p.BluRay.DTS.x264-DON`,
+			want: "REPACK2",
+		},
+		{
+			name: "v3 maps to repack2",
+			path: `C:\Movies\Melancholia.2011.V3.1080p.BluRay.DTS.x264-DON`,
+			want: "REPACK2",
+		},
+		{
+			name: "v4 maps to repack3",
+			path: `C:\Movies\Melancholia.2011.V4.1080p.BluRay.DTS.x264-DON`,
+			want: "REPACK3",
+		},
+		{
+			name: "proper2",
+			path: `C:\Movies\Melancholia.2011.PROPER2.1080p.BluRay.DTS.x264-DON`,
+			want: "PROPER2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			edition, repack := editionFromMeta(api.PreparedMetadata{SourcePath: tc.path}, mediaInfoDoc{})
+			if edition != "" {
+				t.Fatalf("expected empty edition, got %q", edition)
+			}
+			if repack != tc.want {
+				t.Fatalf("expected repack %q, got %q", tc.want, repack)
+			}
+		})
+	}
+}
+
 func TestMediaDurationSecondsParsesMediaInfoDurationFormats(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -743,6 +743,18 @@ func TestAudioFromMediaSkipsCommentaryTitleVariantsForDualAudio(t *testing.T) {
 	}
 }
 
+func TestAudioFromMediaSkipsCompatibilityTitleStringForPrimaryAudio(t *testing.T) {
+	doc := mustParseMediaInfoDoc(`{"media":{"track":[{"@type":"General"},{"@type":"Audio","Format":"AC-3","Channels":"2","ChannelLayout":"L R","StreamOrder":"0","Title_String":"Compatibility Track"},{"@type":"Audio","Format":"MLP FBA","Format_AdditionalFeatures":"16-ch","Channels":"8","ChannelLayout":"L R C LFE Ls Rs Lb Rb","StreamOrder":"1"}]}}`)
+
+	audio, channels, commentary := audioFromMedia(api.PreparedMetadata{}, doc, nil)
+	if audio != "TrueHD 7.1 Atmos" {
+		t.Fatalf("expected compatibility Title_String track to be ignored for primary audio, got %q", audio)
+	}
+	if channels != "7.1" || commentary {
+		t.Fatalf("expected 7.1 with no commentary, got channels=%q commentary=%t", channels, commentary)
+	}
+}
+
 func TestAudioFromMediaAddsDubbedWhenOnlyEnglishTrackPresent(t *testing.T) {
 	doc := mustParseMediaInfoDoc(`{"media":{"track":[{"@type":"General"},{"@type":"Audio","Format":"AC-3","Channels":"6","ChannelLayout":"L R C LFE Ls Rs","Language":"en","StreamOrder":"1"}]}}`)
 	meta := api.PreparedMetadata{

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -303,6 +303,11 @@ func TestEditionFromMetaExtractsRepackFromSourcePath(t *testing.T) {
 			path: `C:\Movies\Melancholia.2011.PROPER2.1080p.BluRay.DTS.x264-DON`,
 			want: "PROPER2",
 		},
+		{
+			name: "parent path marker ignored",
+			path: `C:\Movies\REPACK\Melancholia.2011.1080p.BluRay.DTS.x264-DON`,
+			want: "",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -760,6 +760,18 @@ func TestAudioFromMediaSkipsCompatibilityTitleStringForPrimaryAudio(t *testing.T
 	}
 }
 
+func TestAudioFromMediaSkipsCommentaryTitleStringForPrimaryAudio(t *testing.T) {
+	doc := mustParseMediaInfoDoc(`{"media":{"track":[{"@type":"General"},{"@type":"Audio","Format":"AC-3","Channels":"2","ChannelLayout":"L R","StreamOrder":"0","Title_String":"Director Commentary"},{"@type":"Audio","Format":"MLP FBA","Format_AdditionalFeatures":"16-ch","Channels":"8","ChannelLayout":"L R C LFE Ls Rs Lb Rb","StreamOrder":"1"}]}}`)
+
+	audio, channels, commentary := audioFromMedia(api.PreparedMetadata{}, doc, nil)
+	if audio != "TrueHD 7.1 Atmos" {
+		t.Fatalf("expected commentary Title_String track to be ignored for primary audio, got %q", audio)
+	}
+	if channels != "7.1" || !commentary {
+		t.Fatalf("expected 7.1 with commentary detected, got channels=%q commentary=%t", channels, commentary)
+	}
+}
+
 func TestAudioFromMediaAddsDubbedWhenOnlyEnglishTrackPresent(t *testing.T) {
 	doc := mustParseMediaInfoDoc(`{"media":{"track":[{"@type":"General"},{"@type":"Audio","Format":"AC-3","Channels":"6","ChannelLayout":"L R C LFE Ls Rs","Language":"en","StreamOrder":"1"}]}}`)
 	meta := api.PreparedMetadata{

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -772,6 +772,18 @@ func TestAudioFromMediaSkipsCommentaryTitleStringForPrimaryAudio(t *testing.T) {
 	}
 }
 
+func TestAudioFromMediaDetectsAuro3DFromPrimaryAudioTitle(t *testing.T) {
+	doc := mustParseMediaInfoDoc(`{"media":{"track":[{"@type":"General"},{"@type":"Audio","Format":"AC-3","Channels":"2","ChannelLayout":"L R","StreamOrder":"0","Title_String":"Compatibility Track"},{"@type":"Audio","Format":"DTS","Channels":"6","ChannelLayout":"L R C LFE Ls Rs","StreamOrder":"1","Title_String":"Auro3D"}]}}`)
+
+	audio, channels, commentary := audioFromMedia(api.PreparedMetadata{}, doc, nil)
+	if audio != "DTS 5.1 Auro3D" {
+		t.Fatalf("expected selected primary audio title to drive Auro3D marker, got %q", audio)
+	}
+	if channels != "5.1" || commentary {
+		t.Fatalf("expected 5.1 with no commentary, got channels=%q commentary=%t", channels, commentary)
+	}
+}
+
 func TestAudioFromMediaAddsDubbedWhenOnlyEnglishTrackPresent(t *testing.T) {
 	doc := mustParseMediaInfoDoc(`{"media":{"track":[{"@type":"General"},{"@type":"Audio","Format":"AC-3","Channels":"6","ChannelLayout":"L R C LFE Ls Rs","Language":"en","StreamOrder":"1"}]}}`)
 	meta := api.PreparedMetadata{

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -447,6 +447,18 @@ func TestHDRFromMediaPrefersMediaInfoOverFilenameHDR(t *testing.T) {
 	}
 }
 
+func TestHDRFromMediaNormalizesPQTransferToHDR(t *testing.T) {
+	doc, err := loadMediaInfoDocFromJSONPayload(`{"media":{"track":[{"@type":"General"},{"@type":"Video","colour_primaries":"BT.2020","transfer_characteristics":"PQ"}]}}`)
+	if err != nil {
+		t.Fatalf("parse mediainfo: %v", err)
+	}
+
+	got := hdrFromMedia(doc, nil, api.PreparedMetadata{})
+	if got != "HDR" {
+		t.Fatalf("expected PQ transfer to normalize to HDR, got %q", got)
+	}
+}
+
 func TestHDRFromMediaPrefersBDInfoOverFilenameHDR(t *testing.T) {
 	got := hdrFromMedia(mediaInfoDoc{}, &discparse.BDInfo{
 		Video: []discparse.BDVideo{

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -277,6 +277,20 @@ func TestEditionFromMetaExtractsRepackAndCleansEdition(t *testing.T) {
 	}
 }
 
+func TestEditionFromMetaStripsRepackAliasesFromEdition(t *testing.T) {
+	meta := api.PreparedMetadata{
+		Release: api.ReleaseInfo{Edition: []string{"Director's", "Cut", "V3"}},
+	}
+
+	edition, repack := editionFromMeta(meta, mediaInfoDoc{})
+	if edition != "Director's Cut" {
+		t.Fatalf("expected cleaned edition without repack alias, got %q", edition)
+	}
+	if repack != "REPACK2" {
+		t.Fatalf("expected normalized repack alias, got %q", repack)
+	}
+}
+
 func TestEditionFromMetaExtractsRepackFromSourcePath(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -673,6 +673,23 @@ func TestAudioFromMediaAddsDualAudioForEnglishAndOriginalLanguage(t *testing.T) 
 	}
 }
 
+func TestAudioFromMediaSkipsCommentaryTitleVariantsForDualAudio(t *testing.T) {
+	doc := mustParseMediaInfoDoc(`{"media":{"track":[{"@type":"General"},{"@type":"Audio","Format":"MLP FBA","Format_AdditionalFeatures":"16-ch","Channels":"8","ChannelLayout":"L R C LFE Ls Rs Lb Rb","Language":"en","StreamOrder":"1"},{"@type":"Audio","Format":"AC-3","Channels":"2","ChannelLayout":"L R","Language":"ja","StreamOrder":"2","Title_String":"Director Commentary"}]}}`)
+	meta := api.PreparedMetadata{
+		ExternalMetadata: api.ExternalMetadata{
+			TMDB: &api.TMDBMetadata{OriginalLanguage: "ja"},
+		},
+	}
+
+	audio, channels, commentary := audioFromMedia(meta, doc, nil)
+	if audio != "Dubbed TrueHD Atmos 7.1" {
+		t.Fatalf("expected commentary track to be ignored for dual-audio prefix, got %q", audio)
+	}
+	if channels != "7.1" || !commentary {
+		t.Fatalf("expected 7.1 with commentary detected, got channels=%q commentary=%t", channels, commentary)
+	}
+}
+
 func TestAudioFromMediaAddsDubbedWhenOnlyEnglishTrackPresent(t *testing.T) {
 	doc := mustParseMediaInfoDoc(`{"media":{"track":[{"@type":"General"},{"@type":"Audio","Format":"AC-3","Channels":"6","ChannelLayout":"L R C LFE Ls Rs","Language":"en","StreamOrder":"1"}]}}`)
 	meta := api.PreparedMetadata{

--- a/internal/metadata/naming.go
+++ b/internal/metadata/naming.go
@@ -197,6 +197,9 @@ func BuildReleaseName(req api.ReleaseNameRequest, logger api.Logger) api.Release
 	}
 }
 
+// releaseNameRequestFromMeta converts prepared metadata into the naming input,
+// omitting TV-pack season titles that are stored in EpisodeTitle only as scoped
+// metadata fallback text.
 func releaseNameRequestFromMeta(meta api.PreparedMetadata, logger api.Logger) api.ReleaseNameRequest {
 	if logger == nil {
 		logger = api.NopLogger{}
@@ -269,6 +272,10 @@ func releaseNameRequestFromMeta(meta api.PreparedMetadata, logger api.Logger) ap
 
 	dailyDate := strings.TrimSpace(meta.DailyEpisodeDate)
 	manualDate := strings.EqualFold(category, "TV") && dailyDate != "" && !meta.TVPack
+	episodeTitle := strings.TrimSpace(meta.EpisodeTitle)
+	if meta.TVPack {
+		episodeTitle = ""
+	}
 
 	return api.ReleaseNameRequest{
 		Category:      category,
@@ -289,7 +296,7 @@ func releaseNameRequestFromMeta(meta api.PreparedMetadata, logger api.Logger) ap
 		UHD:           meta.UHD,
 		HDR:           meta.HDR,
 		WebDV:         meta.WebDV,
-		EpisodeTitle:  strings.TrimSpace(meta.EpisodeTitle),
+		EpisodeTitle:  episodeTitle,
 		VideoCodec:    meta.VideoCodec,
 		VideoEncode:   meta.VideoEncode,
 		DiscType:      meta.DiscType,

--- a/internal/metadata/naming.go
+++ b/internal/metadata/naming.go
@@ -43,7 +43,7 @@ func BuildReleaseName(req api.ReleaseNameRequest, logger api.Logger) api.Release
 		resolution = ""
 	}
 
-	audio := strings.TrimSpace(req.Audio)
+	audio := normalizeAudioExtraOrder(strings.TrimSpace(req.Audio))
 	service := strings.TrimSpace(req.Service)
 	season := strings.TrimSpace(req.Season)
 	episode := strings.TrimSpace(req.Episode)
@@ -423,6 +423,46 @@ func isKnownReleaseSource(source string) bool {
 func joinParts(parts ...string) string {
 	combined := strings.Join(parts, " ")
 	return strings.Join(strings.Fields(combined), " ")
+}
+
+// normalizeAudioExtraOrder keeps object-audio markers after the channel token
+// even when an override or parsed input supplied the older "Atmos 7.1" order.
+func normalizeAudioExtraOrder(value string) string {
+	fields := strings.Fields(strings.TrimSpace(value))
+	for idx := 0; idx < len(fields)-1; idx++ {
+		if !strings.EqualFold(fields[idx], "Atmos") || !isAudioChannelToken(fields[idx+1]) {
+			continue
+		}
+		fields[idx], fields[idx+1] = fields[idx+1], fields[idx]
+	}
+	return strings.Join(fields, " ")
+}
+
+// isAudioChannelToken reports whether value is a release-name channel token
+// that can be safely swapped before an adjacent Atmos marker.
+func isAudioChannelToken(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return false
+	}
+	if strings.EqualFold(trimmed, "Unknown") {
+		return true
+	}
+	parts := strings.Split(trimmed, ".")
+	if len(parts) < 2 || len(parts) > 3 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, char := range part {
+			if char < '0' || char > '9' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func sourceIn(source string, candidates ...string) bool {

--- a/internal/metadata/naming_test.go
+++ b/internal/metadata/naming_test.go
@@ -54,7 +54,7 @@ func TestBuildReleaseNameMovieBareWebEncodeUsesWebDLNaming(t *testing.T) {
 		Tag:         "-ETHEL",
 	}, api.NopLogger{})
 
-	expectedName := "Greenland 2: Migration 2026 2160p iT WEB-DL DD+ Atmos 5.1 HDR10+ x265-ETHEL"
+	expectedName := "Greenland 2: Migration 2026 2160p iT WEB-DL DD+ 5.1 Atmos HDR10+ x265-ETHEL"
 	if result.Name != expectedName {
 		t.Fatalf("expected name %q, got %q", expectedName, result.Name)
 	}

--- a/internal/metadata/naming_test.go
+++ b/internal/metadata/naming_test.go
@@ -172,6 +172,38 @@ func TestReleaseNameRequestFromMetaDefaultsToDailyForTVEpisode(t *testing.T) {
 	}
 }
 
+func TestReleaseNameRequestFromMetaTVPackOmitsSeasonTitle(t *testing.T) {
+	meta := api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		Release: api.ReleaseInfo{
+			Title:      "A Spy Among Friends",
+			Resolution: "2160p",
+		},
+		Type:         "WEBDL",
+		Source:       "Web",
+		Service:      "MGMP",
+		Audio:        "DD+ 5.1",
+		VideoEncode:  "H.265",
+		SeasonStr:    "S01",
+		TVPack:       true,
+		EpisodeTitle: "Season 1",
+		Tag:          "-XEBEC",
+	}
+
+	req := releaseNameRequestFromMeta(meta, api.NopLogger{})
+	if req.EpisodeTitle != "" {
+		t.Fatalf("expected tv pack season title omitted from naming request, got %q", req.EpisodeTitle)
+	}
+
+	result := BuildReleaseName(req, api.NopLogger{})
+	if strings.Contains(result.NameNoTag, "Season 1") {
+		t.Fatalf("expected tv pack name to omit season title, got %q", result.NameNoTag)
+	}
+	if !containsAll(result.NameNoTag, []string{"A Spy Among Friends", "S01", "MGMP", "WEB-DL"}) {
+		t.Fatalf("expected tv pack name to keep season and service tokens, got %q", result.NameNoTag)
+	}
+}
+
 func TestReleaseNameRequestFromMetaFallsBackMovieCategory(t *testing.T) {
 	meta := api.PreparedMetadata{
 		SourcePath: `D:\Movies\1982 - Fitzcarraldo [DVD9.PAL]`,

--- a/internal/metadata/service_map.go
+++ b/internal/metadata/service_map.go
@@ -3,6 +3,8 @@
 
 package metadata
 
+// serviceCodeMap maps filename/NFO service aliases to the normalized service
+// token used in generated release names.
 func serviceCodeMap() map[string]string {
 	return map[string]string{
 		"9NOW":                             "9NOW",
@@ -206,6 +208,10 @@ func serviceCodeMap() map[string]string {
 		"MBC":                              "MBC",
 		"MNBC":                             "MNBC",
 		"MSNBC":                            "MNBC",
+		"MGMP":                             "MGMP",
+		"MGM+":                             "MGMP",
+		"MGM Plus":                         "MGMP",
+		"MGMPlus":                          "MGMP",
 		"MTOD":                             "MTOD",
 		"Motor Trend OnDemand":             "MTOD",
 		"MTV":                              "MTV",

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -362,6 +362,23 @@ func TestResolveServiceDarkroom(t *testing.T) {
 	}
 }
 
+func TestResolveServiceMGMPlus(t *testing.T) {
+	t.Parallel()
+
+	service, longName, filename := resolveService(api.PreparedMetadata{
+		SourcePath: `D:\TV\A.Spy.Among.Friends.S01.2160p.MGMP.WEB-DL.DDP5.1.H.265-XEBEC`,
+	})
+	if service != "MGMP" {
+		t.Fatalf("expected MGMP service, got %q", service)
+	}
+	if longName != "MGM Plus" {
+		t.Fatalf("expected MGM Plus long name, got %q", longName)
+	}
+	if filename == "" {
+		t.Fatalf("expected filename to be preserved")
+	}
+}
+
 func TestResolveServiceValue(t *testing.T) {
 	t.Parallel()
 
@@ -376,6 +393,11 @@ func TestResolveServiceValue(t *testing.T) {
 	service, _ = resolveServiceValue("AMAZON")
 	if service != "AMZN" {
 		t.Fatalf("expected AMZN service, got %q", service)
+	}
+
+	service, _ = resolveServiceValue("MGM+")
+	if service != "MGMP" {
+		t.Fatalf("expected MGMP service, got %q", service)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved release-name generation with better handling of audio markers, repack/proper tags, and TV pack episode titles.
  * Added broader support for MGM+ service naming variants.

* **Bug Fixes**
  * Corrected audio token ordering, including Atmos placement.
  * Normalized HDR detection so PQ-based metadata is treated consistently.
  * Improved commentary/compatibility track filtering when identifying primary audio.

* **Tests**
  * Added coverage for repack detection, HDR normalization, audio parsing, and TV pack naming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->