### PR TITLE
fix: preserve metadata overrides and upload job state

### DIFF
--- a/cmd/upbrr/cli_options.go
+++ b/cmd/upbrr/cli_options.go
@@ -51,6 +51,7 @@ type cliOptions struct {
 	EpisodeTitle          string
 	ManualYear            int
 	ManualDate            string
+	UseSeasonEpisode      bool
 	NoSeason              bool
 	NoYear                bool
 	NoAKA                 bool
@@ -197,6 +198,8 @@ func parseCLIOptions(args []string) (cliOptions, map[string]bool, []string, erro
 	fs.IntVar(&opts.ManualYear, "manual-year", 0, "Override release year")
 	fs.IntVar(&opts.ManualYear, "year", 0, "Override release year")
 	fs.StringVar(&opts.ManualDate, "daily", "", "Set daily episode air date")
+	fs.BoolVar(&opts.UseSeasonEpisode, "season-episode", false, "Use season/episode naming for daily releases")
+	fs.BoolVar(&opts.UseSeasonEpisode, "use-season-episode", false, "Use season/episode naming for daily releases")
 	fs.BoolVar(&opts.NoSeason, "no-season", false, "Remove season and episode from name")
 	fs.BoolVar(&opts.NoYear, "no-year", false, "Remove year from name")
 	fs.BoolVar(&opts.NoAKA, "no-aka", false, "Remove AKA from name")
@@ -467,6 +470,7 @@ func cliFlagAliases() map[string]string {
 		"manual-episode-title": "episode-title",
 		"met":                  "episode-title",
 		"year":                 "manual-year",
+		"use-season-episode":   "season-episode",
 		"reg":                  "region",
 		"df":                   "descfile",
 		"pb":                   "desclink",
@@ -601,7 +605,7 @@ func cliHelpSections(name string) []helpSection {
 		{title: "Tracker IDs", names: []string{"ptp", "blu", "aither", "lst", "oe", "hdb", "btn", "bhd", "ulcx"}},
 		{title: "Release Overrides", names: []string{
 			"category", "type", "source", "resolution", "tag", "service", "distributor", "original-language",
-			"edition", "season", "episode", "episode-title", "manual-year", "daily", "region", "no-season", "no-year",
+			"edition", "season", "episode", "episode-title", "manual-year", "daily", "season-episode", "region", "no-season", "no-year",
 			"no-aka", "no-tag", "no-edition", "no-dub", "no-dual", "dual-audio",
 		}},
 		{title: "Metadata IDs", names: []string{"tmdb", "imdb", "mal", "tvdb", "tvmaze"}},
@@ -723,27 +727,28 @@ func buildCLIRequest(opts cliOptions, visited map[string]bool, paths []string, s
 			InteractionMode: opts.interactionMode(),
 		},
 		ReleaseNameOverrides: buildReleaseNameOverrides(visited, releaseOverrideInput{
-			Category:     opts.Category,
-			Type:         opts.Type,
-			Source:       opts.Source,
-			Resolution:   opts.Resolution,
-			Tag:          opts.Tag,
-			Service:      opts.Service,
-			Edition:      opts.Edition,
-			Season:       opts.Season,
-			Episode:      opts.Episode,
-			EpisodeTitle: opts.EpisodeTitle,
-			ManualYear:   opts.ManualYear,
-			ManualDate:   opts.ManualDate,
-			NoSeason:     opts.NoSeason,
-			NoYear:       opts.NoYear,
-			NoAKA:        opts.NoAKA,
-			NoTag:        opts.NoTag,
-			NoEdition:    opts.NoEdition,
-			NoDub:        opts.NoDub,
-			NoDual:       opts.NoDual,
-			DualAudio:    opts.DualAudio,
-			Region:       opts.Region,
+			Category:         opts.Category,
+			Type:             opts.Type,
+			Source:           opts.Source,
+			Resolution:       opts.Resolution,
+			Tag:              opts.Tag,
+			Service:          opts.Service,
+			Edition:          opts.Edition,
+			Season:           opts.Season,
+			Episode:          opts.Episode,
+			EpisodeTitle:     opts.EpisodeTitle,
+			ManualYear:       opts.ManualYear,
+			ManualDate:       opts.ManualDate,
+			UseSeasonEpisode: opts.UseSeasonEpisode,
+			NoSeason:         opts.NoSeason,
+			NoYear:           opts.NoYear,
+			NoAKA:            opts.NoAKA,
+			NoTag:            opts.NoTag,
+			NoEdition:        opts.NoEdition,
+			NoDub:            opts.NoDub,
+			NoDual:           opts.NoDual,
+			DualAudio:        opts.DualAudio,
+			Region:           opts.Region,
 		}),
 		SkipDupeCheck:          opts.SkipDupeCheck,
 		SkipDupeAsActual:       opts.SkipDupeAsActual,
@@ -780,7 +785,7 @@ func buildCLIRequest(opts cliOptions, visited map[string]bool, paths []string, s
 		return api.Request{}, err
 	}
 	req.TrackerIDOverrides = trackerIDs
-	if visited["tmdb"] {
+	if visited["tmdb"] && !visited["category"] {
 		_, category, err := parseTMDBID(opts.TMDB)
 		if err != nil {
 			return api.Request{}, err

--- a/cmd/upbrr/cli_options_test.go
+++ b/cmd/upbrr/cli_options_test.go
@@ -571,6 +571,34 @@ func TestBuildCLIRequestTMDBCompatibilityParsing(t *testing.T) {
 	}
 }
 
+func TestBuildCLIRequestExplicitCategoryBeatsTMDBInference(t *testing.T) {
+	opts, visited, paths, err := parseCLIOptions([]string{"--category", "tv", "--tmdb", "movie/123", "movie.mkv"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	req, err := buildCLIRequest(opts, visited, paths, 4)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if req.ReleaseNameOverrides.Category == nil || *req.ReleaseNameOverrides.Category != "tv" {
+		t.Fatalf("expected explicit category to win, got %#v", req.ReleaseNameOverrides.Category)
+	}
+}
+
+func TestBuildCLIRequestUseSeasonEpisodeOverride(t *testing.T) {
+	opts, visited, paths, err := parseCLIOptions([]string{"--season-episode", "show.mkv"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	req, err := buildCLIRequest(opts, visited, paths, 4)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if req.ReleaseNameOverrides.UseSeasonEpisode == nil || !*req.ReleaseNameOverrides.UseSeasonEpisode {
+		t.Fatalf("expected use season episode override, got %#v", req.ReleaseNameOverrides.UseSeasonEpisode)
+	}
+}
+
 func TestParseCLIOptionsRejectsInvalidTMDBCompatibilityValue(t *testing.T) {
 	if _, _, _, err := parseCLIOptions([]string{"--tmdb", "movie/not-a-number", "movie.mkv"}); err == nil {
 		t.Fatal("expected invalid tmdb compatibility input to fail")

--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -679,27 +679,28 @@ func resolveExportDBPath(configPath string, configProvided bool) (string, error)
 }
 
 type releaseOverrideInput struct {
-	Category     string
-	Type         string
-	Source       string
-	Resolution   string
-	Tag          string
-	Service      string
-	Edition      string
-	Season       string
-	Episode      string
-	EpisodeTitle string
-	ManualYear   int
-	ManualDate   string
-	NoSeason     bool
-	NoYear       bool
-	NoAKA        bool
-	NoTag        bool
-	NoEdition    bool
-	NoDub        bool
-	NoDual       bool
-	DualAudio    bool
-	Region       string
+	Category         string
+	Type             string
+	Source           string
+	Resolution       string
+	Tag              string
+	Service          string
+	Edition          string
+	Season           string
+	Episode          string
+	EpisodeTitle     string
+	ManualYear       int
+	ManualDate       string
+	UseSeasonEpisode bool
+	NoSeason         bool
+	NoYear           bool
+	NoAKA            bool
+	NoTag            bool
+	NoEdition        bool
+	NoDub            bool
+	NoDual           bool
+	DualAudio        bool
+	Region           string
 }
 
 func buildReleaseNameOverrides(visited map[string]bool, input releaseOverrideInput) api.ReleaseNameOverrides {
@@ -739,6 +740,9 @@ func buildReleaseNameOverrides(visited map[string]bool, input releaseOverrideInp
 	}
 	if visited["daily"] {
 		overrides.ManualDate = stringPtr(input.ManualDate)
+	}
+	if visited["season-episode"] {
+		overrides.UseSeasonEpisode = boolPtr(input.UseSeasonEpisode)
 	}
 	if visited["no-season"] {
 		overrides.NoSeason = boolPtr(input.NoSeason)

--- a/gui/frontend/src/app.test.ts
+++ b/gui/frontend/src/app.test.ts
@@ -534,7 +534,7 @@ describe("metadata tracker payloads", () => {
     });
   });
 
-  it("omits cleared metadata text overrides from edit controls", async () => {
+  it("sends cleared metadata overrides from edit controls", async () => {
     const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
     installAppBridge(fetchMetadata);
 
@@ -556,11 +556,16 @@ describe("metadata tracker payloads", () => {
     fireEvent.change(screen.getByLabelText("Anime"), {
       target: { value: "false" },
     });
+    fireEvent.change(screen.getByLabelText("Anime"), {
+      target: { value: "" },
+    });
     fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
 
     await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(2));
     expect(fetchMetadata.mock.calls[1][4]).toEqual({
-      Anime: false,
+      Distributor: "",
+      OriginalLanguage: "",
+      Clear: ["Anime"],
     });
   });
 

--- a/gui/frontend/src/app.test.ts
+++ b/gui/frontend/src/app.test.ts
@@ -13,6 +13,7 @@ import type {
   DupeEntry,
   DupeMatch,
   MetadataPreview,
+  ScreenshotImage,
   ScreenshotPlan,
   TrackerUploadSnapshot,
 } from "./types";
@@ -46,7 +47,20 @@ type FetchMetadata = (
 
 type ResetMetadata = FetchMetadata;
 type SaveConfig = (config: string) => Promise<void>;
-type FetchScreenshotPlan = (sourcePath: string) => Promise<ScreenshotPlan>;
+type FetchScreenshotPlan = (
+  sourcePath: string,
+  overrides: unknown,
+  nameOverrides: unknown,
+  metadataOverrides: unknown,
+) => Promise<ScreenshotPlan>;
+type SaveFinalScreenshotSelections = (
+  sourcePath: string,
+  overrides: unknown,
+  nameOverrides: unknown,
+  metadataOverrides: unknown,
+  images: ScreenshotImage[],
+) => Promise<void>;
+type ReadScreenshotImage = (imagePath: string) => Promise<string>;
 type FetchDescriptionBuilder = (
   sourcePath: string,
   overrides: unknown,
@@ -218,6 +232,8 @@ const installAppBridge = (
     resetMetadata?: ResetMetadata;
     saveConfig?: SaveConfig;
     fetchScreenshotPlan?: FetchScreenshotPlan;
+    saveFinalScreenshotSelections?: SaveFinalScreenshotSelections;
+    readScreenshotImage?: ReadScreenshotImage;
     fetchDescriptionBuilder?: FetchDescriptionBuilder;
     fetchPreparation?: FetchPreparation;
     browseFolder?: () => Promise<string>;
@@ -268,6 +284,9 @@ const installAppBridge = (
         SaveConfig: options.saveConfig ?? (async () => undefined),
         FetchScreenshotPlan:
           options.fetchScreenshotPlan ?? (async (sourcePath: string) => screenshotPlan(sourcePath)),
+        SaveFinalScreenshotSelections:
+          options.saveFinalScreenshotSelections ?? (async () => undefined),
+        ReadScreenshotImage: options.readScreenshotImage ?? (async () => "data:image/png;base64,"),
         FetchDescriptionBuilder:
           options.fetchDescriptionBuilder ??
           (async (sourcePath: string) => descriptionBuilderPreview(sourcePath)),
@@ -465,6 +484,101 @@ describe("metadata tracker payloads", () => {
       Distributor: "Criterion",
       OriginalLanguage: "ja",
       Anime: false,
+    });
+  });
+
+  it("omits cleared metadata text overrides from edit controls", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    installAppBridge(fetchMetadata);
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByText("Edit Release Details"));
+    fireEvent.change(screen.getByLabelText("Distributor"), {
+      target: { value: "   " },
+    });
+    fireEvent.change(screen.getByLabelText("Original language"), {
+      target: { value: "   " },
+    });
+    fireEvent.change(screen.getByLabelText("Anime"), {
+      target: { value: "false" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(2));
+    expect(fetchMetadata.mock.calls[1][4]).toEqual({
+      Anime: false,
+    });
+  });
+
+  it("saves screenshot selections with the metadata overrides used to load the plan", async () => {
+    const existingImage: ScreenshotImage = {
+      Index: 0,
+      TimestampSeconds: 10,
+      Path: "C:\\media\\Example\\screen-001.png",
+      Width: 1920,
+      Height: 1080,
+      SizeBytes: 1024,
+    };
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const fetchScreenshotPlan = vi.fn<FetchScreenshotPlan>(async (sourcePath) => ({
+      ...screenshotPlan(sourcePath),
+      ExistingScreenshots: [existingImage],
+    }));
+    const saveFinalScreenshotSelections = vi.fn<SaveFinalScreenshotSelections>(
+      async () => undefined,
+    );
+    const readScreenshotImage = vi.fn<ReadScreenshotImage>(
+      async () => "data:image/png;base64,AA==",
+    );
+    installAppBridge(fetchMetadata, {
+      fetchScreenshotPlan,
+      saveFinalScreenshotSelections,
+      readScreenshotImage,
+    });
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByText("Edit Release Details"));
+    fireEvent.change(screen.getByLabelText("Distributor"), {
+      target: { value: "Loaded Distributor" },
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Screenshots" }));
+
+    await waitFor(() => expect(fetchScreenshotPlan).toHaveBeenCalledTimes(1));
+    expect(fetchScreenshotPlan.mock.calls[0][3]).toEqual({
+      Distributor: "Loaded Distributor",
+    });
+    await screen.findByRole("button", { name: "Add to final" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.click(screen.getByText("Edit Release Details"));
+    fireEvent.change(screen.getByLabelText("Distributor"), {
+      target: { value: "Drifted Distributor" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Screenshots" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Add to final" }));
+
+    await waitFor(() => expect(saveFinalScreenshotSelections).toHaveBeenCalledTimes(1));
+    expect(saveFinalScreenshotSelections.mock.calls[0][3]).toEqual({
+      Distributor: "Loaded Distributor",
     });
   });
 

--- a/gui/frontend/src/app.test.ts
+++ b/gui/frontend/src/app.test.ts
@@ -12,6 +12,7 @@ import type {
   DupeCheckSnapshot,
   DupeEntry,
   DupeMatch,
+  ExternalPreview,
   MetadataPreview,
   ScreenshotImage,
   ScreenshotPlan,
@@ -22,6 +23,7 @@ import type {
 } from "./types";
 import { isRuntimePathCaseInsensitive, updateBrowserCSRFToken } from "./utils/runtime";
 import { hasFilteredEmptyUploadTrackerSelection } from "./utils/trackerSelection";
+import { EventsOn } from "../wailsjs/runtime/runtime";
 
 vi.mock("../wailsjs/runtime/runtime", () => ({
   EventsOn: vi.fn(() => () => undefined),
@@ -33,6 +35,7 @@ const defaultPathCaseInsensitive = isRuntimePathCaseInsensitive();
 
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
   vi.useRealTimers();
   vi.unstubAllGlobals();
   updateBrowserCSRFToken("", defaultPathCaseInsensitive);
@@ -102,10 +105,31 @@ type FetchPreparation = (
   ignoreDupesFor: string[],
 ) => Promise<unknown>;
 type DetectDiscType = (sourcePath: string) => Promise<string>;
+type StartDupeCheck = (...args: unknown[]) => Promise<string>;
 type StartTrackerUpload = (...args: unknown[]) => Promise<string>;
 type RetryFailedTrackerUpload = (jobID: string) => Promise<string>;
 type CancelTrackerUpload = (jobID: string) => Promise<void>;
 type GetTrackerUploadSnapshot = (jobID: string) => Promise<TrackerUploadSnapshot>;
+
+const deferred = <T>() => {
+  let resolve: (value: T | PromiseLike<T>) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+const runtimeEventHandler = (eventName: string) => {
+  const call = vi
+    .mocked(EventsOn)
+    .mock.calls.find(([registeredName]) => registeredName === eventName);
+  if (!call) {
+    throw new Error(`Missing runtime event subscription for ${eventName}`);
+  }
+  return call[1] as (payload: unknown) => void;
+};
 
 const metadataPreview = (sourcePath: string): MetadataPreview => ({
   SourcePath: sourcePath,
@@ -133,6 +157,36 @@ const metadataPreview = (sourcePath: string): MetadataPreview => ({
   ExternalIDInfo: [],
   ExternalPreview: [],
   TrackerData: [],
+});
+
+const externalPreview = (provider: string, id: number, title: string): ExternalPreview => ({
+  Provider: provider,
+  ID: id,
+  Source: "metadata",
+  Title: title,
+  Year: 2026,
+  Overview: `${title} overview`,
+  PosterURL: "",
+  BackdropURL: "",
+  Category: "movie",
+  OriginalTitle: title,
+  ReleaseDate: "",
+  FirstAirDate: "",
+  LastAirDate: "",
+  OriginalLanguage: "",
+  TMDBType: "",
+  Runtime: 0,
+  Genres: "",
+  Keywords: "",
+  YouTube: "",
+  IMDBType: "",
+  Rating: 0,
+  RatingCount: 0,
+  RuntimeMinutes: 0,
+  Country: "",
+  Premiered: "",
+  IMDBID: provider === "imdb" ? id : 0,
+  TVDBID: 0,
 });
 
 const screenshotPlan = (sourcePath: string): ScreenshotPlan => ({
@@ -264,6 +318,7 @@ const installAppBridge = (
     fetchDescriptionBuilder?: FetchDescriptionBuilder;
     fetchPreparation?: FetchPreparation;
     browseFolder?: () => Promise<string>;
+    startDupeCheck?: StartDupeCheck;
     getDupeCheckSnapshot?: () => Promise<DupeCheckSnapshot>;
     detectDiscType?: DetectDiscType;
     startTrackerUpload?: StartTrackerUpload;
@@ -349,7 +404,7 @@ const installAppBridge = (
           },
         ],
         SavePlaylistSelection: async () => undefined,
-        StartDupeCheck: async () => "dupe-job-1",
+        StartDupeCheck: options.startDupeCheck ?? (async () => "dupe-job-1"),
         GetDupeCheckSnapshot: options.getDupeCheckSnapshot ?? (async () => dupeCheckSnapshot()),
         StartTrackerUpload: options.startTrackerUpload ?? (async () => "upload-job-1"),
         RetryFailedTrackerUpload: options.retryFailedTrackerUpload ?? (async () => "upload-job-2"),
@@ -534,7 +589,7 @@ describe("metadata tracker payloads", () => {
     });
   });
 
-  it("sends cleared metadata overrides from edit controls", async () => {
+  it("omits boolean metadata overrides when edit controls return to Auto", async () => {
     const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
     installAppBridge(fetchMetadata);
 
@@ -565,8 +620,211 @@ describe("metadata tracker payloads", () => {
     expect(fetchMetadata.mock.calls[1][4]).toEqual({
       Distributor: "",
       OriginalLanguage: "",
-      Clear: ["Anime"],
     });
+  });
+
+  it("does not clear inferred metadata flags when Auto is selected after an edit", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    installAppBridge(fetchMetadata);
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByText("Edit Release Details"));
+    fireEvent.change(screen.getByLabelText("Anime"), {
+      target: { value: "false" },
+    });
+    fireEvent.change(screen.getByLabelText("Anime"), {
+      target: { value: "" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(2));
+    expect(fetchMetadata.mock.calls[1][4]).toEqual({});
+  });
+
+  it("clears metadata override edits when the source path changes", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    installAppBridge(fetchMetadata);
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Old" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByText("Edit Release Details"));
+    fireEvent.change(screen.getByLabelText("Distributor"), {
+      target: { value: "Criterion" },
+    });
+    fireEvent.change(screen.getByLabelText("Anime"), {
+      target: { value: "false" },
+    });
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\New" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(2));
+    expect(fetchMetadata.mock.calls[1][0]).toBe("C:\\media\\New");
+    expect(fetchMetadata.mock.calls[1][4]).toEqual({});
+  });
+
+  it("keeps provider display order separate from the initial selected provider", async () => {
+    const preview: MetadataPreview = {
+      ...metadataPreview("C:\\media\\Example"),
+      ExternalIDs: {
+        ...metadataPreview("C:\\media\\Example").ExternalIDs,
+        TMDBID: 456,
+        IMDBID: 123,
+      },
+      ExternalIDInfo: [
+        { Provider: "imdb", ID: 123, Source: "metadata" },
+        { Provider: "tmdb", ID: 456, Source: "metadata" },
+      ],
+      ExternalPreview: [
+        externalPreview("imdb", 123, "IMDB first result"),
+        externalPreview("tmdb", 456, "TMDB display result"),
+      ],
+    };
+    const fetchMetadata = vi.fn<FetchMetadata>(async () => preview);
+    installAppBridge(fetchMetadata);
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+
+    expect(await screen.findByText("IMDB first result")).toBeInTheDocument();
+    expect(screen.queryByText("TMDB display result")).not.toBeInTheDocument();
+
+    const tmdbCard = screen.getByText("TMDB").closest("button");
+    const imdbCard = screen.getByText("IMDB").closest("button");
+    if (!tmdbCard || !imdbCard) {
+      throw new Error("Expected TMDB and IMDB provider cards");
+    }
+    expect(
+      Boolean(tmdbCard.compareDocumentPosition(imdbCard) & Node.DOCUMENT_POSITION_FOLLOWING),
+    ).toBe(true);
+  });
+
+  it("applies metadata progress listener payloads for the active source path", async () => {
+    const pendingMetadata = deferred<MetadataPreview>();
+    const fetchMetadata = vi.fn<FetchMetadata>(() => pendingMetadata.promise);
+    installAppBridge(fetchMetadata);
+    vi.stubGlobal("runtime", {});
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+
+    const metadataProgress = runtimeEventHandler("metadata:progress");
+    await act(async () => {
+      metadataProgress({
+        path: "C:\\media\\Example",
+        phase: "external-ids",
+        status: "running",
+        message: "Resolving IDs",
+        timestamp: "2026-06-17T00:00:00Z",
+      });
+    });
+
+    expect(screen.getByText("Metadata progress")).toBeInTheDocument();
+    expect(screen.getByText("Resolve external IDs")).toBeInTheDocument();
+    expect(screen.getByText("Running")).toBeInTheDocument();
+
+    await act(async () => {
+      metadataProgress({
+        path: "C:\\media\\Other",
+        phase: "media-details",
+        status: "failed",
+        message: "Wrong source",
+        timestamp: "2026-06-17T00:00:01Z",
+      });
+    });
+
+    expect(screen.queryByText("Failed")).not.toBeInTheDocument();
+
+    await act(async () => {
+      metadataProgress({
+        path: "C:\\media\\Example",
+        phase: "complete",
+        status: "completed",
+        message: "Done",
+        timestamp: "2026-06-17T00:00:02Z",
+      });
+    });
+
+    expect(screen.queryByText("Metadata progress")).not.toBeInTheDocument();
+
+    await act(async () => {
+      pendingMetadata.resolve(metadataPreview("C:\\media\\Example"));
+      await pendingMetadata.promise;
+    });
+  });
+
+  it("applies dupe job progress listener payloads for the active job", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const startDupeCheck = vi.fn<StartDupeCheck>(async () => "dupe-job-1");
+    const runningSnapshot: DupeCheckSnapshot = {
+      ...dupeCheckSnapshot(),
+      status: "running",
+      completedCount: 1,
+      summary: {
+        SourcePath: "C:\\media\\Example",
+        Results: [],
+        Notes: [],
+      },
+      finishedAt: "",
+    };
+    const getDupeCheckSnapshot = vi.fn(async () => runningSnapshot);
+    installAppBridge(fetchMetadata, {
+      startDupeCheck,
+      getDupeCheckSnapshot,
+    });
+    vi.stubGlobal("runtime", {});
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+
+    await waitFor(() => expect(startDupeCheck).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(vi.mocked(EventsOn)).toHaveBeenCalledWith("dupe:job:dupe-job-1", expect.any(Function)),
+    );
+    expect(
+      await screen.findByText("Tracker search progress: 1/2 trackers complete"),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      runtimeEventHandler("dupe:job:dupe-job-1")(dupeCheckSnapshot("C:\\media\\Example"));
+    });
+
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+    expect(
+      screen.queryByText("Tracker search progress: 1/2 trackers complete"),
+    ).not.toBeInTheDocument();
   });
 
   it("saves screenshot selections with the overrides used to load the plan", async () => {
@@ -640,6 +898,60 @@ describe("metadata tracker payloads", () => {
     expect(saveFinalScreenshotSelections.mock.calls[0][3]).toEqual({
       Distributor: "Loaded Distributor",
     });
+  });
+
+  it("ignores stale screenshot plan completions after the source path changes", async () => {
+    const existingImage: ScreenshotImage = {
+      Index: 0,
+      TimestampSeconds: 10,
+      Path: "C:\\media\\Old\\screen-001.png",
+      Width: 1920,
+      Height: 1080,
+      SizeBytes: 1024,
+    };
+    const pendingPlan = deferred<ScreenshotPlan>();
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const fetchScreenshotPlan = vi.fn<FetchScreenshotPlan>(() => pendingPlan.promise);
+    const readScreenshotImage = vi.fn<ReadScreenshotImage>(
+      async () => "data:image/png;base64,OLD==",
+    );
+    installAppBridge(fetchMetadata, {
+      fetchScreenshotPlan,
+      readScreenshotImage,
+    });
+
+    render(createElement(App));
+
+    const sourcePath = screen.getByLabelText("Source path");
+    fireEvent.change(sourcePath, {
+      target: { value: "C:\\media\\Old" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Screenshots" }));
+    await waitFor(() => expect(fetchScreenshotPlan).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\New" },
+    });
+
+    await act(async () => {
+      pendingPlan.resolve({
+        ...screenshotPlan("C:\\media\\Old"),
+        ExistingScreenshots: [existingImage],
+      });
+      await pendingPlan.promise;
+    });
+
+    expect(readScreenshotImage).not.toHaveBeenCalled();
+    expect(screen.queryByText("Existing Captures")).not.toBeInTheDocument();
+    expect(screen.queryByAltText("Existing 1")).not.toBeInTheDocument();
   });
 
   it("previews and captures screenshots with the overrides used to load the plan", async () => {
@@ -730,6 +1042,64 @@ describe("metadata tracker payloads", () => {
     expect(listUploadCandidates.mock.calls[0][3]).toEqual({
       Distributor: "Loaded Distributor",
     });
+  });
+
+  it("ignores stale upload candidate completions after leaving the upload path context", async () => {
+    const uploadImage: ScreenshotImage = {
+      Index: 0,
+      TimestampSeconds: 10,
+      Path: "C:\\media\\Old\\screen-001.png",
+      Width: 1920,
+      Height: 1080,
+      SizeBytes: 1024,
+    };
+    const pendingCandidates = deferred<ScreenshotImage[]>();
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const fetchScreenshotPlan = vi.fn<FetchScreenshotPlan>(async (sourcePath) =>
+      screenshotPlan(sourcePath),
+    );
+    const listUploadCandidates = vi.fn<ListUploadCandidates>(() => pendingCandidates.promise);
+    const readScreenshotImage = vi.fn<ReadScreenshotImage>(
+      async () => "data:image/png;base64,OLD==",
+    );
+    installAppBridge(fetchMetadata, {
+      fetchScreenshotPlan,
+      listUploadCandidates,
+      readScreenshotImage,
+    });
+
+    render(createElement(App));
+
+    const sourcePath = screen.getByLabelText("Source path");
+    fireEvent.change(sourcePath, {
+      target: { value: "C:\\media\\Old" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Screenshots" }));
+    await waitFor(() => expect(fetchScreenshotPlan).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Upload Images" }));
+    await waitFor(() => expect(listUploadCandidates).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.change(sourcePath, {
+      target: { value: "C:\\media\\New" },
+    });
+
+    await act(async () => {
+      pendingCandidates.resolve([uploadImage]);
+      await pendingCandidates.promise;
+    });
+
+    expect(readScreenshotImage).not.toHaveBeenCalled();
+    expect(screen.queryByText("Available Images")).not.toBeInTheDocument();
+    expect(screen.queryByAltText("Upload candidate")).not.toBeInTheDocument();
   });
 
   it("excludes dupe-blocked upload targets from metadata fetches", async () => {

--- a/gui/frontend/src/app.test.ts
+++ b/gui/frontend/src/app.test.ts
@@ -15,6 +15,9 @@ import type {
   MetadataPreview,
   ScreenshotImage,
   ScreenshotPlan,
+  ScreenshotPurpose,
+  ScreenshotResult,
+  ScreenshotSelection,
   TrackerUploadSnapshot,
 } from "./types";
 import { isRuntimePathCaseInsensitive, updateBrowserCSRFToken } from "./utils/runtime";
@@ -60,6 +63,27 @@ type SaveFinalScreenshotSelections = (
   metadataOverrides: unknown,
   images: ScreenshotImage[],
 ) => Promise<void>;
+type GenerateScreenshots = (
+  sourcePath: string,
+  overrides: unknown,
+  nameOverrides: unknown,
+  metadataOverrides: unknown,
+  selections: ScreenshotSelection[],
+  purpose: ScreenshotPurpose,
+) => Promise<ScreenshotResult>;
+type PreviewScreenshotFrame = (
+  sourcePath: string,
+  overrides: unknown,
+  nameOverrides: unknown,
+  metadataOverrides: unknown,
+  timestampSeconds: number,
+) => Promise<string>;
+type ListUploadCandidates = (
+  sourcePath: string,
+  overrides: unknown,
+  nameOverrides: unknown,
+  metadataOverrides: unknown,
+) => Promise<ScreenshotImage[]>;
 type ReadScreenshotImage = (imagePath: string) => Promise<string>;
 type FetchDescriptionBuilder = (
   sourcePath: string,
@@ -233,6 +257,9 @@ const installAppBridge = (
     saveConfig?: SaveConfig;
     fetchScreenshotPlan?: FetchScreenshotPlan;
     saveFinalScreenshotSelections?: SaveFinalScreenshotSelections;
+    generateScreenshots?: GenerateScreenshots;
+    previewScreenshotFrame?: PreviewScreenshotFrame;
+    listUploadCandidates?: ListUploadCandidates;
     readScreenshotImage?: ReadScreenshotImage;
     fetchDescriptionBuilder?: FetchDescriptionBuilder;
     fetchPreparation?: FetchPreparation;
@@ -284,9 +311,29 @@ const installAppBridge = (
         SaveConfig: options.saveConfig ?? (async () => undefined),
         FetchScreenshotPlan:
           options.fetchScreenshotPlan ?? (async (sourcePath: string) => screenshotPlan(sourcePath)),
+        GenerateScreenshots:
+          options.generateScreenshots ??
+          (async (
+            sourcePath: string,
+            _overrides: unknown,
+            _nameOverrides: unknown,
+            _metadataOverrides: unknown,
+            _selections: ScreenshotSelection[],
+            purpose: ScreenshotPurpose,
+          ) => ({
+            SourcePath: sourcePath,
+            Purpose: purpose,
+            Images: [],
+            Tonemapped: false,
+            UsedLibplacebo: false,
+            Errors: [],
+          })),
+        PreviewScreenshotFrame:
+          options.previewScreenshotFrame ?? (async () => "data:image/png;base64,PREVIEW=="),
         SaveFinalScreenshotSelections:
           options.saveFinalScreenshotSelections ?? (async () => undefined),
         ReadScreenshotImage: options.readScreenshotImage ?? (async () => "data:image/png;base64,"),
+        ListUploadCandidates: options.listUploadCandidates ?? (async () => []),
         FetchDescriptionBuilder:
           options.fetchDescriptionBuilder ??
           (async (sourcePath: string) => descriptionBuilderPreview(sourcePath)),
@@ -517,7 +564,7 @@ describe("metadata tracker payloads", () => {
     });
   });
 
-  it("saves screenshot selections with the metadata overrides used to load the plan", async () => {
+  it("saves screenshot selections with the overrides used to load the plan", async () => {
     const existingImage: ScreenshotImage = {
       Index: 0,
       TimestampSeconds: 10,
@@ -552,6 +599,8 @@ describe("metadata tracker payloads", () => {
     await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByText("Edit Release Details"));
+    fireEvent.change(screen.getByLabelText("TMDB ID"), { target: { value: "12345" } });
+    fireEvent.change(screen.getByLabelText("Category"), { target: { value: "movie" } });
     fireEvent.change(screen.getByLabelText("Distributor"), {
       target: { value: "Loaded Distributor" },
     });
@@ -563,6 +612,8 @@ describe("metadata tracker payloads", () => {
     fireEvent.click(screen.getByRole("button", { name: "Screenshots" }));
 
     await waitFor(() => expect(fetchScreenshotPlan).toHaveBeenCalledTimes(1));
+    expect(fetchScreenshotPlan.mock.calls[0][1]).toEqual({ TMDBID: 12345 });
+    expect(fetchScreenshotPlan.mock.calls[0][2]).toEqual({ Category: "movie" });
     expect(fetchScreenshotPlan.mock.calls[0][3]).toEqual({
       Distributor: "Loaded Distributor",
     });
@@ -570,6 +621,8 @@ describe("metadata tracker payloads", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Input" }));
     fireEvent.click(screen.getByText("Edit Release Details"));
+    fireEvent.change(screen.getByLabelText("TMDB ID"), { target: { value: "67890" } });
+    fireEvent.change(screen.getByLabelText("Category"), { target: { value: "tv" } });
     fireEvent.change(screen.getByLabelText("Distributor"), {
       target: { value: "Drifted Distributor" },
     });
@@ -577,7 +630,99 @@ describe("metadata tracker payloads", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Add to final" }));
 
     await waitFor(() => expect(saveFinalScreenshotSelections).toHaveBeenCalledTimes(1));
+    expect(saveFinalScreenshotSelections.mock.calls[0][1]).toEqual({ TMDBID: 12345 });
+    expect(saveFinalScreenshotSelections.mock.calls[0][2]).toEqual({ Category: "movie" });
     expect(saveFinalScreenshotSelections.mock.calls[0][3]).toEqual({
+      Distributor: "Loaded Distributor",
+    });
+  });
+
+  it("previews and captures screenshots with the overrides used to load the plan", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const fetchScreenshotPlan = vi.fn<FetchScreenshotPlan>(async (sourcePath) => ({
+      ...screenshotPlan(sourcePath),
+      SuggestedSelections: [
+        {
+          Index: 0,
+          TimestampSeconds: 10,
+          Frame: 240,
+          Source: "auto",
+        },
+      ],
+    }));
+    const previewScreenshotFrame = vi.fn<PreviewScreenshotFrame>(
+      async () => "data:image/png;base64,PREVIEW==",
+    );
+    const generateScreenshots = vi.fn<GenerateScreenshots>(
+      async (sourcePath, _overrides, _nameOverrides, _metadataOverrides, _selections, purpose) => ({
+        SourcePath: sourcePath,
+        Purpose: purpose,
+        Images: [],
+        Tonemapped: false,
+        UsedLibplacebo: false,
+        Errors: [],
+      }),
+    );
+    const listUploadCandidates = vi.fn<ListUploadCandidates>(async () => []);
+    installAppBridge(fetchMetadata, {
+      fetchScreenshotPlan,
+      previewScreenshotFrame,
+      generateScreenshots,
+      listUploadCandidates,
+    });
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByText("Edit Release Details"));
+    fireEvent.change(screen.getByLabelText("TMDB ID"), { target: { value: "12345" } });
+    fireEvent.change(screen.getByLabelText("Category"), { target: { value: "movie" } });
+    fireEvent.change(screen.getByLabelText("Distributor"), {
+      target: { value: "Loaded Distributor" },
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Screenshots" }));
+    await waitFor(() => expect(fetchScreenshotPlan).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.click(screen.getByText("Edit Release Details"));
+    fireEvent.change(screen.getByLabelText("TMDB ID"), { target: { value: "67890" } });
+    fireEvent.change(screen.getByLabelText("Category"), { target: { value: "tv" } });
+    fireEvent.change(screen.getByLabelText("Distributor"), {
+      target: { value: "Drifted Distributor" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Screenshots" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Run preview" }));
+    await waitFor(() => expect(previewScreenshotFrame).toHaveBeenCalledTimes(1));
+    expect(previewScreenshotFrame.mock.calls[0][1]).toEqual({ TMDBID: 12345 });
+    expect(previewScreenshotFrame.mock.calls[0][2]).toEqual({ Category: "movie" });
+    expect(previewScreenshotFrame.mock.calls[0][3]).toEqual({
+      Distributor: "Loaded Distributor",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Generate screenshots" }));
+    await waitFor(() => expect(generateScreenshots).toHaveBeenCalledTimes(1));
+    expect(generateScreenshots.mock.calls[0][1]).toEqual({ TMDBID: 12345 });
+    expect(generateScreenshots.mock.calls[0][2]).toEqual({ Category: "movie" });
+    expect(generateScreenshots.mock.calls[0][3]).toEqual({
+      Distributor: "Loaded Distributor",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Upload Images" }));
+    await waitFor(() => expect(listUploadCandidates).toHaveBeenCalledTimes(1));
+    expect(listUploadCandidates.mock.calls[0][1]).toEqual({ TMDBID: 12345 });
+    expect(listUploadCandidates.mock.calls[0][2]).toEqual({ Category: "movie" });
+    expect(listUploadCandidates.mock.calls[0][3]).toEqual({
       Distributor: "Loaded Distributor",
     });
   });

--- a/gui/frontend/src/app.test.ts
+++ b/gui/frontend/src/app.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { createElement } from "react";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import App, { hasExplicitEmptyReleaseTrackerSelection, ruleBlockingTrackerLabels } from "./app";
@@ -40,6 +40,7 @@ type FetchMetadata = (
   sourceLookupURL: string,
   overrides: unknown,
   nameOverrides: unknown,
+  metadataOverrides: unknown,
   trackers: string[],
 ) => Promise<MetadataPreview>;
 
@@ -50,6 +51,7 @@ type FetchDescriptionBuilder = (
   sourcePath: string,
   overrides: unknown,
   nameOverrides: unknown,
+  metadataOverrides: unknown,
   trackers: string[],
   ignoreDupesFor: string[],
 ) => Promise<DescriptionBuilderPreview>;
@@ -57,6 +59,7 @@ type FetchPreparation = (
   sourcePath: string,
   overrides: unknown,
   nameOverrides: unknown,
+  metadataOverrides: unknown,
   trackers: string[],
   ignoreDupesFor: string[],
 ) => Promise<unknown>;
@@ -433,6 +436,38 @@ describe("hasFilteredEmptyUploadTrackerSelection", () => {
 });
 
 describe("metadata tracker payloads", () => {
+  it("sends metadata overrides from edit controls", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    installAppBridge(fetchMetadata);
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByText("Edit Release Details"));
+    fireEvent.change(screen.getByLabelText("Distributor"), {
+      target: { value: "Criterion" },
+    });
+    fireEvent.change(screen.getByLabelText("Original language"), {
+      target: { value: "ja" },
+    });
+    fireEvent.change(screen.getByLabelText("Anime"), {
+      target: { value: "false" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(2));
+    expect(fetchMetadata.mock.calls[1][4]).toEqual({
+      Distributor: "Criterion",
+      OriginalLanguage: "ja",
+      Anime: false,
+    });
+  });
+
   it("excludes dupe-blocked upload targets from metadata fetches", async () => {
     const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
     installAppBridge(fetchMetadata);
@@ -450,7 +485,7 @@ describe("metadata tracker payloads", () => {
     fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
 
     await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(2));
-    expect(fetchMetadata.mock.calls[1][4]).toEqual(["AITHER", "BLU"]);
+    expect(fetchMetadata.mock.calls[1][5]).toEqual(["AITHER", "BLU"]);
 
     fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
     fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
@@ -461,7 +496,7 @@ describe("metadata tracker payloads", () => {
     fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
 
     await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(3));
-    expect(fetchMetadata.mock.calls[2][4]).toEqual(["AITHER"]);
+    expect(fetchMetadata.mock.calls[2][5]).toEqual(["AITHER"]);
   });
 
   it("does not apply dupe blocks from a previous path to metadata fetches", async () => {
@@ -489,7 +524,7 @@ describe("metadata tracker payloads", () => {
 
     await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(2));
     expect(fetchMetadata.mock.calls[1][0]).toBe("C:\\media\\Other");
-    expect(fetchMetadata.mock.calls[1][4]).toEqual(["AITHER", "BLU"]);
+    expect(fetchMetadata.mock.calls[1][5]).toEqual(["AITHER", "BLU"]);
   });
 
   it("keeps current upload disables when stale dupe state came from another path", async () => {
@@ -518,7 +553,7 @@ describe("metadata tracker payloads", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
     await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(2));
-    expect(fetchMetadata.mock.calls[1][4]).toEqual(["AITHER", "BLU"]);
+    expect(fetchMetadata.mock.calls[1][5]).toEqual(["AITHER", "BLU"]);
 
     fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
     fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
@@ -537,7 +572,7 @@ describe("metadata tracker payloads", () => {
 
     await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(3));
     expect(fetchMetadata.mock.calls[2][0]).toBe("C:\\media\\Other");
-    expect(fetchMetadata.mock.calls[2][4]).toEqual(["BLU"]);
+    expect(fetchMetadata.mock.calls[2][5]).toEqual(["BLU"]);
   });
 
   it("blocks metadata fetch when all selected trackers are filtered out", async () => {
@@ -655,8 +690,41 @@ describe("metadata tracker payloads", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Confirm Selection" }));
 
     await waitFor(() => expect(fetchPreparation).toHaveBeenCalledTimes(1));
-    expect(fetchPreparation.mock.calls[0][3]).toEqual(["AITHER"]);
-    expect(fetchPreparation.mock.calls[0][4]).toEqual([]);
+    expect(fetchPreparation.mock.calls[0][4]).toEqual(["AITHER"]);
+    expect(fetchPreparation.mock.calls[0][5]).toEqual([]);
+  });
+
+  it("sends edited overrides when preparing selected playlists", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const fetchPreparation = vi.fn<FetchPreparation>(async () => ({}));
+    installAppBridge(fetchMetadata, { fetchPreparation });
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+    await screen.findByText("2/2");
+
+    fireEvent.click(screen.getByText("Edit Release Details"));
+    fireEvent.change(screen.getByLabelText("TMDB ID"), { target: { value: "12345" } });
+    fireEvent.change(screen.getByLabelText("Source"), { target: { value: "BluRay" } });
+    fireEvent.change(screen.getByLabelText("Distributor"), { target: { value: "Criterion" } });
+    fireEvent.change(screen.getByLabelText("Anime"), { target: { value: "false" } });
+    fireEvent.click(screen.getByRole("button", { name: "Browse folder" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Confirm Selection" }));
+
+    await waitFor(() => expect(fetchPreparation).toHaveBeenCalledTimes(1));
+    expect(fetchPreparation.mock.calls[0][1]).toEqual({ TMDBID: 12345 });
+    expect(fetchPreparation.mock.calls[0][2]).toEqual({ Source: "BluRay" });
+    expect(fetchPreparation.mock.calls[0][3]).toEqual({
+      Distributor: "Criterion",
+      Anime: false,
+    });
+    expect(fetchPreparation.mock.calls[0][4]).toEqual(["AITHER", "BLU"]);
+    expect(fetchPreparation.mock.calls[0][5]).toEqual([]);
   });
 
   it("does not apply previous path dupe blocks when preparing selected playlists", async () => {
@@ -685,8 +753,8 @@ describe("metadata tracker payloads", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Confirm Selection" }));
 
     await waitFor(() => expect(fetchPreparation).toHaveBeenCalledTimes(1));
-    expect(fetchPreparation.mock.calls[0][3]).toEqual(["AITHER", "BLU"]);
-    expect(fetchPreparation.mock.calls[0][4]).toEqual([]);
+    expect(fetchPreparation.mock.calls[0][4]).toEqual(["AITHER", "BLU"]);
+    expect(fetchPreparation.mock.calls[0][5]).toEqual([]);
   });
 
   it.each([
@@ -735,8 +803,8 @@ describe("metadata tracker payloads", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Confirm Selection" }));
 
     await waitFor(() => expect(fetchPreparation).toHaveBeenCalledTimes(1));
-    expect(fetchPreparation.mock.calls[0][3]).toEqual(["AITHER"]);
-    expect(fetchPreparation.mock.calls[0][4]).toEqual([]);
+    expect(fetchPreparation.mock.calls[0][4]).toEqual(["AITHER"]);
+    expect(fetchPreparation.mock.calls[0][5]).toEqual([]);
   });
 });
 
@@ -774,6 +842,46 @@ describe("tracker upload job tracking", () => {
     await waitFor(() => expect(screen.getByText("Error: start failed")).toBeInTheDocument());
     expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
     expect(getTrackerUploadSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("clears previous upload job state before a failed replacement start resolves", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    let rejectSecondStart: (reason: Error) => void = () => undefined;
+    const startTrackerUpload = vi
+      .fn<StartTrackerUpload>()
+      .mockResolvedValueOnce("upload-job-1")
+      .mockImplementationOnce(
+        () =>
+          new Promise<string>((_resolve, reject) => {
+            rejectSecondStart = reject;
+          }),
+      );
+    const getTrackerUploadSnapshot = vi.fn<GetTrackerUploadSnapshot>().mockResolvedValueOnce(
+      trackerUploadSnapshot("upload-job-1", "failed", {
+        failedTrackers: ["AITHER"],
+        error: "upload failed",
+        finishedAt: "2026-06-17T00:00:01Z",
+      }),
+    );
+    await openTrackerUploadPage(fetchMetadata, { startTrackerUpload, getTrackerUploadSnapshot });
+    fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Retry Failed" })).toBeEnabled());
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
+
+    expect(startTrackerUpload).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+      await Promise.resolve();
+    });
+    expect(getTrackerUploadSnapshot).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      rejectSecondStart(new Error("start failed"));
+    });
+    expect(screen.getByText("Error: start failed")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Retry Failed" })).toBeDisabled();
   });
 
   it("keeps retry upload tracking alive when replacement bootstrap snapshot loading fails", async () => {

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -54,6 +54,7 @@ import type {
   ReleaseNameOverrides,
   ReleaseNameTouchedState,
   ScreenshotImage,
+  ScreenshotOverrideSnapshot,
   ScreenshotPlan,
   ScreenshotPreviewImage,
   ScreenshotPurpose,
@@ -1503,6 +1504,7 @@ export default function App() {
     setExistingImages,
     resetScreenshotState: resetScreenshots,
     handleDeleteTrackerImageURL,
+    getLoadedScreenshotOverrides,
   } = screenshots;
 
   /**
@@ -1617,6 +1619,9 @@ export default function App() {
     uploadCandidates: screenshots.uploadCandidates,
     configuredImageHosts,
     selectedTrackers: selectedUploadImageTrackers,
+    screenshotOverrideSnapshot: screenshots.screenshotPlan
+      ? getLoadedScreenshotOverrides()
+      : undefined,
   });
   const {
     refreshUploadedImages,
@@ -2746,11 +2751,12 @@ export default function App() {
     if (!runner) {
       throw new Error("Screenshot capture is unavailable in this build.");
     }
+    const screenshotOverrides = getLoadedScreenshotOverrides();
     return runner(
       path.trim(),
-      normalizeOverrides(idOverrideState?.overrides || {}),
-      normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-      normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+      screenshotOverrides.external,
+      screenshotOverrides.release,
+      screenshotOverrides.metadata,
       selections,
       purpose,
     );
@@ -2828,11 +2834,12 @@ export default function App() {
     setLivePreviewLoading(true);
     const timestamp = clampPreviewSeconds(timestampSeconds);
     try {
+      const screenshotOverrides = getLoadedScreenshotOverrides();
       const dataUri = await previewer(
         path.trim(),
-        normalizeOverrides(idOverrideState?.overrides || {}),
-        normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-        normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+        screenshotOverrides.external,
+        screenshotOverrides.release,
+        screenshotOverrides.metadata,
         timestamp,
       );
       if (livePreviewRequestId.current !== requestId) {
@@ -3294,13 +3301,21 @@ export default function App() {
   useEffect(() => {
     if (activeTab !== "upload_images") return;
     if (!path.trim()) return;
+    if (dupeChecked && !screenshots.screenshotPlan) return;
     const loadUploadCandidates = async () => {
       try {
+        const screenshotOverrides: ScreenshotOverrideSnapshot = screenshots.screenshotPlan
+          ? getLoadedScreenshotOverrides()
+          : {
+              external: normalizeOverrides(idOverrideState?.overrides || {}),
+              release: normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+              metadata: normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+            };
         const candidates = await globalThis.go?.guiapp?.App?.ListUploadCandidates(
           path.trim(),
-          normalizeOverrides(idOverrideState?.overrides || {}),
-          normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+          screenshotOverrides.external,
+          screenshotOverrides.release,
+          screenshotOverrides.metadata,
         );
         if (!candidates || candidates.length === 0) {
           setExistingImages([]);
@@ -3328,9 +3343,12 @@ export default function App() {
   }, [
     activeTab,
     path,
+    dupeChecked,
+    screenshots.screenshotPlan,
     idOverrideState,
     releaseOverrideState,
     metadataOverrideState,
+    getLoadedScreenshotOverrides,
     setExistingImages,
     readScreenshotImage,
     refreshUploadedImages,

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -38,7 +38,6 @@ import type {
   DupeCheckResult,
   DupeCheckSnapshot,
   DupeCheckSummary,
-  ExternalIDInfo,
   ExternalIDOverrides,
   ExternalIDs,
   HistoryEntry,
@@ -626,21 +625,6 @@ const parseIDInput = (provider: string, value: string) => {
   return Number(normalized);
 };
 
-const providerOrder = ["tmdb", "imdb", "tvdb", "tvmaze"] as const;
-
-const filterAndOrderExternalIDs = (info: ExternalIDInfo[]) => {
-  const orderIndex = new Map<string, number>(
-    providerOrder.map((provider, index) => [provider, index]),
-  );
-
-  return [...info].sort((left, right) => {
-    const leftIndex = orderIndex.get(left.Provider) ?? providerOrder.length;
-    const rightIndex = orderIndex.get(right.Provider) ?? providerOrder.length;
-    if (leftIndex !== rightIndex) return leftIndex - rightIndex;
-    return left.Provider.localeCompare(right.Provider);
-  });
-};
-
 const formatNumber = (value: number) => (value ? value.toString() : "");
 
 const buildIDEditState = (ids: ExternalIDs) => ({
@@ -649,6 +633,23 @@ const buildIDEditState = (ids: ExternalIDs) => ({
   tvdb: formatNumber(ids.TVDBID),
   tvmaze: formatNumber(ids.TVmazeID),
 });
+
+/**
+ * Picks the initially opened metadata preview from backend result order.
+ *
+ * External ID cards may render in a fixed provider display order, so this must
+ * not reuse that sorted list when deciding which provider the backend selected.
+ */
+const defaultSelectedProviderForPreview = (result: MetadataPreview) => {
+  const ids = result.ExternalIDInfo || [];
+  const previews = result.ExternalPreview || [];
+  const previewProviders = new Set(previews.map((item) => item.Provider).filter(Boolean));
+  const firstIDWithPreview = ids.find(
+    (item) => item.Provider && (previewProviders.size === 0 || previewProviders.has(item.Provider)),
+  );
+  if (firstIDWithPreview?.Provider) return firstIDWithPreview.Provider;
+  return previews.find((item) => item.Provider)?.Provider || "";
+};
 
 const buildReleaseEditState = (overrides?: ReleaseNameOverrides): ReleaseNameEditState => ({
   category: overrides?.Category ?? "",
@@ -711,7 +712,7 @@ const buildMetadataEditState = (overrides?: MetadataOverrides): MetadataOverride
   anime: boolOverrideEditValue(overrides?.Anime),
 });
 
-/** Returns metadata fields whose edited tri-state controls were explicitly reset to Auto. */
+/** Returns metadata fields carried by an explicit Clear override payload. */
 const metadataOverrideClears = (overrides?: MetadataOverrides) =>
   new Set((overrides?.Clear || []).map((field) => String(field || "").trim()));
 
@@ -783,6 +784,8 @@ export default function App() {
     () => true,
   );
   const [path, setPath] = useState("");
+  const activePathRef = useRef(path.trim());
+  activePathRef.current = path.trim();
   const [sourcePathHistory, setSourcePathHistory] = useState<SourcePathHistoryEntry[]>(() => {
     try {
       return normalizeSourcePathHistory(
@@ -838,6 +841,7 @@ export default function App() {
   // same tick as a fetch/reset request are not dropped by a stale React closure.
   const metadataProgressActiveRef = useRef(false);
   const metadataProgressTargetRef = useRef("");
+  const uploadCandidatesRequestIdRef = useRef(0);
   const [dupeSummary, setDupeSummary] = useState<DupeCheckSummary>(emptyDupeSummary);
   const [dupeLoading, setDupeLoading] = useState(false);
   const [dupeError, setDupeError] = useState("");
@@ -1001,10 +1005,21 @@ export default function App() {
     [inputHistoryLimit, persistSourcePathHistory],
   );
 
-  const handleSourcePathChange = useCallback((value: string) => {
-    setPath(value);
-    setSourcePathMode(undefined);
+  const resetMetadataOverrideState = useCallback(() => {
+    setMetadataEdits(buildMetadataEditState({}));
+    setMetadataTouched(buildMetadataTouchedState({}));
   }, []);
+
+  const handleSourcePathChange = useCallback(
+    (value: string) => {
+      if (!isSourcePathContextMatch(path, value, isRuntimePathCaseInsensitive())) {
+        resetMetadataOverrideState();
+      }
+      setPath(value);
+      setSourcePathMode(undefined);
+    },
+    [path, resetMetadataOverrideState],
+  );
 
   useEffect(() => {
     setSourcePathHistory((prev) => {
@@ -1457,7 +1472,6 @@ export default function App() {
 
   const metadataOverrideState = useMemo(() => {
     const overrides: MetadataOverrides = {};
-    const clear: string[] = [];
     const distributor = metadataEdits.distributor.trim();
     const originalLanguage = metadataEdits.originalLanguage.trim();
     if (metadataTouched.distributor) {
@@ -1472,27 +1486,19 @@ export default function App() {
     const streamOptimized = parseBoolOverrideEditValue(metadataEdits.streamOptimized);
     const anime = parseBoolOverrideEditValue(metadataEdits.anime);
     if (metadataTouched.personalRelease) {
-      if (personalRelease === null) clear.push("PersonalRelease");
-      else overrides.PersonalRelease = personalRelease;
+      if (personalRelease !== null) overrides.PersonalRelease = personalRelease;
     }
     if (metadataTouched.commentary) {
-      if (commentary === null) clear.push("Commentary");
-      else overrides.Commentary = commentary;
+      if (commentary !== null) overrides.Commentary = commentary;
     }
     if (metadataTouched.webDV) {
-      if (webDV === null) clear.push("WebDV");
-      else overrides.WebDV = webDV;
+      if (webDV !== null) overrides.WebDV = webDV;
     }
     if (metadataTouched.streamOptimized) {
-      if (streamOptimized === null) clear.push("StreamOptimized");
-      else overrides.StreamOptimized = streamOptimized;
+      if (streamOptimized !== null) overrides.StreamOptimized = streamOptimized;
     }
     if (metadataTouched.anime) {
-      if (anime === null) clear.push("Anime");
-      else overrides.Anime = anime;
-    }
-    if (clear.length > 0) {
-      overrides.Clear = clear;
+      if (anime !== null) overrides.Anime = anime;
     }
     return {
       overrides,
@@ -1979,12 +1985,7 @@ export default function App() {
     setIdEdits(buildIDEditState(result.ExternalIDs));
     setReleaseEdits(buildReleaseEditState(result.ReleaseNameOverrides || {}));
     setReleaseTouched(buildReleaseTouchedState(result.ReleaseNameOverrides || {}));
-    const orderedIDs = filterAndOrderExternalIDs(result.ExternalIDInfo || []);
-    if (orderedIDs.length > 0) {
-      setSelectedProvider(orderedIDs[0].Provider);
-    } else {
-      setSelectedProvider("");
-    }
+    setSelectedProvider(defaultSelectedProviderForPreview(result));
     setDupeSummary(emptyDupeSummary);
     setDupeError("");
     setBuilderPreview(emptyDescriptionBuilder);
@@ -2184,6 +2185,9 @@ export default function App() {
       return null;
     }
     const selectedMode = mode ?? inferSourcePathMode(trimmedPath);
+    if (!isSourcePathContextMatch(path, trimmedPath, isRuntimePathCaseInsensitive())) {
+      resetMetadataOverrideState();
+    }
     setPath(trimmedPath);
     setSourcePathMode(selectedMode);
     rememberSourcePath(trimmedPath, selectedMode);
@@ -3325,8 +3329,19 @@ export default function App() {
     if (activeTab !== "upload_images") return;
     if (!path.trim()) return;
     if (dupeChecked && !screenshots.screenshotPlan) return;
+    // Candidate previews are loaded in multiple awaits; keep only the latest
+    // request for the current source path eligible to update upload state.
+    const requestId = uploadCandidatesRequestIdRef.current + 1;
+    uploadCandidatesRequestIdRef.current = requestId;
+    let canceled = false;
+    const isCurrentRequest = () =>
+      !canceled &&
+      uploadCandidatesRequestIdRef.current === requestId &&
+      activePathRef.current === path.trim();
+
     const loadUploadCandidates = async () => {
       try {
+        const sourcePath = path.trim();
         const screenshotOverrides: ScreenshotOverrideSnapshot = screenshots.screenshotPlan
           ? getLoadedScreenshotOverrides()
           : {
@@ -3335,11 +3350,14 @@ export default function App() {
               metadata: normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
             };
         const candidates = await globalThis.go?.guiapp?.App?.ListUploadCandidates(
-          path.trim(),
+          sourcePath,
           screenshotOverrides.external,
           screenshotOverrides.release,
           screenshotOverrides.metadata,
         );
+        if (!isCurrentRequest()) {
+          return;
+        }
         if (!candidates || candidates.length === 0) {
           setExistingImages([]);
           await refreshUploadedImages();
@@ -3354,6 +3372,9 @@ export default function App() {
             }
           }),
         );
+        if (!isCurrentRequest()) {
+          return;
+        }
         setExistingImages(
           previews.filter((entry): entry is ScreenshotPreviewImage => Boolean(entry)),
         );
@@ -3363,6 +3384,12 @@ export default function App() {
       }
     };
     loadUploadCandidates();
+    return () => {
+      canceled = true;
+      if (uploadCandidatesRequestIdRef.current === requestId) {
+        uploadCandidatesRequestIdRef.current += 1;
+      }
+    };
   }, [
     activeTab,
     path,

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -1442,11 +1442,13 @@ export default function App() {
 
   const metadataOverrideState = useMemo(() => {
     const overrides: MetadataOverrides = {};
-    if (metadataTouched.distributor) {
-      overrides.Distributor = metadataEdits.distributor.trim();
+    const distributor = metadataEdits.distributor.trim();
+    const originalLanguage = metadataEdits.originalLanguage.trim();
+    if (metadataTouched.distributor && distributor !== "") {
+      overrides.Distributor = distributor;
     }
-    if (metadataTouched.originalLanguage) {
-      overrides.OriginalLanguage = metadataEdits.originalLanguage.trim();
+    if (metadataTouched.originalLanguage && originalLanguage !== "") {
+      overrides.OriginalLanguage = originalLanguage;
     }
     const personalRelease = parseBoolOverrideEditValue(metadataEdits.personalRelease);
     const commentary = parseBoolOverrideEditValue(metadataEdits.commentary);

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -44,6 +44,9 @@ import type {
   HistoryEntry,
   HistoryOverview,
   ImageHostPolicyMetadata,
+  MetadataOverrideEditState,
+  MetadataOverrides,
+  MetadataOverrideTouchedState,
   MetadataPreview,
   MetadataProgressUpdate,
   PreparationPreview,
@@ -91,6 +94,7 @@ import {
   hasFilteredEmptyUploadTrackerSelection as hasFilteredEmptyUploadTrackerSelectionState,
   resolveSelectedUploadTrackers,
 } from "./utils/trackerSelection";
+import { normalizeMetadataOverrides, normalizeOverrides, normalizeReleaseOverrides } from "./utils";
 
 const appLayoutClass =
   "relative z-[1] block min-h-screen ml-[204px] max-[960px]:ml-0 max-[960px]:pb-[78px]";
@@ -412,6 +416,7 @@ declare global {
               sourceLookupURL: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               trackers: string[],
             ) => Promise<MetadataPreview>;
             ResetMetadata: (
@@ -419,6 +424,7 @@ declare global {
               sourceLookupURL: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               trackers: string[],
             ) => Promise<MetadataPreview>;
             SelectBlurayCandidate: (path: string, releaseID: string) => Promise<MetadataPreview>;
@@ -426,6 +432,7 @@ declare global {
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               trackers: string[],
               ignoreDupesFor: string[],
             ) => Promise<DescriptionBuilderPreview>;
@@ -433,6 +440,7 @@ declare global {
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               trackers: string[],
               ignoreDupesFor: string[],
             ) => Promise<PreparationPreview>;
@@ -440,6 +448,7 @@ declare global {
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               trackers: string[],
               ignoreDupesFor: string[],
               questionnaireAnswers: Record<string, Record<string, string>>,
@@ -452,12 +461,14 @@ declare global {
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               trackers: string[],
             ) => Promise<DupeCheckSummary>;
             StartDupeCheck: (
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               trackers: string[],
             ) => Promise<string>;
             CancelDupeCheck: (jobID: string) => Promise<void>;
@@ -466,11 +477,13 @@ declare global {
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
             ) => Promise<ScreenshotPlan>;
             GenerateScreenshots: (
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               selections: ScreenshotSelection[],
               purpose: ScreenshotPurpose,
             ) => Promise<ScreenshotResult>;
@@ -478,24 +491,28 @@ declare global {
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               timestampSeconds: number,
             ) => Promise<string>;
             DeleteScreenshot: (
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               imagePath: string,
             ) => Promise<void>;
             SaveFinalScreenshotSelections: (
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               images: ScreenshotImage[],
             ) => Promise<void>;
             ImportMenuImages: (
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               paths: string[],
             ) => Promise<void>;
             ReadScreenshotImage: (path: string) => Promise<string>;
@@ -503,16 +520,19 @@ declare global {
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
             ) => Promise<ScreenshotImage[]>;
             ListUploadedImages: (
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
             ) => Promise<UploadedImageLink[]>;
             UploadImages: (
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               trackers: string[],
               host: string,
               images: ScreenshotImage[],
@@ -526,6 +546,7 @@ declare global {
               trackers: string[],
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
             ) => Promise<DescriptionBuilderPreview["Groups"][number]>;
             DiscoverPlaylists: (path: string) => Promise<any[]>;
             SavePlaylistSelection: (
@@ -574,6 +595,7 @@ declare global {
               path: string,
               overrides: ExternalIDOverrides,
               nameOverrides: ReleaseNameOverrides,
+              metadataOverrides: MetadataOverrides,
               trackers: string[],
               ignoreDupesFor: string[],
               questionnaireAnswers: Record<string, Record<string, string>>,
@@ -678,6 +700,39 @@ const buildReleaseTouchedState = (overrides?: ReleaseNameOverrides): ReleaseName
   region: overrides?.Region !== undefined && overrides?.Region !== null,
 });
 
+const buildMetadataEditState = (overrides?: MetadataOverrides): MetadataOverrideEditState => ({
+  distributor: overrides?.Distributor ?? "",
+  originalLanguage: overrides?.OriginalLanguage ?? "",
+  personalRelease: boolOverrideEditValue(overrides?.PersonalRelease),
+  commentary: boolOverrideEditValue(overrides?.Commentary),
+  webDV: boolOverrideEditValue(overrides?.WebDV),
+  streamOptimized: boolOverrideEditValue(overrides?.StreamOptimized),
+  anime: boolOverrideEditValue(overrides?.Anime),
+});
+
+const buildMetadataTouchedState = (
+  overrides?: MetadataOverrides,
+): MetadataOverrideTouchedState => ({
+  distributor: overrides?.Distributor !== undefined && overrides?.Distributor !== null,
+  originalLanguage:
+    overrides?.OriginalLanguage !== undefined && overrides?.OriginalLanguage !== null,
+  personalRelease: overrides?.PersonalRelease !== undefined && overrides?.PersonalRelease !== null,
+  commentary: overrides?.Commentary !== undefined && overrides?.Commentary !== null,
+  webDV: overrides?.WebDV !== undefined && overrides?.WebDV !== null,
+  streamOptimized: overrides?.StreamOptimized !== undefined && overrides?.StreamOptimized !== null,
+  anime: overrides?.Anime !== undefined && overrides?.Anime !== null,
+});
+
+const boolOverrideEditValue = (value?: boolean | null): "" | "true" | "false" => {
+  if (value === undefined || value === null) return "";
+  return value ? "true" : "false";
+};
+
+const parseBoolOverrideEditValue = (value: "" | "true" | "false") => {
+  if (value === "") return null;
+  return value === "true";
+};
+
 const normalizeTag = (value: string) => {
   const trimmed = value.trim();
   if (!trimmed) return "";
@@ -738,6 +793,8 @@ export default function App() {
   const [releaseTouched, setReleaseTouched] = useState(() =>
     buildReleaseTouchedState(emptyPreview.ReleaseNameOverrides),
   );
+  const [metadataEdits, setMetadataEdits] = useState(() => buildMetadataEditState({}));
+  const [metadataTouched, setMetadataTouched] = useState(() => buildMetadataTouchedState({}));
   const [showExternalIDInputUI, setShowExternalIDInputUI] = useState(true);
   const [selectedProvider, setSelectedProvider] = useState<string>("");
   const [activeTab, setActiveTab] = useState("input");
@@ -1383,11 +1440,47 @@ export default function App() {
     return { overrides, dirty, invalid };
   }, [releaseEdits, releaseTouched, preview.ReleaseNameOverrides]);
 
+  const metadataOverrideState = useMemo(() => {
+    const overrides: MetadataOverrides = {};
+    if (metadataTouched.distributor) {
+      overrides.Distributor = metadataEdits.distributor.trim();
+    }
+    if (metadataTouched.originalLanguage) {
+      overrides.OriginalLanguage = metadataEdits.originalLanguage.trim();
+    }
+    const personalRelease = parseBoolOverrideEditValue(metadataEdits.personalRelease);
+    const commentary = parseBoolOverrideEditValue(metadataEdits.commentary);
+    const webDV = parseBoolOverrideEditValue(metadataEdits.webDV);
+    const streamOptimized = parseBoolOverrideEditValue(metadataEdits.streamOptimized);
+    const anime = parseBoolOverrideEditValue(metadataEdits.anime);
+    if (metadataTouched.personalRelease && personalRelease !== null) {
+      overrides.PersonalRelease = personalRelease;
+    }
+    if (metadataTouched.commentary && commentary !== null) {
+      overrides.Commentary = commentary;
+    }
+    if (metadataTouched.webDV && webDV !== null) {
+      overrides.WebDV = webDV;
+    }
+    if (metadataTouched.streamOptimized && streamOptimized !== null) {
+      overrides.StreamOptimized = streamOptimized;
+    }
+    if (metadataTouched.anime && anime !== null) {
+      overrides.Anime = anime;
+    }
+    return {
+      overrides,
+      dirty: Object.keys(overrides).length > 0,
+      invalid: false,
+    };
+  }, [metadataEdits, metadataTouched]);
+
   // Screenshot workflow hook (now idOverrideState/releaseOverrideState are defined)
   const screenshots = useScreenshots({
     path,
     idOverrideState,
     releaseOverrideState,
+    metadataOverrideState,
   });
 
   // Destructure commonly used screenshot variables
@@ -1518,6 +1611,7 @@ export default function App() {
     path,
     idOverrideState,
     releaseOverrideState,
+    metadataOverrideState,
     uploadCandidates: screenshots.uploadCandidates,
     configuredImageHosts,
     selectedTrackers: selectedUploadImageTrackers,
@@ -1835,97 +1929,13 @@ export default function App() {
   const refreshDisabled =
     loading ||
     !path.trim() ||
-    (!idOverrideState?.dirty && !releaseOverrideState?.dirty && !sourceLookupURL.trim()) ||
+    (!idOverrideState?.dirty &&
+      !releaseOverrideState?.dirty &&
+      !metadataOverrideState?.dirty &&
+      !sourceLookupURL.trim()) ||
     idOverrideState?.invalid ||
-    releaseOverrideState?.invalid;
-
-  const normalizeOverrides = (overrides: ExternalIDOverrides) => {
-    const payload: ExternalIDOverrides = {};
-    if (overrides.TMDBID !== null && overrides.TMDBID !== undefined) {
-      payload.TMDBID = overrides.TMDBID;
-    }
-    if (overrides.IMDBID !== null && overrides.IMDBID !== undefined) {
-      payload.IMDBID = overrides.IMDBID;
-    }
-    if (overrides.TVDBID !== null && overrides.TVDBID !== undefined) {
-      payload.TVDBID = overrides.TVDBID;
-    }
-    if (overrides.TVmazeID !== null && overrides.TVmazeID !== undefined) {
-      payload.TVmazeID = overrides.TVmazeID;
-    }
-    return payload;
-  };
-
-  const normalizeReleaseOverrides = (overrides: ReleaseNameOverrides) => {
-    const payload: ReleaseNameOverrides = {};
-    if (overrides.Category !== null && overrides.Category !== undefined) {
-      payload.Category = overrides.Category;
-    }
-    if (overrides.Type !== null && overrides.Type !== undefined) {
-      payload.Type = overrides.Type;
-    }
-    if (overrides.Source !== null && overrides.Source !== undefined) {
-      payload.Source = overrides.Source;
-    }
-    if (overrides.Resolution !== null && overrides.Resolution !== undefined) {
-      payload.Resolution = overrides.Resolution;
-    }
-    if (overrides.Tag !== null && overrides.Tag !== undefined) {
-      payload.Tag = overrides.Tag;
-    }
-    if (overrides.Service !== null && overrides.Service !== undefined) {
-      payload.Service = overrides.Service;
-    }
-    if (overrides.Edition !== null && overrides.Edition !== undefined) {
-      payload.Edition = overrides.Edition;
-    }
-    if (overrides.Season !== null && overrides.Season !== undefined) {
-      payload.Season = overrides.Season;
-    }
-    if (overrides.Episode !== null && overrides.Episode !== undefined) {
-      payload.Episode = overrides.Episode;
-    }
-    if (overrides.EpisodeTitle !== null && overrides.EpisodeTitle !== undefined) {
-      payload.EpisodeTitle = overrides.EpisodeTitle;
-    }
-    if (overrides.ManualYear !== null && overrides.ManualYear !== undefined) {
-      payload.ManualYear = overrides.ManualYear;
-    }
-    if (overrides.ManualDate !== null && overrides.ManualDate !== undefined) {
-      payload.ManualDate = overrides.ManualDate;
-    }
-    if (overrides.UseSeasonEpisode !== null && overrides.UseSeasonEpisode !== undefined) {
-      payload.UseSeasonEpisode = overrides.UseSeasonEpisode;
-    }
-    if (overrides.NoSeason !== null && overrides.NoSeason !== undefined) {
-      payload.NoSeason = overrides.NoSeason;
-    }
-    if (overrides.NoYear !== null && overrides.NoYear !== undefined) {
-      payload.NoYear = overrides.NoYear;
-    }
-    if (overrides.NoAKA !== null && overrides.NoAKA !== undefined) {
-      payload.NoAKA = overrides.NoAKA;
-    }
-    if (overrides.NoTag !== null && overrides.NoTag !== undefined) {
-      payload.NoTag = overrides.NoTag;
-    }
-    if (overrides.NoEdition !== null && overrides.NoEdition !== undefined) {
-      payload.NoEdition = overrides.NoEdition;
-    }
-    if (overrides.NoDub !== null && overrides.NoDub !== undefined) {
-      payload.NoDub = overrides.NoDub;
-    }
-    if (overrides.NoDual !== null && overrides.NoDual !== undefined) {
-      payload.NoDual = overrides.NoDual;
-    }
-    if (overrides.DualAudio !== null && overrides.DualAudio !== undefined) {
-      payload.DualAudio = overrides.DualAudio;
-    }
-    if (overrides.Region !== null && overrides.Region !== undefined) {
-      payload.Region = overrides.Region;
-    }
-    return payload;
-  };
+    releaseOverrideState?.invalid ||
+    metadataOverrideState?.invalid;
 
   const applyPreviewResult = (
     result: MetadataPreview,
@@ -2217,7 +2227,14 @@ export default function App() {
       return false;
     }
     try {
-      await fetcher(path.trim(), {}, {}, selectedTrackers, []);
+      await fetcher(
+        path.trim(),
+        normalizeOverrides(idOverrideState?.overrides || {}),
+        normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+        normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+        selectedTrackers,
+        [],
+      );
       return true;
     } catch (err) {
       setPlaylistPreparationError(String(err));
@@ -2244,6 +2261,7 @@ export default function App() {
   const runFetch = async (
     overrides: ExternalIDOverrides,
     nameOverrides: ReleaseNameOverrides,
+    metadataOverrides: MetadataOverrides,
     hideExternalIDInputUIOnSuccess = false,
     options: { targetPath?: string; targetMode?: SourcePathMode; switchToInput?: boolean } = {},
   ) => {
@@ -2283,6 +2301,7 @@ export default function App() {
         sourceLookupURL.trim(),
         normalizeOverrides(overrides),
         normalizeReleaseOverrides(nameOverrides),
+        normalizeMetadataOverrides(metadataOverrides),
         selectedTrackers,
       );
       applyPreviewResult(result, { switchToInput: options.switchToInput });
@@ -2301,7 +2320,12 @@ export default function App() {
   };
 
   const handleFetch = async () => {
-    await runFetch({}, {}, false);
+    await runFetch(
+      idOverrideState?.overrides || {},
+      releaseOverrideState?.overrides || {},
+      metadataOverrideState?.overrides || {},
+      false,
+    );
   };
 
   const handleSourcePathDrop = async (paths: string[]) => {
@@ -2319,7 +2343,7 @@ export default function App() {
     if (!selection || selection.waitsForPlaylistSelection) {
       return;
     }
-    await runFetch({}, {}, false, {
+    await runFetch({}, {}, {}, false, {
       targetPath: selection.path,
       targetMode: selection.mode,
     });
@@ -2352,17 +2376,28 @@ export default function App() {
     setIdEdits(buildIDEditState(emptyPreview.ExternalIDs));
     setReleaseEdits(buildReleaseEditState({}));
     setReleaseTouched(buildReleaseTouchedState({}));
+    setMetadataEdits(buildMetadataEditState({}));
+    setMetadataTouched(buildMetadataTouchedState({}));
   };
 
   const handleRefresh = async () => {
     if (
-      (!idOverrideState?.dirty && !releaseOverrideState?.dirty && !sourceLookupURL.trim()) ||
+      (!idOverrideState?.dirty &&
+        !releaseOverrideState?.dirty &&
+        !metadataOverrideState?.dirty &&
+        !sourceLookupURL.trim()) ||
       idOverrideState?.invalid ||
-      releaseOverrideState?.invalid
+      releaseOverrideState?.invalid ||
+      metadataOverrideState?.invalid
     ) {
       return;
     }
-    await runFetch(idOverrideState?.overrides || {}, releaseOverrideState?.overrides || {}, true);
+    await runFetch(
+      idOverrideState?.overrides || {},
+      releaseOverrideState?.overrides || {},
+      metadataOverrideState?.overrides || {},
+      true,
+    );
   };
 
   const handleResetMetadata = async () => {
@@ -2397,7 +2432,14 @@ export default function App() {
     setLoading(true);
     setMetadataResetting(true);
     try {
-      const result = await resetter(targetPath, sourceLookupURL.trim(), {}, {}, selectedTrackers);
+      const result = await resetter(
+        targetPath,
+        sourceLookupURL.trim(),
+        {},
+        {},
+        {},
+        selectedTrackers,
+      );
       applyPreviewResult(result);
       setShowExternalIDInputUI(true);
     } catch (err) {
@@ -2494,6 +2536,7 @@ export default function App() {
           path.trim(),
           normalizeOverrides(overrides),
           normalizeReleaseOverrides(nameOverrides),
+          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
           selectedTrackers,
           ignoredDupeTrackers,
         );
@@ -2534,6 +2577,7 @@ export default function App() {
       selectedUploadImageTrackers,
       ignoredDupeTrackers,
       refreshUploadedImages,
+      metadataOverrideState,
     ],
   );
 
@@ -2595,6 +2639,7 @@ export default function App() {
         currentGroup.Trackers || [],
         normalizeOverrides(overrides),
         normalizeReleaseOverrides(nameOverrides),
+        normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
       );
       setBuilderPreview((prev) => upsertBuilderGroup(prev, updatedGroup));
       setBuilderRawByGroup((prev) => ({ ...prev, [groupKey]: updatedGroup.RawDescription || "" }));
@@ -2660,6 +2705,7 @@ export default function App() {
         currentGroup.Trackers || [],
         normalizeOverrides(idOverrideState?.overrides || {}),
         normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+        normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
       );
       const nextPreview = upsertBuilderGroup(builderPreview, updatedGroup);
       const shouldRefreshDryRun =
@@ -2702,6 +2748,7 @@ export default function App() {
       path.trim(),
       normalizeOverrides(idOverrideState?.overrides || {}),
       normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+      normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
       selections,
       purpose,
     );
@@ -2724,6 +2771,7 @@ export default function App() {
       sourceLookupURL.trim(),
       normalizeOverrides(idOverrideState?.overrides || {}),
       normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+      normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
       selectedTrackers,
     );
   };
@@ -2782,6 +2830,7 @@ export default function App() {
         path.trim(),
         normalizeOverrides(idOverrideState?.overrides || {}),
         normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+        normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
         timestamp,
       );
       if (livePreviewRequestId.current !== requestId) {
@@ -3059,6 +3108,7 @@ export default function App() {
         path.trim(),
         normalizeOverrides(idOverrideState?.overrides || {}),
         normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+        normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
         selectedTrackers,
       );
     } catch (err) {
@@ -3188,6 +3238,7 @@ export default function App() {
       path: normalizedPath,
       external: normalizeOverrides(idOverrideState?.overrides || {}),
       release: normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+      metadata: normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
     });
     if (builderAutoRequestKey === requestKey) return;
     setBuilderAutoRequestKey(requestKey);
@@ -3201,6 +3252,7 @@ export default function App() {
     path,
     idOverrideState,
     releaseOverrideState,
+    metadataOverrideState,
     builderAutoRequestKey,
     runDescriptionBuilder,
   ]);
@@ -3246,6 +3298,7 @@ export default function App() {
           path.trim(),
           normalizeOverrides(idOverrideState?.overrides || {}),
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
         );
         if (!candidates || candidates.length === 0) {
           setExistingImages([]);
@@ -3275,6 +3328,7 @@ export default function App() {
     path,
     idOverrideState,
     releaseOverrideState,
+    metadataOverrideState,
     setExistingImages,
     readScreenshotImage,
     refreshUploadedImages,
@@ -3446,6 +3500,11 @@ export default function App() {
     }
   }, []);
 
+  const clearTrackerUploadJob = useCallback(() => {
+    setTrackerUploadJobID("");
+    setTrackerUploadSnapshot(null);
+  }, []);
+
   const handleStartTrackerUpload = useCallback(async () => {
     setTrackerUploadError("");
     const starter = globalThis.go?.guiapp?.App?.StartTrackerUpload;
@@ -3496,13 +3555,14 @@ export default function App() {
       return;
     }
     setTrackerUploadRunning(true);
-    setTrackerUploadSnapshot(null);
+    clearTrackerUploadJob();
     let jobID = "";
     try {
       jobID = await starter(
         path.trim(),
         normalizeOverrides(idOverrideState?.overrides || {}),
         normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+        normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
         selectedTrackers,
         ignoredDupeTrackers,
         cloneQuestionnaireAnswers(trackerQuestionnaireAnswers),
@@ -3513,6 +3573,7 @@ export default function App() {
       );
     } catch (err) {
       setTrackerUploadRunning(false);
+      clearTrackerUploadJob();
       setTrackerUploadError(String(err));
       return;
     }
@@ -3529,6 +3590,7 @@ export default function App() {
     path,
     idOverrideState,
     releaseOverrideState,
+    metadataOverrideState,
     getSelectedUploadTrackers,
     ignoredDupeTrackers,
     trackerDryRunPreview,
@@ -3538,6 +3600,7 @@ export default function App() {
     uploadSkipClientInjection,
     runLogLevel,
     applyTrackerUploadSnapshot,
+    clearTrackerUploadJob,
   ]);
 
   const runTrackerDryRun = useCallback(
@@ -3598,6 +3661,7 @@ export default function App() {
           path.trim(),
           normalizeOverrides(idOverrideState?.overrides || {}),
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
           selectedTrackers,
           ignoredDupeTrackers,
           cloneQuestionnaireAnswers(trackerQuestionnaireAnswers),
@@ -3638,6 +3702,7 @@ export default function App() {
       path,
       idOverrideState,
       releaseOverrideState,
+      metadataOverrideState,
       getSelectedUploadTrackers,
       ignoredDupeTrackers,
       trackerQuestionnaireAnswers,
@@ -3780,6 +3845,10 @@ export default function App() {
 
   const markReleaseTouched = (key: keyof ReleaseNameTouchedState) => {
     setReleaseTouched((prev) => ({ ...prev, [key]: true }));
+  };
+
+  const markMetadataTouched = (key: keyof MetadataOverrideTouchedState) => {
+    setMetadataTouched((prev) => ({ ...prev, [key]: true }));
   };
 
   const applyScreenshotSettings = async () => {
@@ -4269,6 +4338,7 @@ export default function App() {
               path={path}
               overrides={idOverrideState?.overrides || {}}
               nameOverrides={releaseOverrideState?.overrides || {}}
+              metadataOverrides={metadataOverrideState?.overrides || {}}
               browseAvailable={browserNativeBrowseAvailable}
               onImportComplete={() => {
                 setActiveTab("upload_images");
@@ -4411,6 +4481,9 @@ export default function App() {
               releaseEdits={releaseEdits}
               setReleaseEdits={setReleaseEdits}
               markReleaseTouched={markReleaseTouched}
+              metadataEdits={metadataEdits}
+              setMetadataEdits={setMetadataEdits}
+              markMetadataTouched={markMetadataTouched}
               idOverrideState={idOverrideState}
               releaseOverrideState={releaseOverrideState}
               showExternalIDInputUI={showExternalIDInputUI}

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -711,18 +711,32 @@ const buildMetadataEditState = (overrides?: MetadataOverrides): MetadataOverride
   anime: boolOverrideEditValue(overrides?.Anime),
 });
 
-const buildMetadataTouchedState = (
-  overrides?: MetadataOverrides,
-): MetadataOverrideTouchedState => ({
-  distributor: overrides?.Distributor !== undefined && overrides?.Distributor !== null,
-  originalLanguage:
-    overrides?.OriginalLanguage !== undefined && overrides?.OriginalLanguage !== null,
-  personalRelease: overrides?.PersonalRelease !== undefined && overrides?.PersonalRelease !== null,
-  commentary: overrides?.Commentary !== undefined && overrides?.Commentary !== null,
-  webDV: overrides?.WebDV !== undefined && overrides?.WebDV !== null,
-  streamOptimized: overrides?.StreamOptimized !== undefined && overrides?.StreamOptimized !== null,
-  anime: overrides?.Anime !== undefined && overrides?.Anime !== null,
-});
+/** Returns metadata fields whose edited tri-state controls were explicitly reset to Auto. */
+const metadataOverrideClears = (overrides?: MetadataOverrides) =>
+  new Set((overrides?.Clear || []).map((field) => String(field || "").trim()));
+
+const buildMetadataTouchedState = (overrides?: MetadataOverrides): MetadataOverrideTouchedState => {
+  const clears = metadataOverrideClears(overrides);
+  return {
+    distributor:
+      (overrides?.Distributor !== undefined && overrides?.Distributor !== null) ||
+      clears.has("Distributor"),
+    originalLanguage:
+      (overrides?.OriginalLanguage !== undefined && overrides?.OriginalLanguage !== null) ||
+      clears.has("OriginalLanguage"),
+    personalRelease:
+      (overrides?.PersonalRelease !== undefined && overrides?.PersonalRelease !== null) ||
+      clears.has("PersonalRelease"),
+    commentary:
+      (overrides?.Commentary !== undefined && overrides?.Commentary !== null) ||
+      clears.has("Commentary"),
+    webDV: (overrides?.WebDV !== undefined && overrides?.WebDV !== null) || clears.has("WebDV"),
+    streamOptimized:
+      (overrides?.StreamOptimized !== undefined && overrides?.StreamOptimized !== null) ||
+      clears.has("StreamOptimized"),
+    anime: (overrides?.Anime !== undefined && overrides?.Anime !== null) || clears.has("Anime"),
+  };
+};
 
 const boolOverrideEditValue = (value?: boolean | null): "" | "true" | "false" => {
   if (value === undefined || value === null) return "";
@@ -1443,12 +1457,13 @@ export default function App() {
 
   const metadataOverrideState = useMemo(() => {
     const overrides: MetadataOverrides = {};
+    const clear: string[] = [];
     const distributor = metadataEdits.distributor.trim();
     const originalLanguage = metadataEdits.originalLanguage.trim();
-    if (metadataTouched.distributor && distributor !== "") {
+    if (metadataTouched.distributor) {
       overrides.Distributor = distributor;
     }
-    if (metadataTouched.originalLanguage && originalLanguage !== "") {
+    if (metadataTouched.originalLanguage) {
       overrides.OriginalLanguage = originalLanguage;
     }
     const personalRelease = parseBoolOverrideEditValue(metadataEdits.personalRelease);
@@ -1456,20 +1471,28 @@ export default function App() {
     const webDV = parseBoolOverrideEditValue(metadataEdits.webDV);
     const streamOptimized = parseBoolOverrideEditValue(metadataEdits.streamOptimized);
     const anime = parseBoolOverrideEditValue(metadataEdits.anime);
-    if (metadataTouched.personalRelease && personalRelease !== null) {
-      overrides.PersonalRelease = personalRelease;
+    if (metadataTouched.personalRelease) {
+      if (personalRelease === null) clear.push("PersonalRelease");
+      else overrides.PersonalRelease = personalRelease;
     }
-    if (metadataTouched.commentary && commentary !== null) {
-      overrides.Commentary = commentary;
+    if (metadataTouched.commentary) {
+      if (commentary === null) clear.push("Commentary");
+      else overrides.Commentary = commentary;
     }
-    if (metadataTouched.webDV && webDV !== null) {
-      overrides.WebDV = webDV;
+    if (metadataTouched.webDV) {
+      if (webDV === null) clear.push("WebDV");
+      else overrides.WebDV = webDV;
     }
-    if (metadataTouched.streamOptimized && streamOptimized !== null) {
-      overrides.StreamOptimized = streamOptimized;
+    if (metadataTouched.streamOptimized) {
+      if (streamOptimized === null) clear.push("StreamOptimized");
+      else overrides.StreamOptimized = streamOptimized;
     }
-    if (metadataTouched.anime && anime !== null) {
-      overrides.Anime = anime;
+    if (metadataTouched.anime) {
+      if (anime === null) clear.push("Anime");
+      else overrides.Anime = anime;
+    }
+    if (clear.length > 0) {
+      overrides.Clear = clear;
     }
     return {
       overrides,

--- a/gui/frontend/src/hooks/useScreenshots.ts
+++ b/gui/frontend/src/hooks/useScreenshots.ts
@@ -62,6 +62,7 @@ export const useScreenshots = ({
 
   // Refs for state sync
   const finalImagesRef = useRef<ScreenshotPreviewImage[]>([]);
+  const loadedMetadataOverridesRef = useRef<MetadataOverrides>({});
 
   // Memoized tracker image maps
   const trackerImageURLs = useMemo(() => {
@@ -137,12 +138,16 @@ export const useScreenshots = ({
 
       setScreenshotsLoading(true);
       try {
+        const metadataOverrides = normalizeMetadataOverrides(
+          metadataOverrideState?.overrides || {},
+        );
         const result = await fetcher(
           path.trim(),
           normalizeOverrides(idOverrideState?.overrides || {}),
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+          metadataOverrides,
         );
+        loadedMetadataOverridesRef.current = metadataOverrides;
         setScreenshotPlan(result);
         setScreenshotSelections(result.SuggestedSelections || []);
         setLivePreviewImage("");
@@ -252,14 +257,14 @@ export const useScreenshots = ({
           path.trim(),
           normalizeOverrides(idOverrideState?.overrides || {}),
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+          loadedMetadataOverridesRef.current,
           next.map((entry) => entry.image),
         );
       } catch (err) {
         setScreenshotsError(String(err));
       }
     },
-    [path, idOverrideState, releaseOverrideState, metadataOverrideState],
+    [path, idOverrideState, releaseOverrideState],
   );
 
   // Update selection timestamp
@@ -419,7 +424,7 @@ export const useScreenshots = ({
             path.trim(),
             normalizeOverrides(idOverrideState?.overrides || {}),
             normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-            normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+            loadedMetadataOverridesRef.current,
             image.Path,
           );
           deleted.push(image);
@@ -433,7 +438,7 @@ export const useScreenshots = ({
       }
       return deleted;
     },
-    [path, idOverrideState, releaseOverrideState, metadataOverrideState],
+    [path, idOverrideState, releaseOverrideState],
   );
 
   const deleteTrackerImageURL = useCallback(
@@ -447,14 +452,14 @@ export const useScreenshots = ({
           path.trim(),
           normalizeOverrides(idOverrideState?.overrides || {}),
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+          loadedMetadataOverridesRef.current,
           url,
         );
       } catch (err) {
         setScreenshotsError(String(err));
       }
     },
-    [path, idOverrideState, releaseOverrideState, metadataOverrideState],
+    [path, idOverrideState, releaseOverrideState],
   );
 
   const deleteTrackerImageFile = useCallback(
@@ -468,14 +473,14 @@ export const useScreenshots = ({
           path.trim(),
           normalizeOverrides(idOverrideState?.overrides || {}),
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+          loadedMetadataOverridesRef.current,
           imagePath,
         );
       } catch (err) {
         setScreenshotsError(String(err));
       }
     },
-    [path, idOverrideState, releaseOverrideState, metadataOverrideState],
+    [path, idOverrideState, releaseOverrideState],
   );
 
   const removeTrackerImageURLState = useCallback((url: string) => {
@@ -711,6 +716,7 @@ export const useScreenshots = ({
     setLivePreviewError("");
     setDeletedTrackerImages([]);
     finalImagesRef.current = [];
+    loadedMetadataOverridesRef.current = {};
   }, []);
 
   // Sync finalImagesRef with finalImages state

--- a/gui/frontend/src/hooks/useScreenshots.ts
+++ b/gui/frontend/src/hooks/useScreenshots.ts
@@ -33,6 +33,9 @@ export const useScreenshots = ({
   releaseOverrideState,
   metadataOverrideState,
 }: ScreenshotHookProps) => {
+  const activePathRef = useRef(path.trim());
+  activePathRef.current = path.trim();
+
   // State: Plan & suggestions
   const [screenshotPlan, setScreenshotPlan] = useState<ScreenshotPlan | null>(null);
   const [screenshotSelections, setScreenshotSelections] = useState<ScreenshotSelection[]>([]);
@@ -48,6 +51,7 @@ export const useScreenshots = ({
   const [livePreviewImage, setLivePreviewImage] = useState("");
   const [livePreviewLoading, setLivePreviewLoading] = useState(false);
   const [livePreviewError, setLivePreviewError] = useState("");
+  const screenshotPlanRequestId = useRef(0);
   const livePreviewRequestId = useRef(0);
 
   // State: Image collections
@@ -145,7 +149,8 @@ export const useScreenshots = ({
     [],
   );
 
-  // Load screenshot plan from backend
+  // Loads the screenshot plan and its image previews for the current source path.
+  // Async completions from older source paths are ignored after each await.
   const loadScreenshotPlan = useCallback(
     async (revealSelections = false): Promise<ScreenshotPlan | null> => {
       setScreenshotsError("");
@@ -154,20 +159,29 @@ export const useScreenshots = ({
         setScreenshotsError("Screenshot planning is unavailable in this build.");
         return null;
       }
-      if (!path.trim()) {
+      const sourcePath = path.trim();
+      if (!sourcePath) {
         setScreenshotsError("Please select a file or folder.");
         return null;
       }
+
+      const requestId = screenshotPlanRequestId.current + 1;
+      screenshotPlanRequestId.current = requestId;
+      const isCurrentRequestId = () => screenshotPlanRequestId.current === requestId;
+      const isCurrentRequest = () => isCurrentRequestId() && activePathRef.current === sourcePath;
 
       setScreenshotsLoading(true);
       try {
         const loadedOverrides = snapshotCurrentOverrides();
         const result = await fetcher(
-          path.trim(),
+          sourcePath,
           loadedOverrides.external,
           loadedOverrides.release,
           loadedOverrides.metadata,
         );
+        if (!isCurrentRequest()) {
+          return null;
+        }
         loadedMetadataOverridesRef.current = loadedOverrides;
         setScreenshotPlan(result);
         setScreenshotSelections(result.SuggestedSelections || []);
@@ -199,6 +213,9 @@ export const useScreenshots = ({
               }
             }),
           );
+          if (!isCurrentRequest()) {
+            return null;
+          }
           setExistingImages(
             previews.filter((entry): entry is ScreenshotPreviewImage => Boolean(entry)),
           );
@@ -215,6 +232,9 @@ export const useScreenshots = ({
               }
             }),
           );
+          if (!isCurrentRequest()) {
+            return null;
+          }
           setExistingTrackerImages(
             previews.filter((entry): entry is ScreenshotPreviewImage => Boolean(entry)),
           );
@@ -235,6 +255,9 @@ export const useScreenshots = ({
               }
             }),
           );
+          if (!isCurrentRequest()) {
+            return null;
+          }
           setFinalImages(
             previews.filter((entry): entry is ScreenshotPreviewImage => Boolean(entry)),
           );
@@ -242,6 +265,9 @@ export const useScreenshots = ({
 
         return result;
       } catch (err) {
+        if (!isCurrentRequest()) {
+          return null;
+        }
         const message = String(err);
         if (message.includes("screenshot plan requires metadata preview")) {
           setScreenshotsError(
@@ -252,7 +278,9 @@ export const useScreenshots = ({
         }
         return null;
       } finally {
-        setScreenshotsLoading(false);
+        if (isCurrentRequestId()) {
+          setScreenshotsLoading(false);
+        }
       }
     },
     [path, snapshotCurrentOverrides, livePreviewSeconds, readScreenshotImage],
@@ -715,8 +743,9 @@ export const useScreenshots = ({
     }
   }, [trackerImageURLs, handleDeleteTrackerImageURL, saveFinalSelections]);
 
-  // Reset all screenshot state
+  // Reset all screenshot state and invalidate pending plan/image preview loaders.
   const resetScreenshotState = useCallback(() => {
+    screenshotPlanRequestId.current += 1;
     setScreenshotPlan(null);
     setScreenshotSelections([]);
     setScreenshotsLoading(false);

--- a/gui/frontend/src/hooks/useScreenshots.ts
+++ b/gui/frontend/src/hooks/useScreenshots.ts
@@ -12,6 +12,7 @@ import type {
   ExternalIDOverrides,
   MetadataOverrides,
   ReleaseNameOverrides,
+  ScreenshotOverrideSnapshot,
 } from "../types";
 import {
   normalizeMetadataOverrides,
@@ -62,7 +63,29 @@ export const useScreenshots = ({
 
   // Refs for state sync
   const finalImagesRef = useRef<ScreenshotPreviewImage[]>([]);
-  const loadedMetadataOverridesRef = useRef<MetadataOverrides>({});
+  const loadedMetadataOverridesRef = useRef<ScreenshotOverrideSnapshot>({
+    external: {},
+    release: {},
+    metadata: {},
+  });
+
+  /** Captures the current normalized override tuple for a new screenshot plan request. */
+  const snapshotCurrentOverrides = useCallback(
+    (): ScreenshotOverrideSnapshot => ({
+      external: normalizeOverrides(idOverrideState?.overrides || {}),
+      release: normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+      metadata: normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+    }),
+    [idOverrideState, releaseOverrideState, metadataOverrideState],
+  );
+
+  /**
+   * Returns the override tuple from the loaded screenshot plan.
+   *
+   * Callers use this for follow-up screenshot work that must stay bound to the plan
+   * even if the editable override state changes after loading.
+   */
+  const getLoadedScreenshotOverrides = useCallback(() => loadedMetadataOverridesRef.current, []);
 
   // Memoized tracker image maps
   const trackerImageURLs = useMemo(() => {
@@ -138,16 +161,14 @@ export const useScreenshots = ({
 
       setScreenshotsLoading(true);
       try {
-        const metadataOverrides = normalizeMetadataOverrides(
-          metadataOverrideState?.overrides || {},
-        );
+        const loadedOverrides = snapshotCurrentOverrides();
         const result = await fetcher(
           path.trim(),
-          normalizeOverrides(idOverrideState?.overrides || {}),
-          normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-          metadataOverrides,
+          loadedOverrides.external,
+          loadedOverrides.release,
+          loadedOverrides.metadata,
         );
-        loadedMetadataOverridesRef.current = metadataOverrides;
+        loadedMetadataOverridesRef.current = loadedOverrides;
         setScreenshotPlan(result);
         setScreenshotSelections(result.SuggestedSelections || []);
         setLivePreviewImage("");
@@ -234,14 +255,7 @@ export const useScreenshots = ({
         setScreenshotsLoading(false);
       }
     },
-    [
-      path,
-      idOverrideState,
-      releaseOverrideState,
-      metadataOverrideState,
-      livePreviewSeconds,
-      readScreenshotImage,
-    ],
+    [path, snapshotCurrentOverrides, livePreviewSeconds, readScreenshotImage],
   );
 
   // Save final selections
@@ -253,18 +267,19 @@ export const useScreenshots = ({
         return;
       }
       try {
+        const loadedOverrides = loadedMetadataOverridesRef.current;
         await saver(
           path.trim(),
-          normalizeOverrides(idOverrideState?.overrides || {}),
-          normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-          loadedMetadataOverridesRef.current,
+          loadedOverrides.external,
+          loadedOverrides.release,
+          loadedOverrides.metadata,
           next.map((entry) => entry.image),
         );
       } catch (err) {
         setScreenshotsError(String(err));
       }
     },
-    [path, idOverrideState, releaseOverrideState],
+    [path],
   );
 
   // Update selection timestamp
@@ -418,13 +433,14 @@ export const useScreenshots = ({
 
       const deleted: ScreenshotImage[] = [];
       const failures: string[] = [];
+      const loadedOverrides = loadedMetadataOverridesRef.current;
       for (const image of images) {
         try {
           await deleter(
             path.trim(),
-            normalizeOverrides(idOverrideState?.overrides || {}),
-            normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-            loadedMetadataOverridesRef.current,
+            loadedOverrides.external,
+            loadedOverrides.release,
+            loadedOverrides.metadata,
             image.Path,
           );
           deleted.push(image);
@@ -438,7 +454,7 @@ export const useScreenshots = ({
       }
       return deleted;
     },
-    [path, idOverrideState, releaseOverrideState],
+    [path],
   );
 
   const deleteTrackerImageURL = useCallback(
@@ -448,18 +464,19 @@ export const useScreenshots = ({
         return;
       }
       try {
+        const loadedOverrides = loadedMetadataOverridesRef.current;
         await deleter(
           path.trim(),
-          normalizeOverrides(idOverrideState?.overrides || {}),
-          normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-          loadedMetadataOverridesRef.current,
+          loadedOverrides.external,
+          loadedOverrides.release,
+          loadedOverrides.metadata,
           url,
         );
       } catch (err) {
         setScreenshotsError(String(err));
       }
     },
-    [path, idOverrideState, releaseOverrideState],
+    [path],
   );
 
   const deleteTrackerImageFile = useCallback(
@@ -469,18 +486,19 @@ export const useScreenshots = ({
         return;
       }
       try {
+        const loadedOverrides = loadedMetadataOverridesRef.current;
         await deleter(
           path.trim(),
-          normalizeOverrides(idOverrideState?.overrides || {}),
-          normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-          loadedMetadataOverridesRef.current,
+          loadedOverrides.external,
+          loadedOverrides.release,
+          loadedOverrides.metadata,
           imagePath,
         );
       } catch (err) {
         setScreenshotsError(String(err));
       }
     },
-    [path, idOverrideState, releaseOverrideState],
+    [path],
   );
 
   const removeTrackerImageURLState = useCallback((url: string) => {
@@ -716,7 +734,7 @@ export const useScreenshots = ({
     setLivePreviewError("");
     setDeletedTrackerImages([]);
     finalImagesRef.current = [];
-    loadedMetadataOverridesRef.current = {};
+    loadedMetadataOverridesRef.current = { external: {}, release: {}, metadata: {} };
   }, []);
 
   // Sync finalImagesRef with finalImages state
@@ -816,6 +834,7 @@ export const useScreenshots = ({
     // Handlers & utilities
     normalizeImagePath,
     readScreenshotImage,
+    getLoadedScreenshotOverrides,
     loadScreenshotPlan,
     saveFinalSelections,
     updateSelectionTime,

--- a/gui/frontend/src/hooks/useScreenshots.ts
+++ b/gui/frontend/src/hooks/useScreenshots.ts
@@ -10,20 +10,27 @@ import type {
   ScreenshotResult,
   ScreenshotLinkedImage,
   ExternalIDOverrides,
+  MetadataOverrides,
   ReleaseNameOverrides,
 } from "../types";
-import { normalizeOverrides, normalizeReleaseOverrides } from "../utils";
+import {
+  normalizeMetadataOverrides,
+  normalizeOverrides,
+  normalizeReleaseOverrides,
+} from "../utils";
 
 interface ScreenshotHookProps {
   path: string;
   idOverrideState?: { overrides?: ExternalIDOverrides };
   releaseOverrideState?: { overrides?: ReleaseNameOverrides };
+  metadataOverrideState?: { overrides?: MetadataOverrides };
 }
 
 export const useScreenshots = ({
   path,
   idOverrideState,
   releaseOverrideState,
+  metadataOverrideState,
 }: ScreenshotHookProps) => {
   // State: Plan & suggestions
   const [screenshotPlan, setScreenshotPlan] = useState<ScreenshotPlan | null>(null);
@@ -134,6 +141,7 @@ export const useScreenshots = ({
           path.trim(),
           normalizeOverrides(idOverrideState?.overrides || {}),
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
         );
         setScreenshotPlan(result);
         setScreenshotSelections(result.SuggestedSelections || []);
@@ -221,7 +229,14 @@ export const useScreenshots = ({
         setScreenshotsLoading(false);
       }
     },
-    [path, idOverrideState, releaseOverrideState, livePreviewSeconds, readScreenshotImage],
+    [
+      path,
+      idOverrideState,
+      releaseOverrideState,
+      metadataOverrideState,
+      livePreviewSeconds,
+      readScreenshotImage,
+    ],
   );
 
   // Save final selections
@@ -237,13 +252,14 @@ export const useScreenshots = ({
           path.trim(),
           normalizeOverrides(idOverrideState?.overrides || {}),
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
           next.map((entry) => entry.image),
         );
       } catch (err) {
         setScreenshotsError(String(err));
       }
     },
-    [path, idOverrideState, releaseOverrideState],
+    [path, idOverrideState, releaseOverrideState, metadataOverrideState],
   );
 
   // Update selection timestamp
@@ -403,6 +419,7 @@ export const useScreenshots = ({
             path.trim(),
             normalizeOverrides(idOverrideState?.overrides || {}),
             normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+            normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
             image.Path,
           );
           deleted.push(image);
@@ -416,7 +433,7 @@ export const useScreenshots = ({
       }
       return deleted;
     },
-    [path, idOverrideState, releaseOverrideState],
+    [path, idOverrideState, releaseOverrideState, metadataOverrideState],
   );
 
   const deleteTrackerImageURL = useCallback(
@@ -430,13 +447,14 @@ export const useScreenshots = ({
           path.trim(),
           normalizeOverrides(idOverrideState?.overrides || {}),
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
           url,
         );
       } catch (err) {
         setScreenshotsError(String(err));
       }
     },
-    [path, idOverrideState, releaseOverrideState],
+    [path, idOverrideState, releaseOverrideState, metadataOverrideState],
   );
 
   const deleteTrackerImageFile = useCallback(
@@ -450,13 +468,14 @@ export const useScreenshots = ({
           path.trim(),
           normalizeOverrides(idOverrideState?.overrides || {}),
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
           imagePath,
         );
       } catch (err) {
         setScreenshotsError(String(err));
       }
     },
-    [path, idOverrideState, releaseOverrideState],
+    [path, idOverrideState, releaseOverrideState, metadataOverrideState],
   );
 
   const removeTrackerImageURLState = useCallback((url: string) => {

--- a/gui/frontend/src/hooks/useUploadImages.ts
+++ b/gui/frontend/src/hooks/useUploadImages.ts
@@ -7,14 +7,20 @@ import type {
   UploadedImageLink,
   UploadImageHostFailure,
   ExternalIDOverrides,
+  MetadataOverrides,
   ReleaseNameOverrides,
 } from "../types";
-import { normalizeOverrides, normalizeReleaseOverrides } from "../utils";
+import {
+  normalizeMetadataOverrides,
+  normalizeOverrides,
+  normalizeReleaseOverrides,
+} from "../utils";
 
 interface UploadImagesHookProps {
   path: string;
   idOverrideState?: { overrides?: ExternalIDOverrides };
   releaseOverrideState?: { overrides?: ReleaseNameOverrides };
+  metadataOverrideState?: { overrides?: MetadataOverrides };
   uploadCandidates?: ScreenshotPreviewImage[];
   configuredImageHosts?: string[];
   selectedTrackers?: string[];
@@ -24,6 +30,7 @@ export const useUploadImages = ({
   path,
   idOverrideState,
   releaseOverrideState,
+  metadataOverrideState,
   uploadCandidates = [],
   configuredImageHosts = [],
   selectedTrackers = [],
@@ -137,12 +144,13 @@ export const useUploadImages = ({
         path.trim(),
         normalizeOverrides(idOverrideState?.overrides || {}),
         normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+        normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
       );
       setUploadedImageRecords(records || []);
     } catch (err) {
       console.error("Failed to load uploaded images:", err);
     }
-  }, [path, idOverrideState, releaseOverrideState]);
+  }, [path, idOverrideState, releaseOverrideState, metadataOverrideState]);
 
   // Upload selected images to host
   const handleUploadImages = useCallback(
@@ -175,6 +183,7 @@ export const useUploadImages = ({
           path.trim(),
           normalizeOverrides(idOverrideState?.overrides || {}),
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
           selectedTrackers,
           uploadHost,
           selected.map((entry) => entry.image),
@@ -218,6 +227,7 @@ export const useUploadImages = ({
       path,
       idOverrideState,
       releaseOverrideState,
+      metadataOverrideState,
       selectedTrackers,
       uploadHost,
       refreshUploadedImages,
@@ -239,6 +249,7 @@ export const useUploadImages = ({
           path.trim(),
           normalizeOverrides(idOverrideState?.overrides || {}),
           normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
         );
 
         if (!refreshed || refreshed.length === 0) {
@@ -261,7 +272,14 @@ export const useUploadImages = ({
         console.error("Failed to delete uploaded image:", err);
       }
     },
-    [path, idOverrideState, releaseOverrideState, uploadHost, refreshUploadedImages],
+    [
+      path,
+      idOverrideState,
+      releaseOverrideState,
+      metadataOverrideState,
+      uploadHost,
+      refreshUploadedImages,
+    ],
   );
 
   // Reset upload state

--- a/gui/frontend/src/hooks/useUploadImages.ts
+++ b/gui/frontend/src/hooks/useUploadImages.ts
@@ -9,6 +9,7 @@ import type {
   ExternalIDOverrides,
   MetadataOverrides,
   ReleaseNameOverrides,
+  ScreenshotOverrideSnapshot,
 } from "../types";
 import {
   normalizeMetadataOverrides,
@@ -24,6 +25,12 @@ interface UploadImagesHookProps {
   uploadCandidates?: ScreenshotPreviewImage[];
   configuredImageHosts?: string[];
   selectedTrackers?: string[];
+  /**
+   * Loaded screenshot-plan overrides to use for screenshot-derived upload candidates.
+   *
+   * Omit this for non-screenshot upload flows that should use live input overrides.
+   */
+  screenshotOverrideSnapshot?: ScreenshotOverrideSnapshot;
 }
 
 export const useUploadImages = ({
@@ -34,6 +41,7 @@ export const useUploadImages = ({
   uploadCandidates = [],
   configuredImageHosts = [],
   selectedTrackers = [],
+  screenshotOverrideSnapshot,
 }: UploadImagesHookProps) => {
   // State: Host & selection
   const [uploadHost, setUploadHost] = useState<string>("");
@@ -75,6 +83,16 @@ export const useUploadImages = ({
     });
     return map;
   }, [uploadedImageRecords]);
+
+  const getWorkflowOverrides = useCallback(
+    (): ScreenshotOverrideSnapshot =>
+      screenshotOverrideSnapshot || {
+        external: normalizeOverrides(idOverrideState?.overrides || {}),
+        release: normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+        metadata: normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+      },
+    [screenshotOverrideSnapshot, idOverrideState, releaseOverrideState, metadataOverrideState],
+  );
 
   // Initialize host if not set and candidates exist
   useEffect(() => {
@@ -140,17 +158,18 @@ export const useUploadImages = ({
       return;
     }
     try {
+      const workflowOverrides = getWorkflowOverrides();
       const records = await fetcher(
         path.trim(),
-        normalizeOverrides(idOverrideState?.overrides || {}),
-        normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-        normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+        workflowOverrides.external,
+        workflowOverrides.release,
+        workflowOverrides.metadata,
       );
       setUploadedImageRecords(records || []);
     } catch (err) {
       console.error("Failed to load uploaded images:", err);
     }
-  }, [path, idOverrideState, releaseOverrideState, metadataOverrideState]);
+  }, [path, getWorkflowOverrides]);
 
   // Upload selected images to host
   const handleUploadImages = useCallback(
@@ -179,11 +198,12 @@ export const useUploadImages = ({
       setUploadImagesLoading(true);
       setUploadProgress({ current: 0, total: selected.length });
       try {
+        const workflowOverrides = getWorkflowOverrides();
         const result = await uploader(
           path.trim(),
-          normalizeOverrides(idOverrideState?.overrides || {}),
-          normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+          workflowOverrides.external,
+          workflowOverrides.release,
+          workflowOverrides.metadata,
           selectedTrackers,
           uploadHost,
           selected.map((entry) => entry.image),
@@ -223,15 +243,7 @@ export const useUploadImages = ({
         setUploadImagesLoading(false);
       }
     },
-    [
-      path,
-      idOverrideState,
-      releaseOverrideState,
-      metadataOverrideState,
-      selectedTrackers,
-      uploadHost,
-      refreshUploadedImages,
-    ],
+    [path, getWorkflowOverrides, selectedTrackers, uploadHost, refreshUploadedImages],
   );
 
   // Delete a single uploaded image record
@@ -244,12 +256,13 @@ export const useUploadImages = ({
 
       try {
         await globalThis.go?.guiapp?.App?.DeleteUploadedImage(path.trim(), imagePath, host);
+        const workflowOverrides = getWorkflowOverrides();
         // Refresh existing images to reflect deletion
         const refreshed = await globalThis.go?.guiapp?.App?.ListUploadCandidates(
           path.trim(),
-          normalizeOverrides(idOverrideState?.overrides || {}),
-          normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
-          normalizeMetadataOverrides(metadataOverrideState?.overrides || {}),
+          workflowOverrides.external,
+          workflowOverrides.release,
+          workflowOverrides.metadata,
         );
 
         if (!refreshed || refreshed.length === 0) {
@@ -272,14 +285,7 @@ export const useUploadImages = ({
         console.error("Failed to delete uploaded image:", err);
       }
     },
-    [
-      path,
-      idOverrideState,
-      releaseOverrideState,
-      metadataOverrideState,
-      uploadHost,
-      refreshUploadedImages,
-    ],
+    [path, getWorkflowOverrides, uploadHost, refreshUploadedImages],
   );
 
   // Reset upload state

--- a/gui/frontend/src/pages/input/index.tsx
+++ b/gui/frontend/src/pages/input/index.tsx
@@ -22,6 +22,8 @@ import type {
   IMDBReleaseDate,
   IMDBSeasonSummary,
   MetadataPreview,
+  MetadataOverrideEditState,
+  MetadataOverrideTouchedState,
   MetadataProgressUpdate,
   ReleaseNameEditState,
   ReleaseNameTouchedState,
@@ -590,6 +592,9 @@ type Props = Readonly<{
   releaseEdits: ReleaseNameEditState;
   setReleaseEdits: Dispatch<SetStateAction<ReleaseNameEditState>>;
   markReleaseTouched: (key: keyof ReleaseNameTouchedState) => void;
+  metadataEdits: MetadataOverrideEditState;
+  setMetadataEdits: Dispatch<SetStateAction<MetadataOverrideEditState>>;
+  markMetadataTouched: (key: keyof MetadataOverrideTouchedState) => void;
   idOverrideState: OverrideState<Record<string, unknown>>;
   releaseOverrideState: OverrideState<Record<string, unknown>>;
   showExternalIDInputUI: boolean;
@@ -637,6 +642,9 @@ export default function InputPage(props: Props) {
     releaseEdits,
     setReleaseEdits,
     markReleaseTouched,
+    metadataEdits,
+    setMetadataEdits,
+    markMetadataTouched,
     idOverrideState,
     releaseOverrideState,
     showExternalIDInputUI,
@@ -1586,6 +1594,68 @@ export default function InputPage(props: Props) {
                         }}
                       />
                     </div>
+                  </div>
+                </div>
+                <div className="settings-subgroup">
+                  <div className="settings-subgroup__title">Metadata overrides</div>
+                  <div className="settings-grid">
+                    <div className="settings-field">
+                      <label htmlFor="metadata-distributor">Distributor</label>
+                      <input
+                        id="metadata-distributor"
+                        value={metadataEdits.distributor}
+                        onChange={(event) => {
+                          setMetadataEdits((prev) => ({
+                            ...prev,
+                            distributor: event.target.value,
+                          }));
+                          markMetadataTouched("distributor");
+                        }}
+                        placeholder="Criterion"
+                      />
+                    </div>
+                    <div className="settings-field">
+                      <label htmlFor="metadata-original-language">Original language</label>
+                      <input
+                        id="metadata-original-language"
+                        value={metadataEdits.originalLanguage}
+                        onChange={(event) => {
+                          setMetadataEdits((prev) => ({
+                            ...prev,
+                            originalLanguage: event.target.value,
+                          }));
+                          markMetadataTouched("originalLanguage");
+                        }}
+                        placeholder="ja"
+                      />
+                    </div>
+                    {[
+                      ["metadata-personal-release", "Personal release", "personalRelease"],
+                      ["metadata-commentary", "Commentary", "commentary"],
+                      ["metadata-webdv", "WEB-DV", "webDV"],
+                      ["metadata-stream-optimized", "Stream optimized", "streamOptimized"],
+                      ["metadata-anime", "Anime", "anime"],
+                    ].map(([id, label, key]) => (
+                      <div className="settings-field" key={id}>
+                        <label htmlFor={id}>{label}</label>
+                        <select
+                          id={id}
+                          className={compactInputClass}
+                          value={metadataEdits[key as keyof MetadataOverrideEditState]}
+                          onChange={(event) => {
+                            setMetadataEdits((prev) => ({
+                              ...prev,
+                              [key]: event.target.value as "" | "true" | "false",
+                            }));
+                            markMetadataTouched(key as keyof MetadataOverrideTouchedState);
+                          }}
+                        >
+                          <option value="">Auto</option>
+                          <option value="true">Yes</option>
+                          <option value="false">No</option>
+                        </select>
+                      </div>
+                    ))}
                   </div>
                 </div>
                 {idOverrideState?.invalid ? (

--- a/gui/frontend/src/pages/menu_images/index.tsx
+++ b/gui/frontend/src/pages/menu_images/index.tsx
@@ -2,18 +2,20 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useState } from "react";
-import type { ExternalIDOverrides, ReleaseNameOverrides } from "../../types";
+import type { ExternalIDOverrides, MetadataOverrides, ReleaseNameOverrides } from "../../types";
 
 type Props = Readonly<{
   path: string;
   overrides: ExternalIDOverrides;
   nameOverrides: ReleaseNameOverrides;
+  metadataOverrides: MetadataOverrides;
   browseAvailable: boolean;
   onImportComplete: () => void;
 }>;
 
 export default function MenuImagesPage(props: Props) {
-  const { path, overrides, nameOverrides, browseAvailable, onImportComplete } = props;
+  const { path, overrides, nameOverrides, metadataOverrides, browseAvailable, onImportComplete } =
+    props;
 
   const [menuPaths, setMenuPaths] = useState<string[]>([]);
   const [importing, setImporting] = useState(false);
@@ -59,7 +61,7 @@ export default function MenuImagesPage(props: Props) {
     try {
       const importFn = globalThis.go?.guiapp?.App?.ImportMenuImages;
       if (!importFn) throw new Error("Import function not available");
-      await importFn(path, overrides, nameOverrides, menuPaths);
+      await importFn(path, overrides, nameOverrides, metadataOverrides, menuPaths);
       setSuccess(true);
       setMenuPaths([]);
       onImportComplete();

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -57,6 +57,8 @@ export type MetadataOverrides = {
   WebDV?: boolean | null;
   StreamOptimized?: boolean | null;
   Anime?: boolean | null;
+  /** Field names explicitly reset by the user; absent fields continue using prepared metadata. */
+  Clear?: string[] | null;
 };
 
 /**

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -59,6 +59,18 @@ export type MetadataOverrides = {
   Anime?: boolean | null;
 };
 
+/**
+ * Normalized override payloads captured when a screenshot plan is loaded.
+ *
+ * Screenshot preview, capture, selection persistence, and upload-image flows reuse this
+ * tuple so later edits in the input form cannot drift from the plan context.
+ */
+export type ScreenshotOverrideSnapshot = {
+  external: ExternalIDOverrides;
+  release: ReleaseNameOverrides;
+  metadata: MetadataOverrides;
+};
+
 export type ExternalIDInfo = {
   Provider: string;
   ID: number;

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -45,6 +45,20 @@ export type ReleaseNameOverrides = {
   Region?: string | null;
 };
 
+/**
+ * Caller-forced metadata facts sent to Go entrypoints.
+ * Omitted or null fields leave inferred/prepared metadata unchanged.
+ */
+export type MetadataOverrides = {
+  Distributor?: string | null;
+  OriginalLanguage?: string | null;
+  PersonalRelease?: boolean | null;
+  Commentary?: boolean | null;
+  WebDV?: boolean | null;
+  StreamOptimized?: boolean | null;
+  Anime?: boolean | null;
+};
+
 export type ExternalIDInfo = {
   Provider: string;
   ID: number;
@@ -954,6 +968,28 @@ export type ReleaseNameTouchedState = {
   noDual: boolean;
   dualAudio: boolean;
   region: boolean;
+};
+
+/** Form state for editable metadata override controls before normalization. */
+export type MetadataOverrideEditState = {
+  distributor: string;
+  originalLanguage: string;
+  personalRelease: "" | "true" | "false";
+  commentary: "" | "true" | "false";
+  webDV: "" | "true" | "false";
+  streamOptimized: "" | "true" | "false";
+  anime: "" | "true" | "false";
+};
+
+/** Tracks which metadata override controls should be sent to backend requests. */
+export type MetadataOverrideTouchedState = {
+  distributor: boolean;
+  originalLanguage: boolean;
+  personalRelease: boolean;
+  commentary: boolean;
+  webDV: boolean;
+  streamOptimized: boolean;
+  anime: boolean;
 };
 
 export type ReleaseNameIDEditState = {

--- a/gui/frontend/src/utils/helpers.test.ts
+++ b/gui/frontend/src/utils/helpers.test.ts
@@ -3,7 +3,11 @@
 
 import { describe, expect, it } from "vitest";
 
-import { normalizeOverrides, normalizeReleaseOverrides } from "./helpers";
+import {
+  normalizeMetadataOverrides,
+  normalizeOverrides,
+  normalizeReleaseOverrides,
+} from "./helpers";
 
 describe("normalizeOverrides", () => {
   it("keeps zero IDs and drops nullish IDs", () => {
@@ -22,6 +26,58 @@ describe("normalizeOverrides", () => {
 });
 
 describe("normalizeReleaseOverrides", () => {
+  it("keeps every release override field", () => {
+    expect(
+      normalizeReleaseOverrides({
+        Category: "",
+        Type: "remux",
+        Source: "BluRay",
+        Resolution: "2160p",
+        Tag: "-GROUP",
+        Service: "NF",
+        Edition: "Director's Cut",
+        Season: "S01",
+        Episode: "E02",
+        EpisodeTitle: "Pilot",
+        ManualYear: 0,
+        ManualDate: "",
+        UseSeasonEpisode: false,
+        NoSeason: false,
+        NoYear: false,
+        NoAKA: false,
+        NoTag: false,
+        NoEdition: false,
+        NoDub: false,
+        NoDual: false,
+        DualAudio: true,
+        Region: "",
+      }),
+    ).toEqual({
+      Category: "",
+      Type: "remux",
+      Source: "BluRay",
+      Resolution: "2160p",
+      Tag: "-GROUP",
+      Service: "NF",
+      Edition: "Director's Cut",
+      Season: "S01",
+      Episode: "E02",
+      EpisodeTitle: "Pilot",
+      ManualYear: 0,
+      ManualDate: "",
+      UseSeasonEpisode: false,
+      NoSeason: false,
+      NoYear: false,
+      NoAKA: false,
+      NoTag: false,
+      NoEdition: false,
+      NoDub: false,
+      NoDual: false,
+      DualAudio: true,
+      Region: "",
+    });
+  });
+
   it("keeps false and empty-string override values", () => {
     expect(
       normalizeReleaseOverrides({
@@ -35,6 +91,42 @@ describe("normalizeReleaseOverrides", () => {
       Category: "",
       NoYear: false,
       UseSeasonEpisode: true,
+    });
+  });
+});
+
+describe("normalizeMetadataOverrides", () => {
+  it("keeps every metadata override field and preserves false values", () => {
+    expect(
+      normalizeMetadataOverrides({
+        Distributor: "",
+        OriginalLanguage: "ja",
+        PersonalRelease: false,
+        Commentary: true,
+        WebDV: false,
+        StreamOptimized: true,
+        Anime: false,
+      }),
+    ).toEqual({
+      Distributor: "",
+      OriginalLanguage: "ja",
+      PersonalRelease: false,
+      Commentary: true,
+      WebDV: false,
+      StreamOptimized: true,
+      Anime: false,
+    });
+  });
+
+  it("drops nullish metadata override values", () => {
+    expect(
+      normalizeMetadataOverrides({
+        Distributor: null,
+        OriginalLanguage: undefined,
+        PersonalRelease: false,
+      }),
+    ).toEqual({
+      PersonalRelease: false,
     });
   });
 });

--- a/gui/frontend/src/utils/helpers.test.ts
+++ b/gui/frontend/src/utils/helpers.test.ts
@@ -106,6 +106,7 @@ describe("normalizeMetadataOverrides", () => {
         WebDV: false,
         StreamOptimized: true,
         Anime: false,
+        Clear: ["Anime"],
       }),
     ).toEqual({
       Distributor: "",
@@ -115,6 +116,7 @@ describe("normalizeMetadataOverrides", () => {
       WebDV: false,
       StreamOptimized: true,
       Anime: false,
+      Clear: ["Anime"],
     });
   });
 

--- a/gui/frontend/src/utils/helpers.ts
+++ b/gui/frontend/src/utils/helpers.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026, Audionut and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import type { ExternalIDOverrides, ReleaseNameOverrides } from "../types";
+import type { ExternalIDOverrides, MetadataOverrides, ReleaseNameOverrides } from "../types";
 
 /**
  * Normalize external ID overrides by filtering out null/undefined values
@@ -77,6 +77,53 @@ export const normalizeReleaseOverrides = (
   }
   if (overrides.NoAKA !== null && overrides.NoAKA !== undefined) {
     payload.NoAKA = overrides.NoAKA;
+  }
+  if (overrides.NoTag !== null && overrides.NoTag !== undefined) {
+    payload.NoTag = overrides.NoTag;
+  }
+  if (overrides.NoEdition !== null && overrides.NoEdition !== undefined) {
+    payload.NoEdition = overrides.NoEdition;
+  }
+  if (overrides.NoDub !== null && overrides.NoDub !== undefined) {
+    payload.NoDub = overrides.NoDub;
+  }
+  if (overrides.NoDual !== null && overrides.NoDual !== undefined) {
+    payload.NoDual = overrides.NoDual;
+  }
+  if (overrides.DualAudio !== null && overrides.DualAudio !== undefined) {
+    payload.DualAudio = overrides.DualAudio;
+  }
+  if (overrides.Region !== null && overrides.Region !== undefined) {
+    payload.Region = overrides.Region;
+  }
+  return payload;
+};
+
+/**
+ * Normalizes metadata overrides by dropping nullish fields while preserving explicit false values.
+ */
+export const normalizeMetadataOverrides = (overrides: MetadataOverrides): MetadataOverrides => {
+  const payload: MetadataOverrides = {};
+  if (overrides.Distributor !== null && overrides.Distributor !== undefined) {
+    payload.Distributor = overrides.Distributor;
+  }
+  if (overrides.OriginalLanguage !== null && overrides.OriginalLanguage !== undefined) {
+    payload.OriginalLanguage = overrides.OriginalLanguage;
+  }
+  if (overrides.PersonalRelease !== null && overrides.PersonalRelease !== undefined) {
+    payload.PersonalRelease = overrides.PersonalRelease;
+  }
+  if (overrides.Commentary !== null && overrides.Commentary !== undefined) {
+    payload.Commentary = overrides.Commentary;
+  }
+  if (overrides.WebDV !== null && overrides.WebDV !== undefined) {
+    payload.WebDV = overrides.WebDV;
+  }
+  if (overrides.StreamOptimized !== null && overrides.StreamOptimized !== undefined) {
+    payload.StreamOptimized = overrides.StreamOptimized;
+  }
+  if (overrides.Anime !== null && overrides.Anime !== undefined) {
+    payload.Anime = overrides.Anime;
   }
   return payload;
 };

--- a/gui/frontend/src/utils/helpers.ts
+++ b/gui/frontend/src/utils/helpers.ts
@@ -100,10 +100,14 @@ export const normalizeReleaseOverrides = (
 };
 
 /**
- * Normalizes metadata overrides by dropping nullish fields while preserving explicit false values.
+ * Normalizes metadata overrides by dropping nullish fields while preserving explicit clears,
+ * empty strings, and false values.
  */
 export const normalizeMetadataOverrides = (overrides: MetadataOverrides): MetadataOverrides => {
   const payload: MetadataOverrides = {};
+  const clear = (overrides.Clear || [])
+    .map((field) => String(field || "").trim())
+    .filter((field) => field.length > 0);
   if (overrides.Distributor !== null && overrides.Distributor !== undefined) {
     payload.Distributor = overrides.Distributor;
   }
@@ -124,6 +128,9 @@ export const normalizeMetadataOverrides = (overrides: MetadataOverrides): Metada
   }
   if (overrides.Anime !== null && overrides.Anime !== undefined) {
     payload.Anime = overrides.Anime;
+  }
+  if (clear.length > 0) {
+    payload.Clear = clear;
   }
   return payload;
 };

--- a/gui/frontend/src/utils/index.ts
+++ b/gui/frontend/src/utils/index.ts
@@ -1,4 +1,8 @@
 // Copyright (c) 2025-2026, Audionut and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-export { normalizeOverrides, normalizeReleaseOverrides } from "./helpers";
+export {
+  normalizeMetadataOverrides,
+  normalizeOverrides,
+  normalizeReleaseOverrides,
+} from "./helpers";

--- a/gui/frontend/src/utils/runtime.test.ts
+++ b/gui/frontend/src/utils/runtime.test.ts
@@ -47,6 +47,7 @@ describe("browser runtime bridge", () => {
       "C:/media/movie.mkv",
       { TMDBID: 1 },
       { Category: "MOVIE" },
+      { Anime: true },
     );
 
     expect(result).toEqual({ ok: true });
@@ -63,6 +64,7 @@ describe("browser runtime bridge", () => {
           Path: "C:/media/movie.mkv",
           Overrides: { TMDBID: 1 },
           NameOverrides: { Category: "MOVIE" },
+          MetadataOverrides: { Anime: true },
         }),
       }),
     );
@@ -98,6 +100,7 @@ describe("browser runtime bridge", () => {
 
     const result = await (globalThis as any).go.guiapp.App.StartDupeCheck(
       "C:/media/movie.mkv",
+      {},
       {},
       {},
       ["AITHER"],
@@ -142,7 +145,9 @@ describe("browser runtime bridge", () => {
     initializeBrowserBridge("session-a-csrf", false);
 
     await expect(
-      (globalThis as any).go.guiapp.App.StartDupeCheck("C:/media/movie.mkv", {}, {}, ["AITHER"]),
+      (globalThis as any).go.guiapp.App.StartDupeCheck("C:/media/movie.mkv", {}, {}, {}, [
+        "AITHER",
+      ]),
     ).rejects.toThrow("Web session changed in another tab");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
@@ -170,7 +175,7 @@ describe("browser runtime bridge", () => {
     const listener = vi.fn();
     const unsubscribe = subscribeBrowserNativeBrowseAvailability(listener);
 
-    await (globalThis as any).go.guiapp.App.StartDupeCheck("C:/media/movie.mkv", {}, {}, [
+    await (globalThis as any).go.guiapp.App.StartDupeCheck("C:/media/movie.mkv", {}, {}, {}, [
       "AITHER",
     ]);
 

--- a/gui/frontend/src/utils/runtime.ts
+++ b/gui/frontend/src/utils/runtime.ts
@@ -291,6 +291,7 @@ export const initializeBrowserBridge = (
           sourceLookupURL: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           trackers: string[],
         ) =>
           call("FetchMetadata", {
@@ -298,6 +299,7 @@ export const initializeBrowserBridge = (
             SourceLookupURL: sourceLookupURL,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             Trackers: trackers,
           }),
         ResetMetadata: (
@@ -305,6 +307,7 @@ export const initializeBrowserBridge = (
           sourceLookupURL: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           trackers: string[],
         ) =>
           call("ResetMetadata", {
@@ -312,6 +315,7 @@ export const initializeBrowserBridge = (
             SourceLookupURL: sourceLookupURL,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             Trackers: trackers,
           }),
         SelectBlurayCandidate: (path: string, releaseID: string) =>
@@ -323,6 +327,7 @@ export const initializeBrowserBridge = (
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           trackers: string[],
           ignoreDupesFor: string[],
         ) =>
@@ -330,6 +335,7 @@ export const initializeBrowserBridge = (
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             Trackers: trackers,
             IgnoreDupesFor: ignoreDupesFor,
           }),
@@ -337,6 +343,7 @@ export const initializeBrowserBridge = (
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           trackers: string[],
           ignoreDupesFor: string[],
         ) =>
@@ -344,6 +351,7 @@ export const initializeBrowserBridge = (
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             Trackers: trackers,
             IgnoreDupesFor: ignoreDupesFor,
           }),
@@ -351,6 +359,7 @@ export const initializeBrowserBridge = (
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           trackers: string[],
           ignoreDupesFor: string[],
           questionnaireAnswers: Record<string, Record<string, string>>,
@@ -363,6 +372,7 @@ export const initializeBrowserBridge = (
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             Trackers: trackers,
             IgnoreDupesFor: ignoreDupesFor,
             QuestionnaireAnswers: questionnaireAnswers,
@@ -375,38 +385,49 @@ export const initializeBrowserBridge = (
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           trackers: string[],
         ) =>
           call("CheckDupes", {
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             Trackers: trackers,
           }),
         StartDupeCheck: (
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           trackers: string[],
         ) =>
           call("StartDupeCheck", {
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             Trackers: trackers,
           }),
         CancelDupeCheck: (jobID: string) => call("CancelDupeCheck", { JobID: jobID }),
         GetDupeCheckSnapshot: (jobID: string) => call("GetDupeCheckSnapshot", { JobID: jobID }),
-        FetchScreenshotPlan: (path: string, overrides: unknown, nameOverrides: unknown) =>
+        FetchScreenshotPlan: (
+          path: string,
+          overrides: unknown,
+          nameOverrides: unknown,
+          metadataOverrides: unknown,
+        ) =>
           call("FetchScreenshotPlan", {
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
           }),
         GenerateScreenshots: (
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           selections: unknown,
           purpose: string,
         ) =>
@@ -414,6 +435,7 @@ export const initializeBrowserBridge = (
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             Selections: selections,
             Purpose: purpose,
           }),
@@ -421,67 +443,88 @@ export const initializeBrowserBridge = (
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           timestampSeconds: number,
         ) =>
           call("PreviewScreenshotFrame", {
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             TimestampSeconds: timestampSeconds,
           }),
         DeleteScreenshot: (
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           imagePath: string,
         ) =>
           call("DeleteScreenshot", {
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             ImagePath: imagePath,
           }),
         SaveFinalScreenshotSelections: (
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           images: unknown,
         ) =>
           call("SaveFinalScreenshotSelections", {
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             Images: images,
           }),
         ImportMenuImages: (
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           paths: string[],
         ) =>
           call("ImportMenuImages", {
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             Paths: paths,
           }),
         ReadScreenshotImage: (path: string) => call("ReadScreenshotImage", { Path: path }),
-        ListUploadCandidates: (path: string, overrides: unknown, nameOverrides: unknown) =>
+        ListUploadCandidates: (
+          path: string,
+          overrides: unknown,
+          nameOverrides: unknown,
+          metadataOverrides: unknown,
+        ) =>
           call("ListUploadCandidates", {
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
           }),
-        ListUploadedImages: (path: string, overrides: unknown, nameOverrides: unknown) =>
+        ListUploadedImages: (
+          path: string,
+          overrides: unknown,
+          nameOverrides: unknown,
+          metadataOverrides: unknown,
+        ) =>
           call("ListUploadedImages", {
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
           }),
         UploadImages: (
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           trackers: string[],
           host: string,
           images: unknown,
@@ -490,6 +533,7 @@ export const initializeBrowserBridge = (
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             Trackers: trackers,
             Host: host,
             Images: images,
@@ -500,12 +544,14 @@ export const initializeBrowserBridge = (
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           url: string,
         ) =>
           call("DeleteTrackerImageURL", {
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             URL: url,
           }),
         RenderDescription: (raw: string) => call("RenderDescription", { Raw: raw }),
@@ -516,6 +562,7 @@ export const initializeBrowserBridge = (
           trackers: string[],
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
         ) =>
           call("SaveDescriptionOverride", {
             Path: path,
@@ -524,6 +571,7 @@ export const initializeBrowserBridge = (
             Trackers: trackers,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
           }),
         DiscoverPlaylists: (path: string) => call("DiscoverPlaylists", { Path: path }),
         SavePlaylistSelection: (path: string, playlists: string[], useAll: boolean) =>
@@ -655,6 +703,7 @@ export const initializeBrowserBridge = (
           path: string,
           overrides: unknown,
           nameOverrides: unknown,
+          metadataOverrides: unknown,
           trackers: string[],
           ignoreDupesFor: string[],
           questionnaireAnswers: Record<string, Record<string, string>>,
@@ -667,6 +716,7 @@ export const initializeBrowserBridge = (
             Path: path,
             Overrides: overrides,
             NameOverrides: nameOverrides,
+            MetadataOverrides: metadataOverrides,
             Trackers: trackers,
             IgnoreDupesFor: ignoreDupesFor,
             QuestionnaireAnswers: questionnaireAnswers,

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -3311,6 +3311,7 @@ func deepCopyMetadataOverrides(overrides api.MetadataOverrides) api.MetadataOver
 		WebDV:            clonePtr(overrides.WebDV),
 		StreamOptimized:  clonePtr(overrides.StreamOptimized),
 		Anime:            clonePtr(overrides.Anime),
+		Clear:            append([]string(nil), overrides.Clear...),
 	}
 }
 
@@ -4274,6 +4275,9 @@ func overrideSignature(
 	if metadataOverrides.Anime != nil {
 		parts = append(parts, fmt.Sprintf("anime=%t", *metadataOverrides.Anime))
 	}
+	for _, field := range normalizedMetadataOverrideClearFields(metadataOverrides.Clear) {
+		parts = append(parts, "metadataClear="+field)
+	}
 	if trackerOverrides.Anon != nil {
 		parts = append(parts, fmt.Sprintf("anon=%t", *trackerOverrides.Anon))
 	}
@@ -4344,6 +4348,26 @@ func overrideSignature(
 		return ""
 	}
 	return strings.Join(parts, "|")
+}
+
+// normalizedMetadataOverrideClearFields returns stable cache-signature tokens
+// for metadata fields explicitly reset by a request.
+func normalizedMetadataOverrideClearFields(fields []string) []string {
+	normalized := make([]string, 0, len(fields))
+	seen := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		value := strings.ToLower(strings.TrimSpace(field))
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	slices.Sort(normalized)
+	return normalized
 }
 
 func hasExternalIDOverrides(overrides api.ExternalIDOverrides) bool {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -4223,6 +4223,9 @@ func overrideSignature(
 	if nameOverrides.ManualDate != nil {
 		parts = append(parts, "manualDate="+strings.TrimSpace(*nameOverrides.ManualDate))
 	}
+	if nameOverrides.UseSeasonEpisode != nil {
+		parts = append(parts, fmt.Sprintf("useSeasonEpisode=%t", *nameOverrides.UseSeasonEpisode))
+	}
 	if nameOverrides.NoSeason != nil {
 		parts = append(parts, fmt.Sprintf("noSeason=%t", *nameOverrides.NoSeason))
 	}

--- a/internal/core/description_builder_test.go
+++ b/internal/core/description_builder_test.go
@@ -1301,6 +1301,38 @@ func TestFetchTrackerDryRunPreviewUsesCanonicalDescriptionGroups(t *testing.T) {
 	}
 }
 
+func TestOverrideSignatureIncludesUseSeasonEpisode(t *testing.T) {
+	t.Parallel()
+
+	useSeasonEpisode := true
+	withOverride := overrideSignature(
+		api.ExternalIDOverrides{},
+		api.ReleaseNameOverrides{UseSeasonEpisode: &useSeasonEpisode},
+		api.MetadataOverrides{},
+		api.TrackerConfigOverrides{},
+		api.TrackerSiteOverrides{},
+		api.ClientOverrides{},
+		api.TorrentOverrides{},
+		api.ImageHostOverrides{},
+	)
+	withoutOverride := overrideSignature(
+		api.ExternalIDOverrides{},
+		api.ReleaseNameOverrides{},
+		api.MetadataOverrides{},
+		api.TrackerConfigOverrides{},
+		api.TrackerSiteOverrides{},
+		api.ClientOverrides{},
+		api.TorrentOverrides{},
+		api.ImageHostOverrides{},
+	)
+	if withOverride == withoutOverride {
+		t.Fatalf("expected use season episode to affect signature")
+	}
+	if !strings.Contains(withOverride, "useSeasonEpisode=true") {
+		t.Fatalf("expected use season episode field in signature, got %q", withOverride)
+	}
+}
+
 func TestResolveCanonicalDescriptionGroupsSkipsDefaultsWhenExplicitSelectionResolvesEmpty(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/upload_review.go
+++ b/internal/core/upload_review.go
@@ -487,6 +487,7 @@ func applyMetadataOverridesToPreparedMeta(meta *api.PreparedMetadata) {
 	}
 
 	overrides := meta.MetadataOverrides
+	clearMetadataOverrideFieldsFromPreparedMeta(meta, overrides.Clear)
 	if overrides.Distributor != nil {
 		meta.Distributor = strings.TrimSpace(*overrides.Distributor)
 	}
@@ -518,9 +519,6 @@ func applyOriginalLanguageOverrideToPreparedMeta(meta *api.PreparedMetadata, lan
 	}
 
 	trimmed := strings.TrimSpace(*language)
-	if trimmed == "" {
-		return
-	}
 	if meta.ExternalMetadata.TMDB != nil {
 		meta.ExternalMetadata.TMDB.OriginalLanguage = trimmed
 	}
@@ -532,6 +530,33 @@ func applyOriginalLanguageOverrideToPreparedMeta(meta *api.PreparedMetadata, lan
 	}
 	if meta.ExternalMetadata.TVmaze != nil {
 		meta.ExternalMetadata.TVmaze.Language = trimmed
+	}
+}
+
+// clearMetadataOverrideFieldsFromPreparedMeta resets request-scoped prepared
+// metadata fields before non-nil metadata overrides are applied.
+func clearMetadataOverrideFieldsFromPreparedMeta(meta *api.PreparedMetadata, fields []string) {
+	if meta == nil {
+		return
+	}
+	for _, field := range fields {
+		switch strings.ToLower(strings.TrimSpace(field)) {
+		case "distributor":
+			meta.Distributor = ""
+		case "originallanguage":
+			empty := ""
+			applyOriginalLanguageOverrideToPreparedMeta(meta, &empty)
+		case "personalrelease":
+			meta.PersonalRelease = false
+		case "commentary":
+			meta.HasCommentary = false
+		case "webdv":
+			meta.WebDV = false
+		case "streamoptimized":
+			meta.StreamOptimized = 0
+		case "anime":
+			meta.Anime = false
+		}
 	}
 }
 

--- a/internal/core/upload_review_test.go
+++ b/internal/core/upload_review_test.go
@@ -364,6 +364,68 @@ func TestApplyRequestToPreparedMetaAppliesMetadataOverrides(t *testing.T) {
 	}
 }
 
+func TestApplyRequestToPreparedMetaClearsMetadataOverrides(t *testing.T) {
+	t.Parallel()
+
+	meta := applyRequestToPreparedMeta(api.PreparedMetadata{
+		Distributor:     "Criterion",
+		PersonalRelease: true,
+		HasCommentary:   true,
+		WebDV:           true,
+		StreamOptimized: 1,
+		Anime:           true,
+		ExternalMetadata: api.ExternalMetadata{
+			TMDB:   &api.TMDBMetadata{OriginalLanguage: "ja"},
+			IMDB:   &api.IMDBMetadata{OriginalLanguage: "ja"},
+			TVDB:   &api.TVDBMetadata{OriginalLanguage: "jpn"},
+			TVmaze: &api.TVmazeMetadata{Language: "Japanese"},
+		},
+	}, api.Request{
+		MetadataOverrides: api.MetadataOverrides{
+			Clear: []string{
+				"Distributor",
+				"OriginalLanguage",
+				"PersonalRelease",
+				"Commentary",
+				"WebDV",
+				"StreamOptimized",
+				"Anime",
+			},
+		},
+	}, config.Config{}, api.NopLogger{})
+
+	if meta.Distributor != "" {
+		t.Fatalf("expected distributor clear, got %q", meta.Distributor)
+	}
+	if meta.PersonalRelease {
+		t.Fatalf("expected personal release clear")
+	}
+	if meta.HasCommentary {
+		t.Fatalf("expected commentary clear")
+	}
+	if meta.WebDV {
+		t.Fatalf("expected webdv clear")
+	}
+	if meta.StreamOptimized != 0 {
+		t.Fatalf("expected stream optimized clear, got %d", meta.StreamOptimized)
+	}
+	if meta.Anime {
+		t.Fatalf("expected anime clear")
+	}
+	if got := meta.ExternalMetadata.TMDB.OriginalLanguage; got != "" {
+		t.Fatalf("expected tmdb language clear, got %q", got)
+	}
+	if got := meta.ExternalMetadata.IMDB.OriginalLanguage; got != "" {
+		t.Fatalf("expected imdb language clear, got %q", got)
+	}
+	if got := meta.ExternalMetadata.TVDB.OriginalLanguage; got != "" {
+		t.Fatalf("expected tvdb language clear, got %q", got)
+	}
+	if got := meta.ExternalMetadata.TVmaze.Language; got != "" {
+		t.Fatalf("expected tvmaze language clear, got %q", got)
+	}
+}
+
 func TestApplyRequestToPreparedMetaAppliesTorrentOverrides(t *testing.T) {
 	t.Parallel()
 

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -313,7 +313,7 @@ func (a *App) DetectDiscType(path string) (string, error) {
 	return wrapGUIResult(filesystem.DetectDiscType(ctx, path))
 }
 
-func (a *App) FetchMetadata(path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string) (api.MetadataPreview, error) {
+func (a *App) FetchMetadata(path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackers []string) (api.MetadataPreview, error) {
 	if err := a.requireCore(); err != nil {
 		return api.MetadataPreview{}, err
 	}
@@ -344,6 +344,7 @@ func (a *App) FetchMetadata(path string, sourceLookupURL string, overrides api.E
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 
 	return wrapGUIResult(a.currentCore().FetchMetadataPreview(progressCtx, req))
@@ -369,7 +370,7 @@ func (a *App) SelectBlurayCandidate(path string, releaseID string) (api.Metadata
 	return wrapGUIResult(selector.SelectBlurayCandidate(ctx, path, releaseID))
 }
 
-func (a *App) ResetMetadata(path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string) (api.MetadataPreview, error) {
+func (a *App) ResetMetadata(path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackers []string) (api.MetadataPreview, error) {
 	if err := a.requireCore(); err != nil {
 		return api.MetadataPreview{}, err
 	}
@@ -505,6 +506,7 @@ func (a *App) ResetMetadata(path string, sourceLookupURL string, overrides api.E
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 	preview, err := a.currentCore().FetchMetadataPreview(progressCtx, req)
 	if err != nil {
@@ -583,7 +585,7 @@ func removeIfWithinRoot(root string, target string, recursive bool) (bool, error
 	return true, nil
 }
 
-func (a *App) CheckDupes(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string) (api.DupeCheckSummary, error) {
+func (a *App) CheckDupes(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackers []string) (api.DupeCheckSummary, error) {
 	if a == nil || a.currentCore() == nil {
 		return api.DupeCheckSummary{}, errors.New("app not initialized")
 	}
@@ -604,12 +606,16 @@ func (a *App) CheckDupes(path string, overrides api.ExternalIDOverrides, nameOve
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 
 	return wrapGUIResult(a.currentCore().CheckDupes(ctx, req))
 }
 
-func (a *App) FetchPreparation(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string) (api.PreparationPreview, error) {
+// FetchPreparation builds a GUI preparation preview for a host source path.
+// Caller-provided external ID, release-name, and metadata overrides are applied
+// to the same request so BDInfo playlist preparation sees current UI edits.
+func (a *App) FetchPreparation(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackers []string, ignoreDupesFor []string) (api.PreparationPreview, error) {
 	if a == nil || a.currentCore() == nil {
 		return api.PreparationPreview{}, errors.New("app not initialized")
 	}
@@ -631,6 +637,7 @@ func (a *App) FetchPreparation(path string, overrides api.ExternalIDOverrides, n
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 
 	progressCtx := bdinfo.WithProgressReporter(ctx, func(line string) {
@@ -646,7 +653,7 @@ func (a *App) FetchPreparation(path string, overrides api.ExternalIDOverrides, n
 	return wrapGUIResult(a.currentCore().FetchPreparationPreview(progressCtx, req))
 }
 
-func (a *App) FetchTrackerDryRun(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (api.TrackerDryRunPreview, error) {
+func (a *App) FetchTrackerDryRun(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (api.TrackerDryRunPreview, error) {
 	rt, err := a.requireRuntime()
 	if err != nil {
 		return api.TrackerDryRunPreview{}, err
@@ -688,6 +695,7 @@ func (a *App) FetchTrackerDryRun(path string, overrides api.ExternalIDOverrides,
 		Options:                     buildRunUploadOptions(rt.cfg, runOpts),
 		ExternalIDOverrides:         overrides,
 		ReleaseNameOverrides:        nameOverrides,
+		MetadataOverrides:           metadataOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(questionnaireAnswers),
 	}
 	req.Options.DryRun = true
@@ -711,7 +719,7 @@ func (a *App) FetchTrackerDryRun(path string, overrides api.ExternalIDOverrides,
 	return wrapGUIResult(runCore.FetchTrackerDryRunPreview(progressCtx, req))
 }
 
-func (a *App) FetchDescriptionBuilder(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string) (api.DescriptionBuilderPreview, error) {
+func (a *App) FetchDescriptionBuilder(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackers []string, ignoreDupesFor []string) (api.DescriptionBuilderPreview, error) {
 	if a == nil || a.currentCore() == nil {
 		return api.DescriptionBuilderPreview{}, errors.New("app not initialized")
 	}
@@ -732,6 +740,7 @@ func (a *App) FetchDescriptionBuilder(path string, overrides api.ExternalIDOverr
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 
 	return wrapGUIResult(a.currentCore().FetchDescriptionBuilderPreview(ctx, req))
@@ -749,7 +758,7 @@ func (a *App) RenderDescription(raw string) (string, error) {
 	return wrapGUIResult(a.currentCore().RenderDescription(ctx, raw))
 }
 
-func (a *App) SaveDescriptionOverride(path string, groupKey string, raw string, trackers []string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) (api.DescriptionBuilderGroup, error) {
+func (a *App) SaveDescriptionOverride(path string, groupKey string, raw string, trackers []string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) (api.DescriptionBuilderGroup, error) {
 	if a == nil || a.currentCore() == nil {
 		return api.DescriptionBuilderGroup{}, errors.New("app not initialized")
 	}
@@ -770,6 +779,7 @@ func (a *App) SaveDescriptionOverride(path string, groupKey string, raw string, 
 	req.Trackers = slices.Clone(trackers)
 	req.ExternalIDOverrides = overrides
 	req.ReleaseNameOverrides = nameOverrides
+	req.MetadataOverrides = metadataOverrides
 
 	return wrapGUIResult(a.currentCore().SaveDescriptionOverride(ctx, req, raw))
 }
@@ -864,7 +874,7 @@ func (a *App) DeleteHistoryRelease(sourcePath string) error {
 	return nil
 }
 
-func (a *App) FetchScreenshotPlan(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) (api.ScreenshotPlan, error) {
+func (a *App) FetchScreenshotPlan(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) (api.ScreenshotPlan, error) {
 	rt, err := a.requireRuntime()
 	if err != nil {
 		return api.ScreenshotPlan{}, err
@@ -884,12 +894,13 @@ func (a *App) FetchScreenshotPlan(path string, overrides api.ExternalIDOverrides
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 
 	return wrapGUIResult(rt.core.FetchScreenshotPlan(ctx, req))
 }
 
-func (a *App) GenerateScreenshots(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, selections []api.ScreenshotSelection, purpose api.ScreenshotPurpose) (api.ScreenshotResult, error) {
+func (a *App) GenerateScreenshots(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, selections []api.ScreenshotSelection, purpose api.ScreenshotPurpose) (api.ScreenshotResult, error) {
 	rt, err := a.requireRuntime()
 	if err != nil {
 		return api.ScreenshotResult{}, err
@@ -909,12 +920,13 @@ func (a *App) GenerateScreenshots(path string, overrides api.ExternalIDOverrides
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 
 	return wrapGUIResult(rt.core.GenerateScreenshots(ctx, req, selections, purpose))
 }
 
-func (a *App) ListUploadCandidates(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) ([]api.ScreenshotImage, error) {
+func (a *App) ListUploadCandidates(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) ([]api.ScreenshotImage, error) {
 	rt, err := a.requireRuntime()
 	if err != nil {
 		return nil, err
@@ -934,12 +946,13 @@ func (a *App) ListUploadCandidates(path string, overrides api.ExternalIDOverride
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 
 	return wrapGUIResult(rt.core.ListUploadCandidates(ctx, req))
 }
 
-func (a *App) ListUploadedImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) ([]api.UploadedImageLink, error) {
+func (a *App) ListUploadedImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) ([]api.UploadedImageLink, error) {
 	rt, err := a.requireRuntime()
 	if err != nil {
 		return nil, err
@@ -959,12 +972,13 @@ func (a *App) ListUploadedImages(path string, overrides api.ExternalIDOverrides,
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 
 	return wrapGUIResult(rt.core.ListUploadedImages(ctx, req))
 }
 
-func (a *App) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, host string, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
+func (a *App) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackers []string, host string, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
 	rt, err := a.requireRuntime()
 	if err != nil {
 		return api.UploadImagesResult{}, err
@@ -990,6 +1004,7 @@ func (a *App) UploadImages(path string, overrides api.ExternalIDOverrides, nameO
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 		Trackers:             slices.Clone(trackers),
 	}
 
@@ -1022,7 +1037,7 @@ func (a *App) DeleteUploadedImage(path string, imagePath string, host string) er
 	return wrapGUIError(a.currentCore().DeleteUploadedImage(ctx, req, imagePath, host))
 }
 
-func (a *App) PreviewScreenshotFrame(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, timestampSeconds float64) (string, error) {
+func (a *App) PreviewScreenshotFrame(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, timestampSeconds float64) (string, error) {
 	if a == nil || a.currentCore() == nil {
 		return "", errors.New("app not initialized")
 	}
@@ -1041,6 +1056,7 @@ func (a *App) PreviewScreenshotFrame(path string, overrides api.ExternalIDOverri
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 
 	preview, err := a.currentCore().PreviewScreenshotFrame(ctx, req, timestampSeconds)
@@ -1054,7 +1070,7 @@ func (a *App) PreviewScreenshotFrame(path string, overrides api.ExternalIDOverri
 	return "data:image/png;base64," + encoded, nil
 }
 
-func (a *App) DeleteScreenshot(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, imagePath string) error {
+func (a *App) DeleteScreenshot(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, imagePath string) error {
 	if a == nil || a.currentCore() == nil {
 		return errors.New("app not initialized")
 	}
@@ -1076,12 +1092,13 @@ func (a *App) DeleteScreenshot(path string, overrides api.ExternalIDOverrides, n
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 
 	return wrapGUIError(a.currentCore().DeleteScreenshot(ctx, req, imagePath))
 }
 
-func (a *App) DeleteTrackerImageURL(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, url string) error {
+func (a *App) DeleteTrackerImageURL(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, url string) error {
 	if a == nil || a.currentCore() == nil {
 		return errors.New("app not initialized")
 	}
@@ -1103,12 +1120,13 @@ func (a *App) DeleteTrackerImageURL(path string, overrides api.ExternalIDOverrid
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 
 	return wrapGUIError(a.currentCore().DeleteTrackerImageURL(ctx, req, url))
 }
 
-func (a *App) SaveFinalScreenshotSelections(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, images []api.ScreenshotImage) error {
+func (a *App) SaveFinalScreenshotSelections(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, images []api.ScreenshotImage) error {
 	if a == nil || a.currentCore() == nil {
 		return errors.New("app not initialized")
 	}
@@ -1127,12 +1145,13 @@ func (a *App) SaveFinalScreenshotSelections(path string, overrides api.ExternalI
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 
 	return wrapGUIError(a.currentCore().SaveFinalScreenshotSelections(ctx, req, images))
 }
 
-func (a *App) ImportMenuImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, paths []string) error {
+func (a *App) ImportMenuImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, paths []string) error {
 	if a == nil || a.currentCore() == nil {
 		return errors.New("app not initialized")
 	}
@@ -1151,6 +1170,7 @@ func (a *App) ImportMenuImages(path string, overrides api.ExternalIDOverrides, n
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 
 	return wrapGUIError(a.currentCore().ImportMenuImages(ctx, req, paths))

--- a/internal/guiapp/app_core_test.go
+++ b/internal/guiapp/app_core_test.go
@@ -27,7 +27,7 @@ func TestFetchMetadataReportsCoreValidationFailure(t *testing.T) {
 
 	app := &App{coreInitErr: errors.New("invalid config")}
 
-	_, err := app.FetchMetadata("/tmp/example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil)
+	_, err := app.FetchMetadata("/tmp/example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -51,7 +51,7 @@ func TestFetchMetadataPropagatesSkipAutoTorrentSetting(t *testing.T) {
 		core: coreSvc,
 	}
 
-	_, err := app.FetchMetadata("C:\\releases\\Example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil)
+	_, err := app.FetchMetadata("C:\\releases\\Example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil)
 	if err != nil {
 		t.Fatalf("fetch metadata: %v", err)
 	}
@@ -147,22 +147,22 @@ func TestGUIRequestsUseSingleRuntimeSnapshot(t *testing.T) {
 	})
 
 	for range 200 {
-		if _, err := app.FetchScreenshotPlan("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}); err != nil {
+		if _, err := app.FetchScreenshotPlan("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}); err != nil {
 			t.Fatalf("fetch screenshot plan: %v", err)
 		}
-		if _, err := app.GenerateScreenshots("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil, api.ScreenshotPurposeFinal); err != nil {
+		if _, err := app.GenerateScreenshots("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, api.ScreenshotPurposeFinal); err != nil {
 			t.Fatalf("generate screenshots: %v", err)
 		}
-		if _, err := app.ListUploadCandidates("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}); err != nil {
+		if _, err := app.ListUploadCandidates("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}); err != nil {
 			t.Fatalf("list upload candidates: %v", err)
 		}
-		if _, err := app.ListUploadedImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}); err != nil {
+		if _, err := app.ListUploadedImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}); err != nil {
 			t.Fatalf("list uploaded images: %v", err)
 		}
-		if _, err := app.UploadImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil, "host", []api.ScreenshotImage{{Path: "image.jpg"}}); err != nil {
+		if _, err := app.UploadImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, "host", []api.ScreenshotImage{{Path: "image.jpg"}}); err != nil {
 			t.Fatalf("upload images: %v", err)
 		}
-		_, _ = app.FetchTrackerDryRun("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil, nil, nil, nil, false, false, "")
+		_, _ = app.FetchTrackerDryRun("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, nil, nil, nil, false, false, "")
 		select {
 		case err := <-errs:
 			t.Fatal(err)

--- a/internal/guiapp/dupe_jobs.go
+++ b/internal/guiapp/dupe_jobs.go
@@ -44,24 +44,25 @@ type DupeCheckSnapshot struct {
 }
 
 type dupeCheckJob struct {
-	mu             sync.Mutex
-	id             string
-	sourcePath     string
-	overrides      api.ExternalIDOverrides
-	nameOverrides  api.ReleaseNameOverrides
-	trackers       []string
-	states         map[string]DupeCheckTrackerState
-	completedCount int
-	totalCount     int
-	summary        api.DupeCheckSummary
-	status         string
-	errorMessage   string
-	startedAt      time.Time
-	finishedAt     time.Time
-	cancel         context.CancelFunc
+	mu                sync.Mutex
+	id                string
+	sourcePath        string
+	overrides         api.ExternalIDOverrides
+	nameOverrides     api.ReleaseNameOverrides
+	metadataOverrides api.MetadataOverrides
+	trackers          []string
+	states            map[string]DupeCheckTrackerState
+	completedCount    int
+	totalCount        int
+	summary           api.DupeCheckSummary
+	status            string
+	errorMessage      string
+	startedAt         time.Time
+	finishedAt        time.Time
+	cancel            context.CancelFunc
 }
 
-func (a *App) StartDupeCheck(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string) (string, error) {
+func (a *App) StartDupeCheck(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackers []string) (string, error) {
 	if a == nil || a.currentCore() == nil {
 		return "", errors.New("app not initialized")
 	}
@@ -85,16 +86,17 @@ func (a *App) StartDupeCheck(path string, overrides api.ExternalIDOverrides, nam
 	}
 
 	job := &dupeCheckJob{
-		id:            jobID,
-		sourcePath:    trimmedPath,
-		overrides:     overrides,
-		nameOverrides: nameOverrides,
-		trackers:      resolvedTrackers,
-		states:        states,
-		totalCount:    len(states),
-		summary:       api.DupeCheckSummary{SourcePath: trimmedPath},
-		status:        "queued",
-		startedAt:     time.Now().UTC(),
+		id:                jobID,
+		sourcePath:        trimmedPath,
+		overrides:         overrides,
+		nameOverrides:     nameOverrides,
+		metadataOverrides: metadataOverrides,
+		trackers:          resolvedTrackers,
+		states:            states,
+		totalCount:        len(states),
+		summary:           api.DupeCheckSummary{SourcePath: trimmedPath},
+		status:            "queued",
+		startedAt:         time.Now().UTC(),
 	}
 
 	baseCtx := a.runtimeContext()
@@ -176,6 +178,7 @@ func (a *App) runDupeCheckJob(ctx context.Context, eventCtx context.Context, job
 
 		ExternalIDOverrides:  job.overrides,
 		ReleaseNameOverrides: job.nameOverrides,
+		MetadataOverrides:    job.metadataOverrides,
 	}
 
 	summary, err := a.currentCore().CheckDupes(progressCtx, req)

--- a/internal/guiapp/run_options_test.go
+++ b/internal/guiapp/run_options_test.go
@@ -651,7 +651,7 @@ func TestRunTrackerUploadJobRecoversRunUploadPreparedPanic(t *testing.T) {
 	}
 }
 
-func TestRunTrackerUploadJobContainsCleanupPanic(t *testing.T) {
+func TestRunTrackerUploadJobPreservesCompletedStatusAfterCleanupPanic(t *testing.T) {
 	app := &App{}
 	coreSvc := &closeCounterCore{uploads: []uploadPreparedResponse{
 		{
@@ -663,8 +663,11 @@ func TestRunTrackerUploadJobContainsCleanupPanic(t *testing.T) {
 
 	app.runTrackerUploadJob(context.Background(), context.Background(), job)
 
-	if got := job.status; got != "failed" {
-		t.Fatalf("expected failed status after cleanup panic, got %q", got)
+	if got := job.status; got != "completed" {
+		t.Fatalf("expected completed status after cleanup panic, got %q", got)
+	}
+	if got := job.states["BLU"].Status; got != "success" {
+		t.Fatalf("expected tracker success to survive cleanup panic, got %q", got)
 	}
 	if !strings.Contains(job.errorMessage, "core close panicked") {
 		t.Fatalf("expected cleanup panic message, got %q", job.errorMessage)

--- a/internal/guiapp/upload_jobs.go
+++ b/internal/guiapp/upload_jobs.go
@@ -80,6 +80,7 @@ type trackerUploadJob struct {
 	logger               interface{ Close() error }
 	overrides            api.ExternalIDOverrides
 	nameOverrides        api.ReleaseNameOverrides
+	metadataOverrides    api.MetadataOverrides
 	questionnaireAnswers map[string]map[string]string
 	descriptionGroups    []api.DescriptionBuilderGroup
 	trackers             []string
@@ -105,6 +106,7 @@ type trackerUploadRetryRequest struct {
 	sourcePath           string
 	overrides            api.ExternalIDOverrides
 	nameOverrides        api.ReleaseNameOverrides
+	metadataOverrides    api.MetadataOverrides
 	questionnaireAnswers map[string]map[string]string
 	descriptionGroups    []api.DescriptionBuilderGroup
 	failedTrackers       []string
@@ -153,6 +155,7 @@ func trackerUploadRetryRequestFromJob(job *trackerUploadJob) (trackerUploadRetry
 		sourcePath:           job.sourcePath,
 		overrides:            job.overrides,
 		nameOverrides:        job.nameOverrides,
+		metadataOverrides:    job.metadataOverrides,
 		questionnaireAnswers: cloneQuestionnaireAnswers(job.questionnaireAnswers),
 		descriptionGroups:    api.CloneDescriptionBuilderGroups(job.descriptionGroups),
 		failedTrackers:       append([]string(nil), job.failedTrackers...),
@@ -164,13 +167,14 @@ func trackerUploadRetryRequestFromJob(job *trackerUploadJob) (trackerUploadRetry
 
 // StartTrackerUpload starts a Wails upload job for selected trackers and
 // returns its job ID. Snapshots preserve partial upload counts returned with
-// later tracker errors or cancellation. The job captures upload options at
-// start time so failed-tracker retries reuse the original option set.
-func (a *App) StartTrackerUpload(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (string, error) {
-	return a.startTrackerUpload(path, overrides, nameOverrides, trackers, ignoreDupesFor, questionnaireAnswers, descriptionGroups, debug, noSeed, runLogLevel, nil)
+// later tracker errors or cancellation. The job captures metadata overrides and
+// upload options at start time so failed-tracker retries reuse the original
+// request instead of current UI state.
+func (a *App) StartTrackerUpload(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (string, error) {
+	return a.startTrackerUpload(path, overrides, nameOverrides, metadataOverrides, trackers, ignoreDupesFor, questionnaireAnswers, descriptionGroups, debug, noSeed, runLogLevel, nil)
 }
 
-func (a *App) startTrackerUpload(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string, uploadOptions *api.UploadOptions) (string, error) {
+func (a *App) startTrackerUpload(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string, uploadOptions *api.UploadOptions) (string, error) {
 	rt, err := a.requireRuntime()
 	if err != nil {
 		return "", err
@@ -202,6 +206,7 @@ func (a *App) startTrackerUpload(path string, overrides api.ExternalIDOverrides,
 		IgnoreDupesFor:       normalizeTrackerList(ignoreDupesFor),
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 	if err := guishared.SeedRunCorePreparedMeta(baseCtx, rt.core, runCore, seedReq); err != nil {
 		_ = runCore.Close()
@@ -223,6 +228,7 @@ func (a *App) startTrackerUpload(path string, overrides api.ExternalIDOverrides,
 		logger:               runLogger,
 		overrides:            overrides,
 		nameOverrides:        nameOverrides,
+		metadataOverrides:    metadataOverrides,
 		questionnaireAnswers: cloneQuestionnaireAnswers(questionnaireAnswers),
 		descriptionGroups:    api.CloneDescriptionBuilderGroups(descriptionGroups),
 		trackers:             resolvedTrackers,
@@ -270,8 +276,9 @@ func (a *App) CancelTrackerUpload(jobID string) error {
 
 // RetryFailedTrackerUpload starts a new Wails upload job for trackers that
 // failed in the original job. The retry reuses the original job's run options,
-// upload options, questionnaire answers, description groups, and ignore-dupe
-// list instead of rebuilding them from current settings.
+// upload options, metadata overrides, questionnaire answers, description
+// groups, and ignore-dupe list instead of rebuilding them from current
+// settings.
 func (a *App) RetryFailedTrackerUpload(jobID string) (string, error) {
 	if a == nil {
 		return "", errors.New("app not initialized")
@@ -291,7 +298,7 @@ func (a *App) RetryFailedTrackerUpload(jobID string) (string, error) {
 		return "", err
 	}
 
-	return a.startTrackerUpload(retry.sourcePath, retry.overrides, retry.nameOverrides, retry.failedTrackers, retry.ignoreDupesFor, retry.questionnaireAnswers, retry.descriptionGroups, retry.runOptions.Debug, retry.runOptions.NoSeed, retry.runOptions.RunLogLevel, &retry.uploadOptions)
+	return a.startTrackerUpload(retry.sourcePath, retry.overrides, retry.nameOverrides, retry.metadataOverrides, retry.failedTrackers, retry.ignoreDupesFor, retry.questionnaireAnswers, retry.descriptionGroups, retry.runOptions.Debug, retry.runOptions.NoSeed, retry.runOptions.RunLogLevel, &retry.uploadOptions)
 }
 
 // GetTrackerUploadSnapshot returns the current Wails tracker upload job state.
@@ -406,8 +413,7 @@ func (a *App) runTrackerUploadJob(ctx context.Context, eventCtx context.Context,
 	job.cancel = nil
 	job.mu.Unlock()
 	if err := job.closeResources(); err != nil {
-		a.failTrackerUploadJob(eventCtx, job, err.Error())
-		return
+		recordTrackerUploadCleanupError(job, err.Error())
 	}
 	a.emitTrackerUploadSnapshot(eventCtx, job)
 }
@@ -469,6 +475,7 @@ func (a *App) runSingleTrackerUpload(ctx context.Context, job *trackerUploadJob,
 		Options:                     job.uploadOptions,
 		ExternalIDOverrides:         job.overrides,
 		ReleaseNameOverrides:        job.nameOverrides,
+		MetadataOverrides:           job.metadataOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(job.questionnaireAnswers),
 	}
 
@@ -553,6 +560,29 @@ func (a *App) failTrackerUploadJob(eventCtx context.Context, job *trackerUploadJ
 		job.mu.Unlock()
 	}
 	a.emitTrackerUploadSnapshot(eventCtx, job)
+}
+
+// recordTrackerUploadCleanupError surfaces post-terminal cleanup failures
+// without changing a completed, completed-with-errors, or canceled job status.
+func recordTrackerUploadCleanupError(job *trackerUploadJob, message string) {
+	if job == nil {
+		return
+	}
+
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return
+	}
+
+	job.mu.Lock()
+	defer job.mu.Unlock()
+	if job.errorMessage == "" {
+		job.errorMessage = message
+		return
+	}
+	if !strings.Contains(job.errorMessage, message) {
+		job.errorMessage += "; " + message
+	}
 }
 
 // closeTrackerUploadResource converts Close panics into redacted errors for

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -255,6 +255,7 @@ func applyMetadataOverrides(meta *api.PreparedMetadata) {
 	}
 
 	overrides := meta.MetadataOverrides
+	clearMetadataOverrideFields(meta, overrides.Clear)
 	if overrides.Distributor != nil {
 		meta.Distributor = normalizeDistributor(*overrides.Distributor)
 	}
@@ -286,9 +287,6 @@ func applyOriginalLanguageOverride(meta *api.PreparedMetadata, language *string)
 	}
 
 	trimmed := strings.TrimSpace(*language)
-	if trimmed == "" {
-		return
-	}
 	if meta.ExternalMetadata.TMDB != nil {
 		meta.ExternalMetadata.TMDB.OriginalLanguage = trimmed
 	}
@@ -300,6 +298,33 @@ func applyOriginalLanguageOverride(meta *api.PreparedMetadata, language *string)
 	}
 	if meta.ExternalMetadata.TVmaze != nil {
 		meta.ExternalMetadata.TVmaze.Language = trimmed
+	}
+}
+
+// clearMetadataOverrideFields resets prepared metadata fields that the caller
+// explicitly cleared before media-detail overrides are applied.
+func clearMetadataOverrideFields(meta *api.PreparedMetadata, fields []string) {
+	if meta == nil {
+		return
+	}
+	for _, field := range fields {
+		switch strings.ToLower(strings.TrimSpace(field)) {
+		case "distributor":
+			meta.Distributor = ""
+		case "originallanguage":
+			empty := ""
+			applyOriginalLanguageOverride(meta, &empty)
+		case "personalrelease":
+			meta.PersonalRelease = false
+		case "commentary":
+			meta.HasCommentary = false
+		case "webdv":
+			meta.WebDV = false
+		case "streamoptimized":
+			meta.StreamOptimized = 0
+		case "anime":
+			meta.Anime = false
+		}
 	}
 }
 

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -263,6 +263,67 @@ func TestEditionFromMetaSkipsIMDbRuntimeWhenAnimeOverridePresent(t *testing.T) {
 	}
 }
 
+func TestApplyMetadataOverridesClearsFields(t *testing.T) {
+	meta := api.PreparedMetadata{
+		Distributor:     "Criterion",
+		PersonalRelease: true,
+		HasCommentary:   true,
+		WebDV:           true,
+		StreamOptimized: 1,
+		Anime:           true,
+		ExternalMetadata: api.ExternalMetadata{
+			TMDB:   &api.TMDBMetadata{OriginalLanguage: "ja"},
+			IMDB:   &api.IMDBMetadata{OriginalLanguage: "ja"},
+			TVDB:   &api.TVDBMetadata{OriginalLanguage: "jpn"},
+			TVmaze: &api.TVmazeMetadata{Language: "Japanese"},
+		},
+		MetadataOverrides: api.MetadataOverrides{
+			Clear: []string{
+				"Distributor",
+				"OriginalLanguage",
+				"PersonalRelease",
+				"Commentary",
+				"WebDV",
+				"StreamOptimized",
+				"Anime",
+			},
+		},
+	}
+
+	applyMetadataOverrides(&meta)
+
+	if meta.Distributor != "" {
+		t.Fatalf("expected distributor clear, got %q", meta.Distributor)
+	}
+	if meta.PersonalRelease {
+		t.Fatalf("expected personal release clear")
+	}
+	if meta.HasCommentary {
+		t.Fatalf("expected commentary clear")
+	}
+	if meta.WebDV {
+		t.Fatalf("expected webdv clear")
+	}
+	if meta.StreamOptimized != 0 {
+		t.Fatalf("expected stream optimized clear, got %d", meta.StreamOptimized)
+	}
+	if meta.Anime {
+		t.Fatalf("expected anime clear")
+	}
+	if got := meta.ExternalMetadata.TMDB.OriginalLanguage; got != "" {
+		t.Fatalf("expected tmdb language clear, got %q", got)
+	}
+	if got := meta.ExternalMetadata.IMDB.OriginalLanguage; got != "" {
+		t.Fatalf("expected imdb language clear, got %q", got)
+	}
+	if got := meta.ExternalMetadata.TVDB.OriginalLanguage; got != "" {
+		t.Fatalf("expected tvdb language clear, got %q", got)
+	}
+	if got := meta.ExternalMetadata.TVmaze.Language; got != "" {
+		t.Fatalf("expected tvmaze language clear, got %q", got)
+	}
+}
+
 func TestEditionFromMetaExtractsRepackAndCleansEdition(t *testing.T) {
 	meta := api.PreparedMetadata{
 		Release: api.ReleaseInfo{Edition: []string{"Limited", "Extended", "Edition", "REPACK2"}},

--- a/internal/webserver/app_routes.go
+++ b/internal/webserver/app_routes.go
@@ -234,7 +234,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.FetchMetadata(current.ID, req.Path, req.SourceLookupURL, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.ConfirmBDMVRescan)
+		value, err := s.backend.FetchMetadata(r.Context(), current.ID, req.Path, req.SourceLookupURL, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.ConfirmBDMVRescan)
 		if err != nil {
 			writeAppError(w, err)
 			return
@@ -256,7 +256,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.ResetMetadata(current.ID, req.Path, req.SourceLookupURL, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.ConfirmBDMVRescan)
+		value, err := s.backend.ResetMetadata(r.Context(), current.ID, req.Path, req.SourceLookupURL, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.ConfirmBDMVRescan)
 		if err != nil {
 			writeAppError(w, err)
 			return
@@ -273,7 +273,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.SelectBlurayCandidate(req.Path, req.ReleaseID)
+		value, err := s.backend.SelectBlurayCandidate(r.Context(), req.Path, req.ReleaseID)
 		if err != nil {
 			writeAppError(w, err)
 			return
@@ -293,7 +293,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.CheckDupes(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers)
+		value, err := s.backend.CheckDupes(r.Context(), req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -314,7 +314,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.FetchPreparation(current.ID, req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.IgnoreDupesFor)
+		value, err := s.backend.FetchPreparation(r.Context(), current.ID, req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.IgnoreDupesFor)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -340,7 +340,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.FetchTrackerDryRun(current.ID, req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.IgnoreDupesFor, req.QuestionnaireAnswers, req.DescriptionGroups, req.Debug, req.NoSeed, req.RunLogLevel)
+		value, err := s.backend.FetchTrackerDryRun(r.Context(), current.ID, req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.IgnoreDupesFor, req.QuestionnaireAnswers, req.DescriptionGroups, req.Debug, req.NoSeed, req.RunLogLevel)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -361,7 +361,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.FetchDescriptionBuilder(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.IgnoreDupesFor)
+		value, err := s.backend.FetchDescriptionBuilder(r.Context(), req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.IgnoreDupesFor)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -397,7 +397,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.SaveDescriptionOverride(req.Path, req.GroupKey, req.Raw, req.Trackers, req.Overrides, req.NameOverrides, req.MetadataOverrides)
+		value, err := s.backend.SaveDescriptionOverride(r.Context(), req.Path, req.GroupKey, req.Raw, req.Trackers, req.Overrides, req.NameOverrides, req.MetadataOverrides)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -488,7 +488,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.FetchScreenshotPlan(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides)
+		value, err := s.backend.FetchScreenshotPlan(r.Context(), req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -509,7 +509,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.GenerateScreenshots(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Selections, req.Purpose)
+		value, err := s.backend.GenerateScreenshots(r.Context(), req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Selections, req.Purpose)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -529,7 +529,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.PreviewScreenshotFrame(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.TimestampSeconds)
+		value, err := s.backend.PreviewScreenshotFrame(r.Context(), req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.TimestampSeconds)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -549,7 +549,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		if err := s.backend.DeleteScreenshot(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.ImagePath); err != nil {
+		if err := s.backend.DeleteScreenshot(r.Context(), req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.ImagePath); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
@@ -568,7 +568,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		if err := s.backend.DeleteTrackerImageURL(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.URL); err != nil {
+		if err := s.backend.DeleteTrackerImageURL(r.Context(), req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.URL); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
@@ -587,7 +587,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		if err := s.backend.SaveFinalScreenshotSelections(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Images); err != nil {
+		if err := s.backend.SaveFinalScreenshotSelections(r.Context(), req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Images); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
@@ -620,7 +620,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		if err := s.backend.ImportMenuImages(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, importPaths); err != nil {
+		if err := s.backend.ImportMenuImages(r.Context(), req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, importPaths); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
@@ -652,7 +652,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.ListUploadCandidates(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides)
+		value, err := s.backend.ListUploadCandidates(r.Context(), req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -671,7 +671,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.ListUploadedImages(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides)
+		value, err := s.backend.ListUploadedImages(r.Context(), req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -693,7 +693,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.UploadImages(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.Host, req.Images)
+		value, err := s.backend.UploadImages(r.Context(), req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.Host, req.Images)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return

--- a/internal/webserver/app_routes.go
+++ b/internal/webserver/app_routes.go
@@ -226,6 +226,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			SourceLookupURL   string
 			Overrides         api.ExternalIDOverrides
 			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
 			Trackers          []string
 			ConfirmBDMVRescan bool
 		}
@@ -233,7 +234,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.FetchMetadata(current.ID, req.Path, req.SourceLookupURL, req.Overrides, req.NameOverrides, req.Trackers, req.ConfirmBDMVRescan)
+		value, err := s.backend.FetchMetadata(current.ID, req.Path, req.SourceLookupURL, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.ConfirmBDMVRescan)
 		if err != nil {
 			writeAppError(w, err)
 			return
@@ -247,6 +248,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			SourceLookupURL   string
 			Overrides         api.ExternalIDOverrides
 			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
 			Trackers          []string
 			ConfirmBDMVRescan bool
 		}
@@ -254,7 +256,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.ResetMetadata(current.ID, req.Path, req.SourceLookupURL, req.Overrides, req.NameOverrides, req.Trackers, req.ConfirmBDMVRescan)
+		value, err := s.backend.ResetMetadata(current.ID, req.Path, req.SourceLookupURL, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.ConfirmBDMVRescan)
 		if err != nil {
 			writeAppError(w, err)
 			return
@@ -281,16 +283,17 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/CheckDupes", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		var req struct {
-			Path          string
-			Overrides     api.ExternalIDOverrides
-			NameOverrides api.ReleaseNameOverrides
-			Trackers      []string
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
+			Trackers          []string
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.CheckDupes(req.Path, req.Overrides, req.NameOverrides, req.Trackers)
+		value, err := s.backend.CheckDupes(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -300,17 +303,18 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/FetchPreparation", s.requireSession(func(w http.ResponseWriter, r *http.Request, current session) {
 		var req struct {
-			Path           string
-			Overrides      api.ExternalIDOverrides
-			NameOverrides  api.ReleaseNameOverrides
-			Trackers       []string
-			IgnoreDupesFor []string
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
+			Trackers          []string
+			IgnoreDupesFor    []string
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.FetchPreparation(current.ID, req.Path, req.Overrides, req.NameOverrides, req.Trackers, req.IgnoreDupesFor)
+		value, err := s.backend.FetchPreparation(current.ID, req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.IgnoreDupesFor)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -323,6 +327,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			Path                 string
 			Overrides            api.ExternalIDOverrides
 			NameOverrides        api.ReleaseNameOverrides
+			MetadataOverrides    api.MetadataOverrides
 			Trackers             []string
 			IgnoreDupesFor       []string
 			QuestionnaireAnswers map[string]map[string]string
@@ -335,7 +340,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.FetchTrackerDryRun(current.ID, req.Path, req.Overrides, req.NameOverrides, req.Trackers, req.IgnoreDupesFor, req.QuestionnaireAnswers, req.DescriptionGroups, req.Debug, req.NoSeed, req.RunLogLevel)
+		value, err := s.backend.FetchTrackerDryRun(current.ID, req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.IgnoreDupesFor, req.QuestionnaireAnswers, req.DescriptionGroups, req.Debug, req.NoSeed, req.RunLogLevel)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -345,17 +350,18 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/FetchDescriptionBuilder", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		var req struct {
-			Path           string
-			Overrides      api.ExternalIDOverrides
-			NameOverrides  api.ReleaseNameOverrides
-			Trackers       []string
-			IgnoreDupesFor []string
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
+			Trackers          []string
+			IgnoreDupesFor    []string
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.FetchDescriptionBuilder(req.Path, req.Overrides, req.NameOverrides, req.Trackers, req.IgnoreDupesFor)
+		value, err := s.backend.FetchDescriptionBuilder(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.IgnoreDupesFor)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -379,18 +385,19 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/SaveDescriptionOverride", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		var req struct {
-			Path          string
-			GroupKey      string
-			Raw           string
-			Trackers      []string
-			Overrides     api.ExternalIDOverrides
-			NameOverrides api.ReleaseNameOverrides
+			Path              string
+			GroupKey          string
+			Raw               string
+			Trackers          []string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.SaveDescriptionOverride(req.Path, req.GroupKey, req.Raw, req.Trackers, req.Overrides, req.NameOverrides)
+		value, err := s.backend.SaveDescriptionOverride(req.Path, req.GroupKey, req.Raw, req.Trackers, req.Overrides, req.NameOverrides, req.MetadataOverrides)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -472,15 +479,16 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/FetchScreenshotPlan", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		var req struct {
-			Path          string
-			Overrides     api.ExternalIDOverrides
-			NameOverrides api.ReleaseNameOverrides
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.FetchScreenshotPlan(req.Path, req.Overrides, req.NameOverrides)
+		value, err := s.backend.FetchScreenshotPlan(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -490,17 +498,18 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/GenerateScreenshots", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		var req struct {
-			Path          string
-			Overrides     api.ExternalIDOverrides
-			NameOverrides api.ReleaseNameOverrides
-			Selections    []api.ScreenshotSelection
-			Purpose       api.ScreenshotPurpose
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
+			Selections        []api.ScreenshotSelection
+			Purpose           api.ScreenshotPurpose
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.GenerateScreenshots(req.Path, req.Overrides, req.NameOverrides, req.Selections, req.Purpose)
+		value, err := s.backend.GenerateScreenshots(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Selections, req.Purpose)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -510,16 +519,17 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/PreviewScreenshotFrame", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		var req struct {
-			Path             string
-			Overrides        api.ExternalIDOverrides
-			NameOverrides    api.ReleaseNameOverrides
-			TimestampSeconds float64
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
+			TimestampSeconds  float64
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.PreviewScreenshotFrame(req.Path, req.Overrides, req.NameOverrides, req.TimestampSeconds)
+		value, err := s.backend.PreviewScreenshotFrame(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.TimestampSeconds)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -529,16 +539,17 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/DeleteScreenshot", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		var req struct {
-			Path          string
-			Overrides     api.ExternalIDOverrides
-			NameOverrides api.ReleaseNameOverrides
-			ImagePath     string
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
+			ImagePath         string
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		if err := s.backend.DeleteScreenshot(req.Path, req.Overrides, req.NameOverrides, req.ImagePath); err != nil {
+		if err := s.backend.DeleteScreenshot(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.ImagePath); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
@@ -547,16 +558,17 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/DeleteTrackerImageURL", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		var req struct {
-			Path          string
-			Overrides     api.ExternalIDOverrides
-			NameOverrides api.ReleaseNameOverrides
-			URL           string
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
+			URL               string
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		if err := s.backend.DeleteTrackerImageURL(req.Path, req.Overrides, req.NameOverrides, req.URL); err != nil {
+		if err := s.backend.DeleteTrackerImageURL(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.URL); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
@@ -565,16 +577,17 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/SaveFinalScreenshotSelections", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		var req struct {
-			Path          string
-			Overrides     api.ExternalIDOverrides
-			NameOverrides api.ReleaseNameOverrides
-			Images        []api.ScreenshotImage
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
+			Images            []api.ScreenshotImage
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		if err := s.backend.SaveFinalScreenshotSelections(req.Path, req.Overrides, req.NameOverrides, req.Images); err != nil {
+		if err := s.backend.SaveFinalScreenshotSelections(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Images); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
@@ -583,10 +596,11 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/ImportMenuImages", s.requireSession(func(w http.ResponseWriter, r *http.Request, current session) {
 		var req struct {
-			Path          string
-			Overrides     api.ExternalIDOverrides
-			NameOverrides api.ReleaseNameOverrides
-			Paths         []string
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
+			Paths             []string
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
@@ -606,7 +620,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		if err := s.backend.ImportMenuImages(req.Path, req.Overrides, req.NameOverrides, importPaths); err != nil {
+		if err := s.backend.ImportMenuImages(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, importPaths); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
@@ -629,15 +643,16 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/ListUploadCandidates", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		var req struct {
-			Path          string
-			Overrides     api.ExternalIDOverrides
-			NameOverrides api.ReleaseNameOverrides
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.ListUploadCandidates(req.Path, req.Overrides, req.NameOverrides)
+		value, err := s.backend.ListUploadCandidates(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -647,15 +662,16 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/ListUploadedImages", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		var req struct {
-			Path          string
-			Overrides     api.ExternalIDOverrides
-			NameOverrides api.ReleaseNameOverrides
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.ListUploadedImages(req.Path, req.Overrides, req.NameOverrides)
+		value, err := s.backend.ListUploadedImages(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -665,18 +681,19 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/UploadImages", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		var req struct {
-			Path          string
-			Overrides     api.ExternalIDOverrides
-			NameOverrides api.ReleaseNameOverrides
-			Trackers      []string
-			Host          string
-			Images        []api.ScreenshotImage
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
+			Trackers          []string
+			Host              string
+			Images            []api.ScreenshotImage
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.UploadImages(req.Path, req.Overrides, req.NameOverrides, req.Trackers, req.Host, req.Images)
+		value, err := s.backend.UploadImages(req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.Host, req.Images)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -901,16 +918,17 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 
 	mux.HandleFunc("/api/app/StartDupeCheck", s.requireSession(func(w http.ResponseWriter, r *http.Request, current session) {
 		var req struct {
-			Path          string
-			Overrides     api.ExternalIDOverrides
-			NameOverrides api.ReleaseNameOverrides
-			Trackers      []string
+			Path              string
+			Overrides         api.ExternalIDOverrides
+			NameOverrides     api.ReleaseNameOverrides
+			MetadataOverrides api.MetadataOverrides
+			Trackers          []string
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.StartDupeCheck(current.ID, req.Path, req.Overrides, req.NameOverrides, req.Trackers)
+		value, err := s.backend.StartDupeCheck(current.ID, req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -954,6 +972,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			Path                 string
 			Overrides            api.ExternalIDOverrides
 			NameOverrides        api.ReleaseNameOverrides
+			MetadataOverrides    api.MetadataOverrides
 			Trackers             []string
 			IgnoreDupesFor       []string
 			QuestionnaireAnswers map[string]map[string]string
@@ -966,7 +985,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.StartTrackerUpload(current.ID, req.Path, req.Overrides, req.NameOverrides, req.Trackers, req.IgnoreDupesFor, req.QuestionnaireAnswers, req.DescriptionGroups, req.Debug, req.NoSeed, req.RunLogLevel)
+		value, err := s.backend.StartTrackerUpload(current.ID, req.Path, req.Overrides, req.NameOverrides, req.MetadataOverrides, req.Trackers, req.IgnoreDupesFor, req.QuestionnaireAnswers, req.DescriptionGroups, req.Debug, req.NoSeed, req.RunLogLevel)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -180,7 +180,10 @@ func (b *Backend) DetectDiscType(ctx context.Context, path string) (string, erro
 	return wrapWebResult(filesystem.DetectDiscType(ctx, path))
 }
 
-func (b *Backend) FetchMetadata(sessionID string, path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, confirmBDMVRescan bool) (api.MetadataPreview, error) {
+// FetchMetadata builds an embedded-web metadata preview under ctx. Request
+// cancellation remains the parent of the preview timeout so disconnected browser
+// calls can stop core metadata work and progress emission.
+func (b *Backend) FetchMetadata(ctx context.Context, sessionID string, path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, confirmBDMVRescan bool) (api.MetadataPreview, error) {
 	rt, err := b.requireRuntime()
 	if err != nil {
 		return api.MetadataPreview{}, err
@@ -190,7 +193,7 @@ func (b *Backend) FetchMetadata(sessionID string, path string, sourceLookupURL s
 		return api.MetadataPreview{}, errors.New("path is required")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	progressCtx := api.WithMetadataProgressReporter(ctx, func(update api.MetadataProgressUpdate) {
 		if strings.TrimSpace(update.Path) == "" {
@@ -222,7 +225,7 @@ type blurayCandidateSelector interface {
 	SelectBlurayCandidate(ctx context.Context, sourcePath string, releaseID string) (api.MetadataPreview, error)
 }
 
-func (b *Backend) SelectBlurayCandidate(path string, releaseID string) (api.MetadataPreview, error) {
+func (b *Backend) SelectBlurayCandidate(ctx context.Context, path string, releaseID string) (api.MetadataPreview, error) {
 	if strings.TrimSpace(path) == "" {
 		return api.MetadataPreview{}, errors.New("path is required")
 	}
@@ -236,12 +239,12 @@ func (b *Backend) SelectBlurayCandidate(path string, releaseID string) (api.Meta
 	if !ok {
 		return api.MetadataPreview{}, errors.New("blu-ray candidate selection is unavailable in this build")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	return wrapWebResult(selector.SelectBlurayCandidate(ctx, path, releaseID))
 }
 
-func (b *Backend) ResetMetadata(sessionID string, path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, confirmBDMVRescan bool) (api.MetadataPreview, error) {
+func (b *Backend) ResetMetadata(ctx context.Context, sessionID string, path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, confirmBDMVRescan bool) (api.MetadataPreview, error) {
 	if err := b.requireCore(); err != nil {
 		return api.MetadataPreview{}, err
 	}
@@ -253,7 +256,7 @@ func (b *Backend) ResetMetadata(sessionID string, path string, sourceLookupURL s
 		return api.MetadataPreview{}, errors.New("path is required")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	progressCtx := api.WithMetadataProgressReporter(ctx, func(update api.MetadataProgressUpdate) {
 		if strings.TrimSpace(update.Path) == "" {
@@ -343,11 +346,11 @@ func (b *Backend) ResetMetadata(sessionID string, path string, sourceLookupURL s
 	return wrapWebResult(b.currentCore().FetchMetadataPreview(progressCtx, req))
 }
 
-func (b *Backend) CheckDupes(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string) (api.DupeCheckSummary, error) {
+func (b *Backend) CheckDupes(ctx context.Context, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string) (api.DupeCheckSummary, error) {
 	if err := b.requireCore(); err != nil {
 		return api.DupeCheckSummary{}, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	req := api.Request{
 		Paths:    []string{strings.TrimSpace(path)},
@@ -365,11 +368,11 @@ func (b *Backend) CheckDupes(path string, overrides api.ExternalIDOverrides, nam
 // FetchPreparation builds an embedded-web preparation preview for a host source
 // path. External ID, release-name, and metadata overrides come from the current
 // browser request and are applied before BDInfo playlist preparation runs.
-func (b *Backend) FetchPreparation(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, ignoreDupesFor []string) (api.PreparationPreview, error) {
+func (b *Backend) FetchPreparation(ctx context.Context, sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, ignoreDupesFor []string) (api.PreparationPreview, error) {
 	if err := b.requireCore(); err != nil {
 		return api.PreparationPreview{}, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	req := api.Request{
 		Paths:          []string{strings.TrimSpace(path)},
@@ -394,7 +397,7 @@ func (b *Backend) FetchPreparation(sessionID string, path string, overrides api.
 	return wrapWebResult(b.currentCore().FetchPreparationPreview(progressCtx, req))
 }
 
-func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (api.TrackerDryRunPreview, error) {
+func (b *Backend) FetchTrackerDryRun(ctx context.Context, sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (api.TrackerDryRunPreview, error) {
 	rt, err := b.requireRuntime()
 	if err != nil {
 		return api.TrackerDryRunPreview{}, err
@@ -404,7 +407,9 @@ func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides ap
 		return api.TrackerDryRunPreview{}, err
 	}
 	b.logDebugf("web: tracker dry-run request path=%s debug=%t no_seed=%t run_log_level=%s", strings.TrimSpace(path), debug, noSeed, runOpts.RunLogLevel)
-	runCore, runLogger, err := b.buildRunCoreFromSnapshot(rt, runOpts)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
+	defer cancel()
+	runCore, runLogger, err := b.buildRunCoreFromSnapshot(ctx, rt, runOpts)
 	if err != nil {
 		return api.TrackerDryRunPreview{}, err
 	}
@@ -412,8 +417,6 @@ func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides ap
 		_ = runCore.Close()
 		_ = runLogger.Close()
 	}()
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
-	defer cancel()
 	req := api.Request{
 		Paths:                       []string{strings.TrimSpace(path)},
 		Mode:                        api.ModeGUI,
@@ -446,11 +449,11 @@ func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides ap
 	return wrapWebResult(runCore.FetchTrackerDryRunPreview(progressCtx, req))
 }
 
-func (b *Backend) FetchDescriptionBuilder(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, ignoreDupesFor []string) (api.DescriptionBuilderPreview, error) {
+func (b *Backend) FetchDescriptionBuilder(ctx context.Context, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, ignoreDupesFor []string) (api.DescriptionBuilderPreview, error) {
 	if err := b.requireCore(); err != nil {
 		return api.DescriptionBuilderPreview{}, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	req := api.Request{
 		Paths:          []string{strings.TrimSpace(path)},
@@ -475,11 +478,11 @@ func (b *Backend) RenderDescription(raw string) (string, error) {
 	return wrapWebResult(b.currentCore().RenderDescription(ctx, raw))
 }
 
-func (b *Backend) SaveDescriptionOverride(path string, groupKey string, raw string, trackers []string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) (api.DescriptionBuilderGroup, error) {
+func (b *Backend) SaveDescriptionOverride(ctx context.Context, path string, groupKey string, raw string, trackers []string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) (api.DescriptionBuilderGroup, error) {
 	if err := b.requireCore(); err != nil {
 		return api.DescriptionBuilderGroup{}, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	return wrapWebResult(b.currentCore().SaveDescriptionOverride(ctx, api.Request{
 		Paths:                    []string{strings.TrimSpace(path)},
@@ -543,11 +546,13 @@ func (b *Backend) BrowseDirectoryWithinRoots(path string, mode string, roots []s
 	return wrapWebResult(guishared.BrowseDirectoryWithinRoots(api.BrowseDirectoryRequest{Path: path, Mode: mode}, fallback, roots))
 }
 
-func (b *Backend) FetchScreenshotPlan(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) (api.ScreenshotPlan, error) {
+// FetchScreenshotPlan builds screenshot planning data under ctx and applies the
+// embedded-web preview timeout without detaching from request cancellation.
+func (b *Backend) FetchScreenshotPlan(ctx context.Context, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) (api.ScreenshotPlan, error) {
 	if err := b.requireCore(); err != nil {
 		return api.ScreenshotPlan{}, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	req := api.Request{
 		Paths:   []string{path},
@@ -561,11 +566,11 @@ func (b *Backend) FetchScreenshotPlan(path string, overrides api.ExternalIDOverr
 	return wrapWebResult(b.currentCore().FetchScreenshotPlan(ctx, req))
 }
 
-func (b *Backend) GenerateScreenshots(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, selections []api.ScreenshotSelection, purpose api.ScreenshotPurpose) (api.ScreenshotResult, error) {
+func (b *Backend) GenerateScreenshots(ctx context.Context, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, selections []api.ScreenshotSelection, purpose api.ScreenshotPurpose) (api.ScreenshotResult, error) {
 	if err := b.requireCore(); err != nil {
 		return api.ScreenshotResult{}, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	req := api.Request{
 		Paths:   []string{path},
@@ -579,11 +584,11 @@ func (b *Backend) GenerateScreenshots(path string, overrides api.ExternalIDOverr
 	return wrapWebResult(b.currentCore().GenerateScreenshots(ctx, req, selections, purpose))
 }
 
-func (b *Backend) PreviewScreenshotFrame(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, timestampSeconds float64) (string, error) {
+func (b *Backend) PreviewScreenshotFrame(ctx context.Context, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, timestampSeconds float64) (string, error) {
 	if err := b.requireCore(); err != nil {
 		return "", err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	req := api.Request{
 		Paths:   []string{path},
@@ -601,11 +606,11 @@ func (b *Backend) PreviewScreenshotFrame(path string, overrides api.ExternalIDOv
 	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(preview.ImageBytes), nil
 }
 
-func (b *Backend) DeleteScreenshot(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, imagePath string) error {
+func (b *Backend) DeleteScreenshot(ctx context.Context, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, imagePath string) error {
 	if err := b.requireCore(); err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	return wrapWebError(b.currentCore().DeleteScreenshot(ctx, api.Request{
 		Paths:   []string{path},
@@ -618,11 +623,11 @@ func (b *Backend) DeleteScreenshot(path string, overrides api.ExternalIDOverride
 	}, imagePath))
 }
 
-func (b *Backend) DeleteTrackerImageURL(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, imageURL string) error {
+func (b *Backend) DeleteTrackerImageURL(ctx context.Context, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, imageURL string) error {
 	if err := b.requireCore(); err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	return wrapWebError(b.currentCore().DeleteTrackerImageURL(ctx, api.Request{
 		Paths:   []string{path},
@@ -635,11 +640,11 @@ func (b *Backend) DeleteTrackerImageURL(path string, overrides api.ExternalIDOve
 	}, imageURL))
 }
 
-func (b *Backend) SaveFinalScreenshotSelections(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, images []api.ScreenshotImage) error {
+func (b *Backend) SaveFinalScreenshotSelections(ctx context.Context, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, images []api.ScreenshotImage) error {
 	if err := b.requireCore(); err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	return wrapWebError(b.currentCore().SaveFinalScreenshotSelections(ctx, api.Request{
 		Paths:   []string{path},
@@ -652,11 +657,11 @@ func (b *Backend) SaveFinalScreenshotSelections(path string, overrides api.Exter
 	}, images))
 }
 
-func (b *Backend) ImportMenuImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, paths []string) error {
+func (b *Backend) ImportMenuImages(ctx context.Context, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, paths []string) error {
 	if err := b.requireCore(); err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	return wrapWebError(b.currentCore().ImportMenuImages(ctx, api.Request{
 		Paths:   []string{path},
@@ -684,12 +689,14 @@ func (b *Backend) ReadScreenshotImage(path string) (string, error) {
 	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(payload), nil
 }
 
-func (b *Backend) ListUploadCandidates(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) ([]api.ScreenshotImage, error) {
+// ListUploadCandidates returns screenshots available for image-host upload
+// under ctx so browser request cancellation can stop candidate discovery.
+func (b *Backend) ListUploadCandidates(ctx context.Context, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) ([]api.ScreenshotImage, error) {
 	rt, err := b.requireRuntime()
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	return wrapWebResult(rt.core.ListUploadCandidates(ctx, api.Request{
 		Paths:   []string{path},
@@ -702,12 +709,12 @@ func (b *Backend) ListUploadCandidates(path string, overrides api.ExternalIDOver
 	}))
 }
 
-func (b *Backend) ListUploadedImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) ([]api.UploadedImageLink, error) {
+func (b *Backend) ListUploadedImages(ctx context.Context, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) ([]api.UploadedImageLink, error) {
 	rt, err := b.requireRuntime()
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	return wrapWebResult(rt.core.ListUploadedImages(ctx, api.Request{
 		Paths:   []string{path},
@@ -720,12 +727,12 @@ func (b *Backend) ListUploadedImages(path string, overrides api.ExternalIDOverri
 	}))
 }
 
-func (b *Backend) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, host string, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
+func (b *Backend) UploadImages(ctx context.Context, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, host string, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
 	rt, err := b.requireRuntime()
 	if err != nil {
 		return api.UploadImagesResult{}, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	ctx, cancel := context.WithTimeout(ctx, previewTimeout)
 	defer cancel()
 	return wrapWebResult(rt.core.UploadImages(ctx, api.Request{
 		Paths:   []string{path},
@@ -1397,13 +1404,13 @@ func (b *Backend) buildRunOptions(debug bool, noSeed bool, runLogLevel string) (
 // buildRunCoreFromSnapshot creates a per-run core and logger from the same
 // runtime snapshot used to build upload options. The transient core skips
 // startup-only legacy cookie migration while sharing the backend repository.
-func (b *Backend) buildRunCoreFromSnapshot(rt backendRuntimeSnapshot, opts runOptions) (api.Core, *logging.Logger, error) {
+func (b *Backend) buildRunCoreFromSnapshot(ctx context.Context, rt backendRuntimeSnapshot, opts runOptions) (api.Core, *logging.Logger, error) {
 	effectiveLogLevel := logging.ResolveEffectiveLevel(rt.cfg.Logging.Level, opts.RunLogLevel, opts.Debug)
 	logger, err := logging.NewWithLevel(rt.cfg.Logging, rt.cfg.MainSettings.DBPath, effectiveLogLevel)
 	if err != nil {
 		return nil, nil, fmt.Errorf("web: %w", err)
 	}
-	coreSvc, err := core.New(api.CoreDependencies{
+	coreSvc, err := core.NewWithContext(ctx, api.CoreDependencies{
 		Config: rt.cfg,
 		Logger: logger,
 		Services: api.ServiceSet{

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -180,7 +180,7 @@ func (b *Backend) DetectDiscType(ctx context.Context, path string) (string, erro
 	return wrapWebResult(filesystem.DetectDiscType(ctx, path))
 }
 
-func (b *Backend) FetchMetadata(sessionID string, path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, confirmBDMVRescan bool) (api.MetadataPreview, error) {
+func (b *Backend) FetchMetadata(sessionID string, path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, confirmBDMVRescan bool) (api.MetadataPreview, error) {
 	rt, err := b.requireRuntime()
 	if err != nil {
 		return api.MetadataPreview{}, err
@@ -211,6 +211,7 @@ func (b *Backend) FetchMetadata(sessionID string, path string, sourceLookupURL s
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 		ConfirmBDMVRescan:    confirmBDMVRescan,
 	}
 
@@ -240,7 +241,7 @@ func (b *Backend) SelectBlurayCandidate(path string, releaseID string) (api.Meta
 	return wrapWebResult(selector.SelectBlurayCandidate(ctx, path, releaseID))
 }
 
-func (b *Backend) ResetMetadata(sessionID string, path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, confirmBDMVRescan bool) (api.MetadataPreview, error) {
+func (b *Backend) ResetMetadata(sessionID string, path string, sourceLookupURL string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, confirmBDMVRescan bool) (api.MetadataPreview, error) {
 	if err := b.requireCore(); err != nil {
 		return api.MetadataPreview{}, err
 	}
@@ -336,12 +337,13 @@ func (b *Backend) ResetMetadata(sessionID string, path string, sourceLookupURL s
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 		ConfirmBDMVRescan:    confirmBDMVRescan,
 	}
 	return wrapWebResult(b.currentCore().FetchMetadataPreview(progressCtx, req))
 }
 
-func (b *Backend) CheckDupes(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string) (api.DupeCheckSummary, error) {
+func (b *Backend) CheckDupes(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string) (api.DupeCheckSummary, error) {
 	if err := b.requireCore(); err != nil {
 		return api.DupeCheckSummary{}, err
 	}
@@ -355,11 +357,15 @@ func (b *Backend) CheckDupes(path string, overrides api.ExternalIDOverrides, nam
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 	return wrapWebResult(b.currentCore().CheckDupes(ctx, req))
 }
 
-func (b *Backend) FetchPreparation(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, ignoreDupesFor []string) (api.PreparationPreview, error) {
+// FetchPreparation builds an embedded-web preparation preview for a host source
+// path. External ID, release-name, and metadata overrides come from the current
+// browser request and are applied before BDInfo playlist preparation runs.
+func (b *Backend) FetchPreparation(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, ignoreDupesFor []string) (api.PreparationPreview, error) {
 	if err := b.requireCore(); err != nil {
 		return api.PreparationPreview{}, err
 	}
@@ -374,6 +380,7 @@ func (b *Backend) FetchPreparation(sessionID string, path string, overrides api.
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 	progressCtx := bdinfo.WithProgressReporter(ctx, func(line string) {
 		if strings.TrimSpace(line) == "" {
@@ -387,7 +394,7 @@ func (b *Backend) FetchPreparation(sessionID string, path string, overrides api.
 	return wrapWebResult(b.currentCore().FetchPreparationPreview(progressCtx, req))
 }
 
-func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (api.TrackerDryRunPreview, error) {
+func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (api.TrackerDryRunPreview, error) {
 	rt, err := b.requireRuntime()
 	if err != nil {
 		return api.TrackerDryRunPreview{}, err
@@ -417,6 +424,7 @@ func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides ap
 		Options:                     buildRunUploadOptions(rt.cfg, runOpts),
 		ExternalIDOverrides:         overrides,
 		ReleaseNameOverrides:        nameOverrides,
+		MetadataOverrides:           metadataOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(questionnaireAnswers),
 	}
 	req.Options.DryRun = true
@@ -438,7 +446,7 @@ func (b *Backend) FetchTrackerDryRun(sessionID string, path string, overrides ap
 	return wrapWebResult(runCore.FetchTrackerDryRunPreview(progressCtx, req))
 }
 
-func (b *Backend) FetchDescriptionBuilder(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, ignoreDupesFor []string) (api.DescriptionBuilderPreview, error) {
+func (b *Backend) FetchDescriptionBuilder(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, ignoreDupesFor []string) (api.DescriptionBuilderPreview, error) {
 	if err := b.requireCore(); err != nil {
 		return api.DescriptionBuilderPreview{}, err
 	}
@@ -453,6 +461,7 @@ func (b *Backend) FetchDescriptionBuilder(path string, overrides api.ExternalIDO
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 	return wrapWebResult(b.currentCore().FetchDescriptionBuilderPreview(ctx, req))
 }
@@ -466,7 +475,7 @@ func (b *Backend) RenderDescription(raw string) (string, error) {
 	return wrapWebResult(b.currentCore().RenderDescription(ctx, raw))
 }
 
-func (b *Backend) SaveDescriptionOverride(path string, groupKey string, raw string, trackers []string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) (api.DescriptionBuilderGroup, error) {
+func (b *Backend) SaveDescriptionOverride(path string, groupKey string, raw string, trackers []string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) (api.DescriptionBuilderGroup, error) {
 	if err := b.requireCore(); err != nil {
 		return api.DescriptionBuilderGroup{}, err
 	}
@@ -479,6 +488,7 @@ func (b *Backend) SaveDescriptionOverride(path string, groupKey string, raw stri
 		Trackers:                 append([]string{}, trackers...),
 		ExternalIDOverrides:      overrides,
 		ReleaseNameOverrides:     nameOverrides,
+		MetadataOverrides:        metadataOverrides,
 	}, raw))
 }
 
@@ -533,7 +543,7 @@ func (b *Backend) BrowseDirectoryWithinRoots(path string, mode string, roots []s
 	return wrapWebResult(guishared.BrowseDirectoryWithinRoots(api.BrowseDirectoryRequest{Path: path, Mode: mode}, fallback, roots))
 }
 
-func (b *Backend) FetchScreenshotPlan(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) (api.ScreenshotPlan, error) {
+func (b *Backend) FetchScreenshotPlan(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) (api.ScreenshotPlan, error) {
 	if err := b.requireCore(); err != nil {
 		return api.ScreenshotPlan{}, err
 	}
@@ -546,11 +556,12 @@ func (b *Backend) FetchScreenshotPlan(path string, overrides api.ExternalIDOverr
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 	return wrapWebResult(b.currentCore().FetchScreenshotPlan(ctx, req))
 }
 
-func (b *Backend) GenerateScreenshots(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, selections []api.ScreenshotSelection, purpose api.ScreenshotPurpose) (api.ScreenshotResult, error) {
+func (b *Backend) GenerateScreenshots(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, selections []api.ScreenshotSelection, purpose api.ScreenshotPurpose) (api.ScreenshotResult, error) {
 	if err := b.requireCore(); err != nil {
 		return api.ScreenshotResult{}, err
 	}
@@ -563,11 +574,12 @@ func (b *Backend) GenerateScreenshots(path string, overrides api.ExternalIDOverr
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 	return wrapWebResult(b.currentCore().GenerateScreenshots(ctx, req, selections, purpose))
 }
 
-func (b *Backend) PreviewScreenshotFrame(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, timestampSeconds float64) (string, error) {
+func (b *Backend) PreviewScreenshotFrame(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, timestampSeconds float64) (string, error) {
 	if err := b.requireCore(); err != nil {
 		return "", err
 	}
@@ -580,6 +592,7 @@ func (b *Backend) PreviewScreenshotFrame(path string, overrides api.ExternalIDOv
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 	preview, err := b.currentCore().PreviewScreenshotFrame(ctx, req, timestampSeconds)
 	if err != nil {
@@ -588,7 +601,7 @@ func (b *Backend) PreviewScreenshotFrame(path string, overrides api.ExternalIDOv
 	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(preview.ImageBytes), nil
 }
 
-func (b *Backend) DeleteScreenshot(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, imagePath string) error {
+func (b *Backend) DeleteScreenshot(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, imagePath string) error {
 	if err := b.requireCore(); err != nil {
 		return err
 	}
@@ -601,10 +614,11 @@ func (b *Backend) DeleteScreenshot(path string, overrides api.ExternalIDOverride
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}, imagePath))
 }
 
-func (b *Backend) DeleteTrackerImageURL(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, imageURL string) error {
+func (b *Backend) DeleteTrackerImageURL(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, imageURL string) error {
 	if err := b.requireCore(); err != nil {
 		return err
 	}
@@ -617,10 +631,11 @@ func (b *Backend) DeleteTrackerImageURL(path string, overrides api.ExternalIDOve
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}, imageURL))
 }
 
-func (b *Backend) SaveFinalScreenshotSelections(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, images []api.ScreenshotImage) error {
+func (b *Backend) SaveFinalScreenshotSelections(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, images []api.ScreenshotImage) error {
 	if err := b.requireCore(); err != nil {
 		return err
 	}
@@ -633,10 +648,11 @@ func (b *Backend) SaveFinalScreenshotSelections(path string, overrides api.Exter
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}, images))
 }
 
-func (b *Backend) ImportMenuImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, paths []string) error {
+func (b *Backend) ImportMenuImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, paths []string) error {
 	if err := b.requireCore(); err != nil {
 		return err
 	}
@@ -649,6 +665,7 @@ func (b *Backend) ImportMenuImages(path string, overrides api.ExternalIDOverride
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}, paths))
 }
 
@@ -667,7 +684,7 @@ func (b *Backend) ReadScreenshotImage(path string) (string, error) {
 	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(payload), nil
 }
 
-func (b *Backend) ListUploadCandidates(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) ([]api.ScreenshotImage, error) {
+func (b *Backend) ListUploadCandidates(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) ([]api.ScreenshotImage, error) {
 	rt, err := b.requireRuntime()
 	if err != nil {
 		return nil, err
@@ -681,10 +698,11 @@ func (b *Backend) ListUploadCandidates(path string, overrides api.ExternalIDOver
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}))
 }
 
-func (b *Backend) ListUploadedImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) ([]api.UploadedImageLink, error) {
+func (b *Backend) ListUploadedImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides) ([]api.UploadedImageLink, error) {
 	rt, err := b.requireRuntime()
 	if err != nil {
 		return nil, err
@@ -698,10 +716,11 @@ func (b *Backend) ListUploadedImages(path string, overrides api.ExternalIDOverri
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}))
 }
 
-func (b *Backend) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackersList []string, host string, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
+func (b *Backend) UploadImages(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackersList []string, host string, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
 	rt, err := b.requireRuntime()
 	if err != nil {
 		return api.UploadImagesResult{}, err
@@ -715,6 +734,7 @@ func (b *Backend) UploadImages(path string, overrides api.ExternalIDOverrides, n
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 		Trackers:             append([]string{}, trackersList...),
 	}, host, images))
 }

--- a/internal/webserver/backend_repo_test.go
+++ b/internal/webserver/backend_repo_test.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -401,12 +402,56 @@ func TestBackendFetchMetadataPropagatesSkipAutoTorrentSetting(t *testing.T) {
 		hub:  newEventHub(),
 	}
 
-	_, err := backend.FetchMetadata("session", "C:\\releases\\Example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, false)
+	_, err := backend.FetchMetadata(context.Background(), "session", "C:\\releases\\Example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, false)
 	if err != nil {
 		t.Fatalf("fetch metadata: %v", err)
 	}
 	if !coreSvc.fetchReq.Options.SkipAutoTorrent {
 		t.Fatalf("expected skip_auto_torrent request option, got %#v", coreSvc.fetchReq.Options)
+	}
+}
+
+type backendContextCaptureCore struct {
+	preparedMetaTestCore
+}
+
+func (c *backendContextCaptureCore) FetchMetadataPreview(ctx context.Context, _ api.Request) (api.MetadataPreview, error) {
+	return api.MetadataPreview{}, fmt.Errorf("metadata preview context: %w", ctx.Err())
+}
+
+func (c *backendContextCaptureCore) FetchScreenshotPlan(ctx context.Context, _ api.Request) (api.ScreenshotPlan, error) {
+	return api.ScreenshotPlan{}, fmt.Errorf("screenshot plan context: %w", ctx.Err())
+}
+
+func (c *backendContextCaptureCore) ListUploadCandidates(ctx context.Context, _ api.Request) ([]api.ScreenshotImage, error) {
+	return nil, fmt.Errorf("upload candidates context: %w", ctx.Err())
+}
+
+func TestBackendMetadataOperationsUseParentContext(t *testing.T) {
+	t.Parallel()
+
+	backend := &Backend{
+		cfg:  config.Config{ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 3}},
+		core: &backendContextCaptureCore{},
+		hub:  newEventHub(),
+	}
+	canceledContext := func() context.Context {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	}
+
+	_, err := backend.FetchMetadata(canceledContext(), "session", "C:\\releases\\Example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, false)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("FetchMetadata error = %v, want context canceled", err)
+	}
+	_, err = backend.FetchScreenshotPlan(canceledContext(), "C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("FetchScreenshotPlan error = %v, want context canceled", err)
+	}
+	_, err = backend.ListUploadCandidates(canceledContext(), "C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ListUploadCandidates error = %v, want context canceled", err)
 	}
 }
 
@@ -493,19 +538,19 @@ func TestBackendRequestsUseSingleRuntimeSnapshot(t *testing.T) {
 	})
 
 	for range 200 {
-		if _, err := backend.FetchMetadata("session", "C:\\releases\\Example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, false); err != nil {
+		if _, err := backend.FetchMetadata(context.Background(), "session", "C:\\releases\\Example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, false); err != nil {
 			t.Fatalf("fetch metadata: %v", err)
 		}
-		if _, err := backend.UploadImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, "host", []api.ScreenshotImage{{Path: "image.jpg"}}); err != nil {
+		if _, err := backend.UploadImages(context.Background(), "C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, "host", []api.ScreenshotImage{{Path: "image.jpg"}}); err != nil {
 			t.Fatalf("upload images: %v", err)
 		}
-		if _, err := backend.ListUploadCandidates("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}); err != nil {
+		if _, err := backend.ListUploadCandidates(context.Background(), "C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}); err != nil {
 			t.Fatalf("list upload candidates: %v", err)
 		}
-		if _, err := backend.ListUploadedImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}); err != nil {
+		if _, err := backend.ListUploadedImages(context.Background(), "C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}); err != nil {
 			t.Fatalf("list uploaded images: %v", err)
 		}
-		_, _ = backend.FetchTrackerDryRun("session", "C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, nil, nil, nil, false, false, "")
+		_, _ = backend.FetchTrackerDryRun(context.Background(), "session", "C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, nil, nil, nil, false, false, "")
 		select {
 		case err := <-errs:
 			t.Fatal(err)

--- a/internal/webserver/backend_repo_test.go
+++ b/internal/webserver/backend_repo_test.go
@@ -401,7 +401,7 @@ func TestBackendFetchMetadataPropagatesSkipAutoTorrentSetting(t *testing.T) {
 		hub:  newEventHub(),
 	}
 
-	_, err := backend.FetchMetadata("session", "C:\\releases\\Example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil, false)
+	_, err := backend.FetchMetadata("session", "C:\\releases\\Example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, false)
 	if err != nil {
 		t.Fatalf("fetch metadata: %v", err)
 	}
@@ -493,19 +493,19 @@ func TestBackendRequestsUseSingleRuntimeSnapshot(t *testing.T) {
 	})
 
 	for range 200 {
-		if _, err := backend.FetchMetadata("session", "C:\\releases\\Example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil, false); err != nil {
+		if _, err := backend.FetchMetadata("session", "C:\\releases\\Example.mkv", "", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, false); err != nil {
 			t.Fatalf("fetch metadata: %v", err)
 		}
-		if _, err := backend.UploadImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil, "host", []api.ScreenshotImage{{Path: "image.jpg"}}); err != nil {
+		if _, err := backend.UploadImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, "host", []api.ScreenshotImage{{Path: "image.jpg"}}); err != nil {
 			t.Fatalf("upload images: %v", err)
 		}
-		if _, err := backend.ListUploadCandidates("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}); err != nil {
+		if _, err := backend.ListUploadCandidates("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}); err != nil {
 			t.Fatalf("list upload candidates: %v", err)
 		}
-		if _, err := backend.ListUploadedImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}); err != nil {
+		if _, err := backend.ListUploadedImages("C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}); err != nil {
 			t.Fatalf("list uploaded images: %v", err)
 		}
-		_, _ = backend.FetchTrackerDryRun("session", "C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, nil, nil, nil, nil, false, false, "")
+		_, _ = backend.FetchTrackerDryRun("session", "C:\\releases\\Example.mkv", api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, api.MetadataOverrides{}, nil, nil, nil, nil, false, false, "")
 		select {
 		case err := <-errs:
 			t.Fatal(err)

--- a/internal/webserver/jobs.go
+++ b/internal/webserver/jobs.go
@@ -475,7 +475,7 @@ func (b *Backend) startTrackerUpload(sessionID string, path string, overrides ap
 	if err != nil {
 		return "", err
 	}
-	runCore, runLogger, err := b.buildRunCoreFromSnapshot(rt, runOpts)
+	runCore, runLogger, err := b.buildRunCoreFromSnapshot(context.Background(), rt, runOpts)
 	if err != nil {
 		return "", err
 	}

--- a/internal/webserver/jobs.go
+++ b/internal/webserver/jobs.go
@@ -51,22 +51,23 @@ type DupeCheckSnapshot struct {
 }
 
 type dupeCheckJob struct {
-	mu             sync.Mutex
-	sessionID      string
-	id             string
-	sourcePath     string
-	overrides      api.ExternalIDOverrides
-	nameOverrides  api.ReleaseNameOverrides
-	trackers       []string
-	states         map[string]DupeCheckTrackerState
-	completedCount int
-	totalCount     int
-	summary        api.DupeCheckSummary
-	status         string
-	errorMessage   string
-	startedAt      time.Time
-	finishedAt     time.Time
-	cancel         context.CancelFunc
+	mu                sync.Mutex
+	sessionID         string
+	id                string
+	sourcePath        string
+	overrides         api.ExternalIDOverrides
+	nameOverrides     api.ReleaseNameOverrides
+	metadataOverrides api.MetadataOverrides
+	trackers          []string
+	states            map[string]DupeCheckTrackerState
+	completedCount    int
+	totalCount        int
+	summary           api.DupeCheckSummary
+	status            string
+	errorMessage      string
+	startedAt         time.Time
+	finishedAt        time.Time
+	cancel            context.CancelFunc
 }
 
 // TrackerUploadTrackerState reports frontend-visible state for one tracker in
@@ -123,6 +124,7 @@ type trackerUploadJob struct {
 	logger               interface{ Close() error }
 	overrides            api.ExternalIDOverrides
 	nameOverrides        api.ReleaseNameOverrides
+	metadataOverrides    api.MetadataOverrides
 	questionnaireAnswers map[string]map[string]string
 	descriptionGroups    []api.DescriptionBuilderGroup
 	trackers             []string
@@ -151,6 +153,7 @@ type trackerUploadRetryRequest struct {
 	sourcePath           string
 	overrides            api.ExternalIDOverrides
 	nameOverrides        api.ReleaseNameOverrides
+	metadataOverrides    api.MetadataOverrides
 	questionnaireAnswers map[string]map[string]string
 	descriptionGroups    []api.DescriptionBuilderGroup
 	failedTrackers       []string
@@ -219,7 +222,7 @@ func randomJobID() string {
 	return fmt.Sprintf("%d-%x", time.Now().UnixNano(), value.Uint64())
 }
 
-func (b *Backend) StartDupeCheck(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string) (string, error) {
+func (b *Backend) StartDupeCheck(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackers []string) (string, error) {
 	if err := b.requireCore(); err != nil {
 		return "", err
 	}
@@ -239,17 +242,18 @@ func (b *Backend) StartDupeCheck(sessionID string, path string, overrides api.Ex
 		states[normalized] = DupeCheckTrackerState{Tracker: normalized, Status: "queued", Message: "queued"}
 	}
 	job := &dupeCheckJob{
-		sessionID:     sessionID,
-		id:            jobID,
-		sourcePath:    trimmedPath,
-		overrides:     overrides,
-		nameOverrides: nameOverrides,
-		trackers:      resolvedTrackers,
-		states:        states,
-		totalCount:    len(states),
-		summary:       api.DupeCheckSummary{SourcePath: trimmedPath},
-		status:        "queued",
-		startedAt:     time.Now().UTC(),
+		sessionID:         sessionID,
+		id:                jobID,
+		sourcePath:        trimmedPath,
+		overrides:         overrides,
+		nameOverrides:     nameOverrides,
+		metadataOverrides: metadataOverrides,
+		trackers:          resolvedTrackers,
+		states:            states,
+		totalCount:        len(states),
+		summary:           api.DupeCheckSummary{SourcePath: trimmedPath},
+		status:            "queued",
+		startedAt:         time.Now().UTC(),
 	}
 
 	jobCtx, cancel := context.WithCancel(context.Background())
@@ -313,6 +317,7 @@ func (b *Backend) runDupeCheckJob(ctx context.Context, job *dupeCheckJob) {
 		Options:              b.baseUploadOptions(),
 		ExternalIDOverrides:  job.overrides,
 		ReleaseNameOverrides: job.nameOverrides,
+		MetadataOverrides:    job.metadataOverrides,
 	}
 
 	summary, err := b.currentCore().CheckDupes(progressCtx, req)
@@ -434,6 +439,7 @@ func trackerUploadRetryRequestFromJob(job *trackerUploadJob) (trackerUploadRetry
 		sourcePath:           job.sourcePath,
 		overrides:            job.overrides,
 		nameOverrides:        job.nameOverrides,
+		metadataOverrides:    job.metadataOverrides,
 		questionnaireAnswers: cloneQuestionnaireAnswers(job.questionnaireAnswers),
 		descriptionGroups:    api.CloneDescriptionBuilderGroups(job.descriptionGroups),
 		failedTrackers:       append([]string(nil), job.failedTrackers...),
@@ -445,13 +451,14 @@ func trackerUploadRetryRequestFromJob(job *trackerUploadJob) (trackerUploadRetry
 
 // StartTrackerUpload starts an upload job owned by sessionID for selected
 // trackers and returns its job ID. Snapshots preserve partial upload counts
-// returned with later tracker errors or cancellation. The job captures upload
-// options at start time so failed-tracker retries reuse the original option set.
-func (b *Backend) StartTrackerUpload(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (string, error) {
-	return b.startTrackerUpload(sessionID, path, overrides, nameOverrides, trackers, ignoreDupesFor, questionnaireAnswers, descriptionGroups, debug, noSeed, runLogLevel, nil)
+// returned with later tracker errors or cancellation. The job captures metadata
+// overrides and upload options at start time so failed-tracker retries reuse the
+// original request instead of current browser state.
+func (b *Backend) StartTrackerUpload(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string) (string, error) {
+	return b.startTrackerUpload(sessionID, path, overrides, nameOverrides, metadataOverrides, trackers, ignoreDupesFor, questionnaireAnswers, descriptionGroups, debug, noSeed, runLogLevel, nil)
 }
 
-func (b *Backend) startTrackerUpload(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string, uploadOptions *api.UploadOptions) (string, error) {
+func (b *Backend) startTrackerUpload(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, metadataOverrides api.MetadataOverrides, trackers []string, ignoreDupesFor []string, questionnaireAnswers map[string]map[string]string, descriptionGroups []api.DescriptionBuilderGroup, debug bool, noSeed bool, runLogLevel string, uploadOptions *api.UploadOptions) (string, error) {
 	rt, err := b.requireRuntime()
 	if err != nil {
 		return "", err
@@ -480,6 +487,7 @@ func (b *Backend) startTrackerUpload(sessionID string, path string, overrides ap
 		IgnoreDupesFor:       normalizeTrackerList(ignoreDupesFor),
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
+		MetadataOverrides:    metadataOverrides,
 	}
 	seedCtx, cancel := context.WithTimeout(context.Background(), seedPreparedMetaTimeout)
 	defer cancel()
@@ -504,6 +512,7 @@ func (b *Backend) startTrackerUpload(sessionID string, path string, overrides ap
 		logger:               runLogger,
 		overrides:            overrides,
 		nameOverrides:        nameOverrides,
+		metadataOverrides:    metadataOverrides,
 		questionnaireAnswers: cloneQuestionnaireAnswers(questionnaireAnswers),
 		descriptionGroups:    api.CloneDescriptionBuilderGroups(descriptionGroups),
 		trackers:             resolvedTrackers,
@@ -562,7 +571,7 @@ func (b *Backend) RetryFailedTrackerUpload(sessionID string, jobID string) (stri
 	if err != nil {
 		return "", err
 	}
-	return b.startTrackerUpload(retry.sessionID, retry.sourcePath, retry.overrides, retry.nameOverrides, retry.failedTrackers, retry.ignoreDupesFor, retry.questionnaireAnswers, retry.descriptionGroups, retry.runOptions.Debug, retry.runOptions.NoSeed, retry.runOptions.RunLogLevel, &retry.uploadOptions)
+	return b.startTrackerUpload(retry.sessionID, retry.sourcePath, retry.overrides, retry.nameOverrides, retry.metadataOverrides, retry.failedTrackers, retry.ignoreDupesFor, retry.questionnaireAnswers, retry.descriptionGroups, retry.runOptions.Debug, retry.runOptions.NoSeed, retry.runOptions.RunLogLevel, &retry.uploadOptions)
 }
 
 // GetTrackerUploadSnapshot returns an upload job snapshot only to the session
@@ -743,6 +752,7 @@ func (b *Backend) runSingleTrackerUpload(ctx context.Context, job *trackerUpload
 		Options:                     job.uploadOptions,
 		ExternalIDOverrides:         job.overrides,
 		ReleaseNameOverrides:        job.nameOverrides,
+		MetadataOverrides:           job.metadataOverrides,
 		TrackerQuestionnaireAnswers: cloneQuestionnaireAnswers(job.questionnaireAnswers),
 	}
 	return wrapWebResult(job.core.RunUploadPrepared(ctx, req))

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -37,21 +37,23 @@ type Request struct {
 	DescriptionOverrideRaw       string
 	DescriptionOverrideURL       string
 	DescriptionOverrideGroup     string
-	MetadataOverrides            MetadataOverrides
-	TrackerConfigOverrides       TrackerConfigOverrides
-	TrackerSiteOverrides         TrackerSiteOverrides
-	ClientOverrides              ClientOverrides
-	ImageHostOverrides           ImageHostOverrides
-	ScreenshotOverrides          ScreenshotOverrides
-	TorrentOverrides             TorrentOverrides
-	TrackerIDOverrides           map[string]string
-	ExternalIDOverrides          ExternalIDOverrides
-	ExternalIDSelections         map[string]ExternalIDSelection // keyed by source path, value is selected external IDs for that path
-	ReleaseNameOverrides         ReleaseNameOverrides
-	TrackerQuestionnaireAnswers  map[string]map[string]string // keyed by tracker, then questionnaire field key
-	PlaylistSelections           map[string][]string          // keyed by source path, value is selected playlist files
-	PlaylistSelectionsUseAll     map[string]bool              // keyed by source path, value is use-all flag
-	ConfirmBDMVRescan            bool
+	// MetadataOverrides contains optional caller-forced facts used by preview,
+	// preparation, screenshots, and uploads.
+	MetadataOverrides           MetadataOverrides
+	TrackerConfigOverrides      TrackerConfigOverrides
+	TrackerSiteOverrides        TrackerSiteOverrides
+	ClientOverrides             ClientOverrides
+	ImageHostOverrides          ImageHostOverrides
+	ScreenshotOverrides         ScreenshotOverrides
+	TorrentOverrides            TorrentOverrides
+	TrackerIDOverrides          map[string]string
+	ExternalIDOverrides         ExternalIDOverrides
+	ExternalIDSelections        map[string]ExternalIDSelection // keyed by source path, value is selected external IDs for that path
+	ReleaseNameOverrides        ReleaseNameOverrides
+	TrackerQuestionnaireAnswers map[string]map[string]string // keyed by tracker, then questionnaire field key
+	PlaylistSelections          map[string][]string          // keyed by source path, value is selected playlist files
+	PlaylistSelectionsUseAll    map[string]bool              // keyed by source path, value is use-all flag
+	ConfirmBDMVRescan           bool
 }
 
 // ExecutionOptions controls queued and site-check execution behavior.

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -213,6 +213,10 @@ type PreparedMetadata struct {
 	BDInfo                      map[string]any
 }
 
+// MetadataOverrides carries caller-forced metadata facts that override values
+// inferred from external providers, media inspection, or prepared metadata.
+// Nil fields mean "leave the inferred value unchanged"; non-nil false values
+// are explicit overrides and must be preserved across entrypoints.
 type MetadataOverrides struct {
 	Distributor      *string
 	OriginalLanguage *string

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -216,7 +216,9 @@ type PreparedMetadata struct {
 // MetadataOverrides carries caller-forced metadata facts that override values
 // inferred from external providers, media inspection, or prepared metadata.
 // Nil fields mean "leave the inferred value unchanged"; non-nil false values
-// are explicit overrides and must be preserved across entrypoints.
+// are explicit overrides and must be preserved across entrypoints. Clear carries
+// field names whose prepared values should be reset when a caller explicitly
+// clears an existing override.
 type MetadataOverrides struct {
 	Distributor      *string
 	OriginalLanguage *string
@@ -225,6 +227,10 @@ type MetadataOverrides struct {
 	WebDV            *bool
 	StreamOptimized  *bool
 	Anime            *bool
+	// Clear names metadata fields explicitly reset by the caller. Nil fields
+	// outside this list keep prepared metadata; fields in this list clear the
+	// prepared value before any non-nil override is applied.
+	Clear []string
 }
 
 type ClientOverrides struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **`season-episode`** CLI/app release override (including help text and flag alias support).
  * Added **metadata overrides** editing to the UI for common metadata fields and options.
* **Bug Fixes**
  * Ensures the explicitly selected **category** takes priority over TMDB-derived inference.
  * Applies metadata overrides consistently across previews, preparation, screenshot workflows, uploads, and tracker workflows (including retries), so results reflect the selected overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->