### PR TITLE
chore: credential protection robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ internal/webserver/assets/
 internal/guiapp/assets/*
 !internal/guiapp/assets/.keep
 dist/
+docs/
 tmp/
 .trunk/
 *.exe

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,16 @@ Before commit, also run `git diff --check`, changed-package `make gofix-check-ch
 - CLI `cmd/upbrr`; core `internal/core`; services `internal/services`; trackers `internal/trackers`; config `internal/config`.
 - Wails `gui`, `internal/guiapp`; embedded web/API `internal/webserver`; API contracts `pkg/api`; frontend `gui/frontend`.
 
+## Logging Levels
+
+- Keep log levels purposeful across CLI, GUI, embedded web, frontend, tests, and tooling.
+- Add logs for operator-visible progress and decision points, not just final errors. Good logs answer what operation started, what external/local check ran, what decision was made, and how many items were affected.
+- `INFO` should provide concise, relevant progress or outcome details for end users during uploads and other top-level workflows.
+- Warnings should cover failed or blocked outcomes that require attention.
+- `DEBUG` should include richer decision-making context useful for developer troubleshooting.
+- `TRACE` should capture near-complete operational flow for high-fidelity execution reporting.
+- Prefer stable key/value-style fields in message strings (`tracker=%s state=%s decision=%s count=%d`) so logs are searchable.
+
 ## Non-Negotiables
 
 - Keep changes narrow; fix root cause; do not revert user changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,6 +247,14 @@ Alternatively, `make precommit` and `make prepush` run the configured Lefthook c
 
 Keep log levels purposeful. `INFO` should provide concise, relevant progress or outcome details for end users during uploads and other top-level workflows. `DEBUG` should include richer decision-making context useful for developer troubleshooting. `TRACE` should capture near-complete operational flow for high-fidelity execution reporting.
 
+### Sensitive information
+
+Logging should be completely safe for blanket copy/pasting, without exposing any user sensitive credentials. Err on the side of caution.
+Tests should apply redaction for any potentially sensitive information, in order to prevent LLM consumption of personal information/credentials.
+Pay particular attention in API/HTTP/cookie type handling, ensuring redaction of headers and response bodies.
+Gaps fixes in /internal/redaction/redaction.go or /internal/logpolicy/checker.go are especially appreciated.
+Config values should be encrypted where appropriate, and only ever displayed in a redacted state.
+
 ### Path portability
 
 upbrr targets Windows, Linux, and macOS. Do not assume POSIX path behavior in Go code or tests unless the value is explicitly a torrent-internal path, URL path, or remote API payload path.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,11 +250,11 @@ Keep log levels purposeful. `INFO` should provide concise, relevant progress or 
 ### Sensitive information
 
 Logging should be completely safe for blanket copy/pasting, without exposing any user sensitive credentials. Err on the side of caution.
-Tests should apply redaction for any potentially sensitive information, in order to prevent LLM consumption of personal information/credentials.
+Tests should apply redaction for any potentially sensitive information, to prevent LLM consumption of personal information/credentials.
 Pay particular attention in API/HTTP/cookie type handling, ensuring redaction of headers and response bodies.
-Gaps fixes in /internal/redaction/redaction.go or /internal/logpolicy/checker.go are especially appreciated.
+Gaps fixes in `internal/redaction/redaction.go` or `internal/logpolicy/checker.go` are especially appreciated.
 Config values should be encrypted where appropriate, and only ever displayed in a redacted state.
-If an endpoint supports GET/query style and POST/bearer style handling, use the endpoint that puts sensitive credentials in the HTTPS packet, rather than as a plain url parameter.
+If an endpoint supports GET/query style and POST/bearer style handling, use the endpoint that puts sensitive credentials into a secure packet, rather than as a plain URL parameter.
 
 ### Path portability
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,6 +254,7 @@ Tests should apply redaction for any potentially sensitive information, in order
 Pay particular attention in API/HTTP/cookie type handling, ensuring redaction of headers and response bodies.
 Gaps fixes in /internal/redaction/redaction.go or /internal/logpolicy/checker.go are especially appreciated.
 Config values should be encrypted where appropriate, and only ever displayed in a redacted state.
+If an endpoint supports GET/query style and POST/bearer style handling, use the endpoint that puts sensitive credentials in the HTTPS packet, rather than as a plain url parameter.
 
 ### Path portability
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,10 @@ Alternatively, `make precommit` and `make prepush` run the configured Lefthook c
 - `pkg/api` holds request/response types shared across surfaces.
 - The repo currently includes generated and built assets in a few locations; review changes carefully and avoid committing build output by accident.
 
+### Logging levels
+
+Keep log levels purposeful. `INFO` should provide concise, relevant progress or outcome details for end users during uploads and other top-level workflows. `DEBUG` should include richer decision-making context useful for developer troubleshooting. `TRACE` should capture near-complete operational flow for high-fidelity execution reporting.
+
 ### Path portability
 
 upbrr targets Windows, Linux, and macOS. Do not assume POSIX path behavior in Go code or tests unless the value is explicitly a torrent-internal path, URL path, or remote API payload path.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,6 +259,12 @@ upbrr targets Windows, Linux, and macOS. Do not assume POSIX path behavior in Go
 
 `make pathpolicy` runs the repo-local AST checker for hardcoded OS-rooted literals in `filepath` calls, string-built local paths, wrong `path`/`filepath` package use, slash-data filesystem calls, slash assertions without `filepath.ToSlash`, and ad-hoc local path guard helpers outside `internal/pathutil`. Rare intentional checker exceptions need `//pathpolicy:allow <reason>` on the same or previous line. `make lint`, pre-commit, and pre-push run it automatically.
 
+### Sensitive output
+
+Test assertion output is treated as CI-visible log material. Do not print raw cookies, auth headers, API keys, passkeys, passwords, CSRF tokens, OTP secrets, tracker announce URLs, or unredacted request/response bodies in tests, application logs, CLI output, or checker failure text.
+
+Prefer stable state assertions without raw values, such as `expected session cookie` or `got count=%d`. When diagnostic output needs value shape, use `redaction.RedactValue` or `commonhttp.RedactErrorDetail` before formatting it.
+
 ## AI agent instructions
 
 This project uses [AGENTS.md](https://agents.md/) — an open standard for guiding AI coding agents. The root [`AGENTS.md`](./AGENTS.md) file contains always-loaded repo rules and routes agents to scoped references:

--- a/cmd/upbrr/AGENTS.md
+++ b/cmd/upbrr/AGENTS.md
@@ -23,6 +23,7 @@ Add touched service/tracker/internal packages to focused `go test` runs.
 
 ## CLI Output / Logging
 
+- Follow root log-level guidance for CLI logs and stdout/stderr.
 - User-facing stdout/stderr may be copied into issues. Do not print credentials, usernames, passwords, tokens, API keys, auth keys, passkeys, cookie values, 2FA codes, challenge IDs, refreshed API tokens, or secret payloads.
 - CLI dry-run stdout is shareable debug material: redact endpoints and payload values with the existing safe dry-run helpers before printing.
 - Tracker-auth CLI logs should make the pre-dupe auth flow reconstructable without secrets: capability load count, auth-check start with tracker count, validation start per managed tracker with `tracker` and `auth_kind`, status result with `state`, cookie count, encrypted-storage availability and `needs_2fa`, per-tracker decision, and final ready/skipped counts.

--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -446,7 +446,7 @@ func handleCLITrackerAuthStatusWithLogger(ctx context.Context, reader *bufio.Rea
 	message := cliTrackerAuthStatusMessage(status)
 	if isUnattendedNoConfirm(req) {
 		logger.Warnf("cli auth: tracker=%s decision=blocked reason=%s unattended=true", trackerID, cliAuthStatusMessageForLog(status))
-		return status, false, fmt.Errorf("upbrr: tracker auth %s not ready before dupe check: %s", trackerID, message)
+		return status, false, fmt.Errorf("upbrr: unattended tracker auth %s not ready before dupe check: %s", trackerID, message)
 	}
 	fmt.Printf("Skipping %s before dupe check: tracker auth not ready (%s).\n", trackerID, message)
 	return status, false, nil

--- a/cmd/upbrr/interactive_test.go
+++ b/cmd/upbrr/interactive_test.go
@@ -722,8 +722,12 @@ func TestEnsureCLITrackerAuthBeforeDupeCheckFailsUnattendedAuthRequired(t *testi
 	if err == nil {
 		t.Fatal("expected unattended auth-required error")
 	}
-	if !strings.Contains(err.Error(), "tracker auth HDB not ready before dupe check") {
-		t.Fatalf("unexpected error: %v", err)
+	got := err.Error()
+	if !strings.Contains(got, "unattended") {
+		t.Fatal("expected auth-required error to name unattended mode")
+	}
+	if !strings.Contains(got, "login credentials or imported cookies required") {
+		t.Fatal("expected auth-required error to include required user action")
 	}
 }
 

--- a/cmd/upbrr/interactive_test.go
+++ b/cmd/upbrr/interactive_test.go
@@ -482,10 +482,10 @@ func TestEnsureCLITrackerAuthBeforeDupeCheckLogsRuleFailureSkipOnlyForManagedAut
 
 	logs := strings.Join(append(append(append([]string{}, logger.debug...), logger.info...), logger.warn...), "\n")
 	if !strings.Contains(logs, "cli auth: tracker=MTV skipped before auth due to rule failure") {
-		t.Fatalf("expected managed auth rule-failure skip log, got:\n%s", logs)
+		t.Fatal("expected managed auth rule-failure skip log")
 	}
 	if strings.Contains(logs, "tracker=NBL skipped before auth due to rule failure") {
-		t.Fatalf("static api-key tracker should not log auth rule-failure skip, got:\n%s", logs)
+		t.Fatal("static api-key tracker should not log auth rule-failure skip")
 	}
 }
 
@@ -526,7 +526,7 @@ func TestEnsureCLITrackerAuthBeforeDupeCheckHonorsPerTrackerRuleFailureOverride(
 
 	logs := strings.Join(append(append(append([]string{}, logger.debug...), logger.info...), logger.warn...), "\n")
 	if strings.Contains(logs, "tracker=MTV skipped before auth due to rule failure") {
-		t.Fatalf("overridden tracker should not log auth rule-failure skip, got:\n%s", logs)
+		t.Fatal("overridden tracker should not log auth rule-failure skip")
 	}
 }
 
@@ -607,14 +607,14 @@ func TestEnsureCLITrackerAuthBeforeDupeCheckLogsRedactedDecisions(t *testing.T) 
 		"cli auth: tracker=HDB decision=skip state=login_required",
 	} {
 		if !strings.Contains(logs, expected) {
-			t.Fatalf("expected log %q in:\n%s", expected, logs)
+			t.Fatalf("expected log %q", expected)
 		}
 	}
 	if strings.Contains(logs, "hunter2") {
-		t.Fatalf("auth logs leaked password: %s", logs)
+		t.Fatal("auth logs leaked password")
 	}
 	if !strings.Contains(logs, `"password":"[REDACTED]"`) {
-		t.Fatalf("expected redacted password in auth logs, got:\n%s", logs)
+		t.Fatal("expected redacted password in auth logs")
 	}
 }
 

--- a/gui/frontend/AGENTS.md
+++ b/gui/frontend/AGENTS.md
@@ -38,6 +38,13 @@ pnpm --dir gui/frontend run build
 - Preserve CLI, Wails, and embedded web parity when changing request shapes, upload options, prepared metadata, or runtime bridge behavior.
 - Match existing component state patterns before adding new abstraction.
 
+## Frontend Output / Logging
+
+- Follow root log-level guidance for browser-visible diagnostics and runtime bridge logging.
+- Do not expose credentials, tokens, API keys, passkeys, cookies, 2FA codes, challenge IDs, or secret payloads in console output, UI errors, toasts, test failure text, or debug panels.
+- Avoid permanent `console.*` diagnostics. If a diagnostic is intentionally kept, make it dev-scoped, concise, and redacted.
+- User-facing errors should be stable outcomes or next steps; detailed troubleshooting context belongs in developer diagnostics.
+
 ## Styling
 
 - Prefer Tailwind utilities for touched local layout/spacing.

--- a/gui/frontend/src/hooks/useSettingsState.test.ts
+++ b/gui/frontend/src/hooks/useSettingsState.test.ts
@@ -670,6 +670,61 @@ describe("Tracker client selectors", () => {
     expect(screen.getByText("1/1")).toBeInTheDocument();
   });
 
+  it("masks encrypted envelopes on tracker URL fields and preserves them for saves", async () => {
+    const encryptedURL = "upbrr-enc:v1:encrypted-btn-url";
+    (globalThis as typeof globalThis & { go?: any }).go = {
+      guiapp: {
+        App: {
+          GetConfig: async () =>
+            JSON.stringify({
+              Trackers: {
+                DefaultTrackers: [],
+                PreferredTracker: "",
+                Trackers: {
+                  BTN: {
+                    APIKey: "tracker-token",
+                    URL: encryptedURL,
+                    Username: "",
+                    Password: "",
+                  },
+                },
+              },
+            }),
+          GetDefaultConfig: async () => JSON.stringify({}),
+          ListKnownTrackers: async () => ["BTN"],
+          GetImageHostPolicyMetadata: async () => ({}),
+        },
+      },
+    };
+
+    render(createElement(TrackerSettingsHarness));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("BTN", { selector: ".settings-card__summary-name" }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByText("BTN", { selector: ".settings-card__summary-name" }));
+
+    expect(screen.getByLabelText("URL")).toHaveValue("[REDACTED]");
+
+    let payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+      Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
+    };
+    expect(payload.Trackers?.Trackers?.BTN?.URL).toBe(encryptedURL);
+
+    fireEvent.change(screen.getByLabelText("URL"), {
+      target: { value: "https://btn.example" },
+    });
+
+    await waitFor(() => expect(screen.getByLabelText("URL")).toHaveValue("https://btn.example"));
+
+    payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+      Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
+    };
+    expect(payload.Trackers?.Trackers?.BTN?.URL).toBe("https://btn.example");
+  });
+
   it("shows Lostimg as an LST image host only when configured in image hosting", async () => {
     (globalThis as typeof globalThis & { go?: any }).go = {
       guiapp: {

--- a/gui/frontend/src/hooks/useSettingsState.test.ts
+++ b/gui/frontend/src/hooks/useSettingsState.test.ts
@@ -194,11 +194,13 @@ function ImageHostingHarness() {
 
 let latestPayload = "";
 
+/** Captures save payloads without rendering secret-shaped values into DOM snapshots. */
 function PayloadCapture({ value }: { value: string | null }) {
   latestPayload = value ?? "";
   return null;
 }
 
+/** Parses the latest captured payload for focused assertions outside matcher output. */
 function readPayload<T>() {
   return JSON.parse(latestPayload || "{}") as T;
 }

--- a/gui/frontend/src/hooks/useSettingsState.test.ts
+++ b/gui/frontend/src/hooks/useSettingsState.test.ts
@@ -14,6 +14,7 @@ import {
 
 afterEach(() => {
   cleanup();
+  latestPayload = "";
   delete (globalThis as typeof globalThis & { go?: any }).go;
 });
 
@@ -134,7 +135,7 @@ function TorrentClientsHarness() {
     "div",
     null,
     state.renderTorrentClientsSection(false),
-    createElement("pre", { "data-testid": "payload" }, state.buildSavePayload() ?? ""),
+    createElement(PayloadCapture, { value: state.buildSavePayload() }),
   );
 }
 
@@ -154,7 +155,7 @@ function ClientSetupHarness() {
     ...Object.entries(clientSetup).map(([key, value]) =>
       state.renderField(key, value, ["ClientSetup", key], meta[key]),
     ),
-    createElement("pre", { "data-testid": "payload" }, state.buildSavePayload() ?? ""),
+    createElement(PayloadCapture, { value: state.buildSavePayload() }),
   );
 }
 
@@ -165,7 +166,7 @@ function TrackerSettingsHarness() {
     "div",
     null,
     state.renderTrackerSection(false),
-    createElement("pre", { "data-testid": "payload" }, state.buildSavePayload() ?? ""),
+    createElement(PayloadCapture, { value: state.buildSavePayload() }),
   );
 }
 
@@ -176,7 +177,7 @@ function TrackerSettingsAdvancedHarness() {
     "div",
     null,
     state.renderTrackerSection(true),
-    createElement("pre", { "data-testid": "payload" }, state.buildSavePayload() ?? ""),
+    createElement(PayloadCapture, { value: state.buildSavePayload() }),
   );
 }
 
@@ -187,8 +188,19 @@ function ImageHostingHarness() {
     "div",
     null,
     state.renderImageHostingSection(),
-    createElement("pre", { "data-testid": "payload" }, state.buildSavePayload() ?? ""),
+    createElement(PayloadCapture, { value: state.buildSavePayload() }),
   );
+}
+
+let latestPayload = "";
+
+function PayloadCapture({ value }: { value: string | null }) {
+  latestPayload = value ?? "";
+  return null;
+}
+
+function readPayload<T>() {
+  return JSON.parse(latestPayload || "{}") as T;
 }
 
 function AdvancedFieldMetaHarness() {
@@ -304,9 +316,9 @@ describe("renderTorrentClientsSection", () => {
       expect(watchScope.getByLabelText("Watch folder")).toHaveValue("/watch/new"),
     );
 
-    const payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+    const payload = readPayload<{
       TorrentClients?: Record<string, Record<string, unknown>>;
-    };
+    }>();
     expect(payload.TorrentClients?.watcher).toEqual({
       Type: "watch",
       WatchFolder: "/watch/new",
@@ -366,9 +378,9 @@ describe("ClientSetup client selectors", () => {
     fireEvent.change(defaultClientSelect, { target: { value: "" } });
     await waitFor(() => expect(defaultClientSelect).toHaveValue(""));
 
-    const payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+    const payload = readPayload<{
       ClientSetup?: { DefaultClient?: string };
-    };
+    }>();
     expect(payload.ClientSetup?.DefaultClient).toBe("");
   });
 
@@ -420,13 +432,13 @@ describe("ClientSetup client selectors", () => {
 
     await waitFor(() => expect(screen.getByLabelText("Default client")).toHaveValue("watcher"));
 
-    const payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+    const payload = readPayload<{
       ClientSetup?: {
         DefaultClient?: string;
         InjectClients?: string[];
         SearchClients?: string[];
       };
-    };
+    }>();
     expect(payload.ClientSetup?.DefaultClient).toBe("watcher");
     expect(payload.ClientSetup?.InjectClients).toEqual(["watcher"]);
     expect(payload.ClientSetup?.SearchClients).toEqual(["watcher"]);
@@ -474,9 +486,9 @@ describe("Tracker client selectors", () => {
     expect(screen.queryByLabelText("API key")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Passkey")).toHaveValue("[REDACTED]");
 
-    const payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+    const payload = readPayload<{
       Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
-    };
+    }>();
     expect(payload.Trackers?.Trackers?.CZT).toMatchObject({
       Passkey: "user-passkey",
     });
@@ -519,9 +531,9 @@ describe("Tracker client selectors", () => {
       ).toBeInTheDocument(),
     );
 
-    const payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+    const payload = readPayload<{
       Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
-    };
+    }>();
     expect(payload.Trackers?.Trackers?.CZT).toMatchObject({
       Passkey: "",
     });
@@ -593,9 +605,9 @@ describe("Tracker client selectors", () => {
 
     await waitFor(() => expect(screen.getByLabelText("Torrent client")).toHaveValue("watcher"));
 
-    const payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+    const payload = readPayload<{
       Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
-    };
+    }>();
     expect(payload.Trackers?.Trackers?.AITHER?.TorrentClient).toBe("watcher");
   });
 
@@ -708,10 +720,10 @@ describe("Tracker client selectors", () => {
 
     expect(screen.getByLabelText("URL")).toHaveValue("[REDACTED]");
 
-    let payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+    let payload = readPayload<{
       Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
-    };
-    expect(payload.Trackers?.Trackers?.BTN?.URL).toBe(encryptedURL);
+    }>();
+    expect(payload.Trackers?.Trackers?.BTN?.URL === encryptedURL).toBe(true);
 
     fireEvent.change(screen.getByLabelText("URL"), {
       target: { value: "https://btn.example" },
@@ -719,9 +731,9 @@ describe("Tracker client selectors", () => {
 
     await waitFor(() => expect(screen.getByLabelText("URL")).toHaveValue("https://btn.example"));
 
-    payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+    payload = readPayload<{
       Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
-    };
+    }>();
     expect(payload.Trackers?.Trackers?.BTN?.URL).toBe("https://btn.example");
   });
 
@@ -870,9 +882,9 @@ describe("Tracker client selectors", () => {
 
     await waitFor(() => expect(screen.getByLabelText("Image API")).toHaveValue("secret"));
 
-    const payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+    const payload = readPayload<{
       Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
-    };
+    }>();
     expect(payload.Trackers?.Trackers?.RF?.ImgAPI).toBe("secret");
   });
 
@@ -1016,12 +1028,12 @@ describe("Image hosting settings", () => {
 
     await waitFor(() => expect(screen.getByLabelText("LST Lostimg")).toBeChecked());
 
-    const payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+    const payload = readPayload<{
       ImageHosting?: {
         LostimgEnabled?: boolean;
         LostimgAPI?: string;
       };
-    };
+    }>();
     expect(payload.ImageHosting?.LostimgEnabled).toBe(true);
     expect(payload.ImageHosting?.LostimgAPI).toBe("secret");
   });
@@ -1070,9 +1082,9 @@ describe("Image hosting settings", () => {
 
     await waitFor(() => expect(screen.getByLabelText("RF Reelflix")).toBeChecked());
 
-    const payload = JSON.parse(screen.getByTestId("payload").textContent ?? "{}") as {
+    const payload = readPayload<{
       Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
-    };
+    }>();
     expect(payload.Trackers?.Trackers?.RF?.ImageHost).toBe("reelflix");
     expect(payload.Trackers?.Trackers?.RF?.ImgAPI).toBe("secret");
   });

--- a/gui/frontend/src/hooks/useSettingsState.tsx
+++ b/gui/frontend/src/hooks/useSettingsState.tsx
@@ -839,6 +839,7 @@ const buildPathKey = (path: string[]) => path.join(".");
 
 const isEncryptedSecretEnvelope = (value: string) => value.startsWith(ENCRYPTED_SECRET_PREFIX);
 
+/** Masks secret-bearing config strings while retaining originals by config path for save payloads. */
 const maskSensitiveConfig = (input: ConfigMap) => {
   const originals: Record<string, string> = {};
   const walk = (value: ConfigValue, path: string[]): ConfigValue => {

--- a/gui/frontend/src/hooks/useSettingsState.tsx
+++ b/gui/frontend/src/hooks/useSettingsState.tsx
@@ -667,6 +667,7 @@ const trackerHasAdvancedFields = Object.values(trackerSchemas).some((fields) =>
 );
 
 const REDACTED_VALUE = "[REDACTED]";
+const ENCRYPTED_SECRET_PREFIX = "upbrr-enc:v1:";
 const trackerActivationKeys = new Set([
   "APIKey",
   "ApiUser",
@@ -836,6 +837,8 @@ const isSensitiveKeyName = (key: string) => {
 
 const buildPathKey = (path: string[]) => path.join(".");
 
+const isEncryptedSecretEnvelope = (value: string) => value.startsWith(ENCRYPTED_SECRET_PREFIX);
+
 const maskSensitiveConfig = (input: ConfigMap) => {
   const originals: Record<string, string> = {};
   const walk = (value: ConfigValue, path: string[]): ConfigValue => {
@@ -852,7 +855,7 @@ const maskSensitiveConfig = (input: ConfigMap) => {
     }
     if (typeof value === "string") {
       const key = path[path.length - 1] || "";
-      if (value && isSensitiveKeyName(key)) {
+      if (value && (isSensitiveKeyName(key) || isEncryptedSecretEnvelope(value))) {
         originals[buildPathKey(path)] = value;
         return REDACTED_VALUE;
       }
@@ -1322,7 +1325,10 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
     });
 
     const key = path[path.length - 1] || "";
-    if (typeof value === "string" && isSensitiveKeyName(key)) {
+    if (
+      typeof value === "string" &&
+      (isSensitiveKeyName(key) || sensitiveValues[buildPathKey(path)] !== undefined)
+    ) {
       setSensitiveValues((prev) => {
         const next = { ...prev };
         const pathKey = buildPathKey(path);

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -67,15 +67,7 @@ Preserve behavior across CLI, Wails GUI, and embedded web unless intentionally c
 ## Logging / Redaction
 
 - Use context-aware APIs where meaningful.
-- Add logs for operator-visible progress and decision points, not just final errors. Good logs answer what operation started, what external/local check ran, what decision was made, and how many items were affected.
-- Use `Infof` for high-level lifecycle and outcomes: capability/config loaded counts, validation/import/login/delete completed, pre-dupe auth start/complete, selected ready/skipped counts.
-- Use `Warnf` for failed or blocked outcomes that require attention: capability load failure, validation/login/import/delete failure, unattended auth block, skipped tracker after failed 2FA, failed persistence of refreshed auth material.
-- Use `Debugf` for diagnostic filtering details that are useful but not normal operator milestones, such as a tracker skipped before auth because preview rule failures already excluded it.
-- Use `Tracef` for granular step-by-step execution flow when needed; do not put noisy per-step internals at info level.
-- Prefer stable key/value-style fields in message strings (`tracker=%s state=%s decision=%s count=%d`) so logs are searchable.
-- For tracker auth, log safe decisions/status only: tracker ID, auth kind, state, cookie count, encrypted-storage availability, 2FA-needed boolean, ready/keep/skip/blocked/prompt decisions, and aggregate counts.
-- Log both the action and resulting status when auth state can change: after cookie import, remote validation, credential login, 2FA submit, and delete.
-- For manual 2FA flows, log prompt/submit outcomes and whether another prompt is needed; never log the submitted code or challenge ID.
+- Follow root log-level guidance with backend logger methods: `Infof`, `Warnf`, `Debugf`, and `Tracef`.
 - Redact auth status text, remote response details, URLs, and raw errors before logging when they can contain secrets; use `internal/redaction.RedactValue` or tracker/common redaction helpers.
 - No stdlib print/log under `internal/**`.
 - Satisfy `cmd/logpolicy`.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -595,7 +595,7 @@ func TestTrackersConfigCZTPasskeyFieldsRoundTrip(t *testing.T) {
 	}
 	text := string(data)
 	if !strings.Contains(text, "passkey: user-passkey") {
-		t.Fatalf("yaml export missing CZT passkey in:\n%s", text)
+		t.Fatal("yaml export missing CZT passkey")
 	}
 	if strings.Contains(text, "url: https://czteam.example") {
 		t.Fatalf("yaml CZT should not include url")

--- a/internal/cookies/loader_test.go
+++ b/internal/cookies/loader_test.go
@@ -122,13 +122,13 @@ func TestLoadTrackerCookieMapStoredValueOverridesStartupCookie(t *testing.T) {
 		t.Fatalf("LoadTrackerCookieMap: %v", err)
 	}
 	if values["session"] != "from-db" {
-		t.Fatalf("expected db cookie to override startup value, got %#v", values)
+		t.Fatal("expected db cookie to override startup value")
 	}
 	if values["persisted"] != "keep-me" {
-		t.Fatalf("expected db-only cookie to remain available, got %#v", values)
+		t.Fatal("expected db-only cookie to remain available")
 	}
 	if values["fresh"] != "from-file" {
-		t.Fatalf("expected startup-only cookie to be loaded, got %#v", values)
+		t.Fatal("expected startup-only cookie to be loaded")
 	}
 }
 
@@ -141,13 +141,13 @@ func TestCookieMapToHTTPCookiesPreservesCookieValueWhitespace(t *testing.T) {
 		"empty":    "",
 	}, " .example.org ")
 	if len(got) != 1 {
-		t.Fatalf("expected one HTTP cookie, got %#v", got)
+		t.Fatalf("expected one HTTP cookie, got count=%d", len(got))
 	}
 	if got[0].Name != "session" || got[0].Value != " padded " {
-		t.Fatalf("expected cookie value whitespace to be preserved, got %#v", got[0])
+		t.Fatal("expected cookie value whitespace to be preserved")
 	}
 	if got[0].Domain != ".example.org" {
-		t.Fatalf("expected trimmed domain, got %#v", got[0])
+		t.Fatal("expected trimmed domain")
 	}
 }
 
@@ -190,20 +190,20 @@ func TestLoadTrackerHTTPCookiesStoredValueOverridesStartupCookie(t *testing.T) {
 
 	values := httpCookiesToMap(loaded)
 	if values["session"] != "from-db" {
-		t.Fatalf("expected db cookie to override startup value, got %#v", values)
+		t.Fatal("expected db cookie to override startup value")
 	}
 	if values["persisted"] != "keep-me" {
-		t.Fatalf("expected db-only cookie to remain available, got %#v", values)
+		t.Fatal("expected db-only cookie to remain available")
 	}
 	if values["fresh"] != "from-file" {
-		t.Fatalf("expected startup-only cookie to be loaded, got %#v", values)
+		t.Fatal("expected startup-only cookie to be loaded")
 	}
 	for _, cookie := range loaded {
 		if cookie == nil {
 			continue
 		}
 		if cookie.Domain != "bj-share.info" {
-			t.Fatalf("expected domain to be applied, got cookie %#v", cookie)
+			t.Fatal("expected domain to be applied")
 		}
 	}
 }
@@ -348,7 +348,7 @@ func TestDeleteTrackerCookiesRestoresDBCookiesWhenLegacyDeleteFails(t *testing.T
 		t.Fatalf("load restored cookies: %v", err)
 	}
 	if values["session"] != "from-db" {
-		t.Fatalf("expected DB cookie restore after legacy failure, got %#v", values)
+		t.Fatal("expected DB cookie restore after legacy failure")
 	}
 }
 
@@ -405,7 +405,7 @@ func TestDeleteTrackerCookiesRestoresRemovedLegacyCandidateWhenLaterLegacyDelete
 		t.Fatalf("load restored cookies: %v", err)
 	}
 	if values["session"] != "from-db" {
-		t.Fatalf("expected DB cookie restore after legacy failure, got %#v", values)
+		t.Fatal("expected DB cookie restore after legacy failure")
 	}
 }
 

--- a/internal/core/e2e_enabled.go
+++ b/internal/core/e2e_enabled.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -378,7 +379,7 @@ func postE2ETrackerUpload(ctx context.Context, endpoint string, tracker string, 
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return fmt.Errorf("e2e tracker: status %d: %s", resp.StatusCode, strings.TrimSpace(string(payload)))
+		return fmt.Errorf("e2e tracker: status %d: %s", resp.StatusCode, strings.TrimSpace(redaction.RedactValue(string(payload), nil)))
 	}
 	return nil
 }
@@ -461,7 +462,7 @@ func postE2EImageUpload(ctx context.Context, endpoint string, host string, image
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return fmt.Errorf("e2e image: status %d: %s", resp.StatusCode, strings.TrimSpace(string(payload)))
+		return fmt.Errorf("e2e image: status %d: %s", resp.StatusCode, strings.TrimSpace(redaction.RedactValue(string(payload), nil)))
 	}
 	return nil
 }

--- a/internal/dupechecking/ant_test.go
+++ b/internal/dupechecking/ant_test.go
@@ -27,7 +27,7 @@ func TestANTHandlerSendsAPIKeyHeader(t *testing.T) {
 			assertQueryParam(t, query, "o", "json")
 			assertQueryParam(t, query, "tmdb", "123")
 			if got := req.Header.Get("X-Api-Key"); got != "token" {
-				t.Fatalf("unexpected X-API-Key header: got %q want %q", got, "token")
+				t.Fatal("unexpected X-API-Key header")
 			}
 			if got := req.Header.Get("User-Agent"); got == "" {
 				t.Fatal("expected User-Agent header")

--- a/internal/dupechecking/ant_test.go
+++ b/internal/dupechecking/ant_test.go
@@ -21,7 +21,7 @@ func TestANTHandlerSendsAPIKeyHeader(t *testing.T) {
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			query := req.URL.Query()
 			if got := query.Get("apikey"); got != "" {
-				t.Fatalf("apikey should not be sent as a query parameter, got %q", got)
+				t.Fatal("apikey should not be sent as a query parameter")
 			}
 			assertQueryParam(t, query, "t", "search")
 			assertQueryParam(t, query, "o", "json")

--- a/internal/dupechecking/ar_test.go
+++ b/internal/dupechecking/ar_test.go
@@ -51,7 +51,7 @@ func TestARHandlerSearchParsesResultsWithCookieFile(t *testing.T) {
 				t.Fatalf("expected User-Agent header")
 			}
 			if raw := req.Header.Get("Cookie"); !strings.Contains(raw, "session=abc123") {
-				t.Fatalf("expected cookie header to include session token, got %q", raw)
+				t.Fatal("expected cookie header to include session token")
 			}
 
 			body := `{"status":"success","response":{"results":[{"groupName":"Movie.Title.2023.1080p.BluRay-GRP","size":123456789,"fileCount":1,"groupId":44,"torrentId":55}]}}`

--- a/internal/dupechecking/czt_test.go
+++ b/internal/dupechecking/czt_test.go
@@ -501,7 +501,7 @@ func assertCZTSearchRequest(r *http.Request, title string) error {
 		return fmt.Errorf("type query: got %q", got)
 	}
 	if got := r.URL.Query().Get("passkey"); got != "passkey123" {
-		return fmt.Errorf("passkey query: got %q", got)
+		return errors.New("passkey query mismatch")
 	}
 	if got := r.URL.Query().Get("query"); got != title {
 		return fmt.Errorf("query: got %q", got)

--- a/internal/dupechecking/rtf_test.go
+++ b/internal/dupechecking/rtf_test.go
@@ -112,7 +112,7 @@ func TestRTFHandlerRefreshesAndRetriesOn401(t *testing.T) {
 				}
 				body := string(raw)
 				if !strings.Contains(body, `"username":"user"`) || !strings.Contains(body, `"password":"pass"`) {
-					t.Fatalf("unexpected login body %q", body)
+					t.Fatal("unexpected login body fields")
 				}
 				return &http.Response{
 					StatusCode: http.StatusCreated,
@@ -124,7 +124,7 @@ func TestRTFHandlerRefreshesAndRetriesOn401(t *testing.T) {
 				auth := req.Header.Get("Authorization")
 				if searchCalls == 1 {
 					if auth != "old-key" {
-						t.Fatalf("expected first search to use old key, got %q", auth)
+						t.Fatal("expected first search to use old key")
 					}
 					return &http.Response{
 						StatusCode: http.StatusUnauthorized,
@@ -133,7 +133,7 @@ func TestRTFHandlerRefreshesAndRetriesOn401(t *testing.T) {
 					}, nil
 				}
 				if auth != "new-key" {
-					t.Fatalf("expected retry search to use new key, got %q", auth)
+					t.Fatal("expected retry search to use new key")
 				}
 				return &http.Response{
 					StatusCode: http.StatusOK,

--- a/internal/guiapp/app_core_test.go
+++ b/internal/guiapp/app_core_test.go
@@ -791,7 +791,7 @@ func TestSaveConfigMigratesLegacyCookies(t *testing.T) {
 		t.Fatalf("LoadTrackerCookieMap: %v", err)
 	}
 	if got := values["session"]; got != "from-legacy" {
-		t.Fatalf("migrated session cookie: got %q want %q", got, "from-legacy")
+		t.Fatal("migrated session cookie mismatch")
 	}
 }
 

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -449,9 +449,6 @@ func checkSensitiveOutputFile(fset *token.FileSet, root string, path string, tes
 					if !ok {
 						continue
 					}
-					if value.kind == sensitiveBody && !isBodyOutputFormat(sinkArg.format) {
-						continue
-					}
 					if value.kind == sensitiveBody && isRawErrorLikeExpr(sinkArg.expr) {
 						continue
 					}
@@ -618,14 +615,6 @@ func stringArgValue(call *ast.CallExpr, index int) string {
 		return ""
 	}
 	return value
-}
-
-func isBodyOutputFormat(format string) bool {
-	lower := strings.ToLower(format)
-	return strings.Contains(lower, "body") ||
-		strings.Contains(lower, "payload") ||
-		strings.Contains(lower, "request") ||
-		strings.Contains(lower, "response")
 }
 
 func isTestAssertionOutputMethod(name string) bool {
@@ -849,7 +838,8 @@ func sensitivityOfKnownSensitiveCall(model sensitiveModel, call *ast.CallExpr) (
 	switch callName(call) {
 	case "LoadTrackerCookieMap", "LoadTrackerHTTPCookies", "CookieMapToHTTPCookies", "CookiesToMap", "httpCookiesToMap", "cookiesFromJar", "btnCookiesFromJar":
 		return sensitiveValue{kind: sensitiveCookieContainer, label: "cookies"}, true
-	case "postForm", "postMultipart", "postMultipartWithFields", "postMultipartRepeatedFileField", "readAndCloseResponseBody":
+	case "postForm", "postMultipart", "postMultipartWithFields", "postMultipartRepeatedFileField", "readAndCloseResponseBody",
+		"readTVDBResponseBody", "readIMDbResponseBody":
 		return sensitiveValue{kind: sensitiveBody, label: "response body"}, true
 	case "String":
 		if selector, ok := call.Fun.(*ast.SelectorExpr); ok && isSensitiveURLReceiver(model, selector.X) {

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -129,6 +129,8 @@ type Violation struct {
 	Message string
 }
 
+// CheckRepository scans repo-owned Go and frontend test sources for logging and
+// shareable-output patterns that can expose secrets or unsafe diagnostics.
 func CheckRepository(root string) ([]Violation, error) {
 	internalRoot := filepath.Join(root, "internal")
 	if _, err := os.Stat(internalRoot); err != nil {
@@ -223,6 +225,8 @@ var (
 	frontendRawPayloadDOMRe         = regexp.MustCompile("[\"']data-testid[\"']\\s*:\\s*[\"']payload[\"'].*buildSavePayload\\(\\)|buildSavePayload\\(\\).*[\"']data-testid[\"']\\s*:\\s*[\"']payload[\"']")
 )
 
+// checkFrontendTestSensitiveMatchers scans frontend tests for assertions and DOM
+// fixtures that would print encrypted envelopes or save payloads in failure output.
 func checkFrontendTestSensitiveMatchers(root string) ([]Violation, error) {
 	frontendRoot := filepath.Join(root, "gui", "frontend", "src")
 	if _, err := os.Stat(frontendRoot); err != nil {
@@ -257,6 +261,8 @@ func checkFrontendTestSensitiveMatchers(root string) ([]Violation, error) {
 	return violations, nil
 }
 
+// checkFrontendTestSensitiveMatcherFile applies the frontend secret-output regex
+// checks to one test file and reports line-based violations.
 func checkFrontendTestSensitiveMatcherFile(root string, path string) ([]Violation, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -355,6 +361,8 @@ func checkCLISensitiveOutputFile(fset *token.FileSet, root string, path string) 
 	return violations, nil
 }
 
+// checkFile enforces production Go logging policy for internal packages,
+// including logger hygiene, sensitive dataflow, and bounded response-body use.
 func checkFile(fset *token.FileSet, root string, path string) ([]Violation, error) {
 	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
 	if err != nil {
@@ -457,6 +465,8 @@ func checkFile(fset *token.FileSet, root string, path string) ([]Violation, erro
 	return violations, nil
 }
 
+// checkTestFile enforces shareable test-output policy, including secret
+// dataflow and httptest handler fatal-call checks.
 func checkTestFile(fset *token.FileSet, root string, path string) ([]Violation, error) {
 	violations, err := checkSensitiveOutputFile(fset, root, path, true)
 	if err != nil {
@@ -503,10 +513,12 @@ type sensitiveModel struct {
 	testSensitiveFixture bool
 }
 
+// pushScope starts a lexical binding scope for sensitive-value dataflow.
 func (m *sensitiveModel) pushScope() {
 	m.scopes = append(m.scopes, make(map[string]sensitiveBinding))
 }
 
+// popScope drops the current lexical binding scope if one exists.
 func (m *sensitiveModel) popScope() {
 	if len(m.scopes) == 0 {
 		return
@@ -514,6 +526,7 @@ func (m *sensitiveModel) popScope() {
 	m.scopes = m.scopes[:len(m.scopes)-1]
 }
 
+// currentScope returns the active lexical scope, creating one for top-level use.
 func (m *sensitiveModel) currentScope() map[string]sensitiveBinding {
 	if len(m.scopes) == 0 {
 		m.pushScope()
@@ -521,10 +534,13 @@ func (m *sensitiveModel) currentScope() map[string]sensitiveBinding {
 	return m.scopes[len(m.scopes)-1]
 }
 
+// declare records a new binding in the current lexical scope.
 func (m *sensitiveModel) declare(name string, value sensitiveValue, sensitive bool) {
 	m.currentScope()[name] = sensitiveBinding{value: value, sensitive: sensitive}
 }
 
+// assign updates the nearest existing binding or declares one when assignment
+// targets a name not yet seen by the model.
 func (m *sensitiveModel) assign(name string, value sensitiveValue, sensitive bool) {
 	for i := len(m.scopes) - 1; i >= 0; i-- {
 		if _, ok := m.scopes[i][name]; ok {
@@ -535,6 +551,8 @@ func (m *sensitiveModel) assign(name string, value sensitiveValue, sensitive boo
 	m.declare(name, value, sensitive)
 }
 
+// lookup resolves a binding from innermost to outermost scope and returns
+// whether the current value is sensitive.
 func (m *sensitiveModel) lookup(name string) (sensitiveValue, bool) {
 	for i := len(m.scopes) - 1; i >= 0; i-- {
 		binding, ok := m.scopes[i][name]
@@ -553,6 +571,8 @@ type logpolicyAllow struct {
 	used   bool
 }
 
+// checkSensitiveOutputFile tracks sensitive values through one Go file and
+// flags values reaching logs, returned errors, test diagnostics, or artifacts.
 func checkSensitiveOutputFile(fset *token.FileSet, root string, path string, testFile bool) ([]Violation, error) {
 	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments|parser.SkipObjectResolution)
 	if err != nil {
@@ -611,6 +631,8 @@ type sensitiveOutputVisitor struct {
 	scopeStack      []bool
 }
 
+// Visit maintains lexical scope while scanning calls and assignments for
+// sensitive-value propagation.
 func (v *sensitiveOutputVisitor) Visit(node ast.Node) ast.Visitor {
 	if node == nil {
 		if len(v.scopeStack) == 0 {
@@ -641,6 +663,8 @@ func (v *sensitiveOutputVisitor) Visit(node ast.Node) ast.Visitor {
 	return v
 }
 
+// checkCall reports a violation when a modeled sensitive value reaches a sink
+// without a recognized sanitizing wrapper.
 func (v *sensitiveOutputVisitor) checkCall(call *ast.CallExpr) {
 	for _, sinkArg := range sensitiveSinkArgs(call, v.model.aliases, v.testFile, v.functionContext) {
 		if isSafeSensitiveOutputExpr(sinkArg.expr) {
@@ -677,6 +701,8 @@ func isSensitiveScopeNode(node ast.Node) bool {
 	}
 }
 
+// collectLogpolicyAllows indexes line-local allow comments and reports allows
+// that omit a required reason.
 func collectLogpolicyAllows(fset *token.FileSet, relPath string, file *ast.File) (map[int]*logpolicyAllow, []Violation) {
 	allows := make(map[int]*logpolicyAllow)
 	violations := make([]Violation, 0)
@@ -701,6 +727,8 @@ func collectLogpolicyAllows(fset *token.FileSet, relPath string, file *ast.File)
 	return allows, violations
 }
 
+// shouldSuppressLogpolicyViolation consumes a matching allow comment unless the
+// value is a never-allow header such as Cookie or Authorization.
 func shouldSuppressLogpolicyViolation(fset *token.FileSet, allows map[int]*logpolicyAllow, pos token.Pos, value sensitiveValue) bool {
 	if value.kind == sensitiveHTTPHeader && isNeverAllowHeader(value.label) {
 		return false
@@ -732,6 +760,8 @@ type sinkArg struct {
 	format        string
 }
 
+// sensitiveSinkArgs identifies call arguments whose values are user-shareable
+// output for logging, returned errors, test failure messages, or artifacts.
 func sensitiveSinkArgs(call *ast.CallExpr, aliases map[string]string, testFile bool, functionContext string) []sinkArg {
 	if len(call.Args) == 0 {
 		return nil
@@ -855,6 +885,8 @@ func isHTTPErrorSelector(selector *ast.SelectorExpr, aliases map[string]string) 
 	return ok && aliases[pkg.Name] == "net/http" && selector.Sel.Name == "Error"
 }
 
+// checkTestHandlerFatalCalls reports t.Fatal-style calls inside HTTP test
+// handlers, where the handler runs outside the test goroutine.
 func checkTestHandlerFatalCalls(fset *token.FileSet, root string, path string) ([]Violation, error) {
 	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
 	if err != nil {
@@ -938,6 +970,8 @@ func isHTTPRequestPointerType(expr ast.Expr, aliases map[string]string) bool {
 	return ok && aliases[pkg.Name] == "net/http"
 }
 
+// isTestingFatalCall recognizes fatal test methods on conventional testing
+// receivers used by handler fixtures.
 func isTestingFatalCall(call *ast.CallExpr) bool {
 	selector, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
@@ -960,6 +994,8 @@ func isTestingFatalCall(call *ast.CallExpr) bool {
 	}
 }
 
+// checkUnboundedResponseBodyUses flags response bodies that are read without a
+// limit before flowing into redaction, errors, or shareable artifacts.
 func checkUnboundedResponseBodyUses(fset *token.FileSet, relPath string, file *ast.File, aliases map[string]string) []Violation {
 	violations := make([]Violation, 0)
 	for _, decl := range file.Decls {
@@ -983,6 +1019,8 @@ func checkUnboundedResponseBodyUses(fset *token.FileSet, relPath string, file *a
 	return violations
 }
 
+// markUnboundedBodyAssignments updates body-read taint for assignment targets.
+// Single-call tuple assignments taint only the first return value.
 func markUnboundedBodyAssignments(stmt *ast.AssignStmt, aliases map[string]string, unboundedBodyVars map[string]struct{}) {
 	if len(stmt.Rhs) == 1 {
 		for index, target := range stmt.Lhs {
@@ -1012,6 +1050,8 @@ func markUnboundedBodyAssignments(stmt *ast.AssignStmt, aliases map[string]strin
 	}
 }
 
+// isUnboundedResponseBodyRead reports io.ReadAll(resp.Body)-style reads that do
+// not wrap the body with io.LimitReader.
 func isUnboundedResponseBodyRead(expr ast.Expr, aliases map[string]string) bool {
 	call, ok := expr.(*ast.CallExpr)
 	if !ok {
@@ -1034,6 +1074,8 @@ func isUnboundedResponseBodyRead(expr ast.Expr, aliases map[string]string) bool 
 	return isResponseBodyExpr(call.Args[0])
 }
 
+// isUnboundedResponseBodyUseCall reports uses where an unbounded body value is
+// about to become redacted output, an error message, or an artifact.
 func isUnboundedResponseBodyUseCall(call *ast.CallExpr, unboundedBodyVars map[string]struct{}) bool {
 	if len(unboundedBodyVars) == 0 {
 		return false
@@ -1056,6 +1098,8 @@ func isUnboundedResponseBodyUseCall(call *ast.CallExpr, unboundedBodyVars map[st
 	return false
 }
 
+// isResponseBodyErrorOrArtifactHelper recognizes helpers whose output may be
+// returned to users or written into diagnostic artifacts.
 func isResponseBodyErrorOrArtifactHelper(name string) bool {
 	switch name {
 	case "UploadHTTPError", "safeResponsePreview", "safeResponseMessage":
@@ -1065,6 +1109,8 @@ func isResponseBodyErrorOrArtifactHelper(name string) bool {
 	}
 }
 
+// isUnboundedResponseBodyHelperCallName recognizes legacy helpers known to read
+// a response body without enforcing the repo preview limit.
 func isUnboundedResponseBodyHelperCallName(name string) bool {
 	switch name {
 	case "readAndCloseResponseBody":
@@ -1074,6 +1120,8 @@ func isUnboundedResponseBodyHelperCallName(name string) bool {
 	}
 }
 
+// containsUnboundedBodyVar reports whether an expression references a currently
+// tainted unbounded response-body binding.
 func containsUnboundedBodyVar(expr ast.Expr, unboundedBodyVars map[string]struct{}) bool {
 	found := false
 	ast.Inspect(expr, func(node ast.Node) bool {
@@ -1090,6 +1138,7 @@ func containsUnboundedBodyVar(expr ast.Expr, unboundedBodyVars map[string]struct
 	return found
 }
 
+// isLimitReaderCall recognizes io.LimitReader wrappers that bound body reads.
 func isLimitReaderCall(expr ast.Expr, aliases map[string]string) bool {
 	call, ok := expr.(*ast.CallExpr)
 	if !ok {
@@ -1127,6 +1176,8 @@ func isSensitiveTestRawErrorContext(context string, format string) bool {
 		strings.Contains(lowerFormat, "upload rejected")
 }
 
+// markSensitiveAssignment propagates sensitivity through assignments and keeps
+// multi-return calls indexed to the assigned result positions.
 func markSensitiveAssignment(model *sensitiveModel, stmt *ast.AssignStmt) {
 	declare := stmt.Tok == token.DEFINE
 	for index, target := range stmt.Lhs {
@@ -1147,6 +1198,7 @@ func markSensitiveAssignment(model *sensitiveModel, stmt *ast.AssignStmt) {
 	}
 }
 
+// bind applies declaration or assignment semantics for one modeled identifier.
 func (m *sensitiveModel) bind(name string, value sensitiveValue, sensitive bool, declare bool) {
 	if declare {
 		m.declare(name, value, sensitive)
@@ -1155,6 +1207,8 @@ func (m *sensitiveModel) bind(name string, value sensitiveValue, sensitive bool,
 	m.assign(name, value, sensitive)
 }
 
+// markSensitiveRange treats range key and value variables as sensitive when the
+// ranged expression is sensitive.
 func markSensitiveRange(model *sensitiveModel, stmt *ast.RangeStmt) {
 	value, sensitive := sensitivityOfExpr(model, stmt.X)
 	for _, target := range []ast.Expr{stmt.Key, stmt.Value} {
@@ -1165,6 +1219,8 @@ func markSensitiveRange(model *sensitiveModel, stmt *ast.RangeStmt) {
 	}
 }
 
+// sensitivityOfExprResult returns the sensitivity of one assignment result,
+// preserving per-result behavior for known multi-return calls.
 func sensitivityOfExprResult(model *sensitiveModel, expr ast.Expr, resultIndex int) (sensitiveValue, bool) {
 	if call, ok := expr.(*ast.CallExpr); ok {
 		if value, sensitive := sensitivityOfKnownCallResult(model, call, resultIndex); sensitive {
@@ -1177,6 +1233,8 @@ func sensitivityOfExprResult(model *sensitiveModel, expr ast.Expr, resultIndex i
 	return sensitivityOfExpr(model, expr)
 }
 
+// sensitivityOfExpr classifies expressions that directly contain, derive from,
+// or propagate sensitive values.
 func sensitivityOfExpr(model *sensitiveModel, expr ast.Expr) (sensitiveValue, bool) {
 	if expr == nil || isSafeSensitiveOutputExpr(expr) {
 		return sensitiveValue{}, false
@@ -1240,6 +1298,8 @@ func sensitivityOfExpr(model *sensitiveModel, expr ast.Expr) (sensitiveValue, bo
 	return sensitiveValue{}, false
 }
 
+// isSensitivePropagatingCall recognizes wrappers that preserve the sensitive
+// content of their arguments instead of sanitizing it.
 func isSensitivePropagatingCall(model *sensitiveModel, call *ast.CallExpr) bool {
 	switch fun := call.Fun.(type) {
 	case *ast.Ident:
@@ -1257,6 +1317,7 @@ func isSensitivePropagatingCall(model *sensitiveModel, call *ast.CallExpr) bool 
 	return false
 }
 
+// firstSensitiveExpr returns the first sensitive expression in source order.
 func firstSensitiveExpr(model *sensitiveModel, exprs ...ast.Expr) (sensitiveValue, bool) {
 	for _, expr := range exprs {
 		if value, ok := sensitivityOfExpr(model, expr); ok {
@@ -1273,6 +1334,8 @@ func sensitivityOfPayloadIndex(model *sensitiveModel, index *ast.IndexExpr) (sen
 	return sensitiveValue{}, false
 }
 
+// sensitivityOfDirectCall classifies sensitive values produced directly by
+// header, form, query, cookie, URL, and body-read calls.
 func sensitivityOfDirectCall(model *sensitiveModel, call *ast.CallExpr) (sensitiveValue, bool) {
 	if value, ok := sensitivityOfKnownSensitiveCall(model, call); ok {
 		return value, true
@@ -1316,6 +1379,8 @@ func sensitivityOfDirectCall(model *sensitiveModel, call *ast.CallExpr) (sensiti
 	return sensitiveValue{}, false
 }
 
+// sensitivityOfKnownSensitiveCall classifies repo helper calls whose return
+// values carry cookies, response bodies, URLs, or credential-like strings.
 func sensitivityOfKnownSensitiveCall(model *sensitiveModel, call *ast.CallExpr) (sensitiveValue, bool) {
 	name := callName(call)
 	if value, ok := sensitivityOfSensitiveValueHelperCallName(name); ok {
@@ -1335,6 +1400,8 @@ func sensitivityOfKnownSensitiveCall(model *sensitiveModel, call *ast.CallExpr) 
 	return sensitiveValue{}, false
 }
 
+// sensitivityOfSensitiveValueHelperCallName classifies helper names that imply
+// the first returned value is a credential-like secret.
 func sensitivityOfSensitiveValueHelperCallName(name string) (sensitiveValue, bool) {
 	lower := strings.ToLower(strings.TrimSpace(name))
 	if !isSensitiveValueHelperName(lower) {
@@ -1409,6 +1476,8 @@ func sensitivityOfSecretBearingURLExpr(model *sensitiveModel, expr *ast.BinaryEx
 	return sensitiveValue{}, false
 }
 
+// sensitivityOfKnownCallResult models helpers where only the first return value
+// carries sensitive data and trailing returns such as errors are safe by default.
 func sensitivityOfKnownCallResult(model *sensitiveModel, call *ast.CallExpr, resultIndex int) (sensitiveValue, bool) {
 	if resultIndex != 0 {
 		return sensitiveValue{}, false

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -198,6 +198,12 @@ func CheckRepository(root string) ([]Violation, error) {
 		return nil, fmt.Errorf("logpolicy: stat cmd/upbrr root: %w", err)
 	}
 
+	frontendViolations, err := checkFrontendTestSensitiveMatchers(root)
+	if err != nil {
+		return nil, err
+	}
+	violations = append(violations, frontendViolations...)
+
 	sort.Slice(violations, func(i, j int) bool {
 		if violations[i].File != violations[j].File {
 			return violations[i].File < violations[j].File
@@ -208,6 +214,98 @@ func CheckRepository(root string) ([]Violation, error) {
 		return violations[i].Column < violations[j].Column
 	})
 
+	return violations, nil
+}
+
+var (
+	frontendEncryptedEnvelopeDeclRe = regexp.MustCompile("\\b(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*[\"'`]upbrr-enc:")
+	frontendDirectEnvelopeMatcherRe = regexp.MustCompile("\\.(?:toBe|toEqual|toStrictEqual|toContain|toMatch)\\(\\s*(?:[\"'`]upbrr-enc:|([A-Za-z_$][\\w$]*))")
+	frontendRawPayloadDOMRe         = regexp.MustCompile("[\"']data-testid[\"']\\s*:\\s*[\"']payload[\"'].*buildSavePayload\\(\\)|buildSavePayload\\(\\).*[\"']data-testid[\"']\\s*:\\s*[\"']payload[\"']")
+)
+
+func checkFrontendTestSensitiveMatchers(root string) ([]Violation, error) {
+	frontendRoot := filepath.Join(root, "gui", "frontend", "src")
+	if _, err := os.Stat(frontendRoot); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("logpolicy: stat frontend root: %w", err)
+	}
+
+	violations := make([]Violation, 0)
+	err := filepath.WalkDir(frontendRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".test.ts") && !strings.HasSuffix(path, ".test.tsx") {
+			return nil
+		}
+
+		fileViolations, err := checkFrontendTestSensitiveMatcherFile(root, path)
+		if err != nil {
+			return err
+		}
+		violations = append(violations, fileViolations...)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("logpolicy: walk frontend tests: %w", err)
+	}
+	return violations, nil
+}
+
+func checkFrontendTestSensitiveMatcherFile(root string, path string) ([]Violation, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	relPath, err := filepath.Rel(root, path)
+	if err != nil {
+		relPath = path
+	}
+	relPath = filepath.ToSlash(relPath)
+
+	encryptedNames := make(map[string]struct{})
+	for _, match := range frontendEncryptedEnvelopeDeclRe.FindAllSubmatch(content, -1) {
+		if len(match) > 1 {
+			encryptedNames[string(match[1])] = struct{}{}
+		}
+	}
+
+	violations := make([]Violation, 0)
+	for index, line := range strings.Split(string(content), "\n") {
+		match := frontendDirectEnvelopeMatcherRe.FindStringSubmatchIndex(line)
+		if match == nil {
+			continue
+		}
+		if match[2] >= 0 {
+			name := line[match[2]:match[3]]
+			if _, ok := encryptedNames[name]; !ok {
+				continue
+			}
+		}
+		violations = append(violations, Violation{
+			File:    relPath,
+			Line:    index + 1,
+			Column:  match[0] + 1,
+			Message: "frontend test assertions must not print encrypted envelope values; assert a boolean predicate or use static sanitized failure text",
+		})
+	}
+	for index, line := range strings.Split(string(content), "\n") {
+		match := frontendRawPayloadDOMRe.FindStringIndex(line)
+		if match == nil {
+			continue
+		}
+		violations = append(violations, Violation{
+			File:    relPath,
+			Line:    index + 1,
+			Column:  match[0] + 1,
+			Message: "frontend tests must not render raw save payloads into the DOM; Testing Library failures can dump secret payload content",
+		})
+	}
 	return violations, nil
 }
 

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -958,7 +958,7 @@ func isResponseBodyErrorOrArtifactHelper(name string) bool {
 
 func isUnboundedResponseBodyHelperCallName(name string) bool {
 	switch name {
-	case "postForm", "postMultipart", "postMultipartWithFields", "postMultipartRepeatedFileField", "readAndCloseResponseBody":
+	case "readAndCloseResponseBody":
 		return true
 	default:
 		return false

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -382,12 +382,60 @@ type sensitiveValue struct {
 	label string
 }
 
+type sensitiveBinding struct {
+	value     sensitiveValue
+	sensitive bool
+}
+
 type sensitiveModel struct {
 	aliases              map[string]string
-	vars                 map[string]sensitiveValue
+	scopes               []map[string]sensitiveBinding
 	relPath              string
 	testFile             bool
 	testSensitiveFixture bool
+}
+
+func (m *sensitiveModel) pushScope() {
+	m.scopes = append(m.scopes, make(map[string]sensitiveBinding))
+}
+
+func (m *sensitiveModel) popScope() {
+	if len(m.scopes) == 0 {
+		return
+	}
+	m.scopes = m.scopes[:len(m.scopes)-1]
+}
+
+func (m *sensitiveModel) currentScope() map[string]sensitiveBinding {
+	if len(m.scopes) == 0 {
+		m.pushScope()
+	}
+	return m.scopes[len(m.scopes)-1]
+}
+
+func (m *sensitiveModel) declare(name string, value sensitiveValue, sensitive bool) {
+	m.currentScope()[name] = sensitiveBinding{value: value, sensitive: sensitive}
+}
+
+func (m *sensitiveModel) assign(name string, value sensitiveValue, sensitive bool) {
+	for i := len(m.scopes) - 1; i >= 0; i-- {
+		if _, ok := m.scopes[i][name]; ok {
+			m.scopes[i][name] = sensitiveBinding{value: value, sensitive: sensitive}
+			return
+		}
+	}
+	m.declare(name, value, sensitive)
+}
+
+func (m *sensitiveModel) lookup(name string) (sensitiveValue, bool) {
+	for i := len(m.scopes) - 1; i >= 0; i-- {
+		binding, ok := m.scopes[i][name]
+		if !ok {
+			continue
+		}
+		return binding.value, binding.sensitive
+	}
+	return sensitiveValue{}, false
 }
 
 type logpolicyAllow struct {
@@ -420,46 +468,19 @@ func checkSensitiveOutputFile(fset *token.FileSet, root string, path string, tes
 		}
 		model := sensitiveModel{
 			aliases:              aliases,
-			vars:                 make(map[string]sensitiveValue),
 			relPath:              relPath,
 			testFile:             testFile,
 			testSensitiveFixture: testFile && containsSensitiveFixtureLiteral(fn.Body),
 		}
 		functionContext := strings.ToLower(relPath + " " + fn.Name.Name)
-		ast.Inspect(fn.Body, func(node ast.Node) bool {
-			switch typed := node.(type) {
-			case *ast.AssignStmt:
-				markSensitiveAssignment(model, typed.Lhs, typed.Rhs)
-			case *ast.RangeStmt:
-				markSensitiveRange(model, typed)
-			case *ast.CallExpr:
-				for _, sinkArg := range sensitiveSinkArgs(typed, model.aliases, testFile, functionContext) {
-					if isSafeSensitiveOutputExpr(sinkArg.expr) {
-						continue
-					}
-					value, ok := sensitivityOfExpr(model, sinkArg.expr)
-					if !ok && sinkArg.forceRawError {
-						value = sensitiveValue{kind: sensitiveRawError, label: "raw error"}
-						ok = true
-					}
-					if !ok && testFile && model.testSensitiveFixture && isTestLogBufferDumpExpr(sinkArg.expr) {
-						value = sensitiveValue{kind: sensitiveGeneric, label: "test log buffer"}
-						ok = true
-					}
-					if !ok {
-						continue
-					}
-					if value.kind == sensitiveBody && isRawErrorLikeExpr(sinkArg.expr) {
-						continue
-					}
-					if shouldSuppressLogpolicyViolation(fset, allows, sinkArg.expr.Pos(), value) {
-						continue
-					}
-					violations = append(violations, violationAt(fset, relPath, sinkArg.expr.Pos(), sensitiveOutputMessage(value)))
-				}
-			}
-			return true
-		})
+		ast.Walk(&sensitiveOutputVisitor{
+			fset:            fset,
+			allows:          allows,
+			violations:      &violations,
+			model:           &model,
+			testFile:        testFile,
+			functionContext: functionContext,
+		}, fn.Body)
 	}
 
 	for _, allow := range allows {
@@ -470,6 +491,82 @@ func checkSensitiveOutputFile(fset *token.FileSet, root string, path string, tes
 	}
 
 	return violations, nil
+}
+
+type sensitiveOutputVisitor struct {
+	fset            *token.FileSet
+	allows          map[int]*logpolicyAllow
+	violations      *[]Violation
+	model           *sensitiveModel
+	testFile        bool
+	functionContext string
+	scopeStack      []bool
+}
+
+func (v *sensitiveOutputVisitor) Visit(node ast.Node) ast.Visitor {
+	if node == nil {
+		if len(v.scopeStack) == 0 {
+			return nil
+		}
+		pushedScope := v.scopeStack[len(v.scopeStack)-1]
+		v.scopeStack = v.scopeStack[:len(v.scopeStack)-1]
+		if pushedScope {
+			v.model.popScope()
+		}
+		return nil
+	}
+
+	pushedScope := isSensitiveScopeNode(node)
+	if pushedScope {
+		v.model.pushScope()
+	}
+	v.scopeStack = append(v.scopeStack, pushedScope)
+
+	switch typed := node.(type) {
+	case *ast.AssignStmt:
+		markSensitiveAssignment(v.model, typed)
+	case *ast.RangeStmt:
+		markSensitiveRange(v.model, typed)
+	case *ast.CallExpr:
+		v.checkCall(typed)
+	}
+	return v
+}
+
+func (v *sensitiveOutputVisitor) checkCall(call *ast.CallExpr) {
+	for _, sinkArg := range sensitiveSinkArgs(call, v.model.aliases, v.testFile, v.functionContext) {
+		if isSafeSensitiveOutputExpr(sinkArg.expr) {
+			continue
+		}
+		value, ok := sensitivityOfExpr(v.model, sinkArg.expr)
+		if !ok && sinkArg.forceRawError {
+			value = sensitiveValue{kind: sensitiveRawError, label: "raw error"}
+			ok = true
+		}
+		if !ok && v.testFile && v.model.testSensitiveFixture && isTestLogBufferDumpExpr(sinkArg.expr) {
+			value = sensitiveValue{kind: sensitiveGeneric, label: "test log buffer"}
+			ok = true
+		}
+		if !ok {
+			continue
+		}
+		if value.kind == sensitiveBody && isRawErrorLikeExpr(sinkArg.expr) {
+			continue
+		}
+		if shouldSuppressLogpolicyViolation(v.fset, v.allows, sinkArg.expr.Pos(), value) {
+			continue
+		}
+		*v.violations = append(*v.violations, violationAt(v.fset, v.model.relPath, sinkArg.expr.Pos(), sensitiveOutputMessage(value)))
+	}
+}
+
+func isSensitiveScopeNode(node ast.Node) bool {
+	switch node.(type) {
+	case *ast.BlockStmt, *ast.IfStmt, *ast.ForStmt, *ast.RangeStmt, *ast.SwitchStmt, *ast.TypeSwitchStmt, *ast.SelectStmt, *ast.CaseClause, *ast.CommClause:
+		return true
+	default:
+		return false
+	}
 }
 
 func collectLogpolicyAllows(fset *token.FileSet, relPath string, file *ast.File) (map[int]*logpolicyAllow, []Violation) {
@@ -575,8 +672,11 @@ func sensitiveSinkArgs(call *ast.CallExpr, aliases map[string]string, testFile b
 			return sinkArgsWithFormat(call.Args[1:], false, stringArgValue(call, 0))
 		}
 	}
-	if testFile && isTestAssertionOutputMethod(selector.Sel.Name) && hasStringArg(call, 0) {
-		return sinkArgsWithFormat(call.Args[1:], false, stringArgValue(call, 0))
+	if testFile && isTestAssertionOutputMethod(selector.Sel.Name) {
+		if isTestAssertionFormatOutputMethod(selector.Sel.Name) && hasStringArg(call, 0) {
+			return sinkArgsWithFormat(call.Args[1:], false, stringArgValue(call, 0))
+		}
+		return sinkArgs(call.Args, false)
 	}
 
 	return nil
@@ -619,6 +719,15 @@ func stringArgValue(call *ast.CallExpr, index int) string {
 
 func isTestAssertionOutputMethod(name string) bool {
 	switch name {
+	case "Fatal", "Fatalf", "Error", "Errorf", "Log", "Logf":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTestAssertionFormatOutputMethod(name string) bool {
+	switch name {
 	case "Fatalf", "Errorf", "Logf":
 		return true
 	default:
@@ -646,43 +755,45 @@ func isSensitiveHTTPErrorContext(context string) bool {
 	return false
 }
 
-func markSensitiveAssignment(model sensitiveModel, lhs []ast.Expr, rhs []ast.Expr) {
-	for index, target := range lhs {
+func markSensitiveAssignment(model *sensitiveModel, stmt *ast.AssignStmt) {
+	declare := stmt.Tok == token.DEFINE
+	for index, target := range stmt.Lhs {
 		ident, ok := target.(*ast.Ident)
 		if !ok || ident.Name == "_" {
 			continue
 		}
 		rhsIndex := index
-		if len(rhs) == 1 {
+		if len(stmt.Rhs) == 1 {
 			rhsIndex = 0
 		}
-		if rhsIndex >= len(rhs) {
-			delete(model.vars, ident.Name)
+		if rhsIndex >= len(stmt.Rhs) {
+			model.bind(ident.Name, sensitiveValue{}, false, declare)
 			continue
 		}
-		value, sensitive := sensitivityOfExprResult(model, rhs[rhsIndex], index)
-		if !sensitive {
-			delete(model.vars, ident.Name)
-			continue
-		}
-		model.vars[ident.Name] = value
+		value, sensitive := sensitivityOfExprResult(model, stmt.Rhs[rhsIndex], index)
+		model.bind(ident.Name, value, sensitive, declare)
 	}
 }
 
-func markSensitiveRange(model sensitiveModel, stmt *ast.RangeStmt) {
-	value, ok := sensitivityOfExpr(model, stmt.X)
-	if !ok {
+func (m *sensitiveModel) bind(name string, value sensitiveValue, sensitive bool, declare bool) {
+	if declare {
+		m.declare(name, value, sensitive)
 		return
 	}
+	m.assign(name, value, sensitive)
+}
+
+func markSensitiveRange(model *sensitiveModel, stmt *ast.RangeStmt) {
+	value, sensitive := sensitivityOfExpr(model, stmt.X)
 	for _, target := range []ast.Expr{stmt.Key, stmt.Value} {
 		ident, ok := target.(*ast.Ident)
 		if ok && ident.Name != "_" {
-			model.vars[ident.Name] = value
+			model.bind(ident.Name, value, sensitive, stmt.Tok == token.DEFINE)
 		}
 	}
 }
 
-func sensitivityOfExprResult(model sensitiveModel, expr ast.Expr, resultIndex int) (sensitiveValue, bool) {
+func sensitivityOfExprResult(model *sensitiveModel, expr ast.Expr, resultIndex int) (sensitiveValue, bool) {
 	if call, ok := expr.(*ast.CallExpr); ok {
 		if value, sensitive := sensitivityOfKnownCallResult(model, call, resultIndex); sensitive {
 			return value, true
@@ -694,14 +805,13 @@ func sensitivityOfExprResult(model sensitiveModel, expr ast.Expr, resultIndex in
 	return sensitivityOfExpr(model, expr)
 }
 
-func sensitivityOfExpr(model sensitiveModel, expr ast.Expr) (sensitiveValue, bool) {
+func sensitivityOfExpr(model *sensitiveModel, expr ast.Expr) (sensitiveValue, bool) {
 	if expr == nil || isSafeSensitiveOutputExpr(expr) {
 		return sensitiveValue{}, false
 	}
 	switch typed := expr.(type) {
 	case *ast.Ident:
-		value, ok := model.vars[typed.Name]
-		return value, ok
+		return model.lookup(typed.Name)
 	case *ast.ParenExpr:
 		return sensitivityOfExpr(model, typed.X)
 	case *ast.UnaryExpr:
@@ -758,7 +868,7 @@ func sensitivityOfExpr(model sensitiveModel, expr ast.Expr) (sensitiveValue, boo
 	return sensitiveValue{}, false
 }
 
-func isSensitivePropagatingCall(model sensitiveModel, call *ast.CallExpr) bool {
+func isSensitivePropagatingCall(model *sensitiveModel, call *ast.CallExpr) bool {
 	switch fun := call.Fun.(type) {
 	case *ast.Ident:
 		return fun.Name == "string"
@@ -775,7 +885,7 @@ func isSensitivePropagatingCall(model sensitiveModel, call *ast.CallExpr) bool {
 	return false
 }
 
-func firstSensitiveExpr(model sensitiveModel, exprs ...ast.Expr) (sensitiveValue, bool) {
+func firstSensitiveExpr(model *sensitiveModel, exprs ...ast.Expr) (sensitiveValue, bool) {
 	for _, expr := range exprs {
 		if value, ok := sensitivityOfExpr(model, expr); ok {
 			return value, true
@@ -784,14 +894,14 @@ func firstSensitiveExpr(model sensitiveModel, exprs ...ast.Expr) (sensitiveValue
 	return sensitiveValue{}, false
 }
 
-func sensitivityOfPayloadIndex(model sensitiveModel, index *ast.IndexExpr) (sensitiveValue, bool) {
+func sensitivityOfPayloadIndex(model *sensitiveModel, index *ast.IndexExpr) (sensitiveValue, bool) {
 	if value, ok := sensitivityOfExpr(model, index.X); ok {
 		return value, true
 	}
 	return sensitiveValue{}, false
 }
 
-func sensitivityOfDirectCall(model sensitiveModel, call *ast.CallExpr) (sensitiveValue, bool) {
+func sensitivityOfDirectCall(model *sensitiveModel, call *ast.CallExpr) (sensitiveValue, bool) {
 	if value, ok := sensitivityOfKnownSensitiveCall(model, call); ok {
 		return value, true
 	}
@@ -834,7 +944,7 @@ func sensitivityOfDirectCall(model sensitiveModel, call *ast.CallExpr) (sensitiv
 	return sensitiveValue{}, false
 }
 
-func sensitivityOfKnownSensitiveCall(model sensitiveModel, call *ast.CallExpr) (sensitiveValue, bool) {
+func sensitivityOfKnownSensitiveCall(model *sensitiveModel, call *ast.CallExpr) (sensitiveValue, bool) {
 	switch callName(call) {
 	case "LoadTrackerCookieMap", "LoadTrackerHTTPCookies", "CookieMapToHTTPCookies", "CookiesToMap", "httpCookiesToMap", "cookiesFromJar", "btnCookiesFromJar":
 		return sensitiveValue{kind: sensitiveCookieContainer, label: "cookies"}, true
@@ -860,7 +970,7 @@ func callName(call *ast.CallExpr) string {
 	}
 }
 
-func sensitivityOfSelectorExpr(model sensitiveModel, selector *ast.SelectorExpr) (sensitiveValue, bool) {
+func sensitivityOfSelectorExpr(model *sensitiveModel, selector *ast.SelectorExpr) (sensitiveValue, bool) {
 	name := strings.TrimSpace(selector.Sel.Name)
 	if model.testFile && isConfigOwnerTestPath(model.relPath) {
 		return sensitiveValue{}, false
@@ -877,7 +987,7 @@ func sensitivityOfSelectorExpr(model sensitiveModel, selector *ast.SelectorExpr)
 	return sensitiveValue{}, false
 }
 
-func sensitivityOfSecretBearingURLExpr(model sensitiveModel, expr *ast.BinaryExpr) (sensitiveValue, bool) {
+func sensitivityOfSecretBearingURLExpr(model *sensitiveModel, expr *ast.BinaryExpr) (sensitiveValue, bool) {
 	if !binaryExprContainsSecretURLKey(expr) {
 		return sensitiveValue{}, false
 	}
@@ -890,7 +1000,7 @@ func sensitivityOfSecretBearingURLExpr(model sensitiveModel, expr *ast.BinaryExp
 	return sensitiveValue{}, false
 }
 
-func sensitivityOfKnownCallResult(model sensitiveModel, call *ast.CallExpr, resultIndex int) (sensitiveValue, bool) {
+func sensitivityOfKnownCallResult(model *sensitiveModel, call *ast.CallExpr, resultIndex int) (sensitiveValue, bool) {
 	if resultIndex != 0 {
 		return sensitiveValue{}, false
 	}
@@ -1011,7 +1121,7 @@ func isCookieCompositeType(expr ast.Expr) bool {
 	}
 }
 
-func isSensitiveURLReceiver(model sensitiveModel, expr ast.Expr) bool {
+func isSensitiveURLReceiver(model *sensitiveModel, expr ast.Expr) bool {
 	if _, ok := sensitivityOfExpr(model, expr); ok {
 		return true
 	}
@@ -1060,7 +1170,7 @@ func binaryExprContainsSecretURLKey(expr ast.Expr) bool {
 	return found
 }
 
-func containsSensitiveSelector(model sensitiveModel, expr ast.Expr) bool {
+func containsSensitiveSelector(model *sensitiveModel, expr ast.Expr) bool {
 	found := false
 	ast.Inspect(expr, func(node ast.Node) bool {
 		selector, ok := node.(*ast.SelectorExpr)

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -360,7 +360,16 @@ func checkFile(fset *token.FileSet, root string, path string) ([]Violation, erro
 }
 
 func checkTestFile(fset *token.FileSet, root string, path string) ([]Violation, error) {
-	return checkSensitiveOutputFile(fset, root, path, true)
+	violations, err := checkSensitiveOutputFile(fset, root, path, true)
+	if err != nil {
+		return nil, err
+	}
+	handlerViolations, err := checkTestHandlerFatalCalls(fset, root, path)
+	if err != nil {
+		return nil, err
+	}
+	violations = append(violations, handlerViolations...)
+	return violations, nil
 }
 
 type sensitiveKind string
@@ -746,6 +755,111 @@ func isFmtSelector(selector *ast.SelectorExpr, aliases map[string]string, name s
 func isHTTPErrorSelector(selector *ast.SelectorExpr, aliases map[string]string) bool {
 	pkg, ok := selector.X.(*ast.Ident)
 	return ok && aliases[pkg.Name] == "net/http" && selector.Sel.Name == "Error"
+}
+
+func checkTestHandlerFatalCalls(fset *token.FileSet, root string, path string) ([]Violation, error) {
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	aliases := importAliases(file)
+	relPath, err := filepath.Rel(root, path)
+	if err != nil {
+		relPath = path
+	}
+	relPath = filepath.ToSlash(relPath)
+
+	violations := make([]Violation, 0)
+	ast.Inspect(file, func(node ast.Node) bool {
+		lit, ok := node.(*ast.FuncLit)
+		if !ok || !isHTTPHandlerFuncLit(lit, aliases) {
+			return true
+		}
+		ast.Inspect(lit.Body, func(handlerNode ast.Node) bool {
+			if nested, ok := handlerNode.(*ast.FuncLit); ok && nested != lit {
+				return false
+			}
+			call, ok := handlerNode.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if isTestingFatalCall(call) {
+				violations = append(violations, violationAt(fset, relPath, call.Pos(), "httptest handlers must not call t.Fatal/t.Fatalf from the request goroutine; record the error and assert from the test goroutine"))
+			}
+			return true
+		})
+		return false
+	})
+	return violations, nil
+}
+
+func isHTTPHandlerFuncLit(lit *ast.FuncLit, aliases map[string]string) bool {
+	if lit.Type == nil || lit.Type.Params == nil {
+		return false
+	}
+	paramTypes := expandedParamTypes(lit.Type.Params.List)
+	if len(paramTypes) != 2 {
+		return false
+	}
+	return isHTTPResponseWriterType(paramTypes[0], aliases) && isHTTPRequestPointerType(paramTypes[1], aliases)
+}
+
+func expandedParamTypes(fields []*ast.Field) []ast.Expr {
+	result := make([]ast.Expr, 0, len(fields))
+	for _, field := range fields {
+		count := len(field.Names)
+		if count == 0 {
+			count = 1
+		}
+		for range count {
+			result = append(result, field.Type)
+		}
+	}
+	return result
+}
+
+func isHTTPResponseWriterType(expr ast.Expr, aliases map[string]string) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "ResponseWriter" {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && aliases[pkg.Name] == "net/http"
+}
+
+func isHTTPRequestPointerType(expr ast.Expr, aliases map[string]string) bool {
+	star, ok := expr.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	selector, ok := star.X.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "Request" {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && aliases[pkg.Name] == "net/http"
+}
+
+func isTestingFatalCall(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	switch selector.Sel.Name {
+	case "Fatal", "Fatalf", "FailNow":
+	default:
+		return false
+	}
+	receiver, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(receiver.Name) {
+	case "t", "tb":
+		return true
+	default:
+		return false
+	}
 }
 
 func checkUnboundedResponseBodyUses(fset *token.FileSet, relPath string, file *ast.File, aliases map[string]string) []Violation {

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -1538,11 +1538,14 @@ func isTestLogBufferDumpExpr(expr ast.Expr, relPath string) bool {
 		if !ok {
 			return true
 		}
-		switch strings.ToLower(strings.TrimSpace(ident.Name)) {
-		case "logs", "log", "text":
+		switch lower := strings.ToLower(strings.TrimSpace(ident.Name)); {
+		case lower == "log" || lower == "logs" || lower == "text" ||
+			lower == "alllogs" || lower == "infolog" || lower == "tracelog" ||
+			lower == "warnlog" || lower == "errorlog" || lower == "debuglog" ||
+			strings.HasSuffix(lower, "logs"):
 			found = true
 			return false
-		case "input", "output", "redacted", "secret":
+		case lower == "input" || lower == "output" || lower == "redacted" || lower == "secret":
 			if strings.HasPrefix(relPath, "internal/redaction/") {
 				found = true
 				return false

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -674,7 +674,9 @@ func sensitiveSinkArgs(call *ast.CallExpr, aliases map[string]string, testFile b
 	}
 	if testFile && isTestAssertionOutputMethod(selector.Sel.Name) {
 		if isTestAssertionFormatOutputMethod(selector.Sel.Name) && hasStringArg(call, 0) {
-			return sinkArgsWithFormat(call.Args[1:], false, stringArgValue(call, 0))
+			format := stringArgValue(call, 0)
+			forceRawError := isSensitiveTestRawErrorContext(functionContext, format)
+			return sinkArgsWithFormat(call.Args[1:], forceRawError, format)
 		}
 		return sinkArgs(call.Args, false)
 	}
@@ -689,7 +691,7 @@ func sinkArgs(exprs []ast.Expr, forceRawError bool) []sinkArg {
 func sinkArgsWithFormat(exprs []ast.Expr, forceRawError bool, format string) []sinkArg {
 	result := make([]sinkArg, 0, len(exprs))
 	for _, expr := range exprs {
-		result = append(result, sinkArg{expr: expr, forceRawError: forceRawError, format: format})
+		result = append(result, sinkArg{expr: expr, forceRawError: forceRawError && isRawErrorLikeExpr(expr), format: format})
 	}
 	return result
 }
@@ -753,6 +755,20 @@ func isSensitiveHTTPErrorContext(context string) bool {
 		}
 	}
 	return false
+}
+
+func isSensitiveTestRawErrorContext(context string, format string) bool {
+	normalized := canonicalSensitiveKeyName(context)
+	if !strings.Contains(normalized, "uploadrejected") &&
+		!strings.Contains(normalized, "uploadrejection") &&
+		!strings.Contains(normalized, "rejectionmessage") &&
+		!strings.Contains(normalized, "sanitizingerror") {
+		return false
+	}
+	lowerFormat := strings.ToLower(format)
+	return strings.Contains(lowerFormat, "fallback") ||
+		strings.Contains(lowerFormat, "rejection message") ||
+		strings.Contains(lowerFormat, "upload rejected")
 }
 
 func markSensitiveAssignment(model *sensitiveModel, stmt *ast.AssignStmt) {
@@ -1375,7 +1391,7 @@ func sensitiveOutputMessage(value sensitiveValue) string {
 	case sensitiveBody:
 		return "request/response body output must be redacted before printing"
 	case sensitiveRawError:
-		return "auth/cookie/token handler errors must not expose raw errors in responses"
+		return "remote/auth/cookie/token errors must not expose raw errors in logs or responses"
 	case sensitiveGeneric:
 		return "sensitive output must be redacted or replaced with stable state"
 	default:

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -383,8 +383,11 @@ type sensitiveValue struct {
 }
 
 type sensitiveModel struct {
-	aliases map[string]string
-	vars    map[string]sensitiveValue
+	aliases              map[string]string
+	vars                 map[string]sensitiveValue
+	relPath              string
+	testFile             bool
+	testSensitiveFixture bool
 }
 
 type logpolicyAllow struct {
@@ -416,8 +419,11 @@ func checkSensitiveOutputFile(fset *token.FileSet, root string, path string, tes
 			continue
 		}
 		model := sensitiveModel{
-			aliases: aliases,
-			vars:    make(map[string]sensitiveValue),
+			aliases:              aliases,
+			vars:                 make(map[string]sensitiveValue),
+			relPath:              relPath,
+			testFile:             testFile,
+			testSensitiveFixture: testFile && containsSensitiveFixtureLiteral(fn.Body),
 		}
 		functionContext := strings.ToLower(relPath + " " + fn.Name.Name)
 		ast.Inspect(fn.Body, func(node ast.Node) bool {
@@ -434,6 +440,10 @@ func checkSensitiveOutputFile(fset *token.FileSet, root string, path string, tes
 					value, ok := sensitivityOfExpr(model, sinkArg.expr)
 					if !ok && sinkArg.forceRawError {
 						value = sensitiveValue{kind: sensitiveRawError, label: "raw error"}
+						ok = true
+					}
+					if !ok && testFile && model.testSensitiveFixture && isTestLogBufferDumpExpr(sinkArg.expr) {
+						value = sensitiveValue{kind: sensitiveGeneric, label: "test log buffer"}
 						ok = true
 					}
 					if !ok {
@@ -685,9 +695,7 @@ func markSensitiveRange(model sensitiveModel, stmt *ast.RangeStmt) {
 
 func sensitivityOfExprResult(model sensitiveModel, expr ast.Expr, resultIndex int) (sensitiveValue, bool) {
 	if call, ok := expr.(*ast.CallExpr); ok {
-		if value, ok := sensitivityOfKnownCallResult(model, call, resultIndex); ok {
-			return value, true
-		}
+		return sensitivityOfKnownCallResult(model, call, resultIndex)
 	}
 	return sensitivityOfExpr(model, expr)
 }
@@ -711,8 +719,14 @@ func sensitivityOfExpr(model sensitiveModel, expr ast.Expr) (sensitiveValue, boo
 		if isBooleanBinaryOp(typed.Op) {
 			return sensitiveValue{}, false
 		}
+		if value, ok := sensitivityOfSecretBearingURLExpr(model, typed); ok {
+			return value, true
+		}
 		return firstSensitiveExpr(model, typed.X, typed.Y)
 	case *ast.SelectorExpr:
+		if value, ok := sensitivityOfSelectorExpr(model, typed); ok {
+			return value, true
+		}
 		return sensitivityOfExpr(model, typed.X)
 	case *ast.IndexExpr:
 		if value, ok := sensitivityOfPayloadIndex(model, typed); ok {
@@ -738,6 +752,9 @@ func sensitivityOfExpr(model sensitiveModel, expr ast.Expr) (sensitiveValue, boo
 			}
 		}
 	case *ast.CompositeLit:
+		if isCookieCompositeType(typed.Type) {
+			return sensitiveValue{kind: sensitiveCookieContainer, label: "cookies"}, true
+		}
 		for _, elt := range typed.Elts {
 			if value, ok := sensitivityOfExpr(model, elt); ok {
 				return value, true
@@ -781,6 +798,9 @@ func sensitivityOfPayloadIndex(model sensitiveModel, index *ast.IndexExpr) (sens
 }
 
 func sensitivityOfDirectCall(model sensitiveModel, call *ast.CallExpr) (sensitiveValue, bool) {
+	if value, ok := sensitivityOfKnownSensitiveCall(model, call); ok {
+		return value, true
+	}
 	selector, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
 		return sensitiveValue{}, false
@@ -816,6 +836,59 @@ func sensitivityOfDirectCall(model sensitiveModel, call *ast.CallExpr) (sensitiv
 		if ok && model.aliases[pkg.Name] == "io" && len(call.Args) == 1 && isResponseBodyExpr(call.Args[0]) {
 			return sensitiveValue{kind: sensitiveBody, label: "response body"}, true
 		}
+	}
+	return sensitiveValue{}, false
+}
+
+func sensitivityOfKnownSensitiveCall(model sensitiveModel, call *ast.CallExpr) (sensitiveValue, bool) {
+	switch callName(call) {
+	case "LoadTrackerCookieMap", "LoadTrackerHTTPCookies", "CookieMapToHTTPCookies", "CookiesToMap", "httpCookiesToMap", "cookiesFromJar", "btnCookiesFromJar":
+		return sensitiveValue{kind: sensitiveCookieContainer, label: "cookies"}, true
+	case "String":
+		if selector, ok := call.Fun.(*ast.SelectorExpr); ok && isSensitiveURLReceiver(model, selector.X) {
+			return sensitiveValue{kind: sensitiveEndpoint, label: "url"}, true
+		}
+	}
+	return sensitiveValue{}, false
+}
+
+func callName(call *ast.CallExpr) string {
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return fun.Name
+	case *ast.SelectorExpr:
+		return fun.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func sensitivityOfSelectorExpr(model sensitiveModel, selector *ast.SelectorExpr) (sensitiveValue, bool) {
+	name := strings.TrimSpace(selector.Sel.Name)
+	if model.testFile && isConfigOwnerTestPath(model.relPath) {
+		return sensitiveValue{}, false
+	}
+	if isSensitiveConfigFieldName(name) {
+		return sensitiveValue{kind: sensitiveConfigField, label: name}, true
+	}
+	if isSensitiveEndpointFieldName(name) {
+		return sensitiveValue{kind: sensitiveEndpoint, label: name}, true
+	}
+	if name == "URL" && strings.Contains(strings.ToLower(selectorPath(selector.X)), "tracker") {
+		return sensitiveValue{kind: sensitiveEndpoint, label: name}, true
+	}
+	return sensitiveValue{}, false
+}
+
+func sensitivityOfSecretBearingURLExpr(model sensitiveModel, expr *ast.BinaryExpr) (sensitiveValue, bool) {
+	if !binaryExprContainsSecretURLKey(expr) {
+		return sensitiveValue{}, false
+	}
+	if value, ok := firstSensitiveExpr(model, expr.X, expr.Y); ok {
+		return value, true
+	}
+	if containsSensitiveSelector(model, expr) {
+		return sensitiveValue{kind: sensitiveEndpoint, label: "secret URL"}, true
 	}
 	return sensitiveValue{}, false
 }
@@ -899,6 +972,148 @@ func isSensitiveFormKey(key string) bool {
 func isSensitiveQueryKey(key string) bool {
 	switch strings.ToLower(strings.TrimSpace(key)) {
 	case "token", "api_key", "api_token", "passkey", "authkey", "secret", "rsskey":
+		return true
+	default:
+		return false
+	}
+}
+
+func isConfigOwnerTestPath(relPath string) bool {
+	return strings.HasPrefix(relPath, "internal/config/") ||
+		strings.HasPrefix(relPath, "internal/configstore/")
+}
+
+func isSensitiveConfigFieldName(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "apikey", "api_key", "password", "passkey", "token", "authkey", "anticsrftoken", "otpuri", "tmdbapi", "sonarrapikey", "radarrapikey", "qbitpass":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSensitiveEndpointFieldName(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "announceurl", "endpoint":
+		return true
+	default:
+		return false
+	}
+}
+
+func isCookieCompositeType(expr ast.Expr) bool {
+	switch typed := expr.(type) {
+	case *ast.SelectorExpr:
+		return typed.Sel.Name == "Cookie"
+	case *ast.StarExpr:
+		return isCookieCompositeType(typed.X)
+	case *ast.ArrayType:
+		return isCookieCompositeType(typed.Elt)
+	default:
+		return false
+	}
+}
+
+func isSensitiveURLReceiver(model sensitiveModel, expr ast.Expr) bool {
+	if _, ok := sensitivityOfExpr(model, expr); ok {
+		return true
+	}
+	return strings.Contains(strings.ToLower(selectorPath(expr)), "tracker")
+}
+
+func selectorPath(expr ast.Expr) string {
+	switch typed := expr.(type) {
+	case *ast.Ident:
+		return typed.Name
+	case *ast.SelectorExpr:
+		prefix := selectorPath(typed.X)
+		if prefix == "" {
+			return typed.Sel.Name
+		}
+		return prefix + "." + typed.Sel.Name
+	case *ast.IndexExpr:
+		return selectorPath(typed.X)
+	default:
+		return ""
+	}
+}
+
+func binaryExprContainsSecretURLKey(expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		lit, ok := node.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		value, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			return true
+		}
+		lower := strings.ToLower(value)
+		if strings.Contains(lower, "api_key=") ||
+			strings.Contains(lower, "api_token=") ||
+			strings.Contains(lower, "passkey=") ||
+			strings.Contains(lower, "authkey=") ||
+			strings.Contains(lower, "token=") {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func containsSensitiveSelector(model sensitiveModel, expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		selector, ok := node.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if _, sensitive := sensitivityOfSelectorExpr(model, selector); sensitive {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func containsSensitiveFixtureLiteral(node ast.Node) bool {
+	found := false
+	ast.Inspect(node, func(node ast.Node) bool {
+		lit, ok := node.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		value, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			return true
+		}
+		lower := strings.ToLower(value)
+		if strings.Contains(lower, "hunter2") ||
+			strings.Contains(lower, "secret") ||
+			strings.Contains(lower, "api_key") ||
+			strings.Contains(lower, "api-key") ||
+			strings.Contains(lower, "api token") ||
+			strings.Contains(lower, "api_token") ||
+			strings.Contains(lower, "passkey") ||
+			strings.Contains(lower, "authkey") {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func isTestLogBufferDumpExpr(expr ast.Expr) bool {
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(ident.Name)) {
+	case "logs", "log":
 		return true
 	default:
 		return false

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -945,7 +945,11 @@ func sensitivityOfDirectCall(model *sensitiveModel, call *ast.CallExpr) (sensiti
 }
 
 func sensitivityOfKnownSensitiveCall(model *sensitiveModel, call *ast.CallExpr) (sensitiveValue, bool) {
-	switch callName(call) {
+	name := callName(call)
+	if value, ok := sensitivityOfSensitiveValueHelperCallName(name); ok {
+		return value, true
+	}
+	switch name {
 	case "LoadTrackerCookieMap", "LoadTrackerHTTPCookies", "CookieMapToHTTPCookies", "CookiesToMap", "httpCookiesToMap", "cookiesFromJar", "btnCookiesFromJar":
 		return sensitiveValue{kind: sensitiveCookieContainer, label: "cookies"}, true
 	case "postForm", "postMultipart", "postMultipartWithFields", "postMultipartRepeatedFileField", "readAndCloseResponseBody",
@@ -957,6 +961,34 @@ func sensitivityOfKnownSensitiveCall(model *sensitiveModel, call *ast.CallExpr) 
 		}
 	}
 	return sensitiveValue{}, false
+}
+
+func sensitivityOfSensitiveValueHelperCallName(name string) (sensitiveValue, bool) {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if !isSensitiveValueHelperName(lower) {
+		return sensitiveValue{}, false
+	}
+	switch {
+	case strings.Contains(lower, "apikey") || strings.Contains(lower, "api_key") || strings.Contains(lower, "api key"):
+		return sensitiveValue{kind: sensitiveConfigField, label: "APIKey"}, true
+	case strings.Contains(lower, "token"):
+		return sensitiveValue{kind: sensitiveConfigField, label: "token"}, true
+	case strings.Contains(lower, "passkey"):
+		return sensitiveValue{kind: sensitiveConfigField, label: "passkey"}, true
+	case strings.Contains(lower, "authkey"):
+		return sensitiveValue{kind: sensitiveConfigField, label: "authkey"}, true
+	default:
+		return sensitiveValue{}, false
+	}
+}
+
+func isSensitiveValueHelperName(name string) bool {
+	for _, prefix := range []string{"load", "get", "read", "fetch", "lookup", "extract", "parse", "generate", "refresh", "create", "new", "stored", "current"} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func callName(call *ast.CallExpr) string {

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -1110,7 +1110,7 @@ func isSensitiveFormKey(key string) bool {
 
 func isSensitiveQueryKey(key string) bool {
 	switch strings.ToLower(strings.TrimSpace(key)) {
-	case "token", "api_key", "api_token", "passkey", "authkey", "secret", "rsskey":
+	case "token", "apikey", "api_key", "api_token", "passkey", "authkey", "secret", "rsskey":
 		return true
 	default:
 		return false

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -984,16 +984,27 @@ func checkUnboundedResponseBodyUses(fset *token.FileSet, relPath string, file *a
 }
 
 func markUnboundedBodyAssignments(stmt *ast.AssignStmt, aliases map[string]string, unboundedBodyVars map[string]struct{}) {
+	if len(stmt.Rhs) == 1 {
+		for index, target := range stmt.Lhs {
+			ident, ok := target.(*ast.Ident)
+			if !ok || ident.Name == "_" {
+				continue
+			}
+			if index == 0 && isUnboundedResponseBodyRead(stmt.Rhs[0], aliases) {
+				unboundedBodyVars[ident.Name] = struct{}{}
+				continue
+			}
+			delete(unboundedBodyVars, ident.Name)
+		}
+		return
+	}
+
 	for index, target := range stmt.Lhs {
 		ident, ok := target.(*ast.Ident)
 		if !ok || ident.Name == "_" {
 			continue
 		}
-		rhsIndex := index
-		if len(stmt.Rhs) == 1 {
-			rhsIndex = 0
-		}
-		if rhsIndex >= len(stmt.Rhs) || !isUnboundedResponseBodyRead(stmt.Rhs[rhsIndex], aliases) {
+		if index >= len(stmt.Rhs) || !isUnboundedResponseBodyRead(stmt.Rhs[index], aliases) {
 			delete(unboundedBodyVars, ident.Name)
 			continue
 		}

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -968,15 +968,20 @@ func sensitivityOfSensitiveValueHelperCallName(name string) (sensitiveValue, boo
 	if !isSensitiveValueHelperName(lower) {
 		return sensitiveValue{}, false
 	}
+	normalized := canonicalSensitiveKeyName(name)
 	switch {
-	case strings.Contains(lower, "apikey") || strings.Contains(lower, "api_key") || strings.Contains(lower, "api key"):
+	case strings.Contains(normalized, "apikey"):
 		return sensitiveValue{kind: sensitiveConfigField, label: "APIKey"}, true
-	case strings.Contains(lower, "token"):
+	case strings.Contains(normalized, "token"):
 		return sensitiveValue{kind: sensitiveConfigField, label: "token"}, true
-	case strings.Contains(lower, "passkey"):
+	case strings.Contains(normalized, "passkey"):
 		return sensitiveValue{kind: sensitiveConfigField, label: "passkey"}, true
-	case strings.Contains(lower, "authkey"):
+	case strings.Contains(normalized, "authkey"):
 		return sensitiveValue{kind: sensitiveConfigField, label: "authkey"}, true
+	case strings.Contains(normalized, "rsskey"):
+		return sensitiveValue{kind: sensitiveConfigField, label: "rsskey"}, true
+	case strings.Contains(normalized, "torrentpass"):
+		return sensitiveValue{kind: sensitiveConfigField, label: "torrentpass"}, true
 	default:
 		return sensitiveValue{}, false
 	}
@@ -1100,8 +1105,8 @@ func canonicalHeaderName(name string) string {
 }
 
 func isSensitiveFormKey(key string) bool {
-	switch strings.ToLower(strings.TrimSpace(key)) {
-	case "password", "passkey", "token", "auth", "anticsrftoken":
+	switch canonicalSensitiveKeyName(key) {
+	case "password", "passkey", "token", "auth", "apikey", "apitoken", "authkey", "csrf", "anticsrftoken", "secret":
 		return true
 	default:
 		return false
@@ -1109,8 +1114,8 @@ func isSensitiveFormKey(key string) bool {
 }
 
 func isSensitiveQueryKey(key string) bool {
-	switch strings.ToLower(strings.TrimSpace(key)) {
-	case "token", "apikey", "api_key", "api_token", "passkey", "authkey", "secret", "rsskey":
+	switch canonicalSensitiveKeyName(key) {
+	case "token", "apikey", "apitoken", "passkey", "authkey", "secret", "rsskey", "torrentpass", "password", "auth", "csrf", "anticsrftoken":
 		return true
 	default:
 		return false
@@ -1123,12 +1128,16 @@ func isConfigOwnerTestPath(relPath string) bool {
 }
 
 func isSensitiveConfigFieldName(name string) bool {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "apikey", "api_key", "password", "passkey", "token", "authkey", "anticsrftoken", "otpuri", "tmdbapi", "sonarrapikey", "radarrapikey", "qbitpass":
+	switch canonicalSensitiveKeyName(name) {
+	case "apikey", "apitoken", "password", "passkey", "token", "authkey", "anticsrftoken", "otpuri", "tmdbapi", "sonarrapikey", "radarrapikey", "qbitpass", "rsskey", "torrentpass", "secret":
 		return true
 	default:
 		return false
 	}
+}
+
+func canonicalSensitiveKeyName(name string) string {
+	return strings.NewReplacer("_", "", "-", "", " ", "").Replace(strings.ToLower(strings.TrimSpace(name)))
 }
 
 func isSensitiveEndpointFieldName(name string) bool {
@@ -1188,11 +1197,16 @@ func binaryExprContainsSecretURLKey(expr ast.Expr) bool {
 		if err != nil {
 			return true
 		}
-		lower := strings.ToLower(value)
+		lower := canonicalSensitiveURLLiteral(value)
 		if strings.Contains(lower, "api_key=") ||
+			strings.Contains(lower, "apikey=") ||
 			strings.Contains(lower, "api_token=") ||
+			strings.Contains(lower, "apitoken=") ||
 			strings.Contains(lower, "passkey=") ||
 			strings.Contains(lower, "authkey=") ||
+			strings.Contains(lower, "rsskey=") ||
+			strings.Contains(lower, "torrentpass=") ||
+			strings.Contains(lower, "secret=") ||
 			strings.Contains(lower, "token=") {
 			found = true
 			return false
@@ -1200,6 +1214,10 @@ func binaryExprContainsSecretURLKey(expr ast.Expr) bool {
 		return true
 	})
 	return found
+}
+
+func canonicalSensitiveURLLiteral(value string) string {
+	return strings.NewReplacer("_", "", "-", "", " ", "").Replace(strings.ToLower(value))
 }
 
 func containsSensitiveSelector(model *sensitiveModel, expr ast.Expr) bool {
@@ -1229,15 +1247,15 @@ func containsSensitiveFixtureLiteral(node ast.Node) bool {
 		if err != nil {
 			return true
 		}
-		lower := strings.ToLower(value)
+		lower := canonicalSensitiveURLLiteral(value)
 		if strings.Contains(lower, "hunter2") ||
 			strings.Contains(lower, "secret") ||
-			strings.Contains(lower, "api_key") ||
-			strings.Contains(lower, "api-key") ||
-			strings.Contains(lower, "api token") ||
-			strings.Contains(lower, "api_token") ||
+			strings.Contains(lower, "apikey") ||
+			strings.Contains(lower, "apitoken") ||
 			strings.Contains(lower, "passkey") ||
-			strings.Contains(lower, "authkey") {
+			strings.Contains(lower, "authkey") ||
+			strings.Contains(lower, "rsskey") ||
+			strings.Contains(lower, "torrentpass") {
 			found = true
 			return false
 		}

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -1220,7 +1220,7 @@ func isTestLogBufferDumpExpr(expr ast.Expr) bool {
 		return false
 	}
 	switch strings.ToLower(strings.TrimSpace(ident.Name)) {
-	case "logs", "log":
+	case "logs", "log", "text":
 		return true
 	default:
 		return false

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -144,11 +144,17 @@ func CheckRepository(root string) ([]Violation, error) {
 		if entry.IsDir() {
 			return nil
 		}
-		if filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+		if filepath.Ext(path) != ".go" {
 			return nil
 		}
 
-		fileViolations, err := checkFile(fset, root, path)
+		var fileViolations []Violation
+		var err error
+		if strings.HasSuffix(path, "_test.go") {
+			fileViolations, err = checkTestFile(fset, root, path)
+		} else {
+			fileViolations, err = checkFile(fset, root, path)
+		}
 		if err != nil {
 			return err
 		}
@@ -168,11 +174,17 @@ func CheckRepository(root string) ([]Violation, error) {
 			if entry.IsDir() {
 				return nil
 			}
-			if filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+			if filepath.Ext(path) != ".go" {
 				return nil
 			}
 
-			fileViolations, err := checkCLISensitiveOutputFile(fset, root, path)
+			var fileViolations []Violation
+			var err error
+			if strings.HasSuffix(path, "_test.go") {
+				fileViolations, err = checkTestFile(fset, root, path)
+			} else {
+				fileViolations, err = checkCLISensitiveOutputFile(fset, root, path)
+			}
 			if err != nil {
 				return err
 			}
@@ -337,7 +349,648 @@ func checkFile(fset *token.FileSet, root string, path string) ([]Violation, erro
 		return true
 	})
 
+	sensitiveViolations, err := checkSensitiveOutputFile(fset, root, path, false)
+	if err != nil {
+		return nil, err
+	}
+	violations = append(violations, sensitiveViolations...)
+
 	return violations, nil
+}
+
+func checkTestFile(fset *token.FileSet, root string, path string) ([]Violation, error) {
+	return checkSensitiveOutputFile(fset, root, path, true)
+}
+
+type sensitiveKind string
+
+const (
+	sensitiveHTTPHeader      sensitiveKind = "http-header"
+	sensitiveCookieContainer sensitiveKind = "cookie-container"
+	sensitiveFormValue       sensitiveKind = "form-value"
+	sensitiveQueryValue      sensitiveKind = "query-value"
+	sensitiveConfigField     sensitiveKind = "config-field"
+	sensitiveEndpoint        sensitiveKind = "endpoint"
+	sensitivePayload         sensitiveKind = "payload"
+	sensitiveBody            sensitiveKind = "body"
+	sensitiveRawError        sensitiveKind = "raw-error"
+	sensitiveGeneric         sensitiveKind = "generic"
+)
+
+type sensitiveValue struct {
+	kind  sensitiveKind
+	label string
+}
+
+type sensitiveModel struct {
+	aliases map[string]string
+	vars    map[string]sensitiveValue
+}
+
+type logpolicyAllow struct {
+	line   int
+	pos    token.Pos
+	reason string
+	used   bool
+}
+
+func checkSensitiveOutputFile(fset *token.FileSet, root string, path string, testFile bool) ([]Violation, error) {
+	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	relPath, err := filepath.Rel(root, path)
+	if err != nil {
+		relPath = path
+	}
+	relPath = filepath.ToSlash(relPath)
+
+	allows, allowViolations := collectLogpolicyAllows(fset, relPath, file)
+	violations := append([]Violation(nil), allowViolations...)
+	aliases := importAliases(file)
+
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		model := sensitiveModel{
+			aliases: aliases,
+			vars:    make(map[string]sensitiveValue),
+		}
+		functionContext := strings.ToLower(relPath + " " + fn.Name.Name)
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			switch typed := node.(type) {
+			case *ast.AssignStmt:
+				markSensitiveAssignment(model, typed.Lhs, typed.Rhs)
+			case *ast.RangeStmt:
+				markSensitiveRange(model, typed)
+			case *ast.CallExpr:
+				for _, sinkArg := range sensitiveSinkArgs(typed, model.aliases, testFile, functionContext) {
+					if isSafeSensitiveOutputExpr(sinkArg.expr) {
+						continue
+					}
+					value, ok := sensitivityOfExpr(model, sinkArg.expr)
+					if !ok && sinkArg.forceRawError {
+						value = sensitiveValue{kind: sensitiveRawError, label: "raw error"}
+						ok = true
+					}
+					if !ok {
+						continue
+					}
+					if value.kind == sensitiveBody && !isBodyOutputFormat(sinkArg.format) {
+						continue
+					}
+					if value.kind == sensitiveBody && isRawErrorLikeExpr(sinkArg.expr) {
+						continue
+					}
+					if shouldSuppressLogpolicyViolation(fset, allows, sinkArg.expr.Pos(), value) {
+						continue
+					}
+					violations = append(violations, violationAt(fset, relPath, sinkArg.expr.Pos(), sensitiveOutputMessage(value)))
+				}
+			}
+			return true
+		})
+	}
+
+	for _, allow := range allows {
+		if allow.reason == "" || allow.used {
+			continue
+		}
+		violations = append(violations, violationAt(fset, relPath, allow.pos, "unused logpolicy allow comment"))
+	}
+
+	return violations, nil
+}
+
+func collectLogpolicyAllows(fset *token.FileSet, relPath string, file *ast.File) (map[int]*logpolicyAllow, []Violation) {
+	allows := make(map[int]*logpolicyAllow)
+	violations := make([]Violation, 0)
+	for _, group := range file.Comments {
+		for _, comment := range group.List {
+			text := strings.TrimSpace(strings.TrimPrefix(comment.Text, "//"))
+			if !strings.HasPrefix(text, "logpolicy:allow") {
+				continue
+			}
+			reason := strings.TrimSpace(strings.TrimPrefix(text, "logpolicy:allow"))
+			line := fset.Position(comment.Pos()).Line
+			allows[line] = &logpolicyAllow{
+				line:   line,
+				pos:    comment.Pos(),
+				reason: reason,
+			}
+			if reason == "" {
+				violations = append(violations, violationAt(fset, relPath, comment.Pos(), "logpolicy allow comment must include a reason"))
+			}
+		}
+	}
+	return allows, violations
+}
+
+func shouldSuppressLogpolicyViolation(fset *token.FileSet, allows map[int]*logpolicyAllow, pos token.Pos, value sensitiveValue) bool {
+	if value.kind == sensitiveHTTPHeader && isNeverAllowHeader(value.label) {
+		return false
+	}
+	line := fset.Position(pos).Line
+	for _, candidateLine := range []int{line, line - 1} {
+		allow := allows[candidateLine]
+		if allow == nil || allow.reason == "" {
+			continue
+		}
+		allow.used = true
+		return true
+	}
+	return false
+}
+
+func isNeverAllowHeader(label string) bool {
+	switch strings.ToLower(label) {
+	case "cookie", "set-cookie", "authorization", "proxy-authorization":
+		return true
+	default:
+		return false
+	}
+}
+
+type sinkArg struct {
+	expr          ast.Expr
+	forceRawError bool
+	format        string
+}
+
+func sensitiveSinkArgs(call *ast.CallExpr, aliases map[string]string, testFile bool, functionContext string) []sinkArg {
+	if len(call.Args) == 0 {
+		return nil
+	}
+	if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == "panic" {
+		return sinkArgs(call.Args, false)
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return nil
+	}
+
+	if isHTTPErrorSelector(selector, aliases) {
+		if len(call.Args) < 2 {
+			return nil
+		}
+		forceRawError := isSensitiveHTTPErrorContext(functionContext) && isRawErrorLikeExpr(call.Args[1])
+		return []sinkArg{{expr: call.Args[1], forceRawError: forceRawError}}
+	}
+
+	if isFmtSelector(selector, aliases, "Errorf") && testFile && hasStringArg(call, 0) {
+		return sinkArgsWithFormat(call.Args[1:], false, stringArgValue(call, 0))
+	}
+	if isFmtPrintSelector(selector, aliases) && testFile {
+		switch selector.Sel.Name {
+		case "Printf":
+			if hasStringArg(call, 0) {
+				return sinkArgsWithFormat(call.Args[1:], false, stringArgValue(call, 0))
+			}
+		case "Print", "Println":
+			return sinkArgs(call.Args, false)
+		}
+	}
+	if isFmtSelector(selector, aliases, "Fprintf") && testFile {
+		if len(call.Args) > 2 && hasStringArg(call, 1) {
+			return sinkArgsWithFormat(call.Args[2:], false, stringArgValue(call, 1))
+		}
+	}
+
+	if receiver, ok := selector.X.(*ast.Ident); ok && aliases[receiver.Name] != "" {
+		return nil
+	}
+	if _, logger := loggerMethods[selector.Sel.Name]; logger && hasStringArg(call, 0) {
+		if testFile || selector.Sel.Name == "Tracef" || selector.Sel.Name == "Debugf" ||
+			selector.Sel.Name == "Infof" || selector.Sel.Name == "Warnf" || selector.Sel.Name == "Errorf" {
+			return sinkArgsWithFormat(call.Args[1:], false, stringArgValue(call, 0))
+		}
+	}
+	if testFile && isTestAssertionOutputMethod(selector.Sel.Name) && hasStringArg(call, 0) {
+		return sinkArgsWithFormat(call.Args[1:], false, stringArgValue(call, 0))
+	}
+
+	return nil
+}
+
+func sinkArgs(exprs []ast.Expr, forceRawError bool) []sinkArg {
+	return sinkArgsWithFormat(exprs, forceRawError, "")
+}
+
+func sinkArgsWithFormat(exprs []ast.Expr, forceRawError bool, format string) []sinkArg {
+	result := make([]sinkArg, 0, len(exprs))
+	for _, expr := range exprs {
+		result = append(result, sinkArg{expr: expr, forceRawError: forceRawError, format: format})
+	}
+	return result
+}
+
+func hasStringArg(call *ast.CallExpr, index int) bool {
+	if index >= len(call.Args) {
+		return false
+	}
+	lit, ok := call.Args[index].(*ast.BasicLit)
+	return ok && lit.Kind == token.STRING
+}
+
+func stringArgValue(call *ast.CallExpr, index int) string {
+	if index >= len(call.Args) {
+		return ""
+	}
+	lit, ok := call.Args[index].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return ""
+	}
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return ""
+	}
+	return value
+}
+
+func isBodyOutputFormat(format string) bool {
+	lower := strings.ToLower(format)
+	return strings.Contains(lower, "body") ||
+		strings.Contains(lower, "payload") ||
+		strings.Contains(lower, "request") ||
+		strings.Contains(lower, "response")
+}
+
+func isTestAssertionOutputMethod(name string) bool {
+	switch name {
+	case "Fatalf", "Errorf", "Logf":
+		return true
+	default:
+		return false
+	}
+}
+
+func isFmtSelector(selector *ast.SelectorExpr, aliases map[string]string, name string) bool {
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && aliases[pkg.Name] == "fmt" && selector.Sel.Name == name
+}
+
+func isHTTPErrorSelector(selector *ast.SelectorExpr, aliases map[string]string) bool {
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && aliases[pkg.Name] == "net/http" && selector.Sel.Name == "Error"
+}
+
+func isSensitiveHTTPErrorContext(context string) bool {
+	signals := []string{"auth", "cookie", "login", "credential", "csrf", "token"}
+	for _, signal := range signals {
+		if strings.Contains(context, signal) {
+			return true
+		}
+	}
+	return false
+}
+
+func markSensitiveAssignment(model sensitiveModel, lhs []ast.Expr, rhs []ast.Expr) {
+	for index, target := range lhs {
+		ident, ok := target.(*ast.Ident)
+		if !ok || ident.Name == "_" {
+			continue
+		}
+		rhsIndex := index
+		if len(rhs) == 1 {
+			rhsIndex = 0
+		}
+		if rhsIndex >= len(rhs) {
+			delete(model.vars, ident.Name)
+			continue
+		}
+		value, sensitive := sensitivityOfExprResult(model, rhs[rhsIndex], index)
+		if !sensitive {
+			delete(model.vars, ident.Name)
+			continue
+		}
+		model.vars[ident.Name] = value
+	}
+}
+
+func markSensitiveRange(model sensitiveModel, stmt *ast.RangeStmt) {
+	value, ok := sensitivityOfExpr(model, stmt.X)
+	if !ok {
+		return
+	}
+	for _, target := range []ast.Expr{stmt.Key, stmt.Value} {
+		ident, ok := target.(*ast.Ident)
+		if ok && ident.Name != "_" {
+			model.vars[ident.Name] = value
+		}
+	}
+}
+
+func sensitivityOfExprResult(model sensitiveModel, expr ast.Expr, resultIndex int) (sensitiveValue, bool) {
+	if call, ok := expr.(*ast.CallExpr); ok {
+		if value, ok := sensitivityOfKnownCallResult(model, call, resultIndex); ok {
+			return value, true
+		}
+	}
+	return sensitivityOfExpr(model, expr)
+}
+
+func sensitivityOfExpr(model sensitiveModel, expr ast.Expr) (sensitiveValue, bool) {
+	if expr == nil || isSafeSensitiveOutputExpr(expr) {
+		return sensitiveValue{}, false
+	}
+	switch typed := expr.(type) {
+	case *ast.Ident:
+		value, ok := model.vars[typed.Name]
+		return value, ok
+	case *ast.ParenExpr:
+		return sensitivityOfExpr(model, typed.X)
+	case *ast.UnaryExpr:
+		if typed.Op == token.NOT {
+			return sensitiveValue{}, false
+		}
+		return sensitivityOfExpr(model, typed.X)
+	case *ast.BinaryExpr:
+		if isBooleanBinaryOp(typed.Op) {
+			return sensitiveValue{}, false
+		}
+		return firstSensitiveExpr(model, typed.X, typed.Y)
+	case *ast.SelectorExpr:
+		return sensitivityOfExpr(model, typed.X)
+	case *ast.IndexExpr:
+		if value, ok := sensitivityOfPayloadIndex(model, typed); ok {
+			return value, true
+		}
+		return sensitivityOfExpr(model, typed.X)
+	case *ast.SliceExpr:
+		return sensitivityOfExpr(model, typed.X)
+	case *ast.StarExpr:
+		return sensitivityOfExpr(model, typed.X)
+	case *ast.CallExpr:
+		if value, ok := sensitivityOfKnownCallResult(model, typed, 0); ok {
+			return value, true
+		}
+		if value, ok := sensitivityOfDirectCall(model, typed); ok {
+			return value, true
+		}
+		if isSensitivePropagatingCall(model, typed) {
+			for _, arg := range typed.Args {
+				if value, ok := sensitivityOfExpr(model, arg); ok {
+					return value, true
+				}
+			}
+		}
+	case *ast.CompositeLit:
+		for _, elt := range typed.Elts {
+			if value, ok := sensitivityOfExpr(model, elt); ok {
+				return value, true
+			}
+		}
+	}
+	return sensitiveValue{}, false
+}
+
+func isSensitivePropagatingCall(model sensitiveModel, call *ast.CallExpr) bool {
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		return fun.Name == "string"
+	case *ast.SelectorExpr:
+		if pkg, ok := fun.X.(*ast.Ident); ok {
+			switch model.aliases[pkg.Name] {
+			case "fmt":
+				return fun.Sel.Name == "Sprintf"
+			case "strings":
+				return fun.Sel.Name == "TrimSpace"
+			}
+		}
+	}
+	return false
+}
+
+func firstSensitiveExpr(model sensitiveModel, exprs ...ast.Expr) (sensitiveValue, bool) {
+	for _, expr := range exprs {
+		if value, ok := sensitivityOfExpr(model, expr); ok {
+			return value, true
+		}
+	}
+	return sensitiveValue{}, false
+}
+
+func sensitivityOfPayloadIndex(model sensitiveModel, index *ast.IndexExpr) (sensitiveValue, bool) {
+	if value, ok := sensitivityOfExpr(model, index.X); ok {
+		return value, true
+	}
+	return sensitiveValue{}, false
+}
+
+func sensitivityOfDirectCall(model sensitiveModel, call *ast.CallExpr) (sensitiveValue, bool) {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return sensitiveValue{}, false
+	}
+	switch selector.Sel.Name {
+	case "Get":
+		if len(call.Args) != 1 {
+			return sensitiveValue{}, false
+		}
+		key, ok := stringLiteral(call.Args[0])
+		if !ok {
+			return sensitiveValue{}, false
+		}
+		if isHeaderGetCall(selector) && isSensitiveHeaderName(key) {
+			return sensitiveValue{kind: sensitiveHTTPHeader, label: canonicalHeaderName(key)}, true
+		}
+		if isQueryGetCall(selector) && isSensitiveQueryKey(key) {
+			return sensitiveValue{kind: sensitiveQueryValue, label: key}, true
+		}
+	case "FormValue":
+		if len(call.Args) == 1 {
+			key, ok := stringLiteral(call.Args[0])
+			if ok && isSensitiveFormKey(key) {
+				return sensitiveValue{kind: sensitiveFormValue, label: key}, true
+			}
+		}
+	case "Cookies":
+		if len(call.Args) == 0 && isJarCookiesCall(selector) {
+			return sensitiveValue{kind: sensitiveCookieContainer, label: "cookies"}, true
+		}
+	case "ReadAll":
+		pkg, ok := selector.X.(*ast.Ident)
+		if ok && model.aliases[pkg.Name] == "io" && len(call.Args) == 1 && isResponseBodyExpr(call.Args[0]) {
+			return sensitiveValue{kind: sensitiveBody, label: "response body"}, true
+		}
+	}
+	return sensitiveValue{}, false
+}
+
+func sensitivityOfKnownCallResult(model sensitiveModel, call *ast.CallExpr, resultIndex int) (sensitiveValue, bool) {
+	if resultIndex != 0 {
+		return sensitiveValue{}, false
+	}
+	return sensitivityOfDirectCall(model, call)
+}
+
+func isHeaderGetCall(selector *ast.SelectorExpr) bool {
+	receiver, ok := selector.X.(*ast.SelectorExpr)
+	return ok && receiver.Sel.Name == "Header"
+}
+
+func isQueryGetCall(selector *ast.SelectorExpr) bool {
+	call, ok := selector.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	querySelector, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && querySelector.Sel.Name == "Query"
+}
+
+func isJarCookiesCall(selector *ast.SelectorExpr) bool {
+	receiver, ok := selector.X.(*ast.SelectorExpr)
+	return ok && receiver.Sel.Name == "Jar"
+}
+
+func isResponseBodyExpr(expr ast.Expr) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
+	return ok && selector.Sel.Name == "Body"
+}
+
+func stringLiteral(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func isBooleanBinaryOp(op token.Token) bool {
+	return op == token.EQL ||
+		op == token.NEQ ||
+		op == token.LSS ||
+		op == token.LEQ ||
+		op == token.GTR ||
+		op == token.GEQ ||
+		op == token.LAND ||
+		op == token.LOR
+}
+
+func isSensitiveHeaderName(name string) bool {
+	switch canonicalHeaderName(name) {
+	case "cookie", "set-cookie", "authorization", "proxy-authorization", "x-api-key", "x-api-token", "x-auth-token":
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalHeaderName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func isSensitiveFormKey(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "password", "passkey", "token", "auth", "anticsrftoken":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSensitiveQueryKey(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "token", "api_key", "api_token", "passkey", "authkey", "secret", "rsskey":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSafeSensitiveOutputExpr(expr ast.Expr) bool {
+	if containsSafeOutputCall(expr) {
+		return true
+	}
+	switch typed := expr.(type) {
+	case *ast.BasicLit:
+		return true
+	case *ast.Ident:
+		return typed.Name == "true" || typed.Name == "false" || typed.Name == "nil"
+	case *ast.UnaryExpr:
+		return typed.Op == token.NOT
+	case *ast.BinaryExpr:
+		return isBooleanBinaryOp(typed.Op)
+	case *ast.CallExpr:
+		if ident, ok := typed.Fun.(*ast.Ident); ok && ident.Name == "len" {
+			return true
+		}
+		if selector, ok := typed.Fun.(*ast.SelectorExpr); ok {
+			switch selector.Sel.Name {
+			case "Contains", "HasPrefix", "HasSuffix", "EqualFold":
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func containsSafeOutputCall(expr ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if isSafeOutputCall(call) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func isSafeOutputCall(call *ast.CallExpr) bool {
+	if isRedactionCall(call) {
+		return true
+	}
+	switch fun := call.Fun.(type) {
+	case *ast.Ident:
+		lower := strings.ToLower(strings.TrimSpace(fun.Name))
+		return strings.HasPrefix(lower, "redact") || fun.Name == "safeDryRunEndpoint" || fun.Name == "formatDryRunPayloadValue"
+	case *ast.SelectorExpr:
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(fun.Sel.Name)), "redact") {
+			return true
+		}
+		return fun.Sel.Name == "RedactErrorDetail" || fun.Sel.Name == "ExtractHTTPErrorDetail"
+	default:
+		return false
+	}
+}
+
+func sensitiveOutputMessage(value sensitiveValue) string {
+	switch value.kind {
+	case sensitiveHTTPHeader:
+		return "sensitive HTTP header output must be redacted or replaced with stable state"
+	case sensitiveCookieContainer:
+		return "cookie output must be redacted or reduced to count/state"
+	case sensitiveFormValue:
+		return "sensitive form value output must be redacted or replaced with stable state"
+	case sensitiveQueryValue:
+		return "sensitive query value output must be redacted or replaced with stable state"
+	case sensitiveConfigField:
+		return "secret config field output must be redacted or replaced with stable state"
+	case sensitiveEndpoint:
+		return "secret-bearing URL/endpoint output must be redacted before printing"
+	case sensitivePayload:
+		return "secret-bearing payload output must be redacted or reduced to safe fields"
+	case sensitiveBody:
+		return "request/response body output must be redacted before printing"
+	case sensitiveRawError:
+		return "auth/cookie/token handler errors must not expose raw errors in responses"
+	case sensitiveGeneric:
+		return "sensitive output must be redacted or replaced with stable state"
+	default:
+		return "sensitive output must be redacted or replaced with stable state"
+	}
 }
 
 func collectSanitizedVars(file *ast.File) map[string]struct{} {

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -470,7 +470,7 @@ func checkSensitiveOutputFile(fset *token.FileSet, root string, path string, tes
 			aliases:              aliases,
 			relPath:              relPath,
 			testFile:             testFile,
-			testSensitiveFixture: testFile && containsSensitiveFixtureLiteral(fn.Body),
+			testSensitiveFixture: testFile && (containsSensitiveFixtureLiteral(fn.Body) || isRedactionTestPath(relPath)),
 		}
 		functionContext := strings.ToLower(relPath + " " + fn.Name.Name)
 		ast.Walk(&sensitiveOutputVisitor{
@@ -543,7 +543,7 @@ func (v *sensitiveOutputVisitor) checkCall(call *ast.CallExpr) {
 			value = sensitiveValue{kind: sensitiveRawError, label: "raw error"}
 			ok = true
 		}
-		if !ok && v.testFile && v.model.testSensitiveFixture && isTestLogBufferDumpExpr(sinkArg.expr) {
+		if !ok && v.testFile && v.model.testSensitiveFixture && isTestLogBufferDumpExpr(sinkArg.expr, v.model.relPath) {
 			value = sensitiveValue{kind: sensitiveGeneric, label: "test log buffer"}
 			ok = true
 		}
@@ -1264,17 +1264,32 @@ func containsSensitiveFixtureLiteral(node ast.Node) bool {
 	return found
 }
 
-func isTestLogBufferDumpExpr(expr ast.Expr) bool {
-	ident, ok := expr.(*ast.Ident)
-	if !ok {
-		return false
-	}
-	switch strings.ToLower(strings.TrimSpace(ident.Name)) {
-	case "logs", "log", "text":
-		return true
-	default:
-		return false
-	}
+func isRedactionTestPath(relPath string) bool {
+	return strings.HasPrefix(relPath, "internal/redaction/") && strings.HasSuffix(relPath, "_test.go")
+}
+
+func isTestLogBufferDumpExpr(expr ast.Expr, relPath string) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		ident, ok := node.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		switch strings.ToLower(strings.TrimSpace(ident.Name)) {
+		case "logs", "log", "text":
+			found = true
+			return false
+		case "input", "output", "redacted", "secret":
+			if strings.HasPrefix(relPath, "internal/redaction/") {
+				found = true
+				return false
+			}
+			return true
+		default:
+			return true
+		}
+	})
+	return found
 }
 
 func isSafeSensitiveOutputExpr(expr ast.Expr) bool {

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -348,6 +348,7 @@ func checkFile(fset *token.FileSet, root string, path string) ([]Violation, erro
 
 		return true
 	})
+	violations = append(violations, checkUnboundedResponseBodyUses(fset, relPath, file, aliases)...)
 
 	sensitiveViolations, err := checkSensitiveOutputFile(fset, root, path, false)
 	if err != nil {
@@ -745,6 +746,138 @@ func isFmtSelector(selector *ast.SelectorExpr, aliases map[string]string, name s
 func isHTTPErrorSelector(selector *ast.SelectorExpr, aliases map[string]string) bool {
 	pkg, ok := selector.X.(*ast.Ident)
 	return ok && aliases[pkg.Name] == "net/http" && selector.Sel.Name == "Error"
+}
+
+func checkUnboundedResponseBodyUses(fset *token.FileSet, relPath string, file *ast.File, aliases map[string]string) []Violation {
+	violations := make([]Violation, 0)
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		unboundedBodyVars := make(map[string]struct{})
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			switch typed := node.(type) {
+			case *ast.AssignStmt:
+				markUnboundedBodyAssignments(typed, aliases, unboundedBodyVars)
+			case *ast.CallExpr:
+				if isUnboundedResponseBodyUseCall(typed, unboundedBodyVars) {
+					violations = append(violations, violationAt(fset, relPath, typed.Pos(), "response body reads used for logs/errors/artifacts must be bounded before redaction"))
+				}
+			}
+			return true
+		})
+	}
+	return violations
+}
+
+func markUnboundedBodyAssignments(stmt *ast.AssignStmt, aliases map[string]string, unboundedBodyVars map[string]struct{}) {
+	for index, target := range stmt.Lhs {
+		ident, ok := target.(*ast.Ident)
+		if !ok || ident.Name == "_" {
+			continue
+		}
+		rhsIndex := index
+		if len(stmt.Rhs) == 1 {
+			rhsIndex = 0
+		}
+		if rhsIndex >= len(stmt.Rhs) || !isUnboundedResponseBodyRead(stmt.Rhs[rhsIndex], aliases) {
+			delete(unboundedBodyVars, ident.Name)
+			continue
+		}
+		unboundedBodyVars[ident.Name] = struct{}{}
+	}
+}
+
+func isUnboundedResponseBodyRead(expr ast.Expr, aliases map[string]string) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	if isUnboundedResponseBodyHelperCallName(callName(call)) {
+		return true
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	if !ok || aliases[pkg.Name] != "io" || selector.Sel.Name != "ReadAll" || len(call.Args) != 1 {
+		return false
+	}
+	if isLimitReaderCall(call.Args[0], aliases) {
+		return false
+	}
+	return isResponseBodyExpr(call.Args[0])
+}
+
+func isUnboundedResponseBodyUseCall(call *ast.CallExpr, unboundedBodyVars map[string]struct{}) bool {
+	if len(unboundedBodyVars) == 0 {
+		return false
+	}
+	if isRedactionCall(call) {
+		for _, arg := range call.Args {
+			if containsUnboundedBodyVar(arg, unboundedBodyVars) {
+				return true
+			}
+		}
+	}
+	name := callName(call)
+	if isResponseBodyErrorOrArtifactHelper(name) {
+		for _, arg := range call.Args {
+			if containsUnboundedBodyVar(arg, unboundedBodyVars) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isResponseBodyErrorOrArtifactHelper(name string) bool {
+	switch name {
+	case "UploadHTTPError", "safeResponsePreview", "safeResponseMessage":
+		return true
+	default:
+		return false
+	}
+}
+
+func isUnboundedResponseBodyHelperCallName(name string) bool {
+	switch name {
+	case "postForm", "postMultipart", "postMultipartWithFields", "postMultipartRepeatedFileField", "readAndCloseResponseBody":
+		return true
+	default:
+		return false
+	}
+}
+
+func containsUnboundedBodyVar(expr ast.Expr, unboundedBodyVars map[string]struct{}) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		ident, ok := node.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if _, ok := unboundedBodyVars[ident.Name]; ok {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func isLimitReaderCall(expr ast.Expr, aliases map[string]string) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && aliases[pkg.Name] == "io" && selector.Sel.Name == "LimitReader"
 }
 
 func isSensitiveHTTPErrorContext(context string) bool {

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -1101,7 +1101,7 @@ func isSensitiveConfigFieldName(name string) bool {
 
 func isSensitiveEndpointFieldName(name string) bool {
 	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "announceurl", "endpoint":
+	case "announce", "announcelist", "announceurl", "endpoint":
 		return true
 	default:
 		return false

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -220,9 +220,11 @@ func CheckRepository(root string) ([]Violation, error) {
 }
 
 var (
-	frontendEncryptedEnvelopeDeclRe = regexp.MustCompile("\\b(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*[\"'`]upbrr-enc:")
-	frontendDirectEnvelopeMatcherRe = regexp.MustCompile("\\.(?:toBe|toEqual|toStrictEqual|toContain|toMatch)\\(\\s*(?:[\"'`]upbrr-enc:|([A-Za-z_$][\\w$]*))")
-	frontendRawPayloadDOMRe         = regexp.MustCompile("[\"']data-testid[\"']\\s*:\\s*[\"']payload[\"'].*buildSavePayload\\(\\)|buildSavePayload\\(\\).*[\"']data-testid[\"']\\s*:\\s*[\"']payload[\"']")
+	// Frontend secret-output patterns scan complete TS/TSX test files so
+	// typed declarations, multiline matchers, and JSX attributes are covered.
+	frontendEncryptedEnvelopeDeclRe = regexp.MustCompile("\\b(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*(?::[^=;]+)?=\\s*[\"'`]upbrr-enc:")
+	frontendDirectEnvelopeMatcherRe = regexp.MustCompile("\\.(?:toBe|toEqual|toStrictEqual|toContain|toMatch)\\s*\\(\\s*(?:[\"'`]upbrr-enc:|([A-Za-z_$][\\w$]*))")
+	frontendRawPayloadDOMRe         = regexp.MustCompile("(?s)(?:[\"']data-testid[\"']\\s*:\\s*[\"']payload[\"'][^;]*buildSavePayload\\s*\\(\\)|buildSavePayload\\s*\\(\\)[^;]*[\"']data-testid[\"']\\s*:\\s*[\"']payload[\"']|data-testid\\s*=\\s*(?:[\"']payload[\"']|\\{\\s*[\"']payload[\"']\\s*\\})[^;]*buildSavePayload\\s*\\(\\)|buildSavePayload\\s*\\(\\)[^;]*data-testid\\s*=\\s*(?:[\"']payload[\"']|\\{\\s*[\"']payload[\"']\\s*\\}))")
 )
 
 // checkFrontendTestSensitiveMatchers scans frontend tests for assertions and DOM
@@ -262,12 +264,13 @@ func checkFrontendTestSensitiveMatchers(root string) ([]Violation, error) {
 }
 
 // checkFrontendTestSensitiveMatcherFile applies the frontend secret-output regex
-// checks to one test file and reports line-based violations.
+// checks to one full test file and reports source-positioned violations.
 func checkFrontendTestSensitiveMatcherFile(root string, path string) ([]Violation, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
+	text := string(content)
 	relPath, err := filepath.Rel(root, path)
 	if err != nil {
 		relPath = path
@@ -275,44 +278,56 @@ func checkFrontendTestSensitiveMatcherFile(root string, path string) ([]Violatio
 	relPath = filepath.ToSlash(relPath)
 
 	encryptedNames := make(map[string]struct{})
-	for _, match := range frontendEncryptedEnvelopeDeclRe.FindAllSubmatch(content, -1) {
+	for _, match := range frontendEncryptedEnvelopeDeclRe.FindAllStringSubmatch(text, -1) {
 		if len(match) > 1 {
-			encryptedNames[string(match[1])] = struct{}{}
+			encryptedNames[match[1]] = struct{}{}
 		}
 	}
 
 	violations := make([]Violation, 0)
-	for index, line := range strings.Split(string(content), "\n") {
-		match := frontendDirectEnvelopeMatcherRe.FindStringSubmatchIndex(line)
-		if match == nil {
-			continue
-		}
+	for _, match := range frontendDirectEnvelopeMatcherRe.FindAllStringSubmatchIndex(text, -1) {
 		if match[2] >= 0 {
-			name := line[match[2]:match[3]]
+			name := text[match[2]:match[3]]
 			if _, ok := encryptedNames[name]; !ok {
 				continue
 			}
 		}
+		line, column := lineColumnForOffset(content, match[0])
 		violations = append(violations, Violation{
 			File:    relPath,
-			Line:    index + 1,
-			Column:  match[0] + 1,
+			Line:    line,
+			Column:  column,
 			Message: "frontend test assertions must not print encrypted envelope values; assert a boolean predicate or use static sanitized failure text",
 		})
 	}
-	for index, line := range strings.Split(string(content), "\n") {
-		match := frontendRawPayloadDOMRe.FindStringIndex(line)
-		if match == nil {
-			continue
-		}
+	for _, match := range frontendRawPayloadDOMRe.FindAllStringIndex(text, -1) {
+		line, column := lineColumnForOffset(content, match[0])
 		violations = append(violations, Violation{
 			File:    relPath,
-			Line:    index + 1,
-			Column:  match[0] + 1,
+			Line:    line,
+			Column:  column,
 			Message: "frontend tests must not render raw save payloads into the DOM; Testing Library failures can dump secret payload content",
 		})
 	}
 	return violations, nil
+}
+
+// lineColumnForOffset converts a byte offset in scanner input into one-based
+// line and column values for diagnostics.
+func lineColumnForOffset(content []byte, offset int) (int, int) {
+	line, column := 1, 1
+	for index, value := range content {
+		if index >= offset {
+			break
+		}
+		if value == '\n' {
+			line++
+			column = 1
+			continue
+		}
+		column++
+	}
+	return line, column
 }
 
 // checkCLISensitiveOutputFile flags raw dry-run endpoint and payload printing in

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -550,7 +550,7 @@ func sensitiveSinkArgs(call *ast.CallExpr, aliases map[string]string, testFile b
 		return []sinkArg{{expr: call.Args[1], forceRawError: forceRawError}}
 	}
 
-	if isFmtSelector(selector, aliases, "Errorf") && testFile && hasStringArg(call, 0) {
+	if isFmtSelector(selector, aliases, "Errorf") && hasStringArg(call, 0) {
 		return sinkArgsWithFormat(call.Args[1:], false, stringArgValue(call, 0))
 	}
 	if isFmtPrintSelector(selector, aliases) && testFile {
@@ -695,7 +695,12 @@ func markSensitiveRange(model sensitiveModel, stmt *ast.RangeStmt) {
 
 func sensitivityOfExprResult(model sensitiveModel, expr ast.Expr, resultIndex int) (sensitiveValue, bool) {
 	if call, ok := expr.(*ast.CallExpr); ok {
-		return sensitivityOfKnownCallResult(model, call, resultIndex)
+		if value, sensitive := sensitivityOfKnownCallResult(model, call, resultIndex); sensitive {
+			return value, true
+		}
+		if resultIndex != 0 {
+			return sensitiveValue{}, false
+		}
 	}
 	return sensitivityOfExpr(model, expr)
 }
@@ -844,6 +849,8 @@ func sensitivityOfKnownSensitiveCall(model sensitiveModel, call *ast.CallExpr) (
 	switch callName(call) {
 	case "LoadTrackerCookieMap", "LoadTrackerHTTPCookies", "CookieMapToHTTPCookies", "CookiesToMap", "httpCookiesToMap", "cookiesFromJar", "btnCookiesFromJar":
 		return sensitiveValue{kind: sensitiveCookieContainer, label: "cookies"}, true
+	case "postForm", "postMultipart", "postMultipartWithFields", "postMultipartRepeatedFileField", "readAndCloseResponseBody":
+		return sensitiveValue{kind: sensitiveBody, label: "response body"}, true
 	case "String":
 		if selector, ok := call.Fun.(*ast.SelectorExpr); ok && isSensitiveURLReceiver(model, selector.X) {
 			return sensitiveValue{kind: sensitiveEndpoint, label: "url"}, true
@@ -1170,7 +1177,10 @@ func isSafeOutputCall(call *ast.CallExpr) bool {
 	switch fun := call.Fun.(type) {
 	case *ast.Ident:
 		lower := strings.ToLower(strings.TrimSpace(fun.Name))
-		return strings.HasPrefix(lower, "redact") || fun.Name == "safeDryRunEndpoint" || fun.Name == "formatDryRunPayloadValue"
+		return strings.HasPrefix(lower, "redact") ||
+			fun.Name == "safeDryRunEndpoint" ||
+			fun.Name == "formatDryRunPayloadValue" ||
+			fun.Name == "safeResponsePreview"
 	case *ast.SelectorExpr:
 		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(fun.Sel.Name)), "redact") {
 			return true

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -51,7 +51,7 @@ func check(log logger, err error) {
 	}
 }
 
-func TestCheckRepositoryIgnoresTestsAndContextualLogs(t *testing.T) {
+func TestCheckRepositoryAllowsTestStdlibOutputWithoutSensitiveArgs(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "internal", "sample"), 0o755); err != nil {
 		t.Fatalf("mkdir internal sample: %v", err)
@@ -89,6 +89,206 @@ func checkTest() {
 	}
 	if len(violations) != 0 {
 		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
+func TestCheckRepositoryFlagsBTNCookieHeaderPatternInTests(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+import (
+	"net/http"
+	"strings"
+)
+
+type recorder struct{}
+
+func (recorder) Errorf(string, ...any) {}
+
+func check(r *http.Request, handlerErrs recorder) {
+	if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=one") {
+		handlerErrs.Errorf("expected cookie one, got %q", got)
+	}
+	if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=two") {
+		handlerErrs.Errorf("expected cookie two, got %q", got)
+	}
+	if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=three") {
+		handlerErrs.Errorf("expected cookie three, got %q", got)
+	}
+	if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=four") {
+		handlerErrs.Errorf("expected cookie four, got %q", got)
+	}
+	if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=five") {
+		handlerErrs.Errorf("expected cookie five, got %q", got)
+	}
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 5 {
+		t.Fatalf("expected 5 violations, got %d: %#v", len(violations), violations)
+	}
+	for _, violation := range violations {
+		if !strings.Contains(violation.Message, "sensitive HTTP header output") {
+			t.Fatalf("expected sensitive header violation, got %q", violation.Message)
+		}
+	}
+}
+
+func TestCheckRepositoryAllowsCookieHeaderStateAssertionInTests(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+import (
+	"net/http"
+	"strings"
+)
+
+type recorder struct{}
+
+func (recorder) Errorf(string, ...any) {}
+
+func check(r *http.Request, handlerErrs recorder) {
+	if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=one") {
+		handlerErrs.Errorf("expected session cookie")
+	}
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
+func TestCheckRepositoryAllowsRedactedSensitiveHeaderOutput(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+import (
+	"net/http"
+
+	"github.com/autobrr/upbrr/internal/redaction"
+)
+
+func check(t testingT, r *http.Request) {
+	got := r.Header.Get("Authorization")
+	t.Fatalf("expected auth, got %q", redaction.RedactValue(got, nil))
+}
+
+type testingT interface {
+	Fatalf(string, ...any)
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
+func TestCheckRepositoryFlagsSensitiveHeaderFormQueryAndBodyOutput(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func check(t testingT, r *http.Request, resp *http.Response) error {
+	auth := r.Header.Get("Authorization")
+	t.Fatalf("expected auth, got %q", auth)
+	if got := r.FormValue("passkey"); got != "pass" {
+		return fmt.Errorf("expected passkey, got %q", got)
+	}
+	if got := r.URL.Query().Get("secret"); got != "secret" {
+		return fmt.Errorf("expected secret, got %q", got)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	t.Fatalf("unexpected response body %s", string(body))
+	return nil
+}
+
+type testingT interface {
+	Fatalf(string, ...any)
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 4 {
+		t.Fatalf("expected 4 violations, got %d: %#v", len(violations), violations)
+	}
+}
+
+func TestCheckRepositoryAllowsLogpolicyAllowForNonHeaderSensitiveOutput(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func check(r *http.Request) error {
+	if got := r.URL.Query().Get("secret"); got != "fixture-secret" {
+		//logpolicy:allow fake fixture secret is required to diagnose parser shape
+		return fmt.Errorf("expected secret, got %q", got)
+	}
+	return nil
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
+func TestCheckRepositoryReportsMissingAndUnusedLogpolicyAllow(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+func check() {
+	//logpolicy:allow
+	_ = "missing reason"
+	//logpolicy:allow unused fake fixture reason
+	_ = "unused"
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d: %#v", len(violations), violations)
+	}
+	joined := violations[0].Message + "\n" + violations[1].Message
+	if !strings.Contains(joined, "must include a reason") || !strings.Contains(joined, "unused logpolicy allow") {
+		t.Fatalf("expected missing and unused allow violations, got %q", joined)
 	}
 }
 
@@ -861,5 +1061,17 @@ func check(log logger, path string, client string, hash string) {
 		if !strings.Contains(v.Message, "execution flow reporting") {
 			t.Fatalf("expected execution flow debug violation, got %q", v.Message)
 		}
+	}
+}
+
+func writeInternalFixture(t *testing.T, root string, content string) {
+	t.Helper()
+
+	dir := filepath.Join(root, "internal", "sample")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir internal sample: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sample_test.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
 	}
 }

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -215,11 +215,32 @@ func check(t testingT, r *http.Request, resp *http.Response) error {
 	if got := r.FormValue("passkey"); got != "pass" {
 		return fmt.Errorf("expected passkey, got %q", got)
 	}
+	if got := r.FormValue("api-token"); got != "secret" {
+		return fmt.Errorf("expected api-token, got %q", got)
+	}
+	if got := r.FormValue("anti_csrf_token"); got != "secret" {
+		return fmt.Errorf("expected anti_csrf_token, got %q", got)
+	}
 	if got := r.URL.Query().Get("secret"); got != "secret" {
 		return fmt.Errorf("expected secret, got %q", got)
 	}
 	if got := r.URL.Query().Get("apikey"); got != "secret" {
 		return fmt.Errorf("expected apikey, got %q", got)
+	}
+	if got := r.URL.Query().Get("api-key"); got != "secret" {
+		return fmt.Errorf("expected api-key, got %q", got)
+	}
+	if got := r.URL.Query().Get("apiToken"); got != "secret" {
+		return fmt.Errorf("expected apiToken, got %q", got)
+	}
+	if got := r.URL.Query().Get("auth_key"); got != "secret" {
+		return fmt.Errorf("expected auth_key, got %q", got)
+	}
+	if got := r.URL.Query().Get("rss-key"); got != "secret" {
+		return fmt.Errorf("expected rss-key, got %q", got)
+	}
+	if got := r.URL.Query().Get("torrent-pass"); got != "secret" {
+		return fmt.Errorf("expected torrent-pass, got %q", got)
 	}
 	body, _ := io.ReadAll(resp.Body)
 	t.Fatalf("unexpected response body %s", string(body))
@@ -236,8 +257,8 @@ type testingT interface {
 	if err != nil {
 		t.Fatalf("CheckRepository returned error: %v", err)
 	}
-	if len(violations) != 5 {
-		t.Fatalf("expected 5 violations, got %d: %#v", len(violations), violations)
+	if len(violations) != 12 {
+		t.Fatalf("expected 12 violations, got %d: %#v", len(violations), violations)
 	}
 }
 
@@ -424,7 +445,13 @@ type config struct {
 type trackerSet struct{ Trackers map[string]trackerConfig }
 type trackerConfig struct {
 	APIKey string
+	APIToken string
+	AntiCSRFToken string
+	AuthKey string
 	Passkey string
+	RSSKey string
+	Secret string
+	TorrentPass string
 	AnnounceURL string
 	URL string
 }
@@ -433,7 +460,13 @@ type metaInfo struct{ Announce string }
 func check(t testingT, cfg config, meta metaInfo) {
 	t.Fatalf("TMDBAPI mismatch: got %q", cfg.TMDBAPI)
 	t.Fatalf("tracker API key mismatch: got %q", cfg.Trackers.Trackers["BTN"].APIKey)
+	t.Fatalf("tracker API token mismatch: got %q", cfg.Trackers.Trackers["BTN"].APIToken)
+	t.Fatalf("tracker anti-csrf token mismatch: got %q", cfg.Trackers.Trackers["BTN"].AntiCSRFToken)
+	t.Fatalf("tracker auth key mismatch: got %q", cfg.Trackers.Trackers["BTN"].AuthKey)
 	t.Fatalf("tracker passkey mismatch: got %q", cfg.Trackers.Trackers["CZT"].Passkey)
+	t.Fatalf("tracker RSS key mismatch: got %q", cfg.Trackers.Trackers["BTN"].RSSKey)
+	t.Fatalf("tracker secret mismatch: got %q", cfg.Trackers.Trackers["BTN"].Secret)
+	t.Fatalf("tracker torrent pass mismatch: got %q", cfg.Trackers.Trackers["BTN"].TorrentPass)
 	t.Fatalf("tracker announce mismatch: got %q", cfg.Trackers.Trackers["CZT"].AnnounceURL)
 	t.Fatalf("tracker URL mismatch: got %q", cfg.Trackers.Trackers["BTN"].URL)
 	t.Fatalf("torrent announce mismatch: got %q", meta.Announce)
@@ -449,8 +482,8 @@ type testingT interface {
 	if err != nil {
 		t.Fatalf("CheckRepository returned error: %v", err)
 	}
-	if len(violations) != 6 {
-		t.Fatalf("expected 6 violations, got %d: %#v", len(violations), violations)
+	if len(violations) != 12 {
+		t.Fatalf("expected 12 violations, got %d: %#v", len(violations), violations)
 	}
 }
 
@@ -459,11 +492,23 @@ func TestCheckRepositoryFlagsSensitiveHelperReturnOutput(t *testing.T) {
 	content := `package sample
 
 func check(t testingT) {
-	got := loadStoredRTFAPIKey()
-	t.Fatalf("stored token: %q", got)
+	apiKey := loadStoredRTFAPIKey()
+	t.Fatalf("stored token: %q", apiKey)
+	apiToken := refreshAPIToken()
+	t.Fatalf("refreshed token: %q", apiToken)
+	authKey := extractMTVAuthKey()
+	t.Fatalf("auth key: %q", authKey)
+	rssKey := getRSSKey()
+	t.Fatalf("rss key: %q", rssKey)
+	torrentPass := readTorrentPass()
+	t.Fatalf("torrent pass: %q", torrentPass)
 }
 
 func loadStoredRTFAPIKey() string { return "" }
+func refreshAPIToken() string { return "" }
+func extractMTVAuthKey() string { return "" }
+func getRSSKey() string { return "" }
+func readTorrentPass() string { return "" }
 
 type testingT interface {
 	Fatalf(string, ...any)
@@ -475,8 +520,8 @@ type testingT interface {
 	if err != nil {
 		t.Fatalf("CheckRepository returned error: %v", err)
 	}
-	if len(violations) != 1 {
-		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	if len(violations) != 5 {
+		t.Fatalf("expected 5 violations, got %d: %#v", len(violations), violations)
 	}
 }
 
@@ -487,6 +532,16 @@ func TestCheckRepositoryFlagsSecretBearingURLOutput(t *testing.T) {
 func check(t testingT, cfg trackerConfig) {
 	endpoint := "https://tracker.test/api?api_key=" + cfg.APIKey + "&action=upload"
 	t.Fatalf("endpoint: %s", endpoint)
+	hyphenEndpoint := "https://tracker.test/api?api-key=" + cfg.APIKey + "&action=upload"
+	t.Fatalf("endpoint: %s", hyphenEndpoint)
+	camelEndpoint := "https://tracker.test/api?apiToken=" + cfg.APIKey + "&action=upload"
+	t.Fatalf("endpoint: %s", camelEndpoint)
+	authEndpoint := "https://tracker.test/api?auth-key=" + cfg.APIKey + "&action=upload"
+	t.Fatalf("endpoint: %s", authEndpoint)
+	rssEndpoint := "https://tracker.test/api?rss_key=" + cfg.APIKey + "&action=upload"
+	t.Fatalf("endpoint: %s", rssEndpoint)
+	torrentPassEndpoint := "https://tracker.test/api?torrent-pass=" + cfg.APIKey + "&action=upload"
+	t.Fatalf("endpoint: %s", torrentPassEndpoint)
 }
 
 type trackerConfig struct{ APIKey string }
@@ -500,8 +555,8 @@ type testingT interface {
 	if err != nil {
 		t.Fatalf("CheckRepository returned error: %v", err)
 	}
-	if len(violations) != 1 {
-		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	if len(violations) != 6 {
+		t.Fatalf("expected 6 violations, got %d: %#v", len(violations), violations)
 	}
 	if !strings.Contains(violations[0].Message, "secret config field output") {
 		t.Fatalf("expected secret field violation, got %q", violations[0].Message)

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -616,6 +616,74 @@ func check(log logger, body []byte) {
 	}
 }
 
+func TestCheckRepositoryFlagsHelperResponseBodyError(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal", "sample"), 0o755); err != nil {
+		t.Fatalf("mkdir internal sample: %v", err)
+	}
+
+	content := `package sample
+
+import "fmt"
+
+func check() error {
+	body, _, err := postForm()
+	if err != nil {
+		return err
+	}
+	bodyStr := string(body)
+	return fmt.Errorf("sample response: %s", bodyStr)
+}
+`
+
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "redacted") {
+		t.Fatalf("expected redaction violation, got %q", violations[0].Message)
+	}
+}
+
+func TestCheckRepositoryAllowsSafeHelperResponseBodyError(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal", "sample"), 0o755); err != nil {
+		t.Fatalf("mkdir internal sample: %v", err)
+	}
+
+	content := `package sample
+
+import "fmt"
+
+func check() error {
+	body, _, err := postForm()
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("sample response: %s", safeResponsePreview(body))
+}
+`
+
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
 func TestCheckRepositoryFlagsRawUsernameLogging(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "internal", "sample"), 0o755); err != nil {

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -321,6 +321,44 @@ func UploadHTTPError(string, int, []byte) error { return nil }
 	}
 }
 
+func TestCheckRepositoryDoesNotTreatReadAllErrorAsResponseBody(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal", "sample"), 0o755); err != nil {
+		t.Fatalf("mkdir internal sample: %v", err)
+	}
+
+	content := `package sample
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/autobrr/upbrr/internal/redaction"
+)
+
+func check(resp *http.Response) string {
+	body, err := io.ReadAll(resp.Body)
+	_ = body
+	if err != nil {
+		return redaction.RedactValue(err.Error(), nil)
+	}
+	return ""
+}
+`
+
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
 func TestCheckRepositoryKeepsSensitiveBindingsLexicallyScoped(t *testing.T) {
 	root := t.TempDir()
 	content := `package sample

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -29,7 +29,7 @@ func check(log logger, err error) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -76,10 +76,10 @@ func checkTest() {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(mainContent), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(mainContent), 0o600); err != nil {
 		t.Fatalf("write main sample file: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample_test.go"), []byte(testContent), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample_test.go"), []byte(testContent), 0o600); err != nil {
 		t.Fatalf("write test sample file: %v", err)
 	}
 
@@ -303,7 +303,7 @@ func safeResponsePreview([]byte) string { return "" }
 func UploadHTTPError(string, int, []byte) error { return nil }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -781,7 +781,7 @@ type testingT interface {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "redaction", "redaction_test.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "redaction", "redaction_test.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -942,7 +942,7 @@ func check(log logger, body []byte) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -977,7 +977,7 @@ func check(log logger, body []byte) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1013,7 +1013,7 @@ func check(log logger, body []byte) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1046,7 +1046,7 @@ func check() error {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1081,7 +1081,7 @@ func check() error {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1115,7 +1115,7 @@ func check(log logger, current user) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1152,7 +1152,7 @@ func check(log logger, current user) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1182,7 +1182,7 @@ func check(log logger, err error) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1236,7 +1236,7 @@ type testingT interface {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "services", "imagehosting", "uploaders_test.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "services", "imagehosting", "uploaders_test.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1278,7 +1278,7 @@ func check(log logger, current user) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1308,7 +1308,7 @@ func check(log logger, err error) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1341,7 +1341,7 @@ func check(log logger) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1374,7 +1374,7 @@ func check(log logger, tracker string) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1404,7 +1404,7 @@ func check(log logger, rate float64) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1433,7 +1433,7 @@ func TestCheckRepositoryInfofVerbosityBoundary(t *testing.T) {
 		"\tlog.Infof(\"" + aboveBoundary + "\")\n" +
 		"}\n"
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1469,7 +1469,7 @@ func check(log logger) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1505,7 +1505,7 @@ func check(log logger, tracker string) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1538,7 +1538,7 @@ func check(log logger) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1575,7 +1575,7 @@ func check(log logger, path string) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1610,7 +1610,7 @@ func check(log logger, path string) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1644,7 +1644,7 @@ func check(log logger, tracker string, host string, path string, title string) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1679,7 +1679,7 @@ func check(log logger, tracker string) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 
@@ -1722,7 +1722,7 @@ func check(log logger, path string, client string, hash string) {
 }
 `
 
-	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write sample file: %v", err)
 	}
 

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -218,6 +218,9 @@ func check(t testingT, r *http.Request, resp *http.Response) error {
 	if got := r.URL.Query().Get("secret"); got != "secret" {
 		return fmt.Errorf("expected secret, got %q", got)
 	}
+	if got := r.URL.Query().Get("apikey"); got != "secret" {
+		return fmt.Errorf("expected apikey, got %q", got)
+	}
 	body, _ := io.ReadAll(resp.Body)
 	t.Fatalf("unexpected response body %s", string(body))
 	return nil
@@ -233,8 +236,8 @@ type testingT interface {
 	if err != nil {
 		t.Fatalf("CheckRepository returned error: %v", err)
 	}
-	if len(violations) != 4 {
-		t.Fatalf("expected 4 violations, got %d: %#v", len(violations), violations)
+	if len(violations) != 5 {
+		t.Fatalf("expected 5 violations, got %d: %#v", len(violations), violations)
 	}
 }
 

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -238,6 +238,85 @@ type testingT interface {
 	}
 }
 
+func TestCheckRepositoryKeepsSensitiveBindingsLexicallyScoped(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+import (
+	"net/http"
+	"testing"
+)
+
+func checkInnerSensitiveDoesNotLeak(t *testing.T, r *http.Request) {
+	got := "safe"
+	if true {
+		got := r.Header.Get("Cookie")
+		_ = got
+	}
+	t.Fatalf("expected safe value, got %q", got)
+}
+
+func checkInnerSafeDoesNotClearOuterSensitive(t *testing.T, r *http.Request) {
+	got := r.Header.Get("Cookie")
+	if true {
+		got := "safe"
+		t.Logf("inner value: %q", got)
+	}
+	t.Fatalf("expected cookie, got %q", got)
+}
+
+func checkRangeSensitiveDoesNotLeak(t *testing.T, r *http.Request) {
+	got := "safe"
+	for _, got := range r.Cookies() {
+		_ = got
+	}
+	t.Fatalf("expected safe value, got %q", got)
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "HTTP header") {
+		t.Fatalf("expected outer sensitive cookie violation, got %#v", violations[0])
+	}
+}
+
+func TestCheckRepositoryFlagsNonFormatTestOutputMethods(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+import (
+	"io"
+	"net/http"
+	"testing"
+)
+
+func check(t *testing.T, r *http.Request, resp *http.Response) {
+	auth := r.Header.Get("Authorization")
+	t.Fatal(auth)
+	cookies := []*http.Cookie{{Name: "session", Value: "secret"}}
+	t.Error(cookies)
+	body, _ := io.ReadAll(resp.Body)
+	t.Log(body)
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 3 {
+		t.Fatalf("expected 3 violations, got %d: %#v", len(violations), violations)
+	}
+}
+
 func TestCheckRepositoryAllowsLogpolicyAllowForNonHeaderSensitiveOutput(t *testing.T) {
 	root := t.TempDir()
 	content := `package sample

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -850,26 +850,54 @@ func TestCheckRepositoryFlagsFrontendEncryptedEnvelopeMatcherOutput(t *testing.T
 	content := `import { expect, it } from "vitest";
 
 it("preserves encrypted URL", () => {
-  const encryptedURL = "upbrr-enc:v1:encrypted-btn-url";
+  const encryptedURL: string = "upbrr-enc:v1:encrypted-btn-url";
   const payload = { URL: encryptedURL };
-  expect(payload.URL).toBe(encryptedURL);
+  expect(payload.URL).toBe(
+    encryptedURL,
+  );
+  expect(payload.URL).toEqual("upbrr-enc:v1:literal-envelope");
   expect(payload.URL === encryptedURL).toBe(true);
-  createElement("pre", { "data-testid": "payload" }, state.buildSavePayload() ?? "");
+  createElement(
+    "pre",
+    { "data-testid": "payload" },
+    state.buildSavePayload() ?? "",
+  );
 });
 `
 
 	if err := os.WriteFile(filepath.Join(testDir, "useSettingsState.test.ts"), []byte(content), 0o644); err != nil {
 		t.Fatalf("write frontend test file: %v", err)
 	}
+	tsxContent := `import { expect, it } from "vitest";
+
+it("renders payload", () => {
+  return <pre data-testid="payload">{state.buildSavePayload()}</pre>;
+});
+
+it("renders payload with expression attribute", () => {
+  return (
+    <pre data-testid={"payload"}>
+      {state.buildSavePayload()}
+    </pre>
+  );
+});
+`
+
+	if err := os.WriteFile(filepath.Join(testDir, "useSettingsState.test.tsx"), []byte(tsxContent), 0o644); err != nil {
+		t.Fatalf("write frontend tsx test file: %v", err)
+	}
 
 	violations, err := CheckRepository(root)
 	if err != nil {
 		t.Fatalf("CheckRepository returned error: %v", err)
 	}
-	if len(violations) != 2 {
-		t.Fatalf("expected 2 violations, got %d: %#v", len(violations), violations)
+	if len(violations) != 5 {
+		t.Fatalf("expected 5 violations, got %d: %#v", len(violations), violations)
 	}
-	messages := []string{violations[0].Message, violations[1].Message}
+	messages := make([]string, 0, len(violations))
+	for _, violation := range violations {
+		messages = append(messages, violation.Message)
+	}
 	joined := strings.Join(messages, "\n")
 	if !strings.Contains(joined, "encrypted envelope") {
 		t.Fatalf("expected encrypted envelope violation, got %q", joined)

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -451,6 +451,32 @@ type testingT interface {
 	}
 }
 
+func TestCheckRepositoryFlagsSensitiveHelperReturnOutput(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+func check(t testingT) {
+	got := loadStoredRTFAPIKey()
+	t.Fatalf("stored token: %q", got)
+}
+
+func loadStoredRTFAPIKey() string { return "" }
+
+type testingT interface {
+	Fatalf(string, ...any)
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+}
+
 func TestCheckRepositoryFlagsSecretBearingURLOutput(t *testing.T) {
 	root := t.TempDir()
 	content := `package sample

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -1031,7 +1031,7 @@ func TestCheckRepositoryFlagsUnboundedHelperResponseBodyPreview(t *testing.T) {
 import "fmt"
 
 func check() error {
-	body, _, err := postForm()
+	body, err := readAndCloseResponseBody()
 	if err != nil {
 		return err
 	}

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -1006,6 +1006,62 @@ func check(log logger, err error) {
 	}
 }
 
+func TestCheckRepositoryFlagsUploadRejectionErrorOutputInTests(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal", "services", "imagehosting"), 0o755); err != nil {
+		t.Fatalf("mkdir imagehosting sample: %v", err)
+	}
+
+	content := `package imagehosting
+
+import (
+	"context"
+	"strings"
+)
+
+type uploader struct{}
+
+func (u uploader) Upload(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func TestImgboxUploadRejectedUsesFallbackAfterSanitizingError(t testingT) {
+	_, err := uploader{}.Upload(context.Background(), "shot.png")
+	if err == nil {
+		t.Fatal("expected rejected upload to fail")
+	}
+	if !strings.Contains(err.Error(), "imgbox upload rejected: unknown error") {
+		t.Fatalf("expected unknown error fallback, got %v", err)
+	}
+	if strings.Contains(err.Error(), "imgbox upload rejected:  ") {
+		t.Fatalf("rejection message must not be whitespace-only: %v", err)
+	}
+}
+
+type testingT interface {
+	Fatal(...any)
+	Fatalf(string, ...any)
+}
+`
+
+	if err := os.WriteFile(filepath.Join(root, "internal", "services", "imagehosting", "uploaders_test.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d: %#v", len(violations), violations)
+	}
+	for _, violation := range violations {
+		if !strings.Contains(violation.Message, "raw errors") {
+			t.Fatalf("expected raw error violation, got %q", violation.Message)
+		}
+	}
+}
+
 func TestCheckRepositoryAllowsStableCodesInAuthSensitiveLogs(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "internal", "sample"), 0o755); err != nil {
@@ -1499,7 +1555,7 @@ func writeInternalFixture(t *testing.T, root string, content string) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir internal sample: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "sample_test.go"), []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "sample_test.go"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
 }

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -425,13 +425,15 @@ type trackerConfig struct {
 	AnnounceURL string
 	URL string
 }
+type metaInfo struct{ Announce string }
 
-func check(t testingT, cfg config) {
+func check(t testingT, cfg config, meta metaInfo) {
 	t.Fatalf("TMDBAPI mismatch: got %q", cfg.TMDBAPI)
 	t.Fatalf("tracker API key mismatch: got %q", cfg.Trackers.Trackers["BTN"].APIKey)
 	t.Fatalf("tracker passkey mismatch: got %q", cfg.Trackers.Trackers["CZT"].Passkey)
 	t.Fatalf("tracker announce mismatch: got %q", cfg.Trackers.Trackers["CZT"].AnnounceURL)
 	t.Fatalf("tracker URL mismatch: got %q", cfg.Trackers.Trackers["BTN"].URL)
+	t.Fatalf("torrent announce mismatch: got %q", meta.Announce)
 }
 
 type testingT interface {
@@ -444,8 +446,8 @@ type testingT interface {
 	if err != nil {
 		t.Fatalf("CheckRepository returned error: %v", err)
 	}
-	if len(violations) != 5 {
-		t.Fatalf("expected 5 violations, got %d: %#v", len(violations), violations)
+	if len(violations) != 6 {
+		t.Fatalf("expected 6 violations, got %d: %#v", len(violations), violations)
 	}
 }
 

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -632,7 +632,7 @@ func check() error {
 		return err
 	}
 	bodyStr := string(body)
-	return fmt.Errorf("sample response: %s", bodyStr)
+	return fmt.Errorf("sample http %d: %s", 500, bodyStr)
 }
 `
 

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -400,6 +400,87 @@ func check(t *testing.T, r *http.Request, resp *http.Response) {
 	}
 }
 
+func TestCheckRepositoryFlagsFatalCallsInHTTPTestHandlers(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandlerFatal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ok" {
+			t.Fatal("unexpected path")
+		}
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+	}))
+	t.Cleanup(server.Close)
+}
+
+func TestNormalFatal(t *testing.T) {
+	if false {
+		t.Fatal("ordinary test goroutine failure")
+	}
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d: %#v", len(violations), violations)
+	}
+	for _, violation := range violations {
+		if !strings.Contains(violation.Message, "request goroutine") {
+			t.Fatalf("expected handler fatal violation, got %q", violation.Message)
+		}
+	}
+}
+
+func TestCheckRepositoryAllowsHandlerErrorsRecordedOutsideRequestGoroutine(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandlerErrorRecorder(t *testing.T) {
+	var handlerErr error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ok" {
+			handlerErr = errUnexpectedPath
+			return
+		}
+	}))
+	t.Cleanup(server.Close)
+	if handlerErr != nil {
+		t.Fatalf("handler error: %v", handlerErr)
+	}
+}
+
+var errUnexpectedPath error
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
 func TestCheckRepositoryAllowsLogpolicyAllowForNonHeaderSensitiveOutput(t *testing.T) {
 	root := t.TempDir()
 	content := `package sample

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -262,6 +262,65 @@ type testingT interface {
 	}
 }
 
+func TestCheckRepositoryFlagsUnboundedResponseBodyReads(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal", "sample"), 0o755); err != nil {
+		t.Fatalf("mkdir internal sample: %v", err)
+	}
+
+	content := `package sample
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/autobrr/upbrr/internal/redaction"
+)
+
+func unsafe(resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("sample: http %d: %s", resp.StatusCode, redaction.RedactValue(string(body), nil))
+}
+
+func viaHelper(resp *http.Response) error {
+	body, _ := readAndCloseResponseBody(resp)
+	return fmt.Errorf("sample: http %d: %s", resp.StatusCode, safeResponsePreview(body))
+}
+
+func uploadError(resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+	return UploadHTTPError("GPW", resp.StatusCode, body)
+}
+
+func safe(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return fmt.Errorf("sample: http %d: %s", resp.StatusCode, redaction.RedactValue(string(body), nil))
+}
+
+func readAndCloseResponseBody(*http.Response) ([]byte, error) { return nil, nil }
+func safeResponsePreview([]byte) string { return "" }
+func UploadHTTPError(string, int, []byte) error { return nil }
+`
+
+	if err := os.WriteFile(filepath.Join(root, "internal", "sample", "sample.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 3 {
+		t.Fatalf("expected 3 violations, got %d: %#v", len(violations), violations)
+	}
+	for _, violation := range violations {
+		if !strings.Contains(violation.Message, "must be bounded before redaction") {
+			t.Fatalf("expected bounded-read violation, got %q", violation.Message)
+		}
+	}
+}
+
 func TestCheckRepositoryKeepsSensitiveBindingsLexicallyScoped(t *testing.T) {
 	root := t.TempDir()
 	content := `package sample
@@ -873,7 +932,7 @@ func check() error {
 	}
 }
 
-func TestCheckRepositoryAllowsSafeHelperResponseBodyError(t *testing.T) {
+func TestCheckRepositoryFlagsUnboundedHelperResponseBodyPreview(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "internal", "sample"), 0o755); err != nil {
 		t.Fatalf("mkdir internal sample: %v", err)
@@ -900,8 +959,11 @@ func check() error {
 	if err != nil {
 		t.Fatalf("CheckRepository returned error: %v", err)
 	}
-	if len(violations) != 0 {
-		t.Fatalf("expected no violations, got %#v", violations)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "must be bounded before redaction") {
+		t.Fatalf("expected bounded-read violation, got %q", violations[0].Message)
 	}
 }
 

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -604,6 +604,54 @@ type testingT interface {
 	}
 }
 
+func TestCheckRepositoryFlagsRedactionFixtureOutputDump(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal", "redaction"), 0o755); err != nil {
+		t.Fatalf("mkdir internal redaction: %v", err)
+	}
+
+	content := `package redaction
+
+func check(t testingT) {
+	input := "token=secret"
+	output := RedactValue(input, nil)
+	if output == input {
+		t.Fatalf("expected redaction, got %q", output)
+	}
+	for _, secret := range []string{"secret"} {
+		if contains(output, secret) {
+			t.Fatalf("expected %q redacted", secret)
+		}
+	}
+	redacted := RedactPrivateInfo(map[string]any{"token": "secret"}, nil).(map[string]any)
+	if redacted["token"] != "[REDACTED]" {
+		t.Fatalf("expected token redacted, got %#v", redacted["token"])
+	}
+}
+
+type testingT interface {
+	Fatalf(string, ...any)
+}
+`
+
+	if err := os.WriteFile(filepath.Join(root, "internal", "redaction", "redaction_test.go"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 3 {
+		t.Fatalf("expected 3 violations, got %d: %#v", len(violations), violations)
+	}
+	for _, violation := range violations {
+		if !strings.Contains(violation.Message, "sensitive output") {
+			t.Fatalf("expected sensitive output violation, got %q", violation.Message)
+		}
+	}
+}
+
 func TestCheckRepositoryFlagsRawDryRunDetailsOutput(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "internal"), 0o755); err != nil {

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -490,6 +490,12 @@ func check(t testingT, logs string) {
 	}
 }
 
+func checkArtifact(t testingT, text string) {
+	if contains(text, "secret-key") {
+		t.Fatalf("artifact leaked secret body: %s", text)
+	}
+}
+
 func contains(string, string) bool { return false }
 
 type testingT interface {
@@ -502,11 +508,13 @@ type testingT interface {
 	if err != nil {
 		t.Fatalf("CheckRepository returned error: %v", err)
 	}
-	if len(violations) != 1 {
-		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d: %#v", len(violations), violations)
 	}
-	if !strings.Contains(violations[0].Message, "sensitive output") {
-		t.Fatalf("expected sensitive output violation, got %q", violations[0].Message)
+	for _, violation := range violations {
+		if !strings.Contains(violation.Message, "sensitive output") {
+			t.Fatalf("expected sensitive output violation, got %q", violation.Message)
+		}
 	}
 }
 

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -292,6 +292,145 @@ func check() {
 	}
 }
 
+func TestCheckRepositoryFlagsCookieContainerHelperOutput(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/autobrr/upbrr/internal/cookies"
+)
+
+func check(t testingT, dbPath string) {
+	values, _ := cookies.LoadTrackerCookieMap(context.Background(), dbPath, "BTN")
+	t.Fatalf("expected cookies, got %#v", values)
+	httpCookies := cookies.CookieMapToHTTPCookies(map[string]string{"session": "abc"}, "example.test")
+	t.Fatalf("expected cookies, got %#v", httpCookies)
+	t.Fatalf("expected cookie, got %#v", &http.Cookie{Name: "session", Value: "abc"})
+}
+
+type testingT interface {
+	Fatalf(string, ...any)
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 3 {
+		t.Fatalf("expected 3 violations, got %d: %#v", len(violations), violations)
+	}
+	for _, violation := range violations {
+		if !strings.Contains(violation.Message, "cookie output") {
+			t.Fatalf("expected cookie output violation, got %q", violation.Message)
+		}
+	}
+}
+
+func TestCheckRepositoryFlagsSecretConfigFieldOutput(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+type config struct {
+	TMDBAPI string
+	Trackers trackerSet
+}
+type trackerSet struct{ Trackers map[string]trackerConfig }
+type trackerConfig struct {
+	APIKey string
+	Passkey string
+	AnnounceURL string
+	URL string
+}
+
+func check(t testingT, cfg config) {
+	t.Fatalf("TMDBAPI mismatch: got %q", cfg.TMDBAPI)
+	t.Fatalf("tracker API key mismatch: got %q", cfg.Trackers.Trackers["BTN"].APIKey)
+	t.Fatalf("tracker passkey mismatch: got %q", cfg.Trackers.Trackers["CZT"].Passkey)
+	t.Fatalf("tracker announce mismatch: got %q", cfg.Trackers.Trackers["CZT"].AnnounceURL)
+	t.Fatalf("tracker URL mismatch: got %q", cfg.Trackers.Trackers["BTN"].URL)
+}
+
+type testingT interface {
+	Fatalf(string, ...any)
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 5 {
+		t.Fatalf("expected 5 violations, got %d: %#v", len(violations), violations)
+	}
+}
+
+func TestCheckRepositoryFlagsSecretBearingURLOutput(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+func check(t testingT, cfg trackerConfig) {
+	endpoint := "https://tracker.test/api?api_key=" + cfg.APIKey + "&action=upload"
+	t.Fatalf("endpoint: %s", endpoint)
+}
+
+type trackerConfig struct{ APIKey string }
+type testingT interface {
+	Fatalf(string, ...any)
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "secret config field output") {
+		t.Fatalf("expected secret field violation, got %q", violations[0].Message)
+	}
+}
+
+func TestCheckRepositoryFlagsSensitiveFixtureLogBufferDump(t *testing.T) {
+	root := t.TempDir()
+	content := `package sample
+
+func check(t testingT, logs string) {
+	if !contains(logs, "tracker ready") {
+		t.Fatalf("expected tracker ready in logs: %s", logs)
+	}
+	if contains(logs, "hunter2") {
+		t.Fatalf("logs leaked password")
+	}
+}
+
+func contains(string, string) bool { return false }
+
+type testingT interface {
+	Fatalf(string, ...any)
+}
+`
+	writeInternalFixture(t, root, content)
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "sensitive output") {
+		t.Fatalf("expected sensitive output violation, got %q", violations[0].Message)
+	}
+}
+
 func TestCheckRepositoryFlagsRawDryRunDetailsOutput(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "internal"), 0o755); err != nil {

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -799,6 +799,48 @@ type testingT interface {
 	}
 }
 
+func TestCheckRepositoryFlagsFrontendEncryptedEnvelopeMatcherOutput(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal"), 0o755); err != nil {
+		t.Fatalf("mkdir internal: %v", err)
+	}
+	testDir := filepath.Join(root, "gui", "frontend", "src", "hooks")
+	if err := os.MkdirAll(testDir, 0o755); err != nil {
+		t.Fatalf("mkdir frontend test dir: %v", err)
+	}
+
+	content := `import { expect, it } from "vitest";
+
+it("preserves encrypted URL", () => {
+  const encryptedURL = "upbrr-enc:v1:encrypted-btn-url";
+  const payload = { URL: encryptedURL };
+  expect(payload.URL).toBe(encryptedURL);
+  expect(payload.URL === encryptedURL).toBe(true);
+  createElement("pre", { "data-testid": "payload" }, state.buildSavePayload() ?? "");
+});
+`
+
+	if err := os.WriteFile(filepath.Join(testDir, "useSettingsState.test.ts"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write frontend test file: %v", err)
+	}
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d: %#v", len(violations), violations)
+	}
+	messages := []string{violations[0].Message, violations[1].Message}
+	joined := strings.Join(messages, "\n")
+	if !strings.Contains(joined, "encrypted envelope") {
+		t.Fatalf("expected encrypted envelope violation, got %q", joined)
+	}
+	if !strings.Contains(joined, "raw save payloads into the DOM") {
+		t.Fatalf("expected raw payload DOM violation, got %q", joined)
+	}
+}
+
 func TestCheckRepositoryFlagsRawDryRunDetailsOutput(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "internal"), 0o755); err != nil {

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -716,6 +716,13 @@ func check(t testingT, logs string) {
 	}
 }
 
+func checkCombinedLogs(t testingT, infoLog string, traceLog string, warnLog string) {
+	allLogs := infoLog + "\n" + traceLog + "\n" + warnLog
+	if contains(allLogs, "secret-api-key") {
+		t.Fatalf("combined logs leaked secret: %s", allLogs)
+	}
+}
+
 func checkArtifact(t testingT, text string) {
 	if contains(text, "secret-key") {
 		t.Fatalf("artifact leaked secret body: %s", text)
@@ -734,8 +741,8 @@ type testingT interface {
 	if err != nil {
 		t.Fatalf("CheckRepository returned error: %v", err)
 	}
-	if len(violations) != 2 {
-		t.Fatalf("expected 2 violations, got %d: %#v", len(violations), violations)
+	if len(violations) != 3 {
+		t.Fatalf("expected 3 violations, got %d: %#v", len(violations), violations)
 	}
 	for _, violation := range violations {
 		if !strings.Contains(violation.Message, "sensitive output") {

--- a/internal/metadata/arr.go
+++ b/internal/metadata/arr.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/pathutil"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -354,7 +355,7 @@ func doArrJSON(ctx context.Context, httpClient *http.Client, rawURL string, apiK
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(redaction.RedactValue(string(body), nil)))
 	}
 	if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
 		return fmt.Errorf("decode response: %w", err)

--- a/internal/metadata/imdb/client.go
+++ b/internal/metadata/imdb/client.go
@@ -543,7 +543,7 @@ func (c *Client) postGraphQL(ctx context.Context, query string, target any) erro
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		payload, _ := io.ReadAll(resp.Body)
+		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 		return fmt.Errorf("imdb: http %d: %s", resp.StatusCode, strings.TrimSpace(redaction.RedactValue(string(payload), nil)))
 	}
 

--- a/internal/metadata/imdb/client.go
+++ b/internal/metadata/imdb/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/moistari/rls"
 
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
+	"github.com/autobrr/upbrr/internal/redaction"
 
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -543,7 +544,7 @@ func (c *Client) postGraphQL(ctx context.Context, query string, target any) erro
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		payload, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("imdb: http %d: %s", resp.StatusCode, strings.TrimSpace(string(payload)))
+		return fmt.Errorf("imdb: http %d: %s", resp.StatusCode, strings.TrimSpace(redaction.RedactValue(string(payload), nil)))
 	}
 
 	decoder := json.NewDecoder(resp.Body)

--- a/internal/metadata/tmdb/client.go
+++ b/internal/metadata/tmdb/client.go
@@ -567,7 +567,7 @@ func (c *Client) getJSON(ctx context.Context, path string, params map[string]str
 		return errNotFound
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 		return fmt.Errorf("tmdb: http %d: %s", resp.StatusCode, strings.TrimSpace(redaction.RedactValue(string(body), nil)))
 	}
 

--- a/internal/metadata/tmdb/client.go
+++ b/internal/metadata/tmdb/client.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -567,7 +568,7 @@ func (c *Client) getJSON(ctx context.Context, path string, params map[string]str
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("tmdb: http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return fmt.Errorf("tmdb: http %d: %s", resp.StatusCode, strings.TrimSpace(redaction.RedactValue(string(body), nil)))
 	}
 
 	decoder := json.NewDecoder(resp.Body)

--- a/internal/metadata/tracker_data_test.go
+++ b/internal/metadata/tracker_data_test.go
@@ -385,7 +385,7 @@ func TestApplyTrackerClaimsBlocksAitherAndCachesClaims(t *testing.T) {
 			t.Fatalf("unexpected path %q", got)
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer aither-key" {
-			t.Fatalf("unexpected auth header %q", got)
+			t.Fatal("unexpected auth header")
 		}
 		_, _ = w.Write([]byte(`{
 			"data":[

--- a/internal/metadata/tracker_data_test.go
+++ b/internal/metadata/tracker_data_test.go
@@ -382,10 +382,12 @@ func TestApplyTrackerClaimsBlocksAitherAndCachesClaims(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
 		if got := r.URL.Path; got != "/api/internals/claim" {
-			t.Fatalf("unexpected path %q", got)
+			t.Errorf("unexpected path %q", got)
+			return
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer aither-key" {
-			t.Fatal("unexpected auth header")
+			t.Error("unexpected auth header")
+			return
 		}
 		_, _ = w.Write([]byte(`{
 			"data":[

--- a/internal/metadata/tvdb/client.go
+++ b/internal/metadata/tvdb/client.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -1382,7 +1383,7 @@ func (c *Client) getJSON(ctx context.Context, path string, params map[string]str
 		return fmt.Errorf("tvdb: read response body for %s: %w", path, err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("tvdb: http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return fmt.Errorf("tvdb: http %d: %s", resp.StatusCode, strings.TrimSpace(redaction.RedactValue(string(body), nil)))
 	}
 
 	if err := json.Unmarshal(body, target); err != nil {
@@ -1449,7 +1450,7 @@ func (c *Client) loginLocked(ctx context.Context) error {
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("tvdb: login http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return fmt.Errorf("tvdb: login http %d: %s", resp.StatusCode, strings.TrimSpace(redaction.RedactValue(string(body), nil)))
 	}
 
 	var loginResp loginResponse

--- a/internal/metadata/tvdb/client.go
+++ b/internal/metadata/tvdb/client.go
@@ -1449,7 +1449,7 @@ func (c *Client) loginLocked(ctx context.Context) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxTVDBResponseBodyBytes+1))
 		return fmt.Errorf("tvdb: login http %d: %s", resp.StatusCode, strings.TrimSpace(redaction.RedactValue(string(body), nil)))
 	}
 

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -37,6 +37,8 @@ var (
 	apiPathTokenRe      = regexp.MustCompile(`(?i)(/api/torrents/)([A-Za-z0-9]{10,})($|[/?#"])`)
 	proxyPathRe         = regexp.MustCompile(`(?i)(/proxy/)([^/\s?#"]+)`) // /proxy/<secret>
 	queryParamRe        = regexp.MustCompile(`(?i)([?&](api[_-]?key|api[_-]?token|auth|authkey|info_hash|key|passkey|rsskey|token|torrent_pass|uid|user|user_id|userid)=)[^&]+`)
+	keyValueQuotedRe    = regexp.MustCompile(`(?i)\b(api[_-]?key|api[_-]?token|authorization|auth|authkey|cookie|csrf|passkey|password|secret|token|torrent_pass)\b(\s*[:=]\s*)(["'])([^"']*)(["'])`)
+	keyValuePlainRe     = regexp.MustCompile(`(?i)\b(api[_-]?key|api[_-]?token|authorization|auth|authkey|cookie|csrf|passkey|password|secret|token|torrent_pass)\b(\s*[:=]\s*)(bearer\s+)?([^"'\s,;)\]}]+)`)
 	longHexTokenRe      = regexp.MustCompile(`\b[a-fA-F0-9]{32,}\b`)
 )
 
@@ -128,6 +130,8 @@ func RedactValue(value string, sensitiveKeys map[string]struct{}) string {
 	value = apiPathTokenRe.ReplaceAllString(value, `${1}[REDACTED]${3}`)
 	value = proxyPathRe.ReplaceAllString(value, `${1}[REDACTED]`)
 	value = queryParamRe.ReplaceAllString(value, `${1}[REDACTED]`)
+	value = keyValueQuotedRe.ReplaceAllString(value, `${1}${2}${3}[REDACTED]${5}`)
+	value = keyValuePlainRe.ReplaceAllString(value, `${1}${2}${3}[REDACTED]`)
 	value = longHexTokenRe.ReplaceAllString(value, `[REDACTED]`)
 
 	_ = keys

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -36,9 +36,9 @@ var (
 	announcePathTokenRe = regexp.MustCompile(`(?i)(/announce(?:\.php)?/)([A-Za-z0-9]{10,})($|[/?#])`)
 	apiPathTokenRe      = regexp.MustCompile(`(?i)(/api/torrents/)([A-Za-z0-9]{10,})($|[/?#"])`)
 	proxyPathRe         = regexp.MustCompile(`(?i)(/proxy/)([^/\s?#"]+)`) // /proxy/<secret>
-	queryParamRe        = regexp.MustCompile(`(?i)([?&](api[_-]?key|api[_-]?token|auth|authkey|info_hash|key|passkey|rsskey|token|torrent_pass|uid|user|user_id|userid)=)[^&]+`)
-	keyValueQuotedRe    = regexp.MustCompile(`(?i)\b(api[_-]?key|api[_-]?token|authorization|auth|authkey|cookie|csrf|passkey|password|secret|token|torrent_pass)\b(\s*[:=]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')`)
-	keyValuePlainRe     = regexp.MustCompile(`(?i)\b(api[_-]?key|api[_-]?token|authorization|auth|authkey|cookie|csrf|passkey|password|secret|token|torrent_pass)\b(\s*[:=]\s*)(bearer\s+)?([^"'\s,;)\]}]+)`)
+	queryParamRe        = regexp.MustCompile(`(?i)([?&](anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|auth|auth[_-]?key|csrf|info[_-]?hash|key|passkey|password|rss[_-]?key|secret|token|torrent[_-]?pass|uid|user|user[_-]?id|userid)=)[^&]+`)
+	keyValueQuotedRe    = regexp.MustCompile(`(?i)\b(anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|authorization|auth|auth[_-]?key|cookie|csrf|passkey|password|rss[_-]?key|secret|token|torrent[_-]?pass)\b(\s*[:=]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')`)
+	keyValuePlainRe     = regexp.MustCompile(`(?i)\b(anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|authorization|auth|auth[_-]?key|cookie|csrf|passkey|password|rss[_-]?key|secret|token|torrent[_-]?pass)\b(\s*[:=]\s*)(bearer\s+)?([^"'\s,;)\]}]+)`)
 	longHexTokenRe      = regexp.MustCompile(`\b[a-fA-F0-9]{32,}\b`)
 )
 
@@ -193,11 +193,15 @@ func isSensitiveKey(key string, keys map[string]struct{}) bool {
 	if len(keys) == 0 {
 		return false
 	}
-	lower := strings.ToLower(key)
+	lower := canonicalSensitiveKey(key)
 	for candidate := range keys {
-		if strings.Contains(lower, candidate) {
+		if strings.Contains(lower, canonicalSensitiveKey(candidate)) {
 			return true
 		}
 	}
 	return false
+}
+
+func canonicalSensitiveKey(key string) string {
+	return strings.NewReplacer("_", "", "-", "", " ", "").Replace(strings.ToLower(strings.TrimSpace(key)))
 }

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -142,6 +142,8 @@ func RedactValue(value string, sensitiveKeys map[string]struct{}) string {
 	return value
 }
 
+// redactQuotedKeyValue replaces the value part of a matched quoted secret
+// key/value pair while preserving the original quote style.
 func redactQuotedKeyValue(value string) string {
 	matches := keyValueQuotedRe.FindStringSubmatchIndex(value)
 	if len(matches) < 8 || matches[6] < 0 || matches[7] <= matches[6] {
@@ -154,6 +156,8 @@ func redactQuotedKeyValue(value string) string {
 	return value[:matches[6]] + quoted[:1] + "[REDACTED]" + quoted[len(quoted)-1:]
 }
 
+// redactPlainKeyValue replaces the value part of a matched unquoted secret
+// key/value pair without reprocessing an existing redaction marker.
 func redactPlainKeyValue(value string) string {
 	matches := keyValuePlainRe.FindStringSubmatch(value)
 	if len(matches) < 5 {
@@ -204,6 +208,8 @@ func RedactPrivateInfo(data any, sensitiveKeys map[string]struct{}) any {
 	}
 }
 
+// isSensitiveKey compares normalized key spellings so common variants such as
+// api_key, api-key, and apiKey share the same redaction behavior.
 func isSensitiveKey(key string, keys map[string]struct{}) bool {
 	if len(keys) == 0 {
 		return false
@@ -217,6 +223,8 @@ func isSensitiveKey(key string, keys map[string]struct{}) bool {
 	return false
 }
 
+// canonicalSensitiveKey removes separators and case from keys before matching
+// them against the sensitive-key set.
 func canonicalSensitiveKey(key string) string {
 	return strings.NewReplacer("_", "", "-", "", " ", "").Replace(strings.ToLower(strings.TrimSpace(key)))
 }

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -131,7 +131,7 @@ func RedactValue(value string, sensitiveKeys map[string]struct{}) string {
 	value = proxyPathRe.ReplaceAllString(value, `${1}[REDACTED]`)
 	value = queryParamRe.ReplaceAllString(value, `${1}[REDACTED]`)
 	value = keyValueQuotedRe.ReplaceAllStringFunc(value, redactQuotedKeyValue)
-	value = keyValuePlainRe.ReplaceAllString(value, `${1}${2}${3}[REDACTED]`)
+	value = keyValuePlainRe.ReplaceAllStringFunc(value, redactPlainKeyValue)
 	value = longHexTokenRe.ReplaceAllString(value, `[REDACTED]`)
 
 	_ = keys
@@ -148,6 +148,17 @@ func redactQuotedKeyValue(value string) string {
 		return value
 	}
 	return value[:matches[6]] + quoted[:1] + "[REDACTED]" + quoted[len(quoted)-1:]
+}
+
+func redactPlainKeyValue(value string) string {
+	matches := keyValuePlainRe.FindStringSubmatch(value)
+	if len(matches) < 5 {
+		return value
+	}
+	if strings.EqualFold(matches[4], "[REDACTED") || strings.EqualFold(matches[4], "[REDACTED]") {
+		return value
+	}
+	return matches[1] + matches[2] + matches[3] + "[REDACTED]"
 }
 
 // RedactPrivateInfo recursively redacts sensitive values in JSON-like data.

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -39,6 +39,8 @@ var (
 	queryParamRe        = regexp.MustCompile(`(?i)([?&](anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|auth|auth[_-]?key|csrf|info[_-]?hash|key|passkey|password|rss[_-]?key|secret|token|torrent[_-]?pass|uid|user|user[_-]?id|userid)=)[^&]+`)
 	keyValueQuotedRe    = regexp.MustCompile(`(?i)\b(anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|authorization|auth|auth[_-]?key|cookie|csrf|passkey|password|rss[_-]?key|secret|token|torrent[_-]?pass)\b(\s*[:=]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')`)
 	keyValuePlainRe     = regexp.MustCompile(`(?i)\b(anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|authorization|auth|auth[_-]?key|cookie|csrf|passkey|password|rss[_-]?key|secret|token|torrent[_-]?pass)\b(\s*[:=]\s*)(bearer\s+)?([^"'\s,;)\]}]+)`)
+	cookieTailRe        = regexp.MustCompile(`(?i)(\bcookie\b\s*[:=]\s*\[REDACTED\])(?:[;]\s*[^,\r\n]+)+`)
+	authTailRe          = regexp.MustCompile(`(?i)(\bauthorization\b\s*[:=]\s*bearer\s+\[REDACTED\])(?:,\s*[^,\s]+)+`)
 	longHexTokenRe      = regexp.MustCompile(`\b[a-fA-F0-9]{32,}\b`)
 )
 
@@ -132,6 +134,8 @@ func RedactValue(value string, sensitiveKeys map[string]struct{}) string {
 	value = queryParamRe.ReplaceAllString(value, `${1}[REDACTED]`)
 	value = keyValueQuotedRe.ReplaceAllStringFunc(value, redactQuotedKeyValue)
 	value = keyValuePlainRe.ReplaceAllStringFunc(value, redactPlainKeyValue)
+	value = cookieTailRe.ReplaceAllString(value, `${1}`)
+	value = authTailRe.ReplaceAllString(value, `${1}`)
 	value = longHexTokenRe.ReplaceAllString(value, `[REDACTED]`)
 
 	_ = keys

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -37,7 +37,7 @@ var (
 	apiPathTokenRe      = regexp.MustCompile(`(?i)(/api/torrents/)([A-Za-z0-9]{10,})($|[/?#"])`)
 	proxyPathRe         = regexp.MustCompile(`(?i)(/proxy/)([^/\s?#"]+)`) // /proxy/<secret>
 	queryParamRe        = regexp.MustCompile(`(?i)([?&](api[_-]?key|api[_-]?token|auth|authkey|info_hash|key|passkey|rsskey|token|torrent_pass|uid|user|user_id|userid)=)[^&]+`)
-	keyValueQuotedRe    = regexp.MustCompile(`(?i)\b(api[_-]?key|api[_-]?token|authorization|auth|authkey|cookie|csrf|passkey|password|secret|token|torrent_pass)\b(\s*[:=]\s*)(["'])([^"']*)(["'])`)
+	keyValueQuotedRe    = regexp.MustCompile(`(?i)\b(api[_-]?key|api[_-]?token|authorization|auth|authkey|cookie|csrf|passkey|password|secret|token|torrent_pass)\b(\s*[:=]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')`)
 	keyValuePlainRe     = regexp.MustCompile(`(?i)\b(api[_-]?key|api[_-]?token|authorization|auth|authkey|cookie|csrf|passkey|password|secret|token|torrent_pass)\b(\s*[:=]\s*)(bearer\s+)?([^"'\s,;)\]}]+)`)
 	longHexTokenRe      = regexp.MustCompile(`\b[a-fA-F0-9]{32,}\b`)
 )
@@ -130,12 +130,24 @@ func RedactValue(value string, sensitiveKeys map[string]struct{}) string {
 	value = apiPathTokenRe.ReplaceAllString(value, `${1}[REDACTED]${3}`)
 	value = proxyPathRe.ReplaceAllString(value, `${1}[REDACTED]`)
 	value = queryParamRe.ReplaceAllString(value, `${1}[REDACTED]`)
-	value = keyValueQuotedRe.ReplaceAllString(value, `${1}${2}${3}[REDACTED]${5}`)
+	value = keyValueQuotedRe.ReplaceAllStringFunc(value, redactQuotedKeyValue)
 	value = keyValuePlainRe.ReplaceAllString(value, `${1}${2}${3}[REDACTED]`)
 	value = longHexTokenRe.ReplaceAllString(value, `[REDACTED]`)
 
 	_ = keys
 	return value
+}
+
+func redactQuotedKeyValue(value string) string {
+	matches := keyValueQuotedRe.FindStringSubmatchIndex(value)
+	if len(matches) < 8 || matches[6] < 0 || matches[7] <= matches[6] {
+		return value
+	}
+	quoted := value[matches[6]:matches[7]]
+	if len(quoted) < 2 {
+		return value
+	}
+	return value[:matches[6]] + quoted[:1] + "[REDACTED]" + quoted[len(quoted)-1:]
 }
 
 // RedactPrivateInfo recursively redacts sensitive values in JSON-like data.

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -8,7 +8,7 @@ import "testing"
 func TestRedactValueURLPatterns(t *testing.T) {
 	t.Parallel()
 
-	input := "https://tracker.example/0123456789abcdef/announce?passkey=secret&token=abc&info_hash=deadbeef&authkey=private&uid=123"
+	input := "https://tracker.example/0123456789abcdef/announce?passkey=secret&token=abc&info_hash=deadbeef&authkey=private&auth-key=private2&apiKey=api-secret&api-token=api-token-secret&rss_key=rss-secret&torrent-pass=torrent-secret&AntiCsrfToken=csrf-secret&uid=123"
 	output := RedactValue(input, nil)
 
 	if output == input {
@@ -17,7 +17,12 @@ func TestRedactValueURLPatterns(t *testing.T) {
 	if contains(output, "0123456789abcdef") {
 		t.Fatalf("expected passkey redacted, got %q", output)
 	}
-	if contains(output, "secret") || contains(output, "token=abc") || contains(output, "authkey=private") || contains(output, "uid=123") {
+	for _, secret := range []string{"secret", "token=abc", "authkey=private", "auth-key=private2", "api-secret", "api-token-secret", "rss-secret", "torrent-secret", "csrf-secret", "uid=123"} {
+		if contains(output, secret) {
+			t.Fatalf("expected query param %q redacted, got %q", secret, output)
+		}
+	}
+	if !contains(output, "apiKey=[REDACTED]") || !contains(output, "auth-key=[REDACTED]") || !contains(output, "torrent-pass=[REDACTED]") {
 		t.Fatalf("expected query params redacted, got %q", output)
 	}
 }
@@ -75,15 +80,15 @@ func TestRedactValueBareProxyPath(t *testing.T) {
 func TestRedactValuePlainKeyValuePairs(t *testing.T) {
 	t.Parallel()
 
-	input := `api_key: tracker-secret token=plain-token Authorization=Bearer bearer-secret cookie: "session-secret" message=kept`
+	input := `api_key: tracker-secret api-key=hyphen-secret apiToken: camel-secret auth_key=auth-secret rss-key=rss-secret torrentPass=torrent-secret AntiCsrfToken=csrf-secret token=plain-token Authorization=Bearer bearer-secret cookie: "session-secret" message=kept`
 	output := RedactValue(input, nil)
 
-	for _, secret := range []string{"tracker-secret", "plain-token", "bearer-secret", "session-secret"} {
+	for _, secret := range []string{"tracker-secret", "hyphen-secret", "camel-secret", "auth-secret", "rss-secret", "torrent-secret", "csrf-secret", "plain-token", "bearer-secret", "session-secret"} {
 		if contains(output, secret) {
 			t.Fatalf("expected %q redacted, got %q", secret, output)
 		}
 	}
-	for _, marker := range []string{"api_key: [REDACTED]", "token=[REDACTED]", "Authorization=Bearer [REDACTED]", `cookie: "[REDACTED]"`, "message=kept"} {
+	for _, marker := range []string{"api_key: [REDACTED]", "api-key=[REDACTED]", "apiToken: [REDACTED]", "auth_key=[REDACTED]", "rss-key=[REDACTED]", "torrentPass=[REDACTED]", "AntiCsrfToken=[REDACTED]", "token=[REDACTED]", "Authorization=Bearer [REDACTED]", `cookie: "[REDACTED]"`, "message=kept"} {
 		if !contains(output, marker) {
 			t.Fatalf("expected marker %q in %q", marker, output)
 		}
@@ -112,9 +117,13 @@ func TestRedactPrivateInfoJSON(t *testing.T) {
 	t.Parallel()
 
 	input := map[string]any{
-		"token":   "abc",
-		"nested":  map[string]any{"password": "secret"},
-		"entries": []any{"passkey", "value"},
+		"token":         "abc",
+		"apiKey":        "api-secret",
+		"auth_key":      "auth-secret",
+		"torrentPass":   "torrent-secret",
+		"AntiCsrfToken": "csrf-secret",
+		"nested":        map[string]any{"password": "secret", "rss-key": "rss-secret"},
+		"entries":       []any{"passkey", "value"},
 	}
 
 	redacted, ok := RedactPrivateInfo(input, nil).(map[string]any)
@@ -124,12 +133,20 @@ func TestRedactPrivateInfoJSON(t *testing.T) {
 	if redacted["token"] != "[REDACTED]" {
 		t.Fatalf("expected token redacted, got %#v", redacted["token"])
 	}
+	for _, key := range []string{"apiKey", "auth_key", "torrentPass", "AntiCsrfToken"} {
+		if redacted[key] != "[REDACTED]" {
+			t.Fatalf("expected %s redacted, got %#v", key, redacted[key])
+		}
+	}
 	nested, ok := redacted["nested"].(map[string]any)
 	if !ok {
 		t.Fatalf("expected nested redacted value to be map[string]any")
 	}
 	if nested["password"] != "[REDACTED]" {
 		t.Fatalf("expected password redacted, got %#v", nested["password"])
+	}
+	if nested["rss-key"] != "[REDACTED]" {
+		t.Fatalf("expected rss-key redacted, got %#v", nested["rss-key"])
 	}
 }
 

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -12,18 +12,18 @@ func TestRedactValueURLPatterns(t *testing.T) {
 	output := RedactValue(input, nil)
 
 	if output == input {
-		t.Fatalf("expected redaction, got %q", output)
+		t.Fatal("expected redaction to change fixture")
 	}
 	if contains(output, "0123456789abcdef") {
-		t.Fatalf("expected passkey redacted, got %q", output)
+		t.Fatal("expected passkey redacted")
 	}
 	for _, secret := range []string{"secret", "token=abc", "authkey=private", "auth-key=private2", "api-secret", "api-token-secret", "rss-secret", "torrent-secret", "csrf-secret", "uid=123"} {
 		if contains(output, secret) {
-			t.Fatalf("expected query param %q redacted, got %q", secret, output)
+			t.Fatal("expected sensitive query param redacted")
 		}
 	}
 	if !contains(output, "apiKey=[REDACTED]") || !contains(output, "auth-key=[REDACTED]") || !contains(output, "torrent-pass=[REDACTED]") {
-		t.Fatalf("expected query params redacted, got %q", output)
+		t.Fatal("expected query params redacted")
 	}
 }
 
@@ -34,7 +34,7 @@ func TestRedactValueAnnouncePathToken(t *testing.T) {
 	output := RedactValue(input, nil)
 
 	if contains(output, "0123456789abcdef") {
-		t.Fatalf("expected announce path token redacted, got %q", output)
+		t.Fatal("expected announce path token redacted")
 	}
 }
 
@@ -45,10 +45,10 @@ func TestRedactValueTrackerLookupRequestErrors(t *testing.T) {
 	output := RedactValue(input, nil)
 
 	if contains(output, "bhdSecretKey123") || contains(output, "aitherSecretKey123") {
-		t.Fatalf("expected request error secrets redacted, got %q", output)
+		t.Fatal("expected request error secrets redacted")
 	}
 	if !contains(output, "/api/torrents/[REDACTED]") || !contains(output, "api_token=[REDACTED]") {
-		t.Fatalf("expected redacted request error shape preserved, got %q", output)
+		t.Fatal("expected redacted request error shape preserved")
 	}
 }
 
@@ -59,7 +59,7 @@ func TestRedactValueProxyPath(t *testing.T) {
 	output := RedactValue(input, nil)
 
 	if contains(output, "/proxy/secret/") {
-		t.Fatalf("expected proxy secret redacted, got %q", output)
+		t.Fatal("expected proxy secret redacted")
 	}
 }
 
@@ -70,10 +70,10 @@ func TestRedactValueBareProxyPath(t *testing.T) {
 	output := RedactValue(input, nil)
 
 	if contains(output, "/proxy/secret") {
-		t.Fatalf("expected bare proxy secret redacted, got %q", output)
+		t.Fatal("expected bare proxy secret redacted")
 	}
 	if !contains(output, "/proxy/[REDACTED]") {
-		t.Fatalf("expected proxy path shape preserved, got %q", output)
+		t.Fatal("expected proxy path shape preserved")
 	}
 }
 
@@ -85,12 +85,12 @@ func TestRedactValuePlainKeyValuePairs(t *testing.T) {
 
 	for _, secret := range []string{"tracker-secret", "hyphen-secret", "camel-secret", "auth-secret", "rss-secret", "torrent-secret", "csrf-secret", "plain-token", "bearer-secret", "session-secret"} {
 		if contains(output, secret) {
-			t.Fatalf("expected %q redacted, got %q", secret, output)
+			t.Fatal("expected sensitive key/value redacted")
 		}
 	}
 	for _, marker := range []string{"api_key: [REDACTED]", "api-key=[REDACTED]", "apiToken: [REDACTED]", "auth_key=[REDACTED]", "rss-key=[REDACTED]", "torrentPass=[REDACTED]", "AntiCsrfToken=[REDACTED]", "token=[REDACTED]", "Authorization=Bearer [REDACTED]", `cookie: "[REDACTED]"`, "message=kept"} {
 		if !contains(output, marker) {
-			t.Fatalf("expected marker %q in %q", marker, output)
+			t.Fatal("expected redaction marker preserved")
 		}
 	}
 }
@@ -102,10 +102,10 @@ func TestRedactValueDoesNotReredactRedactedQueryValues(t *testing.T) {
 	output := RedactValue(input, nil)
 
 	if contains(output, "[REDACTED]]") {
-		t.Fatalf("expected already-redacted query values to stay stable, got %q", output)
+		t.Fatal("expected already-redacted query values to stay stable")
 	}
 	if !contains(output, "api_key=[REDACTED]&passkey=[REDACTED]") {
-		t.Fatalf("expected query values redacted once, got %q", output)
+		t.Fatal("expected query values redacted once")
 	}
 }
 
@@ -117,12 +117,12 @@ func TestRedactValueQuotedKeyValuePairsWithEscapedQuotes(t *testing.T) {
 
 	for _, secret := range []string{"alpha", "bravo", "charlie", "delta"} {
 		if contains(output, secret) {
-			t.Fatalf("expected %q redacted, got %q", secret, output)
+			t.Fatal("expected quoted secret redacted")
 		}
 	}
 	for _, marker := range []string{`token="[REDACTED]"`, `password='[REDACTED]'`, "message=kept"} {
 		if !contains(output, marker) {
-			t.Fatalf("expected marker %q in %q", marker, output)
+			t.Fatal("expected quoted redaction marker preserved")
 		}
 	}
 }
@@ -145,11 +145,11 @@ func TestRedactPrivateInfoJSON(t *testing.T) {
 		t.Fatalf("expected redacted value to be map[string]any")
 	}
 	if redacted["token"] != "[REDACTED]" {
-		t.Fatalf("expected token redacted, got %#v", redacted["token"])
+		t.Fatal("expected token redacted")
 	}
 	for _, key := range []string{"apiKey", "auth_key", "torrentPass", "AntiCsrfToken"} {
 		if redacted[key] != "[REDACTED]" {
-			t.Fatalf("expected %s redacted, got %#v", key, redacted[key])
+			t.Fatal("expected secret field redacted")
 		}
 	}
 	nested, ok := redacted["nested"].(map[string]any)
@@ -157,10 +157,10 @@ func TestRedactPrivateInfoJSON(t *testing.T) {
 		t.Fatalf("expected nested redacted value to be map[string]any")
 	}
 	if nested["password"] != "[REDACTED]" {
-		t.Fatalf("expected password redacted, got %#v", nested["password"])
+		t.Fatal("expected password redacted")
 	}
 	if nested["rss-key"] != "[REDACTED]" {
-		t.Fatalf("expected rss-key redacted, got %#v", nested["rss-key"])
+		t.Fatal("expected rss-key redacted")
 	}
 }
 

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -95,6 +95,20 @@ func TestRedactValuePlainKeyValuePairs(t *testing.T) {
 	}
 }
 
+func TestRedactValueDoesNotReredactRedactedQueryValues(t *testing.T) {
+	t.Parallel()
+
+	input := "https://tracker.example/upload?api_key=secret-key&passkey=secret-pass"
+	output := RedactValue(input, nil)
+
+	if contains(output, "[REDACTED]]") {
+		t.Fatalf("expected already-redacted query values to stay stable, got %q", output)
+	}
+	if !contains(output, "api_key=[REDACTED]&passkey=[REDACTED]") {
+		t.Fatalf("expected query values redacted once, got %q", output)
+	}
+}
+
 func TestRedactValueQuotedKeyValuePairsWithEscapedQuotes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -90,6 +90,24 @@ func TestRedactValuePlainKeyValuePairs(t *testing.T) {
 	}
 }
 
+func TestRedactValueQuotedKeyValuePairsWithEscapedQuotes(t *testing.T) {
+	t.Parallel()
+
+	input := `token="alpha\"bravo" password='charlie\'delta' message=kept`
+	output := RedactValue(input, nil)
+
+	for _, secret := range []string{"alpha", "bravo", "charlie", "delta"} {
+		if contains(output, secret) {
+			t.Fatalf("expected %q redacted, got %q", secret, output)
+		}
+	}
+	for _, marker := range []string{`token="[REDACTED]"`, `password='[REDACTED]'`, "message=kept"} {
+		if !contains(output, marker) {
+			t.Fatalf("expected marker %q in %q", marker, output)
+		}
+	}
+}
+
 func TestRedactPrivateInfoJSON(t *testing.T) {
 	t.Parallel()
 

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -72,6 +72,24 @@ func TestRedactValueBareProxyPath(t *testing.T) {
 	}
 }
 
+func TestRedactValuePlainKeyValuePairs(t *testing.T) {
+	t.Parallel()
+
+	input := `api_key: tracker-secret token=plain-token Authorization=Bearer bearer-secret cookie: "session-secret" message=kept`
+	output := RedactValue(input, nil)
+
+	for _, secret := range []string{"tracker-secret", "plain-token", "bearer-secret", "session-secret"} {
+		if contains(output, secret) {
+			t.Fatalf("expected %q redacted, got %q", secret, output)
+		}
+	}
+	for _, marker := range []string{"api_key: [REDACTED]", "token=[REDACTED]", "Authorization=Bearer [REDACTED]", `cookie: "[REDACTED]"`, "message=kept"} {
+		if !contains(output, marker) {
+			t.Fatalf("expected marker %q in %q", marker, output)
+		}
+	}
+}
+
 func TestRedactPrivateInfoJSON(t *testing.T) {
 	t.Parallel()
 

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -95,6 +95,19 @@ func TestRedactValuePlainKeyValuePairs(t *testing.T) {
 	}
 }
 
+func TestRedactValueDelimitedAuthAndCookieTails(t *testing.T) {
+	t.Parallel()
+
+	input := `Cookie: uid=first-secret; session=second-secret, Authorization=Bearer alpha-secret,beta-secret token=third-secret`
+	output := RedactValue(input, nil)
+
+	for _, secret := range []string{"first-secret", "second-secret", "alpha-secret", "beta-secret", "third-secret"} {
+		if contains(output, secret) {
+			t.Fatal("expected delimited auth and cookie tails redacted")
+		}
+	}
+}
+
 func TestRedactValueDoesNotReredactRedactedQueryValues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/db/config_test.go
+++ b/internal/services/db/config_test.go
@@ -54,7 +54,7 @@ func TestConfigSectionSaveLoad(t *testing.T) {
 
 	// Verify.
 	if loaded.TMDBAPI != testSettings.TMDBAPI {
-		t.Errorf("TMDBAPI mismatch: got %s, want %s", loaded.TMDBAPI, testSettings.TMDBAPI)
+		t.Error("TMDBAPI mismatch")
 	}
 	if loaded.DBPath != testSettings.DBPath {
 		t.Errorf("DBPath mismatch: got %s, want %s", loaded.DBPath, testSettings.DBPath)

--- a/internal/services/description/description_test.go
+++ b/internal/services/description/description_test.go
@@ -102,14 +102,14 @@ func TestExtractCodeBlocksUsesUniqueNonAliasingPlaceholders(t *testing.T) {
 			t.Fatalf("expected token for block %d", i)
 		}
 		if strings.Contains(builder.String(), block.token) {
-			t.Fatalf("expected generated token %q to be absent from original input", block.token)
+			t.Fatalf("expected generated token for block %d to be absent from original input", i)
 		}
 		for j, other := range blocks {
 			if i == j {
 				continue
 			}
 			if strings.Contains(other.token, block.token) {
-				t.Fatalf("expected token %q not to alias %q", block.token, other.token)
+				t.Fatalf("expected token for block %d not to alias block %d", i, j)
 			}
 		}
 	}

--- a/internal/services/imagehosting/uploaders.go
+++ b/internal/services/imagehosting/uploaders.go
@@ -176,8 +176,8 @@ func (u *imgboxUploader) Upload(ctx context.Context, imagePath string) (uploadRe
 	}
 	if !response.OK && len(response.Files) == 0 {
 		errMsg := "unknown error"
-		if response.Error != "" {
-			errMsg = safeResponseMessage(response.Error)
+		if message := safeResponseMessage(response.Error); message != "" {
+			errMsg = message
 		}
 		bodyStr := safeResponsePreview(body)
 		return uploadResult{}, fmt.Errorf("imgbox upload rejected: %s (response: %s)", errMsg, bodyStr)

--- a/internal/services/imagehosting/uploaders.go
+++ b/internal/services/imagehosting/uploaders.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/httpclient"
+	"github.com/autobrr/upbrr/internal/redaction"
 )
 
 type uploadResult struct {
@@ -155,10 +156,7 @@ func (u *imgboxUploader) Upload(ctx context.Context, imagePath string) (uploadRe
 	}
 	if status != http.StatusOK {
 		// Try to extract error message from response
-		bodyStr := string(body)
-		if len(bodyStr) > 200 {
-			bodyStr = bodyStr[:200] + "..."
-		}
+		bodyStr := safeResponsePreview(body)
 		return uploadResult{}, fmt.Errorf("imgbox upload failed with status %d, response: %s", status, bodyStr)
 	}
 
@@ -173,10 +171,7 @@ func (u *imgboxUploader) Upload(ctx context.Context, imagePath string) (uploadRe
 		Error string `json:"error"`
 	}
 	if err := json.Unmarshal(body, &response); err != nil {
-		bodyStr := string(body)
-		if len(bodyStr) > 200 {
-			bodyStr = bodyStr[:200] + "..."
-		}
+		bodyStr := safeResponsePreview(body)
 		return uploadResult{}, fmt.Errorf("imgbox invalid JSON response: %w, body: %s", err, bodyStr)
 	}
 	if !response.OK && len(response.Files) == 0 {
@@ -184,10 +179,7 @@ func (u *imgboxUploader) Upload(ctx context.Context, imagePath string) (uploadRe
 		if response.Error != "" {
 			errMsg = response.Error
 		}
-		bodyStr := string(body)
-		if len(bodyStr) > 200 {
-			bodyStr = bodyStr[:200] + "..."
-		}
+		bodyStr := safeResponsePreview(body)
 		return uploadResult{}, fmt.Errorf("imgbox upload rejected: %s (response: %s)", errMsg, bodyStr)
 	}
 	if len(response.Files) == 0 {
@@ -386,18 +378,12 @@ func imgboxGetUploadToken(ctx context.Context, client *http.Client, csrfToken st
 		return imgboxUploadToken{}, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		bodyStr := string(body)
-		if len(bodyStr) > 200 {
-			bodyStr = bodyStr[:200] + "..."
-		}
+		bodyStr := safeResponsePreview(body)
 		return imgboxUploadToken{}, fmt.Errorf("imgbox token request failed with status %d, response: %s", resp.StatusCode, bodyStr)
 	}
 	var tokenResp map[string]any
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		bodyStr := string(body)
-		if len(bodyStr) > 200 {
-			bodyStr = bodyStr[:200] + "..."
-		}
+		bodyStr := safeResponsePreview(body)
 		return imgboxUploadToken{}, fmt.Errorf("imgbox token response invalid JSON: %w, body: %s", err, bodyStr)
 	}
 	return imgboxUploadToken{
@@ -1279,6 +1265,14 @@ func readAndCloseResponseBody(resp *http.Response) ([]byte, error) {
 		return nil, fmt.Errorf("image hosting: read response body: %w", err)
 	}
 	return body, nil
+}
+
+func safeResponsePreview(body []byte) string {
+	text := strings.TrimSpace(redaction.RedactValue(string(body), nil))
+	if len(text) > 200 {
+		text = strings.TrimSpace(text[:200]) + "..."
+	}
+	return text
 }
 
 func closeResponseBody(resp *http.Response) {

--- a/internal/services/imagehosting/uploaders.go
+++ b/internal/services/imagehosting/uploaders.go
@@ -45,6 +45,8 @@ type namedBatchUploader interface {
 	UploadBatchWithName(ctx context.Context, imagePaths []string, galleryName string) ([]uploadResult, error)
 }
 
+const maxResponseBodyPreviewBytes int64 = 64 * 1024
+
 func newUploaderRegistry(cfg config.Config, client *http.Client) map[string]uploader {
 	client = httpclient.CloneWithTimeout(client, httpclient.UploadTimeout)
 	return map[string]uploader{
@@ -337,7 +339,7 @@ func imgboxGetCsrfAndCookie(ctx context.Context, client *http.Client) (string, s
 		closeResponseBody(resp)
 		return "", "", fmt.Errorf("imgbox send csrf request: %w", err)
 	}
-	body, err := readAndCloseResponseBody(resp)
+	body, err := readLimitedAndCloseResponseBody(resp)
 	if err != nil {
 		return "", "", err
 	}
@@ -373,7 +375,7 @@ func imgboxGetUploadToken(ctx context.Context, client *http.Client, csrfToken st
 		closeResponseBody(resp)
 		return imgboxUploadToken{}, fmt.Errorf("imgbox send token request: %w", err)
 	}
-	body, err := readAndCloseResponseBody(resp)
+	body, err := readLimitedAndCloseResponseBody(resp)
 	if err != nil {
 		return imgboxUploadToken{}, err
 	}
@@ -1135,7 +1137,7 @@ func postForm(ctx context.Context, client *http.Client, target string, data url.
 		closeResponseBody(resp)
 		return nil, 0, fmt.Errorf("image hosting: send form request to %s: %w", target, err)
 	}
-	body, err := readAndCloseResponseBody(resp)
+	body, err := readLimitedAndCloseResponseBody(resp)
 	if err != nil {
 		return nil, resp.StatusCode, err
 	}
@@ -1202,7 +1204,7 @@ func postMultipartWithFields(ctx context.Context, client *http.Client, target st
 		closeResponseBody(resp)
 		return nil, 0, fmt.Errorf("image hosting: send multipart request to %s: %w", target, err)
 	}
-	bodyBytes, err := readAndCloseResponseBody(resp)
+	bodyBytes, err := readLimitedAndCloseResponseBody(resp)
 	if err != nil {
 		return nil, resp.StatusCode, err
 	}
@@ -1248,19 +1250,19 @@ func postMultipartRepeatedFileField(ctx context.Context, client *http.Client, ta
 		closeResponseBody(resp)
 		return nil, 0, fmt.Errorf("image hosting: send multipart request to %s: %w", target, err)
 	}
-	bodyBytes, err := readAndCloseResponseBody(resp)
+	bodyBytes, err := readLimitedAndCloseResponseBody(resp)
 	if err != nil {
 		return nil, resp.StatusCode, err
 	}
 	return bodyBytes, resp.StatusCode, nil
 }
 
-func readAndCloseResponseBody(resp *http.Response) ([]byte, error) {
+func readLimitedAndCloseResponseBody(resp *http.Response) ([]byte, error) {
 	if resp == nil || resp.Body == nil {
 		return nil, nil
 	}
 	defer closeResponseBody(resp)
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyPreviewBytes))
 	if err != nil {
 		return nil, fmt.Errorf("image hosting: read response body: %w", err)
 	}

--- a/internal/services/imagehosting/uploaders.go
+++ b/internal/services/imagehosting/uploaders.go
@@ -1257,6 +1257,8 @@ func postMultipartRepeatedFileField(ctx context.Context, client *http.Client, ta
 	return bodyBytes, resp.StatusCode, nil
 }
 
+// readLimitedAndCloseResponseBody reads only the diagnostic preview cap from a
+// response body and always closes the body before returning.
 func readLimitedAndCloseResponseBody(resp *http.Response) ([]byte, error) {
 	if resp == nil || resp.Body == nil {
 		return nil, nil
@@ -1269,6 +1271,8 @@ func readLimitedAndCloseResponseBody(resp *http.Response) ([]byte, error) {
 	return body, nil
 }
 
+// safeResponsePreview returns a redacted, length-bounded response snippet for
+// upload errors and diagnostics.
 func safeResponsePreview(body []byte) string {
 	text := safeResponseMessage(string(body))
 	if len(text) > 200 {
@@ -1277,6 +1281,7 @@ func safeResponsePreview(body []byte) string {
 	return text
 }
 
+// safeResponseMessage redacts response text before it reaches errors or logs.
 func safeResponseMessage(value string) string {
 	return strings.TrimSpace(redaction.RedactValue(value, nil))
 }

--- a/internal/services/imagehosting/uploaders.go
+++ b/internal/services/imagehosting/uploaders.go
@@ -177,7 +177,7 @@ func (u *imgboxUploader) Upload(ctx context.Context, imagePath string) (uploadRe
 	if !response.OK && len(response.Files) == 0 {
 		errMsg := "unknown error"
 		if response.Error != "" {
-			errMsg = response.Error
+			errMsg = safeResponseMessage(response.Error)
 		}
 		bodyStr := safeResponsePreview(body)
 		return uploadResult{}, fmt.Errorf("imgbox upload rejected: %s (response: %s)", errMsg, bodyStr)
@@ -662,7 +662,7 @@ func (u *ptScreensUploader) Upload(ctx context.Context, imagePath string) (uploa
 		return uploadResult{}, fmt.Errorf("ptscreens invalid response: %w", err)
 	}
 	if response.Image.URL == "" {
-		return uploadResult{}, fmt.Errorf("ptscreens upload failed: %s", strings.TrimSpace(response.Error.Message))
+		return uploadResult{}, fmt.Errorf("ptscreens upload failed: %s", safeResponseMessage(response.Error.Message))
 	}
 
 	return uploadResult{
@@ -750,7 +750,7 @@ func (u *thrUploader) Upload(ctx context.Context, imagePath string) (uploadResul
 	}
 	imageURL := strings.TrimSpace(response.Image.URL)
 	if imageURL == "" {
-		message := strings.TrimSpace(response.Error.Message)
+		message := safeResponseMessage(response.Error.Message)
 		if message == "" {
 			message = "thr upload failed"
 		}
@@ -811,8 +811,8 @@ func (u *lostimgUploader) uploadBatch(ctx context.Context, imagePaths []string) 
 	if err := json.Unmarshal(body, &response); err != nil {
 		return nil, fmt.Errorf("lostimg invalid response: %w", err)
 	}
-	if strings.TrimSpace(response.Error) != "" {
-		return nil, fmt.Errorf("lostimg upload failed: %s", strings.TrimSpace(response.Error))
+	if safeResponseMessage(response.Error) != "" {
+		return nil, fmt.Errorf("lostimg upload failed: %s", safeResponseMessage(response.Error))
 	}
 
 	urls := response.URLs
@@ -945,7 +945,7 @@ func (u *passTheImageUploader) Upload(ctx context.Context, imagePath string) (up
 		return uploadResult{}, fmt.Errorf("passtheimage invalid response: %w", err)
 	}
 	if response.StatusCode != http.StatusOK {
-		message := strings.TrimSpace(response.Error.Message)
+		message := safeResponseMessage(response.Error.Message)
 		if message == "" {
 			message = "passtheimage upload failed"
 		}
@@ -997,7 +997,7 @@ func (u *reelflixUploader) Upload(ctx context.Context, imagePath string) (upload
 		return uploadResult{}, fmt.Errorf("reelflix invalid response: %w", err)
 	}
 	if response.StatusCode != 0 && response.StatusCode != http.StatusOK {
-		message := strings.TrimSpace(response.Error.Message)
+		message := safeResponseMessage(response.Error.Message)
 		if message == "" {
 			message = "reelflix upload failed"
 		}
@@ -1108,9 +1108,9 @@ func (u *shareXUploader) Upload(ctx context.Context, imagePath string) (uploadRe
 		link = strings.TrimSpace(response.Link)
 	}
 	if link == "" {
-		message := strings.TrimSpace(response.Message)
+		message := safeResponseMessage(response.Message)
 		if message == "" {
-			message = strings.TrimSpace(response.Error)
+			message = safeResponseMessage(response.Error)
 		}
 		if message == "" {
 			message = "sharex upload failed"
@@ -1268,11 +1268,15 @@ func readAndCloseResponseBody(resp *http.Response) ([]byte, error) {
 }
 
 func safeResponsePreview(body []byte) string {
-	text := strings.TrimSpace(redaction.RedactValue(string(body), nil))
+	text := safeResponseMessage(string(body))
 	if len(text) > 200 {
 		text = strings.TrimSpace(text[:200]) + "..."
 	}
 	return text
+}
+
+func safeResponseMessage(value string) string {
+	return strings.TrimSpace(redaction.RedactValue(value, nil))
 }
 
 func closeResponseBody(resp *http.Response) {

--- a/internal/services/imagehosting/uploaders_test.go
+++ b/internal/services/imagehosting/uploaders_test.go
@@ -205,7 +205,7 @@ func TestHDBUploadBatchChunksLargeUploads(t *testing.T) {
 func TestImgboxUploadRejectedUsesFallbackAfterSanitizingError(t *testing.T) {
 	tmpDir := t.TempDir()
 	imagePath := filepath.Join(tmpDir, "shot.png")
-	if err := os.WriteFile(imagePath, []byte("testdata"), 0o644); err != nil {
+	if err := os.WriteFile(imagePath, []byte("testdata"), 0o600); err != nil {
 		t.Fatalf("write temp file: %v", err)
 	}
 
@@ -244,10 +244,10 @@ func TestImgboxUploadRejectedUsesFallbackAfterSanitizingError(t *testing.T) {
 		t.Fatal("expected rejected upload to fail")
 	}
 	if !strings.Contains(err.Error(), "imgbox upload rejected: unknown error") {
-		t.Fatalf("expected unknown error fallback, got %v", err)
+		t.Fatal("expected unknown error fallback")
 	}
 	if strings.Contains(err.Error(), "imgbox upload rejected:  ") {
-		t.Fatalf("rejection message must not be whitespace-only: %v", err)
+		t.Fatal("rejection message must not be whitespace-only")
 	}
 }
 

--- a/internal/services/imagehosting/uploaders_test.go
+++ b/internal/services/imagehosting/uploaders_test.go
@@ -326,7 +326,7 @@ func TestLostimgUploaderPostsRepeatedFileFields(t *testing.T) {
 				t.Fatalf("unexpected request URL: %s", req.URL.String())
 			}
 			if got := req.Header.Get("Authorization"); got != "Bearer secret" {
-				t.Fatalf("expected bearer auth, got %q", got)
+				t.Fatal("expected bearer auth")
 			}
 			mediaType, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
 			if err != nil {
@@ -478,7 +478,7 @@ func TestReelflixUploaderPostsSourceWithAPIKey(t *testing.T) {
 				t.Fatalf("unexpected request URL: %s", req.URL.String())
 			}
 			if got := req.Header.Get("X-Api-Key"); got != "secret" {
-				t.Fatalf("expected X-API-Key, got %q", got)
+				t.Fatal("expected X-API-Key")
 			}
 			mediaType, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
 			if err != nil {

--- a/internal/services/imagehosting/uploaders_test.go
+++ b/internal/services/imagehosting/uploaders_test.go
@@ -548,7 +548,7 @@ func TestReadAndCloseResponseBodyClosesBody(t *testing.T) {
 		t.Fatalf("readAndCloseResponseBody returned error: %v", err)
 	}
 	if string(payload) != "partial response" {
-		t.Fatalf("unexpected payload: %q", string(payload))
+		t.Fatalf("unexpected payload: %q", safeResponsePreview(payload))
 	}
 	if !body.closed {
 		t.Fatal("expected response body to be closed")

--- a/internal/services/imagehosting/uploaders_test.go
+++ b/internal/services/imagehosting/uploaders_test.go
@@ -592,9 +592,9 @@ func TestReadAndCloseResponseBodyClosesBody(t *testing.T) {
 		Body:       body,
 	}
 
-	payload, err := readAndCloseResponseBody(resp)
+	payload, err := readLimitedAndCloseResponseBody(resp)
 	if err != nil {
-		t.Fatalf("readAndCloseResponseBody returned error: %v", err)
+		t.Fatalf("readLimitedAndCloseResponseBody returned error: %v", err)
 	}
 	if string(payload) != "partial response" {
 		t.Fatalf("unexpected payload: %q", safeResponsePreview(payload))

--- a/internal/services/imagehosting/uploaders_test.go
+++ b/internal/services/imagehosting/uploaders_test.go
@@ -202,6 +202,55 @@ func TestHDBUploadBatchChunksLargeUploads(t *testing.T) {
 	}
 }
 
+func TestImgboxUploadRejectedUsesFallbackAfterSanitizingError(t *testing.T) {
+	tmpDir := t.TempDir()
+	imagePath := filepath.Join(tmpDir, "shot.png")
+	if err := os.WriteFile(imagePath, []byte("testdata"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://imgbox.com/":
+				header := make(http.Header)
+				header.Add("Set-Cookie", "session=abc; Path=/")
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     header,
+					Body:       io.NopCloser(strings.NewReader(`<input name="authenticity_token" value="csrf-token">`)),
+				}, nil
+			case "https://imgbox.com/ajax/token/generate":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(`{"token_id":"1","token_secret":"secret","gallery_id":"2","gallery_secret":"gallery"}`)),
+				}, nil
+			case "https://imgbox.com/upload/process":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(`{"ok":false,"error":"   "}`)),
+				}, nil
+			default:
+				t.Fatalf("unexpected request URL: %s", req.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+
+	_, err := (&imgboxUploader{client: client}).Upload(context.Background(), imagePath)
+	if err == nil {
+		t.Fatal("expected rejected upload to fail")
+	}
+	if !strings.Contains(err.Error(), "imgbox upload rejected: unknown error") {
+		t.Fatalf("expected unknown error fallback, got %v", err)
+	}
+	if strings.Contains(err.Error(), "imgbox upload rejected:  ") {
+		t.Fatalf("rejection message must not be whitespace-only: %v", err)
+	}
+}
+
 func TestParseHDBUploadResultsMultipleMatches(t *testing.T) {
 	results, err := parseHDBUploadResults([]byte(
 		"[url=https://img.hdbits.org/a1][img]https://t.hdbits.org/a1.jpg[/img][/url]\n" +

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -97,6 +97,13 @@ func (s *Service) logInfof(format string, args ...any) {
 	s.logger.Infof(format, args...)
 }
 
+func (s *Service) logTracef(format string, args ...any) {
+	if s == nil || s.logger == nil {
+		return
+	}
+	s.logger.Tracef(format, args...)
+}
+
 func (s *Service) logWarnf(format string, args ...any) {
 	if s == nil || s.logger == nil {
 		return
@@ -118,7 +125,11 @@ func (s *Service) logStatus(operation string, status api.TrackerAuthStatus) {
 		)
 		return
 	}
-	s.logInfof(
+	logf := s.logTracef
+	if operation == "login completed" && status.State == StateConfigured {
+		logf = s.logInfof
+	}
+	logf(
 		"tracker auth: %s tracker=%s state=%s cookies=%d encrypted_storage=%t needs_2fa=%t",
 		operation,
 		trackerLogID(status.TrackerID),
@@ -146,7 +157,7 @@ func (s *Service) Capabilities(_ context.Context) (caps []api.TrackerAuthCapabil
 			s.logWarnf("tracker auth: capabilities failed: %v", err)
 			return
 		}
-		s.logInfof("tracker auth: capabilities loaded count=%d", len(caps))
+		s.logTracef("tracker auth: capabilities loaded count=%d", len(caps))
 	}()
 	if err := s.validateTrackerConfigIDs(); err != nil {
 		return nil, err

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -28,12 +28,17 @@ import (
 
 type trackerAuthRecordingLogger struct {
 	api.NopLogger
-	info []string
-	warn []string
+	info  []string
+	trace []string
+	warn  []string
 }
 
 func (l *trackerAuthRecordingLogger) Infof(format string, args ...any) {
 	l.info = append(l.info, fmt.Sprintf(format, args...))
+}
+
+func (l *trackerAuthRecordingLogger) Tracef(format string, args ...any) {
+	l.trace = append(l.trace, fmt.Sprintf(format, args...))
 }
 
 func (l *trackerAuthRecordingLogger) Warnf(format string, args ...any) {
@@ -2154,18 +2159,30 @@ func TestTrackerAuthLogsOperationResultsWithoutSecrets(t *testing.T) {
 	if status.TrackerID != "MTV" {
 		t.Fatalf("expected MTV status, got %#v", status)
 	}
+	if _, err := service.Capabilities(context.Background()); err != nil {
+		t.Fatalf("Capabilities: %v", err)
+	}
 	if _, err := service.ImportCookies(context.Background(), "AR", "cookies.json", "{bad"); err == nil {
 		t.Fatal("expected invalid cookie import to fail")
 	}
 
 	infoLog := strings.Join(logger.info, "\n")
+	traceLog := strings.Join(logger.trace, "\n")
 	warnLog := strings.Join(logger.warn, "\n")
-	allLogs := infoLog + "\n" + warnLog
-	if !strings.Contains(infoLog, "tracker auth: status checked tracker=MTV") {
-		t.Fatalf("expected status info log, got info=%q warn=%q", infoLog, warnLog)
+	allLogs := infoLog + "\n" + traceLog + "\n" + warnLog
+	if !strings.Contains(traceLog, "tracker auth: status checked tracker=MTV") {
+		t.Fatalf("expected status trace log, got info=%q trace=%q warn=%q", infoLog, traceLog, warnLog)
+	}
+	if !strings.Contains(traceLog, "tracker auth: capabilities loaded count=") {
+		t.Fatalf("expected capabilities trace log, got info=%q trace=%q warn=%q", infoLog, traceLog, warnLog)
+	}
+	for _, routine := range []string{"tracker auth: status checked tracker=MTV", "tracker auth: capabilities loaded count="} {
+		if strings.Contains(infoLog, routine) {
+			t.Fatalf("routine tracker auth log used info level: %s", infoLog)
+		}
 	}
 	if !strings.Contains(warnLog, "tracker auth: cookie import failed tracker=AR bytes=4") {
-		t.Fatalf("expected import warning log, got info=%q warn=%q", infoLog, warnLog)
+		t.Fatalf("expected import warning log, got info=%q trace=%q warn=%q", infoLog, traceLog, warnLog)
 	}
 	for _, secret := range []string{"secret-api-key", "secret-user", "secret-password", "{bad"} {
 		if strings.Contains(allLogs, secret) {
@@ -2192,6 +2209,26 @@ func TestTrackerAuthWarningStatusDoesNotLogSuccess(t *testing.T) {
 	}
 	if !strings.Contains(warnLog, "tracker auth: login completed warning tracker=MTV") {
 		t.Fatalf("expected warning log, got info=%q warn=%q", infoLog, warnLog)
+	}
+}
+
+func TestTrackerAuthConfiguredLoginStatusUsesInfo(t *testing.T) {
+	t.Parallel()
+
+	logger := &trackerAuthRecordingLogger{}
+	service := NewServiceWithLogger(config.Config{}, logger)
+	service.logStatus("login completed", api.TrackerAuthStatus{
+		TrackerID: "MTV",
+		State:     StateConfigured,
+	})
+
+	infoLog := strings.Join(logger.info, "\n")
+	traceLog := strings.Join(logger.trace, "\n")
+	if !strings.Contains(infoLog, "tracker auth: login completed tracker=MTV") {
+		t.Fatalf("expected successful login info log, got info=%q trace=%q", infoLog, traceLog)
+	}
+	if strings.Contains(traceLog, "tracker auth: login completed tracker=MTV") {
+		t.Fatalf("successful login logged at trace: info=%q trace=%q", infoLog, traceLog)
 	}
 }
 

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -531,7 +531,8 @@ func TestValidateARStoredCookies(t *testing.T) {
 			return
 		}
 		if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=abc") {
-			t.Fatal("expected AR session cookie")
+			t.Error("expected AR session cookie")
+			return
 		}
 		_, _ = w.Write([]byte(`<a href="/torrents.php?action=download&id=1&auth=session-key">Download</a>`))
 	}))
@@ -603,10 +604,12 @@ func TestValidateFFLoginPersistsCookies(t *testing.T) {
 			_, _ = w.Write([]byte(`<input name="username">`))
 		case "/takelogin.php":
 			if err := r.ParseForm(); err != nil {
-				t.Fatalf("ParseForm: %v", err)
+				t.Errorf("ParseForm: %v", err)
+				return
 			}
 			if r.FormValue("username") != "user" || r.FormValue("password") != "pass" {
-				t.Fatalf("unexpected FF login form: %v", r.Form)
+				t.Error("unexpected FF login form")
+				return
 			}
 			http.SetCookie(w, &http.Cookie{Name: "session", Value: "valid", Path: "/"})
 			w.Header().Set("Location", "/index.php")
@@ -654,10 +657,12 @@ func TestValidateFLLoginPersistsCookies(t *testing.T) {
 			_, _ = w.Write([]byte(`<input name="validator" value="token">`))
 		case "/takelogin.php":
 			if err := r.ParseForm(); err != nil {
-				t.Fatalf("ParseForm: %v", err)
+				t.Errorf("ParseForm: %v", err)
+				return
 			}
 			if r.FormValue("validator") != "token" || r.FormValue("username") != "user" || r.FormValue("password") != "pass" {
-				t.Fatalf("unexpected FL login form: %v", r.Form)
+				t.Error("unexpected FL login form")
+				return
 			}
 			http.SetCookie(w, &http.Cookie{Name: "session", Value: "valid", Path: "/"})
 			_, _ = w.Write([]byte("Logout"))
@@ -705,10 +710,12 @@ func TestValidateTHRChecksCredentialLogin(t *testing.T) {
 			return
 		}
 		if err := r.ParseForm(); err != nil {
-			t.Fatalf("ParseForm: %v", err)
+			t.Errorf("ParseForm: %v", err)
+			return
 		}
 		if r.FormValue("username") != "user" || r.FormValue("password") != "pass" || r.FormValue("ssl") != "yes" {
-			t.Fatalf("unexpected THR login form: %v", r.Form)
+			t.Error("unexpected THR login form")
+			return
 		}
 		_, _ = w.Write([]byte(`<a href="logout.php">Logout</a>`))
 	}))
@@ -2171,22 +2178,22 @@ func TestTrackerAuthLogsOperationResultsWithoutSecrets(t *testing.T) {
 	warnLog := strings.Join(logger.warn, "\n")
 	allLogs := infoLog + "\n" + traceLog + "\n" + warnLog
 	if !strings.Contains(traceLog, "tracker auth: status checked tracker=MTV") {
-		t.Fatalf("expected status trace log, got info=%q trace=%q warn=%q", infoLog, traceLog, warnLog)
+		t.Fatal("expected status trace log")
 	}
 	if !strings.Contains(traceLog, "tracker auth: capabilities loaded count=") {
-		t.Fatalf("expected capabilities trace log, got info=%q trace=%q warn=%q", infoLog, traceLog, warnLog)
+		t.Fatal("expected capabilities trace log")
 	}
 	for _, routine := range []string{"tracker auth: status checked tracker=MTV", "tracker auth: capabilities loaded count="} {
 		if strings.Contains(infoLog, routine) {
-			t.Fatalf("routine tracker auth log used info level: %s", infoLog)
+			t.Fatal("routine tracker auth log used info level")
 		}
 	}
 	if !strings.Contains(warnLog, "tracker auth: cookie import failed tracker=AR bytes=4") {
-		t.Fatalf("expected import warning log, got info=%q trace=%q warn=%q", infoLog, traceLog, warnLog)
+		t.Fatal("expected import warning log")
 	}
 	for _, secret := range []string{"secret-api-key", "secret-user", "secret-password", "{bad"} {
 		if strings.Contains(allLogs, secret) {
-			t.Fatalf("tracker auth log leaked %q: %s", secret, allLogs)
+			t.Fatal("tracker auth log leaked secret")
 		}
 	}
 }

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -508,7 +508,7 @@ func TestValidateRTFRefreshesExpiredAPIKey(t *testing.T) {
 		t.Fatal("expected expired API key to trigger RTF login")
 	}
 	if got := loadStoredTrackerConfig(t, dbPath).Trackers.Trackers["RTF"].APIKey; got != "new-token" {
-		t.Fatalf("expected refreshed token persisted, got %q", got)
+		t.Fatal("expected refreshed token persisted")
 	}
 }
 
@@ -631,7 +631,7 @@ func TestValidateFFLoginPersistsCookies(t *testing.T) {
 		t.Fatalf("LoadTrackerCookieMap: %v", err)
 	}
 	if values["session"] != "valid" {
-		t.Fatalf("expected saved FF login cookies, got %#v", values)
+		t.Fatal("expected saved FF login cookies")
 	}
 }
 
@@ -687,7 +687,7 @@ func TestValidateFLLoginPersistsCookies(t *testing.T) {
 		t.Fatalf("LoadTrackerCookieMap: %v", err)
 	}
 	if values["session"] != "valid" {
-		t.Fatalf("expected saved FL login cookies, got %#v", values)
+		t.Fatal("expected saved FL login cookies")
 	}
 }
 
@@ -1872,7 +1872,7 @@ func TestCookiesToMapPreservesCookieValueWhitespace(t *testing.T) {
 
 	got := CookiesToMap([]*http.Cookie{{Name: " session ", Value: " abc "}})
 	if got["session"] != " abc " {
-		t.Fatalf("cookie value was normalized: %#v", got)
+		t.Fatal("cookie value was normalized")
 	}
 }
 
@@ -1983,7 +1983,7 @@ func TestImportCookiesRejectsMalformedArrayEntryWithoutReplacingCookies(t *testi
 		t.Fatalf("LoadTrackerCookieMap: %v", err)
 	}
 	if values["session"] != "existing" {
-		t.Fatalf("existing cookies changed after failed import: %#v", values)
+		t.Fatal("existing cookies changed after failed import")
 	}
 }
 
@@ -2010,7 +2010,7 @@ func TestImportCookiesRejectsOverCapWithoutReplacingCookies(t *testing.T) {
 		t.Fatalf("LoadTrackerCookieMap: %v", err)
 	}
 	if values["session"] != "existing" {
-		t.Fatalf("existing cookies changed after failed import: %#v", values)
+		t.Fatal("existing cookies changed after failed import")
 	}
 }
 
@@ -2516,7 +2516,7 @@ func TestDeleteARCookieFailureRestoresAuthState(t *testing.T) {
 		t.Fatalf("expected AR cookies to be restored: %v", err)
 	}
 	if cookieValues["session"] != "abc" {
-		t.Fatalf("unexpected restored AR cookies: %#v", cookieValues)
+		t.Fatal("unexpected restored AR cookies")
 	}
 }
 
@@ -2589,7 +2589,7 @@ func TestEnsureSessionPreservesMTVCookiesOnInvalidLookingAdapterText(t *testing.
 				t.Fatalf("LoadTrackerCookieMap: %v", err)
 			}
 			if values[cookieName] != "abc" {
-				t.Fatalf("expected invalid-looking adapter text to preserve cookies, got %#v", values)
+				t.Fatal("expected invalid-looking adapter text to preserve cookies")
 			}
 		})
 	}
@@ -2635,7 +2635,7 @@ func TestValidateTransientAdapterFailurePreservesCookieCount(t *testing.T) {
 		t.Fatalf("LoadTrackerCookieMap: %v", err)
 	}
 	if values["session"] != "abc" {
-		t.Fatalf("expected transient adapter failure to preserve cookies, got %#v", values)
+		t.Fatal("expected transient adapter failure to preserve cookies")
 	}
 }
 

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -257,7 +257,7 @@ func TestValidateBTNStoredCookiesPromotesRemoteSuccess(t *testing.T) {
 		}
 		if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=abc") {
 			select {
-			case handlerErr <- fmt.Errorf("expected BTN session cookie, got %q", got):
+			case handlerErr <- errors.New("expected BTN session cookie"):
 			default:
 			}
 			http.Error(w, "unexpected cookie", http.StatusInternalServerError)
@@ -303,7 +303,7 @@ func TestValidateBTNRemoteSuccessRequiresAPIKey(t *testing.T) {
 		}
 		if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=abc") {
 			select {
-			case handlerErr <- fmt.Errorf("expected BTN session cookie, got %q", got):
+			case handlerErr <- errors.New("expected BTN session cookie"):
 			default:
 			}
 			http.Error(w, "unexpected cookie", http.StatusInternalServerError)
@@ -346,7 +346,7 @@ func TestValidateBTNMissingAPIAfterCookieRefreshUpdatesCookieCount(t *testing.T)
 		case "/upload.php":
 			if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=new") {
 				select {
-				case handlerErr <- fmt.Errorf("expected refreshed BTN session cookie, got %q", got):
+				case handlerErr <- errors.New("expected refreshed BTN session cookie"):
 				default:
 				}
 				http.Error(w, "unexpected cookie", http.StatusInternalServerError)
@@ -502,7 +502,7 @@ func TestValidateRTFRefreshesExpiredAPIKey(t *testing.T) {
 		t.Fatalf("expected successful RTF auth validation, got %#v", status)
 	}
 	if testedToken != "old-token" {
-		t.Fatalf("expected old token validation, got %q", testedToken)
+		t.Fatal("expected old token validation")
 	}
 	if !loginCalled {
 		t.Fatal("expected expired API key to trigger RTF login")
@@ -526,7 +526,7 @@ func TestValidateARStoredCookies(t *testing.T) {
 			return
 		}
 		if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=abc") {
-			t.Fatalf("expected AR session cookie, got %q", got)
+			t.Fatal("expected AR session cookie")
 		}
 		_, _ = w.Write([]byte(`<a href="/torrents.php?action=download&id=1&auth=session-key">Download</a>`))
 	}))

--- a/internal/trackerauth/site_validators.go
+++ b/internal/trackerauth/site_validators.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	arDefaultBaseURL  = "https://alpharatio.cc"
+	authPreviewBytes  = 64 * 1024
 	arBrowsePath      = "/torrents.php"
 	ffDefaultBaseURL  = "https://www.funfile.org"
 	ffLoginPath       = "/takelogin.php"
@@ -61,7 +62,7 @@ func resolveARStoredSessionForTrackerAuth(ctx context.Context, cfg config.Tracke
 		return &ValidationError{TrackerID: "AR", Transient: true, Reason: "remote validation unavailable", Err: fmt.Errorf("trackers: AR session validation request: %w", err)}
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	body, _ := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300)
 	if isLoginRedirect(resp) || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || arLooksLoggedOut(string(body)) {
 		return &ValidationError{TrackerID: "AR", ConfirmedInvalid: true, Reason: "stored session expired", Err: fmt.Errorf("trackers: AR session validation failed status=%d", resp.StatusCode)}
 	}
@@ -107,7 +108,7 @@ func validateFFStoredCookies(ctx context.Context, baseURL string, values []*http
 		return &ValidationError{TrackerID: "FF", Transient: true, Reason: "remote validation unavailable", Err: fmt.Errorf("trackers: FF session validation request: %w", err)}
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	body, _ := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300)
 	if isLoginRedirect(resp) || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || ffLooksLoggedOut(string(body)) {
 		return &ValidationError{TrackerID: "FF", ConfirmedInvalid: true, Reason: "stored session expired", Err: fmt.Errorf("trackers: FF session validation failed status=%d", resp.StatusCode)}
 	}
@@ -183,7 +184,7 @@ func validateFLStoredCookies(ctx context.Context, baseURL string, values []*http
 		return &ValidationError{TrackerID: "FL", Transient: true, Reason: "remote validation unavailable", Err: fmt.Errorf("trackers: FL session validation request: %w", err)}
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	body, _ := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300)
 	if isLoginRedirect(resp) || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || flLooksLoggedOut(string(body)) {
 		return &ValidationError{TrackerID: "FL", ConfirmedInvalid: true, Reason: "stored session expired", Err: fmt.Errorf("trackers: FL session validation failed status=%d", resp.StatusCode)}
 	}
@@ -212,7 +213,7 @@ func loginFLForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath
 	if err != nil {
 		return fmt.Errorf("trackers: FL login page request: %w", err)
 	}
-	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	body, readErr := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300)
 	resp.Body.Close()
 	if readErr != nil {
 		return fmt.Errorf("trackers: FL read login page response: %w", readErr)
@@ -273,7 +274,7 @@ func resolveHDBStoredSessionForTrackerAuth(ctx context.Context, cfg config.Track
 		return &ValidationError{TrackerID: "HDB", Transient: true, Reason: "remote validation unavailable", Err: fmt.Errorf("trackers: HDB session validation request: %w", err)}
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	body, _ := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300)
 	if isLoginRedirect(resp) || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || hdbLooksLoggedOut(string(body)) {
 		return &ValidationError{TrackerID: "HDB", ConfirmedInvalid: true, Reason: "stored session expired", Err: fmt.Errorf("trackers: HDB session validation failed status=%d", resp.StatusCode)}
 	}
@@ -306,7 +307,7 @@ func resolveTHRSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConf
 		return fmt.Errorf("trackers: THR login request: %w", err)
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	body, _ := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 400)
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		return &ValidationError{TrackerID: "THR", ConfirmedInvalid: true, Reason: "login failed", Err: fmt.Errorf("trackers: THR login failed status=%d", resp.StatusCode)}
 	}
@@ -314,6 +315,23 @@ func resolveTHRSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConf
 		return &ValidationError{TrackerID: "THR", ConfirmedInvalid: true, Reason: "login failed", Err: errors.New("trackers: THR login marker not found")}
 	}
 	return nil
+}
+
+// readTrackerAuthResponseBody reads full success-candidate auth pages for
+// marker parsing while keeping failed-status diagnostics bounded.
+func readTrackerAuthResponseBody(resp *http.Response, successCandidate bool) ([]byte, error) {
+	if successCandidate {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("trackers: read auth response body: %w", err)
+		}
+		return body, nil
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, authPreviewBytes))
+	if err != nil {
+		return nil, fmt.Errorf("trackers: read auth response preview: %w", err)
+	}
+	return body, nil
 }
 
 // shouldRefreshStoredCookiesWithCredentials reports whether stored cookies were

--- a/internal/trackerauth/site_validators.go
+++ b/internal/trackerauth/site_validators.go
@@ -62,7 +62,10 @@ func resolveARStoredSessionForTrackerAuth(ctx context.Context, cfg config.Tracke
 		return &ValidationError{TrackerID: "AR", Transient: true, Reason: "remote validation unavailable", Err: fmt.Errorf("trackers: AR session validation request: %w", err)}
 	}
 	defer resp.Body.Close()
-	body, _ := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300)
+	body, readErr := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300)
+	if readErr != nil {
+		return &ValidationError{TrackerID: "AR", Transient: true, Reason: "remote validation unavailable", Err: readErr}
+	}
 	if isLoginRedirect(resp) || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || arLooksLoggedOut(string(body)) {
 		return &ValidationError{TrackerID: "AR", ConfirmedInvalid: true, Reason: "stored session expired", Err: fmt.Errorf("trackers: AR session validation failed status=%d", resp.StatusCode)}
 	}
@@ -108,7 +111,10 @@ func validateFFStoredCookies(ctx context.Context, baseURL string, values []*http
 		return &ValidationError{TrackerID: "FF", Transient: true, Reason: "remote validation unavailable", Err: fmt.Errorf("trackers: FF session validation request: %w", err)}
 	}
 	defer resp.Body.Close()
-	body, _ := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300)
+	body, readErr := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300)
+	if readErr != nil {
+		return &ValidationError{TrackerID: "FF", Transient: true, Reason: "remote validation unavailable", Err: readErr}
+	}
 	if isLoginRedirect(resp) || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || ffLooksLoggedOut(string(body)) {
 		return &ValidationError{TrackerID: "FF", ConfirmedInvalid: true, Reason: "stored session expired", Err: fmt.Errorf("trackers: FF session validation failed status=%d", resp.StatusCode)}
 	}
@@ -184,7 +190,10 @@ func validateFLStoredCookies(ctx context.Context, baseURL string, values []*http
 		return &ValidationError{TrackerID: "FL", Transient: true, Reason: "remote validation unavailable", Err: fmt.Errorf("trackers: FL session validation request: %w", err)}
 	}
 	defer resp.Body.Close()
-	body, _ := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300)
+	body, readErr := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300)
+	if readErr != nil {
+		return &ValidationError{TrackerID: "FL", Transient: true, Reason: "remote validation unavailable", Err: readErr}
+	}
 	if isLoginRedirect(resp) || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || flLooksLoggedOut(string(body)) {
 		return &ValidationError{TrackerID: "FL", ConfirmedInvalid: true, Reason: "stored session expired", Err: fmt.Errorf("trackers: FL session validation failed status=%d", resp.StatusCode)}
 	}
@@ -274,7 +283,10 @@ func resolveHDBStoredSessionForTrackerAuth(ctx context.Context, cfg config.Track
 		return &ValidationError{TrackerID: "HDB", Transient: true, Reason: "remote validation unavailable", Err: fmt.Errorf("trackers: HDB session validation request: %w", err)}
 	}
 	defer resp.Body.Close()
-	body, _ := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300)
+	body, readErr := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300)
+	if readErr != nil {
+		return &ValidationError{TrackerID: "HDB", Transient: true, Reason: "remote validation unavailable", Err: readErr}
+	}
 	if isLoginRedirect(resp) || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || hdbLooksLoggedOut(string(body)) {
 		return &ValidationError{TrackerID: "HDB", ConfirmedInvalid: true, Reason: "stored session expired", Err: fmt.Errorf("trackers: HDB session validation failed status=%d", resp.StatusCode)}
 	}
@@ -307,7 +319,10 @@ func resolveTHRSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConf
 		return fmt.Errorf("trackers: THR login request: %w", err)
 	}
 	defer resp.Body.Close()
-	body, _ := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 400)
+	body, readErr := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 400)
+	if readErr != nil {
+		return &ValidationError{TrackerID: "THR", Transient: true, Reason: "remote validation unavailable", Err: readErr}
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		return &ValidationError{TrackerID: "THR", ConfirmedInvalid: true, Reason: "login failed", Err: fmt.Errorf("trackers: THR login failed status=%d", resp.StatusCode)}
 	}

--- a/internal/trackerauth/site_validators_test.go
+++ b/internal/trackerauth/site_validators_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackerauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestValidateFFStoredCookiesReadsFullSuccessBody(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(strings.Repeat("a", authPreviewBytes+32) + "friends.php"))
+	}))
+	defer server.Close()
+
+	err := validateFFStoredCookies(context.Background(), server.URL, []*http.Cookie{{Name: "session", Value: "ok"}})
+	if err != nil {
+		t.Fatalf("expected marker beyond preview cap to validate session: %v", err)
+	}
+}

--- a/internal/trackerauth/site_validators_test.go
+++ b/internal/trackerauth/site_validators_test.go
@@ -25,3 +25,23 @@ func TestValidateFFStoredCookiesReadsFullSuccessBody(t *testing.T) {
 		t.Fatalf("expected marker beyond preview cap to validate session: %v", err)
 	}
 }
+
+func TestValidateFFStoredCookiesTreatsBodyReadErrorAsTransient(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "64")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("friends.php"))
+	}))
+	defer server.Close()
+
+	err := validateFFStoredCookies(context.Background(), server.URL, []*http.Cookie{{Name: "session", Value: "ok"}})
+	validationErr, ok := asValidationError(err)
+	if !ok {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+	if !validationErr.Transient || validationErr.ConfirmedInvalid {
+		t.Fatalf("expected transient read failure, got %+v", validationErr)
+	}
+}

--- a/internal/trackerdata/client_test.go
+++ b/internal/trackerdata/client_test.go
@@ -197,19 +197,24 @@ func TestLookupANTSendsAPIKeyHeader(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query()
 		if got := query.Get("apikey"); got != "" {
-			t.Fatal("apikey should not be sent as a query parameter")
+			t.Error("apikey should not be sent as a query parameter")
+			return
 		}
 		if got := query.Get("t"); got != "search" {
-			t.Fatalf("unexpected t query value: got %q want %q", got, "search")
+			t.Errorf("unexpected t query value: got %q want %q", got, "search")
+			return
 		}
 		if got := query.Get("filename"); got != "Example.Release.mkv" {
-			t.Fatalf("unexpected filename query value: got %q", got)
+			t.Errorf("unexpected filename query value: got %q", got)
+			return
 		}
 		if got := r.Header.Get("X-Api-Key"); got != "token" {
-			t.Fatal("unexpected X-API-Key header")
+			t.Error("unexpected X-API-Key header")
+			return
 		}
 		if got := r.Header.Get("User-Agent"); got == "" {
-			t.Fatal("expected User-Agent header")
+			t.Error("expected User-Agent header")
+			return
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"item": []map[string]any{

--- a/internal/trackerdata/client_test.go
+++ b/internal/trackerdata/client_test.go
@@ -206,7 +206,7 @@ func TestLookupANTSendsAPIKeyHeader(t *testing.T) {
 			t.Fatalf("unexpected filename query value: got %q", got)
 		}
 		if got := r.Header.Get("X-Api-Key"); got != "token" {
-			t.Fatalf("unexpected X-API-Key header: got %q want %q", got, "token")
+			t.Fatal("unexpected X-API-Key header")
 		}
 		if got := r.Header.Get("User-Agent"); got == "" {
 			t.Fatal("expected User-Agent header")

--- a/internal/trackerdata/client_test.go
+++ b/internal/trackerdata/client_test.go
@@ -197,7 +197,7 @@ func TestLookupANTSendsAPIKeyHeader(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		query := r.URL.Query()
 		if got := query.Get("apikey"); got != "" {
-			t.Fatalf("apikey should not be sent as a query parameter, got %q", got)
+			t.Fatal("apikey should not be sent as a query parameter")
 		}
 		if got := query.Get("t"); got != "search" {
 			t.Fatalf("unexpected t query value: got %q want %q", got, "search")

--- a/internal/trackerdata/unit3d_test.go
+++ b/internal/trackerdata/unit3d_test.go
@@ -138,7 +138,7 @@ func TestSearchTorrentsCBRIncludesPendingAndFiltersTMDB(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		paths = append(paths, r.URL.Path)
 		if got := r.URL.Query().Get("api_token"); got != "secret" {
-			t.Fatalf("api token mismatch: %q", got)
+			t.Fatal("api token mismatch")
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/trackerdata/unit3d_test.go
+++ b/internal/trackerdata/unit3d_test.go
@@ -138,7 +138,8 @@ func TestSearchTorrentsCBRIncludesPendingAndFiltersTMDB(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		paths = append(paths, r.URL.Path)
 		if got := r.URL.Query().Get("api_token"); got != "secret" {
-			t.Fatal("api token mismatch")
+			t.Error("api token mismatch")
+			return
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/trackers/impl/ar/upload_test.go
+++ b/internal/trackers/impl/ar/upload_test.go
@@ -108,7 +108,7 @@ func TestPersistLoginCookiesRejectsEmptyJarWithoutReplacingCookies(t *testing.T)
 		t.Fatalf("LoadTrackerCookieMap: %v", err)
 	}
 	if values["session"] != "existing" {
-		t.Fatalf("empty jar must preserve previous cookies, got %#v", values)
+		t.Fatal("empty jar must preserve previous cookies")
 	}
 }
 
@@ -249,7 +249,7 @@ func TestPersistLoginAuthRestoresPreviousCookiesWhenAuthKeyWriteFails(t *testing
 		t.Fatalf("LoadTrackerCookieMap: %v", err)
 	}
 	if values["session"] != "existing" {
-		t.Fatalf("expected previous cookies restored, got %#v", values)
+		t.Fatal("expected previous cookies restored")
 	}
 }
 
@@ -285,7 +285,7 @@ func TestPersistLoginAuthRestoresPreviousCookiesWhenCallerContextCanceledDuringW
 		t.Fatalf("LoadTrackerCookieMap: %v", err)
 	}
 	if values["session"] != "existing" {
-		t.Fatalf("expected previous cookies restored after cancellation, got %#v", values)
+		t.Fatal("expected previous cookies restored after cancellation")
 	}
 }
 

--- a/internal/trackers/impl/ar/upload_test.go
+++ b/internal/trackers/impl/ar/upload_test.go
@@ -140,7 +140,7 @@ func TestWriteAuthKeyUsesEncryptedStateAndDeletesLegacyFile(t *testing.T) {
 		t.Fatalf("writeAuthKey: %v", err)
 	}
 	if got := readAuthKey(context.Background(), dbPath); got != "encrypted-key" {
-		t.Fatalf("readAuthKey: got %q", got)
+		t.Fatal("expected encrypted auth key")
 	}
 	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
 		t.Fatalf("expected legacy auth key removed, stat err=%v", err)
@@ -188,7 +188,7 @@ func TestWriteAuthKeyFallsBackToExistingLegacyFileWhenWebAuthUnavailable(t *test
 		t.Fatalf("writeAuthKey: %v", err)
 	}
 	if got := readAuthKey(context.Background(), dbPath); got != "updated-legacy-key" {
-		t.Fatalf("readAuthKey: got %q", got)
+		t.Fatal("expected updated legacy auth key")
 	}
 }
 
@@ -204,7 +204,7 @@ func TestWriteAuthKeySucceedsWhenLegacyFileAbsent(t *testing.T) {
 		t.Fatalf("writeAuthKey: %v", err)
 	}
 	if got := readAuthKey(context.Background(), dbPath); got != "encrypted-key" {
-		t.Fatalf("readAuthKey: got %q", got)
+		t.Fatal("expected encrypted auth key")
 	}
 }
 

--- a/internal/trackers/impl/bhd/definition_test.go
+++ b/internal/trackers/impl/bhd/definition_test.go
@@ -141,13 +141,15 @@ func TestUploadRetriesInvalidIMDb(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		if calls == 1 {
 			if imdbID != "456" {
-				t.Fatalf("expected first imdb_id 456, got %q", imdbID)
+				t.Errorf("expected first imdb_id 456, got %q", imdbID)
+				return
 			}
 			_, _ = fmt.Fprint(w, `{"status_code":0,"status_message":"Invalid imdb_id"}`)
 			return
 		}
 		if imdbID != "1" {
-			t.Fatalf("expected retried imdb_id 1, got %q", imdbID)
+			t.Errorf("expected retried imdb_id 1, got %q", imdbID)
+			return
 		}
 		_, _ = fmt.Fprint(w, `{"status_code":1,"status_message":"https://beyond-hd.me/torrent/download/example.7890.torrent"}`)
 	}))

--- a/internal/trackers/impl/bhd/upload.go
+++ b/internal/trackers/impl/bhd/upload.go
@@ -10,11 +10,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -464,11 +466,8 @@ func resolveType(meta api.PreparedMetadata) string {
 
 func resolveEdition(meta api.PreparedMetadata, tags []string) (bool, string) {
 	edition := strings.TrimSpace(meta.Edition)
-	for _, tag := range tags {
-		if tag == "Hybrid" {
-			edition = strings.TrimSpace(strings.ReplaceAll(edition, "Hybrid", ""))
-			break
-		}
+	if slices.Contains(tags, "Hybrid") {
+		edition = strings.TrimSpace(strings.ReplaceAll(edition, "Hybrid", ""))
 	}
 	if edition == "" {
 		return false, ""
@@ -593,9 +592,7 @@ func boolFlag(value bool) string {
 
 func cloneFields(input map[string]string) map[string]string {
 	out := make(map[string]string, len(input))
-	for key, value := range input {
-		out[key] = value
-	}
+	maps.Copy(out, input)
 	return out
 }
 

--- a/internal/trackers/impl/bhdtv/definition_test.go
+++ b/internal/trackers/impl/bhdtv/definition_test.go
@@ -88,7 +88,7 @@ func TestUploadParsesViewAndWritesArtifact(t *testing.T) {
 			t.Fatalf("parse multipart: %v", err)
 		}
 		if got := r.FormValue("api_key"); got != "token" {
-			t.Fatalf("unexpected api key %q", got)
+			t.Fatal("unexpected api key")
 		}
 		if got := r.FormValue("cat"); got != "7" {
 			t.Fatalf("unexpected cat %q", got)

--- a/internal/trackers/impl/bhdtv/definition_test.go
+++ b/internal/trackers/impl/bhdtv/definition_test.go
@@ -85,19 +85,24 @@ func TestUploadParsesViewAndWritesArtifact(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseMultipartForm(2 << 20); err != nil {
-			t.Fatalf("parse multipart: %v", err)
+			t.Errorf("parse multipart: %v", err)
+			return
 		}
 		if got := r.FormValue("api_key"); got != "token" {
-			t.Fatal("unexpected api key")
+			t.Error("unexpected api key")
+			return
 		}
 		if got := r.FormValue("cat"); got != "7" {
-			t.Fatalf("unexpected cat %q", got)
+			t.Errorf("unexpected cat %q", got)
+			return
 		}
 		if got := r.FormValue("subcat"); got != "48" {
-			t.Fatalf("unexpected subcat %q", got)
+			t.Errorf("unexpected subcat %q", got)
+			return
 		}
 		if got := r.FormValue("resolution"); got != "4" {
-			t.Fatalf("unexpected resolution %q", got)
+			t.Errorf("unexpected resolution %q", got)
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"view":"https://www.bit-hdtv.com/details.php?id=99"}}`))

--- a/internal/trackers/impl/bhdtv/upload.go
+++ b/internal/trackers/impl/bhdtv/upload.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -488,8 +489,6 @@ func normalizeResolution(value string) string {
 
 func cloneFields(fields map[string]string) map[string]string {
 	cloned := make(map[string]string, len(fields))
-	for key, value := range fields {
-		cloned[key] = value
-	}
+	maps.Copy(cloned, fields)
 	return cloned
 }

--- a/internal/trackers/impl/bjs/upload.go
+++ b/internal/trackers/impl/bjs/upload.go
@@ -91,7 +91,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	responseBody, _ := io.ReadAll(resp.Body)
+	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	match := idPattern.FindStringSubmatch(finalURL + "\n" + string(responseBody))
 	id := metautil.FirstNonEmptyTrimmed(matchValue(match, 1), matchValue(match, 2))
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 && id != "" {

--- a/internal/trackers/impl/bjs/upload.go
+++ b/internal/trackers/impl/bjs/upload.go
@@ -91,7 +91,10 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	responseBody, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 400, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: BJS read upload response: %w", err)
+	}
 	match := idPattern.FindStringSubmatch(finalURL + "\n" + string(responseBody))
 	id := metautil.FirstNonEmptyTrimmed(matchValue(match, 1), matchValue(match, 2))
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 && id != "" {
@@ -117,8 +120,8 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 			}},
 		}, nil
 	}
-	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "BJS", "upload_failure", responseBody, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("BJS", resp.StatusCode, responseBody)
+	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "BJS", "upload_failure", responsePreview, ".html")
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("BJS", resp.StatusCode, responsePreview)
 }
 
 func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.TrackerDryRunEntry, error) {

--- a/internal/trackers/impl/bt/upload.go
+++ b/internal/trackers/impl/bt/upload.go
@@ -89,7 +89,10 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	responseBody, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 400, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: BT read upload response: %w", err)
+	}
 	match := groupPattern.FindStringSubmatch(finalURL + "\n" + string(responseBody))
 	id := metautil.FirstNonEmptyTrimmed(matchValue(match, 1), matchValue(match, 2))
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 && id != "" {
@@ -115,8 +118,8 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 			}},
 		}, nil
 	}
-	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "BT", "upload_failure", responseBody, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("BT", resp.StatusCode, responseBody)
+	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "BT", "upload_failure", responsePreview, ".html")
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("BT", resp.StatusCode, responsePreview)
 }
 
 func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.TrackerDryRunEntry, error) {

--- a/internal/trackers/impl/bt/upload.go
+++ b/internal/trackers/impl/bt/upload.go
@@ -89,7 +89,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	responseBody, _ := io.ReadAll(resp.Body)
+	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	match := groupPattern.FindStringSubmatch(finalURL + "\n" + string(responseBody))
 	id := metautil.FirstNonEmptyTrimmed(matchValue(match, 1), matchValue(match, 2))
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 && id != "" {

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -111,21 +111,24 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	}
 	defer resp.Body.Close()
 
-	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
 	finalURL := ""
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
 	matches := btnSuccessURLPattern.FindStringSubmatch(finalURL)
 	if len(matches) < 2 {
-		matches = btnSuccessURLPattern.FindStringSubmatch(string(responseBody))
-	}
-	if len(matches) < 2 {
-		failurePath, _ := commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "BTN", "upload-failure", responseBody, ".html")
-		if failurePath != "" {
-			return api.UploadSummary{}, fmt.Errorf("%w failure=%s", commonhttp.UploadHTTPErrorWithURL("BTN", resp.StatusCode, finalURL, responseBody), failurePath)
+		responseBody, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 400, 2048)
+		if err != nil {
+			return api.UploadSummary{}, fmt.Errorf("trackers: BTN read upload response: %w", err)
 		}
-		return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("BTN", resp.StatusCode, finalURL, responseBody)
+		matches = btnSuccessURLPattern.FindStringSubmatch(string(responseBody))
+		if len(matches) < 2 {
+			failurePath, _ := commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "BTN", "upload-failure", responsePreview, ".html")
+			if failurePath != "" {
+				return api.UploadSummary{}, fmt.Errorf("%w failure=%s", commonhttp.UploadHTTPErrorWithURL("BTN", resp.StatusCode, finalURL, responsePreview), failurePath)
+			}
+			return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("BTN", resp.StatusCode, finalURL, responsePreview)
+		}
 	}
 
 	groupID := strings.TrimSpace(matches[1])

--- a/internal/trackers/impl/btn/upload_integration_test.go
+++ b/internal/trackers/impl/btn/upload_integration_test.go
@@ -76,7 +76,7 @@ func TestBTNUploadEndToEndSuccess(t *testing.T) {
 			_, _ = w.Write([]byte("ok"))
 		case r.URL.Path == "/upload.php" && r.Method == http.MethodGet:
 			if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=new") {
-				handlerErrs.Errorf("expected refreshed cookie on upload validation, got %q", got)
+				handlerErrs.Errorf("expected refreshed cookie on upload validation")
 				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
 				return
 			}
@@ -258,14 +258,14 @@ func TestBTNUploadUsesValidImportedCookiesWithoutCredentials(t *testing.T) {
 			http.NotFound(w, r)
 		case r.URL.Path == "/upload.php" && r.Method == http.MethodGet:
 			if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=imported") {
-				handlerErrs.Errorf("expected imported cookie on upload validation, got %q", got)
+				handlerErrs.Errorf("expected imported cookie on upload validation")
 				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
 				return
 			}
 			_, _ = w.Write([]byte(`<form action="/upload.php"><input name="file_input" /></form>`))
 		case r.URL.Path == "/upload.php" && r.Method == http.MethodPost:
 			if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=imported") {
-				handlerErrs.Errorf("expected imported cookie on upload request, got %q", got)
+				handlerErrs.Errorf("expected imported cookie on upload request")
 				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
 				return
 			}
@@ -631,7 +631,7 @@ func TestResolveSessionForTrackerAuthLoginPersistsCookies(t *testing.T) {
 			_, _ = w.Write([]byte("ok"))
 		case "/upload.php":
 			if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=new") {
-				handlerErrs.Errorf("expected refreshed cookie on validation, got %q", got)
+				handlerErrs.Errorf("expected refreshed cookie on validation")
 				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
 				return
 			}
@@ -673,7 +673,7 @@ func TestResolveSessionForTrackerAuthLoginIgnoresIncidentalTwoFactorText(t *test
 			_, _ = w.Write([]byte(`<html><p>Keep your two-factor recovery codes safe.</p></html>`))
 		case "/upload.php":
 			if got := r.Header.Get("Cookie"); !strings.Contains(got, "session=new") {
-				handlerErrs.Errorf("expected refreshed cookie on validation, got %q", got)
+				handlerErrs.Errorf("expected refreshed cookie on validation")
 				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
 				return
 			}

--- a/internal/trackers/impl/commonhttp/commonhttp.go
+++ b/internal/trackers/impl/commonhttp/commonhttp.go
@@ -351,6 +351,7 @@ func WriteFailureArtifact(meta api.PreparedMetadata, dbPath string, tracker stri
 		ext = ".txt"
 	}
 	path := filepath.Join(tmpDir, filename+ext)
+	body = []byte(redaction.RedactValue(string(body), nil))
 	if err := os.WriteFile(path, body, 0o600); err != nil {
 		return "", fmt.Errorf("write failure artifact: %w", err)
 	}

--- a/internal/trackers/impl/commonhttp/commonhttp.go
+++ b/internal/trackers/impl/commonhttp/commonhttp.go
@@ -33,6 +33,10 @@ const maxHTTPErrorDetailLength = 700
 
 const maxHTTPErrorDetailDepth = 10
 
+// DefaultResponsePreviewBytes bounds tracker response bodies used for failure
+// artifacts and error text.
+const DefaultResponsePreviewBytes int64 = 64 * 1024
+
 var htmlTagPattern = regexp.MustCompile(`<[^>]+>`)
 
 // FileField describes one file part in a tracker multipart upload. FieldName is
@@ -322,6 +326,40 @@ func ApplyCookies(req *http.Request, cookies []*http.Cookie) {
 		}
 		req.AddCookie(cookie)
 	}
+}
+
+// ReadUploadResponseBody reads a full success-candidate response for parsers and
+// always returns a bounded preview for diagnostics. Non-success responses are
+// read only up to previewLimit.
+func ReadUploadResponseBody(resp *http.Response, successCandidate bool, previewLimit int64) ([]byte, []byte, error) {
+	if previewLimit <= 0 {
+		previewLimit = DefaultResponsePreviewBytes
+	}
+	var (
+		body []byte
+		err  error
+	)
+	if successCandidate {
+		body, err = io.ReadAll(resp.Body)
+	} else {
+		body, err = io.ReadAll(io.LimitReader(resp.Body, previewLimit))
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("read upload response body: %w", err)
+	}
+	return body, ResponseBodyPreview(body, previewLimit), nil
+}
+
+// ResponseBodyPreview returns body unchanged when it fits the limit, otherwise
+// it returns the prefix used for shareable diagnostics.
+func ResponseBodyPreview(body []byte, previewLimit int64) []byte {
+	if previewLimit <= 0 {
+		previewLimit = DefaultResponsePreviewBytes
+	}
+	if int64(len(body)) <= previewLimit {
+		return body
+	}
+	return body[:previewLimit]
 }
 
 // WriteFailureArtifact stores a tracker failure response under the release temp

--- a/internal/trackers/impl/commonhttp/commonhttp_test.go
+++ b/internal/trackers/impl/commonhttp/commonhttp_test.go
@@ -6,6 +6,8 @@ package commonhttp
 import (
 	"context"
 	"errors"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +26,39 @@ func (s stubCookieStore) GetAllTrackerCookies(context.Context, string, []byte) (
 		return nil, s.err
 	}
 	return s.cookies, nil
+}
+
+func TestReadUploadResponseBodyUsesFullSuccessAndBoundedFailurePreview(t *testing.T) {
+	t.Parallel()
+
+	large := strings.Repeat("a", int(DefaultResponsePreviewBytes)+32)
+	successResp := &http.Response{Body: ioNopCloser(large)}
+	body, preview, err := ReadUploadResponseBody(successResp, true, DefaultResponsePreviewBytes)
+	if err != nil {
+		t.Fatalf("ReadUploadResponseBody success: %v", err)
+	}
+	if len(body) != len(large) {
+		t.Fatalf("expected full success body length %d, got %d", len(large), len(body))
+	}
+	if int64(len(preview)) != DefaultResponsePreviewBytes {
+		t.Fatalf("expected bounded preview length %d, got %d", DefaultResponsePreviewBytes, len(preview))
+	}
+
+	failureResp := &http.Response{Body: ioNopCloser(large)}
+	body, preview, err = ReadUploadResponseBody(failureResp, false, DefaultResponsePreviewBytes)
+	if err != nil {
+		t.Fatalf("ReadUploadResponseBody failure: %v", err)
+	}
+	if int64(len(body)) != DefaultResponsePreviewBytes {
+		t.Fatalf("expected bounded failure body length %d, got %d", DefaultResponsePreviewBytes, len(body))
+	}
+	if string(preview) != string(body) {
+		t.Fatal("expected failure preview to match bounded body")
+	}
+}
+
+func ioNopCloser(value string) io.ReadCloser {
+	return io.NopCloser(strings.NewReader(value))
 }
 
 func TestLoadCookiesForTrackerUsesCookieStoreWhenNoStartupCookieExists(t *testing.T) {

--- a/internal/trackers/impl/commonhttp/commonhttp_test.go
+++ b/internal/trackers/impl/commonhttp/commonhttp_test.go
@@ -62,10 +62,10 @@ func TestWriteFailureArtifactRedactsSensitiveBody(t *testing.T) {
 	}
 	text := string(payload)
 	if strings.Contains(text, "secret-key") || strings.Contains(text, "plain-secret") {
-		t.Fatalf("artifact leaked secret body: %s", text)
+		t.Fatal("artifact leaked secret body")
 	}
 	if !strings.Contains(text, "[REDACTED]") {
-		t.Fatalf("expected redaction marker in artifact: %s", text)
+		t.Fatal("expected redaction marker in artifact")
 	}
 }
 

--- a/internal/trackers/impl/commonhttp/commonhttp_test.go
+++ b/internal/trackers/impl/commonhttp/commonhttp_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
 )
 
 type stubCookieStore struct {
@@ -39,6 +41,31 @@ func TestLoadCookiesForTrackerUsesCookieStoreWhenNoStartupCookieExists(t *testin
 	}
 	if got["session"] != "from-db" {
 		t.Fatalf("expected cookie from store, got %#v", got)
+	}
+}
+
+func TestWriteFailureArtifactRedactsSensitiveBody(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "state", "upbrr.db")
+	meta := api.PreparedMetadata{SourcePath: filepath.Join(root, "source.mkv")}
+	body := []byte(`{"message":"failed","api_key":"secret-key","detail":"token=plain-secret"}`)
+
+	path, err := WriteFailureArtifact(meta, dbPath, "GPW", "upload_failure", body, ".json")
+	if err != nil {
+		t.Fatalf("WriteFailureArtifact: %v", err)
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read artifact: %v", err)
+	}
+	text := string(payload)
+	if strings.Contains(text, "secret-key") || strings.Contains(text, "plain-secret") {
+		t.Fatalf("artifact leaked secret body: %s", text)
+	}
+	if !strings.Contains(text, "[REDACTED]") {
+		t.Fatalf("expected redaction marker in artifact: %s", text)
 	}
 }
 

--- a/internal/trackers/impl/czt/upload.go
+++ b/internal/trackers/impl/czt/upload.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"maps"
 	"net/http"
 	"net/url"
@@ -115,7 +114,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: CZT upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	responseBody, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode == http.StatusCreated, commonhttp.DefaultResponsePreviewBytes)
 	if err != nil {
 		return api.UploadSummary{}, fmt.Errorf("trackers: CZT read upload response: %w", err)
 	}
@@ -129,8 +128,8 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	// release name already exists; surface it as an error (the response still
 	// carries the existing torrent for callers who want to cross-seed).
 	if resp.StatusCode != http.StatusCreated {
-		_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, trackerName, "upload_failure", responseBody, ".json")
-		return api.UploadSummary{}, commonhttp.UploadHTTPError(trackerName, resp.StatusCode, responseBody)
+		_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, trackerName, "upload_failure", responsePreview, ".json")
+		return api.UploadSummary{}, commonhttp.UploadHTTPError(trackerName, resp.StatusCode, responsePreview)
 	}
 
 	torrentIDValue, err := parseCZTUploadID(responseBody)
@@ -138,8 +137,8 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: CZT parse upload response id: %w", err)
 	}
 	if torrentIDValue <= 0 {
-		_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, trackerName, "upload_failure", responseBody, ".json")
-		return api.UploadSummary{}, commonhttp.UploadHTTPError(trackerName, resp.StatusCode, responseBody)
+		_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, trackerName, "upload_failure", responsePreview, ".json")
+		return api.UploadSummary{}, commonhttp.UploadHTTPError(trackerName, resp.StatusCode, responsePreview)
 	}
 
 	torrentID := strconv.Itoa(torrentIDValue)

--- a/internal/trackers/impl/czt/upload.go
+++ b/internal/trackers/impl/czt/upload.go
@@ -115,7 +115,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: CZT upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	responseBody, err := io.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	if err != nil {
 		return api.UploadSummary{}, fmt.Errorf("trackers: CZT read upload response: %w", err)
 	}

--- a/internal/trackers/impl/czt/upload_test.go
+++ b/internal/trackers/impl/czt/upload_test.go
@@ -880,13 +880,13 @@ func assertCZTUploadRequest(r *http.Request, expectedPath string) error {
 		return fmt.Errorf("expected upload path %q, got %q", expectedPath, r.URL.Path)
 	}
 	if got := r.Header.Get("Authorization"); got != "" {
-		return fmt.Errorf("expected no authorization header, got %q", got)
+		return errors.New("expected no authorization header")
 	}
 	if err := r.ParseMultipartForm(5 << 20); err != nil {
 		return fmt.Errorf("parse multipart: %w", err)
 	}
 	if got := r.FormValue("passkey"); got != "pass" {
-		return fmt.Errorf("expected passkey form field, got %q", got)
+		return errors.New("expected passkey form field")
 	}
 	if got := r.FormValue("user_descr"); !strings.Contains(got, "[img]https://img.example/raw.jpg[/img]") {
 		return fmt.Errorf("expected raw screenshot img tag in payload, got %q", got)

--- a/internal/trackers/impl/czt/upload_test.go
+++ b/internal/trackers/impl/czt/upload_test.go
@@ -276,6 +276,33 @@ func TestUploadResponseParseBoundaries(t *testing.T) {
 	}
 }
 
+func TestUploadSuccessParsesLargeResponse(t *testing.T) {
+	padding := strings.Repeat("a", 70*1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprintf(
+			w,
+			`{"name":%q,"id":123,"download_url":"/download.php?id=123","torrent_b64":" "}`,
+			padding,
+		)
+	}))
+	defer server.Close()
+
+	result, err := upload(context.Background(), cztUploadRequest(t, server.URL))
+	if err != nil {
+		t.Fatalf("unexpected upload error: %v", err)
+	}
+	if result.Uploaded != 1 || len(result.UploadedTorrents) != 1 {
+		t.Fatalf("expected remote success without artifact failure, got %+v", result)
+	}
+	if result.UploadedTorrents[0].TorrentID != "123" {
+		t.Fatalf("expected torrent ID 123, got %q", result.UploadedTorrents[0].TorrentID)
+	}
+	if result.UploadedTorrents[0].DownloadURL != server.URL+"/download.php?id=123" {
+		t.Fatalf("expected download URL from large response, got %q", result.UploadedTorrents[0].DownloadURL)
+	}
+}
+
 func TestUploadResponseBadLocalFieldPreservesRemoteSuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)

--- a/internal/trackers/impl/dc/upload.go
+++ b/internal/trackers/impl/dc/upload.go
@@ -78,12 +78,15 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	}
 	defer resp.Body.Close()
 
-	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	responseBody, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: DC read upload response: %w", err)
+	}
 	var decoded uploadResponse
 	if len(responseBody) > 0 {
 		if err := json.Unmarshal(responseBody, &decoded); err != nil {
 			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-				return api.UploadSummary{}, commonhttp.UploadHTTPError("DC", resp.StatusCode, responseBody)
+				return api.UploadSummary{}, commonhttp.UploadHTTPError("DC", resp.StatusCode, responsePreview)
 			}
 			return api.UploadSummary{}, fmt.Errorf("trackers: DC decode response: %w", err)
 		}
@@ -114,10 +117,10 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		}, nil
 	}
 
-	if _, artifactErr := commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "DC", "upload_failure", responseBody, ".json"); artifactErr != nil && req.Logger != nil {
+	if _, artifactErr := commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "DC", "upload_failure", responsePreview, ".json"); artifactErr != nil && req.Logger != nil {
 		req.Logger.Warnf("trackers: DC failure artifact write failed: %v", artifactErr)
 	}
-	message := metautil.FirstNonEmptyTrimmed(commonhttp.ExtractHTTPErrorDetail(responseBody), commonhttp.RedactErrorDetail(decoded.Message), commonhttp.RedactErrorDetail(string(responseBody)), "upload failed")
+	message := metautil.FirstNonEmptyTrimmed(commonhttp.ExtractHTTPErrorDetail(responsePreview), commonhttp.RedactErrorDetail(decoded.Message), commonhttp.RedactErrorDetail(string(responsePreview)), "upload failed")
 	return api.UploadSummary{}, fmt.Errorf("trackers: DC %s", message)
 }
 

--- a/internal/trackers/impl/dc/upload.go
+++ b/internal/trackers/impl/dc/upload.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -77,7 +78,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	}
 	defer resp.Body.Close()
 
-	responseBody, _ := io.ReadAll(resp.Body)
+	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	var decoded uploadResponse
 	if len(responseBody) > 0 {
 		if err := json.Unmarshal(responseBody, &decoded); err != nil {
@@ -377,8 +378,6 @@ func isSD(meta api.PreparedMetadata) bool {
 
 func cloneFields(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 	return out
 }

--- a/internal/trackers/impl/ff/upload.go
+++ b/internal/trackers/impl/ff/upload.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -76,7 +77,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	defer resp.Body.Close()
 	location := resp.Header.Get("Location")
 	match := idPattern.FindStringSubmatch(location)
-	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	if resp.StatusCode == http.StatusFound && len(match) >= 2 {
 		id := match[1]
 		tURL := torrentURL + id
@@ -390,8 +391,6 @@ func isSD(meta api.PreparedMetadata) bool {
 
 func cloneFields(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 	return out
 }

--- a/internal/trackers/impl/fl/upload_test.go
+++ b/internal/trackers/impl/fl/upload_test.go
@@ -179,7 +179,7 @@ func TestPersistLoginCookiesRejectsEmptyResponseWithoutReplacingCookies(t *testi
 		t.Fatalf("LoadTrackerCookieMap: %v", err)
 	}
 	if values["session"] != "existing" {
-		t.Fatalf("empty response must preserve previous cookies, got %#v", values)
+		t.Fatal("empty response must preserve previous cookies")
 	}
 }
 

--- a/internal/trackers/impl/gpw/upload.go
+++ b/internal/trackers/impl/gpw/upload.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -65,7 +66,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api.php?api_key="+req.TrackerConfig.APIKey+"&action=upload", bytes.NewReader(body))
 	if err != nil {
-		return api.UploadSummary{}, fmt.Errorf("trackers: GPW upload request build: %w", err)
+		return api.UploadSummary{}, fmt.Errorf("trackers: GPW upload request build: %s", commonhttp.RedactErrorDetail(err.Error()))
 	}
 	httpReq.Header.Set("Content-Type", contentType)
 	httpReq.Header.Set("User-Agent", "upbrr")
@@ -170,7 +171,7 @@ func lookupGroupID(ctx context.Context, apiKey string, meta api.PreparedMetadata
 	url := fmt.Sprintf("%s/api.php?api_key=%s&action=torrent&req=group&imdbID=tt%07d", baseURL, apiKey, meta.ExternalIDs.IMDBID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "", fmt.Errorf("trackers: GPW torrent URL lookup request build: %w", err)
+		return "", fmt.Errorf("trackers: GPW torrent URL lookup request build: %s", commonhttp.RedactErrorDetail(err.Error()))
 	}
 	resp, err := httpclient.New(httpclient.DefaultTimeout).Do(req)
 	if err != nil {
@@ -234,9 +235,7 @@ func buildFields(req trackers.UploadRequest, trackerCfg config.TrackerConfig, de
 		fields["characters[]"] = ""
 		fields["main_artist_number"] = "1"
 	}
-	for key, value := range resolveMediaFlags(meta) {
-		fields[key] = value
-	}
+	maps.Copy(fields, resolveMediaFlags(meta))
 	if meta.Scene {
 		fields["scene"] = "on"
 	}
@@ -582,8 +581,6 @@ func onOff(value bool) string {
 
 func cloneFields(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 	return out
 }

--- a/internal/trackers/impl/gpw/upload.go
+++ b/internal/trackers/impl/gpw/upload.go
@@ -75,7 +75,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: GPW upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	responseBody, _ := io.ReadAll(resp.Body)
+	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	var decoded apiResponse
 	if err := json.Unmarshal(responseBody, &decoded); err != nil {
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/internal/trackers/impl/gpw/upload.go
+++ b/internal/trackers/impl/gpw/upload.go
@@ -75,11 +75,14 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: GPW upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	responseBody, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: GPW read upload response: %w", err)
+	}
 	var decoded apiResponse
 	if err := json.Unmarshal(responseBody, &decoded); err != nil {
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return api.UploadSummary{}, commonhttp.UploadHTTPError("GPW", resp.StatusCode, responseBody)
+			return api.UploadSummary{}, commonhttp.UploadHTTPError("GPW", resp.StatusCode, responsePreview)
 		}
 		return api.UploadSummary{}, fmt.Errorf("trackers: GPW decode response: %w", err)
 	}
@@ -99,8 +102,8 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		}
 		return api.UploadSummary{Uploaded: 1, UploadedTorrents: []api.UploadedTorrent{{Tracker: "GPW", TorrentID: id, TorrentURL: tURL, DownloadURL: tURL, TorrentPath: artifactPath}}}, nil
 	}
-	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "GPW", "upload_failure", responseBody, ".json")
-	return api.UploadSummary{}, fmt.Errorf("trackers: GPW %s", metautil.FirstNonEmptyTrimmed(commonhttp.ExtractHTTPErrorDetail(responseBody), commonhttp.RedactErrorDetail(decoded.Error), commonhttp.RedactErrorDetail(decoded.Message), "upload failed"))
+	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "GPW", "upload_failure", responsePreview, ".json")
+	return api.UploadSummary{}, fmt.Errorf("trackers: GPW %s", metautil.FirstNonEmptyTrimmed(commonhttp.ExtractHTTPErrorDetail(responsePreview), commonhttp.RedactErrorDetail(decoded.Error), commonhttp.RedactErrorDetail(decoded.Message), "upload failed"))
 }
 
 func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.TrackerDryRunEntry, error) {

--- a/internal/trackers/impl/hdb/definition_test.go
+++ b/internal/trackers/impl/hdb/definition_test.go
@@ -89,23 +89,29 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 			uploadSeen = true
 			if ct := r.Header.Get("Content-Type"); !strings.Contains(ct, "multipart/form-data") {
 				t.Errorf("expected multipart content-type, got %q", ct)
+				return
 			}
 			if err := r.ParseMultipartForm(5 << 20); err != nil {
-				t.Fatalf("parse multipart: %v", err)
+				t.Errorf("parse multipart: %v", err)
+				return
 			}
 			if r.FormValue("name") == "" {
-				t.Fatal("expected upload name field")
+				t.Error("expected upload name field")
+				return
 			}
 			if descr := r.FormValue("descr"); !strings.Contains(descr, "https://t.hdbits.org/rehosted.jpg") {
-				t.Fatalf("expected provided rehosted screenshot in description, got %q", descr)
+				t.Errorf("expected provided rehosted screenshot in description, got %q", descr)
+				return
 			}
 			files := r.MultipartForm.File["file"]
 			if len(files) == 0 {
-				t.Fatal("expected torrent file in multipart form")
+				t.Error("expected torrent file in multipart form")
+				return
 			}
 			f, err := files[0].Open()
 			if err != nil {
-				t.Fatalf("open uploaded file: %v", err)
+				t.Errorf("open uploaded file: %v", err)
+				return
 			}
 			_, _ = io.ReadAll(f)
 			_ = f.Close()
@@ -116,7 +122,8 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 		case strings.HasPrefix(r.URL.Path, "/download.php/"):
 			downloadSeen = true
 			if r.URL.Query().Get("id") != "123" {
-				t.Fatalf("expected id=123, got %q", r.URL.Query().Get("id"))
+				t.Errorf("expected id=123, got %q", r.URL.Query().Get("id"))
+				return
 			}
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("reseed-torrent-bytes"))

--- a/internal/trackers/impl/hds/upload.go
+++ b/internal/trackers/impl/hds/upload.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"path/filepath"
 	"regexp"
@@ -82,7 +83,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	responseBody, _ := io.ReadAll(resp.Body)
+	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	combined := finalURL + "\n" + string(responseBody)
 	match := idPattern.FindStringSubmatch(combined)
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 && len(match) >= 2 {
@@ -410,8 +411,6 @@ func supportsHDSResolution(value string) bool {
 
 func cloneFields(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 	return out
 }

--- a/internal/trackers/impl/hds/upload.go
+++ b/internal/trackers/impl/hds/upload.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"maps"
 	"net/http"
 	"path/filepath"
@@ -83,7 +82,10 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	responseBody, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 400, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: HDS read upload response: %w", err)
+	}
 	combined := finalURL + "\n" + string(responseBody)
 	match := idPattern.FindStringSubmatch(combined)
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 && len(match) >= 2 {
@@ -111,8 +113,8 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		}, nil
 	}
 
-	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "HDS", "upload_failure", responseBody, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("HDS", resp.StatusCode, responseBody)
+	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "HDS", "upload_failure", responsePreview, ".html")
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("HDS", resp.StatusCode, responsePreview)
 }
 
 func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.TrackerDryRunEntry, error) {

--- a/internal/trackers/impl/hdt/upload.go
+++ b/internal/trackers/impl/hdt/upload.go
@@ -74,7 +74,10 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	responseBody, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 400, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: HDT read upload response: %w", err)
+	}
 	combined := finalURL + "\n" + string(responseBody)
 	id := ""
 	if match := detailsPattern.FindStringSubmatch(combined); len(match) >= 2 {
@@ -106,8 +109,8 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 			}},
 		}, nil
 	}
-	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "HDT", "upload_failure", responseBody, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("HDT", resp.StatusCode, responseBody)
+	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "HDT", "upload_failure", responsePreview, ".html")
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("HDT", resp.StatusCode, responsePreview)
 }
 
 func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.TrackerDryRunEntry, error) {

--- a/internal/trackers/impl/hdt/upload.go
+++ b/internal/trackers/impl/hdt/upload.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -73,7 +74,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	responseBody, _ := io.ReadAll(resp.Body)
+	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	combined := finalURL + "\n" + string(responseBody)
 	id := ""
 	if match := detailsPattern.FindStringSubmatch(combined); len(match) >= 2 {
@@ -432,8 +433,6 @@ func boolString(value bool) string {
 
 func cloneFields(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 	return out
 }

--- a/internal/trackers/impl/is/upload.go
+++ b/internal/trackers/impl/is/upload.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"maps"
 	"net/http"
 	"path/filepath"
@@ -86,7 +85,10 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	responseBody, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 400, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: IS read upload response: %w", err)
+	}
 	id, success := successfulUploadResponse(finalURL, string(responseBody))
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 && success {
 		if id != "" {
@@ -114,8 +116,8 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		}
 		return api.UploadSummary{Uploaded: 1}, nil
 	}
-	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "IS", "upload_failure", responseBody, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("IS", resp.StatusCode, responseBody)
+	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "IS", "upload_failure", responsePreview, ".html")
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("IS", resp.StatusCode, responsePreview)
 }
 
 func successfulUploadResponse(finalURL string, responseBody string) (string, bool) {

--- a/internal/trackers/impl/is/upload.go
+++ b/internal/trackers/impl/is/upload.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"path/filepath"
 	"regexp"
@@ -85,7 +86,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	responseBody, _ := io.ReadAll(resp.Body)
+	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	id, success := successfulUploadResponse(finalURL, string(responseBody))
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 && success {
 		if id != "" {
@@ -437,8 +438,6 @@ func yesNo(value bool) string {
 
 func cloneFields(in map[string]string) map[string]string {
 	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
+	maps.Copy(out, in)
 	return out
 }

--- a/internal/trackers/impl/mtv/definition_test.go
+++ b/internal/trackers/impl/mtv/definition_test.go
@@ -124,7 +124,7 @@ func TestDefinitionUploadLoginBootstrapSuccess(t *testing.T) {
 				t.Fatalf("parse login form: %v", err)
 			}
 			if r.FormValue("username") != "user" || r.FormValue("password") != "pass" {
-				t.Fatalf("unexpected login creds user=%q pass=%q", r.FormValue("username"), r.FormValue("password"))
+				t.Fatal("unexpected login credentials")
 			}
 			http.SetCookie(w, &http.Cookie{Name: "session", Value: "cookievalue", Path: "/"})
 			http.Redirect(w, r, "/index.php", http.StatusFound)

--- a/internal/trackers/impl/mtv/definition_test.go
+++ b/internal/trackers/impl/mtv/definition_test.go
@@ -66,10 +66,12 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 			_, _ = w.Write([]byte("...authkey=1234567890abcdef1234567890abcdef..."))
 		case "/upload.php":
 			if err := r.ParseMultipartForm(5 << 20); err != nil {
-				t.Fatalf("parse multipart: %v", err)
+				t.Errorf("parse multipart: %v", err)
+				return
 			}
 			if r.FormValue("auth") == "" {
-				t.Fatal("expected auth field")
+				t.Error("expected auth field")
+				return
 			}
 			http.Redirect(w, r, "/torrents.php?id=55", http.StatusFound)
 		case "/torrents.php":
@@ -121,10 +123,12 @@ func TestDefinitionUploadLoginBootstrapSuccess(t *testing.T) {
 				return
 			}
 			if err := r.ParseForm(); err != nil {
-				t.Fatalf("parse login form: %v", err)
+				t.Errorf("parse login form: %v", err)
+				return
 			}
 			if r.FormValue("username") != "user" || r.FormValue("password") != "pass" {
-				t.Fatal("unexpected login credentials")
+				t.Error("unexpected login credentials")
+				return
 			}
 			http.SetCookie(w, &http.Cookie{Name: "session", Value: "cookievalue", Path: "/"})
 			http.Redirect(w, r, "/index.php", http.StatusFound)
@@ -137,15 +141,18 @@ func TestDefinitionUploadLoginBootstrapSuccess(t *testing.T) {
 			_, _ = w.Write([]byte("...authkey=abcdefabcdefabcdefabcdefabcdefab..."))
 		case "/upload.php":
 			if err := r.ParseMultipartForm(5 << 20); err != nil {
-				t.Fatalf("parse multipart: %v", err)
+				t.Errorf("parse multipart: %v", err)
+				return
 			}
 			if r.FormValue("auth") == "" {
-				t.Fatal("expected auth field")
+				t.Error("expected auth field")
+				return
 			}
 			http.Redirect(w, r, "/torrents.php?id=99", http.StatusFound)
 		case "/torrents.php":
 			if _, err := url.ParseRequestURI(r.RequestURI); err != nil {
-				t.Fatalf("invalid request uri: %v", err)
+				t.Errorf("invalid request uri: %v", err)
+				return
 			}
 			w.WriteHeader(http.StatusOK)
 		default:

--- a/internal/trackers/impl/mtv/upload_test.go
+++ b/internal/trackers/impl/mtv/upload_test.go
@@ -239,7 +239,8 @@ func TestResolveSessionForTrackerAuthPostsLoginToRedirectedHost(t *testing.T) {
 		case r.URL.Path == "/login" && r.Method == http.MethodGet:
 			_, _ = w.Write([]byte(`<input name="token" value="abcdefghijklmnop">`))
 		case r.URL.Path == "/login" && r.Method == http.MethodPost && strings.HasPrefix(r.Host, "localhost:"):
-			t.Fatalf("login POST used original host")
+			t.Error("login POST used original host")
+			return
 		case r.URL.Path == "/login" && r.Method == http.MethodPost:
 			postedCanonicalLogin = true
 			http.SetCookie(w, &http.Cookie{Name: "session", Value: "fresh", Path: "/"})
@@ -293,11 +294,13 @@ func TestUploadPostsToRedirectedLoginHost(t *testing.T) {
 			http.SetCookie(w, &http.Cookie{Name: "session", Value: "fresh", Path: "/"})
 			_, _ = w.Write([]byte(`authkey=abcdefghijklmnopqrstuvwxyzABCDEF`))
 		case r.URL.Path == mtvUploadPath && r.Method == http.MethodPost && strings.HasPrefix(r.Host, "localhost:"):
-			t.Fatalf("upload POST used original host")
+			t.Error("upload POST used original host")
+			return
 		case r.URL.Path == mtvUploadPath && r.Method == http.MethodPost:
 			postedCanonicalUpload = true
 			if _, err := r.Cookie("session"); err != nil {
-				t.Fatalf("expected session cookie on canonical upload: %v", err)
+				t.Errorf("expected session cookie on canonical upload: %v", err)
+				return
 			}
 			http.Redirect(w, r, canonicalURL+"/torrents.php?id=1", http.StatusFound)
 		case r.URL.Path == "/torrents.php":
@@ -406,7 +409,8 @@ func TestResolveSessionForTrackerAuthLoginUsesManual2FACode(t *testing.T) {
 				return
 			}
 			if err := r.ParseForm(); err != nil {
-				t.Fatalf("ParseForm: %v", err)
+				t.Errorf("ParseForm: %v", err)
+				return
 			}
 			gotCode = r.FormValue("code")
 			http.SetCookie(w, &http.Cookie{Name: "session", Value: "new", Path: "/"})

--- a/internal/trackers/impl/mtv/upload_test.go
+++ b/internal/trackers/impl/mtv/upload_test.go
@@ -55,7 +55,7 @@ func TestExtractMTVAuthKeyMatchesUploadAssistantShape(t *testing.T) {
 			t.Parallel()
 
 			if got := extractMTVAuthKey(body); got != auth {
-				t.Fatalf("expected %q, got %q", auth, got)
+				t.Fatal("expected extracted auth key")
 			}
 		})
 	}

--- a/internal/trackers/impl/nbl/upload.go
+++ b/internal/trackers/impl/nbl/upload.go
@@ -56,7 +56,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	if err != nil {
 		return api.UploadSummary{}, fmt.Errorf("trackers: NBL read response: %w", err)
 	}

--- a/internal/trackers/impl/nbl/upload.go
+++ b/internal/trackers/impl/nbl/upload.go
@@ -56,12 +56,12 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	bodyBytes, bodyPreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 300, commonhttp.DefaultResponsePreviewBytes)
 	if err != nil {
 		return api.UploadSummary{}, fmt.Errorf("trackers: NBL read response: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return api.UploadSummary{}, commonhttp.UploadHTTPError("NBL", resp.StatusCode, bodyBytes)
+		return api.UploadSummary{}, commonhttp.UploadHTTPError("NBL", resp.StatusCode, bodyPreview)
 	}
 
 	payload := map[string]any{}

--- a/internal/trackers/impl/ptp/definition_test.go
+++ b/internal/trackers/impl/ptp/definition_test.go
@@ -330,7 +330,7 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 					t.Fatalf("expected upload torrent announce stripped, got %q", uploadedMeta.Announce)
 				}
 				if r.FormValue("AntiCsrfToken") != "csrf-token" {
-					t.Fatalf("expected csrf token, got %q", r.FormValue("AntiCsrfToken"))
+					t.Fatal("expected csrf token")
 				}
 				if r.FormValue("title") != "Movie" {
 					t.Fatalf("expected new-group title field")

--- a/internal/trackers/impl/ptp/definition_test.go
+++ b/internal/trackers/impl/ptp/definition_test.go
@@ -287,10 +287,12 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 		switch r.URL.RequestURI() {
 		case ptpLoginPath:
 			if err := r.ParseForm(); err != nil {
-				t.Fatalf("parse login: %v", err)
+				t.Errorf("parse login: %v", err)
+				return
 			}
 			if r.FormValue("username") != "user" || r.FormValue("password") != "pass" {
-				t.Fatalf("unexpected login credentials")
+				t.Error("unexpected login credentials")
+				return
 			}
 			http.SetCookie(w, &http.Cookie{Name: "session", Value: "cookievalue", Path: "/"})
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -301,39 +303,49 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 			switch r.URL.Path {
 			case ptpUploadPath:
 				if err := r.ParseMultipartForm(5 << 20); err != nil {
-					t.Fatalf("parse multipart: %v", err)
+					t.Errorf("parse multipart: %v", err)
+					return
 				}
 				files := r.MultipartForm.File["file_input"]
 				if len(files) != 1 {
-					t.Fatalf("expected one torrent file, got %d", len(files))
+					t.Errorf("expected one torrent file, got %d", len(files))
+					return
 				}
 				uploaded, err := files[0].Open()
 				if err != nil {
-					t.Fatalf("open uploaded torrent: %v", err)
+					t.Errorf("open uploaded torrent: %v", err)
+					return
 				}
 				defer uploaded.Close()
 				payload, err := io.ReadAll(uploaded)
 				if err != nil {
-					t.Fatalf("read uploaded torrent: %v", err)
+					t.Errorf("read uploaded torrent: %v", err)
+					return
 				}
 				uploadedMeta, err := metainfo.Load(bytes.NewReader(payload))
 				if err != nil {
-					t.Fatalf("load uploaded torrent: %v", err)
+					t.Errorf("load uploaded torrent: %v", err)
+					return
 				}
 				if uploadedMeta.Comment != "upbrr" {
-					t.Fatalf("expected cleaned upload torrent comment, got %q", uploadedMeta.Comment)
+					t.Errorf("expected cleaned upload torrent comment, got %q", uploadedMeta.Comment)
+					return
 				}
 				if uploadedMeta.CreatedBy != "uploaded with upbrr" {
-					t.Fatalf("expected cleaned upload torrent created-by, got %q", uploadedMeta.CreatedBy)
+					t.Errorf("expected cleaned upload torrent created-by, got %q", uploadedMeta.CreatedBy)
+					return
 				}
 				if uploadedMeta.Announce != "" {
-					t.Fatal("expected upload torrent announce stripped")
+					t.Error("expected upload torrent announce stripped")
+					return
 				}
 				if r.FormValue("AntiCsrfToken") != "csrf-token" {
-					t.Fatal("expected csrf token")
+					t.Error("expected csrf token")
+					return
 				}
 				if r.FormValue("title") != "Movie" {
-					t.Fatalf("expected new-group title field")
+					t.Error("expected new-group title field")
+					return
 				}
 				http.Redirect(w, r, "/torrents.php?id=555&torrentid=666", http.StatusFound)
 			case ptpTorrentPath:
@@ -411,10 +423,12 @@ func TestLoginAndFetchAntiCsrfTokenHandles2FA(t *testing.T) {
 			return
 		}
 		if err := r.ParseForm(); err != nil {
-			t.Fatalf("parse login: %v", err)
+			t.Errorf("parse login: %v", err)
+			return
 		}
 		if r.FormValue("username") != "user" || r.FormValue("password") != "pass" || r.FormValue("passkey") != "passkey" || r.FormValue("keeplogged") != "1" {
-			t.Fatalf("unexpected login form: %v", r.Form)
+			t.Error("unexpected login form")
+			return
 		}
 		if r.FormValue("TfaCode") == "" {
 			_ = json.NewEncoder(w).Encode(map[string]any{"Result": "TfaRequired"})
@@ -422,11 +436,13 @@ func TestLoginAndFetchAntiCsrfTokenHandles2FA(t *testing.T) {
 		}
 		secondLogin = true
 		if r.FormValue("TfaType") != "normal" {
-			t.Fatalf("expected TfaType normal, got %q", r.FormValue("TfaType"))
+			t.Errorf("expected TfaType normal, got %q", r.FormValue("TfaType"))
+			return
 		}
 		code := r.FormValue("TfaCode")
 		if len(code) != 6 || strings.Trim(code, "0123456789") != "" {
-			t.Fatalf("expected six digit TfaCode, got %q", code)
+			t.Errorf("expected six digit TfaCode, got %q", code)
+			return
 		}
 		http.SetCookie(w, &http.Cookie{Name: "session", Value: "cookievalue", Path: "/"})
 		_ = json.NewEncoder(w).Encode(map[string]any{

--- a/internal/trackers/impl/ptp/definition_test.go
+++ b/internal/trackers/impl/ptp/definition_test.go
@@ -265,7 +265,7 @@ func TestResolveUploadTorrentPathReusesPreparedPTPArtifact(t *testing.T) {
 		t.Fatalf("load prepared artifact: %v", err)
 	}
 	if torrentMeta.Announce != "https://please.passthepopcorn.me/passkey/announce" {
-		t.Fatalf("expected prepared announce preserved, got %q", torrentMeta.Announce)
+		t.Fatal("expected prepared announce preserved")
 	}
 	info, err := torrentMeta.UnmarshalInfo()
 	if err != nil {
@@ -327,7 +327,7 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 					t.Fatalf("expected cleaned upload torrent created-by, got %q", uploadedMeta.CreatedBy)
 				}
 				if uploadedMeta.Announce != "" {
-					t.Fatalf("expected upload torrent announce stripped, got %q", uploadedMeta.Announce)
+					t.Fatal("expected upload torrent announce stripped")
 				}
 				if r.FormValue("AntiCsrfToken") != "csrf-token" {
 					t.Fatal("expected csrf token")

--- a/internal/trackers/impl/ptp/upload_test.go
+++ b/internal/trackers/impl/ptp/upload_test.go
@@ -221,7 +221,8 @@ func TestResolveSessionForTrackerAuthLoginUsesManual2FACode(t *testing.T) {
 			return
 		}
 		if err := r.ParseForm(); err != nil {
-			t.Fatalf("ParseForm: %v", err)
+			t.Errorf("ParseForm: %v", err)
+			return
 		}
 		loginRequests++
 		if loginRequests == 1 {

--- a/internal/trackers/impl/pts/upload.go
+++ b/internal/trackers/impl/pts/upload.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"maps"
 	"net/http"
 	"net/url"
@@ -72,7 +71,10 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: PTS upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	responseBody, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode == http.StatusFound || resp.StatusCode == http.StatusSeeOther, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: PTS read upload response: %w", err)
+	}
 
 	location := strings.TrimSpace(resp.Header.Get("Location"))
 	torrentID := parseUploadID(location, string(responseBody))
@@ -100,8 +102,8 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		}, nil
 	}
 
-	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "PTS", "upload_failure", responseBody, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("PTS", resp.StatusCode, responseBody)
+	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "PTS", "upload_failure", responsePreview, ".html")
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("PTS", resp.StatusCode, responsePreview)
 }
 
 func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.TrackerDryRunEntry, error) {

--- a/internal/trackers/impl/pts/upload.go
+++ b/internal/trackers/impl/pts/upload.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -71,7 +72,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: PTS upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	responseBody, _ := io.ReadAll(resp.Body)
+	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 
 	location := strings.TrimSpace(resp.Header.Get("Location"))
 	torrentID := parseUploadID(location, string(responseBody))
@@ -281,9 +282,7 @@ func questionnaireAnswers(meta api.PreparedMetadata) map[string]string {
 
 func cloneFields(input map[string]string) map[string]string {
 	out := make(map[string]string, len(input))
-	for key, value := range input {
-		out[key] = value
-	}
+	maps.Copy(out, input)
 	return out
 }
 

--- a/internal/trackers/impl/rtf/upload_test.go
+++ b/internal/trackers/impl/rtf/upload_test.go
@@ -109,7 +109,7 @@ func TestUploadRefreshesExpiredAPIKeyAndPersistsIt(t *testing.T) {
 		t.Fatal("expected upload to use refreshed token")
 	}
 	if got := loadStoredRTFAPIKey(t, dbPath); got != "new-token" {
-		t.Fatalf("expected refreshed token persisted, got %q", got)
+		t.Fatal("expected refreshed token persisted")
 	}
 }
 
@@ -154,7 +154,7 @@ func TestUploadBlockedExpiredAPIKeyDoesNotRefreshOrPersist(t *testing.T) {
 		t.Fatalf("blocked upload must not call RTF auth or upload endpoints, got %d requests", requests)
 	}
 	if got := loadStoredRTFAPIKey(t, dbPath); got != "old-token" {
-		t.Fatalf("blocked upload must leave stored token unchanged, got %q", got)
+		t.Fatal("blocked upload must leave stored token unchanged")
 	}
 }
 
@@ -257,7 +257,7 @@ func TestUploadGeneratesMissingAPIKeyFromCredentials(t *testing.T) {
 		t.Fatal("expected upload to use generated token")
 	}
 	if got := loadStoredRTFAPIKey(t, dbPath); got != "generated-token" {
-		t.Fatalf("expected generated token persisted, got %q", got)
+		t.Fatal("expected generated token persisted")
 	}
 }
 

--- a/internal/trackers/impl/rtf/upload_test.go
+++ b/internal/trackers/impl/rtf/upload_test.go
@@ -100,13 +100,13 @@ func TestUploadRefreshesExpiredAPIKeyAndPersistsIt(t *testing.T) {
 		t.Fatalf("expected upload success, got %#v", summary)
 	}
 	if testedToken != "old-token" {
-		t.Fatalf("expected old token to be tested, got %q", testedToken)
+		t.Fatal("expected old token to be tested")
 	}
 	if !loginCalled {
 		t.Fatal("expected expired token to trigger API login")
 	}
 	if uploadToken != "new-token" {
-		t.Fatalf("expected upload to use refreshed token, got %q", uploadToken)
+		t.Fatal("expected upload to use refreshed token")
 	}
 	if got := loadStoredRTFAPIKey(t, dbPath); got != "new-token" {
 		t.Fatalf("expected refreshed token persisted, got %q", got)
@@ -202,7 +202,7 @@ func TestUploadUsesValidAPIKeyWithoutRefresh(t *testing.T) {
 		t.Fatal("valid token should not trigger API login")
 	}
 	if uploadToken != "valid-token" {
-		t.Fatalf("expected upload to use original token, got %q", uploadToken)
+		t.Fatal("expected upload to use original token")
 	}
 }
 
@@ -254,7 +254,7 @@ func TestUploadGeneratesMissingAPIKeyFromCredentials(t *testing.T) {
 		t.Fatal("missing token should refresh directly without API test")
 	}
 	if uploadToken != "generated-token" {
-		t.Fatalf("expected upload to use generated token, got %q", uploadToken)
+		t.Fatal("expected upload to use generated token")
 	}
 	if got := loadStoredRTFAPIKey(t, dbPath); got != "generated-token" {
 		t.Fatalf("expected generated token persisted, got %q", got)

--- a/internal/trackers/impl/spd/upload.go
+++ b/internal/trackers/impl/spd/upload.go
@@ -82,7 +82,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: SPD upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	responseBody, _ := io.ReadAll(resp.Body)
+	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 
 	var decoded uploadResponse
 	if err := json.Unmarshal(responseBody, &decoded); err != nil {

--- a/internal/trackers/impl/spd/upload.go
+++ b/internal/trackers/impl/spd/upload.go
@@ -82,13 +82,16 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: SPD upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	responseBody, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode == http.StatusOK, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: SPD read upload response: %w", err)
+	}
 
 	var decoded uploadResponse
 	if err := json.Unmarshal(responseBody, &decoded); err != nil {
-		_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "SPD", "upload_failure", responseBody, ".txt")
+		_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "SPD", "upload_failure", responsePreview, ".txt")
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return api.UploadSummary{}, commonhttp.UploadHTTPError("SPD", resp.StatusCode, responseBody)
+			return api.UploadSummary{}, commonhttp.UploadHTTPError("SPD", resp.StatusCode, responsePreview)
 		}
 		return api.UploadSummary{}, fmt.Errorf("trackers: SPD decode response: %w", err)
 	}
@@ -115,8 +118,8 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		}, nil
 	}
 
-	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "SPD", "upload_failure", responseBody, ".json")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("SPD", resp.StatusCode, responseBody)
+	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "SPD", "upload_failure", responsePreview, ".json")
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("SPD", resp.StatusCode, responsePreview)
 }
 
 func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.TrackerDryRunEntry, error) {

--- a/internal/trackers/impl/thr/upload.go
+++ b/internal/trackers/impl/thr/upload.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -69,7 +70,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: THR upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 
 	finalURL := ""
 	if resp.Request != nil && resp.Request.URL != nil {
@@ -302,9 +303,7 @@ func containsWord(a string, b string) bool {
 
 func cloneFields(input map[string]string) map[string]string {
 	out := make(map[string]string, len(input))
-	for key, value := range input {
-		out[key] = value
-	}
+	maps.Copy(out, input)
 	return out
 }
 

--- a/internal/trackers/impl/tl/upload.go
+++ b/internal/trackers/impl/tl/upload.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"maps"
 	"net/http"
 	"net/http/cookiejar"
@@ -65,7 +64,11 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: TL upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	successCandidate := resp.StatusCode == http.StatusFound || (req.TrackerConfig.APIUpload && resp.StatusCode >= 200 && resp.StatusCode < 300)
+	responseBody, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, successCandidate, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: TL read upload response: %w", err)
+	}
 
 	torrentID := ""
 	if req.TrackerConfig.APIUpload {
@@ -77,8 +80,8 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		torrentID = strings.TrimPrefix(strings.TrimSpace(resp.Header.Get("Location")), "/successfulupload?torrentID=")
 	}
 	if torrentID == "" {
-		_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "TL", "upload_failure", responseBody, ".html")
-		return api.UploadSummary{}, commonhttp.UploadHTTPError("TL", resp.StatusCode, responseBody)
+		_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "TL", "upload_failure", responsePreview, ".html")
+		return api.UploadSummary{}, commonhttp.UploadHTTPError("TL", resp.StatusCode, responsePreview)
 	}
 
 	urlValue := torrentURL + torrentID

--- a/internal/trackers/impl/tl/upload.go
+++ b/internal/trackers/impl/tl/upload.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -64,7 +65,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: TL upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	responseBody, _ := io.ReadAll(resp.Body)
+	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 
 	torrentID := ""
 	if req.TrackerConfig.APIUpload {
@@ -426,9 +427,7 @@ func boolWord(cond bool, yes string, no string) string {
 
 func cloneFields(input map[string]string) map[string]string {
 	out := make(map[string]string, len(input))
-	for key, value := range input {
-		out[key] = value
-	}
+	maps.Copy(out, input)
 	return out
 }
 

--- a/internal/trackers/impl/tvc/upload.go
+++ b/internal/trackers/impl/tvc/upload.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"maps"
 	"net/http"
 	"net/url"
@@ -76,10 +75,13 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: TVC upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	responseBody, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode == http.StatusOK, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: TVC read upload response: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
-		_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "TVC", "upload_failure", responseBody, ".txt")
-		return api.UploadSummary{}, commonhttp.UploadHTTPError("TVC", resp.StatusCode, responseBody)
+		_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "TVC", "upload_failure", responsePreview, ".txt")
+		return api.UploadSummary{}, commonhttp.UploadHTTPError("TVC", resp.StatusCode, responsePreview)
 	}
 
 	payload := string(responseBody)

--- a/internal/trackers/impl/tvc/upload.go
+++ b/internal/trackers/impl/tvc/upload.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"path" //nolint:depguard // Extracts tracker response URL path basename.
@@ -65,7 +66,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL+"?api_token="+url.QueryEscape(strings.TrimSpace(req.TrackerConfig.APIKey)), bytes.NewReader(body))
 	if err != nil {
-		return api.UploadSummary{}, fmt.Errorf("trackers: TVC build upload request: %w", err)
+		return api.UploadSummary{}, fmt.Errorf("trackers: TVC build upload request: %s", commonhttp.RedactErrorDetail(err.Error()))
 	}
 	httpReq.Header.Set("Content-Type", contentType)
 	httpReq.Header.Set("User-Agent", "Mozilla/5.0")
@@ -374,9 +375,7 @@ func videoSuffix(codec string) string {
 
 func cloneFields(input map[string]string) map[string]string {
 	out := make(map[string]string, len(input))
-	for key, value := range input {
-		out[key] = value
-	}
+	maps.Copy(out, input)
 	return out
 }
 

--- a/internal/trackers/impl/tvc/upload.go
+++ b/internal/trackers/impl/tvc/upload.go
@@ -76,7 +76,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 		return api.UploadSummary{}, fmt.Errorf("trackers: TVC upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	responseBody, _ := io.ReadAll(resp.Body)
+	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	if resp.StatusCode != http.StatusOK {
 		_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.AppConfig.MainSettings.DBPath, "TVC", "upload_failure", responseBody, ".txt")
 		return api.UploadSummary{}, commonhttp.UploadHTTPError("TVC", resp.StatusCode, responseBody)

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -177,16 +177,16 @@ func uploadUnit3D(ctx context.Context, req trackers.UploadRequest) (api.UploadSu
 
 	logger.Debugf("trackers: %s received HTTP %d response", trackerName, resp.StatusCode)
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	body, bodyPreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices, commonhttp.DefaultResponsePreviewBytes)
 	if err != nil {
 		logger.Errorf("trackers: %s failed to read response body: %v", trackerName, err)
 		return api.UploadSummary{}, fmt.Errorf("trackers: %s read response body: %w", trackerName, err)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		err := commonhttp.UploadHTTPError(trackerName, resp.StatusCode, body)
+		err := commonhttp.UploadHTTPError(trackerName, resp.StatusCode, bodyPreview)
 		logger.Errorf("trackers: %s upload request failed: %v", trackerName, err)
-		if len(body) > 0 {
-			logger.Tracef("trackers: %s response body: %s", trackerName, redaction.RedactValue(string(body), nil))
+		if len(bodyPreview) > 0 {
+			logger.Tracef("trackers: %s response body: %s", trackerName, redaction.RedactValue(string(bodyPreview), nil))
 		}
 		return api.UploadSummary{}, err
 	}
@@ -194,11 +194,11 @@ func uploadUnit3D(ctx context.Context, req trackers.UploadRequest) (api.UploadSu
 	var result unit3dUploadResponse
 	if err := json.Unmarshal(body, &result); err != nil {
 		logger.Errorf("trackers: %s failed to parse response JSON: %v", trackerName, err)
-		logger.Tracef("trackers: %s response body: %s", trackerName, redaction.RedactValue(string(body), nil))
+		logger.Tracef("trackers: %s response body: %s", trackerName, redaction.RedactValue(string(bodyPreview), nil))
 		return api.UploadSummary{}, fmt.Errorf("trackers: %s response json: %w", trackerName, err)
 	}
 	if !result.Success {
-		message := commonhttp.ExtractHTTPErrorDetail(body)
+		message := commonhttp.ExtractHTTPErrorDetail(bodyPreview)
 		if message == "" {
 			message = commonhttp.RedactErrorDetail(result.Message)
 		}

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -177,7 +177,7 @@ func uploadUnit3D(ctx context.Context, req trackers.UploadRequest) (api.UploadSu
 
 	logger.Debugf("trackers: %s received HTTP %d response", trackerName, resp.StatusCode)
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	if err != nil {
 		logger.Errorf("trackers: %s failed to read response body: %v", trackerName, err)
 		return api.UploadSummary{}, fmt.Errorf("trackers: %s read response body: %w", trackerName, err)

--- a/internal/trackers/service_test.go
+++ b/internal/trackers/service_test.go
@@ -2152,7 +2152,7 @@ func assertTrackerArtifact(t *testing.T, torrentPath string, wantAnnounce string
 		t.Fatalf("load tracker artifact: %v", err)
 	}
 	if torrentMeta.Announce != wantAnnounce {
-		t.Fatalf("expected announce %q, got %q", wantAnnounce, torrentMeta.Announce)
+		t.Fatal("expected tracker artifact announce")
 	}
 	info, err := torrentMeta.UnmarshalInfo()
 	if err != nil {

--- a/internal/trackers/upload_artifact_test.go
+++ b/internal/trackers/upload_artifact_test.go
@@ -51,10 +51,10 @@ func TestResolveUploadTorrentPathWritesCleanBaseCopy(t *testing.T) {
 
 	cleaned := readTestMetaInfo(t, got)
 	if cleaned.Announce != "" {
-		t.Fatalf("expected announce cleared, got %q", cleaned.Announce)
+		t.Fatal("expected announce cleared")
 	}
 	if len(cleaned.AnnounceList) != 0 {
-		t.Fatalf("expected announce-list cleared, got %#v", cleaned.AnnounceList)
+		t.Fatal("expected announce-list cleared")
 	}
 	if len(cleaned.Nodes) != 0 {
 		t.Fatalf("expected nodes cleared, got %#v", cleaned.Nodes)
@@ -179,10 +179,10 @@ func TestWriteUploadTorrentPreservesPieceLayers(t *testing.T) {
 		t.Fatalf("expected piece layers preserved, got %#v", cleaned.PieceLayers)
 	}
 	if cleaned.Announce != "" {
-		t.Fatalf("expected announce cleared, got %q", cleaned.Announce)
+		t.Fatal("expected announce cleared")
 	}
 	if len(cleaned.AnnounceList) != 0 {
-		t.Fatalf("expected announce-list cleared, got %#v", cleaned.AnnounceList)
+		t.Fatal("expected announce-list cleared")
 	}
 	if len(cleaned.Nodes) != 0 {
 		t.Fatalf("expected nodes cleared, got %#v", cleaned.Nodes)
@@ -227,7 +227,7 @@ func TestResolveUploadTorrentPathWithoutCleanTargetLeavesOriginalUnchanged(t *te
 
 	original := readTestMetaInfo(t, torrentPath)
 	if original.Announce != "https://tracker.example/announce" {
-		t.Fatalf("expected original announce unchanged, got %q", original.Announce)
+		t.Fatal("expected original announce unchanged")
 	}
 	if original.Comment != "private tracker comment" {
 		t.Fatalf("expected original comment unchanged, got %q", original.Comment)
@@ -255,10 +255,10 @@ func TestWritePersonalizedTorrentSetsTrackerFields(t *testing.T) {
 
 	updated := readTestMetaInfo(t, outputPath)
 	if updated.Announce != "https://new.example/announce" {
-		t.Fatalf("expected announce set, got %q", updated.Announce)
+		t.Fatal("expected announce set")
 	}
 	if len(updated.AnnounceList) != 1 || len(updated.AnnounceList[0]) != 1 || updated.AnnounceList[0][0] != "https://new.example/announce" {
-		t.Fatalf("expected announce-list set, got %#v", updated.AnnounceList)
+		t.Fatal("expected announce-list set")
 	}
 	if updated.Comment != "https://tracker.example/torrents/123" {
 		t.Fatalf("expected tracker comment, got %q", updated.Comment)
@@ -305,7 +305,7 @@ func TestPrepareTrackerUploadTorrentCreatesSpecificArtifact(t *testing.T) {
 
 	artifact := readTestMetaInfo(t, meta.TorrentPath)
 	if artifact.Announce != "https://new.example/announce" {
-		t.Fatalf("expected announce set, got %q", artifact.Announce)
+		t.Fatal("expected announce set")
 	}
 	assertInfoSource(t, artifact, "HDBits")
 
@@ -315,7 +315,7 @@ func TestPrepareTrackerUploadTorrentCreatesSpecificArtifact(t *testing.T) {
 	}
 	cleaned := readTestMetaInfo(t, cleanBase)
 	if cleaned.Announce != "" {
-		t.Fatalf("expected clean base announce cleared, got %q", cleaned.Announce)
+		t.Fatal("expected clean base announce cleared")
 	}
 	assertInfoSource(t, cleaned, "")
 }
@@ -340,7 +340,7 @@ func TestPrepareTrackerUploadTorrentUsesDefaultAnnounce(t *testing.T) {
 	}
 	artifact := readTestMetaInfo(t, meta.TorrentPath)
 	if artifact.Announce != "https://tracker.avistaz.to/announce" {
-		t.Fatalf("expected default announce, got %q", artifact.Announce)
+		t.Fatal("expected default announce")
 	}
 	assertInfoSource(t, artifact, "AvistaZ")
 }
@@ -382,7 +382,7 @@ func TestPrepareDryRunInjectionTorrentCreatesGenericTrackerArtifact(t *testing.T
 
 	artifact := readTestMetaInfo(t, meta.TorrentPath)
 	if artifact.Announce != "https://luminarr.me/announce/passkey" {
-		t.Fatalf("expected announce set, got %q", artifact.Announce)
+		t.Fatal("expected announce set")
 	}
 	assertInfoSource(t, artifact, "LUME")
 }

--- a/internal/webserver/backend_repo_test.go
+++ b/internal/webserver/backend_repo_test.go
@@ -228,7 +228,7 @@ func TestNormalizeExportableConfigDoesNotMutateSource(t *testing.T) {
 	normalized.Trackers.DefaultTrackers[0] = "BTN"
 
 	if got := source.Trackers.Trackers["AITHER"].APIKey; got != "source-token" {
-		t.Fatalf("source tracker map mutated: got %q", got)
+		t.Fatal("source tracker map mutated")
 	}
 	if got := source.Trackers.DefaultTrackers[0]; got != "AITHER" {
 		t.Fatalf("source default tracker slice mutated: got %q", got)
@@ -376,7 +376,7 @@ func TestBackendGetConfigDatabaseConfigUsesSingleRuntimeSnapshotForDBPath(t *tes
 			t.Fatalf("expected DB-loaded screens=%d, got %d", stored.ScreenshotHandling.Screens, exported.ScreenshotHandling.Screens)
 		}
 		if exported.MainSettings.TMDBAPI != stored.MainSettings.TMDBAPI {
-			t.Fatalf("expected DB-loaded TMDB API, got %q", exported.MainSettings.TMDBAPI)
+			t.Fatal("expected DB-loaded TMDB API")
 		}
 		if exported.MainSettings.DBPath != wantDBPath {
 			t.Fatalf("DBPath fallback: got %q want %q", exported.MainSettings.DBPath, wantDBPath)
@@ -707,7 +707,7 @@ func TestBackendSaveConfigAfterInvalidStartupMigratesLegacyCookies(t *testing.T)
 		t.Fatalf("load migrated tracker cookies: %v", err)
 	}
 	if got := values["session"]; got != "from-legacy" {
-		t.Fatalf("migrated session cookie: got %q want %q", got, "from-legacy")
+		t.Fatal("migrated session cookie mismatch")
 	}
 }
 
@@ -753,7 +753,7 @@ func TestBackendSaveConfigRetriesLegacyCookieMigrationAfterAuthAppears(t *testin
 		t.Fatalf("load migrated tracker cookies: %v", err)
 	}
 	if got := values["session"]; got != "from-retry" {
-		t.Fatalf("migrated session cookie after retry: got %q want %q", got, "from-retry")
+		t.Fatal("migrated session cookie after retry mismatch")
 	}
 }
 

--- a/internal/webserver/base_path.go
+++ b/internal/webserver/base_path.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"path" //nolint:depguard // Normalizes URL route paths, not local filesystem paths.
+	"slices"
 	"strings"
 
 	"github.com/autobrr/upbrr/internal/redaction"
@@ -134,12 +135,7 @@ func redactURLUserinfo(value string) string {
 }
 
 func hasUnsafeBaseURLPathSegment(pathValue string) bool {
-	for _, segment := range strings.Split(strings.ReplaceAll(pathValue, `\`, "/"), "/") {
-		if segment == ".." {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(strings.Split(strings.ReplaceAll(pathValue, `\`, "/"), "/"), "..")
 }
 
 // externalBasePath derives the externally visible route prefix from baseURL.

--- a/internal/webserver/routes_auth_test.go
+++ b/internal/webserver/routes_auth_test.go
@@ -928,7 +928,7 @@ func TestTrackerAuthDeleteCanceledContextDoesNotDeleteCookies(t *testing.T) {
 		t.Fatalf("LoadTrackerCookieMap: %v", loadErr)
 	}
 	if values["session"] != "abc" {
-		t.Fatalf("canceled delete changed cookies: %#v", values)
+		t.Fatal("canceled delete changed cookies")
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redaction of sensitive values in errors, logs, browser-visible output, and failure artifacts.
  * Safer handling of non-success HTTP responses now redacts and uses a bounded preview payload across metadata/services and tracker uploads.
  * Prevented leaking secrets through unbounded response reads in tracker auth flows.
* **New Features**
  * Frontend now recognizes encrypted-secret “envelopes” and masks them as `[REDACTED]` while preserving the underlying value for saves.
* **Documentation**
  * Expanded logging level and sensitive-output guidance for CLI/GUI and internal contributors.
* **Tests**
  * Simplified assertion/failure messages to avoid printing sensitive values; added/extended log policy validation coverage.
* **Chores**
  * Updated ignore rules to exclude `docs/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->