### PR TITLE
fix: strip trailing tvdb title year before applying searchyear

### DIFF
--- a/internal/metadata/naming.go
+++ b/internal/metadata/naming.go
@@ -93,6 +93,7 @@ func BuildReleaseName(req api.ReleaseNameRequest, logger api.Logger) api.Release
 	if category == "TV" {
 		searchYear := strings.TrimSpace(req.SearchYear)
 		if parsedYear, err := strconv.Atoi(searchYear); err == nil && parsedYear > 0 {
+			title = trimTrailingParentheticalYear(title, parsedYear)
 			year = parsedYear
 		} else {
 			year = 0
@@ -263,6 +264,7 @@ func releaseNameRequestFromMeta(meta api.PreparedMetadata, logger api.Logger) ap
 	title, altTitle, year := resolveReleaseNameTitle(category, meta)
 	searchYear := ""
 	if strings.EqualFold(category, "TV") && year > 0 {
+		title = trimTrailingParentheticalYear(title, year)
 		searchYear = strconv.Itoa(year)
 	}
 	tvdbYearSource := ""
@@ -372,6 +374,18 @@ func resolveReleaseNameTitle(category string, meta api.PreparedMetadata) (string
 		}
 	}
 	return title, altTitle, year
+}
+
+func trimTrailingParentheticalYear(title string, year int) string {
+	trimmed := strings.TrimSpace(title)
+	if year <= 0 {
+		return trimmed
+	}
+	suffix := "(" + strconv.Itoa(year) + ")"
+	if !strings.HasSuffix(trimmed, suffix) {
+		return trimmed
+	}
+	return strings.TrimSpace(strings.TrimSuffix(trimmed, suffix))
 }
 
 func inferReleaseTypeFromName(path string) string {

--- a/internal/metadata/naming_test.go
+++ b/internal/metadata/naming_test.go
@@ -417,6 +417,43 @@ func TestReleaseNameRequestFromMetaTVSearchYearComesFromTVDB(t *testing.T) {
 	}
 }
 
+func TestReleaseNameRequestFromMetaTVStripsBracketedTVDBYear(t *testing.T) {
+	sourceName := "Example.Show.2024.S01.720p.NF.WEB-DL.DDP5.1.x264-GRP"
+	meta := api.PreparedMetadata{
+		SourcePath:  sourceName,
+		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		Type:        "WEBDL",
+		Source:      "Web",
+		Audio:       "DD+ 5.1 Atmos",
+		VideoEncode: "H.264",
+		Service:     "NF",
+		SeasonStr:   "S01",
+		TVPack:      true,
+		Release: api.ReleaseInfo{
+			Title:      "Example Show",
+			Year:       2024,
+			Resolution: "720p",
+		},
+		ExternalMetadata: api.ExternalMetadata{
+			TVDB: &api.TVDBMetadata{NameEnglish: "Example Show (2024)", Year: 2024, YearFromAlias: true},
+		},
+		Tag: "-GRP",
+	}
+
+	req := releaseNameRequestFromMeta(meta, api.NopLogger{})
+	if req.Title != "Example Show" {
+		t.Fatalf("expected bracketed year stripped from tvdb title, got %q", req.Title)
+	}
+	if req.SearchYear != "2024" {
+		t.Fatalf("expected tv search year, got %q", req.SearchYear)
+	}
+	result := BuildReleaseName(req, api.NopLogger{})
+	expected := "Example Show 2024 S01 720p NF WEB-DL DD+ 5.1 Atmos H.264-GRP"
+	if result.Name != expected {
+		t.Fatalf("expected release name %q, got %q", expected, result.Name)
+	}
+}
+
 func TestReleaseNameRequestFromMetaTVOmitsSearchYearWhenTVDBYearNotAliasDerived(t *testing.T) {
 	meta := api.PreparedMetadata{
 		SourcePath:  `D:\Shows\Example.Show.S01E01.1080p.BluRay.x264`,
@@ -482,6 +519,26 @@ func TestBuildReleaseNameTVUsesSearchYearOverRequestYear(t *testing.T) {
 	}
 	if strings.Contains(result.NameNoTag, "1999") {
 		t.Fatalf("expected tv release name to ignore request year when search year is set, got %q", result.NameNoTag)
+	}
+}
+
+func TestBuildReleaseNameTVStripsDuplicateParentheticalSearchYear(t *testing.T) {
+	result := BuildReleaseName(api.ReleaseNameRequest{
+		Category:    "TV",
+		Type:        "WEBDL",
+		Title:       "Example Show (2024)",
+		SearchYear:  "2024",
+		Season:      "S01",
+		Resolution:  "1080p",
+		Service:     "NF",
+		Audio:       "AAC 2.0",
+		VideoEncode: "H.264",
+		Tag:         "-GRP",
+	}, api.NopLogger{})
+
+	expected := "Example Show 2024 S01 1080p NF WEB-DL AAC 2.0 H.264-GRP"
+	if result.Name != expected {
+		t.Fatalf("expected release name %q, got %q", expected, result.Name)
 	}
 }
 


### PR DESCRIPTION
Addresses further discussion in https://github.com/autobrr/upbrr/issues/155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TV release naming so titles no longer include duplicate year suffixes.
  * When a TV title already includes a year in parentheses, the final release name now keeps the year only once in the expected place.
  * Release name generation now handles TV metadata more cleanly, producing more consistent and readable names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->