### PR TITLE
fix(gui): preserve pathed dupe tracker status

### DIFF
--- a/internal/guiapp/dupe_jobs.go
+++ b/internal/guiapp/dupe_jobs.go
@@ -206,27 +206,26 @@ func (a *App) runDupeCheckJob(ctx context.Context, eventCtx context.Context, job
 
 	job.summary = summary
 	for _, result := range summary.Results {
-		tracker := strings.ToUpper(strings.TrimSpace(result.Tracker))
-		if tracker == "" {
-			continue
+		for _, tracker := range dupeResultTrackerNames(result) {
+			state := job.states[tracker]
+			if state.Tracker == "" {
+				state.Tracker = tracker
+				job.trackers = append(job.trackers, tracker)
+				job.totalCount++
+			}
+			if !isDupeTerminalStatus(state.Status) {
+				job.completedCount++
+			}
+			state.Status = resultStatus(result)
+			state.Message = resultMessage(result)
+			state.Result = result
+			state.Result.Tracker = tracker
+			if state.StartedAt == "" {
+				state.StartedAt = job.startedAt.Format(time.RFC3339)
+			}
+			state.FinishedAt = job.finishedAt.Format(time.RFC3339)
+			job.states[tracker] = state
 		}
-		state := job.states[tracker]
-		if state.Tracker == "" {
-			state.Tracker = tracker
-			job.trackers = append(job.trackers, tracker)
-			job.totalCount++
-		}
-		if !isDupeTerminalStatus(state.Status) {
-			job.completedCount++
-		}
-		state.Status = resultStatus(result)
-		state.Message = resultMessage(result)
-		state.Result = result
-		if state.StartedAt == "" {
-			state.StartedAt = job.startedAt.Format(time.RFC3339)
-		}
-		state.FinishedAt = job.finishedAt.Format(time.RFC3339)
-		job.states[tracker] = state
 	}
 
 	if hasFailedDupeState(job.states) {
@@ -315,6 +314,26 @@ func upsertDupeSummaryResult(summary *api.DupeCheckSummary, result api.DupeCheck
 		return
 	}
 	summary.Results = append(summary.Results, result)
+}
+
+// dupeResultTrackerNames expands grouped dupe summary labels into the
+// per-tracker state keys used by frontend snapshots.
+func dupeResultTrackerNames(result api.DupeCheckResult) []string {
+	trackers := strings.Split(result.Tracker, ",")
+	names := make([]string, 0, len(trackers))
+	seen := make(map[string]struct{}, len(trackers))
+	for _, tracker := range trackers {
+		name := strings.ToUpper(strings.TrimSpace(tracker))
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	return names
 }
 
 func hasFailedDupeState(states map[string]DupeCheckTrackerState) bool {

--- a/internal/guiapp/run_options_test.go
+++ b/internal/guiapp/run_options_test.go
@@ -42,6 +42,7 @@ type closeCounterCore struct {
 	importedMeta api.PreparedMetadata
 	importedReq  api.Request
 	fetchReq     api.Request
+	dupeSummary  api.DupeCheckSummary
 	uploads      []uploadPreparedResponse
 	uploadCalls  int
 }
@@ -90,7 +91,7 @@ func (c *closeCounterCore) FetchTrackerDryRunPreview(context.Context, api.Reques
 }
 
 func (c *closeCounterCore) CheckDupes(context.Context, api.Request) (api.DupeCheckSummary, error) {
-	return api.DupeCheckSummary{}, nil
+	return c.dupeSummary, nil
 }
 
 func (c *closeCounterCore) BuildUploadReview(context.Context, api.Request) (api.UploadReview, error) {
@@ -569,6 +570,43 @@ func TestRunTrackerUploadJobCountsPartialErrorAndContinues(t *testing.T) {
 	}
 }
 
+func TestRunDupeCheckJobSplitsGroupedPathedResultsIntoTrackerStates(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &closeCounterCore{dupeSummary: api.DupeCheckSummary{
+		SourcePath: `C:\Media\Movie.mkv`,
+		Results: []api.DupeCheckResult{
+			{
+				Tracker:  "AITHER, BLU",
+				HasDupes: true,
+				Status:   "completed",
+				Notes:    []string{"pathed torrent match found; skipping dupe search"},
+			},
+			{Tracker: "RF", Status: "completed"},
+		},
+	}}
+	job := newDupeCheckJobTestJob(coreSvc.dupeSummary.SourcePath, []string{"AITHER", "BLU", "RF"})
+	app := &App{core: coreSvc}
+
+	app.runDupeCheckJob(context.Background(), nil, job)
+
+	if got := job.completedCount; got != 3 {
+		t.Fatalf("expected all trackers completed, got %d", got)
+	}
+	if _, ok := job.states["AITHER, BLU"]; ok {
+		t.Fatal("did not expect grouped tracker state")
+	}
+	for _, tracker := range []string{"AITHER", "BLU"} {
+		state := job.states[tracker]
+		if got := state.Status; got != "completed" {
+			t.Fatalf("expected %s completed, got %q", tracker, got)
+		}
+		if got := state.Result.Tracker; got != tracker {
+			t.Fatalf("expected %s result tracker, got %q", tracker, got)
+		}
+	}
+}
+
 func TestRunTrackerUploadJobIgnoresNegativeUploadedCount(t *testing.T) {
 	app := &App{}
 	coreSvc := &closeCounterCore{uploads: []uploadPreparedResponse{
@@ -689,6 +727,22 @@ func newTrackerUploadJobTestJob(coreSvc api.Core, trackers []string) *trackerUpl
 	}
 	for _, tracker := range trackers {
 		job.states[tracker] = TrackerUploadTrackerState{Tracker: tracker, Status: "queued", Message: "queued"}
+	}
+	return job
+}
+
+func newDupeCheckJobTestJob(sourcePath string, trackers []string) *dupeCheckJob {
+	job := &dupeCheckJob{
+		id:         "dupe-job",
+		sourcePath: sourcePath,
+		trackers:   trackers,
+		states:     make(map[string]DupeCheckTrackerState, len(trackers)),
+		totalCount: len(trackers),
+		status:     "queued",
+		startedAt:  time.Now().UTC(),
+	}
+	for _, tracker := range trackers {
+		job.states[tracker] = DupeCheckTrackerState{Tracker: tracker, Status: "queued", Message: "queued"}
 	}
 	return job
 }

--- a/internal/webserver/jobs.go
+++ b/internal/webserver/jobs.go
@@ -334,20 +334,22 @@ func (b *Backend) runDupeCheckJob(ctx context.Context, job *dupeCheckJob) {
 	}
 	job.summary = summary
 	for _, result := range summary.Results {
-		tracker := strings.ToUpper(strings.TrimSpace(result.Tracker))
-		state := job.states[tracker]
-		if !isDupeTerminalStatus(state.Status) {
-			job.completedCount++
+		for _, tracker := range dupeResultTrackerNames(result) {
+			state := job.states[tracker]
+			if !isDupeTerminalStatus(state.Status) {
+				job.completedCount++
+			}
+			state.Tracker = tracker
+			state.Status = resultStatus(result)
+			state.Message = resultMessage(result)
+			state.Result = result
+			state.Result.Tracker = tracker
+			if state.StartedAt == "" {
+				state.StartedAt = job.startedAt.Format(time.RFC3339)
+			}
+			state.FinishedAt = job.finishedAt.Format(time.RFC3339)
+			job.states[tracker] = state
 		}
-		state.Tracker = tracker
-		state.Status = resultStatus(result)
-		state.Message = resultMessage(result)
-		state.Result = result
-		if state.StartedAt == "" {
-			state.StartedAt = job.startedAt.Format(time.RFC3339)
-		}
-		state.FinishedAt = job.finishedAt.Format(time.RFC3339)
-		job.states[tracker] = state
 	}
 	if hasFailedDupeState(job.states) {
 		job.status = "completed_with_errors"
@@ -760,6 +762,26 @@ func upsertDupeSummaryResult(summary *api.DupeCheckSummary, result api.DupeCheck
 		}
 	}
 	summary.Results = append(summary.Results, result)
+}
+
+// dupeResultTrackerNames expands grouped dupe summary labels into the
+// per-tracker state keys used by frontend snapshots.
+func dupeResultTrackerNames(result api.DupeCheckResult) []string {
+	trackers := strings.Split(result.Tracker, ",")
+	names := make([]string, 0, len(trackers))
+	seen := make(map[string]struct{}, len(trackers))
+	for _, tracker := range trackers {
+		name := strings.ToUpper(strings.TrimSpace(tracker))
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	return names
 }
 
 func hasFailedDupeState(states map[string]DupeCheckTrackerState) bool {

--- a/internal/webserver/jobs_test.go
+++ b/internal/webserver/jobs_test.go
@@ -21,6 +21,7 @@ type preparedMetaTestCore struct {
 	importedMeta api.PreparedMetadata
 	importedReq  api.Request
 	fetchReq     api.Request
+	dupeSummary  api.DupeCheckSummary
 	uploads      []uploadPreparedResponse
 	uploadCalls  int
 }
@@ -65,7 +66,7 @@ func (c *preparedMetaTestCore) FetchTrackerDryRunPreview(context.Context, api.Re
 }
 
 func (c *preparedMetaTestCore) CheckDupes(context.Context, api.Request) (api.DupeCheckSummary, error) {
-	return api.DupeCheckSummary{}, nil
+	return c.dupeSummary, nil
 }
 
 func (c *preparedMetaTestCore) BuildUploadReview(context.Context, api.Request) (api.UploadReview, error) {
@@ -363,6 +364,44 @@ func TestRunTrackerUploadJobCountsPartialErrorAndContinues(t *testing.T) {
 	}
 }
 
+func TestRunDupeCheckJobSplitsGroupedPathedResultsIntoTrackerStates(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &preparedMetaTestCore{dupeSummary: api.DupeCheckSummary{
+		SourcePath: `C:\Media\Movie.mkv`,
+		Results: []api.DupeCheckResult{
+			{
+				Tracker:  "AITHER, BLU",
+				HasDupes: true,
+				Status:   "completed",
+				Notes:    []string{"pathed torrent match found; skipping dupe search"},
+			},
+			{Tracker: "RF", Status: "completed"},
+		},
+	}}
+	job := newDupeCheckJobTestJob("session-a", coreSvc.dupeSummary.SourcePath, []string{"AITHER", "BLU", "RF"})
+	backend := &Backend{core: coreSvc, hub: newEventHub()}
+	backend.dupeWG.Add(1)
+
+	backend.runDupeCheckJob(context.Background(), job)
+
+	if got := job.completedCount; got != 3 {
+		t.Fatalf("expected all trackers completed, got %d", got)
+	}
+	if _, ok := job.states["AITHER, BLU"]; ok {
+		t.Fatal("did not expect grouped tracker state")
+	}
+	for _, tracker := range []string{"AITHER", "BLU"} {
+		state := job.states[tracker]
+		if got := state.Status; got != "completed" {
+			t.Fatalf("expected %s completed, got %q", tracker, got)
+		}
+		if got := state.Result.Tracker; got != tracker {
+			t.Fatalf("expected %s result tracker, got %q", tracker, got)
+		}
+	}
+}
+
 func TestRunTrackerUploadJobIgnoresNegativeUploadedCount(t *testing.T) {
 	backend := &Backend{hub: newEventHub()}
 	coreSvc := &preparedMetaTestCore{uploads: []uploadPreparedResponse{
@@ -644,6 +683,23 @@ func newTrackerUploadJobTestJob(coreSvc api.Core, trackers []string) *trackerUpl
 	}
 	for _, tracker := range trackers {
 		job.states[tracker] = TrackerUploadTrackerState{Tracker: tracker, Status: "queued", Message: "queued"}
+	}
+	return job
+}
+
+func newDupeCheckJobTestJob(sessionID string, sourcePath string, trackers []string) *dupeCheckJob {
+	job := &dupeCheckJob{
+		sessionID:  sessionID,
+		id:         "dupe-job",
+		sourcePath: sourcePath,
+		trackers:   trackers,
+		states:     make(map[string]DupeCheckTrackerState, len(trackers)),
+		totalCount: len(trackers),
+		status:     "queued",
+		startedAt:  time.Now().UTC(),
+	}
+	for _, tracker := range trackers {
+		job.states[tracker] = DupeCheckTrackerState{Tracker: tracker, Status: "queued", Message: "queued"}
 	}
 	return job
 }


### PR DESCRIPTION
## Summary

- Expand grouped pathed dupe-check results back into individual tracker job states for Wails GUI and embedded web snapshots.
- Preserve per-tracker `Result.Tracker` values so frontend status, availability, and upload eligibility see each tracker as completed/in-client.
- Add GUI and web regressions for grouped pathed results like `AITHER, BLU`.

## Root cause

The regression became visible after `88f671d9` (`fix(trackers): enforce MediaInfo encode settings for all UNIT3D trackers`, PR #148). That PR also brought in the frontend grouped-dupe display changes that prefer per-tracker job snapshot results over compact `DupeCheckSummary.Results` rows.

Core already grouped existing-client matches into a comma-labeled pathed result (`AITHER, BLU`) for compact display. The backend job finalizers did not split that grouped result back into the individual tracker state keys used by snapshots, so the frontend saw the real tracker rows as queued/missing and lost their existing-in-client status.

## Validation

- `go test ./internal/guiapp ./internal/webserver -run "TestRunDupeCheckJobSplitsGroupedPathedResultsIntoTrackerStates" -count=1`
- `go test -race -v -timeout 20m ./internal/guiapp ./internal/webserver ./internal/guishared ./pkg/api`
- `git diff --check`
- `make gofix-check-changed`
- `make lint`
- pre-commit hook: Go format, logpolicy, pathpolicy
- pre-push hook: go lint