### PR TITLE
feat(metadata): add several German Streaming-Services

### DIFF
--- a/internal/metadata/service_map.go
+++ b/internal/metadata/service_map.go
@@ -7,6 +7,8 @@ package metadata
 // token used in generated release names.
 func serviceCodeMap() map[string]string {
 	return map[string]string{
+		"3SAT":                             "3SAT",
+		"3Sat":                             "3SAT",
 		"9NOW":                             "9NOW",
 		"9Now":                             "9NOW",
 		"AND":                              "AND",
@@ -30,6 +32,10 @@ func serviceCodeMap() map[string]string {
 		"Animal Planet":                    "ANPL",
 		"AOL":                              "AOL",
 		"ARD":                              "ARD",
+		"ARD Mediathek":                    "ARD",
+		"ARDP":                             "ARDP",
+		"ARD Plus":                         "ARDP",
+		"ARTE":                             "ARTE",
 		"AS":                               "AS",
 		"Adult Swim":                       "AS",
 		"ATK":                              "ATK",
@@ -190,6 +196,7 @@ func serviceCodeMap() map[string]string {
 		"ITV":                              "ITV",
 		"JOYN":                             "JOYN",
 		"KAYO":                             "KAYO",
+		"KiKA":                             "KiKA",
 		"KNOW":                             "KNOW",
 		"Knowledge Network":                "KNOW",
 		"KNPY":                             "KNPY",


### PR DESCRIPTION
adds:
- 3SAT: https://www.3sat.de/ (cooperation by German, Swiss and Austrian Public Broadcasters)
- ARD: https://www.ardmediathek.de/ (only added the long name)
- ARDP: https://www.ardplus.de/
- ARTE: https://www.arte.tv/ (cooperation by German and French Public Broadcasters)
- KiKA: https://www.kika.de/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for additional service names and aliases, including 3SAT, ARD-related entries, ARTE, and KiKA.
  * Improved matching so more user-entered variations resolve to the correct service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->