### PR TITLE
fix(metadata): correct tvdb hanlding

### DIFF
--- a/gui/frontend/src/pages/input/index.test.tsx
+++ b/gui/frontend/src/pages/input/index.test.tsx
@@ -1,0 +1,127 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { MetadataPreview, ReleaseNameEditState, ReleaseNameTouchedState } from "../../types";
+import InputPage from "./index";
+
+const preview: MetadataPreview = {
+  SourcePath: "C:\\media\\Example.mkv",
+  TrackerName: "AITHER",
+  ReleaseName: "Example.2026.1080p",
+  Warnings: [],
+  ReleaseNameOverrides: {},
+  ExternalIDs: {
+    TMDBID: 0,
+    IMDBID: 0,
+    TVDBID: 0,
+    TVmazeID: 0,
+    Category: "TV",
+    SourceTMDB: "",
+    SourceIMDB: "",
+    SourceTVDB: "",
+    SourceTVmaze: "",
+  },
+  ExternalIDCandidates: {
+    TMDB: [],
+    IMDB: [],
+    TMDBAutoSelected: false,
+    IMDBAutoSelected: false,
+  },
+  ExternalIDInfo: [],
+  ExternalPreview: [],
+  TrackerData: [],
+};
+
+const releaseEdits: ReleaseNameEditState = {
+  category: "",
+  type: "",
+  source: "",
+  resolution: "",
+  tag: "",
+  service: "",
+  edition: "",
+  season: "",
+  episode: "",
+  episodeTitle: "",
+  manualYear: "",
+  manualDate: "",
+  useSeasonEpisode: false,
+  noSeason: false,
+  noYear: false,
+  noAKA: false,
+  noTag: false,
+  noEdition: false,
+  noDub: false,
+  noDual: false,
+  dualAudio: false,
+  region: "",
+};
+
+describe("InputPage metadata progress", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders tracker data fallback progress updates", () => {
+    render(
+      <InputPage
+        path="C:\media\Example.mkv"
+        handleSourcePathChange={vi.fn()}
+        sourcePathHistory={[]}
+        handleSourcePathHistorySelect={vi.fn()}
+        sourceLookupURL=""
+        setSourceLookupURL={vi.fn()}
+        browseAvailable={false}
+        handleBrowseFile={vi.fn()}
+        handleBrowseFolder={vi.fn()}
+        handleFetch={vi.fn()}
+        handleRefresh={vi.fn()}
+        handleResetMetadata={vi.fn()}
+        loading={false}
+        metadataResetting={false}
+        metadataProgressActive={true}
+        metadataProgressUpdates={[
+          {
+            path: "C:\\media\\Example.mkv",
+            phase: "tracker-data-fallback",
+            message: "Retrying tracker data",
+            status: "running",
+            level: "info",
+            timestamp: "2026-06-29T00:00:00Z",
+          },
+        ]}
+        error=""
+        preview={preview}
+        trackerUploadItems={[]}
+        releasePageTrackerSelection={{}}
+        setReleasePageTrackerSelection={vi.fn()}
+        idEdits={{ tmdb: "", imdb: "", tvdb: "", tvmaze: "" }}
+        setIdEdits={vi.fn()}
+        releaseEdits={releaseEdits}
+        setReleaseEdits={vi.fn()}
+        markReleaseTouched={vi.fn<(key: keyof ReleaseNameTouchedState) => void>()}
+        idOverrideState={{ overrides: {}, dirty: false, invalid: false }}
+        releaseOverrideState={{ overrides: {}, dirty: false, invalid: false }}
+        showExternalIDInputUI={false}
+        refreshDisabled={false}
+        selectedProvider=""
+        setSelectedProvider={vi.fn()}
+        setLightboxImage={vi.fn()}
+        setLightboxAlt={vi.fn()}
+        runDebug={false}
+        setRunDebug={vi.fn()}
+        runLogLevel=""
+        setRunLogLevel={vi.fn()}
+        runLogLevelTouched={false}
+        setRunLogLevelTouched={vi.fn()}
+        trackerIconSrcByName={{}}
+      />,
+    );
+
+    expect(screen.getByText("Retry tracker data")).toBeInTheDocument();
+    expect(screen.getByText("Running")).toBeInTheDocument();
+  });
+});

--- a/gui/frontend/src/pages/input/index.tsx
+++ b/gui/frontend/src/pages/input/index.tsx
@@ -842,10 +842,13 @@ export default function InputPage(props: Props) {
     ? buildPreviewDetails(selectedPreview, tvdbDisplayMode)
     : [];
 
+  // Keep this aligned with the backend FetchMetadataPreview phase emissions so
+  // progress updates advance without skipping backend work.
   const metadataPhaseOrder = [
     { key: "prepare", label: "Prepare metadata" },
     { key: "tracker-data", label: "Get tracker data" },
     { key: "mediainfo-ids", label: "Apply MediaInfo IDs" },
+    { key: "arr", label: "Apply Sonarr/Radarr data" },
     { key: "external-ids", label: "Resolve external IDs" },
     { key: "media-details", label: "Apply media details" },
     { key: "tracker-claims", label: "Check tracker claims" },

--- a/gui/frontend/src/pages/input/index.tsx
+++ b/gui/frontend/src/pages/input/index.tsx
@@ -843,10 +843,11 @@ export default function InputPage(props: Props) {
     : [];
 
   // Keep this aligned with the backend FetchMetadataPreview phase emissions so
-  // progress updates advance without skipping backend work.
+  // progress updates advance without skipping backend work, including fallback retries.
   const metadataPhaseOrder = [
     { key: "prepare", label: "Prepare metadata" },
     { key: "tracker-data", label: "Get tracker data" },
+    { key: "tracker-data-fallback", label: "Retry tracker data" },
     { key: "mediainfo-ids", label: "Apply MediaInfo IDs" },
     { key: "arr", label: "Apply Sonarr/Radarr data" },
     { key: "external-ids", label: "Resolve external IDs" },

--- a/gui/frontend/src/pages/input/index.tsx
+++ b/gui/frontend/src/pages/input/index.tsx
@@ -848,6 +848,7 @@ export default function InputPage(props: Props) {
     { key: "mediainfo-ids", label: "Apply MediaInfo IDs" },
     { key: "external-ids", label: "Resolve external IDs" },
     { key: "media-details", label: "Apply media details" },
+    { key: "tracker-claims", label: "Check tracker claims" },
     { key: "complete", label: "Complete" },
   ];
 

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -213,6 +213,12 @@ export type TVDBMetadata = {
   OverviewEnglish: string;
   FirstAired: string;
   Year: number;
+  /** True when Year is naming-eligible for TV release names. */
+  YearFromAlias: boolean;
+  /** TVDB source used for Year, such as first_aired, translation_name, translation_alias, extended_alias, or slug. */
+  YearSource: string;
+  /** "high" for explicit title or alias years; "low" for guarded slug-derived naming years. */
+  YearConfidence: string;
   Type: string;
   Status: string;
   Network: string;

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -644,6 +644,10 @@ func (c *Core) CheckDupes(ctx context.Context, req api.Request) (api.DupeCheckSu
 	if err != nil {
 		return api.DupeCheckSummary{}, fmt.Errorf("core: %w", err)
 	}
+	meta, err = c.services.Metadata.ApplyTrackerClaims(ctx, meta)
+	if err != nil {
+		return api.DupeCheckSummary{}, fmt.Errorf("core: %w", err)
+	}
 
 	c.storeRefreshedDupeCache(meta.SourcePath, overrideSignature(meta.ExternalIDOverrides, meta.ReleaseNameOverrides, meta.MetadataOverrides, meta.TrackerConfigOverrides, meta.TrackerSiteOverrides, meta.ClientOverrides, meta.TorrentOverrides, meta.ImageHostOverrides, meta.ScreenshotOverrides), meta)
 
@@ -1914,6 +1918,13 @@ func (c *Core) FetchMetadataPreview(ctx context.Context, req api.Request) (api.M
 	if err := emitPhase("media-details", "Applying media details", func() error {
 		var applyErr error
 		meta, applyErr = c.services.Metadata.ApplyMediaDetails(ctx, meta)
+		return wrapCoreError(applyErr)
+	}); err != nil {
+		return api.MetadataPreview{}, err
+	}
+	if err := emitPhase("tracker-claims", "Checking tracker claims", func() error {
+		var applyErr error
+		meta, applyErr = c.services.Metadata.ApplyTrackerClaims(ctx, meta)
 		return wrapCoreError(applyErr)
 	}); err != nil {
 		return api.MetadataPreview{}, err

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -39,6 +39,23 @@ func hasUploadProgress(updates []api.UploadProgressUpdate, task string, status s
 	return false
 }
 
+func metadataProgressContainsOrdered(updates []api.MetadataProgressUpdate, want []api.MetadataProgressUpdate) bool {
+	if len(want) == 0 {
+		return true
+	}
+	next := 0
+	for _, update := range updates {
+		if update.Phase != want[next].Phase || update.Status != want[next].Status {
+			continue
+		}
+		next++
+		if next == len(want) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestFirstRequestedTracker(t *testing.T) {
 	t.Parallel()
 
@@ -1361,6 +1378,45 @@ func TestFetchMetadataPreviewRunsPathedSearchWithStoredTrackerData(t *testing.T)
 	}
 	if !containsCoreString(metaSvc.enrichMeta.TrackersRemove, "AITHER") {
 		t.Fatalf("expected fresh AITHER removal, got %v", metaSvc.enrichMeta.TrackersRemove)
+	}
+}
+
+func TestFetchMetadataPreviewEmitsTrackerClaimsAfterMediaDetails(t *testing.T) {
+	t.Parallel()
+
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   &stubMeta{},
+			Clients:    &stubClient{},
+		},
+		Repository: trackerRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	updates := make([]api.MetadataProgressUpdate, 0)
+	ctx := api.WithMetadataProgressReporter(context.Background(), func(update api.MetadataProgressUpdate) {
+		updates = append(updates, update)
+	})
+	_, err = core.FetchMetadataPreview(ctx, api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeGUI,
+	})
+	if err != nil {
+		t.Fatalf("fetch metadata preview: %v", err)
+	}
+
+	want := []api.MetadataProgressUpdate{
+		{Phase: "media-details", Status: "completed"},
+		{Phase: "tracker-claims", Status: "running"},
+		{Phase: "tracker-claims", Status: "completed"},
+		{Phase: "complete", Status: "completed"},
+	}
+	if !metadataProgressContainsOrdered(updates, want) {
+		t.Fatalf("expected ordered progress %v in %#v", want, updates)
 	}
 }
 
@@ -4179,6 +4235,10 @@ func (s *stubMeta) ResolveExternalIDs(_ context.Context, meta api.PreparedMetada
 }
 
 func (s *stubMeta) ApplyMediaDetails(_ context.Context, meta api.PreparedMetadata) (api.PreparedMetadata, error) {
+	return meta, nil
+}
+
+func (s *stubMeta) ApplyTrackerClaims(_ context.Context, meta api.PreparedMetadata) (api.PreparedMetadata, error) {
 	return meta, nil
 }
 

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -1715,6 +1715,50 @@ func TestCheckDupesUsesPathedTrackerDataWithFreshStoredSnapshot(t *testing.T) {
 	}
 }
 
+func TestCheckDupesAppliesTrackerClaimsBeforeDupeCheck(t *testing.T) {
+	t.Parallel()
+
+	metaSvc := &stubMeta{
+		applyTrackerClaims: func(meta api.PreparedMetadata) api.PreparedMetadata {
+			meta.BlockedTrackers = map[string][]api.TrackerBlockReason{
+				"AITHER": {api.TrackerBlockReasonClaim},
+			}
+			return meta
+		},
+	}
+	dupes := &stubDupes{}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   metaSvc,
+			Clients:    &stubClient{},
+			Dupes:      dupes,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	_, err = core.CheckDupes(context.Background(), api.Request{
+		Paths: []string{"/tmp/a"},
+		Mode:  api.ModeCLI,
+		Options: api.UploadOptions{
+			SkipAutoTorrent: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("check dupes: %v", err)
+	}
+	if metaSvc.trackerClaimsCalls != 1 {
+		t.Fatalf("expected tracker claims applied once, got %d calls", metaSvc.trackerClaimsCalls)
+	}
+	if got := dupes.lastMeta.BlockedTrackers["AITHER"]; len(got) != 1 || got[0] != api.TrackerBlockReasonClaim {
+		t.Fatalf("expected dupe check to receive claim-blocked metadata, got %#v", dupes.lastMeta.BlockedTrackers)
+	}
+}
+
 func TestCheckDupesReusesCLIMetadataPreviewCache(t *testing.T) {
 	t.Parallel()
 
@@ -4171,15 +4215,19 @@ func (s stubFS) ValidatePaths(_ context.Context, paths []string) ([]string, erro
 }
 
 type stubMeta struct {
-	calls        int
-	enrichCalls  int
-	refreshCalls int
-	resolveCalls int
-	options      api.UploadOptions
-	prepared     api.PreparedMetadata
-	enrichMeta   api.PreparedMetadata
-	enriched     api.PreparedMetadata
-	resolved     api.PreparedMetadata
+	calls              int
+	enrichCalls        int
+	refreshCalls       int
+	resolveCalls       int
+	trackerClaimsCalls int
+	options            api.UploadOptions
+	prepared           api.PreparedMetadata
+	enrichMeta         api.PreparedMetadata
+	enriched           api.PreparedMetadata
+	resolved           api.PreparedMetadata
+	// applyTrackerClaims lets tests inject the metadata mutation normally
+	// returned by claim checks.
+	applyTrackerClaims func(api.PreparedMetadata) api.PreparedMetadata
 }
 
 func (s *stubMeta) Prepare(_ context.Context, req api.Request) (api.PreparedMetadata, error) {
@@ -4239,6 +4287,10 @@ func (s *stubMeta) ApplyMediaDetails(_ context.Context, meta api.PreparedMetadat
 }
 
 func (s *stubMeta) ApplyTrackerClaims(_ context.Context, meta api.PreparedMetadata) (api.PreparedMetadata, error) {
+	s.trackerClaimsCalls++
+	if s.applyTrackerClaims != nil {
+		return s.applyTrackerClaims(meta), nil
+	}
 	return meta, nil
 }
 

--- a/internal/core/e2e_enabled.go
+++ b/internal/core/e2e_enabled.go
@@ -199,6 +199,10 @@ func (e2eMetadataService) ApplyMediaDetails(_ context.Context, meta api.Prepared
 	return meta, nil
 }
 
+func (e2eMetadataService) ApplyTrackerClaims(_ context.Context, meta api.PreparedMetadata) (api.PreparedMetadata, error) {
+	return meta, nil
+}
+
 type e2eTorrentService struct {
 	dbPath string
 }

--- a/internal/core/upload_review_test.go
+++ b/internal/core/upload_review_test.go
@@ -110,6 +110,10 @@ func (*recordingReviewMetadata) ApplyMediaDetails(_ context.Context, meta api.Pr
 	return meta, nil
 }
 
+func (*recordingReviewMetadata) ApplyTrackerClaims(_ context.Context, meta api.PreparedMetadata) (api.PreparedMetadata, error) {
+	return meta, nil
+}
+
 type recordingReviewTorrent struct {
 	calls int
 	err   error

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -1589,6 +1589,8 @@ func mapTVDBMetadata(tvdbID int, fallbackName string, details tvdb.SeriesMetadat
 	}
 }
 
+// mergeTVDBMetadata fills missing stored TVDB fields from newer metadata and
+// refreshes alias-year provenance when TVDB title evidence changes.
 func mergeTVDBMetadata(target *api.TVDBMetadata, incoming *api.TVDBMetadata) {
 	if target == nil || incoming == nil {
 		return
@@ -1617,9 +1619,7 @@ func mergeTVDBMetadata(target *api.TVDBMetadata, incoming *api.TVDBMetadata) {
 	// Alias-derived years are naming-eligible, so refresh or clear the provenance when newer TVDB details change that status.
 	switch {
 	case incoming.YearFromAlias:
-		if !target.YearFromAlias {
-			target.Year = incoming.Year
-		}
+		target.Year = incoming.Year
 		target.YearFromAlias = true
 		target.YearSource = incoming.YearSource
 		target.YearConfidence = incoming.YearConfidence

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -1804,9 +1804,7 @@ func (s *Service) applyTVEpisodeMetadata(
 			if mappedSeason, mappedEpisode, err := xemClient.MapAbsoluteEpisode(ctx, ids.TVDBID, absoluteEpisode); err == nil {
 				season = metautil.FirstInt(mappedSeason, season)
 				episode = metautil.FirstInt(mappedEpisode, episode)
-			} else if errors.Is(err, thexem.ErrUnavailable) {
-				// XEM can be blocked by Cloudflare; silently fall back to TVDB/TMDb episode data.
-			} else if s.logger != nil {
+			} else if !errors.Is(err, thexem.ErrUnavailable) && s.logger != nil {
 				s.logger.Debugf("metadata: thexem absolute mapping failed: %v", err)
 			}
 			if season == 0 {

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -1884,14 +1884,15 @@ func (s *Service) applyTVEpisodeMetadata(
 					meta.TVDBAiredDate = strings.TrimSpace(match.Aired)
 					preferredTVDBEpisodeTitle := strings.TrimSpace(match.EpisodeName)
 					englishTVDBEpisodeTitle := ""
-					// Only use original TVDB episode names when the series language is unknown or English.
-					allowOriginalTVDBEpisodeTitle := true
+					englishTVDBEpisodeOverview := ""
+					// Only use original TVDB episode text when the series language is unknown or English.
+					allowOriginalTVDBEpisodeText := true
 					if external != nil {
 						if external.TVDB == nil {
 							external.TVDB = &api.TVDBMetadata{TVDBID: ids.TVDBID}
 						}
 						if strings.TrimSpace(external.TVDB.OriginalLanguage) != "" && !isEnglishLanguage(external.TVDB.OriginalLanguage) {
-							allowOriginalTVDBEpisodeTitle = false
+							allowOriginalTVDBEpisodeText = false
 						}
 						external.TVDB.EpisodeSeason = match.SeasonNumber
 						external.TVDB.EpisodeNumber = match.EpisodeNumber
@@ -1914,14 +1915,19 @@ func (s *Service) applyTVEpisodeMetadata(
 						}
 						external.TVDB.HasEnglish = tvdbHasEnglishContent(external.TVDB)
 						englishTVDBEpisodeTitle = strings.TrimSpace(external.TVDB.EpisodeNameEnglish)
+						englishTVDBEpisodeOverview = strings.TrimSpace(external.TVDB.EpisodeOverviewEnglish)
 						preferredTVDBEpisodeTitle = metautil.FirstNonEmptyTrimmed(external.TVDB.EpisodeNameEnglish, preferredTVDBEpisodeTitle)
 					}
 					if englishTVDBEpisodeTitle != "" {
 						tvdbEpisodeTitle = englishTVDBEpisodeTitle
-					} else if allowOriginalTVDBEpisodeTitle && !isGenericEpisodeTitle(preferredTVDBEpisodeTitle) {
+					} else if allowOriginalTVDBEpisodeText && !isGenericEpisodeTitle(preferredTVDBEpisodeTitle) {
 						tvdbEpisodeTitle = preferredTVDBEpisodeTitle
 					}
-					tvdbEpisodeOverview = strings.TrimSpace(match.Overview)
+					if englishTVDBEpisodeOverview != "" {
+						tvdbEpisodeOverview = englishTVDBEpisodeOverview
+					} else if allowOriginalTVDBEpisodeText {
+						tvdbEpisodeOverview = strings.TrimSpace(match.Overview)
+					}
 					if episodeYear == 0 {
 						episodeYear = match.Year
 					}

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -1881,9 +1881,14 @@ func (s *Service) applyTVEpisodeMetadata(
 					meta.TVDBAiredDate = strings.TrimSpace(match.Aired)
 					preferredTVDBEpisodeTitle := strings.TrimSpace(match.EpisodeName)
 					englishTVDBEpisodeTitle := ""
+					// Only use original TVDB episode names when the series language is unknown or English.
+					allowOriginalTVDBEpisodeTitle := true
 					if external != nil {
 						if external.TVDB == nil {
 							external.TVDB = &api.TVDBMetadata{TVDBID: ids.TVDBID}
+						}
+						if strings.TrimSpace(external.TVDB.OriginalLanguage) != "" && !isEnglishLanguage(external.TVDB.OriginalLanguage) {
+							allowOriginalTVDBEpisodeTitle = false
 						}
 						external.TVDB.EpisodeSeason = match.SeasonNumber
 						external.TVDB.EpisodeNumber = match.EpisodeNumber
@@ -1910,7 +1915,7 @@ func (s *Service) applyTVEpisodeMetadata(
 					}
 					if englishTVDBEpisodeTitle != "" {
 						tvdbEpisodeTitle = englishTVDBEpisodeTitle
-					} else if !isGenericEpisodeTitle(preferredTVDBEpisodeTitle) {
+					} else if allowOriginalTVDBEpisodeTitle && !isGenericEpisodeTitle(preferredTVDBEpisodeTitle) {
 						tvdbEpisodeTitle = preferredTVDBEpisodeTitle
 					}
 					tvdbEpisodeOverview = strings.TrimSpace(match.Overview)

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -1803,6 +1803,8 @@ func (s *Service) applyTVEpisodeMetadata(
 			if mappedSeason, mappedEpisode, err := xemClient.MapAbsoluteEpisode(ctx, ids.TVDBID, absoluteEpisode); err == nil {
 				season = metautil.FirstInt(mappedSeason, season)
 				episode = metautil.FirstInt(mappedEpisode, episode)
+			} else if errors.Is(err, thexem.ErrUnavailable) {
+				// XEM can be blocked by Cloudflare; silently fall back to TVDB/TMDb episode data.
 			} else if s.logger != nil {
 				s.logger.Debugf("metadata: thexem absolute mapping failed: %v", err)
 			}

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -1624,7 +1624,9 @@ func mergeTVDBMetadata(target *api.TVDBMetadata, incoming *api.TVDBMetadata) {
 		target.YearFromAlias = true
 		target.YearSource = incoming.YearSource
 		target.YearConfidence = incoming.YearConfidence
-	case target.YearFromAlias:
+	case target.YearFromAlias && incoming.Year > 0 && strings.TrimSpace(incoming.YearSource) != "":
+		// Only a sourced replacement year can clear alias provenance;
+		// translation misses can return no usable year evidence.
 		target.Year = incoming.Year
 		target.YearFromAlias = false
 		target.YearSource = incoming.YearSource
@@ -2172,8 +2174,11 @@ func parseTVDBAliasNameYear(alias string) (string, int, bool) {
 	}
 	name := trimmed
 	year := 0
-	match := tvdbAliasYearPattern.FindStringSubmatch(trimmed)
-	if len(match) == 2 {
+	// TVDB alias precedence uses the final year-bearing disambiguator while
+	// cleanup removes every year token from the display name.
+	matches := tvdbAliasYearPattern.FindAllStringSubmatch(trimmed, -1)
+	if len(matches) > 0 {
+		match := matches[len(matches)-1]
 		parsed, err := strconv.Atoi(match[1])
 		if err != nil {
 			return "", 0, false

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"golang.org/x/sync/errgroup"
 
@@ -1831,7 +1832,7 @@ func (s *Service) applyTVEpisodeMetadata(
 		meta.DailyEpisodeDate = dailyDate
 	}
 
-	episodeTitle := strings.TrimSpace(meta.EpisodeTitle)
+	episodeTitle := discardSeriesEpisodeTitle(strings.TrimSpace(meta.EpisodeTitle), meta, external)
 	episodeOverview := strings.TrimSpace(meta.EpisodeOverview)
 	episodeYear := meta.EpisodeYear
 
@@ -2092,6 +2093,62 @@ func isGenericEpisodeTitle(value string) bool {
 		return true
 	}
 	return genericEpisodePattern.MatchString(trimmed)
+}
+
+// discardSeriesEpisodeTitle clears parsed episode titles that duplicate a known
+// series title so provider episode titles can still populate the release name.
+func discardSeriesEpisodeTitle(episodeTitle string, meta api.PreparedMetadata, external *api.ExternalMetadata) string {
+	if episodeTitle == "" || !episodeTitleMatchesSeriesTitle(episodeTitle, meta, external) {
+		return episodeTitle
+	}
+	return ""
+}
+
+func episodeTitleMatchesSeriesTitle(episodeTitle string, meta api.PreparedMetadata, external *api.ExternalMetadata) bool {
+	episodeKey := titleIdentityKey(episodeTitle)
+	if len(episodeKey) < 6 {
+		return false
+	}
+	for _, title := range seriesTitleCandidates(meta, external) {
+		if episodeKey == titleIdentityKey(title) {
+			return true
+		}
+	}
+	return false
+}
+
+func seriesTitleCandidates(meta api.PreparedMetadata, external *api.ExternalMetadata) []string {
+	candidates := []string{
+		meta.Release.Title,
+		meta.Release.Subtitle,
+	}
+	if external == nil {
+		return candidates
+	}
+	if external.TMDB != nil {
+		candidates = append(candidates, external.TMDB.Title, external.TMDB.OriginalTitle)
+	}
+	if external.IMDB != nil {
+		candidates = append(candidates, external.IMDB.Title)
+	}
+	if external.TVDB != nil {
+		candidates = append(candidates, external.TVDB.Name, external.TVDB.NameEnglish)
+	}
+	if external.TVmaze != nil {
+		candidates = append(candidates, external.TVmaze.Name)
+	}
+	return candidates
+}
+
+// titleIdentityKey compares titles across punctuation and spacing differences.
+func titleIdentityKey(value string) string {
+	var builder strings.Builder
+	for _, r := range strings.TrimSpace(value) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			builder.WriteRune(unicode.ToLower(r))
+		}
+	}
+	return builder.String()
 }
 
 func sanitizeEpisodeTitle(value string) string {

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -596,6 +596,21 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 				} else {
 					mergeTVDBMetadata(metadata.TVDB, mapped)
 				}
+				if s.logger != nil && metadata.TVDB != nil {
+					namingYear := 0
+					if metadata.TVDB.YearFromAlias {
+						namingYear = metadata.TVDB.Year
+					}
+					s.logger.Tracef(
+						"metadata: tvdb year resolved id=%d first_aired_year=%d naming_year=%d naming_year_source=%q naming_year_confidence=%q naming_eligible=%t",
+						metadata.TVDB.TVDBID,
+						parseYearFromDate(metadata.TVDB.FirstAired),
+						namingYear,
+						metadata.TVDB.YearSource,
+						metadata.TVDB.YearConfidence,
+						metadata.TVDB.YearFromAlias,
+					)
+				}
 				if strings.TrimSpace(tvdbName) == "" {
 					tvdbName = strings.TrimSpace(mapped.Name)
 				}
@@ -1527,9 +1542,16 @@ func mapTVDBMetadata(tvdbID int, fallbackName string, details tvdb.SeriesMetadat
 	}
 	year := parseYearFromDate(details.FirstAired)
 	yearFromAlias := false
-	if details.SeriesYear > 0 {
+	yearSource := "first_aired"
+	yearConfidence := ""
+	if year == 0 {
+		yearSource = ""
+	}
+	if details.SeriesYear > 0 && strings.TrimSpace(details.SeriesYearSource) != "" {
 		year = details.SeriesYear
 		yearFromAlias = true
+		yearSource = strings.TrimSpace(details.SeriesYearSource)
+		yearConfidence = strings.TrimSpace(details.SeriesYearConfidence)
 	}
 	name := metautil.FirstNonEmptyTrimmed(details.Name, fallbackName)
 	aliases := make([]string, 0, len(details.Aliases))
@@ -1553,6 +1575,8 @@ func mapTVDBMetadata(tvdbID int, fallbackName string, details tvdb.SeriesMetadat
 		FirstAired:       strings.TrimSpace(details.FirstAired),
 		Year:             year,
 		YearFromAlias:    yearFromAlias,
+		YearSource:       yearSource,
+		YearConfidence:   yearConfidence,
 		Type:             strings.TrimSpace(details.Type),
 		Status:           strings.TrimSpace(details.Status),
 		Network:          strings.TrimSpace(details.Network),
@@ -1590,8 +1614,27 @@ func mergeTVDBMetadata(target *api.TVDBMetadata, incoming *api.TVDBMetadata) {
 	if target.Year == 0 {
 		target.Year = incoming.Year
 	}
-	if incoming.YearFromAlias {
+	// Alias-derived years are naming-eligible, so refresh or clear the provenance when newer TVDB details change that status.
+	switch {
+	case incoming.YearFromAlias:
+		if !target.YearFromAlias {
+			target.Year = incoming.Year
+		}
 		target.YearFromAlias = true
+		target.YearSource = incoming.YearSource
+		target.YearConfidence = incoming.YearConfidence
+	case target.YearFromAlias:
+		target.Year = incoming.Year
+		target.YearFromAlias = false
+		target.YearSource = incoming.YearSource
+		target.YearConfidence = incoming.YearConfidence
+	default:
+		if strings.TrimSpace(target.YearSource) == "" {
+			target.YearSource = incoming.YearSource
+		}
+		if strings.TrimSpace(target.YearConfidence) == "" {
+			target.YearConfidence = incoming.YearConfidence
+		}
 	}
 	if strings.TrimSpace(target.Type) == "" {
 		target.Type = incoming.Type
@@ -1821,6 +1864,15 @@ func (s *Service) applyTVEpisodeMetadata(
 					if aliasYear > 0 {
 						external.TVDB.Year = aliasYear
 						external.TVDB.YearFromAlias = true
+						// Preserve the series-level source when the alias string was synthesized from TVDB title metadata.
+						yearSource := "extended_alias"
+						yearConfidence := "high"
+						if episodes.SeriesYear == aliasYear && strings.TrimSpace(episodes.SeriesYearSource) != "" {
+							yearSource = strings.TrimSpace(episodes.SeriesYearSource)
+							yearConfidence = strings.TrimSpace(episodes.SeriesYearConfidence)
+						}
+						external.TVDB.YearSource = yearSource
+						external.TVDB.YearConfidence = yearConfidence
 					}
 				}
 			}

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -1703,6 +1703,59 @@ func TestApplyTVEpisodeMetadataTVDBAliasYearApplied(t *testing.T) {
 	}
 }
 
+func TestApplyTVEpisodeMetadataTVDBAliasYearPreservesSource(t *testing.T) {
+	tests := []struct {
+		name       string
+		yearSource string
+		confidence string
+	}{
+		{name: "translation name", yearSource: "translation_name", confidence: "high"},
+		{name: "translation alias", yearSource: "translation_alias", confidence: "high"},
+		{name: "extended alias", yearSource: "extended_alias", confidence: "high"},
+		{name: "slug", yearSource: "slug", confidence: "low"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewService(&fakeRepo{})
+			tmdbClient := &stubTMDB{}
+			tvdbClient := &stubTVDB{
+				episodes: tvdb.EpisodesData{
+					SeriesYear:           2011,
+					SeriesYearSource:     tt.yearSource,
+					SeriesYearConfidence: tt.confidence,
+				},
+				specificAlias: "Hunter x Hunter (2011)",
+			}
+
+			meta := api.PreparedMetadata{
+				SourcePath: "/media/Hunter.x.Hunter.S01E01.mkv",
+			}
+			ids := &api.ExternalIDs{
+				TMDBID:   100,
+				TVDBID:   200,
+				Category: "TV",
+			}
+			external := &api.ExternalMetadata{
+				TMDB: &api.TMDBMetadata{OriginalLanguage: "ja"},
+				TVDB: &api.TVDBMetadata{TVDBID: 200},
+			}
+
+			_ = svc.applyTVEpisodeMetadata(context.Background(), meta, ids, external, tmdbClient, tvdbClient, &stubTVmaze{})
+
+			if external.TVDB.Year != 2011 {
+				t.Fatalf("expected alias year 2011, got %d", external.TVDB.Year)
+			}
+			if external.TVDB.YearSource != tt.yearSource {
+				t.Fatalf("expected preserved year source %q, got %q", tt.yearSource, external.TVDB.YearSource)
+			}
+			if external.TVDB.YearConfidence != tt.confidence {
+				t.Fatalf("expected preserved year confidence %q, got %q", tt.confidence, external.TVDB.YearConfidence)
+			}
+		})
+	}
+}
+
 func TestApplyTVEpisodeMetadataTVDBTitleOnlyAliasAppliedWithoutYear(t *testing.T) {
 	svc := NewService(&fakeRepo{})
 	tmdbClient := &stubTMDB{}
@@ -1981,20 +2034,80 @@ func TestResolveExternalIDsTVDBSlugYearNotUsedForNamingYear(t *testing.T) {
 	}
 }
 
+func TestMapTVDBMetadataAPIYearDoesNotBecomeNamingYear(t *testing.T) {
+	mapped := mapTVDBMetadata(402296, "", tvdb.SeriesMetadata{
+		TVDBID:           402296,
+		Name:             "A Spy Among Friends",
+		NameEnglish:      "A Spy Among Friends",
+		SeriesYear:       2022,
+		FirstAired:       "2022-12-08",
+		OriginalLanguage: "eng",
+		HasEnglish:       true,
+	})
+
+	if mapped == nil {
+		t.Fatalf("expected mapped metadata")
+	}
+	if mapped.Year != 2022 {
+		t.Fatalf("expected first-aired tvdb year 2022, got %d", mapped.Year)
+	}
+	if mapped.YearFromAlias {
+		t.Fatalf("expected api year not to mark YearFromAlias")
+	}
+	if mapped.YearSource != "first_aired" {
+		t.Fatalf("expected first_aired year source, got %q", mapped.YearSource)
+	}
+}
+
+func TestMergeTVDBMetadataClearsStaleAliasYear(t *testing.T) {
+	target := &api.TVDBMetadata{
+		TVDBID:         402296,
+		Name:           "A Spy Among Friends",
+		Year:           2025,
+		YearFromAlias:  true,
+		YearSource:     "translation_alias",
+		YearConfidence: "high",
+	}
+	incoming := &api.TVDBMetadata{
+		TVDBID:     402296,
+		Name:       "A Spy Among Friends",
+		FirstAired: "2022-12-08",
+		Year:       2022,
+		YearSource: "first_aired",
+	}
+
+	mergeTVDBMetadata(target, incoming)
+
+	if target.Year != 2022 {
+		t.Fatalf("expected stale alias year replaced with incoming first-aired year, got %d", target.Year)
+	}
+	if target.YearFromAlias {
+		t.Fatalf("expected incoming non-alias metadata to clear YearFromAlias")
+	}
+	if target.YearSource != "first_aired" {
+		t.Fatalf("expected incoming non-alias year source, got %q", target.YearSource)
+	}
+	if target.YearConfidence != "" {
+		t.Fatalf("expected alias confidence cleared, got %q", target.YearConfidence)
+	}
+}
+
 func TestResolveExternalIDsTVDBExplicitSeriesYearUsedForNamingYear(t *testing.T) {
 	repo := &fakeRepo{}
 	tmdbClient := &stubTMDB{}
 	imdbClient := &stubIMDB{}
 	tvdbClient := &stubTVDB{
 		seriesMetadata: tvdb.SeriesMetadata{
-			TVDBID:           200,
-			Name:             "Cats Eye",
-			NameEnglish:      "Cats Eye",
-			SeriesYear:       2025,
-			Slug:             "cats-eye-2025",
-			FirstAired:       "2010-10-01",
-			OriginalLanguage: "jpn",
-			HasEnglish:       true,
+			TVDBID:               200,
+			Name:                 "Cats Eye",
+			NameEnglish:          "Cats Eye",
+			SeriesYear:           2025,
+			SeriesYearSource:     "translation_alias",
+			SeriesYearConfidence: "high",
+			Slug:                 "cats-eye-2025",
+			FirstAired:           "2010-10-01",
+			OriginalLanguage:     "jpn",
+			HasEnglish:           true,
 		},
 	}
 
@@ -2026,6 +2139,9 @@ func TestResolveExternalIDsTVDBExplicitSeriesYearUsedForNamingYear(t *testing.T)
 	}
 	if !result.ExternalMetadata.TVDB.YearFromAlias {
 		t.Fatalf("expected explicit series year to mark YearFromAlias")
+	}
+	if result.ExternalMetadata.TVDB.YearSource != "translation_alias" {
+		t.Fatalf("expected translation alias year source, got %q", result.ExternalMetadata.TVDB.YearSource)
 	}
 }
 

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -368,9 +368,10 @@ func (s *stubTVDB) GetEpisodeTranslation(_ context.Context, episodeID int, _ str
 }
 
 type stubTVmaze struct {
-	result tvmaze.SearchResult
-	calls  int
-	inputs []tvmaze.SearchInput
+	result      tvmaze.SearchResult
+	episodeData *tvmaze.EpisodeData
+	calls       int
+	inputs      []tvmaze.SearchInput
 }
 
 func (s *stubTVmaze) Search(_ context.Context, input tvmaze.SearchInput) (tvmaze.SearchResult, error) {
@@ -380,7 +381,7 @@ func (s *stubTVmaze) Search(_ context.Context, input tvmaze.SearchInput) (tvmaze
 }
 
 func (s *stubTVmaze) GetEpisodeByNumber(_ context.Context, _, _, _ int, _ tvmaze.EpisodeLookupContext) (*tvmaze.EpisodeData, error) {
-	return nil, nil
+	return s.episodeData, nil
 }
 
 func (s *stubTVmaze) GetEpisodeByDate(_ context.Context, _ int, _ string) (*tvmaze.EpisodeData, error) {
@@ -1895,6 +1896,43 @@ func TestApplyTVEpisodeMetadataTVDBEpisodeTitleSkipsOriginalWhenEnglishMissing(t
 
 	if updated.EpisodeTitle != "" {
 		t.Fatalf("expected non-english original episode title to be skipped, got %q", updated.EpisodeTitle)
+	}
+}
+
+func TestApplyTVEpisodeMetadataDiscardsSeriesTitleAsEpisodeTitle(t *testing.T) {
+	svc := NewService(&fakeRepo{})
+	tmdbClient := &stubTMDB{}
+	tvmazeClient := &stubTVmaze{
+		episodeData: &tvmaze.EpisodeData{
+			EpisodeName:   "The Long Road",
+			SeasonNumber:  4,
+			EpisodeNumber: 11,
+		},
+	}
+
+	meta := api.PreparedMetadata{
+		SourcePath:   "/media/Re.ZERO.S04E11.mkv",
+		SeasonInt:    4,
+		EpisodeInt:   11,
+		EpisodeTitle: "Re:ZERO -Starting Life in Another World-",
+		ExternalIDs:  api.ExternalIDs{Category: "TV"},
+		ExternalMetadata: api.ExternalMetadata{
+			TVDB: &api.TVDBMetadata{NameEnglish: "Re: ZERO, Starting Life in Another World"},
+		},
+	}
+	ids := &api.ExternalIDs{
+		TVDBID:   200,
+		TVmazeID: 300,
+		Category: "TV",
+	}
+	external := &api.ExternalMetadata{
+		TVDB: &api.TVDBMetadata{TVDBID: 200, NameEnglish: "Re: ZERO, Starting Life in Another World"},
+	}
+
+	updated := svc.applyTVEpisodeMetadata(context.Background(), meta, ids, external, tmdbClient, &stubTVDB{}, tvmazeClient)
+
+	if updated.EpisodeTitle != "The Long Road" {
+		t.Fatalf("expected provider episode title to replace duplicate series title, got %q", updated.EpisodeTitle)
 	}
 }
 

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -1864,7 +1864,7 @@ func TestApplyTVEpisodeMetadataTVDBEpisodeTranslationApplied(t *testing.T) {
 	}
 }
 
-func TestApplyTVEpisodeMetadataTVDBEpisodeTitleFallsBackToOriginalWhenEnglishMissing(t *testing.T) {
+func TestApplyTVEpisodeMetadataTVDBEpisodeTitleSkipsOriginalWhenEnglishMissing(t *testing.T) {
 	svc := NewService(&fakeRepo{})
 	tmdbClient := &stubTMDB{}
 	tvdbClient := &stubTVDB{
@@ -1893,8 +1893,8 @@ func TestApplyTVEpisodeMetadataTVDBEpisodeTitleFallsBackToOriginalWhenEnglishMis
 
 	updated := svc.applyTVEpisodeMetadata(context.Background(), meta, ids, external, tmdbClient, tvdbClient, &stubTVmaze{})
 
-	if updated.EpisodeTitle != "Native Title 3" {
-		t.Fatalf("expected original episode title fallback, got %q", updated.EpisodeTitle)
+	if updated.EpisodeTitle != "" {
+		t.Fatalf("expected non-english original episode title to be skipped, got %q", updated.EpisodeTitle)
 	}
 }
 

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -1894,6 +1894,9 @@ func TestApplyTVEpisodeMetadataTVDBEpisodeTranslationApplied(t *testing.T) {
 	if updated.EpisodeTitle != "" {
 		t.Fatalf("expected episode title blanked when title contains episode/tba, got %q", updated.EpisodeTitle)
 	}
+	if updated.EpisodeOverview != "English episode overview" {
+		t.Fatalf("expected english episode overview, got %q", updated.EpisodeOverview)
+	}
 }
 
 func TestApplyTVEpisodeMetadataTVDBEpisodeTitleSkipsOriginalWhenEnglishMissing(t *testing.T) {
@@ -1927,6 +1930,9 @@ func TestApplyTVEpisodeMetadataTVDBEpisodeTitleSkipsOriginalWhenEnglishMissing(t
 
 	if updated.EpisodeTitle != "" {
 		t.Fatalf("expected non-english original episode title to be skipped, got %q", updated.EpisodeTitle)
+	}
+	if updated.EpisodeOverview != "" {
+		t.Fatalf("expected non-english original episode overview to be skipped, got %q", updated.EpisodeOverview)
 	}
 }
 

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -1704,6 +1704,37 @@ func TestApplyTVEpisodeMetadataTVDBAliasYearApplied(t *testing.T) {
 	}
 }
 
+func TestApplyTVEpisodeMetadataTVDBAliasYearUsesLastYear(t *testing.T) {
+	svc := NewService(&fakeRepo{})
+	tmdbClient := &stubTMDB{}
+	tvdbClient := &stubTVDB{specificAlias: "Hunter x Hunter (1999) (2011)"}
+
+	meta := api.PreparedMetadata{
+		SourcePath: "/media/Hunter.x.Hunter.S01E01.mkv",
+	}
+	ids := &api.ExternalIDs{
+		TMDBID:   100,
+		TVDBID:   200,
+		Category: "TV",
+	}
+	external := &api.ExternalMetadata{
+		TMDB: &api.TMDBMetadata{OriginalLanguage: "ja"},
+		TVDB: &api.TVDBMetadata{TVDBID: 200},
+	}
+
+	_ = svc.applyTVEpisodeMetadata(context.Background(), meta, ids, external, tmdbClient, tvdbClient, &stubTVmaze{})
+
+	if external.TVDB.Name != "Hunter x Hunter" {
+		t.Fatalf("expected cleaned alias title, got %q", external.TVDB.Name)
+	}
+	if external.TVDB.Year != 2011 {
+		t.Fatalf("expected last alias year 2011, got %d", external.TVDB.Year)
+	}
+	if !external.TVDB.YearFromAlias {
+		t.Fatal("expected multi-year alias to mark YearFromAlias")
+	}
+}
+
 func TestApplyTVEpisodeMetadataTVDBAliasYearPreservesSource(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -2127,6 +2158,39 @@ func TestMergeTVDBMetadataClearsStaleAliasYear(t *testing.T) {
 	}
 	if target.YearConfidence != "" {
 		t.Fatalf("expected alias confidence cleared, got %q", target.YearConfidence)
+	}
+}
+
+func TestMergeTVDBMetadataPreservesAliasYearWhenIncomingHasNoYearSource(t *testing.T) {
+	target := &api.TVDBMetadata{
+		TVDBID:         200,
+		Name:           "Cats Eye",
+		Year:           2025,
+		YearFromAlias:  true,
+		YearSource:     "translation_alias",
+		YearConfidence: "high",
+	}
+	incoming := &api.TVDBMetadata{
+		TVDBID:      200,
+		NameEnglish: "Cat's Eye",
+	}
+
+	mergeTVDBMetadata(target, incoming)
+
+	if target.Year != 2025 {
+		t.Fatalf("expected alias year preserved, got %d", target.Year)
+	}
+	if !target.YearFromAlias {
+		t.Fatal("expected YearFromAlias preserved")
+	}
+	if target.YearSource != "translation_alias" {
+		t.Fatalf("expected alias year source preserved, got %q", target.YearSource)
+	}
+	if target.YearConfidence != "high" {
+		t.Fatalf("expected alias confidence preserved, got %q", target.YearConfidence)
+	}
+	if target.NameEnglish != "Cat's Eye" {
+		t.Fatalf("expected unrelated missing fields to merge, got %q", target.NameEnglish)
 	}
 }
 

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -2092,6 +2092,40 @@ func TestMergeTVDBMetadataClearsStaleAliasYear(t *testing.T) {
 	}
 }
 
+func TestMergeTVDBMetadataRefreshesAliasYear(t *testing.T) {
+	target := &api.TVDBMetadata{
+		TVDBID:         200,
+		Name:           "Cats Eye",
+		Year:           2024,
+		YearFromAlias:  true,
+		YearSource:     "extended_alias",
+		YearConfidence: "medium",
+	}
+	incoming := &api.TVDBMetadata{
+		TVDBID:         200,
+		Name:           "Cats Eye",
+		Year:           2025,
+		YearFromAlias:  true,
+		YearSource:     "translation_alias",
+		YearConfidence: "high",
+	}
+
+	mergeTVDBMetadata(target, incoming)
+
+	if target.Year != 2025 {
+		t.Fatalf("expected alias-derived year refreshed from incoming metadata, got %d", target.Year)
+	}
+	if !target.YearFromAlias {
+		t.Fatalf("expected alias-derived year provenance to remain set")
+	}
+	if target.YearSource != "translation_alias" {
+		t.Fatalf("expected incoming alias year source, got %q", target.YearSource)
+	}
+	if target.YearConfidence != "high" {
+		t.Fatalf("expected incoming alias confidence, got %q", target.YearConfidence)
+	}
+}
+
 func TestResolveExternalIDsTVDBExplicitSeriesYearUsedForNamingYear(t *testing.T) {
 	repo := &fakeRepo{}
 	tmdbClient := &stubTMDB{}

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -35,7 +35,7 @@ var numericPattern = regexp.MustCompile(`\d+`)
 var releaseTokenSeparatorPattern = regexp.MustCompile(`[^A-Z0-9]+`)
 
 // ApplyMediaDetails enriches prepared metadata from MediaInfo, BDInfo, filename
-// tokens, overrides, and tracker policies, then rebuilds the release name.
+// tokens, overrides, and tracker rules, then rebuilds the release name.
 func (s *Service) ApplyMediaDetails(ctx context.Context, meta api.PreparedMetadata) (api.PreparedMetadata, error) {
 	select {
 	case <-ctx.Done():
@@ -190,12 +190,14 @@ func (s *Service) ApplyMediaDetails(ctx context.Context, meta api.PreparedMetada
 	if err != nil {
 		return api.PreparedMetadata{}, err
 	}
-	meta, err = s.applyTrackerClaims(ctx, meta)
-	if err != nil {
-		return api.PreparedMetadata{}, err
-	}
 
 	return meta, nil
+}
+
+// ApplyTrackerClaims refreshes claim-based tracker blocks after media details
+// and tracker rules have populated the release attributes used for matching.
+func (s *Service) ApplyTrackerClaims(ctx context.Context, meta api.PreparedMetadata) (api.PreparedMetadata, error) {
+	return s.applyTrackerClaims(ctx, meta)
 }
 
 // RefreshPreparedMetadata reapplies request-scoped audio, naming, rule, and

--- a/internal/metadata/naming.go
+++ b/internal/metadata/naming.go
@@ -281,6 +281,11 @@ func releaseNameRequestFromMeta(meta api.PreparedMetadata, logger api.Logger) ap
 	episodeTitle := strings.TrimSpace(meta.EpisodeTitle)
 	if meta.TVPack {
 		episodeTitle = ""
+	} else if titleIdentityKey(episodeTitle) != "" {
+		episodeTitleKey := titleIdentityKey(episodeTitle)
+		if episodeTitleKey == titleIdentityKey(title) || episodeTitleKey == titleIdentityKey(altTitle) {
+			episodeTitle = ""
+		}
 	}
 
 	return api.ReleaseNameRequest{

--- a/internal/metadata/naming.go
+++ b/internal/metadata/naming.go
@@ -265,10 +265,16 @@ func releaseNameRequestFromMeta(meta api.PreparedMetadata, logger api.Logger) ap
 	if strings.EqualFold(category, "TV") && year > 0 {
 		searchYear = strconv.Itoa(year)
 	}
+	tvdbYearSource := ""
+	tvdbYearFromAlias := false
+	if strings.EqualFold(category, "TV") && meta.ExternalMetadata.TVDB != nil {
+		tvdbYearSource = strings.TrimSpace(meta.ExternalMetadata.TVDB.YearSource)
+		tvdbYearFromAlias = meta.ExternalMetadata.TVDB.YearFromAlias
+	}
 
 	typeValue = normalizeReleaseTypeForCategory(category, typeValue, source, meta.SourcePath)
 
-	logger.Tracef("metadata: release name request resolved category=%q type=%q base_type=%q source=%q season=%q episode=%q date=%q tv_pack=%t", category, typeValue, baseType, source, strings.TrimSpace(meta.SeasonStr), strings.TrimSpace(meta.EpisodeStr), strings.TrimSpace(meta.DailyEpisodeDate), meta.TVPack)
+	logger.Tracef("metadata: release name request resolved category=%q type=%q base_type=%q source=%q season=%q episode=%q date=%q tv_pack=%t year=%d search_year=%q year_source=%q tvdb_year_from_alias=%t", category, typeValue, baseType, source, strings.TrimSpace(meta.SeasonStr), strings.TrimSpace(meta.EpisodeStr), strings.TrimSpace(meta.DailyEpisodeDate), meta.TVPack, year, searchYear, tvdbYearSource, tvdbYearFromAlias)
 
 	dailyDate := strings.TrimSpace(meta.DailyEpisodeDate)
 	manualDate := strings.EqualFold(category, "TV") && dailyDate != "" && !meta.TVPack

--- a/internal/metadata/naming_test.go
+++ b/internal/metadata/naming_test.go
@@ -4,6 +4,7 @@
 package metadata
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -198,6 +199,9 @@ func TestReleaseNameRequestFromMetaTVPackOmitsSeasonTitle(t *testing.T) {
 	result := BuildReleaseName(req, api.NopLogger{})
 	if strings.Contains(result.NameNoTag, "Season 1") {
 		t.Fatalf("expected tv pack name to omit season title, got %q", result.NameNoTag)
+	}
+	if strings.Contains(result.NameNoTag, "2022") {
+		t.Fatalf("expected tv pack name to omit ordinary tvdb year, got %q", result.NameNoTag)
 	}
 	if !containsAll(result.NameNoTag, []string{"A Spy Among Friends", "S01", "MGMP", "WEB-DL"}) {
 		t.Fatalf("expected tv pack name to keep season and service tokens, got %q", result.NameNoTag)
@@ -410,6 +414,31 @@ func TestReleaseNameRequestFromMetaTVOmitsSearchYearWhenTVDBYearNotAliasDerived(
 	}
 }
 
+func TestReleaseNameRequestFromMetaLogsTVDBYearSource(t *testing.T) {
+	meta := api.PreparedMetadata{
+		SourcePath:  `D:\Shows\Example.Show.S01E01.1080p.BluRay.x264`,
+		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		Type:        "ENCODE",
+		Source:      "BluRay",
+		Release:     api.ReleaseInfo{Title: "Example Show", Resolution: "1080p"},
+		ExternalMetadata: api.ExternalMetadata{
+			TVDB: &api.TVDBMetadata{Name: "TVDB Name", Year: 2024, YearSource: "first_aired"},
+		},
+	}
+	logger := &captureLogger{}
+
+	req := releaseNameRequestFromMeta(meta, logger)
+	if req.SearchYear != "" {
+		t.Fatalf("expected empty tv search year, got %q", req.SearchYear)
+	}
+	if !logger.contains(`year_source="first_aired"`) {
+		t.Fatalf("expected year source in trace logs, got %#v", logger.lines)
+	}
+	if !logger.contains(`tvdb_year_from_alias=false`) {
+		t.Fatalf("expected tvdb_year_from_alias=false in trace logs, got %#v", logger.lines)
+	}
+}
+
 func TestBuildReleaseNameTVUsesSearchYearOverRequestYear(t *testing.T) {
 	result := BuildReleaseName(api.ReleaseNameRequest{
 		Category:    "TV",
@@ -499,4 +528,37 @@ func containsAll(value string, parts []string) bool {
 		}
 	}
 	return true
+}
+
+type captureLogger struct {
+	lines []string
+}
+
+func (l *captureLogger) Tracef(format string, args ...any) {
+	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+}
+
+func (l *captureLogger) Debugf(format string, args ...any) {
+	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+}
+
+func (l *captureLogger) Infof(format string, args ...any) {
+	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+}
+
+func (l *captureLogger) Warnf(format string, args ...any) {
+	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+}
+
+func (l *captureLogger) Errorf(format string, args ...any) {
+	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+}
+
+func (l *captureLogger) contains(value string) bool {
+	for _, line := range l.lines {
+		if strings.Contains(line, value) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/metadata/naming_test.go
+++ b/internal/metadata/naming_test.go
@@ -173,6 +173,29 @@ func TestReleaseNameRequestFromMetaDefaultsToDailyForTVEpisode(t *testing.T) {
 	}
 }
 
+func TestReleaseNameRequestFromMetaOmitsSeriesTitleEpisodeTitle(t *testing.T) {
+	meta := api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		ExternalMetadata: api.ExternalMetadata{
+			TVDB: &api.TVDBMetadata{NameEnglish: "Re: ZERO, Starting Life in Another World"},
+		},
+		Type:         "ENCODE",
+		SeasonStr:    "S04",
+		EpisodeStr:   "E11",
+		EpisodeTitle: "Re:ZERO -Starting Life in Another World-",
+	}
+
+	req := releaseNameRequestFromMeta(meta, api.NopLogger{})
+	if req.EpisodeTitle != "" {
+		t.Fatalf("expected duplicate series episode title omitted, got %q", req.EpisodeTitle)
+	}
+
+	result := BuildReleaseName(req, api.NopLogger{})
+	if strings.Contains(result.NameNoTag, "Re:ZERO -Starting Life in Another World-") {
+		t.Fatalf("expected release name to omit duplicate episode title, got %q", result.NameNoTag)
+	}
+}
+
 func TestReleaseNameRequestFromMetaTVPackOmitsSeasonTitle(t *testing.T) {
 	meta := api.PreparedMetadata{
 		ExternalIDs: api.ExternalIDs{Category: "TV"},

--- a/internal/metadata/release.go
+++ b/internal/metadata/release.go
@@ -28,6 +28,7 @@ func ParseReleaseInfo(path string) api.ReleaseInfo {
 	release := rls.ParseString(base)
 	typeValue := parsedReleaseType(base, release.Source, release.Other, release.Codec)
 	sourceValue := parsedReleaseSource(base, release.Source, typeValue)
+	groupValue := parsedReleaseGroup(base, release.Group, release.Site)
 	season := release.Series
 	episode := release.Episode
 	if season == 0 || episode == 0 {
@@ -66,7 +67,7 @@ func ParseReleaseInfo(path string) api.ReleaseInfo {
 		Collection: release.Collection,
 		Region:     release.Region,
 		Size:       release.Size,
-		Group:      release.Group,
+		Group:      groupValue,
 		Disc:       release.Disc,
 		Season:     season,
 		Episode:    episode,
@@ -106,4 +107,21 @@ func parsedReleaseSource(base string, source string, typeValue string) string {
 		return "UHDTV"
 	}
 	return trimmed
+}
+
+// parsedReleaseGroup preserves explicit parser groups and treats a leading
+// bracket site token as the group when no explicit suffix group was parsed.
+func parsedReleaseGroup(base string, group string, site string) string {
+	trimmedGroup := strings.TrimSpace(group)
+	if trimmedGroup != "" {
+		return trimmedGroup
+	}
+	trimmedSite := strings.TrimSpace(site)
+	if trimmedSite == "" {
+		return ""
+	}
+	if !strings.HasPrefix(strings.TrimSpace(base), "["+trimmedSite+"]") {
+		return ""
+	}
+	return trimmedSite
 }

--- a/internal/metadata/release_test.go
+++ b/internal/metadata/release_test.go
@@ -12,6 +12,8 @@ func TestParseReleaseInfo(t *testing.T) {
 		category string
 		typ      string
 		source   string
+		site     string
+		group    string
 	}{
 		{
 			name:     "empty input returns defaults",
@@ -76,6 +78,22 @@ func TestParseReleaseInfo(t *testing.T) {
 			typ:      "ENCODE",
 			source:   "BluRay",
 		},
+		{
+			name:     "leading bracket anime group falls back from site",
+			input:    "[SubsPlease] Re Zero kara Hajimeru Isekai Seikatsu - 77 (1080p) [F7DAEC64].mkv",
+			category: "TV",
+			site:     "SubsPlease",
+			group:    "SubsPlease",
+		},
+		{
+			name:     "explicit release group wins over leading bracket site",
+			input:    "[SubsPlease] Show.S01E02.1080p.WEB-DL.x264-GRP.mkv",
+			category: "TV",
+			typ:      "WEBDL",
+			source:   "Web",
+			site:     "SubsPlease",
+			group:    "GRP",
+		},
 	}
 
 	for _, tc := range tests {
@@ -92,6 +110,12 @@ func TestParseReleaseInfo(t *testing.T) {
 			}
 			if release.Source != tc.source {
 				t.Errorf("expected source %q, got %q", tc.source, release.Source)
+			}
+			if tc.site != "" && release.Site != tc.site {
+				t.Errorf("expected site %q, got %q", tc.site, release.Site)
+			}
+			if tc.group != "" && release.Group != tc.group {
+				t.Errorf("expected group %q, got %q", tc.group, release.Group)
 			}
 		})
 	}

--- a/internal/metadata/release_test.go
+++ b/internal/metadata/release_test.go
@@ -35,6 +35,7 @@ func TestParseReleaseInfo(t *testing.T) {
 			category: "MOVIE",
 			typ:      "WEBDL",
 			source:   "Web",
+			group:    "GRP",
 		},
 		{
 			name:     "episode uses tv category and webdl source",
@@ -42,6 +43,7 @@ func TestParseReleaseInfo(t *testing.T) {
 			category: "TV",
 			typ:      "WEBDL",
 			source:   "Web",
+			group:    "GRP",
 		},
 		{
 			name:     "season pack uses tv category",
@@ -49,6 +51,7 @@ func TestParseReleaseInfo(t *testing.T) {
 			category: "TV",
 			typ:      "WEBDL",
 			source:   "Web",
+			group:    "GRP",
 		},
 		{
 			name:     "bare web filename uses webdl before webrip",
@@ -56,6 +59,7 @@ func TestParseReleaseInfo(t *testing.T) {
 			category: "MOVIE",
 			typ:      "WEBDL",
 			source:   "Web",
+			group:    "GRP",
 		},
 		{
 			name:     "webrip filename uses webrip",
@@ -63,6 +67,7 @@ func TestParseReleaseInfo(t *testing.T) {
 			category: "MOVIE",
 			typ:      "WEBRIP",
 			source:   "Web",
+			group:    "GRP",
 		},
 		{
 			name:     "bluray remux preserves distinct source and type",
@@ -70,6 +75,7 @@ func TestParseReleaseInfo(t *testing.T) {
 			category: "MOVIE",
 			typ:      "REMUX",
 			source:   "BluRay",
+			group:    "GRP",
 		},
 		{
 			name:     "bluray encode infers encode type",
@@ -77,6 +83,7 @@ func TestParseReleaseInfo(t *testing.T) {
 			category: "MOVIE",
 			typ:      "ENCODE",
 			source:   "BluRay",
+			group:    "GRP",
 		},
 		{
 			name:     "leading bracket anime group falls back from site",
@@ -111,10 +118,10 @@ func TestParseReleaseInfo(t *testing.T) {
 			if release.Source != tc.source {
 				t.Errorf("expected source %q, got %q", tc.source, release.Source)
 			}
-			if tc.site != "" && release.Site != tc.site {
+			if release.Site != tc.site {
 				t.Errorf("expected site %q, got %q", tc.site, release.Site)
 			}
-			if tc.group != "" && release.Group != tc.group {
+			if release.Group != tc.group {
 				t.Errorf("expected group %q, got %q", tc.group, release.Group)
 			}
 		})

--- a/internal/metadata/thexem/client.go
+++ b/internal/metadata/thexem/client.go
@@ -22,6 +22,9 @@ import (
 )
 
 const defaultBaseURL = "https://thexem.info"
+
+// maxHTTPErrorBodyBytes caps upstream error pages before sanitizing them.
+const maxHTTPErrorBodyBytes = 16 * 1024
 const maxHTTPErrorDetailLength = 240
 const thexemUserAgent = "upbrr"
 
@@ -32,6 +35,7 @@ var (
 	htmlScriptStylePattern = regexp.MustCompile(`(?is)<script[^>]*>.*?</script>|<style[^>]*>.*?</style>`)
 	htmlTagPattern         = regexp.MustCompile(`(?s)<[^>]+>`)
 	ipv4Pattern            = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}\b`)
+	ipv6Pattern            = regexp.MustCompile(`(?i)\b(?:[0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}(?:%\w+)?\b`)
 )
 
 type Client struct {
@@ -82,8 +86,7 @@ func (c *Client) MapAbsoluteEpisode(ctx context.Context, tvdbID, absoluteEp int)
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		detail := httpErrorDetail(body)
+		detail := httpErrorDetail(resp.Body)
 		if isUnavailableHTTP(resp.StatusCode, detail) {
 			return 0, 0, fmt.Errorf("thexem: map/single: %w", ErrUnavailable)
 		}
@@ -122,8 +125,7 @@ func (c *Client) GetSeasonNames(ctx context.Context, tvdbID int) (map[int][]stri
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		detail := httpErrorDetail(body)
+		detail := httpErrorDetail(resp.Body)
 		if isUnavailableHTTP(resp.StatusCode, detail) {
 			return nil, fmt.Errorf("thexem: map/names: %w", ErrUnavailable)
 		}
@@ -180,9 +182,11 @@ func (c *Client) MatchSeasonByName(ctx context.Context, tvdbID int, title string
 }
 
 // httpErrorDetail keeps upstream failure text useful without logging raw HTML,
-// script content, IP addresses, or unbounded response bodies.
-func httpErrorDetail(body []byte) string {
-	text := strings.TrimSpace(redaction.RedactValue(string(body), nil))
+// script content, IP addresses, or more than maxHTTPErrorBodyBytes from the
+// response body.
+func httpErrorDetail(body io.Reader) string {
+	payload, _ := io.ReadAll(io.LimitReader(body, maxHTTPErrorBodyBytes))
+	text := strings.TrimSpace(redaction.RedactValue(string(payload), nil))
 	if text == "" {
 		return "empty response body"
 	}
@@ -192,6 +196,7 @@ func httpErrorDetail(body []byte) string {
 	text = htmlScriptStylePattern.ReplaceAllString(text, " ")
 	text = htmlTagPattern.ReplaceAllString(text, " ")
 	text = ipv4Pattern.ReplaceAllString(text, "[REDACTED_IP]")
+	text = ipv6Pattern.ReplaceAllString(text, "[REDACTED_IP]")
 	text = strings.Join(strings.Fields(redaction.RedactValue(text, nil)), " ")
 	if len(text) <= maxHTTPErrorDetailLength {
 		return text

--- a/internal/metadata/thexem/client.go
+++ b/internal/metadata/thexem/client.go
@@ -4,7 +4,6 @@
 package thexem
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,15 +11,28 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
 const defaultBaseURL = "https://thexem.info"
+const maxHTTPErrorDetailLength = 240
+const thexemUserAgent = "upbrr"
+
+// ErrUnavailable reports that XEM blocked or refused an otherwise valid lookup.
+var ErrUnavailable = errors.New("thexem: unavailable")
+
+var (
+	htmlScriptStylePattern = regexp.MustCompile(`(?is)<script[^>]*>.*?</script>|<style[^>]*>.*?</style>`)
+	htmlTagPattern         = regexp.MustCompile(`(?s)<[^>]+>`)
+	ipv4Pattern            = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}\b`)
+)
 
 type Client struct {
 	baseURL    string
@@ -47,17 +59,21 @@ func (c *Client) MapAbsoluteEpisode(ctx context.Context, tvdbID, absoluteEp int)
 		return 0, 0, errors.New("thexem: invalid ids")
 	}
 
-	form := url.Values{}
-	form.Set("id", strconv.Itoa(tvdbID))
-	form.Set("origin", "tvdb")
-	form.Set("absolute", strconv.Itoa(absoluteEp))
+	params := url.Values{}
+	params.Set("id", strconv.Itoa(tvdbID))
+	params.Set("origin", "tvdb")
+	params.Set("absolute", strconv.Itoa(absoluteEp))
+	params.Set("destination", "scene")
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/map/single", bytes.NewBufferString(form.Encode()))
+	// XEM documents map/single as query parameters; keep this as GET to match
+	// the public API shape and avoid form posts through Cloudflare.
+	endpoint := c.baseURL + "/map/single?" + params.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return 0, 0, fmt.Errorf("thexem: build map/single request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", thexemUserAgent)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -67,7 +83,11 @@ func (c *Client) MapAbsoluteEpisode(ctx context.Context, tvdbID, absoluteEp int)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
-		return 0, 0, fmt.Errorf("thexem: map/single http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		detail := httpErrorDetail(body)
+		if isUnavailableHTTP(resp.StatusCode, detail) {
+			return 0, 0, fmt.Errorf("thexem: map/single: %w", ErrUnavailable)
+		}
+		return 0, 0, fmt.Errorf("thexem: map/single http %d: %s", resp.StatusCode, detail)
 	}
 
 	var payload map[string]any
@@ -93,6 +113,7 @@ func (c *Client) GetSeasonNames(ctx context.Context, tvdbID int) (map[int][]stri
 		return nil, fmt.Errorf("thexem: build map/names request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", thexemUserAgent)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -102,7 +123,11 @@ func (c *Client) GetSeasonNames(ctx context.Context, tvdbID int) (map[int][]stri
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("thexem: map/names http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		detail := httpErrorDetail(body)
+		if isUnavailableHTTP(resp.StatusCode, detail) {
+			return nil, fmt.Errorf("thexem: map/names: %w", ErrUnavailable)
+		}
+		return nil, fmt.Errorf("thexem: map/names http %d: %s", resp.StatusCode, detail)
 	}
 
 	var payload map[string]any
@@ -152,6 +177,30 @@ func (c *Client) MatchSeasonByName(ctx context.Context, tvdbID int, title string
 		return 0, errors.New("thexem: no confident season name match")
 	}
 	return scores[0].season, nil
+}
+
+// httpErrorDetail keeps upstream failure text useful without logging raw HTML,
+// script content, IP addresses, or unbounded response bodies.
+func httpErrorDetail(body []byte) string {
+	text := strings.TrimSpace(redaction.RedactValue(string(body), nil))
+	if text == "" {
+		return "empty response body"
+	}
+	if strings.Contains(text, "Cloudflare") && strings.Contains(text, "you have been blocked") {
+		return "Cloudflare block page"
+	}
+	text = htmlScriptStylePattern.ReplaceAllString(text, " ")
+	text = htmlTagPattern.ReplaceAllString(text, " ")
+	text = ipv4Pattern.ReplaceAllString(text, "[REDACTED_IP]")
+	text = strings.Join(strings.Fields(redaction.RedactValue(text, nil)), " ")
+	if len(text) <= maxHTTPErrorDetailLength {
+		return text
+	}
+	return strings.TrimSpace(text[:maxHTTPErrorDetailLength]) + "..."
+}
+
+func isUnavailableHTTP(status int, detail string) bool {
+	return status == http.StatusForbidden && strings.EqualFold(strings.TrimSpace(detail), "Cloudflare block page")
 }
 
 func parseSeasonEpisode(payload map[string]any) (int, int) {

--- a/internal/metadata/thexem/client_test.go
+++ b/internal/metadata/thexem/client_test.go
@@ -103,7 +103,7 @@ func TestHTTPErrorDetailCompactsCloudflareBlock(t *testing.T) {
 func TestMapAbsoluteEpisodeCloudflareBlockIsUnavailable(t *testing.T) {
 	t.Parallel()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = w.Write([]byte(`<html><title>Attention Required! | Cloudflare</title><body>Sorry, you have been blocked</body></html>`))
 	}))

--- a/internal/metadata/thexem/client_test.go
+++ b/internal/metadata/thexem/client_test.go
@@ -23,10 +23,14 @@ func TestMapAbsoluteEpisode(t *testing.T) {
 			return
 		}
 		if r.Method != http.MethodGet {
-			t.Fatalf("expected GET request, got %s", r.Method)
+			t.Errorf("expected GET request, got %s", r.Method)
+			http.Error(w, "unexpected request method", http.StatusMethodNotAllowed)
+			return
 		}
 		if got := r.Header.Get("User-Agent"); got != thexemUserAgent {
-			t.Fatalf("expected User-Agent %q, got %q", thexemUserAgent, got)
+			t.Errorf("expected User-Agent %q, got %q", thexemUserAgent, got)
+			http.Error(w, "unexpected user agent", http.StatusBadRequest)
+			return
 		}
 		query := r.URL.Query()
 		if query.Get("id") != "123" || query.Get("origin") != "tvdb" || query.Get("absolute") != "43" || query.Get("destination") != "scene" {
@@ -59,7 +63,9 @@ func TestGetSeasonNamesAndMatch(t *testing.T) {
 			return
 		}
 		if got := r.Header.Get("User-Agent"); got != thexemUserAgent {
-			t.Fatalf("expected User-Agent %q, got %q", thexemUserAgent, got)
+			t.Errorf("expected User-Agent %q, got %q", thexemUserAgent, got)
+			http.Error(w, "unexpected user agent", http.StatusBadRequest)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"1":["Anime"],"2":["Anime Season 2","Second Season"]}}`))
@@ -89,8 +95,8 @@ func TestGetSeasonNamesAndMatch(t *testing.T) {
 func TestHTTPErrorDetailCompactsCloudflareBlock(t *testing.T) {
 	t.Parallel()
 
-	body := []byte(`<html><head><title>Attention Required! | Cloudflare</title></head><body><h1>Sorry, you have been blocked</h1><span>Your IP: 103.95.115.127</span><script>var ip="103.95.115.127"</script></body></html>`)
-	got := httpErrorDetail(body)
+	body := `<html><head><title>Attention Required! | Cloudflare</title></head><body><h1>Sorry, you have been blocked</h1><span>Your IP: 103.95.115.127</span><script>var ip="103.95.115.127"</script></body></html>`
+	got := httpErrorDetail(strings.NewReader(body))
 
 	if got != "Cloudflare block page" {
 		t.Fatalf("expected compact cloudflare detail, got %q", got)
@@ -124,13 +130,73 @@ func TestMapAbsoluteEpisodeCloudflareBlockIsUnavailable(t *testing.T) {
 func TestHTTPErrorDetailCompactsHTMLAndRedactsIP(t *testing.T) {
 	t.Parallel()
 
-	body := []byte(`<html><body><h1>Forbidden</h1><p>blocked ip 103.95.115.127</p><script>secret()</script></body></html>`)
-	got := httpErrorDetail(body)
+	body := `<html><body><h1>Forbidden</h1><p>blocked ip 103.95.115.127 and 2001:db8::1</p><script>secret()</script></body></html>`
+	got := httpErrorDetail(strings.NewReader(body))
 
 	if !strings.Contains(got, "Forbidden") {
 		t.Fatalf("expected html text preserved, got %q", got)
 	}
-	if strings.Contains(got, "103.95.115.127") || strings.Contains(got, "secret()") || strings.Contains(got, "<body") {
+	if strings.Contains(got, "103.95.115.127") || strings.Contains(got, "2001:db8::1") || strings.Contains(got, "secret()") || strings.Contains(got, "<body") {
 		t.Fatalf("expected html noise redacted, got %q", got)
 	}
+}
+
+func TestMapAbsoluteEpisodeHTTPErrorRedactsIPs(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "blocked 103.95.115.127 2001:db8::1", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), api.NopLogger{})
+	client.baseURL = server.URL
+
+	_, _, err := client.MapAbsoluteEpisode(context.Background(), 123, 43)
+	if err == nil {
+		t.Fatalf("expected http error")
+	}
+	got := err.Error()
+	if strings.Contains(got, "103.95.115.127") || strings.Contains(got, "2001:db8::1") {
+		t.Fatalf("expected returned error to redact IPs, got %q", got)
+	}
+}
+
+func TestHTTPErrorDetailLimitsBodyBeforeSanitize(t *testing.T) {
+	t.Parallel()
+
+	reader := &boundedErrorReader{
+		payload: strings.Repeat("x", maxHTTPErrorBodyBytes+1),
+		limit:   maxHTTPErrorBodyBytes,
+	}
+	got := httpErrorDetail(reader)
+
+	if reader.failed {
+		t.Fatalf("expected body read capped before reader failure")
+	}
+	if got == "" {
+		t.Fatalf("expected non-empty detail")
+	}
+}
+
+type boundedErrorReader struct {
+	payload string
+	offset  int
+	limit   int
+	failed  bool
+}
+
+// Read records any attempt to consume more than limit so the test can prove
+// httpErrorDetail bounds the body before sanitizing it.
+func (r *boundedErrorReader) Read(p []byte) (int, error) {
+	if r.offset >= r.limit {
+		r.failed = true
+		return 0, errors.New("read past limit")
+	}
+	n := copy(p, r.payload[r.offset:])
+	if r.offset+n > r.limit {
+		n = r.limit - r.offset
+	}
+	r.offset += n
+	return n, nil
 }

--- a/internal/metadata/thexem/client_test.go
+++ b/internal/metadata/thexem/client_test.go
@@ -5,8 +5,10 @@ package thexem
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/autobrr/upbrr/pkg/api"
@@ -20,8 +22,14 @@ func TestMapAbsoluteEpisode(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
-		_ = r.ParseForm()
-		if r.FormValue("id") != "123" || r.FormValue("absolute") != "43" {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET request, got %s", r.Method)
+		}
+		if got := r.Header.Get("User-Agent"); got != thexemUserAgent {
+			t.Fatalf("expected User-Agent %q, got %q", thexemUserAgent, got)
+		}
+		query := r.URL.Query()
+		if query.Get("id") != "123" || query.Get("origin") != "tvdb" || query.Get("absolute") != "43" || query.Get("destination") != "scene" {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -50,6 +58,9 @@ func TestGetSeasonNamesAndMatch(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
+		if got := r.Header.Get("User-Agent"); got != thexemUserAgent {
+			t.Fatalf("expected User-Agent %q, got %q", thexemUserAgent, got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"1":["Anime"],"2":["Anime Season 2","Second Season"]}}`))
 	}))
@@ -72,5 +83,54 @@ func TestGetSeasonNamesAndMatch(t *testing.T) {
 	}
 	if season != 2 {
 		t.Fatalf("expected season 2, got %d", season)
+	}
+}
+
+func TestHTTPErrorDetailCompactsCloudflareBlock(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`<html><head><title>Attention Required! | Cloudflare</title></head><body><h1>Sorry, you have been blocked</h1><span>Your IP: 103.95.115.127</span><script>var ip="103.95.115.127"</script></body></html>`)
+	got := httpErrorDetail(body)
+
+	if got != "Cloudflare block page" {
+		t.Fatalf("expected compact cloudflare detail, got %q", got)
+	}
+	if strings.Contains(got, "103.95.115.127") || strings.Contains(got, "<html") {
+		t.Fatalf("expected raw html and ip removed, got %q", got)
+	}
+}
+
+func TestMapAbsoluteEpisodeCloudflareBlockIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`<html><title>Attention Required! | Cloudflare</title><body>Sorry, you have been blocked</body></html>`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), api.NopLogger{})
+	client.baseURL = server.URL
+
+	season, episode, err := client.MapAbsoluteEpisode(context.Background(), 123, 43)
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("expected unavailable error, got %v", err)
+	}
+	if season != 0 || episode != 0 {
+		t.Fatalf("expected no mapping on unavailable response, got season=%d episode=%d", season, episode)
+	}
+}
+
+func TestHTTPErrorDetailCompactsHTMLAndRedactsIP(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`<html><body><h1>Forbidden</h1><p>blocked ip 103.95.115.127</p><script>secret()</script></body></html>`)
+	got := httpErrorDetail(body)
+
+	if !strings.Contains(got, "Forbidden") {
+		t.Fatalf("expected html text preserved, got %q", got)
+	}
+	if strings.Contains(got, "103.95.115.127") || strings.Contains(got, "secret()") || strings.Contains(got, "<body") {
+		t.Fatalf("expected html noise redacted, got %q", got)
 	}
 }

--- a/internal/metadata/tvdb/client.go
+++ b/internal/metadata/tvdb/client.go
@@ -175,6 +175,10 @@ func (c *Client) GetEpisodesWithLanguage(ctx context.Context, seriesID int, quer
 				if c.logger != nil {
 					c.logger.Tracef("tvdb: episodes cache hit series_id=%d language=%s episodes=%d", seriesID, languageKey, len(cached.Episodes))
 				}
+				if upgraded, ok := applyLegacySeriesYearProvenance(cached); ok {
+					cached = upgraded
+					_ = writeEpisodesCache(cachePath, cached)
+				}
 				needsSeriesDetails := strings.TrimSpace(cached.SeriesTitle) == "" && cached.SeriesYear == 0
 				needsSeriesDetails = needsSeriesDetails || (cached.SeriesYear > 0 && strings.TrimSpace(cached.SeriesYearSource) == "")
 				if needsSeriesDetails {
@@ -858,8 +862,16 @@ func seriesTranslationMetadata(data seriesExtendedDataResponse, translation seri
 	return seriesMetadataFields{title: title}
 }
 
-// aliasYear returns the first standalone year embedded in an alias.
+// aliasYear returns the naming year carried by an alias. Parenthesized disambiguation years win over
+// earlier title years, while plain standalone years remain a fallback for aliases without parentheses.
 func aliasYear(alias string) (int, bool) {
+	if matches := yearAliasPattern.FindAllStringSubmatch(alias, -1); len(matches) > 0 {
+		year, err := strconv.Atoi(matches[len(matches)-1][1])
+		if err != nil {
+			return 0, false
+		}
+		return year, true
+	}
 	yearText := extractYearFromText(alias)
 	if yearText == "" {
 		return 0, false
@@ -1122,6 +1134,25 @@ func applySeriesDetails(data EpisodesData, details seriesDetails) EpisodesData {
 	return data
 }
 
+// applyLegacySeriesYearProvenance fills missing naming provenance for old episode caches only when the
+// cached title or English alias proves the cached year. It leaves source-less API years non-eligible.
+func applyLegacySeriesYearProvenance(data EpisodesData) (EpisodesData, bool) {
+	if data.SeriesYear <= 0 || strings.TrimSpace(data.SeriesYearSource) != "" {
+		return data, false
+	}
+	if year, ok := explicitTitleYear(data.SeriesTitle); ok && year == data.SeriesYear {
+		data.SeriesYearSource = seriesYearSourceTranslationName
+		data.SeriesYearConfidence = seriesYearConfidenceHigh
+		return data, true
+	}
+	if year, ok := matchingAliasYear(episodeAliasNames(data.Aliases), data.SeriesTitle); ok && year == data.SeriesYear {
+		data.SeriesYearSource = seriesYearSourceExtendedAlias
+		data.SeriesYearConfidence = seriesYearConfidenceHigh
+		return data, true
+	}
+	return data, false
+}
+
 func specificSeriesAlias(data EpisodesData) string {
 	title := strings.TrimSpace(data.SeriesTitle)
 	if title != "" {
@@ -1192,6 +1223,21 @@ func extractYearFromText(text string) string {
 		return trimmed[start:end]
 	}
 	return ""
+}
+
+// episodeAliasNames returns non-empty English episode-cache aliases for provenance checks.
+func episodeAliasNames(values []Alias) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if !isEnglishCode(value.Language) {
+			continue
+		}
+		name := strings.TrimSpace(value.Name)
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 func isASCIIDigit(ch byte) bool {

--- a/internal/metadata/tvdb/client.go
+++ b/internal/metadata/tvdb/client.go
@@ -26,7 +26,12 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-const defaultBaseURL = "https://api4.thetvdb.com/v4"
+const (
+	defaultBaseURL = "https://api4.thetvdb.com/v4"
+	// maxTVDBResponseBodyBytes bounds TVDB metadata responses before status
+	// detail formatting or JSON decode.
+	maxTVDBResponseBodyBytes = 16 << 20
+)
 
 var (
 	errNotFound             = errors.New("tvdb: not found")
@@ -1362,10 +1367,6 @@ func (c *Client) getJSON(ctx context.Context, path string, params map[string]str
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("tvdb read response body: %w", err)
-	}
 	if resp.StatusCode == http.StatusUnauthorized {
 		if err := c.refreshToken(ctx); err != nil {
 			return err
@@ -1375,6 +1376,11 @@ func (c *Client) getJSON(ctx context.Context, path string, params map[string]str
 	if resp.StatusCode == http.StatusNotFound {
 		return errNotFound
 	}
+
+	body, err := readTVDBResponseBody(resp.Body)
+	if err != nil {
+		return fmt.Errorf("tvdb: read response body for %s: %w", path, err)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("tvdb: http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
@@ -1383,6 +1389,20 @@ func (c *Client) getJSON(ctx context.Context, path string, params map[string]str
 		return fmt.Errorf("tvdb: decode %s: %w", path, err)
 	}
 	return nil
+}
+
+// readTVDBResponseBody returns a complete TVDB response payload up to
+// maxTVDBResponseBodyBytes and reports oversized responses instead of
+// truncating JSON or upstream error details.
+func readTVDBResponseBody(body io.Reader) ([]byte, error) {
+	payload, err := io.ReadAll(io.LimitReader(body, maxTVDBResponseBodyBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read limited response body: %w", err)
+	}
+	if len(payload) > maxTVDBResponseBodyBytes {
+		return nil, fmt.Errorf("response exceeds %d bytes", maxTVDBResponseBodyBytes)
+	}
+	return payload, nil
 }
 
 func (c *Client) ensureToken(ctx context.Context) error {

--- a/internal/metadata/tvdb/client.go
+++ b/internal/metadata/tvdb/client.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,6 +34,16 @@ var (
 	yearPattern             = regexp.MustCompile(`(?:19|20)\d{2}`)
 	nonAlphaNumSpacePattern = regexp.MustCompile(`[^a-z0-9 ]+`)
 	multiSpacePattern       = regexp.MustCompile(`\s+`)
+)
+
+const (
+	seriesYearSourceTranslationName  = "translation_name"
+	seriesYearSourceTranslationAlias = "translation_alias"
+	seriesYearSourceExtendedAlias    = "extended_alias"
+	seriesYearSourceSlug             = "slug"
+
+	seriesYearConfidenceHigh = "high"
+	seriesYearConfidenceLow  = "low"
 )
 
 var cityTimezoneMap = map[string]string{
@@ -164,7 +175,9 @@ func (c *Client) GetEpisodesWithLanguage(ctx context.Context, seriesID int, quer
 				if c.logger != nil {
 					c.logger.Tracef("tvdb: episodes cache hit series_id=%d language=%s episodes=%d", seriesID, languageKey, len(cached.Episodes))
 				}
-				if strings.TrimSpace(cached.SeriesTitle) == "" && cached.SeriesYear == 0 {
+				needsSeriesDetails := strings.TrimSpace(cached.SeriesTitle) == "" && cached.SeriesYear == 0
+				needsSeriesDetails = needsSeriesDetails || (cached.SeriesYear > 0 && strings.TrimSpace(cached.SeriesYearSource) == "")
+				if needsSeriesDetails {
 					if details, err := c.fetchSeriesDetails(ctx, seriesID, language); err == nil {
 						cached = applySeriesDetails(cached, details)
 						if cachePath != "" {
@@ -191,15 +204,17 @@ func (c *Client) GetEpisodesWithLanguage(ctx context.Context, seriesID int, quer
 		details = fetchedDetails
 	}
 	data := EpisodesData{
-		Episodes:           episodes,
-		Aliases:            details.aliases,
-		Slug:               slug,
-		SeriesTitle:        details.seriesTitle,
-		SeriesYear:         details.seriesYear,
-		AirsDays:           details.airsDays,
-		AirsTime:           details.airsTime,
-		AirsTimezone:       details.airsTimezone,
-		AirsTimezoneSource: details.airsTimezoneSource,
+		Episodes:             episodes,
+		Aliases:              details.aliases,
+		Slug:                 slug,
+		SeriesTitle:          details.seriesTitle,
+		SeriesYear:           details.seriesYear,
+		SeriesYearSource:     details.seriesYearSource,
+		SeriesYearConfidence: details.seriesYearConfidence,
+		AirsDays:             details.airsDays,
+		AirsTime:             details.airsTime,
+		AirsTimezone:         details.airsTimezone,
+		AirsTimezoneSource:   details.airsTimezoneSource,
 	}
 
 	if cachePath != "" && len(episodes) > 0 {
@@ -284,6 +299,8 @@ func (c *Client) GetSeriesMetadataWithLanguage(ctx context.Context, seriesID int
 		metadata.NameEnglish = metautil.FirstNonEmptyTrimmed(seriesMeta.title, metadata.NameEnglish)
 	}
 	metadata.SeriesYear = seriesMeta.year
+	metadata.SeriesYearSource = seriesMeta.yearSource
+	metadata.SeriesYearConfidence = seriesMeta.yearConfidence
 
 	if metadata.Name == "" && len(resp.Data.Aliases) > 0 {
 		metadata.Name = strings.TrimSpace(resp.Data.Aliases[0].Name)
@@ -306,11 +323,17 @@ func (c *Client) GetSeriesMetadataWithLanguage(ctx context.Context, seriesID int
 
 	if c.logger != nil {
 		c.logger.Tracef(
-			"tvdb: series metadata loaded series_id=%d language=%q name=%q first_aired=%q",
+			"tvdb: series metadata loaded series_id=%d language=%q name=%q first_aired=%q api_year=%d series_year=%d series_year_source=%q series_year_confidence=%q name_english=%q slug=%q",
 			seriesID,
 			normalizeLanguageParam(language),
 			metadata.Name,
 			metadata.FirstAired,
+			int(resp.Data.Year),
+			metadata.SeriesYear,
+			metadata.SeriesYearSource,
+			metadata.SeriesYearConfidence,
+			metadata.NameEnglish,
+			metadata.Slug,
 		)
 	}
 
@@ -444,13 +467,15 @@ func (c *Client) fetchEpisodes(ctx context.Context, seriesID int, language strin
 }
 
 type seriesDetails struct {
-	aliases            []Alias
-	seriesTitle        string
-	seriesYear         int
-	airsDays           []string
-	airsTime           string
-	airsTimezone       string
-	airsTimezoneSource string
+	aliases              []Alias
+	seriesTitle          string
+	seriesYear           int
+	seriesYearSource     string
+	seriesYearConfidence string
+	airsDays             []string
+	airsTime             string
+	airsTimezone         string
+	airsTimezoneSource   string
 }
 
 func (c *Client) fetchSeriesDetails(ctx context.Context, seriesID int, language string) (seriesDetails, error) {
@@ -466,13 +491,15 @@ func (c *Client) fetchSeriesDetails(ctx context.Context, seriesID int, language 
 	}
 	seriesMeta := seriesTranslationMetadata(resp.Data, translation)
 	return seriesDetails{
-		aliases:            mapAliases(resp.Data.Aliases),
-		seriesTitle:        seriesMeta.title,
-		seriesYear:         seriesMeta.year,
-		airsDays:           airsDays,
-		airsTime:           airsTime,
-		airsTimezone:       airsTimezone,
-		airsTimezoneSource: airsTimezoneSource,
+		aliases:              mapAliases(resp.Data.Aliases),
+		seriesTitle:          seriesMeta.title,
+		seriesYear:           seriesMeta.year,
+		seriesYearSource:     seriesMeta.yearSource,
+		seriesYearConfidence: seriesMeta.yearConfidence,
+		airsDays:             airsDays,
+		airsTime:             airsTime,
+		airsTimezone:         airsTimezone,
+		airsTimezoneSource:   airsTimezoneSource,
 	}, nil
 }
 
@@ -753,38 +780,161 @@ func deriveEnglishSeriesOverview(data seriesExtendedDataResponse, requestLanguag
 }
 
 type seriesMetadataFields struct {
-	title string
-	year  int
+	title          string
+	year           int
+	yearSource     string
+	yearConfidence string
 }
 
 func seriesTranslationMetadata(data seriesExtendedDataResponse, translation seriesTranslationDataResponse) seriesMetadataFields {
 	translationAliases := trimStringList(translation.Aliases)
 	extendedEnglishAliases := englishAliasNames(data.Aliases)
-	englishAliases := append(append([]string{}, translationAliases...), extendedEnglishAliases...)
 
 	fallbackTitle := ""
+	fallbackYearSource := ""
 	if len(translationAliases) > 0 {
 		fallbackTitle = translationAliases[len(translationAliases)-1]
+		fallbackYearSource = seriesYearSourceTranslationAlias
 	} else if len(extendedEnglishAliases) > 0 {
 		fallbackTitle = extendedEnglishAliases[len(extendedEnglishAliases)-1]
+		fallbackYearSource = seriesYearSourceExtendedAlias
 	}
 
-	title := metautil.FirstNonEmptyTrimmed(translation.Name, fallbackTitle)
-	year := 0
-	for _, alias := range englishAliases {
-		if parsed := extractYearFromText(alias); parsed != "" {
-			year, _ = strconv.Atoi(parsed)
-			break
+	translationName := strings.TrimSpace(translation.Name)
+	title := metautil.FirstNonEmptyTrimmed(translationName, fallbackTitle)
+	if year, ok := explicitTitleYear(translationName); ok {
+		return seriesMetadataFields{
+			title:          title,
+			year:           year,
+			yearSource:     seriesYearSourceTranslationName,
+			yearConfidence: seriesYearConfidenceHigh,
 		}
 	}
-	if len(englishAliases) == 0 {
-		if data.Year != 0 {
-			year = int(data.Year)
-		} else if parsed := extractYearFromText(data.Slug); parsed != "" {
-			year, _ = strconv.Atoi(parsed)
+	if translationName == "" {
+		if year, ok := aliasYear(fallbackTitle); ok {
+			return seriesMetadataFields{
+				title:          title,
+				year:           year,
+				yearSource:     fallbackYearSource,
+				yearConfidence: seriesYearConfidenceHigh,
+			}
+		}
+	} else {
+		if year, ok := matchingAliasYear(translationAliases, title); ok {
+			return seriesMetadataFields{
+				title:          title,
+				year:           year,
+				yearSource:     seriesYearSourceTranslationAlias,
+				yearConfidence: seriesYearConfidenceHigh,
+			}
+		}
+		if year, ok := matchingAliasYear(extendedEnglishAliases, title); ok {
+			return seriesMetadataFields{
+				title:          title,
+				year:           year,
+				yearSource:     seriesYearSourceExtendedAlias,
+				yearConfidence: seriesYearConfidenceHigh,
+			}
 		}
 	}
-	return seriesMetadataFields{title: title, year: year}
+	if year, ok := slugFallbackYear(data.Slug, data.Name, translation.Name, translationAliases, extendedEnglishAliases); ok {
+		return seriesMetadataFields{
+			title:          title,
+			year:           year,
+			yearSource:     seriesYearSourceSlug,
+			yearConfidence: seriesYearConfidenceLow,
+		}
+	}
+	return seriesMetadataFields{title: title}
+}
+
+// aliasYear returns the first standalone year embedded in an alias.
+func aliasYear(alias string) (int, bool) {
+	yearText := extractYearFromText(alias)
+	if yearText == "" {
+		return 0, false
+	}
+	year, err := strconv.Atoi(yearText)
+	if err != nil {
+		return 0, false
+	}
+	return year, true
+}
+
+// explicitTitleYear returns a naming-safe title year only when the title carries an explicit parenthesized year.
+func explicitTitleYear(title string) (int, bool) {
+	matches := yearAliasPattern.FindStringSubmatch(title)
+	if len(matches) != 2 {
+		return 0, false
+	}
+	year, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, false
+	}
+	return year, true
+}
+
+func matchingAliasYear(aliases []string, title string) (int, bool) {
+	for _, alias := range aliases {
+		if normalizedTitleWithoutYear(title) != "" && normalizedTitleWithoutYear(alias) != normalizedTitleWithoutYear(title) {
+			continue
+		}
+		if year, ok := aliasYear(alias); ok {
+			return year, true
+		}
+	}
+	return 0, false
+}
+
+func slugFallbackYear(slug, originalTitle, translationName string, translationAliases, extendedEnglishAliases []string) (int, bool) {
+	slugYear := extractYearFromText(slug)
+	if slugYear == "" {
+		return 0, false
+	}
+	if cleanEnglishTitleExists(translationName, translationAliases, extendedEnglishAliases) {
+		return 0, false
+	}
+	slugBase := normalizedTitleWithoutYear(strings.ReplaceAll(slug, "-", " "))
+	if slugBase == "" {
+		return 0, false
+	}
+	originalBase := normalizedTitleWithoutYear(originalTitle)
+	if comparableTitleBase(originalBase) && originalBase != slugBase {
+		return 0, false
+	}
+	year, err := strconv.Atoi(slugYear)
+	if err != nil {
+		return 0, false
+	}
+	return year, true
+}
+
+func comparableTitleBase(value string) bool {
+	return len(strings.ReplaceAll(value, " ", "")) >= 3
+}
+
+func cleanEnglishTitleExists(translationName string, translationAliases, extendedEnglishAliases []string) bool {
+	for _, value := range append(append([]string{translationName}, translationAliases...), extendedEnglishAliases...) {
+		if strings.TrimSpace(value) != "" && extractYearFromText(value) == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizedTitleWithoutYear(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	withoutYear := yearAliasPattern.ReplaceAllString(trimmed, " ")
+	withoutYear = yearPattern.ReplaceAllString(withoutYear, " ")
+	withoutYear = strings.ReplaceAll(withoutYear, "×", "x")
+	withoutYear = strings.ReplaceAll(withoutYear, "&", " and ")
+	withoutYear = strings.ToLower(withoutYear)
+	withoutYear = nonAlphaNumSpacePattern.ReplaceAllString(withoutYear, " ")
+	withoutYear = multiSpacePattern.ReplaceAllString(withoutYear, " ")
+	return strings.TrimSpace(withoutYear)
 }
 
 func englishAliasNames(values []aliasResponse) []string {
@@ -832,12 +982,7 @@ func (c *Client) fetchSeriesTranslation(ctx context.Context, seriesID int, langu
 }
 
 func containsEnglishTranslation(values []string) bool {
-	for _, value := range values {
-		if isEnglishCode(value) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(values, isEnglishCode)
 }
 
 func selectEnglishAlias(values []aliasResponse) string {
@@ -943,8 +1088,14 @@ func applySeriesDetails(data EpisodesData, details seriesDetails) EpisodesData {
 	if strings.TrimSpace(data.SeriesTitle) == "" {
 		data.SeriesTitle = details.seriesTitle
 	}
-	if data.SeriesYear == 0 {
+	if data.SeriesYear == 0 || strings.TrimSpace(data.SeriesYearSource) == "" {
 		data.SeriesYear = details.seriesYear
+	}
+	if strings.TrimSpace(data.SeriesYearSource) == "" {
+		data.SeriesYearSource = details.seriesYearSource
+	}
+	if strings.TrimSpace(data.SeriesYearConfidence) == "" {
+		data.SeriesYearConfidence = details.seriesYearConfidence
 	}
 	if len(data.AirsDays) == 0 {
 		data.AirsDays = details.airsDays
@@ -964,12 +1115,24 @@ func applySeriesDetails(data EpisodesData, details seriesDetails) EpisodesData {
 func specificSeriesAlias(data EpisodesData) string {
 	title := strings.TrimSpace(data.SeriesTitle)
 	if title != "" {
-		if data.SeriesYear > 0 {
+		if data.SeriesYear > 0 && seriesYearSourceNamingEligible(data.SeriesYearSource) {
+			if extractYearFromText(title) == strconv.Itoa(data.SeriesYear) {
+				return title
+			}
 			return fmt.Sprintf("%s (%d)", title, data.SeriesYear)
 		}
 		return title
 	}
 	return explicitYearAlias(data.Aliases)
+}
+
+func seriesYearSourceNamingEligible(source string) bool {
+	switch strings.TrimSpace(source) {
+	case seriesYearSourceTranslationName, seriesYearSourceTranslationAlias, seriesYearSourceExtendedAlias, seriesYearSourceSlug:
+		return true
+	default:
+		return false
+	}
 }
 
 func explicitYearAlias(aliases []Alias) string {
@@ -1352,6 +1515,32 @@ type seriesResult struct {
 type aliasResponse struct {
 	Name     string `json:"name"`
 	Language string `json:"language"`
+}
+
+// UnmarshalJSON accepts both object aliases and the string aliases returned by TVDB search.
+func (a *aliasResponse) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		*a = aliasResponse{}
+		return nil
+	}
+	if trimmed[0] == '"' {
+		var name string
+		if err := json.Unmarshal(trimmed, &name); err != nil {
+			return fmt.Errorf("tvdb: unmarshal alias string: %w", err)
+		}
+		*a = aliasResponse{Name: strings.TrimSpace(name), Language: "eng"}
+		return nil
+	}
+	var payload struct {
+		Name     string `json:"name"`
+		Language string `json:"language"`
+	}
+	if err := json.Unmarshal(trimmed, &payload); err != nil {
+		return fmt.Errorf("tvdb: unmarshal alias object: %w", err)
+	}
+	*a = aliasResponse{Name: strings.TrimSpace(payload.Name), Language: strings.TrimSpace(payload.Language)}
+	return nil
 }
 
 type episodesResponse struct {

--- a/internal/metadata/tvdb/client.go
+++ b/internal/metadata/tvdb/client.go
@@ -786,6 +786,8 @@ type seriesMetadataFields struct {
 	yearConfidence string
 }
 
+// seriesTranslationMetadata selects English title metadata and returns only
+// naming-eligible years proven by explicit translation or alias evidence.
 func seriesTranslationMetadata(data seriesExtendedDataResponse, translation seriesTranslationDataResponse) seriesMetadataFields {
 	translationAliases := trimStringList(translation.Aliases)
 	extendedEnglishAliases := englishAliasNames(data.Aliases)
@@ -816,6 +818,14 @@ func seriesTranslationMetadata(data seriesExtendedDataResponse, translation seri
 				title:          title,
 				year:           year,
 				yearSource:     fallbackYearSource,
+				yearConfidence: seriesYearConfidenceHigh,
+			}
+		}
+		if year, ok := matchingAliasYear(extendedEnglishAliases, title); ok {
+			return seriesMetadataFields{
+				title:          title,
+				year:           year,
+				yearSource:     seriesYearSourceExtendedAlias,
 				yearConfidence: seriesYearConfidenceHigh,
 			}
 		}

--- a/internal/metadata/tvdb/client_test.go
+++ b/internal/metadata/tvdb/client_test.go
@@ -400,6 +400,83 @@ func TestGetEpisodesUsesExplicitTranslationAliasYear(t *testing.T) {
 	}
 }
 
+func TestGetEpisodesUpgradesLegacyCachedAliasYearSource(t *testing.T) {
+	cacheDir := t.TempDir()
+	cachePath := filepath.Join(cacheDir, "12-eng.json")
+	if err := writeEpisodesCache(cachePath, EpisodesData{
+		Episodes: []Episode{
+			{ID: 1, SeasonNumber: 1, Number: 1, Name: "Pilot"},
+		},
+		Aliases: []Alias{
+			{Name: "Cat's Eye", Language: "eng"},
+			{Name: "Cat's Eye (2025)", Language: "eng"},
+		},
+		SeriesTitle: "Cat's Eye",
+		SeriesYear:  2025,
+	}); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "offline", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), nil, "api-key", cacheDir)
+	client.baseURL = server.URL
+
+	data, alias, err := client.GetEpisodes(context.Background(), 12, EpisodeQuery{Season: 1, Episode: 1})
+	if err != nil {
+		t.Fatalf("get episodes failed: %v", err)
+	}
+	if alias != "Cat's Eye (2025)" {
+		t.Fatalf("expected legacy cached alias year to remain naming-eligible, got %q", alias)
+	}
+	if data.SeriesYearSource != seriesYearSourceExtendedAlias || data.SeriesYearConfidence != seriesYearConfidenceHigh {
+		t.Fatalf("expected upgraded legacy source/high confidence, got source=%q confidence=%q", data.SeriesYearSource, data.SeriesYearConfidence)
+	}
+
+	refreshed, ok := readEpisodesCache(cachePath)
+	if !ok {
+		t.Fatalf("expected upgraded cache to be readable")
+	}
+	if refreshed.SeriesYearSource != seriesYearSourceExtendedAlias || refreshed.SeriesYearConfidence != seriesYearConfidenceHigh {
+		t.Fatalf("expected upgraded cache provenance, got source=%q confidence=%q", refreshed.SeriesYearSource, refreshed.SeriesYearConfidence)
+	}
+}
+
+func TestGetEpisodesDoesNotUpgradeUnprovenLegacyCachedYear(t *testing.T) {
+	cacheDir := t.TempDir()
+	if err := writeEpisodesCache(filepath.Join(cacheDir, "12-eng.json"), EpisodesData{
+		Episodes: []Episode{
+			{ID: 1, SeasonNumber: 1, Number: 1, Name: "Pilot"},
+		},
+		SeriesTitle: "A Spy Among Friends",
+		SeriesYear:  2022,
+	}); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "offline", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), nil, "api-key", cacheDir)
+	client.baseURL = server.URL
+
+	data, alias, err := client.GetEpisodes(context.Background(), 12, EpisodeQuery{Season: 1, Episode: 1})
+	if err != nil {
+		t.Fatalf("get episodes failed: %v", err)
+	}
+	if alias != "A Spy Among Friends" {
+		t.Fatalf("expected unproven cached year to stay out of alias, got %q", alias)
+	}
+	if data.SeriesYearSource != "" || data.SeriesYearConfidence != "" {
+		t.Fatalf("expected no legacy provenance without title/alias proof, got source=%q confidence=%q", data.SeriesYearSource, data.SeriesYearConfidence)
+	}
+}
+
 func TestSeriesTranslationMetadataUsesSelectedFallbackAliasYear(t *testing.T) {
 	t.Run("selected alias year", func(t *testing.T) {
 		got := seriesTranslationMetadata(seriesExtendedDataResponse{}, seriesTranslationDataResponse{
@@ -447,6 +524,32 @@ func TestSeriesTranslationMetadataUsesSelectedFallbackAliasYear(t *testing.T) {
 		}
 		if got.yearSource != seriesYearSourceExtendedAlias || got.yearConfidence != seriesYearConfidenceHigh {
 			t.Fatalf("expected extended alias source/high confidence, got source=%q confidence=%q", got.yearSource, got.yearConfidence)
+		}
+	})
+
+	t.Run("alias suffix year beats title year", func(t *testing.T) {
+		got := seriesTranslationMetadata(seriesExtendedDataResponse{}, seriesTranslationDataResponse{
+			Name:    "Hunter x Hunter (2011)",
+			Aliases: []string{"Hunter x Hunter (2011) (2024)"},
+		})
+
+		if got.title != "Hunter x Hunter (2011)" {
+			t.Fatalf("expected translation name title, got %q", got.title)
+		}
+		if got.year != 2011 || got.yearSource != seriesYearSourceTranslationName {
+			t.Fatalf("expected translation name year to win for explicit title, got year=%d source=%q", got.year, got.yearSource)
+		}
+
+		got = seriesTranslationMetadata(seriesExtendedDataResponse{}, seriesTranslationDataResponse{
+			Name:    "Hunter x Hunter 2011",
+			Aliases: []string{"Hunter x Hunter 2011 (2024)"},
+		})
+
+		if got.year != 2024 {
+			t.Fatalf("expected explicit alias suffix year 2024, got %d", got.year)
+		}
+		if got.yearSource != seriesYearSourceTranslationAlias || got.yearConfidence != seriesYearConfidenceHigh {
+			t.Fatalf("expected translation alias source/high confidence, got source=%q confidence=%q", got.yearSource, got.yearConfidence)
 		}
 	})
 }

--- a/internal/metadata/tvdb/client_test.go
+++ b/internal/metadata/tvdb/client_test.go
@@ -429,6 +429,26 @@ func TestSeriesTranslationMetadataUsesSelectedFallbackAliasYear(t *testing.T) {
 			t.Fatalf("expected no year from unselected matching alias, got year=%d source=%q confidence=%q", got.year, got.yearSource, got.yearConfidence)
 		}
 	})
+
+	t.Run("clean selected alias uses extended alias year", func(t *testing.T) {
+		got := seriesTranslationMetadata(seriesExtendedDataResponse{
+			Aliases: []aliasResponse{
+				{Name: "Cats Eye (2025)", Language: "eng"},
+			},
+		}, seriesTranslationDataResponse{
+			Aliases: []string{"Cats Eye"},
+		})
+
+		if got.title != "Cats Eye" {
+			t.Fatalf("expected selected fallback alias title, got %q", got.title)
+		}
+		if got.year != 2025 {
+			t.Fatalf("expected extended alias year 2025, got %d", got.year)
+		}
+		if got.yearSource != seriesYearSourceExtendedAlias || got.yearConfidence != seriesYearConfidenceHigh {
+			t.Fatalf("expected extended alias source/high confidence, got source=%q confidence=%q", got.yearSource, got.yearConfidence)
+		}
+	})
 }
 
 func TestSeriesTranslationMetadataUsesOnlyExplicitTranslationNameYear(t *testing.T) {

--- a/internal/metadata/tvdb/client_test.go
+++ b/internal/metadata/tvdb/client_test.go
@@ -54,8 +54,16 @@ func TestSpecificSeriesAliasDoesNotUseSlugFallback(t *testing.T) {
 		t.Fatalf("expected explicit alias year to win, got %q", got)
 	}
 
-	if got := specificSeriesAlias(EpisodesData{SeriesTitle: "Cats Eye", SeriesYear: 2025}); got != "Cats Eye (2025)" {
+	if got := specificSeriesAlias(EpisodesData{SeriesTitle: "Cats Eye", SeriesYear: 2025}); got != "Cats Eye" {
+		t.Fatalf("expected source-less series year to be ignored, got %q", got)
+	}
+
+	if got := specificSeriesAlias(EpisodesData{SeriesTitle: "Cats Eye", SeriesYear: 2025, SeriesYearSource: seriesYearSourceTranslationAlias}); got != "Cats Eye (2025)" {
 		t.Fatalf("expected explicit series title/year, got %q", got)
+	}
+
+	if got := specificSeriesAlias(EpisodesData{SeriesTitle: "Hunter x Hunter (2011)", SeriesYear: 2011, SeriesYearSource: seriesYearSourceTranslationName}); got != "Hunter x Hunter (2011)" {
+		t.Fatalf("expected title year not to be duplicated, got %q", got)
 	}
 }
 
@@ -195,6 +203,37 @@ func TestSearchSeriesAlwaysUsesEnglishLanguage(t *testing.T) {
 	}
 }
 
+func TestSearchSeriesDecodesStringAliases(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			_, _ = w.Write([]byte(`{"data":{"token":"token"}}`))
+		case "/search":
+			_, _ = w.Write([]byte(`{"data":[{"tvdb_id":252322,"name":"Hunter x Hunter","year":"2011","aliases":["Hunter x Hunter (2011)"]}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), nil, "api-key", "")
+	client.baseURL = server.URL
+
+	results, selected, err := client.SearchSeries(context.Background(), "Hunter x Hunter", "2011")
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if selected != 252322 {
+		t.Fatalf("expected selected id 252322, got %d", selected)
+	}
+	if len(results) != 1 || len(results[0].Aliases) != 1 {
+		t.Fatalf("expected decoded alias, got %#v", results)
+	}
+	if results[0].Aliases[0].Name != "Hunter x Hunter (2011)" || results[0].Aliases[0].Language != "eng" {
+		t.Fatalf("expected english string alias, got %#v", results[0].Aliases[0])
+	}
+}
+
 func TestGetEpisodesLanguagePreference(t *testing.T) {
 	episodeLang := ""
 	extendedLang := ""
@@ -294,6 +333,38 @@ func TestGetEpisodesUsesTranslationSeriesMetadataWithoutSlugFallback(t *testing.
 	}
 }
 
+func TestGetEpisodesIgnoresAPIYearForNamingYear(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			_, _ = w.Write([]byte(`{"data":{"token":"token"}}`))
+		case "/series/12/episodes/default":
+			_, _ = w.Write([]byte(`{"data":{"episodes":[{"id":1,"seasonNumber":1,"number":1,"name":"Pilot"}],"slug":"a-spy-among-friends"}}`))
+		case "/series/12/extended":
+			_, _ = w.Write([]byte(`{"data":{"name":"A Spy Among Friends","slug":"a-spy-among-friends","year":2022,"firstAired":"2022-12-08","aliases":[]}}`))
+		case "/series/12/translations/eng":
+			_, _ = w.Write([]byte(`{"data":{"name":"A Spy Among Friends","aliases":[]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), nil, "api-key", "")
+	client.baseURL = server.URL
+
+	data, alias, err := client.GetEpisodes(context.Background(), 12, EpisodeQuery{Season: 1, Episode: 1})
+	if err != nil {
+		t.Fatalf("get episodes failed: %v", err)
+	}
+	if alias != "A Spy Among Friends" {
+		t.Fatalf("expected translated title without api year, got %q", alias)
+	}
+	if data.SeriesYear != 0 || data.SeriesYearSource != "" {
+		t.Fatalf("expected no naming year from api year, got year=%d source=%q", data.SeriesYear, data.SeriesYearSource)
+	}
+}
+
 func TestGetEpisodesUsesExplicitTranslationAliasYear(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -323,6 +394,155 @@ func TestGetEpisodesUsesExplicitTranslationAliasYear(t *testing.T) {
 	}
 	if data.SeriesYear != 2025 {
 		t.Fatalf("expected explicit series year 2025, got %d", data.SeriesYear)
+	}
+	if data.SeriesYearSource != seriesYearSourceTranslationAlias || data.SeriesYearConfidence != seriesYearConfidenceHigh {
+		t.Fatalf("expected translation alias source/high confidence, got source=%q confidence=%q", data.SeriesYearSource, data.SeriesYearConfidence)
+	}
+}
+
+func TestSeriesTranslationMetadataUsesSelectedFallbackAliasYear(t *testing.T) {
+	t.Run("selected alias year", func(t *testing.T) {
+		got := seriesTranslationMetadata(seriesExtendedDataResponse{}, seriesTranslationDataResponse{
+			Aliases: []string{"Same Show (2020)", "Same Show (2024)"},
+		})
+
+		if got.title != "Same Show (2024)" {
+			t.Fatalf("expected selected fallback alias title, got %q", got.title)
+		}
+		if got.year != 2024 {
+			t.Fatalf("expected selected fallback alias year 2024, got %d", got.year)
+		}
+		if got.yearSource != seriesYearSourceTranslationAlias || got.yearConfidence != seriesYearConfidenceHigh {
+			t.Fatalf("expected translation alias source/high confidence, got source=%q confidence=%q", got.yearSource, got.yearConfidence)
+		}
+	})
+
+	t.Run("selected alias without year", func(t *testing.T) {
+		got := seriesTranslationMetadata(seriesExtendedDataResponse{}, seriesTranslationDataResponse{
+			Aliases: []string{"Same Show (2020)", "Same Show"},
+		})
+
+		if got.title != "Same Show" {
+			t.Fatalf("expected selected fallback alias title, got %q", got.title)
+		}
+		if got.year != 0 || got.yearSource != "" || got.yearConfidence != "" {
+			t.Fatalf("expected no year from unselected matching alias, got year=%d source=%q confidence=%q", got.year, got.yearSource, got.yearConfidence)
+		}
+	})
+}
+
+func TestSeriesTranslationMetadataUsesOnlyExplicitTranslationNameYear(t *testing.T) {
+	t.Run("parenthesized year", func(t *testing.T) {
+		got := seriesTranslationMetadata(seriesExtendedDataResponse{}, seriesTranslationDataResponse{
+			Name: "Hunter x Hunter (2011)",
+		})
+
+		if got.year != 2011 || got.yearSource != seriesYearSourceTranslationName {
+			t.Fatalf("expected explicit translation name year, got year=%d source=%q", got.year, got.yearSource)
+		}
+	})
+
+	t.Run("bare numeric title", func(t *testing.T) {
+		got := seriesTranslationMetadata(seriesExtendedDataResponse{}, seriesTranslationDataResponse{
+			Name: "Show 2024",
+		})
+
+		if got.title != "Show 2024" {
+			t.Fatalf("expected title preserved, got %q", got.title)
+		}
+		if got.year != 0 || got.yearSource != "" || got.yearConfidence != "" {
+			t.Fatalf("expected bare numeric title not to become naming year, got year=%d source=%q confidence=%q", got.year, got.yearSource, got.yearConfidence)
+		}
+	})
+}
+
+func TestGetEpisodesUsesTranslationNameYear(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			_, _ = w.Write([]byte(`{"data":{"token":"token"}}`))
+		case "/series/12/episodes/default":
+			_, _ = w.Write([]byte(`{"data":{"episodes":[{"id":1,"seasonNumber":1,"number":1,"name":"Pilot"}],"slug":"hunter-x-hunter-2011"}}`))
+		case "/series/12/extended":
+			_, _ = w.Write([]byte(`{"data":{"name":"ハンター×ハンター","slug":"hunter-x-hunter-2011","aliases":[]}}`))
+		case "/series/12/translations/eng":
+			_, _ = w.Write([]byte(`{"data":{"name":"Hunter x Hunter (2011)","aliases":[]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), nil, "api-key", "")
+	client.baseURL = server.URL
+
+	data, alias, err := client.GetEpisodes(context.Background(), 12, EpisodeQuery{Season: 1, Episode: 1})
+	if err != nil {
+		t.Fatalf("get episodes failed: %v", err)
+	}
+	if alias != "Hunter x Hunter (2011)" {
+		t.Fatalf("expected translation name year without duplication, got %q", alias)
+	}
+	if data.SeriesYear != 2011 || data.SeriesYearSource != seriesYearSourceTranslationName {
+		t.Fatalf("expected translation name year, got year=%d source=%q", data.SeriesYear, data.SeriesYearSource)
+	}
+}
+
+func TestGetEpisodesUsesSlugFallbackWhenNoEnglishEvidence(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			_, _ = w.Write([]byte(`{"data":{"token":"token"}}`))
+		case "/series/12/episodes/default":
+			_, _ = w.Write([]byte(`{"data":{"episodes":[{"id":1,"seasonNumber":1,"number":1,"name":"Pilot"}],"slug":"hunter-x-hunter-2011"}}`))
+		case "/series/12/extended":
+			_, _ = w.Write([]byte(`{"data":{"name":"ハンター×ハンター","slug":"hunter-x-hunter-2011","aliases":[]}}`))
+		case "/series/12/translations/eng":
+			_, _ = w.Write([]byte(`{"data":{"name":"","aliases":[]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), nil, "api-key", "")
+	client.baseURL = server.URL
+
+	data, _, err := client.GetEpisodes(context.Background(), 12, EpisodeQuery{Season: 1, Episode: 1})
+	if err != nil {
+		t.Fatalf("get episodes failed: %v", err)
+	}
+	if data.SeriesYear != 2011 || data.SeriesYearSource != seriesYearSourceSlug || data.SeriesYearConfidence != seriesYearConfidenceLow {
+		t.Fatalf("expected low-confidence slug year, got year=%d source=%q confidence=%q", data.SeriesYear, data.SeriesYearSource, data.SeriesYearConfidence)
+	}
+}
+
+func TestGetEpisodesRejectsMismatchedSlugFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			_, _ = w.Write([]byte(`{"data":{"token":"token"}}`))
+		case "/series/12/episodes/default":
+			_, _ = w.Write([]byte(`{"data":{"episodes":[{"id":1,"seasonNumber":1,"number":1,"name":"Pilot"}],"slug":"wrong-show-2025"}}`))
+		case "/series/12/extended":
+			_, _ = w.Write([]byte(`{"data":{"name":"Original Show","slug":"wrong-show-2025","aliases":[]}}`))
+		case "/series/12/translations/eng":
+			_, _ = w.Write([]byte(`{"data":{"name":"","aliases":[]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), nil, "api-key", "")
+	client.baseURL = server.URL
+
+	data, _, err := client.GetEpisodes(context.Background(), 12, EpisodeQuery{Season: 1, Episode: 1})
+	if err != nil {
+		t.Fatalf("get episodes failed: %v", err)
+	}
+	if data.SeriesYear != 0 || data.SeriesYearSource != "" {
+		t.Fatalf("expected mismatched slug year rejected, got year=%d source=%q", data.SeriesYear, data.SeriesYearSource)
 	}
 }
 

--- a/internal/metadata/tvdb/client_test.go
+++ b/internal/metadata/tvdb/client_test.go
@@ -6,6 +6,7 @@ package tvdb
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -231,6 +232,60 @@ func TestSearchSeriesDecodesStringAliases(t *testing.T) {
 	}
 	if results[0].Aliases[0].Name != "Hunter x Hunter (2011)" || results[0].Aliases[0].Language != "eng" {
 		t.Fatalf("expected english string alias, got %#v", results[0].Aliases[0])
+	}
+}
+
+func TestGetJSONRejectsOversizedSuccessResponse(t *testing.T) {
+	client := NewClient(&http.Client{Transport: tvdbRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/login":
+			return tvdbTestResponse(http.StatusOK, `{"data":{"token":"token"}}`), nil
+		case "/oversized":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(&repeatingReader{remaining: maxTVDBResponseBodyBytes + 1}),
+				Request:    req,
+			}, nil
+		default:
+			return tvdbTestResponse(http.StatusNotFound, ""), nil
+		}
+	})}, nil, "api-key", "")
+	client.baseURL = "https://tvdb.test"
+
+	var target map[string]any
+	err := client.getJSON(context.Background(), "/oversized", nil, &target)
+	if err == nil {
+		t.Fatal("expected oversized response error")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected oversized response error, got %v", err)
+	}
+}
+
+func TestGetJSONRejectsOversizedErrorResponse(t *testing.T) {
+	client := NewClient(&http.Client{Transport: tvdbRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/login":
+			return tvdbTestResponse(http.StatusOK, `{"data":{"token":"token"}}`), nil
+		case "/oversized":
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Body:       io.NopCloser(&repeatingReader{remaining: maxTVDBResponseBodyBytes + 1}),
+				Request:    req,
+			}, nil
+		default:
+			return tvdbTestResponse(http.StatusNotFound, ""), nil
+		}
+	})}, nil, "api-key", "")
+	client.baseURL = "https://tvdb.test"
+
+	var target map[string]any
+	err := client.getJSON(context.Background(), "/oversized", nil, &target)
+	if err == nil {
+		t.Fatal("expected oversized response error")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected oversized response error, got %v", err)
 	}
 }
 
@@ -801,4 +856,36 @@ func TestGetEpisodeTranslation(t *testing.T) {
 	if translated.Overview != "English episode overview" {
 		t.Fatalf("expected translated overview, got %q", translated.Overview)
 	}
+}
+
+type tvdbRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f tvdbRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func tvdbTestResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+type repeatingReader struct {
+	remaining int64
+}
+
+func (r *repeatingReader) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:int(r.remaining)]
+	}
+	for i := range p {
+		p[i] = 'x'
+	}
+	r.remaining -= int64(len(p))
+	return len(p), nil
 }

--- a/internal/metadata/tvdb/client_test.go
+++ b/internal/metadata/tvdb/client_test.go
@@ -417,7 +417,7 @@ func TestGetEpisodesUpgradesLegacyCachedAliasYearSource(t *testing.T) {
 		t.Fatalf("write cache: %v", err)
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "offline", http.StatusServiceUnavailable)
 	}))
 	defer server.Close()
@@ -457,7 +457,7 @@ func TestGetEpisodesDoesNotUpgradeUnprovenLegacyCachedYear(t *testing.T) {
 		t.Fatalf("write cache: %v", err)
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "offline", http.StatusServiceUnavailable)
 	}))
 	defer server.Close()

--- a/internal/metadata/tvdb/types.go
+++ b/internal/metadata/tvdb/types.go
@@ -11,23 +11,27 @@ type SeriesSearchResult struct {
 }
 
 type SeriesMetadata struct {
-	TVDBID           int
-	Name             string
-	NameEnglish      string
-	SeriesYear       int
-	Overview         string
-	OverviewEnglish  string
-	Slug             string
-	FirstAired       string
-	Type             string
-	Status           string
-	Network          string
-	OriginalCountry  string
-	OriginalLanguage string
-	HasEnglish       bool
-	Genres           []string
-	Poster           string
-	Aliases          []Alias
+	TVDBID      int
+	Name        string
+	NameEnglish string
+	SeriesYear  int
+	// SeriesYearSource identifies the TVDB title signal that made SeriesYear safe for release-name disambiguation.
+	SeriesYearSource string
+	// SeriesYearConfidence is "high" for explicit title/alias years and "low" for guarded slug-derived years.
+	SeriesYearConfidence string
+	Overview             string
+	OverviewEnglish      string
+	Slug                 string
+	FirstAired           string
+	Type                 string
+	Status               string
+	Network              string
+	OriginalCountry      string
+	OriginalLanguage     string
+	HasEnglish           bool
+	Genres               []string
+	Poster               string
+	Aliases              []Alias
 }
 
 type Alias struct {
@@ -36,15 +40,19 @@ type Alias struct {
 }
 
 type EpisodesData struct {
-	Episodes           []Episode
-	Aliases            []Alias
-	Slug               string
-	SeriesTitle        string
-	SeriesYear         int
-	AirsDays           []string
-	AirsTime           string
-	AirsTimezone       string
-	AirsTimezoneSource string
+	Episodes    []Episode
+	Aliases     []Alias
+	Slug        string
+	SeriesTitle string
+	SeriesYear  int
+	// SeriesYearSource identifies the TVDB title signal that made SeriesYear safe for release-name disambiguation.
+	SeriesYearSource string
+	// SeriesYearConfidence is "high" for explicit title/alias years and "low" for guarded slug-derived years.
+	SeriesYearConfidence string
+	AirsDays             []string
+	AirsTime             string
+	AirsTimezone         string
+	AirsTimezoneSource   string
 }
 
 type Episode struct {

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -30,6 +30,9 @@ type MetadataService interface {
 	ApplyArrData(ctx context.Context, meta PreparedMetadata) (PreparedMetadata, error)
 	ResolveExternalIDs(ctx context.Context, meta PreparedMetadata) (PreparedMetadata, error)
 	ApplyMediaDetails(ctx context.Context, meta PreparedMetadata) (PreparedMetadata, error)
+	// ApplyTrackerClaims applies claim-based tracker blocks using metadata that
+	// has already been enriched with media details and tracker rule state.
+	ApplyTrackerClaims(ctx context.Context, meta PreparedMetadata) (PreparedMetadata, error)
 }
 
 type TrackerService interface {

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -582,14 +582,19 @@ type IMDBSeasonSummary struct {
 }
 
 type TVDBMetadata struct {
-	TVDBID                 int
-	Name                   string
-	NameEnglish            string
-	Overview               string
-	OverviewEnglish        string
-	FirstAired             string
-	Year                   int
-	YearFromAlias          bool
+	TVDBID          int
+	Name            string
+	NameEnglish     string
+	Overview        string
+	OverviewEnglish string
+	FirstAired      string
+	Year            int
+	// YearFromAlias reports whether Year is naming-eligible for TV release names.
+	YearFromAlias bool
+	// YearSource identifies the TVDB source used for Year, such as first_aired, translation_name, translation_alias, extended_alias, or slug.
+	YearSource string
+	// YearConfidence is "high" for explicit TVDB title/alias years and "low" for guarded slug-derived naming years.
+	YearConfidence         string
 	Type                   string
 	Status                 string
 	Network                string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TV naming now tracks resolved release-year source and confidence (including alias vs non-alias handling) to improve naming accuracy.
  * Metadata preview progress now includes a **“Check tracker claims”** phase.

* **Bug Fixes**
  * Prevents incorrect/duplicated TV year tokens and improves TV metadata merge/provenance consistency (including legacy cache upgrades).
  * Refines episode title/overview selection and deduping to avoid repeating the series title.
  * Improves release group/site extraction for bracketed filenames.
  * Enhances TheXem episode mapping error handling with cleaner unavailable/block detection.

* **Tests**
  * Expanded coverage for year provenance, naming edge cases, UI phase ordering, and TheXem/map/release parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->