### PR TITLE
fix: btn auth handling

### DIFF
--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -437,7 +437,7 @@ func handleCLITrackerAuthStatusWithLogger(ctx context.Context, reader *bufio.Rea
 	if status.Needs2FA && strings.TrimSpace(status.ChallengeID) != "" {
 		if isUnattendedNoConfirm(req) {
 			logger.Warnf("cli auth: tracker=%s decision=blocked reason=2fa_required unattended=true", trackerID)
-			return status, false, fmt.Errorf("upbrr: tracker auth %s requires 2FA before dupe check", trackerID)
+			return status, false, fmt.Errorf("upbrr: unattended tracker auth %s requires 2FA before dupe check", trackerID)
 		}
 		logger.Infof("cli auth: tracker=%s decision=prompt_2fa", trackerID)
 		return promptCLITrackerAuth2FAWithLogger(ctx, reader, authSvc, trackerID, status, logger)

--- a/cmd/upbrr/interactive_test.go
+++ b/cmd/upbrr/interactive_test.go
@@ -761,7 +761,7 @@ func TestEnsureCLITrackerAuthBeforeDupeCheckFailsUnattendedBTN2FA(t *testing.T) 
 	if err == nil {
 		t.Fatal("expected unattended BTN 2FA error")
 	}
-	if !strings.Contains(err.Error(), "tracker auth BTN requires 2FA before dupe check") {
+	if !strings.Contains(err.Error(), "unattended tracker auth BTN requires 2FA before dupe check") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/cmd/upbrr/interactive_test.go
+++ b/cmd/upbrr/interactive_test.go
@@ -405,6 +405,15 @@ func TestEnsureCLITrackerAuthBeforeDupeCheckValidatesApplicableTrackers(t *testi
 				SupportsAutoLogin: true,
 			},
 			{
+				TrackerID:          "BTN",
+				AuthKind:           "api_key_cookies_login_manual_2fa",
+				SupportsCookieFile: true,
+				SupportsLogin:      true,
+				SupportsAutoLogin:  true,
+				SupportsManual2FA:  true,
+				RequiresAPIKey:     true,
+			},
+			{
 				TrackerID:      "AITHER",
 				AuthKind:       "api_key",
 				RequiresAPIKey: true,
@@ -412,6 +421,7 @@ func TestEnsureCLITrackerAuthBeforeDupeCheckValidatesApplicableTrackers(t *testi
 		},
 		validateStatus: map[string]api.TrackerAuthStatus{
 			"PTP": {TrackerID: "PTP", State: trackerauth.StateConfigured},
+			"BTN": {TrackerID: "BTN", State: trackerauth.StateConfigured},
 		},
 	}
 
@@ -420,16 +430,16 @@ func TestEnsureCLITrackerAuthBeforeDupeCheckValidatesApplicableTrackers(t *testi
 		bufio.NewReader(strings.NewReader("")),
 		authSvc,
 		api.Request{Options: api.UploadOptions{InteractionMode: api.InteractionModeInteractive}},
-		[]string{"PTP", "AITHER", "BLU"},
+		[]string{"PTP", "BTN", "AITHER", "BLU"},
 	)
 	if err != nil {
 		t.Fatalf("ensureCLITrackerAuthBeforeDupeCheck: %v", err)
 	}
-	if strings.Join(got, ",") != "PTP,AITHER,BLU" {
-		t.Fatalf("expected PTP and non-applicable trackers to continue, got %#v", got)
+	if strings.Join(got, ",") != "PTP,BTN,AITHER,BLU" {
+		t.Fatalf("expected PTP, BTN, and non-applicable trackers to continue, got %#v", got)
 	}
-	if strings.Join(authSvc.validated, ",") != "PTP" {
-		t.Fatalf("expected only applicable PTP validation, got %#v", authSvc.validated)
+	if strings.Join(authSvc.validated, ",") != "PTP,BTN" {
+		t.Fatalf("expected applicable PTP and BTN validation, got %#v", authSvc.validated)
 	}
 }
 
@@ -713,6 +723,45 @@ func TestEnsureCLITrackerAuthBeforeDupeCheckFailsUnattendedAuthRequired(t *testi
 		t.Fatal("expected unattended auth-required error")
 	}
 	if !strings.Contains(err.Error(), "tracker auth HDB not ready before dupe check") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureCLITrackerAuthBeforeDupeCheckFailsUnattendedBTN2FA(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &cliTrackerAuthForTest{
+		capabilities: []api.TrackerAuthCapability{{
+			TrackerID:          "BTN",
+			AuthKind:           "api_key_cookies_login_manual_2fa",
+			SupportsCookieFile: true,
+			SupportsLogin:      true,
+			SupportsAutoLogin:  true,
+			SupportsManual2FA:  true,
+			RequiresAPIKey:     true,
+		}},
+		validateStatus: map[string]api.TrackerAuthStatus{
+			"BTN": {
+				TrackerID:   "BTN",
+				State:       trackerauth.StateLoginRequired,
+				Needs2FA:    true,
+				ChallengeID: "challenge-1",
+				Message:     "2FA required",
+			},
+		},
+	}
+
+	_, err := ensureCLITrackerAuthBeforeDupeCheckWithService(
+		context.Background(),
+		bufio.NewReader(strings.NewReader("")),
+		authSvc,
+		api.Request{Options: api.UploadOptions{InteractionMode: api.InteractionModeUnattended}},
+		[]string{"BTN"},
+	)
+	if err == nil {
+		t.Fatal("expected unattended BTN 2FA error")
+	}
+	if !strings.Contains(err.Error(), "tracker auth BTN requires 2FA before dupe check") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/gui/frontend/src/pages/settings/index.test.tsx
+++ b/gui/frontend/src/pages/settings/index.test.tsx
@@ -19,6 +19,7 @@ const baseProps = {
   settingsError: "",
   trackerSelectionNames: [
     "AR",
+    "BTN",
     "COOKIE",
     "FAST",
     "FF",
@@ -183,6 +184,18 @@ describe("SettingsPage", () => {
               requiresPasskey: false,
             },
             {
+              trackerID: "BTN",
+              displayName: "BTN",
+              authKind: "api_key_cookies_login_manual_2fa",
+              supportsCookieFile: true,
+              supportsLogin: true,
+              supportsAutoLogin: true,
+              supportsTOTP: true,
+              supportsManual2FA: true,
+              requiresAPIKey: true,
+              requiresPasskey: false,
+            },
+            {
               trackerID: "AR",
               displayName: "AR",
               authKind: "cookies_login",
@@ -291,6 +304,7 @@ describe("SettingsPage", () => {
     );
 
     const mtvTitle = await screen.findByText("MTV");
+    const btnTitle = await screen.findByText("BTN");
     const arTitle = await screen.findByText("AR");
     const hdbTitle = await screen.findByText("HDB");
     const ffTitle = await screen.findByText("FF");
@@ -299,6 +313,7 @@ describe("SettingsPage", () => {
     const thrTitle = await screen.findByText("THR");
     const ascTitle = await screen.findByText("ASC");
     const mtvCard = mtvTitle.closest(".tracker-auth-card");
+    const btnCard = btnTitle.closest(".tracker-auth-card");
     const arCard = arTitle.closest(".tracker-auth-card");
     const hdbCard = hdbTitle.closest(".tracker-auth-card");
     const ffCard = ffTitle.closest(".tracker-auth-card");
@@ -308,6 +323,7 @@ describe("SettingsPage", () => {
     const ascCard = ascTitle.closest(".tracker-auth-card");
 
     expect(mtvCard).not.toBeNull();
+    expect(btnCard).not.toBeNull();
     expect(arCard).not.toBeNull();
     expect(hdbCard).not.toBeNull();
     expect(ffCard).not.toBeNull();
@@ -317,6 +333,9 @@ describe("SettingsPage", () => {
     expect(ascCard).not.toBeNull();
     expect(
       within(mtvCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
+    ).toBeInTheDocument();
+    expect(
+      within(btnCard as HTMLElement).getByRole("button", { name: "Check Auth" }),
     ).toBeInTheDocument();
     expect(
       within(arCard as HTMLElement).getByRole("button", { name: "Check Auth" }),

--- a/gui/frontend/src/pages/settings/index.tsx
+++ b/gui/frontend/src/pages/settings/index.tsx
@@ -39,7 +39,17 @@ const trackerAuthChipClass =
 const trackerAuthMetaClass = "m-0 text-[0.8rem] text-[var(--muted)]";
 
 /** Trackers with backend adapters that can perform a remote auth check. */
-const remoteAuthValidationTrackers = new Set(["AR", "FF", "FL", "HDB", "MTV", "PTP", "RTF", "THR"]);
+const remoteAuthValidationTrackers = new Set([
+  "AR",
+  "BTN",
+  "FF",
+  "FL",
+  "HDB",
+  "MTV",
+  "PTP",
+  "RTF",
+  "THR",
+]);
 
 /** Builds the case-insensitive key shared by main tracker config and tracker auth rows. */
 const trackerNameKey = (name: string) => name.trim().toLowerCase();

--- a/internal/cookies/loader.go
+++ b/internal/cookies/loader.go
@@ -414,7 +414,7 @@ func loadTrackerCookieMapFromFiles(dbPath string, trackerID string) (map[string]
 		case ".txt":
 			cookies, err := commonhttp.LoadNetscapeCookies(candidate, "")
 			if err != nil {
-				if !errors.Is(err, fs.ErrNotExist) && firstLoadErr == nil {
+				if !isIgnorableLegacyNetscapeLoadErr(err) && firstLoadErr == nil {
 					firstLoadErr = fmt.Errorf("cookies: load legacy cookie file %s: %w", candidate, err)
 				}
 				continue
@@ -450,7 +450,7 @@ func loadTrackerHTTPCookiesFromFiles(dbPath string, trackerID string, domain str
 		case ".txt":
 			cookies, err := commonhttp.LoadNetscapeCookies(candidate, domain)
 			if err != nil {
-				if !errors.Is(err, fs.ErrNotExist) && firstLoadErr == nil {
+				if !isIgnorableLegacyNetscapeLoadErr(err) && firstLoadErr == nil {
 					firstLoadErr = fmt.Errorf("cookies: load legacy cookie file %s: %w", candidate, err)
 				}
 				continue
@@ -477,6 +477,16 @@ func loadTrackerHTTPCookiesFromFiles(dbPath string, trackerID string, domain str
 	}
 
 	return nil, fmt.Errorf("%w: no cookies found for tracker %s", ErrTrackerCookiesNotFound, trackerID)
+}
+
+// isIgnorableLegacyNetscapeLoadErr reports whether a legacy Netscape file
+// failed for the same reasons as a missing candidate: absent file or no cookies
+// matching the requested import.
+func isIgnorableLegacyNetscapeLoadErr(err error) bool {
+	if errors.Is(err, fs.ErrNotExist) {
+		return true
+	}
+	return strings.Contains(err.Error(), "no valid cookies found")
 }
 
 func httpCookiesToMap(values []*http.Cookie) map[string]string {

--- a/internal/cookies/loader.go
+++ b/internal/cookies/loader.go
@@ -23,6 +23,10 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+// ErrTrackerCookiesNotFound reports that neither encrypted storage nor legacy
+// cookie files contained usable cookies for a tracker.
+var ErrTrackerCookiesNotFound = errors.New("cookies: tracker cookies not found")
+
 // LoadTrackerCookieMap returns cookies for trackerID from encrypted database
 // storage and legacy cookie files. Database values override legacy file values
 // when both sources contain the same cookie name.
@@ -404,11 +408,15 @@ func openTrackerCookieStore(ctx context.Context, dbPath string) (*CookieStore, [
 }
 
 func loadTrackerCookieMapFromFiles(dbPath string, trackerID string) (map[string]string, error) {
+	var firstLoadErr error
 	for _, candidate := range commonhttp.CookiePathCandidates(dbPath, trackerID, ".txt", ".json") {
 		switch strings.ToLower(filepath.Ext(candidate)) {
 		case ".txt":
 			cookies, err := commonhttp.LoadNetscapeCookies(candidate, "")
 			if err != nil {
+				if !errors.Is(err, fs.ErrNotExist) && firstLoadErr == nil {
+					firstLoadErr = fmt.Errorf("cookies: load legacy cookie file %s: %w", candidate, err)
+				}
 				continue
 			}
 			values := httpCookiesToMap(cookies)
@@ -418,6 +426,9 @@ func loadTrackerCookieMapFromFiles(dbPath string, trackerID string) (map[string]
 		case ".json":
 			values, err := commonhttp.LoadJSONCookieMap(candidate)
 			if err != nil {
+				if !errors.Is(err, fs.ErrNotExist) && firstLoadErr == nil {
+					firstLoadErr = fmt.Errorf("cookies: load legacy cookie file %s: %w", candidate, err)
+				}
 				continue
 			}
 			if len(values) > 0 {
@@ -425,16 +436,23 @@ func loadTrackerCookieMapFromFiles(dbPath string, trackerID string) (map[string]
 			}
 		}
 	}
+	if firstLoadErr != nil {
+		return nil, firstLoadErr
+	}
 
-	return nil, fmt.Errorf("cookies: no cookies found for tracker %s", trackerID)
+	return nil, fmt.Errorf("%w: no cookies found for tracker %s", ErrTrackerCookiesNotFound, trackerID)
 }
 
 func loadTrackerHTTPCookiesFromFiles(dbPath string, trackerID string, domain string) ([]*http.Cookie, error) {
+	var firstLoadErr error
 	for _, candidate := range commonhttp.CookiePathCandidates(dbPath, trackerID, ".txt", ".json") {
 		switch strings.ToLower(filepath.Ext(candidate)) {
 		case ".txt":
 			cookies, err := commonhttp.LoadNetscapeCookies(candidate, domain)
 			if err != nil {
+				if !errors.Is(err, fs.ErrNotExist) && firstLoadErr == nil {
+					firstLoadErr = fmt.Errorf("cookies: load legacy cookie file %s: %w", candidate, err)
+				}
 				continue
 			}
 			if len(cookies) > 0 {
@@ -443,6 +461,9 @@ func loadTrackerHTTPCookiesFromFiles(dbPath string, trackerID string, domain str
 		case ".json":
 			values, err := commonhttp.LoadJSONCookieMap(candidate)
 			if err != nil {
+				if !errors.Is(err, fs.ErrNotExist) && firstLoadErr == nil {
+					firstLoadErr = fmt.Errorf("cookies: load legacy cookie file %s: %w", candidate, err)
+				}
 				continue
 			}
 			cookies := CookieMapToHTTPCookies(values, domain)
@@ -451,8 +472,11 @@ func loadTrackerHTTPCookiesFromFiles(dbPath string, trackerID string, domain str
 			}
 		}
 	}
+	if firstLoadErr != nil {
+		return nil, firstLoadErr
+	}
 
-	return nil, fmt.Errorf("cookies: no cookies found for tracker %s", trackerID)
+	return nil, fmt.Errorf("%w: no cookies found for tracker %s", ErrTrackerCookiesNotFound, trackerID)
 }
 
 func httpCookiesToMap(values []*http.Cookie) map[string]string {

--- a/internal/cookies/loader_test.go
+++ b/internal/cookies/loader_test.go
@@ -6,6 +6,7 @@ package cookies
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -204,6 +205,56 @@ func TestLoadTrackerHTTPCookiesStoredValueOverridesStartupCookie(t *testing.T) {
 		if cookie.Domain != "bj-share.info" {
 			t.Fatalf("expected domain to be applied, got cookie %#v", cookie)
 		}
+	}
+}
+
+func TestLoadTrackerCookieMapMalformedLegacyJSONSurfacesParseError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	jsonPath := legacyCookiePathByExt(t, dbPath, "BTN", ".json")
+	if err := os.MkdirAll(filepath.Dir(jsonPath), 0o755); err != nil {
+		t.Fatalf("mkdir cookie dir: %v", err)
+	}
+	if err := os.WriteFile(jsonPath, []byte(`{"session":`), 0o600); err != nil {
+		t.Fatalf("write malformed cookie file: %v", err)
+	}
+
+	_, err := LoadTrackerCookieMap(ctx, dbPath, "BTN")
+	if err == nil {
+		t.Fatal("expected malformed cookie file error")
+	}
+	if errors.Is(err, ErrTrackerCookiesNotFound) {
+		t.Fatalf("expected parse error, got not-found: %v", err)
+	}
+	if !strings.Contains(err.Error(), "unmarshal") {
+		t.Fatalf("expected JSON parse context, got %v", err)
+	}
+}
+
+func TestLoadTrackerHTTPCookiesMalformedLegacyJSONSurfacesParseError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	jsonPath := legacyCookiePathByExt(t, dbPath, "BTN", ".json")
+	if err := os.MkdirAll(filepath.Dir(jsonPath), 0o755); err != nil {
+		t.Fatalf("mkdir cookie dir: %v", err)
+	}
+	if err := os.WriteFile(jsonPath, []byte(`{"session":`), 0o600); err != nil {
+		t.Fatalf("write malformed cookie file: %v", err)
+	}
+
+	_, err := LoadTrackerHTTPCookies(ctx, dbPath, "BTN", "backup.landof.tv")
+	if err == nil {
+		t.Fatal("expected malformed cookie file error")
+	}
+	if errors.Is(err, ErrTrackerCookiesNotFound) {
+		t.Fatalf("expected parse error, got not-found: %v", err)
+	}
+	if !strings.Contains(err.Error(), "unmarshal") {
+		t.Fatalf("expected JSON parse context, got %v", err)
 	}
 }
 
@@ -408,6 +459,20 @@ func writeLegacyCookieCandidates(t *testing.T, dbPath string, trackerID string) 
 		}
 	}
 	return candidates
+}
+
+// legacyCookiePathByExt selects the concrete legacy candidate path for tests
+// that need to seed one cookie format without depending on candidate ordering.
+func legacyCookiePathByExt(t *testing.T, dbPath string, trackerID string, ext string) string {
+	t.Helper()
+
+	for _, candidate := range commonhttp.CookiePathCandidates(dbPath, trackerID, ".txt", ".json") {
+		if filepath.Ext(candidate) == ext {
+			return candidate
+		}
+	}
+	t.Fatalf("expected %s legacy cookie path", ext)
+	return ""
 }
 
 func rejectTrackerCookieDeletes(ctx context.Context, t *testing.T, dbPath string) {

--- a/internal/cookies/loader_test.go
+++ b/internal/cookies/loader_test.go
@@ -213,7 +213,7 @@ func TestLoadTrackerCookieMapMalformedLegacyJSONSurfacesParseError(t *testing.T)
 
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
-	jsonPath := legacyCookiePathByExt(t, dbPath, "BTN", ".json")
+	jsonPath := legacyBTNCookiePathByExt(t, dbPath, ".json")
 	if err := os.MkdirAll(filepath.Dir(jsonPath), 0o755); err != nil {
 		t.Fatalf("mkdir cookie dir: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestLoadTrackerHTTPCookiesMalformedLegacyJSONSurfacesParseError(t *testing.
 
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
-	jsonPath := legacyCookiePathByExt(t, dbPath, "BTN", ".json")
+	jsonPath := legacyBTNCookiePathByExt(t, dbPath, ".json")
 	if err := os.MkdirAll(filepath.Dir(jsonPath), 0o755); err != nil {
 		t.Fatalf("mkdir cookie dir: %v", err)
 	}
@@ -255,6 +255,59 @@ func TestLoadTrackerHTTPCookiesMalformedLegacyJSONSurfacesParseError(t *testing.
 	}
 	if !strings.Contains(err.Error(), "unmarshal") {
 		t.Fatalf("expected JSON parse context, got %v", err)
+	}
+}
+
+func TestLoadTrackerCookieMapIgnoresLegacyNetscapeNoValidCookies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "empty", content: ""},
+		{name: "comment-only", content: "# Netscape HTTP Cookie File\n# no cookies\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+			txtPath := legacyBTNCookiePathByExt(t, dbPath, ".txt")
+			if err := os.MkdirAll(filepath.Dir(txtPath), 0o755); err != nil {
+				t.Fatalf("mkdir cookie dir: %v", err)
+			}
+			if err := os.WriteFile(txtPath, []byte(tt.content), 0o600); err != nil {
+				t.Fatalf("write legacy txt cookie file: %v", err)
+			}
+
+			_, err := LoadTrackerCookieMap(ctx, dbPath, "BTN")
+			if !errors.Is(err, ErrTrackerCookiesNotFound) {
+				t.Fatalf("expected not-found for no valid Netscape cookies, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadTrackerHTTPCookiesIgnoresLegacyNetscapeDomainMismatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	txtPath := legacyBTNCookiePathByExt(t, dbPath, ".txt")
+	if err := os.MkdirAll(filepath.Dir(txtPath), 0o755); err != nil {
+		t.Fatalf("mkdir cookie dir: %v", err)
+	}
+	content := ".example.org\tTRUE\t/\tTRUE\t0\tsession\tfrom-file\n"
+	if err := os.WriteFile(txtPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write legacy txt cookie file: %v", err)
+	}
+
+	_, err := LoadTrackerHTTPCookies(ctx, dbPath, "BTN", "backup.landof.tv")
+	if !errors.Is(err, ErrTrackerCookiesNotFound) {
+		t.Fatalf("expected not-found for domain-mismatched Netscape cookies, got %v", err)
 	}
 }
 
@@ -461,12 +514,12 @@ func writeLegacyCookieCandidates(t *testing.T, dbPath string, trackerID string) 
 	return candidates
 }
 
-// legacyCookiePathByExt selects the concrete legacy candidate path for tests
+// legacyBTNCookiePathByExt selects the concrete legacy candidate path for tests
 // that need to seed one cookie format without depending on candidate ordering.
-func legacyCookiePathByExt(t *testing.T, dbPath string, trackerID string, ext string) string {
+func legacyBTNCookiePathByExt(t *testing.T, dbPath string, ext string) string {
 	t.Helper()
 
-	for _, candidate := range commonhttp.CookiePathCandidates(dbPath, trackerID, ".txt", ".json") {
+	for _, candidate := range commonhttp.CookiePathCandidates(dbPath, "BTN", ".txt", ".json") {
 		if filepath.Ext(candidate) == ext {
 			return candidate
 		}

--- a/internal/guiapp/tracker_auth_import_test.go
+++ b/internal/guiapp/tracker_auth_import_test.go
@@ -156,6 +156,31 @@ func TestAppTestTrackerAuthUsesRuntimeContext(t *testing.T) {
 	}
 }
 
+func TestAppLoginTrackerAuthBTNCookiesWithoutAPIPreservesMissingAPIStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newGUITrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "BTN", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	app := &App{
+		runtimeCtx: newAppRuntimeContext(ctx),
+		cfg:        config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}},
+	}
+
+	status, err := app.LoginTrackerAuth("BTN", api.TrackerAuthLoginRequest{})
+	if err != nil {
+		t.Fatalf("LoginTrackerAuth: %v", err)
+	}
+	if status.State != "login_required" || status.CookieCount != 1 || !strings.Contains(status.Message, "API key is required") {
+		t.Fatalf("expected BTN cookie-only Wails login to preserve missing API status, got %#v", status)
+	}
+	if strings.Contains(status.Message, "username/password missing") {
+		t.Fatalf("missing credentials masked missing API status: %#v", status)
+	}
+}
+
 func newGUITrackerAuthTestDB(t *testing.T) string {
 	t.Helper()
 

--- a/internal/trackerauth/adapters.go
+++ b/internal/trackerauth/adapters.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/cookies"
+	"github.com/autobrr/upbrr/internal/trackers/impl/btn"
 	"github.com/autobrr/upbrr/internal/trackers/impl/mtv"
 	"github.com/autobrr/upbrr/internal/trackers/impl/ptp"
 	"github.com/autobrr/upbrr/internal/trackers/impl/rtf"
@@ -31,6 +32,8 @@ func defaultAdapters() map[string]Adapter {
 		switch spec.id {
 		case "AR":
 			adapters[spec.id] = trackerAdapter{capability: validationOnlyCapability(spec), resolve: resolveARStoredSessionForTrackerAuth}
+		case "BTN":
+			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: btn.ResolveSessionForTrackerAuthLogin}
 		case "FF":
 			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: resolveFFSessionForTrackerAuth}
 		case "FL":
@@ -146,6 +149,9 @@ func classifyAdapterError(trackerID string, err error) error {
 	if validation, ok := asValidationError(err); ok {
 		return validation
 	}
+	if strings.EqualFold(trackerID, "BTN") && strings.Contains(strings.ToLower(err.Error()), "stored session confirmed invalid") {
+		return &ValidationError{TrackerID: trackerID, ConfirmedInvalid: true, Reason: "stored session expired", Err: err}
+	}
 	if isSubmitted2FARejected(err) {
 		return &ValidationError{TrackerID: trackerID, Transient: true, Submitted2FARejected: true, Reason: "submitted 2FA rejected", Err: err}
 	}
@@ -164,7 +170,7 @@ func classifyAdapterError(trackerID string, err error) error {
 }
 
 func isSubmitted2FARejected(err error) bool {
-	return errors.Is(err, ptp.ErrSubmitted2FARejected) || errors.Is(err, mtv.ErrSubmitted2FARejected)
+	return errors.Is(err, ptp.ErrSubmitted2FARejected) || errors.Is(err, mtv.ErrSubmitted2FARejected) || errors.Is(err, btn.ErrSubmitted2FARejected)
 }
 
 // contains2FARequiredText matches only the standalone "2FA required" phrase so

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -267,8 +267,8 @@ func (s *Service) Validate(ctx context.Context, trackerID string) (status api.Tr
 
 // Login runs credential-based tracker auth when supported and returns status for
 // missing credentials, unsupported remote login, or 2FA. Trackers with separate
-// API prerequisites, such as BTN, may complete credential auth while still
-// returning a prerequisite status instead of configured.
+// API prerequisites, such as BTN, keep the narrower prerequisite status when
+// credential login cannot proceed or completes without making the tracker ready.
 func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAuthLoginRequest) (status api.TrackerAuthStatus, err error) {
 	defer func() {
 		if err != nil {
@@ -290,7 +290,9 @@ func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAu
 	trackerCfg := mustTrackerConfig(s.cfg, spec.id)
 	status = s.statusForSpec(ctx, spec)
 	if status.State == StateLoginRequired && !hasUsableLoginConfig(spec, trackerCfg) {
-		status.Message = "username/password missing"
+		if !hasSpecificLoginBlocker(status) {
+			status.Message = "username/password missing"
+		}
 		return status, nil
 	}
 
@@ -578,6 +580,13 @@ func hasUsableLoginConfig(spec trackerSpec, cfg config.TrackerConfig) bool {
 		return false
 	}
 	return true
+}
+
+// hasSpecificLoginBlocker reports whether status already explains a prerequisite
+// more specific than the generic login-required message.
+func hasSpecificLoginBlocker(status api.TrackerAuthStatus) bool {
+	message := strings.TrimSpace(status.Message)
+	return message != "" && message != validationMessage(trackerSpec{}, status)
 }
 
 func (s *Service) encryptedStorageAvailable() bool {

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -251,6 +251,7 @@ func (s *Service) Validate(ctx context.Context, trackerID string) (status api.Tr
 			}
 			return status, nil
 		}
+		status = s.statusForSpec(ctx, spec)
 		if isBTNSpec(spec) && !s.btnAPIKeyConfigured() {
 			status.State = StateLoginRequired
 			status.Message = btnMissingAPIKeyMessage()
@@ -514,7 +515,7 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) api.Track
 		status.State = StateEncryptedStorageUnavailable
 	}
 	status.Message = validationMessage(spec, status)
-	if uploadAuthNeedsCookiesOrLogin(spec) && hasAPIKey && status.CookieCount == 0 && !hasCredentials {
+	if status.State != StateEncryptedStorageUnavailable && uploadAuthNeedsCookiesOrLogin(spec) && hasAPIKey && status.CookieCount == 0 && !hasCredentials {
 		status.Message = uploadAuthRequiredMessage(spec)
 	}
 	if missingBTNAPIKey {
@@ -1121,6 +1122,12 @@ func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
 	status.LastError = redact(err.Error())
 	status.Message = "remote auth test failed"
 
+	if isCookieStorageFailure(err) {
+		status.State = StateEncryptedStorageUnavailable
+		status.Message = "cookie storage unavailable; see error details"
+		return
+	}
+
 	var authRequired *AuthRequiredError
 	if errors.As(err, &authRequired) {
 		status.State = StateLoginRequired
@@ -1162,6 +1169,18 @@ func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
 		status.CookieCount = 0
 		status.Message = "stored session expired or invalid"
 	}
+}
+
+// isCookieStorageFailure recognizes cookie persistence/load failures that should
+// be exposed as storage-unavailable rather than login-required auth states.
+func isCookieStorageFailure(err error) bool {
+	if err == nil || errors.Is(err, cookies.ErrTrackerCookiesNotFound) {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "cookies:") ||
+		strings.Contains(lower, "cookie store") ||
+		strings.Contains(lower, "legacy cookie file")
 }
 
 // CookiesToMap converts HTTP cookies to a name/value map, ignoring nil cookies

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -180,7 +180,8 @@ func (s *Service) Status(ctx context.Context, trackerID string) (status api.Trac
 
 // ImportCookies parses supplied cookie content, saves it for trackerID, and
 // returns refreshed auth status from persisted cookie/auth state. Parser errors
-// leave existing stored cookies unchanged.
+// leave existing stored cookies unchanged. BTN imports still report a missing
+// API-key prerequisite when cookies alone do not make the tracker upload-ready.
 func (s *Service) ImportCookies(ctx context.Context, trackerID string, fileName string, content string) (status api.TrackerAuthStatus, err error) {
 	defer func() {
 		if err != nil {
@@ -207,14 +208,18 @@ func (s *Service) ImportCookies(ctx context.Context, trackerID string, fileName 
 		return api.TrackerAuthStatus{}, fmt.Errorf("tracker auth: import %s cookies: %w", spec.id, err)
 	}
 	status = s.statusForSpec(ctx, spec)
-	status.State = StateHasCookies
-	status.Message = "cookies imported"
+	if status.State != StateLoginRequired || !isBTNSpec(spec) || !strings.Contains(status.Message, "API key is required") {
+		status.State = StateHasCookies
+		status.Message = "cookies imported"
+	}
 	return status, nil
 }
 
 // Validate returns tracker auth status after a remote validation check when the
 // tracker has an adapter. Confirmed-invalid stored sessions are deleted and
-// reported as login-required status without returning an error.
+// reported as login-required status without returning an error. BTN session
+// success remains login-required until the API token needed for torrent
+// resolution is configured.
 func (s *Service) Validate(ctx context.Context, trackerID string) (status api.TrackerAuthStatus, err error) {
 	defer func() {
 		if err != nil {
@@ -246,6 +251,11 @@ func (s *Service) Validate(ctx context.Context, trackerID string) (status api.Tr
 			}
 			return status, nil
 		}
+		if isBTNSpec(spec) && !s.btnAPIKeyConfigured() {
+			status.State = StateLoginRequired
+			status.Message = btnMissingAPIKeyMessage()
+			return status, nil
+		}
 		status.State = StateConfigured
 		status.Message = "remote auth check succeeded"
 		return status, nil
@@ -254,7 +264,10 @@ func (s *Service) Validate(ctx context.Context, trackerID string) (status api.Tr
 	return status, nil
 }
 
-// Login runs credential-based tracker auth when supported and returns status for missing credentials, unsupported remote login, or 2FA.
+// Login runs credential-based tracker auth when supported and returns status for
+// missing credentials, unsupported remote login, or 2FA. Trackers with separate
+// API prerequisites, such as BTN, may complete credential auth while still
+// returning a prerequisite status instead of configured.
 func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAuthLoginRequest) (status api.TrackerAuthStatus, err error) {
 	defer func() {
 		if err != nil {
@@ -273,8 +286,9 @@ func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAu
 	if !spec.login {
 		return api.TrackerAuthStatus{}, fmt.Errorf("tracker auth: %s does not support credential login", spec.id)
 	}
+	trackerCfg := mustTrackerConfig(s.cfg, spec.id)
 	status = s.statusForSpec(ctx, spec)
-	if status.State == StateLoginRequired {
+	if status.State == StateLoginRequired && !hasUsableLoginConfig(spec, trackerCfg) {
 		status.Message = "username/password missing"
 		return status, nil
 	}
@@ -282,7 +296,7 @@ func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAu
 	if _, ok := s.adapterFor(spec.id); ok {
 		session, ensureErr := s.EnsureSession(ctx, EnsureRequest{
 			TrackerID: spec.id,
-			Config:    mustTrackerConfig(s.cfg, spec.id),
+			Config:    trackerCfg,
 			DBPath:    s.cfg.MainSettings.DBPath,
 			AutoLogin: true,
 			Login:     req,
@@ -293,6 +307,9 @@ func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAu
 				status.ChallengeID = session.ChallengeID
 			}
 			return status, nil
+		}
+		if isBTNSpec(spec) && !s.btnAPIKeyConfigured() {
+			return s.statusForSpec(ctx, spec), nil
 		}
 		status.State = StateConfigured
 		status.Message = "remote login/auth check succeeded"
@@ -305,7 +322,8 @@ func (s *Service) Login(ctx context.Context, trackerID string, req api.TrackerAu
 // Submit2FA completes an active manual 2FA challenge. Adapter failures return
 // refreshed status without consuming the challenge; only failures classified
 // with [ValidationError.Submitted2FARejected] keep the challenge visible for
-// another try.
+// another try. Successful challenge completion clears the challenge fields but
+// does not override separate tracker prerequisites such as BTN's API key.
 func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string) (status api.TrackerAuthStatus, err error) {
 	logTrackerID := ""
 	defer func() {
@@ -362,12 +380,15 @@ func (s *Service) Submit2FA(ctx context.Context, challengeID string, code string
 	if err != nil {
 		return api.TrackerAuthStatus{}, err
 	}
-	if strings.TrimSpace(session.State) == "" || session.State == SessionStateReady {
+	missingBTNAPIKey := isBTNSpec(trackerSpec{id: challenge.TrackerID}) && !s.btnAPIKeyConfigured()
+	if (strings.TrimSpace(session.State) == "" || session.State == SessionStateReady) && !missingBTNAPIKey {
 		status.State = StateConfigured
 	}
 	status.Needs2FA = false
 	status.ChallengeID = ""
-	status.Message = "2FA auth completed"
+	if !missingBTNAPIKey {
+		status.Message = "2FA auth completed"
+	}
 	return status, nil
 }
 
@@ -449,6 +470,9 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) api.Track
 
 	cfg, hasCfg := trackerConfig(s.cfg, spec.id)
 	hasAPIKey := spec.apiKey && configAPIKey(cfg) != ""
+	if isBTNSpec(spec) {
+		hasAPIKey = s.btnAPIKeyConfigured()
+	}
 	hasPasskey := strings.TrimSpace(cfg.Passkey) != ""
 	hasCredentials := spec.login && hasCfg && hasUsableLoginConfig(spec, cfg)
 	if spec.cookies {
@@ -461,8 +485,12 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) api.Track
 		}
 	}
 
-	if hasAPIKey && (!isMTVSpec(spec) || status.CookieCount > 0 || hasCredentials) {
+	if hasAPIKey && (!uploadAuthNeedsCookiesOrLogin(spec) || hasCredentials || (isMTVSpec(spec) && status.CookieCount > 0)) {
 		status.State = StateConfigured
+	}
+	missingBTNAPIKey := isBTNSpec(spec) && !hasAPIKey && (status.CookieCount > 0 || hasCredentials)
+	if missingBTNAPIKey {
+		status.State = StateLoginRequired
 	}
 	if passkeyCoversAuth(spec) && hasPasskey {
 		status.State = StateConfigured
@@ -482,22 +510,56 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) api.Track
 			status.State = StateLoginRequired
 		}
 	}
-	if spec.cookies && status.CookieCount == 0 && !encryptedStorage && authStatusRequiresEncryptedStorage(spec, hasCredentials, hasAPIKey, hasPasskey) {
+	if !missingBTNAPIKey && spec.cookies && status.CookieCount == 0 && !encryptedStorage && authStatusRequiresEncryptedStorage(spec, hasCredentials, hasAPIKey, hasPasskey) {
 		status.State = StateEncryptedStorageUnavailable
 	}
 	status.Message = validationMessage(spec, status)
-	if isMTVSpec(spec) && hasAPIKey && status.CookieCount == 0 && !hasCredentials {
-		status.Message = "API key covers Torznab/search; imported cookies or login credentials required for upload auth"
+	if uploadAuthNeedsCookiesOrLogin(spec) && hasAPIKey && status.CookieCount == 0 && !hasCredentials {
+		status.Message = uploadAuthRequiredMessage(spec)
+	}
+	if missingBTNAPIKey {
+		status.Message = btnMissingAPIKeyMessage()
 	}
 	return status
+}
+
+// btnAPIKeyConfigured reports whether BTN has an API token in tracker config or
+// legacy metadata; a valid browser session is not upload-ready without it.
+func (s *Service) btnAPIKeyConfigured() bool {
+	return strings.TrimSpace(config.ResolveBTNAPIToken(s.cfg)) != ""
+}
+
+// btnMissingAPIKeyMessage is the shared user-visible status for BTN when
+// cookies or credentials can cover upload auth but torrent resolution cannot run.
+func btnMissingAPIKeyMessage() string {
+	return "API key is required for torrent resolution; imported cookies or login credentials cover upload auth"
 }
 
 func isMTVSpec(spec trackerSpec) bool {
 	return strings.EqualFold(spec.id, "MTV")
 }
 
+func isBTNSpec(spec trackerSpec) bool {
+	return strings.EqualFold(spec.id, "BTN")
+}
+
 func isHDBSpec(spec trackerSpec) bool {
 	return strings.EqualFold(spec.id, "HDB")
+}
+
+// uploadAuthNeedsCookiesOrLogin reports trackers where an API key is necessary
+// but does not prove upload-session readiness.
+func uploadAuthNeedsCookiesOrLogin(spec trackerSpec) bool {
+	return isMTVSpec(spec) || isBTNSpec(spec)
+}
+
+// uploadAuthRequiredMessage explains the split between API/search auth and
+// browser-session upload auth for trackers that need both.
+func uploadAuthRequiredMessage(spec trackerSpec) string {
+	if isBTNSpec(spec) {
+		return "API key covers torrent resolution; imported cookies or login credentials required for upload auth"
+	}
+	return "API key covers Torznab/search; imported cookies or login credentials required for upload auth"
 }
 
 func passkeyCoversAuth(spec trackerSpec) bool {
@@ -529,10 +591,10 @@ func authStatusRequiresEncryptedStorage(spec trackerSpec, hasCredentials bool, h
 	if passkeyCoversAuth(spec) && hasPasskey {
 		return false
 	}
-	if spec.apiKey && hasAPIKey && !isMTVSpec(spec) {
+	if spec.apiKey && hasAPIKey && !uploadAuthNeedsCookiesOrLogin(spec) {
 		return false
 	}
-	return !hasAPIKey || isMTVSpec(spec) || hasCredentials
+	return !hasAPIKey || uploadAuthNeedsCookiesOrLogin(spec) || hasCredentials
 }
 
 // specFor resolves built-in and configured tracker IDs through normalizeTrackerID
@@ -598,7 +660,7 @@ func (s *Service) specs() []trackerSpec {
 		if strings.TrimSpace(cfg.Username) != "" || strings.TrimSpace(cfg.Password) != "" {
 			if !ok || spec.login {
 				spec.login = true
-				spec.autoLogin = spec.autoLogin || spec.id == "AR" || spec.id == "FF" || spec.id == "FL" || spec.id == "MTV" || spec.id == "PTP" || spec.id == "RTF" || spec.id == "THR"
+				spec.autoLogin = spec.autoLogin || spec.id == "AR" || spec.id == "BTN" || spec.id == "FF" || spec.id == "FL" || spec.id == "MTV" || spec.id == "PTP" || spec.id == "RTF" || spec.id == "THR"
 				if spec.authKind == "config" {
 					spec.authKind = "credential_login"
 				}
@@ -621,6 +683,7 @@ func (s *Service) specs() []trackerSpec {
 func builtInSpecs() []trackerSpec {
 	return []trackerSpec{
 		{id: "AR", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
+		{id: "BTN", authKind: "api_key_cookies_login_manual_2fa", cookies: true, login: true, autoLogin: true, totp: true, manual2FA: true, apiKey: true, needsCredentials: true, notes: []string{"API key is required for torrent resolution; cookies/login cover upload auth."}},
 		{id: "FF", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
 		{id: "FL", authKind: "cookies_login", cookies: true, login: true, autoLogin: true, needsCredentials: true},
 		{id: "MTV", authKind: "api_key_cookies_login_manual_2fa", cookies: true, login: true, autoLogin: true, totp: true, manual2FA: true, apiKey: true, needsCredentials: true, notes: []string{"API key covers Torznab/search; cookies/login cover upload authkey."}},

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -20,6 +20,7 @@ import (
 	servicedb "github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/internal/trackers/impl/btn"
+	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
 	"github.com/autobrr/upbrr/internal/trackers/impl/mtv"
 	"github.com/autobrr/upbrr/internal/trackers/impl/ptp"
 	"github.com/autobrr/upbrr/pkg/api"
@@ -248,13 +249,19 @@ func TestValidateBTNStoredCookiesPromotesRemoteSuccess(t *testing.T) {
 	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "BTN", map[string]string{"session": "abc"}); err != nil {
 		t.Fatalf("SaveTrackerCookieMap: %v", err)
 	}
+	handlerErr := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/upload.php" {
 			http.NotFound(w, r)
 			return
 		}
 		if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=abc") {
-			t.Fatalf("expected BTN session cookie, got %q", got)
+			select {
+			case handlerErr <- fmt.Errorf("expected BTN session cookie, got %q", got):
+			default:
+			}
+			http.Error(w, "unexpected cookie", http.StatusInternalServerError)
+			return
 		}
 		_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
 	}))
@@ -267,6 +274,11 @@ func TestValidateBTNStoredCookiesPromotesRemoteSuccess(t *testing.T) {
 			"BTN": {URL: server.URL},
 		}},
 	}).Validate(ctx, "BTN")
+	select {
+	case err := <-handlerErr:
+		t.Fatal(err)
+	default:
+	}
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
@@ -309,6 +321,52 @@ func TestValidateBTNRemoteSuccessRequiresAPIKey(t *testing.T) {
 	}
 }
 
+func TestValidateBTNMissingAPIAfterCookieRefreshUpdatesCookieCount(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	handlerErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login.php":
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
+			_, _ = w.Write([]byte("ok"))
+		case "/upload.php":
+			if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=new") {
+				select {
+				case handlerErr <- fmt.Errorf("expected refreshed BTN session cookie, got %q", got):
+				default:
+				}
+				http.Error(w, "unexpected cookie", http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	status, err := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"BTN": {URL: server.URL, Username: "user", Password: "pass"},
+		}},
+	}).Validate(ctx, "BTN")
+	select {
+	case err := <-handlerErr:
+		t.Fatal(err)
+	default:
+	}
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.State != StateLoginRequired || status.CookieCount != 1 || !strings.Contains(status.Message, "API key is required") {
+		t.Fatalf("expected missing API status to include refreshed cookie count, got %#v", status)
+	}
+}
+
 func TestValidateBTNInvalidCookiesDeletesOnlyConfirmedInvalid(t *testing.T) {
 	t.Parallel()
 
@@ -341,6 +399,40 @@ func TestValidateBTNInvalidCookiesDeletesOnlyConfirmedInvalid(t *testing.T) {
 	}
 	if _, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "BTN"); err == nil {
 		t.Fatal("expected BTN cookies to be deleted")
+	}
+}
+
+func TestValidateBTNCookieStorageFailureReportsStorageStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	jsonPath := trackerAuthLegacyCookiePathByExt(t, dbPath, "BTN", ".json")
+	if err := os.MkdirAll(filepath.Dir(jsonPath), 0o755); err != nil {
+		t.Fatalf("mkdir cookie dir: %v", err)
+	}
+	if err := os.WriteFile(jsonPath, []byte(`{"session":`), 0o600); err != nil {
+		t.Fatalf("write malformed cookie file: %v", err)
+	}
+
+	status, err := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Metadata:     config.MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"BTN": {Username: "user", Password: "pass"},
+		}},
+	}).Validate(ctx, "BTN")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.State != StateEncryptedStorageUnavailable {
+		t.Fatalf("expected storage-unavailable state, got %#v", status)
+	}
+	if !strings.Contains(status.Message, "cookie storage unavailable") {
+		t.Fatalf("expected storage failure message, got %#v", status)
+	}
+	if !strings.Contains(status.LastError, "unmarshal") {
+		t.Fatalf("expected parse error detail for CLI/frontend consumers, got %#v", status)
 	}
 }
 
@@ -1308,6 +1400,9 @@ func TestStatusConfiguredAuthReportsEncryptedStorageUnavailableWhenPersistenceRe
 			}
 			if status.EncryptedStorage {
 				t.Fatalf("expected storage availability to remain visible as false: %#v", status)
+			}
+			if !strings.Contains(status.Message, "encrypted cookie storage unavailable") {
+				t.Fatalf("expected storage-specific message, got %#v", status)
 			}
 		})
 	}
@@ -2528,6 +2623,20 @@ func newTrackerAuthTestDB(t *testing.T) string {
 	}
 	_ = repo.Close()
 	return dbPath
+}
+
+// trackerAuthLegacyCookiePathByExt selects the concrete legacy candidate path
+// for auth-status tests that seed malformed cookie files by format.
+func trackerAuthLegacyCookiePathByExt(t *testing.T, dbPath string, trackerID string, ext string) string {
+	t.Helper()
+
+	for _, candidate := range commonhttp.CookiePathCandidates(dbPath, trackerID, ".txt", ".json") {
+		if filepath.Ext(candidate) == ext {
+			return candidate
+		}
+	}
+	t.Fatalf("expected %s legacy cookie path", ext)
+	return ""
 }
 
 func saveTrackerAuthTestConfig(t *testing.T, dbPath string, cfg config.Config) {

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -295,13 +295,19 @@ func TestValidateBTNRemoteSuccessRequiresAPIKey(t *testing.T) {
 	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "BTN", map[string]string{"session": "abc"}); err != nil {
 		t.Fatalf("SaveTrackerCookieMap: %v", err)
 	}
+	handlerErr := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/upload.php" {
 			http.NotFound(w, r)
 			return
 		}
 		if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=abc") {
-			t.Fatalf("expected BTN session cookie, got %q", got)
+			select {
+			case handlerErr <- fmt.Errorf("expected BTN session cookie, got %q", got):
+			default:
+			}
+			http.Error(w, "unexpected cookie", http.StatusInternalServerError)
+			return
 		}
 		_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
 	}))
@@ -313,6 +319,11 @@ func TestValidateBTNRemoteSuccessRequiresAPIKey(t *testing.T) {
 			"BTN": {URL: server.URL},
 		}},
 	}).Validate(ctx, "BTN")
+	select {
+	case err := <-handlerErr:
+		t.Fatal(err)
+	default:
+	}
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
@@ -1234,6 +1245,29 @@ func TestLoginBTNCredentialsWithoutAPIAttemptsSessionValidation(t *testing.T) {
 	}
 	if status.State != StateLoginRequired || !strings.Contains(status.Message, "API key is required") {
 		t.Fatalf("expected successful BTN login to preserve missing API status, got %#v", status)
+	}
+}
+
+func TestLoginBTNCookiesWithoutAPIPreservesMissingAPIStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "BTN", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+
+	status, err := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+	}).Login(ctx, "BTN", api.TrackerAuthLoginRequest{})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if status.State != StateLoginRequired || status.CookieCount != 1 || !strings.Contains(status.Message, "API key is required") {
+		t.Fatalf("expected BTN cookie-only login to preserve missing API status, got %#v", status)
+	}
+	if strings.Contains(status.Message, "username/password missing") {
+		t.Fatalf("missing credentials masked missing API status: %#v", status)
 	}
 }
 

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/autobrr/upbrr/internal/cookies"
 	servicedb "github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
+	"github.com/autobrr/upbrr/internal/trackers/impl/btn"
 	"github.com/autobrr/upbrr/internal/trackers/impl/mtv"
 	"github.com/autobrr/upbrr/internal/trackers/impl/ptp"
 	"github.com/autobrr/upbrr/pkg/api"
@@ -91,6 +92,12 @@ func TestDefaultAdaptersExposeMTVPTPManual2FAChallenge(t *testing.T) {
 			},
 			server: newMTVManual2FAServer,
 		},
+		"BTN": {
+			cfg: func(serverURL string) config.TrackerConfig {
+				return config.TrackerConfig{URL: serverURL, APIKey: "api-token", Username: "user", Password: "pass"}
+			},
+			server: newBTNManual2FAServer,
+		},
 		"PTP": {
 			cfg: func(serverURL string) config.TrackerConfig {
 				return config.TrackerConfig{
@@ -143,6 +150,207 @@ func TestDefaultAdaptersExposeMTVPTPManual2FAChallenge(t *testing.T) {
 				})
 			}
 		})
+	}
+}
+
+func TestBTNCapabilityAndLocalStatusSemantics(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	cfg := config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Metadata:     config.MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"BTN": {},
+		}},
+	}
+	service := NewService(cfg)
+	caps, err := service.Capabilities(ctx)
+	if err != nil {
+		t.Fatalf("Capabilities: %v", err)
+	}
+	var btnCap api.TrackerAuthCapability
+	for _, cap := range caps {
+		if cap.TrackerID == "BTN" {
+			btnCap = cap
+			break
+		}
+	}
+	if btnCap.TrackerID == "" {
+		t.Fatal("expected BTN capability")
+	}
+	if !btnCap.RequiresAPIKey || !btnCap.SupportsCookieFile || !btnCap.SupportsLogin || !btnCap.SupportsAutoLogin || !btnCap.SupportsTOTP || !btnCap.SupportsManual2FA {
+		t.Fatalf("unexpected BTN capability: %#v", btnCap)
+	}
+
+	status, err := service.Status(ctx, "BTN")
+	if err != nil {
+		t.Fatalf("Status api-key only: %v", err)
+	}
+	if status.State != StateLoginRequired && status.State != StateNotConfigured {
+		t.Fatalf("BTN API-key-only must not be upload-ready, got %#v", status)
+	}
+	if !strings.Contains(status.Message, "imported cookies or login credentials required") {
+		t.Fatalf("expected upload-auth message, got %#v", status)
+	}
+
+	cfg.Trackers.Trackers["BTN"] = config.TrackerConfig{Username: "user", Password: "pass"}
+	service = NewService(cfg)
+	status, err = service.Status(ctx, "BTN")
+	if err != nil {
+		t.Fatalf("Status credentials: %v", err)
+	}
+	if status.State != StateConfigured {
+		t.Fatalf("expected BTN API key plus credentials configured, got %#v", status)
+	}
+
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "BTN", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	cfg.Trackers.Trackers["BTN"] = config.TrackerConfig{}
+	service = NewService(cfg)
+	status, err = service.Status(ctx, "BTN")
+	if err != nil {
+		t.Fatalf("Status cookies: %v", err)
+	}
+	if status.State != StateHasCookies || status.CookieCount != 1 {
+		t.Fatalf("expected BTN stored cookies to remain local has_cookies, got %#v", status)
+	}
+
+	cfg.Metadata.BTNAPI = ""
+	cfg.Trackers.Trackers["BTN"] = config.TrackerConfig{Username: "user", Password: "pass"}
+	service = NewService(cfg)
+	status, err = service.Status(ctx, "BTN")
+	if err != nil {
+		t.Fatalf("Status missing API key: %v", err)
+	}
+	if status.State != StateLoginRequired || !strings.Contains(status.Message, "API key is required") {
+		t.Fatalf("expected missing API key to block BTN upload readiness, got %#v", status)
+	}
+
+	cfg.MainSettings.DBPath = filepath.Join(t.TempDir(), "missing-auth", "upbrr.db")
+	service = NewService(cfg)
+	status, err = service.Status(ctx, "BTN")
+	if err != nil {
+		t.Fatalf("Status missing API key without encrypted storage: %v", err)
+	}
+	if status.State != StateLoginRequired || status.EncryptedStorage || !strings.Contains(status.Message, "API key is required") {
+		t.Fatalf("expected missing API key to take precedence over encrypted storage, got %#v", status)
+	}
+}
+
+func TestValidateBTNStoredCookiesPromotesRemoteSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "BTN", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/upload.php" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=abc") {
+			t.Fatalf("expected BTN session cookie, got %q", got)
+		}
+		_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
+	}))
+	t.Cleanup(server.Close)
+
+	status, err := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Metadata:     config.MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"BTN": {URL: server.URL},
+		}},
+	}).Validate(ctx, "BTN")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.State != StateConfigured || status.Message != "remote auth check succeeded" {
+		t.Fatalf("expected successful BTN auth validation, got %#v", status)
+	}
+}
+
+func TestValidateBTNRemoteSuccessRequiresAPIKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "BTN", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/upload.php" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=abc") {
+			t.Fatalf("expected BTN session cookie, got %q", got)
+		}
+		_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
+	}))
+	t.Cleanup(server.Close)
+
+	status, err := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"BTN": {URL: server.URL},
+		}},
+	}).Validate(ctx, "BTN")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.State != StateLoginRequired || status.CookieCount != 1 || !strings.Contains(status.Message, "API key is required") {
+		t.Fatalf("expected validated BTN session to remain blocked by missing API key, got %#v", status)
+	}
+}
+
+func TestValidateBTNInvalidCookiesDeletesOnlyConfirmedInvalid(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "BTN", map[string]string{"session": "expired"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/upload.php" {
+			http.NotFound(w, r)
+			return
+		}
+		http.Redirect(w, r, "/login.php", http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+
+	status, err := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Metadata:     config.MetadataConfig{BTNAPI: "legacy-token"},
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"BTN": {URL: server.URL},
+		}},
+	}).Validate(ctx, "BTN")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.State != StateLoginRequired || status.CookieCount != 0 {
+		t.Fatalf("expected confirmed-invalid BTN cookies to be deleted, got %#v", status)
+	}
+	if _, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "BTN"); err == nil {
+		t.Fatal("expected BTN cookies to be deleted")
+	}
+}
+
+func TestClassifyAdapterErrorRecognizesBTNSubmitted2FARejected(t *testing.T) {
+	t.Parallel()
+
+	err := classifyAdapterError("BTN", fmt.Errorf("login failed: %w", btn.ErrSubmitted2FARejected))
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) || !validationErr.Transient || !validationErr.Submitted2FARejected || validationErr.ConfirmedInvalid {
+		t.Fatalf("expected retry-visible BTN submitted 2FA rejection, got %v", err)
 	}
 }
 
@@ -461,6 +669,58 @@ func TestSubmit2FARetriesAdapterLoginWithCurrentConfigAndCode(t *testing.T) {
 	}
 	if gotCode != "654321" || gotDBPath != dbPath || gotUsername != "user" {
 		t.Fatalf("unexpected adapter retry args code=%q db=%q username=%q", gotCode, gotDBPath, gotUsername)
+	}
+}
+
+func TestSubmit2FABTNSuccessPreservesMissingAPIStatus(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newTrackerAuthTestDB(t)
+	cfg := config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"BTN": {Username: "user", Password: "pass"},
+			},
+		},
+	}
+	var gotCode string
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{
+			TrackerID:         "BTN",
+			SupportsLogin:     true,
+			SupportsManual2FA: true,
+		},
+		validate: func() (Session, error) {
+			return Session{}, &Needs2FAError{TrackerID: "BTN"}
+		},
+		submit: func(_ context.Context, _ config.TrackerConfig, _ string, req api.TrackerAuthLoginRequest) (Session, error) {
+			gotCode = req.Code
+			return Session{TrackerID: "BTN", State: SessionStateReady}, nil
+		},
+	}
+	service := NewService(cfg)
+	service.adapters = map[string]Adapter{"BTN": adapter}
+
+	status, err := service.Login(context.Background(), "BTN", api.TrackerAuthLoginRequest{})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if strings.TrimSpace(status.ChallengeID) == "" {
+		t.Fatalf("expected challenge: %#v", status)
+	}
+	status, err = service.Submit2FA(context.Background(), status.ChallengeID, "654321")
+	if err != nil {
+		t.Fatalf("Submit2FA: %v", err)
+	}
+	if gotCode != "654321" {
+		t.Fatalf("unexpected submitted code %q", gotCode)
+	}
+	if status.Needs2FA || status.ChallengeID != "" {
+		t.Fatalf("expected challenge cleared after successful submit, got %#v", status)
+	}
+	if status.State != StateLoginRequired || !strings.Contains(status.Message, "API key is required") {
+		t.Fatalf("expected successful BTN 2FA to preserve missing API status, got %#v", status)
 	}
 }
 
@@ -847,6 +1107,41 @@ func TestLoginMissingCredentialsReturnsLoginRequiredWithoutChallenge(t *testing.
 	}
 	if status.Needs2FA || strings.TrimSpace(status.ChallengeID) != "" {
 		t.Fatalf("missing credentials must not create manual 2FA challenge: %#v", status)
+	}
+}
+
+func TestLoginBTNCredentialsWithoutAPIAttemptsSessionValidation(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: newTrackerAuthTestDB(t)},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"BTN": {Username: "user", Password: "pass"},
+			},
+		},
+	}
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{TrackerID: "BTN", SupportsLogin: true},
+		validate: func() (Session, error) {
+			return Session{}, &AuthRequiredError{TrackerID: "BTN", Reason: "login required"}
+		},
+		login: func() (Session, error) {
+			return Session{TrackerID: "BTN", State: SessionStateReady}, nil
+		},
+	}
+	service := NewService(cfg)
+	service.adapters = map[string]Adapter{"BTN": adapter}
+
+	status, err := service.Login(context.Background(), "BTN", api.TrackerAuthLoginRequest{})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if adapter.validateCalls != 1 || adapter.loginCalls != 1 {
+		t.Fatalf("expected BTN session validation and login, got validate=%d login=%d", adapter.validateCalls, adapter.loginCalls)
+	}
+	if status.State != StateLoginRequired || !strings.Contains(status.Message, "API key is required") {
+		t.Fatalf("expected successful BTN login to preserve missing API status, got %#v", status)
 	}
 }
 
@@ -1616,6 +1911,27 @@ func TestImportCookiesReportsMergedCookieCount(t *testing.T) {
 	}
 }
 
+func TestImportCookiesPreservesBTNMissingAPIStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	service := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"BTN": {},
+		}},
+	})
+
+	status, err := service.ImportCookies(ctx, "BTN", "cookies.json", `{"session":"abc"}`)
+	if err != nil {
+		t.Fatalf("ImportCookies: %v", err)
+	}
+	if status.State != StateLoginRequired || status.CookieCount != 1 || !strings.Contains(status.Message, "API key is required") {
+		t.Fatalf("expected missing BTN API to survive cookie import, got %#v", status)
+	}
+}
+
 func TestCapabilitiesAdvertiseOnlySupportedManual2FA(t *testing.T) {
 	t.Parallel()
 
@@ -2257,6 +2573,23 @@ func newMTVManual2FAServer(t *testing.T) *httptest.Server {
 			http.Redirect(w, r, "/twofactor/login", http.StatusFound)
 		case "/twofactor/login":
 			_, _ = w.Write([]byte(`<input name="token" value="ponmlkjihgfedcba">`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newBTNManual2FAServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/upload.php":
+			_, _ = w.Write([]byte(`<form action="/login.php"><input type="password" name="password"></form>`))
+		case "/login.php":
+			_, _ = w.Write([]byte(`<form><input name="codenumber" value=""></form><p>2FA required</p>`))
 		default:
 			http.NotFound(w, r)
 		}

--- a/internal/trackers/impl/btn/definition.go
+++ b/internal/trackers/impl/btn/definition.go
@@ -65,8 +65,5 @@ func validateBTNRequest(req trackers.UploadRequest) error {
 	if strings.TrimSpace(config.ResolveBTNAPIToken(req.AppConfig)) == "" {
 		return errors.New("trackers: BTN requires trackers.BTN.api_key")
 	}
-	if strings.TrimSpace(req.TrackerConfig.Username) == "" || strings.TrimSpace(req.TrackerConfig.Password) == "" {
-		return errors.New("trackers: BTN missing username/password")
-	}
 	return nil
 }

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -887,14 +887,11 @@ func resolveBTN2FACode(cfg config.TrackerConfig, login api.TrackerAuthLoginReque
 	return resolve2FACode(strings.TrimSpace(cfg.OTPURI))
 }
 
-// btnLoginNeeds2FA recognizes login responses that ask for a BTN manual 2FA
-// code instead of accepting the submitted credentials.
+// btnLoginNeeds2FA recognizes BTN login responses that render the manual 2FA
+// challenge field instead of accepting the submitted credentials.
 func btnLoginNeeds2FA(body string) bool {
 	lower := strings.ToLower(body)
-	return strings.Contains(lower, "2fa required") ||
-		strings.Contains(lower, "two-factor") ||
-		strings.Contains(lower, "two factor") ||
-		strings.Contains(lower, "name=\"codenumber\"") ||
+	return strings.Contains(lower, "name=\"codenumber\"") ||
 		strings.Contains(lower, "name='codenumber'")
 }
 

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -51,6 +51,15 @@ var (
 	btnSuccessURLPattern   = regexp.MustCompile(`torrents\.php\?id=(\d+)(?:&torrentid=(\d+))?`)
 )
 
+// ErrSubmitted2FARejected marks a BTN failure after a submitted manual 2FA code
+// reached the tracker and was rejected.
+var ErrSubmitted2FARejected = errors.New("trackers: BTN submitted 2FA rejected")
+
+var (
+	errBTNCookiesMissing          = errors.New("trackers: BTN cookies not configured")
+	errBTNSessionConfirmedInvalid = errors.New("trackers: BTN stored session confirmed invalid")
+)
+
 type uploadContext struct {
 	baseURL   string
 	uploadURL string
@@ -73,9 +82,11 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if err != nil {
 		return api.UploadSummary{}, err
 	}
-	if err := login(ctx, uploadCtx, req.TrackerConfig); err != nil {
+	client, err := ensureBTNUploadSession(ctx, req.TrackerConfig, req.AppConfig.MainSettings.DBPath, uploadCtx)
+	if err != nil {
 		return api.UploadSummary{}, err
 	}
+	uploadCtx.client = client
 
 	data, err := prepareUploadData(ctx, req, uploadCtx)
 	if err != nil {
@@ -210,32 +221,196 @@ func newUploadContext(ctx context.Context, req trackers.UploadRequest) (uploadCo
 		apiURL:    resolveBTNAPIURL(req.TrackerConfig),
 		client:    client,
 	}
-	loadCookies(ctx, client, req.AppConfig.MainSettings.DBPath, baseURL)
+	loadBTNCookiesIntoJar(ctx, client, req.AppConfig.MainSettings.DBPath, baseURL)
 	return uploadCtx, nil
 }
 
-func login(ctx context.Context, uploadCtx uploadContext, cfg config.TrackerConfig) error {
+// ensureBTNUploadSession validates imported BTN cookies before credential login.
+// Credential login cookies are persisted only after the refreshed client reaches
+// the upload page, so failed or incomplete logins do not replace stored auth.
+func ensureBTNUploadSession(ctx context.Context, cfg config.TrackerConfig, dbPath string, uploadCtx uploadContext) (*http.Client, error) {
+	values, cookieErr := loadBTNCookies(ctx, dbPath)
+	if cookieErr == nil && len(values) > 0 {
+		if client, err := newBTNClientWithCookies(uploadCtx.baseURL, values); err == nil {
+			if err := validateBTNClientSession(ctx, client, uploadCtx.baseURL); err == nil {
+				return client, nil
+			} else if !errors.Is(err, errBTNSessionConfirmedInvalid) {
+				return nil, err
+			}
+		}
+	}
+	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
+		return nil, errors.New("trackers: BTN cookie invalid/missing and username/password not configured")
+	}
+	client, err := loginBTNSession(ctx, cfg, uploadCtx.baseURL, api.TrackerAuthLoginRequest{})
+	if err != nil {
+		return nil, err
+	}
+	if err := validateBTNClientSession(ctx, client, uploadCtx.baseURL); err != nil {
+		return nil, err
+	}
+	if err := persistBTNCookies(ctx, dbPath, uploadCtx.baseURL, client.Jar); err != nil {
+		return nil, fmt.Errorf("trackers: BTN persist cookies after successful login: %w", err)
+	}
+	return client, nil
+}
+
+// ResolveSessionForTrackerAuth validates BTN stored cookies or logs in with
+// configured credentials. Credential login must produce reusable cookies before
+// refreshed cookies are persisted.
+func ResolveSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string) error {
+	return ResolveSessionForTrackerAuthLogin(ctx, cfg, dbPath, api.TrackerAuthLoginRequest{})
+}
+
+// ResolveSessionForTrackerAuthLogin validates BTN stored cookies or logs in
+// with configured credentials. Refreshed cookies are persisted only after the
+// upload page confirms the session. Manual login.Code is preferred over
+// configured TOTP. Missing 2FA input preserves existing cookies; a rejected
+// submitted code returns [ErrSubmitted2FARejected] before persistence.
+func ResolveSessionForTrackerAuthLogin(ctx context.Context, cfg config.TrackerConfig, dbPath string, login api.TrackerAuthLoginRequest) error {
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
+	if baseURL == "" {
+		baseURL = btnDefaultBaseURL
+	}
+	err := validateBTNStoredCookies(ctx, baseURL, dbPath)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, errBTNCookiesMissing) && !errors.Is(err, errBTNSessionConfirmedInvalid) {
+		return err
+	}
+	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
+		if errors.Is(err, errBTNSessionConfirmedInvalid) {
+			return err
+		}
+		return errors.New("trackers: BTN cookie invalid/missing and username/password not configured")
+	}
+	client, err := loginBTNSession(ctx, cfg, baseURL, login)
+	if err != nil {
+		return err
+	}
+	if err := validateBTNClientSession(ctx, client, baseURL); err != nil {
+		if strings.TrimSpace(login.Code) != "" && errors.Is(err, errBTNSessionConfirmedInvalid) {
+			return fmt.Errorf("trackers: BTN submitted 2FA validation failed: %w", ErrSubmitted2FARejected)
+		}
+		return err
+	}
+	if err := persistBTNCookies(ctx, dbPath, baseURL, client.Jar); err != nil {
+		return fmt.Errorf("trackers: BTN persist cookies after successful login: %w", err)
+	}
+	return nil
+}
+
+// validateBTNStoredCookies checks persisted BTN cookies against the upload page.
+// Confirmed logged-out evidence is returned distinctly so tracker auth can delete
+// stale cookies; ambiguous remote or parser failures preserve stored cookies.
+func validateBTNStoredCookies(ctx context.Context, baseURL string, dbPath string) error {
+	values, err := loadBTNCookies(ctx, dbPath)
+	if err != nil || len(values) == 0 {
+		return errBTNCookiesMissing
+	}
+	client, err := newBTNClientWithCookies(baseURL, values)
+	if err != nil {
+		return err
+	}
+	return validateBTNClientSession(ctx, client, baseURL)
+}
+
+// loginBTNSession performs the credential login step and leaves cookie
+// persistence to callers after they validate the resulting upload session.
+func loginBTNSession(ctx context.Context, cfg config.TrackerConfig, baseURL string, login api.TrackerAuthLoginRequest) (*http.Client, error) {
+	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
+		return nil, errors.New("trackers: BTN requires username/password")
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("trackers: BTN create login cookie jar: %w", err)
+	}
+	client := &http.Client{Timeout: 45 * time.Second, Jar: jar}
 	values := url.Values{}
 	values.Set("username", strings.TrimSpace(cfg.Username))
 	values.Set("password", strings.TrimSpace(cfg.Password))
 	values.Set("keeplogged", "1")
-	if code, err := resolve2FACode(strings.TrimSpace(cfg.OTPURI)); err == nil && code != "" {
+	if code, err := resolveBTN2FACode(cfg, login); err == nil && code != "" {
 		values.Set("codenumber", code)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(uploadCtx.baseURL, "/")+btnLoginPath, strings.NewReader(values.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(baseURL, "/")+btnLoginPath, strings.NewReader(values.Encode()))
 	if err != nil {
-		return fmt.Errorf("trackers: BTN login request: %w", err)
+		return nil, fmt.Errorf("trackers: BTN login request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("User-Agent", "upbrr")
 
-	resp, err := uploadCtx.client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("trackers: BTN login request: %w", err)
+		return nil, fmt.Errorf("trackers: BTN login request: %w", err)
 	}
 	defer resp.Body.Close()
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if readErr != nil {
+		return nil, fmt.Errorf("trackers: BTN read login response: %w", readErr)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return fmt.Errorf("trackers: BTN login failed status=%d", resp.StatusCode)
+		if strings.TrimSpace(login.Code) != "" && resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("trackers: BTN login failed status=%d: %w", resp.StatusCode, ErrSubmitted2FARejected)
+		}
+		return nil, fmt.Errorf("trackers: BTN login failed status=%d", resp.StatusCode)
+	}
+	bodyText := string(body)
+	if btnLoginNeeds2FA(bodyText) {
+		if strings.TrimSpace(login.Code) != "" {
+			return nil, fmt.Errorf("trackers: BTN login failed: %w", ErrSubmitted2FARejected)
+		}
+		if _, err := resolveBTN2FACode(config.TrackerConfig{OTPURI: cfg.OTPURI}, api.TrackerAuthLoginRequest{}); err != nil {
+			return nil, fmt.Errorf("trackers: BTN 2FA required: %w", err)
+		}
+	}
+	if btnLoginFailed(bodyText) {
+		if strings.TrimSpace(login.Code) != "" {
+			return nil, fmt.Errorf("trackers: BTN login failed: %w", ErrSubmitted2FARejected)
+		}
+		return nil, errors.New("trackers: BTN login failed")
+	}
+	return client, nil
+}
+
+// validateBTNClientSession confirms the client can reach BTN's upload page.
+// It treats explicit login redirects and logged-out markers as invalid session
+// evidence while keeping layout misses and upstream failures transient.
+func validateBTNClientSession(ctx context.Context, client *http.Client, baseURL string) error {
+	if client == nil {
+		return errors.New("trackers: BTN session client missing")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+btnUploadPath, nil)
+	if err != nil {
+		return fmt.Errorf("trackers: BTN upload auth request build: %w", err)
+	}
+	req.Header.Set("User-Agent", "upbrr")
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("trackers: BTN upload auth request: %w", err)
+	}
+	defer resp.Body.Close()
+	finalPath := ""
+	if resp.Request != nil && resp.Request.URL != nil {
+		finalPath = strings.ToLower(resp.Request.URL.EscapedPath())
+	}
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if readErr != nil {
+		return fmt.Errorf("trackers: BTN read upload auth response: %w", readErr)
+	}
+	bodyText := string(body)
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || strings.Contains(finalPath, "login") || btnLoggedOutPage(bodyText) {
+		return fmt.Errorf("%w: login required", errBTNSessionConfirmedInvalid)
+	}
+	if resp.StatusCode >= 500 {
+		return fmt.Errorf("trackers: BTN upload auth unavailable status=%d", resp.StatusCode)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("trackers: BTN upload auth failed status=%d", resp.StatusCode)
+	}
+	if !btnLooksLikeUploadPage(bodyText) {
+		return errors.New("trackers: BTN upload auth page validation failed")
 	}
 	return nil
 }
@@ -583,12 +758,45 @@ func resolveAndDownloadViaAPI(ctx context.Context, apiURL string, apiToken strin
 	return nil
 }
 
-func loadCookies(ctx context.Context, client *http.Client, dbPath string, baseURL string) {
+// loadBTNCookiesIntoJar best-effort seeds an upload client with persisted BTN
+// cookies. Missing or unreadable cookies leave the caller's client unchanged.
+func loadBTNCookiesIntoJar(ctx context.Context, client *http.Client, dbPath string, baseURL string) {
 	if client == nil || client.Jar == nil {
 		return
 	}
+	values, err := loadBTNCookies(ctx, dbPath)
+	if err != nil {
+		return
+	}
+	setBTNCookies(client.Jar, baseURL, values)
+}
+
+// loadBTNCookies reads persisted BTN cookies and wraps storage errors with
+// tracker context for upload and tracker-auth callers.
+func loadBTNCookies(ctx context.Context, dbPath string) (map[string]string, error) {
 	values, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "BTN")
 	if err != nil {
+		return nil, fmt.Errorf("trackers: %w", err)
+	}
+	return values, nil
+}
+
+// newBTNClientWithCookies creates a short-lived BTN client with a fresh cookie
+// jar populated from the supplied stored cookie map.
+func newBTNClientWithCookies(baseURL string, values map[string]string) (*http.Client, error) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("trackers: BTN create session cookie jar: %w", err)
+	}
+	setBTNCookies(jar, baseURL, values)
+	return &http.Client{Timeout: 45 * time.Second, Jar: jar}, nil
+}
+
+// setBTNCookies mirrors stored BTN cookie values into jar for baseURL. Invalid
+// base URLs or nil jars are ignored because callers treat cookie seeding as
+// best-effort before explicit session validation.
+func setBTNCookies(jar http.CookieJar, baseURL string, values map[string]string) {
+	if jar == nil {
 		return
 	}
 	parsed, err := url.Parse(baseURL)
@@ -600,7 +808,92 @@ func loadCookies(ctx context.Context, client *http.Client, dbPath string, baseUR
 		// #nosec G124 -- Outbound tracker jar cookie mirrors configured BTN session values.
 		jarCookies = append(jarCookies, &http.Cookie{Name: name, Value: value, Domain: parsed.Hostname(), Path: "/"})
 	}
-	client.Jar.SetCookies(parsed, jarCookies)
+	jar.SetCookies(parsed, jarCookies)
+}
+
+// persistBTNCookies saves cookies extracted from a caller-validated BTN client jar.
+func persistBTNCookies(ctx context.Context, dbPath string, baseURL string, jar http.CookieJar) error {
+	values, err := btnCookiesFromJar(baseURL, jar)
+	if err != nil {
+		return err
+	}
+	if len(values) == 0 {
+		return errors.New("trackers: BTN login returned no usable cookies")
+	}
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "BTN", values); err != nil {
+		return fmt.Errorf("trackers: BTN save cookies: %w", err)
+	}
+	return nil
+}
+
+// btnCookiesFromJar extracts non-empty BTN cookie names and values for baseURL
+// after a caller has validated that the jar represents a usable session.
+func btnCookiesFromJar(baseURL string, jar http.CookieJar) (map[string]string, error) {
+	if jar == nil {
+		return nil, errors.New("trackers: BTN login returned no cookie jar")
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("trackers: BTN parse cookie URL: %w", err)
+	}
+	out := make(map[string]string)
+	for _, cookie := range jar.Cookies(parsed) {
+		if cookie == nil || strings.TrimSpace(cookie.Name) == "" || strings.TrimSpace(cookie.Value) == "" {
+			continue
+		}
+		out[strings.TrimSpace(cookie.Name)] = cookie.Value
+	}
+	return out, nil
+}
+
+// resolveBTN2FACode returns a manually submitted code before falling back to
+// the configured TOTP URI.
+func resolveBTN2FACode(cfg config.TrackerConfig, login api.TrackerAuthLoginRequest) (string, error) {
+	if code := strings.TrimSpace(login.Code); code != "" {
+		return code, nil
+	}
+	return resolve2FACode(strings.TrimSpace(cfg.OTPURI))
+}
+
+// btnLoginNeeds2FA recognizes login responses that ask for a BTN manual 2FA
+// code instead of accepting the submitted credentials.
+func btnLoginNeeds2FA(body string) bool {
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "2fa required") ||
+		strings.Contains(lower, "two-factor") ||
+		strings.Contains(lower, "two factor") ||
+		strings.Contains(lower, "name=\"codenumber\"") ||
+		strings.Contains(lower, "name='codenumber'")
+}
+
+// btnLoginFailed recognizes explicit BTN credential or submitted-code failures
+// in successful HTTP responses.
+func btnLoginFailed(body string) bool {
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "invalid login") ||
+		strings.Contains(lower, "incorrect password") ||
+		strings.Contains(lower, "invalid code") ||
+		strings.Contains(lower, "incorrect code") ||
+		strings.Contains(lower, "login failed")
+}
+
+// btnLoggedOutPage recognizes upload-page responses that prove the session is
+// logged out and safe to classify as confirmed-invalid auth.
+func btnLoggedOutPage(body string) bool {
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "<form") && (strings.Contains(lower, "password") || strings.Contains(lower, "login.php")) ||
+		strings.Contains(lower, "you must be logged in") ||
+		strings.Contains(lower, "please log in")
+}
+
+// btnLooksLikeUploadPage recognizes enough upload-page structure to confirm a
+// BTN session without depending on one exact page layout.
+func btnLooksLikeUploadPage(body string) bool {
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "upload") ||
+		strings.Contains(lower, "name=\"file_input\"") ||
+		strings.Contains(lower, "name='file_input'") ||
+		strings.Contains(lower, "autofill")
 }
 
 func resolve2FACode(otpURI string) (string, error) {

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -167,6 +167,9 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 	if err := validateBTNRequest(req); err != nil {
 		return api.TrackerDryRunEntry{}, err
 	}
+	if err := validateBTNDryRunUploadAuth(ctx, req); err != nil {
+		return api.TrackerDryRunEntry{}, err
+	}
 
 	uploadCtx, err := newUploadContext(ctx, req)
 	if err != nil {
@@ -204,6 +207,24 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 	}, nil
 }
 
+// validateBTNDryRunUploadAuth checks only local auth prerequisites needed before
+// an upload can authenticate. It does not perform remote login or persist cookies
+// during dry-run, and it preserves storage/decrypt failures instead of treating
+// them as missing cookies.
+func validateBTNDryRunUploadAuth(ctx context.Context, req trackers.UploadRequest) error {
+	values, cookieErr := loadBTNCookies(ctx, req.AppConfig.MainSettings.DBPath)
+	if cookieErr == nil && len(values) > 0 {
+		return nil
+	}
+	if cookieErr != nil && !errors.Is(cookieErr, errBTNCookiesMissing) {
+		return cookieErr
+	}
+	if strings.TrimSpace(req.TrackerConfig.Username) == "" || strings.TrimSpace(req.TrackerConfig.Password) == "" {
+		return errors.New("trackers: BTN cookie invalid/missing and username/password not configured")
+	}
+	return nil
+}
+
 func newUploadContext(ctx context.Context, req trackers.UploadRequest) (uploadContext, error) {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
@@ -238,6 +259,9 @@ func ensureBTNUploadSession(ctx context.Context, cfg config.TrackerConfig, dbPat
 				return nil, err
 			}
 		}
+	}
+	if cookieErr != nil && !errors.Is(cookieErr, errBTNCookiesMissing) {
+		return nil, cookieErr
 	}
 	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
 		return nil, errors.New("trackers: BTN cookie invalid/missing and username/password not configured")
@@ -303,10 +327,14 @@ func ResolveSessionForTrackerAuthLogin(ctx context.Context, cfg config.TrackerCo
 
 // validateBTNStoredCookies checks persisted BTN cookies against the upload page.
 // Confirmed logged-out evidence is returned distinctly so tracker auth can delete
-// stale cookies; ambiguous remote or parser failures preserve stored cookies.
+// stale cookies; storage/decrypt failures and ambiguous remote/parser failures
+// preserve stored cookies and block credential login.
 func validateBTNStoredCookies(ctx context.Context, baseURL string, dbPath string) error {
 	values, err := loadBTNCookies(ctx, dbPath)
-	if err != nil || len(values) == 0 {
+	if err != nil {
+		return err
+	}
+	if len(values) == 0 {
 		return errBTNCookiesMissing
 	}
 	client, err := newBTNClientWithCookies(baseURL, values)
@@ -771,11 +799,15 @@ func loadBTNCookiesIntoJar(ctx context.Context, client *http.Client, dbPath stri
 	setBTNCookies(client.Jar, baseURL, values)
 }
 
-// loadBTNCookies reads persisted BTN cookies and wraps storage errors with
-// tracker context for upload and tracker-auth callers.
+// loadBTNCookies reads persisted BTN cookies and maps only typed not-found
+// results to the BTN missing-cookie sentinel. Storage, parse, and decrypt errors
+// are returned with tracker context so callers can avoid replacing valid state.
 func loadBTNCookies(ctx context.Context, dbPath string) (map[string]string, error) {
 	values, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "BTN")
 	if err != nil {
+		if errors.Is(err, cookies.ErrTrackerCookiesNotFound) {
+			return nil, errBTNCookiesMissing
+		}
 		return nil, fmt.Errorf("trackers: %w", err)
 	}
 	return values, nil
@@ -890,10 +922,16 @@ func btnLoggedOutPage(body string) bool {
 // BTN session without depending on one exact page layout.
 func btnLooksLikeUploadPage(body string) bool {
 	lower := strings.ToLower(body)
-	return strings.Contains(lower, "upload") ||
-		strings.Contains(lower, "name=\"file_input\"") ||
-		strings.Contains(lower, "name='file_input'") ||
-		strings.Contains(lower, "autofill")
+	hasForm := strings.Contains(lower, "<form")
+	hasUploadAction := strings.Contains(lower, "action=\"/upload.php") ||
+		strings.Contains(lower, "action='/upload.php") ||
+		strings.Contains(lower, "action=\"upload.php") ||
+		strings.Contains(lower, "action='upload.php")
+	hasFileInput := strings.Contains(lower, "name=\"file_input\"") ||
+		strings.Contains(lower, "name='file_input'")
+	hasAutofill := strings.Contains(lower, "name=\"autofill\"") ||
+		strings.Contains(lower, "name='autofill'")
+	return hasForm && (hasFileInput || (hasUploadAction && hasAutofill))
 }
 
 func resolve2FACode(otpURI string) (string, error) {

--- a/internal/trackers/impl/btn/upload_integration_test.go
+++ b/internal/trackers/impl/btn/upload_integration_test.go
@@ -349,6 +349,161 @@ func TestBTNUploadUsesValidImportedCookiesWithoutCredentials(t *testing.T) {
 	}
 }
 
+func TestBTNUploadStoredCookieLoadErrorPreventsLogin(t *testing.T) {
+	t.Parallel()
+
+	var loginCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login.php":
+			loginCalls.Add(1)
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
+			_, _ = w.Write([]byte("ok"))
+		case "/upload.php":
+			_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := os.WriteFile(dbPath, []byte("not a sqlite database"), 0o600); err != nil {
+		t.Fatalf("write corrupt db: %v", err)
+	}
+
+	_, err := ensureBTNUploadSession(context.Background(), config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath, uploadContext{baseURL: server.URL})
+	if err == nil {
+		t.Fatal("expected stored cookie load error")
+	}
+	if errors.Is(err, errBTNCookiesMissing) || strings.Contains(err.Error(), "cookie invalid/missing") {
+		t.Fatalf("expected storage error, got %v", err)
+	}
+	if loginCalls.Load() != 0 {
+		t.Fatalf("expected storage error to prevent login, got %d login calls", loginCalls.Load())
+	}
+}
+
+func TestBTNDryRunRequiresUploadAuthPrerequisites(t *testing.T) {
+	t.Parallel()
+
+	baseReq := newBTNDryRunTestRequest(t, newBTNAuthDB(t))
+	_, err := buildUploadDryRun(context.Background(), baseReq)
+	if err == nil || !strings.Contains(err.Error(), "cookie invalid/missing and username/password not configured") {
+		t.Fatalf("expected BTN dry-run to block API-key-only upload auth, got %v", err)
+	}
+
+	credentialsReq := newBTNDryRunTestRequest(t, newBTNAuthDB(t))
+	credentialsReq.TrackerConfig.Username = "user"
+	credentialsReq.TrackerConfig.Password = "pass"
+	entry, err := buildUploadDryRun(context.Background(), credentialsReq)
+	if err != nil {
+		t.Fatalf("BuildUploadDryRun with credentials: %v", err)
+	}
+	if entry.Status != "ready" {
+		t.Fatalf("expected credentials to satisfy dry-run upload auth prerequisites, got %#v", entry)
+	}
+
+	cookieDBPath := newBTNAuthDB(t)
+	if err := cookies.SaveTrackerCookieMap(context.Background(), cookieDBPath, "BTN", map[string]string{"session": "imported"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	cookieReq := newBTNDryRunTestRequest(t, cookieDBPath)
+	entry, err = buildUploadDryRun(context.Background(), cookieReq)
+	if err != nil {
+		t.Fatalf("BuildUploadDryRun with stored cookies: %v", err)
+	}
+	if entry.Status != "ready" {
+		t.Fatalf("expected stored cookies to satisfy dry-run upload auth prerequisites, got %#v", entry)
+	}
+}
+
+func TestResolveSessionForTrackerAuthLoginStorageErrorPreventsLogin(t *testing.T) {
+	t.Parallel()
+
+	var loginCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login.php":
+			loginCalls.Add(1)
+			_, _ = w.Write([]byte(`<form><input name="codenumber" /></form><p>2FA required</p>`))
+		case "/upload.php":
+			_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := os.WriteFile(dbPath, []byte("not a sqlite database"), 0o600); err != nil {
+		t.Fatalf("write corrupt db: %v", err)
+	}
+
+	err := ResolveSessionForTrackerAuthLogin(context.Background(), config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath, api.TrackerAuthLoginRequest{})
+	if err == nil {
+		t.Fatal("expected stored cookie load error")
+	}
+	if errors.Is(err, errBTNCookiesMissing) || strings.Contains(err.Error(), "2FA required") {
+		t.Fatalf("expected storage error, got %v", err)
+	}
+	if loginCalls.Load() != 0 {
+		t.Fatalf("expected storage error to prevent login or 2FA, got %d login calls", loginCalls.Load())
+	}
+}
+
+func TestResolveSessionForTrackerAuthLoginDecryptErrorPreventsPersistence(t *testing.T) {
+	t.Parallel()
+
+	var loginCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login.php":
+			loginCalls.Add(1)
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
+			_, _ = w.Write([]byte("ok"))
+		case "/upload.php":
+			_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := context.Background()
+	dbPath := newBTNAuthDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "BTN", map[string]string{"session": "old"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	corruptBTNCookieAuthTag(t, dbPath)
+
+	err := ResolveSessionForTrackerAuthLogin(ctx, config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath, api.TrackerAuthLoginRequest{})
+	if err == nil {
+		t.Fatal("expected stored cookie decrypt error")
+	}
+	if errors.Is(err, errBTNCookiesMissing) || strings.Contains(err.Error(), "cookie invalid/missing") {
+		t.Fatalf("expected decrypt storage error, got %v", err)
+	}
+	if loginCalls.Load() != 0 {
+		t.Fatalf("expected decrypt error to prevent login, got %d login calls", loginCalls.Load())
+	}
+	if _, loadErr := loadBTNCookies(ctx, dbPath); loadErr == nil || !strings.Contains(loadErr.Error(), "decryption failed") {
+		t.Fatalf("expected original corrupt cookie to remain unreadable, got %v", loadErr)
+	}
+}
+
 func TestBTNPrepareUploadDataFailsOnAutofillFailure(t *testing.T) {
 	t.Parallel()
 
@@ -408,6 +563,58 @@ func TestBTNUploadCredentialLoginDoesNotPersistInvalidSession(t *testing.T) {
 	}
 	if values, err := loadBTNCookies(ctx, dbPath); err == nil {
 		t.Fatalf("expected invalid login cookies not to persist, got %#v", values)
+	}
+}
+
+func TestValidateBTNClientSessionRequiresUploadFormStructure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{
+			name:    "help page upload text rejected",
+			body:    `<html><h1>Upload help</h1><p>Use the upload page to submit releases.</p></html>`,
+			wantErr: true,
+		},
+		{
+			name:    "transient success body rejected",
+			body:    `<html><body>ok</body></html>`,
+			wantErr: true,
+		},
+		{
+			name:    "real upload form accepted",
+			body:    `<form action="/upload.php"><input name="file_input" /></form>`,
+			wantErr: false,
+		},
+		{
+			name:    "autofill upload form accepted",
+			body:    `<form action="upload.php"><input name="autofill" /></form>`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/upload.php" {
+					http.NotFound(w, r)
+					return
+				}
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
+
+			err := validateBTNClientSession(context.Background(), server.Client(), server.URL)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected upload auth page validation error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validateBTNClientSession: %v", err)
+			}
+		})
 	}
 }
 
@@ -650,4 +857,80 @@ func newBTNAuthDB(t *testing.T) string {
 	}
 	_ = repo.Close()
 	return dbPath
+}
+
+// corruptBTNCookieAuthTag keeps the BTN cookie row present while making its
+// encrypted value fail authentication, exercising decrypt-error handling without
+// falling back to the missing-cookie path.
+func corruptBTNCookieAuthTag(t *testing.T, dbPath string) {
+	t.Helper()
+
+	ctx := context.Background()
+	repo, err := servicedb.OpenWithLoggerContext(ctx, dbPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("OpenWithLoggerContext: %v", err)
+	}
+	defer repo.Close()
+
+	result, err := repo.RawDB().ExecContext(ctx, `UPDATE tracker_cookies SET auth_tag = ? WHERE tracker_id = ? AND cookie_name = ?`, "AAAAAAAAAAAAAAAAAAAAAA==", "BTN", "session")
+	if err != nil {
+		t.Fatalf("corrupt BTN cookie auth tag: %v", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		t.Fatalf("corrupt BTN cookie rows affected: %v", err)
+	}
+	if affected != 1 {
+		t.Fatalf("expected one corrupt BTN cookie row, got %d", affected)
+	}
+}
+
+// newBTNDryRunTestRequest returns a minimal TV upload request with a BTN API key.
+// Callers add credentials or stored cookies to exercise dry-run auth gating.
+func newBTNDryRunTestRequest(t *testing.T, dbPath string) trackers.UploadRequest {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	sourcePath := filepath.Join(tempDir, "Example.Show.S01E01.mkv")
+	if err := os.WriteFile(sourcePath, []byte("video"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	torrentPath := filepath.Join(tempDir, "input.torrent")
+	if err := os.WriteFile(torrentPath, []byte("d8:announce13:https://x.ee"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+	return trackers.UploadRequest{
+		Tracker: "BTN",
+		Meta: api.PreparedMetadata{
+			SourcePath:          sourcePath,
+			TorrentPath:         torrentPath,
+			ReleaseName:         "Example.Show.S01E01.1080p.WEB-DL.x265-GRP",
+			Type:                "WEBDL",
+			Source:              "WEB-DL",
+			Container:           "MKV",
+			VideoEncode:         "x265",
+			VideoCodec:          "HEVC",
+			SeasonInt:           1,
+			EpisodeInt:          1,
+			EpisodeTitle:        "Episode One",
+			EpisodeOverview:     "Overview",
+			TVDBAiredDate:       "2025-01-01",
+			DescriptionOverride: "[b]Test[/b] description",
+			ExternalIDs: api.ExternalIDs{
+				Category: "TV",
+			},
+			Release: api.ReleaseInfo{
+				Resolution: "1080p",
+				Season:     1,
+				Episode:    1,
+			},
+		},
+		TrackerConfig: config.TrackerConfig{},
+		AppConfig: config.Config{
+			MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+			Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+				"BTN": {APIKey: strings.Repeat("x", 30)},
+			}},
+		},
+	}
 }

--- a/internal/trackers/impl/btn/upload_integration_test.go
+++ b/internal/trackers/impl/btn/upload_integration_test.go
@@ -660,6 +660,48 @@ func TestResolveSessionForTrackerAuthLoginPersistsCookies(t *testing.T) {
 	}
 }
 
+func TestResolveSessionForTrackerAuthLoginIgnoresIncidentalTwoFactorText(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newBTNAuthDB(t)
+	handlerErrs := newHTTPHandlerErrorRecorder(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login.php":
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
+			_, _ = w.Write([]byte(`<html><p>Keep your two-factor recovery codes safe.</p></html>`))
+		case "/upload.php":
+			if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=new") {
+				handlerErrs.Errorf("expected refreshed cookie on validation, got %q", got)
+				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuthLogin(ctx, config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath, api.TrackerAuthLoginRequest{})
+	handlerErrs.Check()
+	if err != nil {
+		t.Fatalf("ResolveSessionForTrackerAuthLogin: %v", err)
+	}
+	values, err := loadBTNCookies(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("loadBTNCookies: %v", err)
+	}
+	if values["session"] != "new" {
+		t.Fatalf("expected persisted BTN cookies, got %#v", values)
+	}
+}
+
 func TestResolveSessionForTrackerAuthLoginRequiresManual2FA(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/impl/btn/upload_integration_test.go
+++ b/internal/trackers/impl/btn/upload_integration_test.go
@@ -6,6 +6,8 @@ package btn
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,10 +18,42 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/autobrr/upbrr/internal/authmaterial"
 	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/cookies"
+	servicedb "github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
+
+// httpHandlerErrorRecorder lets httptest handlers capture assertion failures
+// and report them from the owning test goroutine.
+type httpHandlerErrorRecorder struct {
+	t        *testing.T
+	mu       sync.Mutex
+	messages []string
+}
+
+func newHTTPHandlerErrorRecorder(t *testing.T) *httpHandlerErrorRecorder {
+	t.Helper()
+	return &httpHandlerErrorRecorder{t: t}
+}
+
+func (r *httpHandlerErrorRecorder) Errorf(format string, args ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.messages = append(r.messages, fmt.Sprintf(format, args...))
+}
+
+func (r *httpHandlerErrorRecorder) Check() {
+	r.t.Helper()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.messages) > 0 {
+		r.t.Fatalf("handler assertion failed: %s", strings.Join(r.messages, "; "))
+	}
+}
 
 func TestBTNUploadEndToEndSuccess(t *testing.T) {
 	t.Parallel()
@@ -31,13 +65,22 @@ func TestBTNUploadEndToEndSuccess(t *testing.T) {
 	var uploadFormMu sync.Mutex
 	uploadFormValues := map[string]string{}
 	uploadFileCount := 0
+	handlerErrs := newHTTPHandlerErrorRecorder(t)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/login.php" && r.Method == http.MethodPost:
 			loginCalls.Add(1)
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
+		case r.URL.Path == "/upload.php" && r.Method == http.MethodGet:
+			if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=new") {
+				handlerErrs.Errorf("expected refreshed cookie on upload validation, got %q", got)
+				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
 		case r.URL.Path == "/upload.php" && r.Method == http.MethodPost:
 			contentType := r.Header.Get("Content-Type")
 			if strings.HasPrefix(contentType, "application/x-www-form-urlencoded") {
@@ -59,7 +102,9 @@ func TestBTNUploadEndToEndSuccess(t *testing.T) {
 			}
 			uploadCalls.Add(1)
 			if err := r.ParseMultipartForm(4 << 20); err != nil {
-				t.Fatalf("parse multipart form: %v", err)
+				handlerErrs.Errorf("parse multipart form: %v", err)
+				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
+				return
 			}
 			uploadFormMu.Lock()
 			for key, values := range r.MultipartForm.Value {
@@ -84,6 +129,7 @@ func TestBTNUploadEndToEndSuccess(t *testing.T) {
 	defer server.Close()
 
 	tempDir := t.TempDir()
+	dbPath := newBTNAuthDB(t)
 	sourcePath := filepath.Join(tempDir, "Example.Show.S01E01.mkv")
 	if err := os.WriteFile(sourcePath, []byte("video"), 0o600); err != nil {
 		t.Fatalf("write source: %v", err)
@@ -125,7 +171,7 @@ func TestBTNUploadEndToEndSuccess(t *testing.T) {
 			Password: "pass",
 		},
 		AppConfig: config.Config{
-			MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(tempDir, "db.sqlite")},
+			MainSettings: config.MainSettingsConfig{DBPath: dbPath},
 			Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
 				"BTN": {APIKey: strings.Repeat("x", 30)},
 			}},
@@ -133,6 +179,7 @@ func TestBTNUploadEndToEndSuccess(t *testing.T) {
 	}
 
 	summary, err := upload(context.Background(), req)
+	handlerErrs.Check()
 	if err != nil {
 		t.Fatalf("upload failed: %v", err)
 	}
@@ -197,6 +244,111 @@ func TestBTNUploadEndToEndSuccess(t *testing.T) {
 	}
 }
 
+func TestBTNUploadUsesValidImportedCookiesWithoutCredentials(t *testing.T) {
+	t.Parallel()
+
+	var loginCalls atomic.Int32
+	var autofillCalls atomic.Int32
+	var uploadCalls atomic.Int32
+	handlerErrs := newHTTPHandlerErrorRecorder(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/login.php":
+			loginCalls.Add(1)
+			http.NotFound(w, r)
+		case r.URL.Path == "/upload.php" && r.Method == http.MethodGet:
+			if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=imported") {
+				handlerErrs.Errorf("expected imported cookie on upload validation, got %q", got)
+				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
+		case r.URL.Path == "/upload.php" && r.Method == http.MethodPost:
+			if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=imported") {
+				handlerErrs.Errorf("expected imported cookie on upload request, got %q", got)
+				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
+				return
+			}
+			if strings.HasPrefix(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+				autofillCalls.Add(1)
+				_, _ = w.Write([]byte(`
+					<input name="artist" value="Example Show" />
+					<input name="title" value="Episode One" />
+					<input name="seriesid" value="999" />
+					<textarea name="album_desc">Episode overview: TBA</textarea>
+					<select name="format"><option selected value="MKV">MKV</option></select>
+					<select name="bitrate"><option selected value="H.265">H.265</option></select>
+					<select name="media"><option selected value="WEB-DL">WEB-DL</option></select>
+					<select name="resolution"><option selected value="1080p">1080p</option></select>
+				`))
+				return
+			}
+			uploadCalls.Add(1)
+			w.Header().Set("Location", "/torrents.php?id=123&torrentid=456")
+			w.WriteHeader(http.StatusFound)
+		case r.URL.Path == "/torrents.php" && r.URL.Query().Get("action") == "download":
+			_, _ = w.Write([]byte("d8:announce13:https://x.ee"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	dbPath := newBTNAuthDB(t)
+	if err := cookies.SaveTrackerCookieMap(context.Background(), dbPath, "BTN", map[string]string{"session": "imported"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	sourcePath := filepath.Join(tempDir, "Example.Show.S01E01.mkv")
+	if err := os.WriteFile(sourcePath, []byte("video"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	torrentPath := filepath.Join(tempDir, "input.torrent")
+	if err := os.WriteFile(torrentPath, []byte("d8:announce13:https://x.ee"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+
+	req := trackers.UploadRequest{
+		Tracker: "BTN",
+		Meta: api.PreparedMetadata{
+			SourcePath:  sourcePath,
+			TorrentPath: torrentPath,
+			ReleaseName: "Example.Show.S01E01.1080p.WEB-DL.x265-GRP",
+			Type:        "WEBDL",
+			Source:      "WEB-DL",
+			Container:   "MKV",
+			VideoEncode: "x265",
+			VideoCodec:  "HEVC",
+			SeasonInt:   1,
+			EpisodeInt:  1,
+			ExternalIDs: api.ExternalIDs{Category: "TV"},
+			Release:     api.ReleaseInfo{Resolution: "1080p", Season: 1, Episode: 1},
+		},
+		TrackerConfig: config.TrackerConfig{URL: server.URL},
+		AppConfig: config.Config{
+			MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+			Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+				"BTN": {APIKey: strings.Repeat("x", 30)},
+			}},
+		},
+	}
+
+	summary, err := upload(context.Background(), req)
+	handlerErrs.Check()
+	if err != nil {
+		t.Fatalf("upload failed: %v", err)
+	}
+	if summary.Uploaded != 1 {
+		t.Fatalf("expected upload success, got %#v", summary)
+	}
+	if loginCalls.Load() != 0 {
+		t.Fatalf("expected no login with valid imported cookies, got %d", loginCalls.Load())
+	}
+	if autofillCalls.Load() != 1 || uploadCalls.Load() != 1 {
+		t.Fatalf("expected autofill/upload calls, got autofill=%d upload=%d", autofillCalls.Load(), uploadCalls.Load())
+	}
+}
+
 func TestBTNPrepareUploadDataFailsOnAutofillFailure(t *testing.T) {
 	t.Parallel()
 
@@ -228,6 +380,125 @@ func TestBTNPrepareUploadDataFailsOnAutofillFailure(t *testing.T) {
 	}
 }
 
+func TestBTNUploadCredentialLoginDoesNotPersistInvalidSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newBTNAuthDB(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login.php":
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
+			_, _ = w.Write([]byte("ok"))
+		case "/upload.php":
+			_, _ = w.Write([]byte(`<form action="/login.php"><input type="password" name="password" /></form>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := ensureBTNUploadSession(ctx, config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath, uploadContext{baseURL: server.URL})
+	if !errors.Is(err, errBTNSessionConfirmedInvalid) {
+		t.Fatalf("expected invalid session error, got %v", err)
+	}
+	if values, err := loadBTNCookies(ctx, dbPath); err == nil {
+		t.Fatalf("expected invalid login cookies not to persist, got %#v", values)
+	}
+}
+
+func TestResolveSessionForTrackerAuthLoginPersistsCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newBTNAuthDB(t)
+	handlerErrs := newHTTPHandlerErrorRecorder(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login.php":
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
+			_, _ = w.Write([]byte("ok"))
+		case "/upload.php":
+			if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=new") {
+				handlerErrs.Errorf("expected refreshed cookie on validation, got %q", got)
+				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuthLogin(ctx, config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath, api.TrackerAuthLoginRequest{})
+	handlerErrs.Check()
+	if err != nil {
+		t.Fatalf("ResolveSessionForTrackerAuthLogin: %v", err)
+	}
+	values, err := loadBTNCookies(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("loadBTNCookies: %v", err)
+	}
+	if values["session"] != "new" {
+		t.Fatalf("expected persisted BTN cookies, got %#v", values)
+	}
+}
+
+func TestResolveSessionForTrackerAuthLoginRequiresManual2FA(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newBTNAuthDB(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/login.php" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`<form><input name="codenumber" /></form><p>2FA required</p>`))
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuthLogin(context.Background(), config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath, api.TrackerAuthLoginRequest{})
+	if err == nil || !strings.Contains(err.Error(), "2FA required") {
+		t.Fatalf("expected 2FA required error, got %v", err)
+	}
+}
+
+func TestResolveSessionForTrackerAuthLoginMarksSubmitted2FARejected(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newBTNAuthDB(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/login.php" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`<p>invalid code</p>`))
+	}))
+	t.Cleanup(server.Close)
+
+	err := ResolveSessionForTrackerAuthLogin(context.Background(), config.TrackerConfig{
+		URL:      server.URL,
+		Username: "user",
+		Password: "pass",
+	}, dbPath, api.TrackerAuthLoginRequest{Code: "000000"})
+	if !errors.Is(err, ErrSubmitted2FARejected) {
+		t.Fatalf("expected submitted 2FA rejection marker, got %v", err)
+	}
+}
+
 func TestBTNUploadFallsBackToAPIResolution(t *testing.T) {
 	t.Parallel()
 
@@ -237,8 +508,11 @@ func TestBTNUploadFallsBackToAPIResolution(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/login.php" && r.Method == http.MethodPost:
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
+		case r.URL.Path == "/upload.php" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
 		case r.URL.Path == "/upload.php" && r.Method == http.MethodPost:
 			contentType := r.Header.Get("Content-Type")
 			if strings.HasPrefix(contentType, "application/x-www-form-urlencoded") {
@@ -281,6 +555,7 @@ func TestBTNUploadFallsBackToAPIResolution(t *testing.T) {
 	defer server.Close()
 
 	tempDir := t.TempDir()
+	dbPath := newBTNAuthDB(t)
 	sourcePath := filepath.Join(tempDir, "Example.Show.S01E01.mkv")
 	if err := os.WriteFile(sourcePath, []byte("video"), 0o600); err != nil {
 		t.Fatalf("write source: %v", err)
@@ -320,12 +595,12 @@ func TestBTNUploadFallsBackToAPIResolution(t *testing.T) {
 			URL:      server.URL,
 			Username: "user",
 			Password: "pass",
-			Unknown: map[string]interface{}{
+			Unknown: map[string]any{
 				"api_url": server.URL + "/rpc",
 			},
 		},
 		AppConfig: config.Config{
-			MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(tempDir, "db.sqlite")},
+			MainSettings: config.MainSettingsConfig{DBPath: dbPath},
 			Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
 				"BTN": {APIKey: strings.Repeat("x", 30)},
 			}},
@@ -355,4 +630,24 @@ func TestBTNUploadFallsBackToAPIResolution(t *testing.T) {
 	if apiDownloadCalls.Load() != 1 {
 		t.Fatalf("expected one API download call, got %d", apiDownloadCalls.Load())
 	}
+}
+
+func newBTNAuthDB(t *testing.T) string {
+	t.Helper()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "upbrr.db")
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "long-enough-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	repo, err := servicedb.OpenWithLoggerContext(ctx, dbPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("OpenWithLoggerContext: %v", err)
+	}
+	if err := repo.MigrateContext(ctx); err != nil {
+		_ = repo.Close()
+		t.Fatalf("MigrateContext: %v", err)
+	}
+	_ = repo.Close()
+	return dbPath
 }

--- a/internal/webserver/routes_auth_test.go
+++ b/internal/webserver/routes_auth_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/pkg/api"
 
 	"golang.org/x/crypto/argon2"
 )
@@ -801,6 +802,31 @@ func TestTrackerAuthBackendUsesRequestContext(t *testing.T) {
 	}
 	if !strings.Contains(status.LastError, "context canceled") {
 		t.Fatalf("expected context canceled status, got %#v", status)
+	}
+}
+
+func TestTrackerAuthBackendLoginBTNCookiesWithoutAPIPreservesMissingAPIStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthWebTestDB(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "BTN", map[string]string{"session": "abc"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	backend := &Backend{cfg: config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}}}
+
+	status, err := backend.LoginTrackerAuth(ctx, "BTN", api.TrackerAuthLoginRequest{})
+	if err != nil {
+		t.Fatalf("LoginTrackerAuth: %v", err)
+	}
+	if status.State != "login_required" || status.CookieCount != 1 || !strings.Contains(status.Message, "API key is required") {
+		t.Fatalf("expected BTN cookie-only web login to preserve missing API status, got %#v", status)
+	}
+	if strings.Contains(status.Message, "username/password missing") {
+		t.Fatalf("missing credentials masked missing API status: %#v", status)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BTN support for auth checks, manual 2FA, and upload session handling.
  * Expanded which trackers show the “Check Auth” action in Settings (including BTN).
  * BTN can now use valid imported cookies for uploads without requiring credentials.
* **Bug Fixes**
  * Improved BTN error handling when an API key is missing (including GUI and backend messaging).
  * Clarified unattended-mode messaging for 2FA-before-duplicate-check failures.
  * More reliable stored-cookie handling and invalid-session cleanup behavior, ensuring correct retry/rejected states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->