### PR TITLE
feat(metadata): srrdb imdb: scene detection + canonical-name rename detection

### DIFF
--- a/gui/frontend/src/hooks/useSettingsState.tsx
+++ b/gui/frontend/src/hooks/useSettingsState.tsx
@@ -753,6 +753,7 @@ const sectionFieldMeta: Record<string, Record<string, FieldMeta>> = {
     InputHistoryLimit: { key: "InputHistoryLimit", label: "Input history limit", type: "number" },
     UseFavicons: { key: "UseFavicons", label: "Use favicons" },
     FaviconOnly: { key: "FaviconOnly", label: "Favicon only" },
+    SceneDetection: { key: "SceneDetection", label: "Scene detection (srrdb)" },
   },
   Metadata: {
     BTNAPI: { key: "BTNAPI", advanced: true, sensitive: true },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ type MainSettingsConfig struct {
 	DBPath              string `yaml:"db_path"`
 	UseFavicons         bool   `yaml:"use_favicons"`
 	FaviconOnly         bool   `yaml:"favicon_only"`
+	SceneDetection      bool   `yaml:"scene_detection"`
 }
 
 type mainSettingsConfigAlias MainSettingsConfig
@@ -57,6 +58,7 @@ func (c *MainSettingsConfig) UnmarshalYAML(value *yaml.Node) error {
 	var raw mainSettingsConfigAlias
 	raw.InputHistoryLimit = DefaultInputHistoryLimit
 	raw.UseFavicons = true
+	raw.SceneDetection = true
 	if err := value.Decode(&raw); err != nil {
 		return fmt.Errorf("config: decode main settings yaml: %w", err)
 	}
@@ -68,6 +70,7 @@ func (c *MainSettingsConfig) UnmarshalJSON(data []byte) error {
 	var raw mainSettingsConfigAlias
 	raw.InputHistoryLimit = DefaultInputHistoryLimit
 	raw.UseFavicons = true
+	raw.SceneDetection = true
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return fmt.Errorf("config: decode main settings json: %w", err)
 	}

--- a/internal/config/defaults/example.yaml
+++ b/internal/config/defaults/example.yaml
@@ -5,6 +5,7 @@ main_settings:
   tracker_pass_checks: 1
   input_history_limit: 20
   db_path: ""
+  scene_detection: true
 
 image_hosting:
   img_host_1: ""

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -186,12 +186,67 @@ func (s *Service) ApplyMediaDetails(ctx context.Context, meta api.PreparedMetada
 	ApplyRequestScopedAudioPolicy(&meta, s.cfg, s.logger)
 	RebuildReleaseName(&meta, s.logger)
 
+	// Scene detection runs here — after external IDs are resolved and the release
+	// name is rebuilt — so the srrdb imdb: lookup has a resolved IMDb id and full
+	// normalized metadata, and so rename/scene fields are populated before tracker
+	// rules (which read meta.Scene / meta.SceneNFOPath / meta.SceneRenamed).
+	meta = s.applySceneDetection(ctx, meta)
+
 	meta, err = s.applyTrackerRules(ctx, meta)
 	if err != nil {
 		return api.PreparedMetadata{}, err
 	}
 
 	return meta, nil
+}
+
+// applySceneDetection runs srrdb scene/rename detection and copies the result
+// onto meta. It is strictly best-effort: srrdb being slow or down, or any
+// non-cancellation error, never fails ApplyMediaDetails. Detection is gated by
+// config (scene_detection) via a nil detector.
+func (s *Service) applySceneDetection(ctx context.Context, meta api.PreparedMetadata) api.PreparedMetadata {
+	if s.scene == nil {
+		return meta
+	}
+	result, err := s.scene.Detect(ctx, meta)
+	if err != nil {
+		switch {
+		case isSceneNFOError(err):
+			if s.logger != nil {
+				s.logger.Warnf("metadata: scene nfo side effect failed: %v", err)
+			}
+			// The primary match may still be present alongside a recoverable NFO
+			// side-effect error; apply it when it carries data.
+			if !sceneResultHasData(result) {
+				return meta
+			}
+		default:
+			// Context cancellation or any transient failure: skip scene, never block.
+			if s.logger != nil {
+				s.logger.Debugf("metadata: scene detect skipped: %v", err)
+			}
+			return meta
+		}
+	}
+	applySceneResult(&meta, result)
+	// Detection now runs after ID resolution, so backfill a scene-discovered IMDb
+	// id only when resolution found none, so upload payloads still carry it.
+	if meta.ExternalIDs.IMDBID == 0 && result.IMDBID > 0 {
+		meta.ExternalIDs.IMDBID = result.IMDBID
+	}
+	if s.logger != nil {
+		if meta.Scene {
+			s.logger.Debugf("metadata: scene release detected name=%q imdb=%d renamed=%t", meta.SceneName, meta.SceneIMDB, meta.SceneRenamed)
+		}
+		if meta.SceneNFOPath != "" {
+			if meta.SceneNFONew {
+				s.logger.Debugf("metadata: scene nfo downloaded %s", meta.SceneNFOPath)
+			} else {
+				s.logger.Debugf("metadata: scene nfo found %s", meta.SceneNFOPath)
+			}
+		}
+	}
+	return meta
 }
 
 // ApplyTrackerClaims refreshes claim-based tracker blocks after media details

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -21,6 +21,7 @@ import (
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	"github.com/autobrr/upbrr/internal/paths"
 	"github.com/autobrr/upbrr/internal/pathutil"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
@@ -190,7 +191,13 @@ func (s *Service) ApplyMediaDetails(ctx context.Context, meta api.PreparedMetada
 	// name is rebuilt — so the srrdb imdb: lookup has a resolved IMDb id and full
 	// normalized metadata, and so rename/scene fields are populated before tracker
 	// rules (which read meta.Scene / meta.SceneNFOPath / meta.SceneRenamed).
-	meta = s.applySceneDetection(ctx, meta)
+	meta, err = s.applySceneDetection(ctx, meta)
+	if err != nil {
+		return api.PreparedMetadata{}, err
+	}
+	// Scene detection can supply the service (from the NFO), which WEB release
+	// names embed, so rebuild once more to fold in scene-derived metadata.
+	RebuildReleaseName(&meta, s.logger)
 
 	meta, err = s.applyTrackerRules(ctx, meta)
 	if err != nil {
@@ -201,31 +208,34 @@ func (s *Service) ApplyMediaDetails(ctx context.Context, meta api.PreparedMetada
 }
 
 // applySceneDetection runs srrdb scene/rename detection and copies the result
-// onto meta. It is strictly best-effort: srrdb being slow or down, or any
-// non-cancellation error, never fails ApplyMediaDetails. Detection is gated by
-// config (scene_detection) via a nil detector.
-func (s *Service) applySceneDetection(ctx context.Context, meta api.PreparedMetadata) api.PreparedMetadata {
+// onto meta. It is best-effort for transient srrdb/network failures (skip scene,
+// never block the upload), but context cancellation/deadline is propagated so the
+// pipeline aborts rather than continuing into tracker rules. Detection is gated
+// by config (scene_detection) via a nil detector.
+func (s *Service) applySceneDetection(ctx context.Context, meta api.PreparedMetadata) (api.PreparedMetadata, error) {
 	if s.scene == nil {
-		return meta
+		return meta, nil
 	}
 	result, err := s.scene.Detect(ctx, meta)
 	if err != nil {
 		switch {
+		case isContextError(ctx, err):
+			return meta, fmt.Errorf("metadata: scene detect: %w", err)
 		case isSceneNFOError(err):
 			if s.logger != nil {
-				s.logger.Warnf("metadata: scene nfo side effect failed: %v", err)
+				s.logger.Warnf("metadata: scene nfo side effect failed: %s", redaction.RedactValue(err.Error(), nil))
 			}
 			// The primary match may still be present alongside a recoverable NFO
 			// side-effect error; apply it when it carries data.
 			if !sceneResultHasData(result) {
-				return meta
+				return meta, nil
 			}
 		default:
-			// Context cancellation or any transient failure: skip scene, never block.
+			// Transient srrdb/network failure: skip scene, never block the upload.
 			if s.logger != nil {
-				s.logger.Debugf("metadata: scene detect skipped: %v", err)
+				s.logger.Debugf("metadata: scene detect skipped: %s", redaction.RedactValue(err.Error(), nil))
 			}
-			return meta
+			return meta, nil
 		}
 	}
 	applySceneResult(&meta, result)
@@ -246,7 +256,7 @@ func (s *Service) applySceneDetection(ctx context.Context, meta api.PreparedMeta
 			}
 		}
 	}
-	return meta
+	return meta, nil
 }
 
 // ApplyTrackerClaims refreshes claim-based tracker blocks after media details

--- a/internal/metadata/scene.go
+++ b/internal/metadata/scene.go
@@ -208,9 +208,17 @@ func (d *srrdbDetector) Detect(ctx context.Context, meta api.PreparedMetadata) (
 	// Detection now runs after external-ID resolution (ApplyMediaDetails), so a
 	// resolved IMDb id is normally available. The IMDb-keyed search returns the
 	// full scene release set for the title regardless of filename, which is the
-	// robust primary path; the exact r: search is only a no-IMDb fallback.
+	// robust primary path. If it yields no confident match (e.g. truncated results
+	// or srrdb not keying the release to this id), fall through to the exact r:
+	// search, which is also the fallback when no IMDb id is known.
 	if imdbID := sceneIMDbID(meta); imdbID > 0 {
-		return d.detectViaIMDB(ctx, meta, cands, imdbID)
+		result, err := d.detectViaIMDB(ctx, meta, cands, imdbID)
+		if err != nil {
+			return result, err
+		}
+		if result.IsScene {
+			return result, nil
+		}
 	}
 	return d.detectViaR(ctx, cands)
 }
@@ -760,9 +768,12 @@ func (d *srrdbDetector) fetchIMDB(ctx context.Context, release string) (srrdbIMD
 const (
 	// srrdbIMDBPageSize is the observed per-page cap of the imdb: search.
 	srrdbIMDBPageSize = 40
-	// srrdbIMDBMaxPages bounds the imdb: fan-out so a title with a very large
-	// release history can never trigger an unbounded number of requests.
-	srrdbIMDBMaxPages = 5
+	// srrdbIMDBMaxPages is a safety backstop on the imdb: fan-out. Pagination
+	// normally stops naturally once resultsCount is collected; this only bounds a
+	// pathological response. It is set well above any real title's scene release
+	// count (the largest observed are well under 100) so completeness is not the
+	// limiting factor — 25 pages = 1000 releases.
+	srrdbIMDBMaxPages = 25
 )
 
 // sceneIMDbID returns the resolved IMDb id on meta in precedence order. Detection

--- a/internal/metadata/scene.go
+++ b/internal/metadata/scene.go
@@ -48,6 +48,12 @@ type SceneResult struct {
 	NFOPath string
 	// NFONew reports whether NFOPath was downloaded during this detection run.
 	NFONew bool
+	// Renamed reports that a scene release was identified via the imdb: fallback
+	// (the exact r: name missed) and the on-disk basename differs from the
+	// canonical scene media filename, i.e. the release was renamed/modified.
+	Renamed bool
+	// RenamedReason is an operator-facing explanation set when Renamed is true.
+	RenamedReason string
 }
 
 type sceneNFOError struct {
@@ -82,6 +88,7 @@ type srrdbDetector struct {
 	baseURL  string
 	cacheDir string
 	nfoDir   string
+	logger   api.Logger
 }
 
 func newSRRDBDetector(client *http.Client, baseURL, cacheDir, nfoDir string) *srrdbDetector {
@@ -96,7 +103,25 @@ func newSRRDBDetector(client *http.Client, baseURL, cacheDir, nfoDir string) *sr
 		baseURL:  baseURL,
 		cacheDir: strings.TrimSpace(cacheDir),
 		nfoDir:   strings.TrimSpace(nfoDir),
+		logger:   api.NopLogger{},
 	}
+}
+
+// log returns a non-nil logger for decision/diagnostic output.
+func (d *srrdbDetector) log() api.Logger {
+	if d.logger == nil {
+		return api.NopLogger{}
+	}
+	return d.logger
+}
+
+// srrdbUserAgent identifies upbrr to srrdb (which sends no rate-limit headers and
+// asks callers not to scrape); a descriptive agent keeps us a good citizen.
+const srrdbUserAgent = "upbrr/scene-detector (+https://github.com/autobrr/upbrr)"
+
+// setSRRDBHeaders applies the shared User-Agent to every srrdb request.
+func setSRRDBHeaders(req *http.Request) {
+	req.Header.Set("User-Agent", srrdbUserAgent)
 }
 
 func (d *srrdbDetector) Detect(ctx context.Context, meta api.PreparedMetadata) (SceneResult, error) {
@@ -110,10 +135,18 @@ func (d *srrdbDetector) Detect(ctx context.Context, meta api.PreparedMetadata) (
 	if err != nil {
 		return SceneResult{}, fmt.Errorf("scene: build request: %w", err)
 	}
+	setSRRDBHeaders(req)
 
 	resp, err := d.client.Do(req)
 	if err != nil {
-		return SceneResult{}, fmt.Errorf("scene: srrdb request: %w", err)
+		// srrdb being unreachable/slow must never block an upload, so soft-fail the
+		// r: search the same way the imdb: fallback does. Context cancellation still
+		// propagates as fatal.
+		if isContextError(ctx, err) {
+			return SceneResult{}, fmt.Errorf("scene: srrdb request: %w", err)
+		}
+		d.log().Debugf("metadata: scene r: search soft-failed: %v", err)
+		return SceneResult{}, nil
 	}
 	defer resp.Body.Close()
 
@@ -123,14 +156,32 @@ func (d *srrdbDetector) Detect(ctx context.Context, meta api.PreparedMetadata) (
 
 	var payload srrdbResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		return SceneResult{}, fmt.Errorf("scene: decode response: %w", err)
-	}
-
-	if payload.ResultsCount <= 0 || len(payload.Results) == 0 {
+		// A truncated/malformed body is a transient srrdb failure, not an
+		// upload-blocking condition; soft-fail unless the context was cancelled.
+		if isContextError(ctx, err) {
+			return SceneResult{}, fmt.Errorf("scene: decode response: %w", err)
+		}
+		d.log().Debugf("metadata: scene r: decode soft-failed: %v", err)
 		return SceneResult{}, nil
 	}
 
-	result := payload.Results[0]
+	if payload.ResultsCount <= 0 || len(payload.Results) == 0 {
+		// The exact dotted-name search missed. A renamed/modified scene release
+		// deviates from its canonical name, so fall back to an IMDb-keyed lookup
+		// (independent of filename) and match locally. Stays entirely soft: srrdb
+		// being unreachable or returning nothing must never block an upload.
+		return d.detectViaIMDB(ctx, meta, base)
+	}
+
+	// The exact r: name matched, so the on-disk name is already canonical (case
+	// differences aside) and is by definition not renamed.
+	return d.buildSceneResult(ctx, payload.Results[0], false, "")
+}
+
+// buildSceneResult turns a matched srrdb release into a SceneResult, resolving the
+// IMDb id and attaching the NFO/external IDs exactly as the r: path always has.
+// renamed/renamedReason carry the imdb: fallback's canonical-name verdict.
+func (d *srrdbDetector) buildSceneResult(ctx context.Context, result srrdbSearchResult, renamed bool, renamedReason string) (SceneResult, error) {
 	imdbID := parseSRRDBIMDbID(result.IMDBID)
 	if imdbID == 0 {
 		if details, err := d.fetchIMDB(ctx, result.Release); err == nil {
@@ -139,9 +190,11 @@ func (d *srrdbDetector) Detect(ctx context.Context, meta api.PreparedMetadata) (
 	}
 
 	scene := SceneResult{
-		IsScene:   true,
-		SceneName: strings.TrimSpace(result.Release),
-		IMDBID:    imdbID,
+		IsScene:       true,
+		SceneName:     strings.TrimSpace(result.Release),
+		IMDBID:        imdbID,
+		Renamed:       renamed,
+		RenamedReason: renamedReason,
 	}
 	if strings.EqualFold(result.HasNFO, "yes") {
 		path, downloaded, err := d.fetchNFO(ctx, result.Release)
@@ -171,6 +224,60 @@ func (d *srrdbDetector) Detect(ctx context.Context, meta api.PreparedMetadata) (
 	return scene, nil
 }
 
+// detectViaIMDB is the renamed-release fallback: keyed off an already-known IMDb
+// id, it lists every scene release for the title, score-matches the best
+// candidate against the parsed release tokens, then compares the canonical media
+// filename to the on-disk basename to flag a rename. It is strictly best-effort —
+// every failure path returns a no-match (except context cancellation), never an
+// error that could block an upload.
+func (d *srrdbDetector) detectViaIMDB(ctx context.Context, meta api.PreparedMetadata, localBase string) (SceneResult, error) {
+	imdbID := sceneIMDbID(meta)
+	if imdbID == 0 {
+		return SceneResult{}, nil
+	}
+
+	releases, err := d.fetchIMDBReleases(ctx, imdbID)
+	if err != nil {
+		if isContextError(ctx, err) {
+			return SceneResult{}, err
+		}
+		d.log().Debugf("metadata: scene imdb fallback soft-failed imdb=%d: %v", imdbID, err)
+		return SceneResult{}, nil
+	}
+	if len(releases) == 0 {
+		return SceneResult{}, nil
+	}
+
+	best, score := bestSceneCandidate(meta, localBase, releases)
+	if best == nil {
+		d.log().Debugf("metadata: scene imdb fallback no confident candidate imdb=%d candidates=%d", imdbID, len(releases))
+		return SceneResult{}, nil
+	}
+	d.log().Debugf("metadata: scene imdb fallback matched imdb=%d candidates=%d release=%q score=%d", imdbID, len(releases), best.Release, score)
+
+	renamed, reason := d.detectRename(ctx, best.Release, localBase)
+	if renamed {
+		d.log().Infof("metadata: scene release renamed imdb=%d release=%q", imdbID, best.Release)
+	}
+	return d.buildSceneResult(ctx, *best, renamed, reason)
+}
+
+// detectRename compares the canonical media filename(s) recorded for a scene
+// release against the on-disk basename. It is conservative: a name that matches
+// any canonical media file (case differences tolerated, like srrdb's r: search),
+// or any inability to read the release details, yields "not renamed".
+func (d *srrdbDetector) detectRename(ctx context.Context, release, localBase string) (bool, string) {
+	details, err := d.fetchDetails(ctx, release)
+	if err != nil {
+		return false, ""
+	}
+	canonical := canonicalMediaBase(details.ArchivedFiles, localBase)
+	if canonical == "" {
+		return false, ""
+	}
+	return true, fmt.Sprintf("source renamed from scene release: on-disk %q does not match canonical %q", localBase, canonical)
+}
+
 // isContextError reports cancellation and deadline errors from err or ctx.
 func isContextError(ctx context.Context, err error) bool {
 	if err == nil {
@@ -185,19 +292,42 @@ func isContextError(ctx context.Context, err error) bool {
 	return false
 }
 
+// srrdbSearchResult is one entry from an srrdb search response. The r: and imdb:
+// searches share this shape; imdb: additionally populates IsForeign and Size.
+type srrdbSearchResult struct {
+	Release   string `json:"release"`
+	IMDBID    string `json:"imdbId"`
+	HasNFO    string `json:"hasNFO"`
+	IsForeign string `json:"isForeign"`
+	Size      int64  `json:"size"`
+}
+
 type srrdbResponse struct {
-	ResultsCount int `json:"resultsCount"`
-	Results      []struct {
-		Release string `json:"release"`
-		IMDBID  string `json:"imdbId"`
-		HasNFO  string `json:"hasNFO"`
-	} `json:"results"`
+	ResultsCount int                 `json:"resultsCount"`
+	Results      []srrdbSearchResult `json:"results"`
+}
+
+// srrdbIMDBSearchResponse is the /v1/search/imdb:<id> payload: the full release
+// list for a title keyed off its IMDb id, independent of the on-disk filename.
+type srrdbIMDBSearchResponse struct {
+	ResultsCount int                 `json:"resultsCount"`
+	Results      []srrdbSearchResult `json:"results"`
 }
 
 type srrdbDetailsResponse struct {
 	Files []struct {
 		Name string `json:"name"`
 	} `json:"files"`
+	// ArchivedFiles lists the files inside the release archive; Name is the
+	// canonical media filename used for rename detection, with CRC/Size kept for
+	// the stronger content-tamper signal.
+	ArchivedFiles []srrdbArchivedFile `json:"archived-files"`
+}
+
+type srrdbArchivedFile struct {
+	Name string `json:"name"`
+	CRC  string `json:"crc"`
+	Size int64  `json:"size"`
 }
 
 type srrdbIMDBResponse struct {
@@ -356,6 +486,7 @@ func (d *srrdbDetector) fetchNFO(ctx context.Context, release string) (string, b
 	if err != nil {
 		return "", false, errors.Join(detailsErr, fmt.Errorf("scene: build nfo request: %w", err))
 	}
+	setSRRDBHeaders(req)
 	resp, err := d.client.Do(req)
 	if err != nil {
 		return "", false, errors.Join(detailsErr, fmt.Errorf("scene: nfo request: %w", err))
@@ -393,6 +524,7 @@ func (d *srrdbDetector) fetchDetails(ctx context.Context, release string) (srrdb
 	if err != nil {
 		return srrdbDetailsResponse{}, fmt.Errorf("scene: build details request: %w", err)
 	}
+	setSRRDBHeaders(req)
 	resp, err := d.client.Do(req)
 	if err != nil {
 		return srrdbDetailsResponse{}, fmt.Errorf("scene: details request: %w", err)
@@ -423,6 +555,7 @@ func (d *srrdbDetector) fetchIMDB(ctx context.Context, release string) (srrdbIMD
 	if err != nil {
 		return srrdbIMDBResponse{}, fmt.Errorf("scene: build imdb request: %w", err)
 	}
+	setSRRDBHeaders(req)
 	resp, err := d.client.Do(req)
 	if err != nil {
 		return srrdbIMDBResponse{}, fmt.Errorf("scene: imdb request: %w", err)
@@ -436,4 +569,132 @@ func (d *srrdbDetector) fetchIMDB(ctx context.Context, release string) (srrdbIMD
 		return srrdbIMDBResponse{}, fmt.Errorf("scene: decode imdb: %w", err)
 	}
 	return payload, nil
+}
+
+const (
+	// srrdbIMDBPageSize is the observed per-page cap of the imdb: search.
+	srrdbIMDBPageSize = 40
+	// srrdbIMDBMaxPages bounds the imdb: fan-out so a title with a very large
+	// release history can never trigger an unbounded number of requests.
+	srrdbIMDBMaxPages = 5
+)
+
+// sceneIMDbID returns the IMDb id already resolved on meta at scene-detection
+// time (Prepare runs before ResolveExternalIDs), in precedence order. A source
+// lookup URL or a prior persisted resolution is what makes the rename fallback
+// possible; 0 means "no id known" and the fallback is skipped.
+func sceneIMDbID(meta api.PreparedMetadata) int {
+	if id := meta.ExternalIDOverrides.IMDBID; id != nil && *id > 0 {
+		return *id
+	}
+	if meta.ExternalIDs.IMDBID > 0 {
+		return meta.ExternalIDs.IMDBID
+	}
+	if meta.ArrIMDBID > 0 {
+		return meta.ArrIMDBID
+	}
+	return 0
+}
+
+// fetchIMDBReleases lists every scene release for an IMDb id via the imdb:
+// search, paginating up to srrdbIMDBMaxPages. The id is a validated integer, so
+// the URL cannot be influenced by parsed metadata (no SSRF surface).
+func (d *srrdbDetector) fetchIMDBReleases(ctx context.Context, imdbID int) ([]srrdbSearchResult, error) {
+	if imdbID <= 0 {
+		return nil, nil
+	}
+	all := make([]srrdbSearchResult, 0, srrdbIMDBPageSize)
+	total := -1
+	for page := 1; page <= srrdbIMDBMaxPages; page++ {
+		payload, err := d.fetchIMDBReleasePage(ctx, imdbID, page)
+		if err != nil {
+			return all, err
+		}
+		all = append(all, payload.Results...)
+		total = payload.ResultsCount
+		if len(payload.Results) < srrdbIMDBPageSize {
+			break
+		}
+		if total >= 0 && len(all) >= total {
+			break
+		}
+	}
+	if total > len(all) {
+		d.log().Debugf("metadata: scene imdb fallback truncated imdb=%d collected=%d total=%d cap=%d", imdbID, len(all), total, srrdbIMDBMaxPages)
+	}
+	return all, nil
+}
+
+func (d *srrdbDetector) fetchIMDBReleasePage(ctx context.Context, imdbID, page int) (srrdbIMDBSearchResponse, error) {
+	endpoint := fmt.Sprintf("%s/v1/search/imdb:%d/order:date/page:%d", strings.TrimRight(d.baseURL, "/"), imdbID, page)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return srrdbIMDBSearchResponse{}, fmt.Errorf("scene: build imdb search request: %w", err)
+	}
+	setSRRDBHeaders(req)
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return srrdbIMDBSearchResponse{}, fmt.Errorf("scene: imdb search request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return srrdbIMDBSearchResponse{}, nil
+	}
+	var payload srrdbIMDBSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return srrdbIMDBSearchResponse{}, fmt.Errorf("scene: decode imdb search: %w", err)
+	}
+	return payload, nil
+}
+
+// sceneMediaExtensions are the archive members treated as the primary media file
+// for rename detection.
+var sceneMediaExtensions = map[string]struct{}{
+	".mkv": {}, ".mp4": {}, ".avi": {}, ".ts": {}, ".m2ts": {},
+	".vob": {}, ".iso": {}, ".wmv": {}, ".mov": {}, ".m4v": {},
+}
+
+// canonicalMediaBase reports the canonical media basename to flag as a rename, or
+// "" when the on-disk basename matches a canonical media file (case differences
+// tolerated, like srrdb's r: search) or no media file can be identified. The
+// representative name returned is the largest matching media file.
+func canonicalMediaBase(archived []srrdbArchivedFile, localBase string) string {
+	wantBase := strings.TrimSpace(localBase)
+	representative := ""
+	var representativeSize int64 = -1
+	for _, file := range archived {
+		stem, ext, ok := sceneMediaStem(file.Name)
+		if !ok {
+			continue
+		}
+		if _, isMedia := sceneMediaExtensions[ext]; !isMedia {
+			continue
+		}
+		if strings.EqualFold(stem, wantBase) {
+			return ""
+		}
+		if file.Size > representativeSize {
+			representativeSize = file.Size
+			representative = stem
+		}
+	}
+	return representative
+}
+
+// sceneMediaStem splits an srrdb archive member name (slash-data, never a local
+// path) into its trimmed basename stem and lower-cased extension using plain
+// string operations so no filesystem path API is applied to remote data.
+func sceneMediaStem(name string) (stem, ext string, ok bool) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return "", "", false
+	}
+	if idx := strings.LastIndexAny(trimmed, "/\\"); idx >= 0 {
+		trimmed = trimmed[idx+1:]
+	}
+	dot := strings.LastIndex(trimmed, ".")
+	if dot <= 0 {
+		return "", "", false
+	}
+	return strings.TrimSpace(trimmed[:dot]), strings.ToLower(trimmed[dot:]), true
 }

--- a/internal/metadata/scene.go
+++ b/internal/metadata/scene.go
@@ -202,8 +202,11 @@ func sceneLocalCandidates(meta api.PreparedMetadata) sceneCandidates {
 func (d *srrdbDetector) Detect(ctx context.Context, meta api.PreparedMetadata) (SceneResult, error) {
 	cands := sceneLocalCandidates(meta)
 	if cands.empty() {
+		d.log().Tracef("metadata: scene detection skipped: no local candidates")
 		return SceneResult{}, nil
 	}
+	imdbID := sceneIMDbID(meta)
+	d.log().Debugf("metadata: scene detection start imdb=%d folders=%d files=%d media_present=%t", imdbID, len(cands.folders), len(cands.files), strings.TrimSpace(cands.mediaFilename) != "")
 
 	// Detection now runs after external-ID resolution (ApplyMediaDetails), so a
 	// resolved IMDb id is normally available. The IMDb-keyed search returns the
@@ -211,7 +214,7 @@ func (d *srrdbDetector) Detect(ctx context.Context, meta api.PreparedMetadata) (
 	// robust primary path. If it yields no confident match (e.g. truncated results
 	// or srrdb not keying the release to this id), fall through to the exact r:
 	// search, which is also the fallback when no IMDb id is known.
-	if imdbID := sceneIMDbID(meta); imdbID > 0 {
+	if imdbID > 0 {
 		result, err := d.detectViaIMDB(ctx, meta, cands, imdbID)
 		if err != nil {
 			return result, err
@@ -227,6 +230,7 @@ func (d *srrdbDetector) Detect(ctx context.Context, meta api.PreparedMetadata) (
 // the local folder/filename, then verifies the media filename. Strictly
 // best-effort: every failure returns a no-match (except context cancellation).
 func (d *srrdbDetector) detectViaIMDB(ctx context.Context, meta api.PreparedMetadata, cands sceneCandidates, imdbID int) (SceneResult, error) {
+	d.log().Tracef("metadata: scene imdb search start imdb=%d", imdbID)
 	releases, err := d.fetchIMDBReleases(ctx, imdbID)
 	if err != nil {
 		if isContextError(ctx, err) {
@@ -236,12 +240,14 @@ func (d *srrdbDetector) detectViaIMDB(ctx context.Context, meta api.PreparedMeta
 		return SceneResult{}, nil
 	}
 	if len(releases) == 0 {
+		d.log().Debugf("metadata: scene imdb search no results imdb=%d", imdbID)
 		return SceneResult{}, nil
 	}
+	d.log().Debugf("metadata: scene imdb search results imdb=%d count=%d", imdbID, len(releases))
 
 	best, source := selectSceneRelease(meta, cands, releases)
 	if best == nil {
-		d.log().Debugf("metadata: scene imdb no confident candidate imdb=%d candidates=%d folders=%v files=%v", imdbID, len(releases), cands.folders, cands.files)
+		d.log().Debugf("metadata: scene imdb no confident candidate imdb=%d candidates=%d folders=%d files=%d", imdbID, len(releases), len(cands.folders), len(cands.files))
 		return SceneResult{}, nil
 	}
 	return d.finishSceneMatch(ctx, cands, *best, source, "imdb")
@@ -253,6 +259,7 @@ func (d *srrdbDetector) detectViaR(ctx context.Context, cands sceneCandidates) (
 	names := make([]string, 0, len(cands.folders)+len(cands.files))
 	names = append(names, cands.folders...)
 	names = append(names, cands.files...)
+	d.log().Debugf("metadata: scene r search start candidates=%d", len(names))
 	for _, name := range names {
 		release, ok, err := d.searchExactR(ctx, name)
 		if err != nil {
@@ -266,6 +273,7 @@ func (d *srrdbDetector) detectViaR(ctx context.Context, cands sceneCandidates) (
 			return d.finishSceneMatch(ctx, cands, release, "r", "r")
 		}
 	}
+	d.log().Debugf("metadata: scene r search no match candidates=%d", len(names))
 	return SceneResult{}, nil
 }
 
@@ -275,6 +283,7 @@ func (d *srrdbDetector) searchExactR(ctx context.Context, name string) (srrdbSea
 	if trimmed == "" {
 		return srrdbSearchResult{}, false, nil
 	}
+	d.log().Tracef("metadata: scene r search candidate=%q", trimmed)
 	endpoint := fmt.Sprintf("%s/v1/search/r:%s", strings.TrimRight(d.baseURL, "/"), url.PathEscape(trimmed))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -287,6 +296,7 @@ func (d *srrdbDetector) searchExactR(ctx context.Context, name string) (srrdbSea
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		d.log().Tracef("metadata: scene r search candidate=%q status=%d", trimmed, resp.StatusCode)
 		return srrdbSearchResult{}, false, nil
 	}
 	var payload srrdbResponse
@@ -294,8 +304,10 @@ func (d *srrdbDetector) searchExactR(ctx context.Context, name string) (srrdbSea
 		return srrdbSearchResult{}, false, fmt.Errorf("scene: decode r search: %w", err)
 	}
 	if payload.ResultsCount <= 0 || len(payload.Results) == 0 {
+		d.log().Tracef("metadata: scene r search candidate=%q results=0", trimmed)
 		return srrdbSearchResult{}, false, nil
 	}
+	d.log().Tracef("metadata: scene r search candidate=%q results=%d selected=%q", trimmed, len(payload.Results), payload.Results[0].Release)
 	return payload.Results[0], true, nil
 }
 
@@ -333,7 +345,7 @@ func (d *srrdbDetector) finishSceneMatch(ctx context.Context, cands sceneCandida
 		reason = sceneRenamedReason
 		d.log().Infof("metadata: scene release renamed or modified via=%s", matchSource)
 	}
-	d.log().Debugf("metadata: scene matched mode=%s via=%s release=%q folders=%v media=%q renamed=%t", mode, matchSource, release.Release, cands.folders, cands.mediaFilename, renamed)
+	d.log().Debugf("metadata: scene matched mode=%s via=%s release=%q folders=%v media=%q has_nfo=%t renamed=%t", mode, matchSource, release.Release, cands.folders, cands.mediaFilename, strings.EqualFold(release.HasNFO, "yes"), renamed)
 	return d.buildSceneResult(ctx, release, renamed, reason)
 }
 
@@ -355,6 +367,7 @@ func (d *srrdbDetector) buildSceneResult(ctx context.Context, result srrdbSearch
 		Renamed:       renamed,
 		RenamedReason: renamedReason,
 	}
+	d.log().Tracef("metadata: scene result imdb=%d has_nfo=%q renamed=%t", scene.IMDBID, result.HasNFO, scene.Renamed)
 	if strings.EqualFold(result.HasNFO, "yes") {
 		path, downloaded, err := d.fetchNFO(ctx, result.Release)
 		if err != nil && isContextError(ctx, err) {
@@ -363,6 +376,7 @@ func (d *srrdbDetector) buildSceneResult(ctx context.Context, result srrdbSearch
 		if path != "" {
 			scene.NFOPath = path
 			scene.NFONew = downloaded
+			d.log().Tracef("metadata: scene nfo attached downloaded=%t", downloaded)
 			if nfoIDs, readErr := parseNFOExternalIDs(path); readErr == nil {
 				scene.TMDBID = nfoIDs.TMDBID
 				if scene.IMDBID == 0 {
@@ -373,11 +387,17 @@ func (d *srrdbDetector) buildSceneResult(ctx context.Context, result srrdbSearch
 				scene.MALID = nfoIDs.MALID
 				scene.Service = nfoIDs.Service
 				scene.ServiceLongName = nfoIDs.ServiceLongName
+				d.log().Tracef("metadata: scene nfo ids tmdb=%d imdb=%d tvdb=%d tvmaze=%d mal=%d service_present=%t", scene.TMDBID, scene.IMDBID, scene.TVDBID, scene.TVmazeID, scene.MALID, scene.Service != "")
+			} else {
+				d.log().Debugf("metadata: scene nfo id parse failed: %v", readErr)
 			}
 		}
 		if err != nil {
+			d.log().Debugf("metadata: scene nfo side effect failed: %v", err)
 			return scene, newSceneNFOError(err)
 		}
+	} else {
+		d.log().Debugf("metadata: scene nfo not advertised has_nfo=%q", result.HasNFO)
 	}
 
 	return scene, nil
@@ -637,9 +657,12 @@ func (d *srrdbDetector) fetchNFO(ctx context.Context, release string) (string, b
 	if trimmed == "" {
 		return "", false, nil
 	}
+	d.log().Tracef("metadata: scene nfo lookup start release=%q", trimmed)
 	fileBase := strings.ToLower(trimmed)
+	detailsNFO := false
 	var detailsErr error
 	if details, err := d.fetchDetails(ctx, trimmed); err == nil {
+		d.log().Tracef("metadata: scene nfo details loaded release=%q files=%d", trimmed, len(details.Files))
 		for _, file := range details.Files {
 			name := strings.TrimSpace(file.Name)
 			if strings.HasSuffix(strings.ToLower(name), ".nfo") {
@@ -647,55 +670,70 @@ func (d *srrdbDetector) fetchNFO(ctx context.Context, release string) (string, b
 				if strings.TrimSpace(base) != "" {
 					fileBase = strings.ToLower(base)
 				}
+				detailsNFO = true
+				d.log().Tracef("metadata: scene nfo details selected release=%q file=%q", trimmed, name)
 				break
 			}
 		}
 	} else if isContextError(ctx, err) {
 		return "", false, err
 	} else {
+		d.log().Debugf("metadata: scene nfo details failed release=%q: %v", trimmed, err)
 		detailsErr = err
 	}
 
 	cacheDir := d.cacheDir
 	if cacheDir == "" {
+		d.log().Debugf("metadata: scene nfo cache unavailable release=%q reason=missing_cache_dir", trimmed)
 		return "", false, errors.Join(detailsErr, errors.New("scene: nfo cache: missing cache dir"))
 	}
 	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		d.log().Debugf("metadata: scene nfo cache unavailable release=%q: %v", trimmed, err)
 		return "", false, errors.Join(detailsErr, fmt.Errorf("scene: nfo cache: %w", err))
 	}
 	nfoDir := d.nfoDir
 	if nfoDir == "" {
+		d.log().Debugf("metadata: scene nfo dir unavailable release=%q reason=missing_nfo_dir", trimmed)
 		return "", false, errors.Join(detailsErr, errors.New("scene: nfo cache: missing nfo dir"))
 	}
 	if err := os.MkdirAll(nfoDir, 0o700); err != nil {
+		d.log().Debugf("metadata: scene nfo dir unavailable release=%q: %v", trimmed, err)
 		return "", false, errors.Join(detailsErr, fmt.Errorf("scene: nfo dir: %w", err))
 	}
 	path := filepath.Join(nfoDir, fileBase+".nfo")
 	if _, err := os.Stat(path); err == nil {
+		d.log().Debugf("metadata: scene nfo cache hit release=%q path=%s details_error=%t", trimmed, path, detailsErr != nil)
 		return path, false, detailsErr
 	}
 
+	d.log().Tracef("metadata: scene nfo downloading release=%q file=%q details_nfo=%t details_error=%t", trimmed, fileBase+".nfo", detailsNFO, detailsErr != nil)
 	nfoURL := fmt.Sprintf("https://www.srrdb.com/download/file/%s/%s.nfo", url.PathEscape(trimmed), url.PathEscape(fileBase))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, nfoURL, nil)
 	if err != nil {
+		d.log().Debugf("metadata: scene nfo request build failed release=%q: %v", trimmed, err)
 		return "", false, errors.Join(detailsErr, fmt.Errorf("scene: build nfo request: %w", err))
 	}
 	setSRRDBHeaders(req)
 	resp, err := d.client.Do(req)
 	if err != nil {
+		d.log().Debugf("metadata: scene nfo request failed release=%q: %v", trimmed, err)
 		return "", false, errors.Join(detailsErr, fmt.Errorf("scene: nfo request: %w", err))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		d.log().Debugf("metadata: scene nfo unavailable release=%q status=%d details_error=%t", trimmed, resp.StatusCode, detailsErr != nil)
 		return "", false, detailsErr
 	}
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
+		d.log().Debugf("metadata: scene nfo read failed release=%q: %v", trimmed, err)
 		return "", false, errors.Join(detailsErr, fmt.Errorf("scene: read nfo: %w", err))
 	}
 	if err := os.WriteFile(path, data, 0o600); err != nil {
+		d.log().Debugf("metadata: scene nfo write failed release=%q path=%s: %v", trimmed, path, err)
 		return "", false, errors.Join(detailsErr, fmt.Errorf("scene: write nfo: %w", err))
 	}
+	d.log().Debugf("metadata: scene nfo downloaded release=%q path=%s bytes=%d details_error=%t", trimmed, path, len(data), detailsErr != nil)
 	return path, true, detailsErr
 }
 
@@ -708,11 +746,14 @@ func (d *srrdbDetector) fetchDetails(ctx context.Context, release string) (srrdb
 			if cached, err := os.ReadFile(cachePath); err == nil {
 				var payload srrdbDetailsResponse
 				if err := json.Unmarshal(cached, &payload); err == nil {
+					d.log().Tracef("metadata: scene details cache hit release=%q path=%s", release, cachePath)
 					return payload, nil
 				}
+				d.log().Debugf("metadata: scene details cache invalid release=%q path=%s: %v", release, cachePath, err)
 			}
 		}
 	}
+	d.log().Tracef("metadata: scene details fetch release=%q", release)
 	endpoint := fmt.Sprintf("%s/v1/details/%s", strings.TrimRight(d.baseURL, "/"), url.PathEscape(release))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -725,6 +766,7 @@ func (d *srrdbDetector) fetchDetails(ctx context.Context, release string) (srrdb
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		d.log().Tracef("metadata: scene details fetch status release=%q status=%d", release, resp.StatusCode)
 		return srrdbDetailsResponse{}, nil
 	}
 	var payload srrdbDetailsResponse
@@ -736,6 +778,7 @@ func (d *srrdbDetector) fetchDetails(ctx context.Context, release string) (srrdb
 			_ = os.WriteFile(cachePath, data, 0o600)
 		}
 	}
+	d.log().Tracef("metadata: scene details fetched release=%q files=%d archived=%d", release, len(payload.Files), len(payload.ArchivedFiles))
 	return payload, nil
 }
 
@@ -809,6 +852,7 @@ func (d *srrdbDetector) fetchIMDBReleases(ctx context.Context, imdbID int) ([]sr
 		}
 		all = append(all, payload.Results...)
 		total = payload.ResultsCount
+		d.log().Tracef("metadata: scene imdb search page imdb=%d page=%d results=%d total=%d collected=%d", imdbID, page, len(payload.Results), total, len(all))
 		if len(payload.Results) < srrdbIMDBPageSize {
 			break
 		}
@@ -839,6 +883,7 @@ func (d *srrdbDetector) fetchIMDBReleasePage(ctx context.Context, imdbID, page i
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		d.log().Tracef("metadata: scene imdb search status imdb=%d page=%d status=%d", imdbID, page, resp.StatusCode)
 		return srrdbIMDBSearchResponse{}, nil
 	}
 	var payload srrdbIMDBSearchResponse

--- a/internal/metadata/scene.go
+++ b/internal/metadata/scene.go
@@ -124,58 +124,209 @@ func setSRRDBHeaders(req *http.Request) {
 	req.Header.Set("User-Agent", srrdbUserAgent)
 }
 
+// formatSRRDBIMDbID renders an IMDb id in srrdb's required zero-padded tt form
+// (132245 -> "tt0132245"). Integer storage drops leading zeroes and srrdb rejects
+// an unpadded numeric id ("Invalid value for imdb"), so the query must re-pad.
+// Returns "" for a non-positive id.
+func formatSRRDBIMDbID(id int) string {
+	if id <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("tt%07d", id)
+}
+
+// sceneCandidates holds the local on-disk name signals used to select and verify
+// a scene release. folders are release-folder basenames kept whole (so dotted
+// tokens survive); files are media basenames with the media extension stripped;
+// mediaFilename is the on-disk media basename WITH extension for the
+// case-sensitive rename comparison.
+type sceneCandidates struct {
+	folders       []string
+	files         []string
+	mediaFilename string
+}
+
+func (c sceneCandidates) empty() bool {
+	return len(c.folders) == 0 && len(c.files) == 0
+}
+
+// primaryLocalBase returns the most descriptive local name for scoring/foreign
+// heuristics: the folder when known, else the file.
+func (c sceneCandidates) primaryLocalBase() string {
+	if len(c.folders) > 0 {
+		return c.folders[0]
+	}
+	if len(c.files) > 0 {
+		return c.files[0]
+	}
+	return ""
+}
+
+// sceneLocalCandidates derives folder and file name candidates from the prepared
+// paths. VideoPath is the primary media file; SourcePath is the release root — a
+// folder for folder releases (its basename is the canonical dotted name) or the
+// media file itself for single-file releases.
+func sceneLocalCandidates(meta api.PreparedMetadata) sceneCandidates {
+	video := strings.TrimSpace(meta.VideoPath)
+	source := strings.TrimSpace(meta.SourcePath)
+	var c sceneCandidates
+
+	addFile := func(base string) {
+		if stem := stripSceneMediaExt(base); stem != "" && !containsFold(c.files, stem) {
+			c.files = append(c.files, stem)
+		}
+	}
+
+	if video != "" {
+		base := pathutil.Base(video)
+		c.mediaFilename = strings.TrimSpace(base)
+		addFile(base)
+	}
+	if source != "" && !pathutil.SamePath(source, video) {
+		base := pathutil.Base(source)
+		switch {
+		case looksLikeSceneMediaFile(base):
+			addFile(base)
+			if c.mediaFilename == "" {
+				c.mediaFilename = strings.TrimSpace(base)
+			}
+		case base != "" && base != ".":
+			if !containsFold(c.folders, base) {
+				c.folders = append(c.folders, base)
+			}
+		}
+	}
+	return c
+}
+
 func (d *srrdbDetector) Detect(ctx context.Context, meta api.PreparedMetadata) (SceneResult, error) {
-	base := sceneBase(meta)
-	if base == "" {
+	cands := sceneLocalCandidates(meta)
+	if cands.empty() {
 		return SceneResult{}, nil
 	}
 
-	endpoint := fmt.Sprintf("%s/v1/search/r:%s", strings.TrimRight(d.baseURL, "/"), url.PathEscape(base))
+	// Detection now runs after external-ID resolution (ApplyMediaDetails), so a
+	// resolved IMDb id is normally available. The IMDb-keyed search returns the
+	// full scene release set for the title regardless of filename, which is the
+	// robust primary path; the exact r: search is only a no-IMDb fallback.
+	if imdbID := sceneIMDbID(meta); imdbID > 0 {
+		return d.detectViaIMDB(ctx, meta, cands, imdbID)
+	}
+	return d.detectViaR(ctx, cands)
+}
+
+// detectViaIMDB lists every scene release for the title, selects the one matching
+// the local folder/filename, then verifies the media filename. Strictly
+// best-effort: every failure returns a no-match (except context cancellation).
+func (d *srrdbDetector) detectViaIMDB(ctx context.Context, meta api.PreparedMetadata, cands sceneCandidates, imdbID int) (SceneResult, error) {
+	releases, err := d.fetchIMDBReleases(ctx, imdbID)
+	if err != nil {
+		if isContextError(ctx, err) {
+			return SceneResult{}, err
+		}
+		d.log().Debugf("metadata: scene imdb search soft-failed imdb=%d: %v", imdbID, err)
+		return SceneResult{}, nil
+	}
+	if len(releases) == 0 {
+		return SceneResult{}, nil
+	}
+
+	best, source := selectSceneRelease(meta, cands, releases)
+	if best == nil {
+		d.log().Debugf("metadata: scene imdb no confident candidate imdb=%d candidates=%d folders=%v files=%v", imdbID, len(releases), cands.folders, cands.files)
+		return SceneResult{}, nil
+	}
+	return d.finishSceneMatch(ctx, cands, *best, source, "imdb")
+}
+
+// detectViaR is the no-IMDb fallback: an exact r: lookup over the folder
+// candidates (the canonical dotted name) first, then the media filename.
+func (d *srrdbDetector) detectViaR(ctx context.Context, cands sceneCandidates) (SceneResult, error) {
+	names := make([]string, 0, len(cands.folders)+len(cands.files))
+	names = append(names, cands.folders...)
+	names = append(names, cands.files...)
+	for _, name := range names {
+		release, ok, err := d.searchExactR(ctx, name)
+		if err != nil {
+			if isContextError(ctx, err) {
+				return SceneResult{}, err
+			}
+			d.log().Debugf("metadata: scene r: search soft-failed name=%q: %v", name, err)
+			return SceneResult{}, nil
+		}
+		if ok {
+			return d.finishSceneMatch(ctx, cands, release, "r", "r")
+		}
+	}
+	return SceneResult{}, nil
+}
+
+// searchExactR performs a single exact r: search and returns the first result.
+func (d *srrdbDetector) searchExactR(ctx context.Context, name string) (srrdbSearchResult, bool, error) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return srrdbSearchResult{}, false, nil
+	}
+	endpoint := fmt.Sprintf("%s/v1/search/r:%s", strings.TrimRight(d.baseURL, "/"), url.PathEscape(trimmed))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return SceneResult{}, fmt.Errorf("scene: build request: %w", err)
+		return srrdbSearchResult{}, false, fmt.Errorf("scene: build r search request: %w", err)
 	}
 	setSRRDBHeaders(req)
-
 	resp, err := d.client.Do(req)
 	if err != nil {
-		// srrdb being unreachable/slow must never block an upload, so soft-fail the
-		// r: search the same way the imdb: fallback does. Context cancellation still
-		// propagates as fatal.
-		if isContextError(ctx, err) {
-			return SceneResult{}, fmt.Errorf("scene: srrdb request: %w", err)
-		}
-		d.log().Debugf("metadata: scene r: search soft-failed: %v", err)
-		return SceneResult{}, nil
+		return srrdbSearchResult{}, false, fmt.Errorf("scene: r search request: %w", err)
 	}
 	defer resp.Body.Close()
-
 	if resp.StatusCode != http.StatusOK {
-		return SceneResult{}, nil
+		return srrdbSearchResult{}, false, nil
 	}
-
 	var payload srrdbResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		// A truncated/malformed body is a transient srrdb failure, not an
-		// upload-blocking condition; soft-fail unless the context was cancelled.
-		if isContextError(ctx, err) {
-			return SceneResult{}, fmt.Errorf("scene: decode response: %w", err)
-		}
-		d.log().Debugf("metadata: scene r: decode soft-failed: %v", err)
-		return SceneResult{}, nil
+		return srrdbSearchResult{}, false, fmt.Errorf("scene: decode r search: %w", err)
 	}
-
 	if payload.ResultsCount <= 0 || len(payload.Results) == 0 {
-		// The exact dotted-name search missed. A renamed/modified scene release
-		// deviates from its canonical name, so fall back to an IMDb-keyed lookup
-		// (independent of filename) and match locally. Stays entirely soft: srrdb
-		// being unreachable or returning nothing must never block an upload.
-		return d.detectViaIMDB(ctx, meta, base)
+		return srrdbSearchResult{}, false, nil
 	}
+	return payload.Results[0], true, nil
+}
 
-	// The exact r: name matched, so the on-disk name is already canonical (case
-	// differences aside) and is by definition not renamed.
-	return d.buildSceneResult(ctx, payload.Results[0], false, "")
+// selectSceneRelease picks the srrdb release that matches the local names, using
+// case-insensitive equality (only for selecting the right release when local
+// casing differs): exact folder match, then exact filename/release-name match,
+// then metadata scoring to break ties / reject weak candidates.
+func selectSceneRelease(meta api.PreparedMetadata, cands sceneCandidates, releases []srrdbSearchResult) (*srrdbSearchResult, string) {
+	for _, folder := range cands.folders {
+		for i := range releases {
+			if strings.EqualFold(strings.TrimSpace(releases[i].Release), folder) {
+				return &releases[i], "folder"
+			}
+		}
+	}
+	for _, file := range cands.files {
+		for i := range releases {
+			if strings.EqualFold(strings.TrimSpace(releases[i].Release), file) {
+				return &releases[i], "filename"
+			}
+		}
+	}
+	if best, _ := bestSceneCandidate(meta, cands.primaryLocalBase(), releases); best != nil {
+		return best, "score"
+	}
+	return nil, ""
+}
+
+// finishSceneMatch verifies the media filename against the selected release and
+// builds the SceneResult.
+func (d *srrdbDetector) finishSceneMatch(ctx context.Context, cands sceneCandidates, release srrdbSearchResult, matchSource, mode string) (SceneResult, error) {
+	renamed := d.detectRenamed(ctx, release.Release, cands)
+	reason := ""
+	if renamed {
+		reason = sceneRenamedReason
+		d.log().Infof("metadata: scene release renamed or modified via=%s", matchSource)
+	}
+	d.log().Debugf("metadata: scene matched mode=%s via=%s release=%q folders=%v media=%q renamed=%t", mode, matchSource, release.Release, cands.folders, cands.mediaFilename, renamed)
+	return d.buildSceneResult(ctx, release, renamed, reason)
 }
 
 // buildSceneResult turns a matched srrdb release into a SceneResult, resolving the
@@ -224,63 +375,110 @@ func (d *srrdbDetector) buildSceneResult(ctx context.Context, result srrdbSearch
 	return scene, nil
 }
 
-// detectViaIMDB is the renamed-release fallback: keyed off an already-known IMDb
-// id, it lists every scene release for the title, score-matches the best
-// candidate against the parsed release tokens, then compares the canonical media
-// filename to the on-disk basename to flag a rename. It is strictly best-effort —
-// every failure path returns a no-match (except context cancellation), never an
-// error that could block an upload.
-func (d *srrdbDetector) detectViaIMDB(ctx context.Context, meta api.PreparedMetadata, localBase string) (SceneResult, error) {
-	imdbID := sceneIMDbID(meta)
-	if imdbID == 0 {
-		return SceneResult{}, nil
-	}
-
-	releases, err := d.fetchIMDBReleases(ctx, imdbID)
-	if err != nil {
-		if isContextError(ctx, err) {
-			return SceneResult{}, err
-		}
-		d.log().Debugf("metadata: scene imdb fallback soft-failed imdb=%d: %v", imdbID, err)
-		return SceneResult{}, nil
-	}
-	if len(releases) == 0 {
-		return SceneResult{}, nil
-	}
-
-	best, score := bestSceneCandidate(meta, localBase, releases)
-	if best == nil {
-		d.log().Debugf("metadata: scene imdb fallback no confident candidate imdb=%d candidates=%d", imdbID, len(releases))
-		return SceneResult{}, nil
-	}
-	d.log().Debugf("metadata: scene imdb fallback matched imdb=%d candidates=%d release=%q score=%d", imdbID, len(releases), best.Release, score)
-
-	renamed, reason := d.detectRename(ctx, best.Release, localBase)
-	if renamed {
-		d.log().Infof("metadata: scene release renamed or modified imdb=%d", imdbID)
-	}
-	return d.buildSceneResult(ctx, *best, renamed, reason)
-}
-
 // sceneRenamedReason is intentionally generic: it does not disclose the
 // canonical scene name, so the fix is not simply "rename the file back". A
 // modified release should be investigated (hash/provenance) rather than papered
 // over with a rename.
 const sceneRenamedReason = "source does not match its original scene release name (renamed or modified); verify the file hash and source provenance"
 
-// detectRename compares the canonical media filename(s) recorded for a scene
-// release against the on-disk basename. It is conservative: a name that matches
-// any canonical media file (case differences tolerated, like srrdb's r: search),
-// or any inability to read the release details, yields "not renamed".
-func (d *srrdbDetector) detectRename(ctx context.Context, release, localBase string) (bool, string) {
+// detectRenamed reports whether the local media file was renamed/modified from
+// the selected scene release. The local media filename is compared to the
+// release's archived media filenames CASE-SENSITIVELY — srrdb archived names are
+// authoritative, so a casing-only difference is a rename. It is conservative: no
+// media file to compare, no archived media, or any details-fetch failure yields
+// "not renamed".
+func (d *srrdbDetector) detectRenamed(ctx context.Context, release string, cands sceneCandidates) bool {
+	local := strings.TrimSpace(cands.mediaFilename)
+	if local == "" {
+		return false
+	}
 	details, err := d.fetchDetails(ctx, release)
 	if err != nil {
-		return false, ""
+		return false
 	}
-	if canonicalMediaBase(details.ArchivedFiles, localBase) == "" {
-		return false, ""
+	renamed, matched := archivedMediaRenamed(details.ArchivedFiles, local)
+	if !matched {
+		return false
 	}
-	return true, sceneRenamedReason
+	return renamed
+}
+
+// archivedMediaRenamed reports whether the local media filename fails to match
+// (case-sensitively) any archived scene media filename. matched is false when the
+// release has no identifiable media member to compare against.
+func archivedMediaRenamed(archived []srrdbArchivedFile, localMediaFilename string) (renamed, matched bool) {
+	want := strings.TrimSpace(localMediaFilename)
+	found := false
+	for _, file := range archived {
+		base, ok := archivedMediaName(file.Name)
+		if !ok {
+			continue
+		}
+		found = true
+		if base == want { // case-sensitive: srrdb is authoritative
+			return false, true
+		}
+	}
+	if !found {
+		return false, false
+	}
+	return true, true
+}
+
+// archivedMediaName returns the original-case basename (with extension) of an
+// archived media member, or ok=false for non-media members. srrdb archive names
+// are slash-data, handled with plain string ops (no local-path API).
+func archivedMediaName(name string) (string, bool) {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return "", false
+	}
+	if idx := strings.LastIndexAny(trimmed, "/\\"); idx >= 0 {
+		trimmed = trimmed[idx+1:]
+	}
+	dot := strings.LastIndex(trimmed, ".")
+	if dot <= 0 {
+		return "", false
+	}
+	if _, isMedia := sceneMediaExtensions[strings.ToLower(trimmed[dot:])]; !isMedia {
+		return "", false
+	}
+	return trimmed, true
+}
+
+// stripSceneMediaExt removes a recognized media extension from a basename,
+// returning the stem; a name without a media extension is returned unchanged so
+// folder-like names keep their dotted tokens.
+func stripSceneMediaExt(base string) string {
+	trimmed := strings.TrimSpace(base)
+	if dot := strings.LastIndex(trimmed, "."); dot > 0 {
+		if _, ok := sceneMediaExtensions[strings.ToLower(trimmed[dot:])]; ok {
+			return strings.TrimSpace(trimmed[:dot])
+		}
+	}
+	return trimmed
+}
+
+// looksLikeSceneMediaFile reports whether a basename ends in a recognized media
+// extension.
+func looksLikeSceneMediaFile(base string) bool {
+	trimmed := strings.TrimSpace(base)
+	dot := strings.LastIndex(trimmed, ".")
+	if dot <= 0 {
+		return false
+	}
+	_, ok := sceneMediaExtensions[strings.ToLower(trimmed[dot:])]
+	return ok
+}
+
+// containsFold reports case-insensitive membership.
+func containsFold(list []string, want string) bool {
+	for _, v := range list {
+		if strings.EqualFold(v, want) {
+			return true
+		}
+	}
+	return false
 }
 
 // isContextError reports cancellation and deadline errors from err or ctx.
@@ -426,23 +624,6 @@ func parseNFOService(text string) (string, string) {
 	return "", ""
 }
 
-func sceneBase(meta api.PreparedMetadata) string {
-	candidate := strings.TrimSpace(meta.VideoPath)
-	if candidate == "" {
-		candidate = strings.TrimSpace(meta.SourcePath)
-	}
-	if candidate == "" {
-		return ""
-	}
-
-	base := pathutil.Base(candidate)
-	ext := filepath.Ext(base)
-	if ext != "" {
-		base = strings.TrimSuffix(base, ext)
-	}
-	return strings.TrimSpace(base)
-}
-
 func (d *srrdbDetector) fetchNFO(ctx context.Context, release string) (string, bool, error) {
 	trimmed := strings.TrimSpace(release)
 	if trimmed == "" {
@@ -584,10 +765,10 @@ const (
 	srrdbIMDBMaxPages = 5
 )
 
-// sceneIMDbID returns the IMDb id already resolved on meta at scene-detection
-// time (Prepare runs before ResolveExternalIDs), in precedence order. A source
-// lookup URL or a prior persisted resolution is what makes the rename fallback
-// possible; 0 means "no id known" and the fallback is skipped.
+// sceneIMDbID returns the resolved IMDb id on meta in precedence order. Detection
+// runs in ApplyMediaDetails, after ResolveExternalIDs, so meta.ExternalIDs.IMDBID
+// is normally populated; 0 means "no id known" and the imdb: search is skipped in
+// favor of the r: fallback.
 func sceneIMDbID(meta api.PreparedMetadata) int {
 	if id := meta.ExternalIDOverrides.IMDBID; id != nil && *id > 0 {
 		return *id
@@ -631,7 +812,11 @@ func (d *srrdbDetector) fetchIMDBReleases(ctx context.Context, imdbID int) ([]sr
 }
 
 func (d *srrdbDetector) fetchIMDBReleasePage(ctx context.Context, imdbID, page int) (srrdbIMDBSearchResponse, error) {
-	endpoint := fmt.Sprintf("%s/v1/search/imdb:%d/order:date/page:%d", strings.TrimRight(d.baseURL, "/"), imdbID, page)
+	imdb := formatSRRDBIMDbID(imdbID)
+	if imdb == "" {
+		return srrdbIMDBSearchResponse{}, nil
+	}
+	endpoint := fmt.Sprintf("%s/v1/search/imdb:%s/order:date/page:%d", strings.TrimRight(d.baseURL, "/"), imdb, page)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return srrdbIMDBSearchResponse{}, fmt.Errorf("scene: build imdb search request: %w", err)
@@ -657,49 +842,4 @@ func (d *srrdbDetector) fetchIMDBReleasePage(ctx context.Context, imdbID, page i
 var sceneMediaExtensions = map[string]struct{}{
 	".mkv": {}, ".mp4": {}, ".avi": {}, ".ts": {}, ".m2ts": {},
 	".vob": {}, ".iso": {}, ".wmv": {}, ".mov": {}, ".m4v": {},
-}
-
-// canonicalMediaBase reports the canonical media basename to flag as a rename, or
-// "" when the on-disk basename matches a canonical media file (case differences
-// tolerated, like srrdb's r: search) or no media file can be identified. The
-// representative name returned is the largest matching media file.
-func canonicalMediaBase(archived []srrdbArchivedFile, localBase string) string {
-	wantBase := strings.TrimSpace(localBase)
-	representative := ""
-	var representativeSize int64 = -1
-	for _, file := range archived {
-		stem, ext, ok := sceneMediaStem(file.Name)
-		if !ok {
-			continue
-		}
-		if _, isMedia := sceneMediaExtensions[ext]; !isMedia {
-			continue
-		}
-		if strings.EqualFold(stem, wantBase) {
-			return ""
-		}
-		if file.Size > representativeSize {
-			representativeSize = file.Size
-			representative = stem
-		}
-	}
-	return representative
-}
-
-// sceneMediaStem splits an srrdb archive member name (slash-data, never a local
-// path) into its trimmed basename stem and lower-cased extension using plain
-// string operations so no filesystem path API is applied to remote data.
-func sceneMediaStem(name string) (stem, ext string, ok bool) {
-	trimmed := strings.TrimSpace(name)
-	if trimmed == "" {
-		return "", "", false
-	}
-	if idx := strings.LastIndexAny(trimmed, "/\\"); idx >= 0 {
-		trimmed = trimmed[idx+1:]
-	}
-	dot := strings.LastIndex(trimmed, ".")
-	if dot <= 0 {
-		return "", "", false
-	}
-	return strings.TrimSpace(trimmed[:dot]), strings.ToLower(trimmed[dot:]), true
 }

--- a/internal/metadata/scene.go
+++ b/internal/metadata/scene.go
@@ -257,10 +257,16 @@ func (d *srrdbDetector) detectViaIMDB(ctx context.Context, meta api.PreparedMeta
 
 	renamed, reason := d.detectRename(ctx, best.Release, localBase)
 	if renamed {
-		d.log().Infof("metadata: scene release renamed imdb=%d release=%q", imdbID, best.Release)
+		d.log().Infof("metadata: scene release renamed or modified imdb=%d", imdbID)
 	}
 	return d.buildSceneResult(ctx, *best, renamed, reason)
 }
+
+// sceneRenamedReason is intentionally generic: it does not disclose the
+// canonical scene name, so the fix is not simply "rename the file back". A
+// modified release should be investigated (hash/provenance) rather than papered
+// over with a rename.
+const sceneRenamedReason = "source does not match its original scene release name (renamed or modified); verify the file hash and source provenance"
 
 // detectRename compares the canonical media filename(s) recorded for a scene
 // release against the on-disk basename. It is conservative: a name that matches
@@ -271,11 +277,10 @@ func (d *srrdbDetector) detectRename(ctx context.Context, release, localBase str
 	if err != nil {
 		return false, ""
 	}
-	canonical := canonicalMediaBase(details.ArchivedFiles, localBase)
-	if canonical == "" {
+	if canonicalMediaBase(details.ArchivedFiles, localBase) == "" {
 		return false, ""
 	}
-	return true, fmt.Sprintf("source renamed from scene release: on-disk %q does not match canonical %q", localBase, canonical)
+	return true, sceneRenamedReason
 }
 
 // isContextError reports cancellation and deadline errors from err or ctx.

--- a/internal/metadata/scene_scoring.go
+++ b/internal/metadata/scene_scoring.go
@@ -103,13 +103,19 @@ func scoreSceneCandidate(meta api.PreparedMetadata, wantRes string, localForeign
 		score += scoreTokenField(codec, tokens)
 	}
 
-	score += scoreEditions(rel.Edition, tokens)
+	editionScore, editionConflict := scoreEditions(rel.Edition, tokens)
+	score += editionScore
 
+	// A foreign-language/dub candidate is a different release from an
+	// English/original-language local one; treat it as an incompatibility, not just
+	// a score penalty, so it cannot be matched (and then flagged as renamed).
+	foreignConflict := false
 	if strings.EqualFold(strings.TrimSpace(cand.IsForeign), "yes") {
 		if localForeign {
 			score++
 		} else {
 			score -= 3
+			foreignConflict = true
 		}
 	}
 
@@ -117,7 +123,9 @@ func scoreSceneCandidate(meta api.PreparedMetadata, wantRes string, localForeign
 	// among {resolution matched, year matched, group matched}. Two signals is the
 	// false-positive guard: a single agreement (e.g. only the year, when the local
 	// resolution is unknown) is too weak to confidently claim a scene match and
-	// then flag a rename.
+	// then flag a rename. Foreign/edition incompatibilities are hard failures: a
+	// mismatched edition or foreign variant is the wrong release regardless of how
+	// many other signals agree.
 	strong := 0
 	if resMatched {
 		strong++
@@ -128,7 +136,7 @@ func scoreSceneCandidate(meta api.PreparedMetadata, wantRes string, localForeign
 	if groupOK {
 		strong++
 	}
-	eligible := resOK && strong >= 2
+	eligible := resOK && strong >= 2 && !foreignConflict && !editionConflict
 	return score, eligible
 }
 
@@ -146,10 +154,11 @@ func scoreTokenField(value string, tokens map[string]struct{}) int {
 	return 0
 }
 
-// scoreEditions rewards matching edition markers and penalises mismatches so an
-// "Extended" candidate is not chosen for a theatrical local release (and vice
-// versa) — the multi-edition disambiguation case.
-func scoreEditions(localEditions []string, tokens map[string]struct{}) int {
+// scoreEditions rewards matching edition markers and reports an incompatibility
+// so an "Extended" candidate is not chosen for a theatrical local release (and
+// vice versa) — the multi-edition disambiguation case. conflict is true when the
+// candidate and local disagree on any edition marker.
+func scoreEditions(localEditions []string, tokens map[string]struct{}) (score int, conflict bool) {
 	local := make(map[string]struct{})
 	for _, edition := range localEditions {
 		for _, part := range sceneTokenSplit.Split(strings.ToLower(strings.TrimSpace(edition)), -1) {
@@ -158,7 +167,6 @@ func scoreEditions(localEditions []string, tokens map[string]struct{}) int {
 			}
 		}
 	}
-	score := 0
 	for _, kw := range sceneEditionKeywords {
 		_, inCand := tokens[kw]
 		_, inLocal := local[kw]
@@ -167,11 +175,13 @@ func scoreEditions(localEditions []string, tokens map[string]struct{}) int {
 			score += 2
 		case inCand && !inLocal:
 			score -= 2
+			conflict = true
 		case !inCand && inLocal:
 			score--
+			conflict = true
 		}
 	}
-	return score
+	return score, conflict
 }
 
 // releaseLooksForeign reports whether the local release is itself a

--- a/internal/metadata/scene_scoring.go
+++ b/internal/metadata/scene_scoring.go
@@ -35,15 +35,12 @@ var sceneForeignKeywords = []string{
 	"dual", "vff", "vfq", "truefrench", "subbed", "dubbed",
 }
 
-// bestSceneCandidate picks the scene release that best matches the parsed local
+// bestSceneCandidate picks the scene release that best matches the prepared
 // metadata, or (nil, 0) when no candidate clears the structural eligibility bar.
-// Eligibility — not just the highest score — is what guards against
+// Eligibility, not just the highest score, is what guards against
 // false-flagging a non-scene release.
 func bestSceneCandidate(meta api.PreparedMetadata, localBase string, candidates []srrdbSearchResult) (*srrdbSearchResult, int) {
-	wantRes := strings.ToLower(strings.TrimSpace(meta.Release.Resolution))
-	if wantRes == "" {
-		wantRes = scanSceneResolution(localBase)
-	}
+	wantRes := sceneResolution(meta, localBase)
 	localForeign := releaseLooksForeign(meta, localBase)
 
 	bestIdx := -1
@@ -64,12 +61,11 @@ func bestSceneCandidate(meta api.PreparedMetadata, localBase string, candidates 
 	return &candidates[bestIdx], bestScore
 }
 
-// scoreSceneCandidate scores one candidate against the parsed release tokens.
+// scoreSceneCandidate scores one candidate against the effective release tokens.
 // Eligibility is false for structural conflicts such as resolution mismatch,
 // known-group mismatch, foreign-language mismatch, or edition mismatch.
 func scoreSceneCandidate(meta api.PreparedMetadata, wantRes string, localForeign bool, cand srrdbSearchResult) (int, bool) {
 	tokens := sceneTokens(cand.Release)
-	rel := meta.Release
 	score := 0
 
 	resOK := true
@@ -84,8 +80,8 @@ func scoreSceneCandidate(meta api.PreparedMetadata, wantRes string, localForeign
 	}
 
 	yearOK := false
-	if rel.Year > 0 {
-		if _, ok := tokens[strconv.Itoa(rel.Year)]; ok {
+	if year := sceneYear(meta); year > 0 {
+		if _, ok := tokens[strconv.Itoa(year)]; ok {
 			score += 3
 			yearOK = true
 		}
@@ -103,12 +99,12 @@ func scoreSceneCandidate(meta api.PreparedMetadata, wantRes string, localForeign
 		}
 	}
 
-	score += scoreTokenField(rel.Source, tokens)
-	for _, codec := range rel.Codec {
+	score += scoreTokenField(sceneSource(meta), tokens)
+	for _, codec := range sceneCodecs(meta) {
 		score += scoreTokenField(codec, tokens)
 	}
 
-	editionScore, editionConflict := scoreEditions(rel.Edition, tokens)
+	editionScore, editionConflict := scoreEditions(sceneEditions(meta), tokens)
 	score += editionScore
 
 	// A foreign-language/dub candidate is a different release from an
@@ -143,6 +139,106 @@ func scoreSceneCandidate(meta api.PreparedMetadata, wantRes string, localForeign
 	}
 	eligible := resOK && strong >= 2 && !groupConflict && !foreignConflict && !editionConflict
 	return score, eligible
+}
+
+// sceneResolution returns the normalized resolution available after media
+// details and release-name overrides, falling back to the local name when needed.
+func sceneResolution(meta api.PreparedMetadata, localBase string) string {
+	if meta.ReleaseNameOverrides.Resolution != nil {
+		if resolution := strings.ToLower(strings.TrimSpace(*meta.ReleaseNameOverrides.Resolution)); resolution != "" {
+			return resolution
+		}
+	}
+	for _, value := range []string{
+		meta.Release.Resolution,
+		meta.ReleaseNameNoTag,
+		meta.ReleaseNameClean,
+		meta.ReleaseName,
+		localBase,
+	} {
+		if resolution := scanSceneResolution(value); resolution != "" {
+			return resolution
+		}
+	}
+	return ""
+}
+
+// sceneYear returns the best title year known after tracker, Arr, and external
+// metadata enrichment. Parsed filename year is only one possible source.
+func sceneYear(meta api.PreparedMetadata) int {
+	if meta.ReleaseNameOverrides.ManualYear != nil && *meta.ReleaseNameOverrides.ManualYear > 0 {
+		return *meta.ReleaseNameOverrides.ManualYear
+	}
+	if meta.Release.Year > 0 {
+		return meta.Release.Year
+	}
+	if meta.ArrYear > 0 {
+		return meta.ArrYear
+	}
+	if meta.ExternalMetadata.TMDB != nil && meta.ExternalMetadata.TMDB.Year > 0 {
+		return meta.ExternalMetadata.TMDB.Year
+	}
+	if meta.ExternalMetadata.IMDB != nil && meta.ExternalMetadata.IMDB.Year > 0 {
+		return meta.ExternalMetadata.IMDB.Year
+	}
+	if meta.ExternalMetadata.TVDB != nil && meta.ExternalMetadata.TVDB.Year > 0 {
+		return meta.ExternalMetadata.TVDB.Year
+	}
+	if meta.ExternalMetadata.TVmaze != nil {
+		return parseSceneYearPrefix(meta.ExternalMetadata.TVmaze.Premiered)
+	}
+	return 0
+}
+
+// parseSceneYearPrefix accepts YYYY-prefixed date strings such as TVmaze's
+// Premiered value and returns 0 when no valid positive year is present.
+func parseSceneYearPrefix(value string) int {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) < 4 {
+		return 0
+	}
+	year, err := strconv.Atoi(trimmed[:4])
+	if err != nil || year <= 0 {
+		return 0
+	}
+	return year
+}
+
+// sceneSource returns the source label used for scoring, preferring manual
+// release-name overrides before the normalized media source and parsed source.
+func sceneSource(meta api.PreparedMetadata) string {
+	if meta.ReleaseNameOverrides.Source != nil {
+		if source := strings.TrimSpace(*meta.ReleaseNameOverrides.Source); source != "" {
+			return source
+		}
+	}
+	if source := strings.TrimSpace(meta.Source); source != "" {
+		return source
+	}
+	return strings.TrimSpace(meta.Release.Source)
+}
+
+// sceneCodecs returns every codec-like token known after media analysis so
+// parsed filename codecs and MediaInfo-derived codecs can both influence ties.
+func sceneCodecs(meta api.PreparedMetadata) []string {
+	values := make([]string, 0, len(meta.Release.Codec)+2)
+	values = append(values, meta.Release.Codec...)
+	values = append(values, meta.VideoEncode, meta.VideoCodec)
+	return values
+}
+
+// sceneEditions returns the effective edition markers for mismatch checks,
+// preferring manual naming overrides before normalized and parsed editions.
+func sceneEditions(meta api.PreparedMetadata) []string {
+	if meta.ReleaseNameOverrides.Edition != nil {
+		if edition := strings.TrimSpace(*meta.ReleaseNameOverrides.Edition); edition != "" {
+			return []string{edition}
+		}
+	}
+	if edition := strings.TrimSpace(meta.Edition); edition != "" {
+		return []string{edition}
+	}
+	return meta.Release.Edition
 }
 
 // scoreTokenField awards a point when any token of a parsed field (e.g. source
@@ -222,13 +318,20 @@ func releaseLooksForeign(meta api.PreparedMetadata, localBase string) bool {
 	return false
 }
 
-// sceneGroup resolves the parsed release group, falling back to the trailing tag
-// like the tracker rules do.
+// sceneGroup resolves the effective release group used for scene matching.
+// Manual release-name tag overrides win over parsed groups, because they also
+// drive the rebuilt upload name.
 func sceneGroup(meta api.PreparedMetadata) string {
+	if meta.ReleaseNameOverrides.Tag != nil {
+		return strings.TrimPrefix(strings.TrimSpace(*meta.ReleaseNameOverrides.Tag), "-")
+	}
+	if tag := strings.TrimSpace(meta.Tag); tag != "" {
+		return strings.TrimPrefix(tag, "-")
+	}
 	if group := strings.TrimSpace(meta.Release.Group); group != "" {
 		return group
 	}
-	return strings.TrimPrefix(strings.TrimSpace(meta.Tag), "-")
+	return ""
 }
 
 // sceneReleaseGroup returns the trailing scene group after the final dash.

--- a/internal/metadata/scene_scoring.go
+++ b/internal/metadata/scene_scoring.go
@@ -36,9 +36,9 @@ var sceneForeignKeywords = []string{
 }
 
 // bestSceneCandidate picks the scene release that best matches the parsed local
-// metadata, or (nil, 0) when no candidate clears the structural eligibility bar
-// (matching resolution plus year or group agreement). Eligibility — not just the
-// highest score — is what guards against false-flagging a non-scene release.
+// metadata, or (nil, 0) when no candidate clears the structural eligibility bar.
+// Eligibility — not just the highest score — is what guards against
+// false-flagging a non-scene release.
 func bestSceneCandidate(meta api.PreparedMetadata, localBase string, candidates []srrdbSearchResult) (*srrdbSearchResult, int) {
 	wantRes := strings.ToLower(strings.TrimSpace(meta.Release.Resolution))
 	if wantRes == "" {
@@ -64,8 +64,9 @@ func bestSceneCandidate(meta api.PreparedMetadata, localBase string, candidates 
 	return &candidates[bestIdx], bestScore
 }
 
-// scoreSceneCandidate scores one candidate against the parsed release tokens and
-// reports whether it is structurally eligible to be considered a match.
+// scoreSceneCandidate scores one candidate against the parsed release tokens.
+// Eligibility is false for structural conflicts such as resolution mismatch,
+// known-group mismatch, foreign-language mismatch, or edition mismatch.
 func scoreSceneCandidate(meta api.PreparedMetadata, wantRes string, localForeign bool, cand srrdbSearchResult) (int, bool) {
 	tokens := sceneTokens(cand.Release)
 	rel := meta.Release
@@ -90,11 +91,15 @@ func scoreSceneCandidate(meta api.PreparedMetadata, wantRes string, localForeign
 		}
 	}
 
+	group := sceneGroup(meta)
 	groupOK := false
-	if group := sceneGroup(meta); group != "" {
-		if strings.HasSuffix(strings.ToUpper(strings.TrimSpace(cand.Release)), "-"+strings.ToUpper(group)) {
+	groupConflict := false
+	if group != "" {
+		if strings.EqualFold(sceneReleaseGroup(cand.Release), group) {
 			score += 3
 			groupOK = true
+		} else {
+			groupConflict = true
 		}
 	}
 
@@ -123,9 +128,9 @@ func scoreSceneCandidate(meta api.PreparedMetadata, wantRes string, localForeign
 	// among {resolution matched, year matched, group matched}. Two signals is the
 	// false-positive guard: a single agreement (e.g. only the year, when the local
 	// resolution is unknown) is too weak to confidently claim a scene match and
-	// then flag a rename. Foreign/edition incompatibilities are hard failures: a
-	// mismatched edition or foreign variant is the wrong release regardless of how
-	// many other signals agree.
+	// then flag a rename. A known local group must match; a different scene group
+	// is a different release, regardless of title/year/resolution agreement.
+	// Foreign/edition incompatibilities are hard failures for the same reason.
 	strong := 0
 	if resMatched {
 		strong++
@@ -136,7 +141,7 @@ func scoreSceneCandidate(meta api.PreparedMetadata, wantRes string, localForeign
 	if groupOK {
 		strong++
 	}
-	eligible := resOK && strong >= 2 && !foreignConflict && !editionConflict
+	eligible := resOK && strong >= 2 && !groupConflict && !foreignConflict && !editionConflict
 	return score, eligible
 }
 
@@ -224,6 +229,16 @@ func sceneGroup(meta api.PreparedMetadata) string {
 		return group
 	}
 	return strings.TrimPrefix(strings.TrimSpace(meta.Tag), "-")
+}
+
+// sceneReleaseGroup returns the trailing scene group after the final dash.
+// Releases without a dash have no group for scoring purposes.
+func sceneReleaseGroup(release string) string {
+	trimmed := strings.TrimSpace(release)
+	if idx := strings.LastIndex(trimmed, "-"); idx >= 0 {
+		return strings.TrimSpace(trimmed[idx+1:])
+	}
+	return ""
 }
 
 func sceneTokens(value string) map[string]struct{} {

--- a/internal/metadata/scene_scoring.go
+++ b/internal/metadata/scene_scoring.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package metadata
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+// sceneTokenSplit breaks a release name into its dotted/spaced/underscored
+// tokens for case-insensitive set comparison.
+var sceneTokenSplit = regexp.MustCompile(`[.\s_\-]+`)
+
+var sceneResolutionTokens = []string{"8640p", "4320p", "2160p", "1440p", "1080p", "1080i", "720p", "576p", "576i", "480p", "480i"}
+
+// sceneEditionKeywords are the edition markers used to disambiguate between
+// multiple releases of the same title (e.g. theatrical vs. extended).
+var sceneEditionKeywords = []string{
+	"extended", "unrated", "directors", "director", "remastered", "theatrical",
+	"uncut", "imax", "ultimate", "redux", "despecialized", "criterion", "noir",
+}
+
+// sceneForeignKeywords flag a release as a foreign-language/dub variant so an
+// English-only local release is not matched against one. "dl" is deliberately
+// excluded: it is the WEB-DL protocol token, not a language marker, and would
+// misclassify every WEB-DL release as foreign.
+var sceneForeignKeywords = []string{
+	"german", "french", "italian", "spanish", "dutch", "danish", "swedish",
+	"norwegian", "finnish", "polish", "czech", "hungarian", "portuguese",
+	"russian", "korean", "japanese", "chinese", "hindi", "nordic", "multi",
+	"dual", "vff", "vfq", "truefrench", "subbed", "dubbed",
+}
+
+// bestSceneCandidate picks the scene release that best matches the parsed local
+// metadata, or (nil, 0) when no candidate clears the structural eligibility bar
+// (matching resolution plus year or group agreement). Eligibility — not just the
+// highest score — is what guards against false-flagging a non-scene release.
+func bestSceneCandidate(meta api.PreparedMetadata, localBase string, candidates []srrdbSearchResult) (*srrdbSearchResult, int) {
+	wantRes := strings.ToLower(strings.TrimSpace(meta.Release.Resolution))
+	if wantRes == "" {
+		wantRes = scanSceneResolution(localBase)
+	}
+	localForeign := releaseLooksForeign(meta, localBase)
+
+	bestIdx := -1
+	bestScore := 0
+	for i := range candidates {
+		score, eligible := scoreSceneCandidate(meta, wantRes, localForeign, candidates[i])
+		if !eligible {
+			continue
+		}
+		if bestIdx == -1 || score > bestScore {
+			bestIdx = i
+			bestScore = score
+		}
+	}
+	if bestIdx == -1 {
+		return nil, 0
+	}
+	return &candidates[bestIdx], bestScore
+}
+
+// scoreSceneCandidate scores one candidate against the parsed release tokens and
+// reports whether it is structurally eligible to be considered a match.
+func scoreSceneCandidate(meta api.PreparedMetadata, wantRes string, localForeign bool, cand srrdbSearchResult) (int, bool) {
+	tokens := sceneTokens(cand.Release)
+	rel := meta.Release
+	score := 0
+
+	resOK := true
+	resMatched := false
+	if wantRes != "" {
+		if _, ok := tokens[wantRes]; ok {
+			score += 3
+			resMatched = true
+		} else {
+			resOK = false
+		}
+	}
+
+	yearOK := false
+	if rel.Year > 0 {
+		if _, ok := tokens[strconv.Itoa(rel.Year)]; ok {
+			score += 3
+			yearOK = true
+		}
+	}
+
+	groupOK := false
+	if group := sceneGroup(meta); group != "" {
+		if strings.HasSuffix(strings.ToUpper(strings.TrimSpace(cand.Release)), "-"+strings.ToUpper(group)) {
+			score += 3
+			groupOK = true
+		}
+	}
+
+	score += scoreTokenField(rel.Source, tokens)
+	for _, codec := range rel.Codec {
+		score += scoreTokenField(codec, tokens)
+	}
+
+	score += scoreEditions(rel.Edition, tokens)
+
+	if strings.EqualFold(strings.TrimSpace(cand.IsForeign), "yes") {
+		if localForeign {
+			score++
+		} else {
+			score -= 3
+		}
+	}
+
+	// Require no resolution conflict plus at least two independent strong signals
+	// among {resolution matched, year matched, group matched}. Two signals is the
+	// false-positive guard: a single agreement (e.g. only the year, when the local
+	// resolution is unknown) is too weak to confidently claim a scene match and
+	// then flag a rename.
+	strong := 0
+	if resMatched {
+		strong++
+	}
+	if yearOK {
+		strong++
+	}
+	if groupOK {
+		strong++
+	}
+	eligible := resOK && strong >= 2
+	return score, eligible
+}
+
+// scoreTokenField awards a point when any token of a parsed field (e.g. source
+// "WEB-DL", codec "H.264") appears in the candidate.
+func scoreTokenField(value string, tokens map[string]struct{}) int {
+	for _, part := range sceneTokenSplit.Split(strings.ToLower(strings.TrimSpace(value)), -1) {
+		if part == "" {
+			continue
+		}
+		if _, ok := tokens[part]; ok {
+			return 1
+		}
+	}
+	return 0
+}
+
+// scoreEditions rewards matching edition markers and penalises mismatches so an
+// "Extended" candidate is not chosen for a theatrical local release (and vice
+// versa) — the multi-edition disambiguation case.
+func scoreEditions(localEditions []string, tokens map[string]struct{}) int {
+	local := make(map[string]struct{})
+	for _, edition := range localEditions {
+		for _, part := range sceneTokenSplit.Split(strings.ToLower(strings.TrimSpace(edition)), -1) {
+			if part != "" {
+				local[part] = struct{}{}
+			}
+		}
+	}
+	score := 0
+	for _, kw := range sceneEditionKeywords {
+		_, inCand := tokens[kw]
+		_, inLocal := local[kw]
+		switch {
+		case inCand && inLocal:
+			score += 2
+		case inCand && !inLocal:
+			score -= 2
+		case !inCand && inLocal:
+			score--
+		}
+	}
+	return score
+}
+
+// releaseLooksForeign reports whether the local release is itself a
+// foreign-language/dub variant, so that foreign candidates are preferred rather
+// than penalised for it.
+func releaseLooksForeign(meta api.PreparedMetadata, localBase string) bool {
+	// Parsed language metadata is authoritative when present: a non-English entry
+	// means foreign, and an English-only set means not foreign — the name-token
+	// heuristic below must not override it (e.g. a "dual"/"multi" token on an
+	// otherwise English release).
+	knownLanguage := false
+	for _, lang := range meta.Release.Language {
+		normalized := strings.ToLower(strings.TrimSpace(lang))
+		if normalized == "" {
+			continue
+		}
+		knownLanguage = true
+		if normalized != "english" && normalized != "en" {
+			return true
+		}
+	}
+	if knownLanguage {
+		return false
+	}
+
+	// No language metadata: fall back to a best-effort scan of the on-disk name.
+	tokens := sceneTokens(localBase)
+	for _, kw := range sceneForeignKeywords {
+		if _, ok := tokens[kw]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// sceneGroup resolves the parsed release group, falling back to the trailing tag
+// like the tracker rules do.
+func sceneGroup(meta api.PreparedMetadata) string {
+	if group := strings.TrimSpace(meta.Release.Group); group != "" {
+		return group
+	}
+	return strings.TrimPrefix(strings.TrimSpace(meta.Tag), "-")
+}
+
+func sceneTokens(value string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, token := range sceneTokenSplit.Split(strings.ToLower(value), -1) {
+		token = strings.TrimSpace(token)
+		if token != "" {
+			set[token] = struct{}{}
+		}
+	}
+	return set
+}
+
+func scanSceneResolution(value string) string {
+	lower := strings.ToLower(value)
+	for _, candidate := range sceneResolutionTokens {
+		if strings.Contains(lower, candidate) {
+			return candidate
+		}
+	}
+	return ""
+}

--- a/internal/metadata/scene_scoring_test.go
+++ b/internal/metadata/scene_scoring_test.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestBestSceneCandidate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		release   api.ReleaseInfo
+		tag       string
+		localBase string
+		cands     []srrdbSearchResult
+		wantPick  string // "" means expect no confident match
+	}{
+		{
+			name:      "exact tokens (renamed dots to spaces) match",
+			release:   api.ReleaseInfo{Resolution: "1080p", Year: 2014, Group: "GRP", Source: "BluRay", Codec: []string{"x264"}},
+			localBase: "Fury 2014 1080p BluRay x264 GRP",
+			cands: []srrdbSearchResult{
+				// Same title at a different resolution must not be matched.
+				{Release: "Fury.2014.720p.BluRay.x264-GRP"},
+				{Release: "Fury.2014.1080p.BluRay.x264-GRP"},
+			},
+			wantPick: "Fury.2014.1080p.BluRay.x264-GRP",
+		},
+		{
+			name:      "foreign dub is not chosen for an english release",
+			release:   api.ReleaseInfo{Resolution: "1080p", Year: 1994, Group: "GRP", Language: []string{"English"}},
+			localBase: "The Shawshank Redemption 1994 1080p BluRay x264 GRP",
+			cands: []srrdbSearchResult{
+				{Release: "The.Shawshank.Redemption.1994.German.DL.1080p.BluRay.x264-GRP", IsForeign: "yes"},
+				{Release: "The.Shawshank.Redemption.1994.1080p.BluRay.x264-GRP", IsForeign: "no"},
+			},
+			wantPick: "The.Shawshank.Redemption.1994.1080p.BluRay.x264-GRP",
+		},
+		{
+			name:      "multi-edition prefers the matching theatrical cut",
+			release:   api.ReleaseInfo{Resolution: "2160p", Year: 2014, Group: "GRP"},
+			localBase: "Movie 2014 2160p BluRay x265 GRP",
+			cands: []srrdbSearchResult{
+				{Release: "Movie.2014.Extended.2160p.BluRay.x265-GRP"},
+				{Release: "Movie.2014.2160p.BluRay.x265-GRP"},
+			},
+			wantPick: "Movie.2014.2160p.BluRay.x265-GRP",
+		},
+		{
+			name:      "multi-edition prefers the matching extended cut",
+			release:   api.ReleaseInfo{Resolution: "2160p", Year: 2014, Group: "GRP", Edition: []string{"Extended"}},
+			localBase: "Movie 2014 Extended 2160p BluRay x265 GRP",
+			cands: []srrdbSearchResult{
+				{Release: "Movie.2014.2160p.BluRay.x265-GRP"},
+				{Release: "Movie.2014.Extended.2160p.BluRay.x265-GRP"},
+			},
+			wantPick: "Movie.2014.Extended.2160p.BluRay.x265-GRP",
+		},
+		{
+			name:      "season pack matches on resolution and group without a year",
+			release:   api.ReleaseInfo{Resolution: "1080p", Group: "GRP", Source: "WEB-DL"},
+			localBase: "Show S01 1080p WEB-DL GRP",
+			cands: []srrdbSearchResult{
+				{Release: "Show.S01.1080p.WEB-DL.DDP5.1.H.264-GRP"},
+				{Release: "Other.Show.S01.720p.WEB-DL-GRP"},
+			},
+			wantPick: "Show.S01.1080p.WEB-DL.DDP5.1.H.264-GRP",
+		},
+		{
+			name:      "english web-dl is not misclassified as a foreign dub",
+			release:   api.ReleaseInfo{Resolution: "1080p", Year: 2019, Group: "YIFY", Source: "WEB-DL", Language: []string{"English"}},
+			localBase: "Movie 2019 1080p WEB-DL DDP5 1 H 264 YIFY",
+			cands: []srrdbSearchResult{
+				{Release: "Movie.2019.German.DL.1080p.BluRay.x264-YIFY", IsForeign: "yes"},
+				{Release: "Movie.2019.1080p.WEB-DL.DDP5.1.H.264-YIFY", IsForeign: "no"},
+			},
+			wantPick: "Movie.2019.1080p.WEB-DL.DDP5.1.H.264-YIFY",
+		},
+		{
+			name:      "year-only agreement with unknown resolution is not confident",
+			release:   api.ReleaseInfo{Year: 2008, Group: "P2PGROUP"},
+			localBase: "Movie 2008 DVDRip x264 P2PGROUP",
+			cands: []srrdbSearchResult{
+				{Release: "Movie.2008.R5.XviD-SCENEGROUP"},
+			},
+			wantPick: "",
+		},
+		{
+			name:      "no candidate at the right resolution is not matched",
+			release:   api.ReleaseInfo{Resolution: "2160p", Year: 2014, Group: "GRP"},
+			localBase: "Movie 2014 2160p BluRay x265 GRP",
+			cands: []srrdbSearchResult{
+				{Release: "Movie.2014.1080p.BluRay.x264-GRP"},
+				{Release: "Movie.2014.720p.BluRay.x264-GRP"},
+			},
+			wantPick: "",
+		},
+		{
+			name:      "wrong year and group is not matched",
+			release:   api.ReleaseInfo{Resolution: "1080p", Year: 2014, Group: "GRP"},
+			localBase: "Movie 2014 1080p BluRay x264 GRP",
+			cands: []srrdbSearchResult{
+				{Release: "Different.Movie.1999.1080p.BluRay.x264-OTHER"},
+			},
+			wantPick: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			meta := api.PreparedMetadata{Release: tc.release, Tag: tc.tag}
+			best, score := bestSceneCandidate(meta, tc.localBase, tc.cands)
+			if tc.wantPick == "" {
+				if best != nil {
+					t.Fatalf("expected no confident match, got %q (score %d)", best.Release, score)
+				}
+				return
+			}
+			if best == nil {
+				t.Fatalf("expected match %q, got none", tc.wantPick)
+			}
+			if best.Release != tc.wantPick {
+				t.Fatalf("picked %q (score %d), want %q", best.Release, score, tc.wantPick)
+			}
+		})
+	}
+}
+
+func TestCanonicalMediaBase(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		archived  []srrdbArchivedFile
+		localBase string
+		want      string
+	}{
+		{
+			name: "renamed local basename returns canonical media name",
+			archived: []srrdbArchivedFile{
+				{Name: "fury.2014.1080p.bluray.x264-grp.nfo", Size: 100},
+				{Name: "fury.2014.1080p.bluray.x264-grp.mkv", Size: 8000000000},
+			},
+			localBase: "Fury 2014 1080p BluRay x264 GRP",
+			want:      "fury.2014.1080p.bluray.x264-grp",
+		},
+		{
+			name: "matching basename (case aside) is not a rename",
+			archived: []srrdbArchivedFile{
+				{Name: "Fury.2014.1080p.BluRay.x264-GRP.mkv", Size: 8000000000},
+			},
+			localBase: "fury.2014.1080p.bluray.x264-grp",
+			want:      "",
+		},
+		{
+			name: "season pack: local episode matching a canonical file is not a rename",
+			archived: []srrdbArchivedFile{
+				{Name: "show.s01e01.1080p.web-dl-grp.mkv", Size: 2000000000},
+				{Name: "show.s01e02.1080p.web-dl-grp.mkv", Size: 2100000000},
+			},
+			localBase: "Show.S01E02.1080p.WEB-DL-GRP",
+			want:      "",
+		},
+		{
+			name: "no media files yields no verdict",
+			archived: []srrdbArchivedFile{
+				{Name: "release.nfo", Size: 100},
+				{Name: "sample/something.txt", Size: 10},
+			},
+			localBase: "Whatever",
+			want:      "",
+		},
+		{
+			name:      "largest media file is chosen as representative",
+			localBase: "renamed name",
+			archived: []srrdbArchivedFile{
+				{Name: "movie-sample.mkv", Size: 50000000},
+				{Name: "movie.2014.1080p.bluray.x264-grp.mkv", Size: 9000000000},
+			},
+			want: "movie.2014.1080p.bluray.x264-grp",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := canonicalMediaBase(tc.archived, tc.localBase)
+			if got != tc.want {
+				t.Fatalf("canonicalMediaBase = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/metadata/scene_scoring_test.go
+++ b/internal/metadata/scene_scoring_test.go
@@ -132,68 +132,120 @@ func TestBestSceneCandidate(t *testing.T) {
 	}
 }
 
-func TestCanonicalMediaBase(t *testing.T) {
+func TestArchivedMediaRenamed(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name      string
-		archived  []srrdbArchivedFile
-		localBase string
-		want      string
+		name        string
+		archived    []srrdbArchivedFile
+		localMedia  string
+		wantRenamed bool
+		wantMatched bool
 	}{
 		{
-			name: "renamed local basename returns canonical media name",
+			name: "renamed local filename is flagged",
 			archived: []srrdbArchivedFile{
-				{Name: "fury.2014.1080p.bluray.x264-grp.nfo", Size: 100},
-				{Name: "fury.2014.1080p.bluray.x264-grp.mkv", Size: 8000000000},
+				{Name: "driven.2001.1080p.bluray.x264-moovee.nfo", Size: 100},
+				{Name: "driven.2001.1080p.bluray.x264-moovee.mkv", Size: 8000000000},
 			},
-			localBase: "Fury 2014 1080p BluRay x264 GRP",
-			want:      "fury.2014.1080p.bluray.x264-grp",
+			localMedia:  "moovee-driven.mkv",
+			wantRenamed: true,
+			wantMatched: true,
 		},
 		{
-			name: "matching basename (case aside) is not a rename",
+			name: "exact case-sensitive filename match is not renamed",
 			archived: []srrdbArchivedFile{
-				{Name: "Fury.2014.1080p.BluRay.x264-GRP.mkv", Size: 8000000000},
+				{Name: "driven.2001.1080p.bluray.x264-moovee.mkv", Size: 8000000000},
 			},
-			localBase: "fury.2014.1080p.bluray.x264-grp",
-			want:      "",
+			localMedia:  "driven.2001.1080p.bluray.x264-moovee.mkv",
+			wantRenamed: false,
+			wantMatched: true,
 		},
 		{
-			name: "season pack: local episode matching a canonical file is not a rename",
+			name: "casing-only difference is treated as renamed (srrdb authoritative)",
+			archived: []srrdbArchivedFile{
+				{Name: "driven.2001.1080p.bluray.x264-moovee.mkv", Size: 8000000000},
+			},
+			localMedia:  "Driven.2001.1080p.BluRay.x264-MOOVEE.mkv",
+			wantRenamed: true,
+			wantMatched: true,
+		},
+		{
+			name: "season pack: local episode matching a canonical file is not renamed",
 			archived: []srrdbArchivedFile{
 				{Name: "show.s01e01.1080p.web-dl-grp.mkv", Size: 2000000000},
 				{Name: "show.s01e02.1080p.web-dl-grp.mkv", Size: 2100000000},
 			},
-			localBase: "Show.S01E02.1080p.WEB-DL-GRP",
-			want:      "",
+			localMedia:  "show.s01e02.1080p.web-dl-grp.mkv",
+			wantRenamed: false,
+			wantMatched: true,
 		},
 		{
-			name: "no media files yields no verdict",
+			name: "no archived media member yields no verdict",
 			archived: []srrdbArchivedFile{
 				{Name: "release.nfo", Size: 100},
 				{Name: "sample/something.txt", Size: 10},
 			},
-			localBase: "Whatever",
-			want:      "",
-		},
-		{
-			name:      "largest media file is chosen as representative",
-			localBase: "renamed name",
-			archived: []srrdbArchivedFile{
-				{Name: "movie-sample.mkv", Size: 50000000},
-				{Name: "movie.2014.1080p.bluray.x264-grp.mkv", Size: 9000000000},
-			},
-			want: "movie.2014.1080p.bluray.x264-grp",
+			localMedia:  "whatever.mkv",
+			wantRenamed: false,
+			wantMatched: false,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := canonicalMediaBase(tc.archived, tc.localBase)
-			if got != tc.want {
-				t.Fatalf("canonicalMediaBase = %q, want %q", got, tc.want)
+			renamed, matched := archivedMediaRenamed(tc.archived, tc.localMedia)
+			if renamed != tc.wantRenamed || matched != tc.wantMatched {
+				t.Fatalf("archivedMediaRenamed = (renamed=%t matched=%t), want (renamed=%t matched=%t)", renamed, matched, tc.wantRenamed, tc.wantMatched)
 			}
 		})
+	}
+}
+
+func TestFormatSRRDBIMDbID(t *testing.T) {
+	t.Parallel()
+	cases := map[int]string{
+		132245:  "tt0132245",
+		111161:  "tt0111161",
+		6946580: "tt6946580",
+		0:       "",
+		-5:      "",
+	}
+	for id, want := range cases {
+		if got := formatSRRDBIMDbID(id); got != want {
+			t.Fatalf("formatSRRDBIMDbID(%d) = %q, want %q", id, got, want)
+		}
+	}
+}
+
+func TestSceneLocalCandidates(t *testing.T) {
+	t.Parallel()
+
+	// Folder release: SourcePath is the release folder, VideoPath the media file.
+	c := sceneLocalCandidates(api.PreparedMetadata{
+		SourcePath: "/data/Driven.2001.1080p.BluRay.x264-MOOVEE",
+		VideoPath:  "/data/Driven.2001.1080p.BluRay.x264-MOOVEE/moovee-driven.mkv",
+	})
+	if len(c.folders) != 1 || c.folders[0] != "Driven.2001.1080p.BluRay.x264-MOOVEE" {
+		t.Fatalf("folder candidates = %v, want [Driven.2001.1080p.BluRay.x264-MOOVEE]", c.folders)
+	}
+	if len(c.files) != 1 || c.files[0] != "moovee-driven" {
+		t.Fatalf("file candidates = %v, want [moovee-driven]", c.files)
+	}
+	if c.mediaFilename != "moovee-driven.mkv" {
+		t.Fatalf("mediaFilename = %q, want moovee-driven.mkv", c.mediaFilename)
+	}
+
+	// Single-file release: SourcePath == VideoPath, no folder candidate.
+	single := sceneLocalCandidates(api.PreparedMetadata{
+		SourcePath: "/data/movie.2020.1080p.bluray.x264-grp.mkv",
+		VideoPath:  "/data/movie.2020.1080p.bluray.x264-grp.mkv",
+	})
+	if len(single.folders) != 0 {
+		t.Fatalf("single-file folder candidates = %v, want none", single.folders)
+	}
+	if len(single.files) != 1 || single.files[0] != "movie.2020.1080p.bluray.x264-grp" {
+		t.Fatalf("single-file file candidates = %v", single.files)
 	}
 }

--- a/internal/metadata/scene_scoring_test.go
+++ b/internal/metadata/scene_scoring_test.go
@@ -13,10 +13,13 @@ import (
 func TestBestSceneCandidate(t *testing.T) {
 	t.Parallel()
 
+	manualTag := "-MOOVEE"
 	cases := []struct {
 		name      string
+		meta      api.PreparedMetadata
 		release   api.ReleaseInfo
 		tag       string
+		overrides api.ReleaseNameOverrides
 		localBase string
 		cands     []srrdbSearchResult
 		wantPick  string // "" means expect no confident match
@@ -110,6 +113,43 @@ func TestBestSceneCandidate(t *testing.T) {
 			wantPick: "Movie.2015.1080p.WEB-DL.H.264-MONKEE",
 		},
 		{
+			name:      "manual tag override wins over parsed filename group",
+			release:   api.ReleaseInfo{Resolution: "1080p", Year: 2001, Group: "driven", Source: "BluRay", Codec: []string{"x264"}},
+			tag:       "-driven",
+			overrides: api.ReleaseNameOverrides{Tag: &manualTag},
+			localBase: "moovee-driven",
+			cands: []srrdbSearchResult{
+				{Release: "Driven.2001.1080p.BluRay.x264-MOOVEE", IsForeign: "no"},
+			},
+			wantPick: "Driven.2001.1080p.BluRay.x264-MOOVEE",
+		},
+		{
+			name: "external metadata year participates when parser year is missing",
+			meta: api.PreparedMetadata{
+				Release:          api.ReleaseInfo{Resolution: "1080p"},
+				ExternalMetadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{Year: 2001}},
+			},
+			localBase: "moovee-driven",
+			cands: []srrdbSearchResult{
+				{Release: "Driven.2001.1080p.BluRay.x264-MOOVEE", IsForeign: "no"},
+			},
+			wantPick: "Driven.2001.1080p.BluRay.x264-MOOVEE",
+		},
+		{
+			name: "media-derived codec participates when parser codec is missing",
+			meta: api.PreparedMetadata{
+				Release:          api.ReleaseInfo{Resolution: "1080p"},
+				ExternalMetadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{Year: 2001}},
+				VideoEncode:      "x264",
+			},
+			localBase: "Driven 2001 1080p",
+			cands: []srrdbSearchResult{
+				{Release: "Driven.2001.1080p.BluRay.x265-OTHER", IsForeign: "no"},
+				{Release: "Driven.2001.1080p.BluRay.x264-MOOVEE", IsForeign: "no"},
+			},
+			wantPick: "Driven.2001.1080p.BluRay.x264-MOOVEE",
+		},
+		{
 			name:      "no candidate at the right resolution is not matched",
 			release:   api.ReleaseInfo{Resolution: "2160p", Year: 2014, Group: "GRP"},
 			localBase: "Movie 2014 2160p BluRay x265 GRP",
@@ -133,7 +173,18 @@ func TestBestSceneCandidate(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			meta := api.PreparedMetadata{Release: tc.release, Tag: tc.tag}
+			meta := api.PreparedMetadata{Release: tc.release, Tag: tc.tag, ReleaseNameOverrides: tc.overrides}
+			if tc.meta.SourcePath != "" ||
+				tc.meta.VideoPath != "" ||
+				tc.meta.Release.Resolution != "" ||
+				tc.meta.ExternalMetadata.TMDB != nil ||
+				tc.meta.ExternalMetadata.IMDB != nil ||
+				tc.meta.ExternalMetadata.TVDB != nil ||
+				tc.meta.ExternalMetadata.TVmaze != nil ||
+				tc.meta.VideoEncode != "" ||
+				tc.meta.VideoCodec != "" {
+				meta = tc.meta
+			}
 			best, score := bestSceneCandidate(meta, tc.localBase, tc.cands)
 			if tc.wantPick == "" {
 				if best != nil {

--- a/internal/metadata/scene_scoring_test.go
+++ b/internal/metadata/scene_scoring_test.go
@@ -92,6 +92,24 @@ func TestBestSceneCandidate(t *testing.T) {
 			wantPick: "",
 		},
 		{
+			name:      "known local group must match candidate group",
+			release:   api.ReleaseInfo{Resolution: "1080p", Year: 2015, Group: "monkee", Source: "WEB-DL", Codec: []string{"H.264"}},
+			localBase: "7 Days in Hell 2015 1080p AMZN WEB-DL DD+ 5.1 H.264-monkee",
+			cands: []srrdbSearchResult{
+				{Release: "7.Days.in.Hell.2015.1080p.WEB.H264-DiMEPiECE", IsForeign: "no"},
+			},
+			wantPick: "",
+		},
+		{
+			name:      "known local group match is case-insensitive",
+			release:   api.ReleaseInfo{Resolution: "1080p", Year: 2015, Group: "monkee", Source: "WEB-DL", Codec: []string{"H.264"}},
+			localBase: "Movie 2015 1080p WEB-DL H.264-monkee",
+			cands: []srrdbSearchResult{
+				{Release: "Movie.2015.1080p.WEB-DL.H.264-MONKEE", IsForeign: "no"},
+			},
+			wantPick: "Movie.2015.1080p.WEB-DL.H.264-MONKEE",
+		},
+		{
 			name:      "no candidate at the right resolution is not matched",
 			release:   api.ReleaseInfo{Resolution: "2160p", Year: 2014, Group: "GRP"},
 			localBase: "Movie 2014 2160p BluRay x265 GRP",

--- a/internal/metadata/scene_scoring_test.go
+++ b/internal/metadata/scene_scoring_test.go
@@ -4,6 +4,7 @@
 package metadata
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/autobrr/upbrr/pkg/api"
@@ -222,13 +223,16 @@ func TestFormatSRRDBIMDbID(t *testing.T) {
 func TestSceneLocalCandidates(t *testing.T) {
 	t.Parallel()
 
+	base := t.TempDir()
+
 	// Folder release: SourcePath is the release folder, VideoPath the media file.
+	const folder = "Driven.2001.1080p.BluRay.x264-MOOVEE"
 	c := sceneLocalCandidates(api.PreparedMetadata{
-		SourcePath: "/data/Driven.2001.1080p.BluRay.x264-MOOVEE",
-		VideoPath:  "/data/Driven.2001.1080p.BluRay.x264-MOOVEE/moovee-driven.mkv",
+		SourcePath: filepath.Join(base, folder),
+		VideoPath:  filepath.Join(base, folder, "moovee-driven.mkv"),
 	})
-	if len(c.folders) != 1 || c.folders[0] != "Driven.2001.1080p.BluRay.x264-MOOVEE" {
-		t.Fatalf("folder candidates = %v, want [Driven.2001.1080p.BluRay.x264-MOOVEE]", c.folders)
+	if len(c.folders) != 1 || c.folders[0] != folder {
+		t.Fatalf("folder candidates = %v, want [%s]", c.folders, folder)
 	}
 	if len(c.files) != 1 || c.files[0] != "moovee-driven" {
 		t.Fatalf("file candidates = %v, want [moovee-driven]", c.files)
@@ -238,10 +242,8 @@ func TestSceneLocalCandidates(t *testing.T) {
 	}
 
 	// Single-file release: SourcePath == VideoPath, no folder candidate.
-	single := sceneLocalCandidates(api.PreparedMetadata{
-		SourcePath: "/data/movie.2020.1080p.bluray.x264-grp.mkv",
-		VideoPath:  "/data/movie.2020.1080p.bluray.x264-grp.mkv",
-	})
+	singlePath := filepath.Join(base, "movie.2020.1080p.bluray.x264-grp.mkv")
+	single := sceneLocalCandidates(api.PreparedMetadata{SourcePath: singlePath, VideoPath: singlePath})
 	if len(single.folders) != 0 {
 		t.Fatalf("single-file folder candidates = %v, want none", single.folders)
 	}

--- a/internal/metadata/scene_test.go
+++ b/internal/metadata/scene_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -344,6 +345,253 @@ func TestSceneDetectorSRRDBNFOContextCancellationIsFatal(t *testing.T) {
 	}
 	if result.IsScene {
 		t.Fatalf("expected cancellation to abort scene match, got %#v", result)
+	}
+}
+
+// srrdbFallbackHandler routes the srrdb endpoints used by the imdb: fallback so
+// tests can drive scene/rename detection without touching the live service.
+type srrdbFallbackHandler struct {
+	imdbPages map[int]string // page -> JSON body for /v1/search/imdb:<id>/...
+	details   map[string]string
+	rEmpty    bool // r: search returns an empty result set (forces the fallback)
+	imdbStat  int  // non-zero overrides the imdb: search status code
+}
+
+func (h srrdbFallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	path := r.URL.Path
+	switch {
+	case strings.Contains(path, "/v1/search/r:"):
+		if h.rEmpty {
+			_, _ = w.Write([]byte(`{"resultsCount":0,"results":[]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"resultsCount":0,"results":[]}`))
+	case strings.Contains(path, "/v1/search/imdb:"):
+		if h.imdbStat != 0 {
+			w.WriteHeader(h.imdbStat)
+			return
+		}
+		page := 1
+		if idx := strings.Index(path, "page:"); idx >= 0 {
+			if p, err := strconv.Atoi(path[idx+len("page:"):]); err == nil {
+				page = p
+			}
+		}
+		if body, ok := h.imdbPages[page]; ok {
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		_, _ = w.Write([]byte(`{"resultsCount":0,"results":[]}`))
+	case strings.HasPrefix(path, "/v1/details/"):
+		release := strings.TrimPrefix(path, "/v1/details/")
+		if body, ok := h.details[release]; ok {
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		_, _ = w.Write([]byte(`{"files":[],"archived-files":[]}`))
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func renamedSceneMeta(videoPath string) api.PreparedMetadata {
+	return api.PreparedMetadata{
+		VideoPath:   videoPath,
+		ExternalIDs: api.ExternalIDs{IMDBID: 111161},
+		Release: api.ReleaseInfo{
+			Resolution: "1080p",
+			Year:       2014,
+			Group:      "GRP",
+			Source:     "BluRay",
+			Codec:      []string{"x264"},
+		},
+	}
+}
+
+func TestSceneDetectorIMDBFallbackDetectsRename(t *testing.T) {
+	handler := srrdbFallbackHandler{
+		rEmpty: true,
+		imdbPages: map[int]string{
+			1: `{"resultsCount":1,"results":[{"release":"Fury.2014.1080p.BluRay.x264-GRP","imdbId":"111161","hasNFO":"no","isForeign":"no"}]}`,
+		},
+		details: map[string]string{
+			"Fury.2014.1080p.BluRay.x264-GRP": `{"files":[],"archived-files":[{"name":"fury.2014.1080p.bluray.x264-grp.mkv","crc":"AABBCCDD","size":8000000000}]}`,
+		},
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), renamedSceneMeta("/data/Fury 2014 1080p BluRay x264 GRP.mkv"))
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if !result.IsScene {
+		t.Fatalf("expected scene via imdb fallback")
+	}
+	if !result.Renamed {
+		t.Fatalf("expected renamed verdict")
+	}
+	if result.SceneName != "Fury.2014.1080p.BluRay.x264-GRP" {
+		t.Fatalf("unexpected scene name: %q", result.SceneName)
+	}
+	if result.IMDBID != 111161 {
+		t.Fatalf("unexpected imdb id: %d", result.IMDBID)
+	}
+	if strings.TrimSpace(result.RenamedReason) == "" {
+		t.Fatalf("expected a rename reason")
+	}
+}
+
+func TestSceneDetectorIMDBFallbackUnmodifiedNotRenamed(t *testing.T) {
+	handler := srrdbFallbackHandler{
+		rEmpty: true,
+		imdbPages: map[int]string{
+			1: `{"resultsCount":1,"results":[{"release":"Fury.2014.1080p.BluRay.x264-GRP","imdbId":"111161","hasNFO":"no"}]}`,
+		},
+		details: map[string]string{
+			"Fury.2014.1080p.BluRay.x264-GRP": `{"archived-files":[{"name":"Fury.2014.1080p.BluRay.x264-GRP.mkv","size":8000000000}]}`,
+		},
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	// On-disk name equals the canonical media basename (case aside), so although
+	// the r: search missed, this must not be flagged as renamed.
+	result, err := detector.Detect(context.Background(), renamedSceneMeta("/data/fury.2014.1080p.bluray.x264-grp.mkv"))
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if !result.IsScene {
+		t.Fatalf("expected scene match")
+	}
+	if result.Renamed {
+		t.Fatalf("did not expect a rename verdict, reason=%q", result.RenamedReason)
+	}
+}
+
+func TestSceneDetectorIMDBFallbackPaginates(t *testing.T) {
+	// Page 1 is full (40 wrong-resolution entries); the match is only on page 2.
+	var page1 strings.Builder
+	page1.WriteString(`{"resultsCount":41,"results":[`)
+	for i := 0; i < 40; i++ {
+		if i > 0 {
+			page1.WriteString(",")
+		}
+		page1.WriteString(`{"release":"Fury.2014.720p.BluRay.x264-GRP","imdbId":"111161"}`)
+	}
+	page1.WriteString(`]}`)
+
+	handler := srrdbFallbackHandler{
+		rEmpty: true,
+		imdbPages: map[int]string{
+			1: page1.String(),
+			2: `{"resultsCount":41,"results":[{"release":"Fury.2014.1080p.BluRay.x264-GRP","imdbId":"111161"}]}`,
+		},
+		details: map[string]string{
+			"Fury.2014.1080p.BluRay.x264-GRP": `{"archived-files":[{"name":"fury.2014.1080p.bluray.x264-grp.mkv","size":8000000000}]}`,
+		},
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), renamedSceneMeta("/data/Fury 2014 1080p BluRay x264 GRP.mkv"))
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if !result.IsScene || result.SceneName != "Fury.2014.1080p.BluRay.x264-GRP" {
+		t.Fatalf("expected paginated match, got %#v", result)
+	}
+}
+
+func TestSceneDetectorIMDBFallbackSoftFailsOnError(t *testing.T) {
+	handler := srrdbFallbackHandler{rEmpty: true, imdbStat: http.StatusInternalServerError}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), renamedSceneMeta("/data/Fury 2014 1080p BluRay x264 GRP.mkv"))
+	if err != nil {
+		t.Fatalf("expected soft-fail (nil error), got %v", err)
+	}
+	if result.IsScene || result.Renamed {
+		t.Fatalf("expected no scene match on srrdb error, got %#v", result)
+	}
+}
+
+func TestSceneDetectorRSearchSoftFailsOnNetworkError(t *testing.T) {
+	// srrdb unreachable on the initial r: search must not block an upload.
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("connection refused")
+	})}
+	detector := newSRRDBDetector(client, "https://api.srrdb.com", t.TempDir(), t.TempDir())
+
+	result, err := detector.Detect(context.Background(), renamedSceneMeta("/data/Fury 2014 1080p BluRay x264 GRP.mkv"))
+	if err != nil {
+		t.Fatalf("expected soft-fail (nil error) on r: network error, got %v", err)
+	}
+	if result.IsScene || result.Renamed {
+		t.Fatalf("expected no scene match on srrdb outage, got %#v", result)
+	}
+}
+
+func TestSceneDetectorRSearchSoftFailsOnMalformedBody(t *testing.T) {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/v1/search/r:Example.Release", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resultsCount":1,"results":[`)) // truncated JSON
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), api.PreparedMetadata{VideoPath: "/data/Example.Release.mkv"})
+	if err != nil {
+		t.Fatalf("expected soft-fail (nil error) on malformed r: body, got %v", err)
+	}
+	if result.IsScene {
+		t.Fatalf("expected no scene match on malformed body, got %#v", result)
+	}
+}
+
+func TestSceneDetectorIMDBFallbackSkippedWithoutIMDbID(t *testing.T) {
+	handler := srrdbFallbackHandler{rEmpty: true}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	meta := renamedSceneMeta("/data/Fury 2014 1080p BluRay x264 GRP.mkv")
+	meta.ExternalIDs = api.ExternalIDs{} // no known id at detect time
+	result, err := detector.Detect(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if result.IsScene {
+		t.Fatalf("expected no fallback without an imdb id, got %#v", result)
+	}
+}
+
+func TestSceneDetectorIMDBFallbackNoConfidentCandidate(t *testing.T) {
+	// Only wrong-resolution releases exist for the title: no confident match.
+	handler := srrdbFallbackHandler{
+		rEmpty: true,
+		imdbPages: map[int]string{
+			1: `{"resultsCount":2,"results":[{"release":"Fury.2014.720p.BluRay.x264-GRP","imdbId":"111161"},{"release":"Fury.2014.480p.DVDRip.x264-GRP","imdbId":"111161"}]}`,
+		},
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), renamedSceneMeta("/data/Fury 2014 1080p BluRay x264 GRP.mkv"))
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if result.IsScene || result.Renamed {
+		t.Fatalf("expected no match for a non-matching candidate set, got %#v", result)
 	}
 }
 

--- a/internal/metadata/scene_test.go
+++ b/internal/metadata/scene_test.go
@@ -458,9 +458,9 @@ func TestSceneDetectorIMDBFallbackUnmodifiedNotRenamed(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
-	// On-disk name equals the canonical media basename (case aside), so although
-	// the r: search missed, this must not be flagged as renamed.
-	result, err := detector.Detect(context.Background(), renamedSceneMeta("/data/fury.2014.1080p.bluray.x264-grp.mkv"))
+	// On-disk media filename exactly matches the archived scene media filename, so
+	// this must not be flagged as renamed.
+	result, err := detector.Detect(context.Background(), renamedSceneMeta("/data/Fury.2014.1080p.BluRay.x264-GRP.mkv"))
 	if err != nil {
 		t.Fatalf("Detect error: %v", err)
 	}
@@ -469,6 +469,77 @@ func TestSceneDetectorIMDBFallbackUnmodifiedNotRenamed(t *testing.T) {
 	}
 	if result.Renamed {
 		t.Fatalf("did not expect a rename verdict, reason=%q", result.RenamedReason)
+	}
+}
+
+func TestSceneDetectorIMDBFallbackCaseOnlyDiffIsRenamed(t *testing.T) {
+	handler := srrdbFallbackHandler{
+		rEmpty: true,
+		imdbPages: map[int]string{
+			1: `{"resultsCount":1,"results":[{"release":"Fury.2014.1080p.BluRay.x264-GRP","imdbId":"111161","hasNFO":"no"}]}`,
+		},
+		details: map[string]string{
+			"Fury.2014.1080p.BluRay.x264-GRP": `{"archived-files":[{"name":"fury.2014.1080p.bluray.x264-grp.mkv","size":8000000000}]}`,
+		},
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	// Local media filename matches the archived one except for casing; srrdb is
+	// authoritative, so a casing-only difference is a rename.
+	result, err := detector.Detect(context.Background(), renamedSceneMeta("/data/Fury.2014.1080p.BluRay.x264-GRP.mkv"))
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if !result.IsScene || !result.Renamed {
+		t.Fatalf("expected scene + renamed on casing-only difference, got %#v", result)
+	}
+}
+
+func TestSceneDetectorDrivenFolderMatchDetectsRenamedFile(t *testing.T) {
+	// The maintainer's case: folder is the canonical scene name; the media file
+	// inside is renamed. IMDb tt0132245 is resolved; the imdb: search returns the
+	// release set; the folder candidate selects the exact release; the media file
+	// differs from the archived scene filename ⇒ scene + renamed.
+	const release = "Driven.2001.1080p.BluRay.x264-MOOVEE"
+	handler := srrdbFallbackHandler{
+		rEmpty: true,
+		imdbPages: map[int]string{
+			1: `{"resultsCount":3,"results":[` +
+				`{"release":"Driven.2001.German.DL.1080p.BluRay.x264-DETAiLS","imdbId":"0132245","isForeign":"yes"},` +
+				`{"release":"Driven.2001.1080p.BluRay.x264-MOOVEE","imdbId":"0132245","isForeign":"no"},` +
+				`{"release":"Driven.2001.720p.BluRay.x264-CiNEFiLE","imdbId":"0132245","isForeign":"no"}]}`,
+		},
+		details: map[string]string{
+			release: `{"archived-files":[{"name":"driven.2001.1080p.bluray.x264-moovee.mkv","crc":"9CDDBFCD","size":4695029966}]}`,
+		},
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	meta := api.PreparedMetadata{
+		SourcePath:  "/data/Driven.2001.1080p.BluRay.x264-MOOVEE",
+		VideoPath:   "/data/Driven.2001.1080p.BluRay.x264-MOOVEE/moovee-driven.mkv",
+		ExternalIDs: api.ExternalIDs{IMDBID: 132245},
+		Release:     api.ReleaseInfo{Resolution: "1080p", Year: 2001, Group: "MOOVEE", Source: "BluRay", Codec: []string{"x264"}, Language: []string{"English"}},
+	}
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if !result.IsScene {
+		t.Fatalf("expected scene match via folder candidate")
+	}
+	if result.SceneName != release {
+		t.Fatalf("expected release %q, got %q", release, result.SceneName)
+	}
+	if result.IMDBID != 132245 {
+		t.Fatalf("expected imdb 132245, got %d", result.IMDBID)
+	}
+	if !result.Renamed || strings.TrimSpace(result.RenamedReason) == "" {
+		t.Fatalf("expected renamed verdict for renamed media file, got %#v", result)
 	}
 }
 
@@ -523,18 +594,52 @@ func TestSceneDetectorIMDBFallbackSoftFailsOnError(t *testing.T) {
 }
 
 func TestSceneDetectorRSearchSoftFailsOnNetworkError(t *testing.T) {
-	// srrdb unreachable on the initial r: search must not block an upload.
+	// srrdb unreachable on the r: fallback (no imdb) must not block an upload.
 	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return nil, errors.New("connection refused")
 	})}
 	detector := newSRRDBDetector(client, "https://api.srrdb.com", t.TempDir(), t.TempDir())
 
-	result, err := detector.Detect(context.Background(), renamedSceneMeta("/data/Fury 2014 1080p BluRay x264 GRP.mkv"))
+	meta := renamedSceneMeta("/data/Fury 2014 1080p BluRay x264 GRP.mkv")
+	meta.ExternalIDs = api.ExternalIDs{} // force the r: fallback path
+	result, err := detector.Detect(context.Background(), meta)
 	if err != nil {
 		t.Fatalf("expected soft-fail (nil error) on r: network error, got %v", err)
 	}
 	if result.IsScene || result.Renamed {
 		t.Fatalf("expected no scene match on srrdb outage, got %#v", result)
+	}
+}
+
+func TestSceneDetectorRFallbackFolderFirstWhenNoIMDb(t *testing.T) {
+	// No imdb id: the r: fallback tries the canonical folder candidate first.
+	const release = "Driven.2001.1080p.BluRay.x264-MOOVEE"
+	handler := http.NewServeMux()
+	handler.HandleFunc("/v1/search/r:"+release, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resultsCount":1,"results":[{"release":"` + release + `","imdbId":"0132245"}]}`))
+	})
+	handler.HandleFunc("/v1/details/"+release, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"archived-files":[{"name":"driven.2001.1080p.bluray.x264-moovee.mkv","size":4695029966}]}`))
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	meta := api.PreparedMetadata{
+		SourcePath: "/data/" + release,
+		VideoPath:  "/data/" + release + "/driven.2001.1080p.bluray.x264-moovee.mkv",
+	}
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if !result.IsScene || result.SceneName != release {
+		t.Fatalf("expected r: folder match %q, got %#v", release, result)
+	}
+	if result.Renamed {
+		t.Fatalf("did not expect rename (media filename matches archived), got reason=%q", result.RenamedReason)
 	}
 }
 

--- a/internal/metadata/scene_test.go
+++ b/internal/metadata/scene_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/autobrr/upbrr/pkg/api"
@@ -353,8 +354,9 @@ func TestSceneDetectorSRRDBNFOContextCancellationIsFatal(t *testing.T) {
 type srrdbFallbackHandler struct {
 	imdbPages map[int]string // page -> JSON body for /v1/search/imdb:<id>/...
 	details   map[string]string
-	rEmpty    bool // r: search returns an empty result set (forces the fallback)
-	imdbStat  int  // non-zero overrides the imdb: search status code
+	rResults  map[string]string // r:<name> -> JSON body (name is the unescaped search term)
+	imdbStat  int               // non-zero overrides the imdb: search status code
+	imdbHits  *atomic.Int32     // when set, counts /v1/search/imdb: requests
 }
 
 func (h srrdbFallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -362,12 +364,16 @@ func (h srrdbFallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	path := r.URL.Path
 	switch {
 	case strings.Contains(path, "/v1/search/r:"):
-		if h.rEmpty {
-			_, _ = w.Write([]byte(`{"resultsCount":0,"results":[]}`))
+		name := path[strings.Index(path, "/v1/search/r:")+len("/v1/search/r:"):]
+		if body, ok := h.rResults[name]; ok {
+			_, _ = w.Write([]byte(body))
 			return
 		}
 		_, _ = w.Write([]byte(`{"resultsCount":0,"results":[]}`))
 	case strings.Contains(path, "/v1/search/imdb:"):
+		if h.imdbHits != nil {
+			h.imdbHits.Add(1)
+		}
 		if h.imdbStat != 0 {
 			w.WriteHeader(h.imdbStat)
 			return
@@ -411,7 +417,6 @@ func renamedSceneMeta(videoPath string) api.PreparedMetadata {
 
 func TestSceneDetectorIMDBFallbackDetectsRename(t *testing.T) {
 	handler := srrdbFallbackHandler{
-		rEmpty: true,
 		imdbPages: map[int]string{
 			1: `{"resultsCount":1,"results":[{"release":"Fury.2014.1080p.BluRay.x264-GRP","imdbId":"111161","hasNFO":"no","isForeign":"no"}]}`,
 		},
@@ -446,7 +451,6 @@ func TestSceneDetectorIMDBFallbackDetectsRename(t *testing.T) {
 
 func TestSceneDetectorIMDBFallbackUnmodifiedNotRenamed(t *testing.T) {
 	handler := srrdbFallbackHandler{
-		rEmpty: true,
 		imdbPages: map[int]string{
 			1: `{"resultsCount":1,"results":[{"release":"Fury.2014.1080p.BluRay.x264-GRP","imdbId":"111161","hasNFO":"no"}]}`,
 		},
@@ -474,7 +478,6 @@ func TestSceneDetectorIMDBFallbackUnmodifiedNotRenamed(t *testing.T) {
 
 func TestSceneDetectorIMDBFallbackCaseOnlyDiffIsRenamed(t *testing.T) {
 	handler := srrdbFallbackHandler{
-		rEmpty: true,
 		imdbPages: map[int]string{
 			1: `{"resultsCount":1,"results":[{"release":"Fury.2014.1080p.BluRay.x264-GRP","imdbId":"111161","hasNFO":"no"}]}`,
 		},
@@ -504,7 +507,6 @@ func TestSceneDetectorDrivenFolderMatchDetectsRenamedFile(t *testing.T) {
 	// differs from the archived scene filename ⇒ scene + renamed.
 	const release = "Driven.2001.1080p.BluRay.x264-MOOVEE"
 	handler := srrdbFallbackHandler{
-		rEmpty: true,
 		imdbPages: map[int]string{
 			1: `{"resultsCount":3,"results":[` +
 				`{"release":"Driven.2001.German.DL.1080p.BluRay.x264-DETAiLS","imdbId":"0132245","isForeign":"yes"},` +
@@ -556,7 +558,6 @@ func TestSceneDetectorIMDBFallbackPaginates(t *testing.T) {
 	page1.WriteString(`]}`)
 
 	handler := srrdbFallbackHandler{
-		rEmpty: true,
 		imdbPages: map[int]string{
 			1: page1.String(),
 			2: `{"resultsCount":41,"results":[{"release":"Fury.2014.1080p.BluRay.x264-GRP","imdbId":"111161"}]}`,
@@ -579,7 +580,7 @@ func TestSceneDetectorIMDBFallbackPaginates(t *testing.T) {
 }
 
 func TestSceneDetectorIMDBFallbackSoftFailsOnError(t *testing.T) {
-	handler := srrdbFallbackHandler{rEmpty: true, imdbStat: http.StatusInternalServerError}
+	handler := srrdbFallbackHandler{imdbStat: http.StatusInternalServerError}
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
@@ -663,7 +664,8 @@ func TestSceneDetectorRSearchSoftFailsOnMalformedBody(t *testing.T) {
 }
 
 func TestSceneDetectorIMDBFallbackSkippedWithoutIMDbID(t *testing.T) {
-	handler := srrdbFallbackHandler{rEmpty: true}
+	imdbHits := &atomic.Int32{}
+	handler := srrdbFallbackHandler{imdbHits: imdbHits}
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
@@ -677,12 +679,48 @@ func TestSceneDetectorIMDBFallbackSkippedWithoutIMDbID(t *testing.T) {
 	if result.IsScene {
 		t.Fatalf("expected no fallback without an imdb id, got %#v", result)
 	}
+	if got := imdbHits.Load(); got != 0 {
+		t.Fatalf("expected no imdb: request without an imdb id, got %d", got)
+	}
+}
+
+func TestSceneDetectorFallsBackToRWhenIMDbFindsNoMatch(t *testing.T) {
+	// IMDb id is known, but the imdb: search returns only a non-matching release;
+	// Detect must fall through to the exact r: folder search rather than give up.
+	const release = "Driven.2001.1080p.BluRay.x264-MOOVEE"
+	handler := srrdbFallbackHandler{
+		imdbPages: map[int]string{
+			1: `{"resultsCount":1,"results":[{"release":"Driven.2001.720p.BluRay.x264-CiNEFiLE","imdbId":"0132245"}]}`,
+		},
+		rResults: map[string]string{
+			release: `{"resultsCount":1,"results":[{"release":"` + release + `","imdbId":"0132245"}]}`,
+		},
+		details: map[string]string{
+			release: `{"archived-files":[{"name":"driven.2001.1080p.bluray.x264-moovee.mkv","size":4695029966}]}`,
+		},
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	meta := api.PreparedMetadata{
+		SourcePath:  "/data/" + release,
+		VideoPath:   "/data/" + release + "/driven.2001.1080p.bluray.x264-moovee.mkv",
+		ExternalIDs: api.ExternalIDs{IMDBID: 132245},
+		Release:     api.ReleaseInfo{Resolution: "1080p", Year: 2001, Group: "MOOVEE"},
+	}
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if !result.IsScene || result.SceneName != release {
+		t.Fatalf("expected r: fallback match %q after imdb miss, got %#v", release, result)
+	}
 }
 
 func TestSceneDetectorIMDBFallbackNoConfidentCandidate(t *testing.T) {
 	// Only wrong-resolution releases exist for the title: no confident match.
 	handler := srrdbFallbackHandler{
-		rEmpty: true,
 		imdbPages: map[int]string{
 			1: `{"resultsCount":2,"results":[{"release":"Fury.2014.720p.BluRay.x264-GRP","imdbId":"111161"},{"release":"Fury.2014.480p.DVDRip.x264-GRP","imdbId":"111161"}]}`,
 		},

--- a/internal/metadata/scene_test.go
+++ b/internal/metadata/scene_test.go
@@ -6,6 +6,7 @@ package metadata
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -23,6 +24,23 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+type sceneLogRecorder struct {
+	api.NopLogger
+	lines []string
+}
+
+func (r *sceneLogRecorder) Debugf(format string, args ...any) {
+	r.lines = append(r.lines, fmt.Sprintf(format, args...))
+}
+
+func (r *sceneLogRecorder) Tracef(format string, args ...any) {
+	r.lines = append(r.lines, fmt.Sprintf(format, args...))
+}
+
+func (r *sceneLogRecorder) join() string {
+	return strings.Join(r.lines, "\n")
 }
 
 func TestSceneDetectorSRRDB(t *testing.T) {
@@ -83,6 +101,62 @@ func TestSceneDetectorSRRDBFetchesIMDbWhenSearchOmitsIt(t *testing.T) {
 	}
 	if result.IMDBID != 7654321 {
 		t.Fatalf("unexpected imdb id: %d", result.IMDBID)
+	}
+}
+
+func TestSceneDetectorSRRDBLogsNFODownloadLifecycle(t *testing.T) {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/v1/search/r:Example.Release", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resultsCount":1,"results":[{"release":"Example.Release.2024.1080p-WEB","imdbId":"1234567","hasNFO":"yes"}]}`))
+	})
+	handler.HandleFunc("/v1/details/Example.Release.2024.1080p-WEB", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"files":[{"name":"Example.Release.Custom.NFO"}]}`))
+	})
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client := server.Client()
+	baseTransport := client.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	client.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if strings.EqualFold(req.URL.Host, "www.srrdb.com") {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("URL: https://www.imdb.com/title/tt1234567/")),
+				Request:    req,
+			}, nil
+		}
+		return baseTransport.RoundTrip(req)
+	})
+
+	logger := &sceneLogRecorder{}
+	detector := newSRRDBDetector(client, server.URL, t.TempDir(), t.TempDir())
+	detector.logger = logger
+
+	result, err := detector.Detect(context.Background(), api.PreparedMetadata{VideoPath: "/data/Example.Release.mkv"})
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if result.NFOPath == "" || !result.NFONew {
+		t.Fatalf("expected downloaded NFO, got path=%q new=%t", result.NFOPath, result.NFONew)
+	}
+	logs := logger.join()
+	for _, want := range []string{
+		"metadata: scene nfo lookup start",
+		"metadata: scene nfo details selected",
+		"metadata: scene nfo downloading",
+		"metadata: scene nfo downloaded",
+		"metadata: scene nfo attached downloaded=true",
+	} {
+		if !strings.Contains(logs, want) {
+			t.Fatalf("expected log %q in:\n%s", want, logs)
+		}
 	}
 }
 
@@ -379,8 +453,8 @@ func (h srrdbFallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		page := 1
-		if idx := strings.Index(path, "page:"); idx >= 0 {
-			if p, err := strconv.Atoi(path[idx+len("page:"):]); err == nil {
+		if _, after, ok := strings.Cut(path, "page:"); ok {
+			if p, err := strconv.Atoi(after); err == nil {
 				page = p
 			}
 		}
@@ -549,7 +623,7 @@ func TestSceneDetectorIMDBFallbackPaginates(t *testing.T) {
 	// Page 1 is full (40 wrong-resolution entries); the match is only on page 2.
 	var page1 strings.Builder
 	page1.WriteString(`{"resultsCount":41,"results":[`)
-	for i := 0; i < 40; i++ {
+	for i := range 40 {
 		if i > 0 {
 			page1.WriteString(",")
 		}

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -495,11 +495,7 @@ func (s *Service) Prepare(ctx context.Context, req api.Request) (api.PreparedMet
 	s.logger.Debugf("metadata: source size %d bytes", size)
 
 	storedInfoHash := ""
-	var storedMetadata db.FileMetadata
-	hasStoredMetadata := false
 	if existing, err := s.repo.GetByPath(ctx, primary); err == nil {
-		storedMetadata = existing
-		hasStoredMetadata = true
 		meta.StoredUpdatedAt = existing.UpdatedAt
 		if metadataFingerprintMatches(primary, meta, existing) {
 			meta.StoredDataFresh = true
@@ -528,51 +524,10 @@ func (s *Service) Prepare(ctx context.Context, req api.Request) (api.PreparedMet
 		}
 	}
 
-	if s.scene != nil {
-		result, err := s.scene.Detect(ctx, meta)
-		recoverableNFOError := false
-		if err != nil {
-			if isSceneNFOError(err) {
-				recoverableNFOError = true
-				s.logger.Warnf("metadata: scene nfo side effect failed: %v", err)
-			} else {
-				return api.PreparedMetadata{}, fmt.Errorf("metadata: scene detect: %w", err)
-			}
-		}
-		if !recoverableNFOError || sceneResultHasData(result) {
-			applySceneResult(&meta, result)
-		} else if hasStoredMetadata {
-			applyStoredSceneMetadata(&meta, storedMetadata)
-		}
-		if meta.Scene {
-			s.logger.Debugf("metadata: scene release detected")
-		}
-		if meta.SceneTMDBID > 0 {
-			s.logger.Debugf("metadata: scene tmdb detected %d", meta.SceneTMDBID)
-		}
-		if meta.SceneIMDB > 0 {
-			s.logger.Debugf("metadata: scene imdb detected %d", meta.SceneIMDB)
-		}
-		if meta.SceneTVDBID > 0 {
-			s.logger.Debugf("metadata: scene tvdb detected %d", meta.SceneTVDBID)
-		}
-		if meta.SceneTVmazeID > 0 {
-			s.logger.Debugf("metadata: scene tvmaze detected %d", meta.SceneTVmazeID)
-		}
-		if meta.SceneMALID > 0 {
-			s.logger.Debugf("metadata: scene mal detected %d", meta.SceneMALID)
-		}
-		if meta.Service != "" && strings.TrimSpace(result.Service) != "" {
-			s.logger.Debugf("metadata: scene service detected %q", meta.Service)
-		}
-		if meta.SceneNFOPath != "" {
-			if meta.SceneNFONew {
-				s.logger.Debugf("metadata: scene nfo downloaded %s", meta.SceneNFOPath)
-			} else {
-				s.logger.Debugf("metadata: scene nfo found %s", meta.SceneNFOPath)
-			}
-		}
-	}
+	// Scene detection was moved out of Prepare into ApplyMediaDetails: it needs a
+	// resolved IMDb id and the rebuilt release name (both produced after
+	// ResolveExternalIDs), so running it here — before tracker/external-ID
+	// resolution — missed renamed releases entirely.
 	if release.Title != "" || release.Alt != "" || release.Subtitle != "" || release.Artist != "" || release.Year != 0 || release.Month != 0 || release.Day != 0 || release.Source != "" || release.Resolution != "" || release.Ext != "" || release.Site != "" || release.Genre != "" || release.Channels != "" || release.Collection != "" || release.Region != "" || release.Size != "" || release.Group != "" || release.Disc != "" || release.Type != "" || release.Category != "" || len(release.Codec) > 0 || len(release.Audio) > 0 || len(release.HDR) > 0 || len(release.Language) > 0 {
 		s.logger.Debugf(
 			"metadata: release parsed category=%q type=%q artist=%q title=%q subtitle=%q alt=%q year=%d month=%d day=%d source=%q resolution=%q codec=%v audio=%v hdr=%v ext=%q language=%v site=%q genre=%q channels=%q collection=%q region=%q size=%q group=%q disc=%q",
@@ -693,9 +648,6 @@ func (s *Service) Prepare(ctx context.Context, req api.Request) (api.PreparedMet
 		VideoPath:  meta.VideoPath,
 		FileList:   meta.FileList,
 		SourceSize: meta.SourceSize,
-		Scene:      meta.Scene,
-		SceneName:  meta.SceneName,
-		SceneIMDB:  meta.SceneIMDB,
 		Category:   api.NormalizeCategory(meta.Release.Category),
 		Type:       meta.Release.Type,
 		Artist:     meta.Release.Artist,
@@ -765,14 +717,6 @@ func applySceneResult(meta *api.PreparedMetadata, result SceneResult) {
 	meta.SceneNFONew = result.NFONew
 	meta.SceneRenamed = result.Renamed
 	meta.SceneRenamedReason = result.RenamedReason
-}
-
-// applyStoredSceneMetadata restores persisted scene fields when a detector
-// returns only a recoverable side-effect error and no fresh scene data.
-func applyStoredSceneMetadata(meta *api.PreparedMetadata, stored db.FileMetadata) {
-	meta.Scene = stored.Scene
-	meta.SceneName = stored.SceneName
-	meta.SceneIMDB = stored.SceneIMDB
 }
 
 // extractM2TSFromPlaylist parses selected playlist files and extracts m2ts file references.

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -211,8 +211,13 @@ func NewService(repo db.MetadataRepository, opts ...Option) *Service {
 		service.cacheDir = cacheDir
 		service.nfoDir = nfoDir
 	}
-	if service.scene == nil {
-		service.scene = newSRRDBDetector(nil, "", service.cacheDir, service.nfoDir)
+	// Scene detection adds srrdb network fan-out to every prepared item, so it is
+	// gated by config (default on). Disabling it makes zero srrdb requests; an
+	// explicitly injected detector (WithSceneDetector) is always honored.
+	if service.scene == nil && service.cfg.MainSettings.SceneDetection {
+		detector := newSRRDBDetector(nil, "", service.cacheDir, service.nfoDir)
+		detector.logger = service.logger
+		service.scene = detector
 	}
 	if service.tracker == nil {
 		service.tracker = trackerdata.NewClient(service.cfg, service.logger, nil)
@@ -758,6 +763,8 @@ func applySceneResult(meta *api.PreparedMetadata, result SceneResult) {
 	}
 	meta.SceneNFOPath = result.NFOPath
 	meta.SceneNFONew = result.NFONew
+	meta.SceneRenamed = result.Renamed
+	meta.SceneRenamedReason = result.RenamedReason
 }
 
 // applyStoredSceneMetadata restores persisted scene fields when a detector

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -92,24 +92,13 @@ func TestPrepare(t *testing.T) {
 	}
 }
 
-func TestPrepareCopiesSceneResultAfterRecoverableNFOFailure(t *testing.T) {
+func TestApplySceneDetectionCopiesResultAfterRecoverableNFOFailure(t *testing.T) {
 	t.Parallel()
 
-	base := t.TempDir()
-	path := filepath.Join(base, "Example.Release")
-	if err := os.MkdirAll(path, 0o755); err != nil {
-		t.Fatalf("mkdir failed: %v", err)
-	}
-	videoPath := filepath.Join(path, "Example.Release.mkv")
-	if err := os.WriteFile(videoPath, []byte("video"), 0o600); err != nil {
-		t.Fatalf("write video failed: %v", err)
-	}
-
+	// Scene detection runs in ApplyMediaDetails now; applySceneDetection is the
+	// plumbing that copies the result and surfaces a recoverable NFO side effect.
 	logger := &recordingLogger{}
-	repo := &stubRepo{}
-	cfg := config.Config{MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(base, "db.sqlite")}}
-	service := NewService(repo,
-		WithMediaInfoExporter(&stubMediaInfo{}),
+	service := NewService(&stubRepo{},
 		WithSceneDetector(staticSceneDetector{
 			result: SceneResult{
 				IsScene:   true,
@@ -121,16 +110,9 @@ func TestPrepareCopiesSceneResultAfterRecoverableNFOFailure(t *testing.T) {
 			err: newSceneNFOError(errors.New("scene: write nfo: permission denied")),
 		}),
 		WithLogger(logger),
-		WithConfig(cfg),
 	)
 
-	meta, err := service.Prepare(context.Background(), api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeCLI,
-	})
-	if err != nil {
-		t.Fatalf("prepare failed: %v", err)
-	}
+	meta := service.applySceneDetection(context.Background(), api.PreparedMetadata{})
 	if !meta.Scene || meta.SceneName != "Example.Release.2024.1080p-WEB" {
 		t.Fatalf("expected scene result copied, got scene=%t name=%q", meta.Scene, meta.SceneName)
 	}
@@ -142,53 +124,21 @@ func TestPrepareCopiesSceneResultAfterRecoverableNFOFailure(t *testing.T) {
 	}
 }
 
-func TestPrepareRetainsStoredSceneMetadataAfterZeroRecoverableNFOFailure(t *testing.T) {
+func TestApplySceneDetectionBackfillsIMDbID(t *testing.T) {
 	t.Parallel()
 
-	base := t.TempDir()
-	path := filepath.Join(base, "Cached.Scene.Release")
-	if err := os.MkdirAll(path, 0o755); err != nil {
-		t.Fatalf("mkdir failed: %v", err)
-	}
-	videoPath := filepath.Join(path, "Cached.Scene.Release.mkv")
-	if err := os.WriteFile(videoPath, []byte("video"), 0o600); err != nil {
-		t.Fatalf("write video failed: %v", err)
-	}
-
-	logger := &recordingLogger{}
-	repo := &stubRepo{
-		existing: db.FileMetadata{
-			Path:      videoPath,
-			Scene:     true,
-			SceneName: "Cached.Scene.Release.2024.1080p-WEB",
-			SceneIMDB: 7654321,
-		},
-	}
-	cfg := config.Config{MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(base, "db.sqlite")}}
-	service := NewService(repo,
-		WithMediaInfoExporter(&stubMediaInfo{}),
-		WithSceneDetector(staticSceneDetector{
-			err: newSceneNFOError(errors.New("scene: write nfo: permission denied")),
-		}),
-		WithLogger(logger),
-		WithConfig(cfg),
+	service := NewService(&stubRepo{},
+		WithSceneDetector(staticSceneDetector{result: SceneResult{IsScene: true, IMDBID: 132245}}),
 	)
-
-	meta, err := service.Prepare(context.Background(), api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeCLI,
-	})
-	if err != nil {
-		t.Fatalf("prepare failed: %v", err)
+	// No externally-resolved id: the scene-discovered id backfills ExternalIDs.
+	meta := service.applySceneDetection(context.Background(), api.PreparedMetadata{})
+	if meta.ExternalIDs.IMDBID != 132245 {
+		t.Fatalf("expected scene imdb backfilled, got %d", meta.ExternalIDs.IMDBID)
 	}
-	if !meta.Scene || meta.SceneName != "Cached.Scene.Release.2024.1080p-WEB" || meta.SceneIMDB != 7654321 {
-		t.Fatalf("expected stored scene metadata retained, got scene=%t name=%q imdb=%d", meta.Scene, meta.SceneName, meta.SceneIMDB)
-	}
-	if !repo.saved.Scene || repo.saved.SceneName != "Cached.Scene.Release.2024.1080p-WEB" || repo.saved.SceneIMDB != 7654321 {
-		t.Fatalf("expected saved scene metadata retained, got scene=%t name=%q imdb=%d", repo.saved.Scene, repo.saved.SceneName, repo.saved.SceneIMDB)
-	}
-	if len(logger.warnings) != 1 || !strings.Contains(logger.warnings[0], "scene nfo side effect failed") {
-		t.Fatalf("expected visible NFO warning, got %#v", logger.warnings)
+	// An already-resolved id is not overwritten.
+	meta = service.applySceneDetection(context.Background(), api.PreparedMetadata{ExternalIDs: api.ExternalIDs{IMDBID: 999}})
+	if meta.ExternalIDs.IMDBID != 999 {
+		t.Fatalf("expected resolved imdb preserved, got %d", meta.ExternalIDs.IMDBID)
 	}
 }
 
@@ -401,28 +351,14 @@ func TestResolveServiceValue(t *testing.T) {
 	}
 }
 
-func TestPrepareAppliesSceneServiceFromNFO(t *testing.T) {
-	base := t.TempDir()
-	path := filepath.Join(base, "Greenland.2.Migration.2026.HDR.2160p.WEB.h265-ETHEL.mkv")
-	if err := os.WriteFile(path, []byte("video"), 0o644); err != nil {
-		t.Fatalf("write video failed: %v", err)
-	}
+func TestApplySceneDetectionAppliesServiceFromNFO(t *testing.T) {
+	t.Parallel()
 
-	repo := &stubRepo{}
-	cfg := config.Config{MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(base, "db.sqlite")}}
-	service := NewService(repo,
-		WithMediaInfoExporter(&stubMediaInfo{}),
+	service := NewService(&stubRepo{},
 		WithSceneDetector(staticSceneDetector{result: SceneResult{IsScene: true, Service: "iT", ServiceLongName: "iTunes"}}),
-		WithConfig(cfg),
 	)
 
-	meta, err := service.Prepare(context.Background(), api.Request{
-		Paths: []string{path},
-		Mode:  api.ModeCLI,
-	})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	meta := service.applySceneDetection(context.Background(), api.PreparedMetadata{})
 	if meta.Service != "iT" {
 		t.Fatalf("expected iT service from scene nfo, got %q", meta.Service)
 	}

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -112,7 +112,10 @@ func TestApplySceneDetectionCopiesResultAfterRecoverableNFOFailure(t *testing.T)
 		WithLogger(logger),
 	)
 
-	meta := service.applySceneDetection(context.Background(), api.PreparedMetadata{})
+	meta, err := service.applySceneDetection(context.Background(), api.PreparedMetadata{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if !meta.Scene || meta.SceneName != "Example.Release.2024.1080p-WEB" {
 		t.Fatalf("expected scene result copied, got scene=%t name=%q", meta.Scene, meta.SceneName)
 	}
@@ -131,14 +134,33 @@ func TestApplySceneDetectionBackfillsIMDbID(t *testing.T) {
 		WithSceneDetector(staticSceneDetector{result: SceneResult{IsScene: true, IMDBID: 132245}}),
 	)
 	// No externally-resolved id: the scene-discovered id backfills ExternalIDs.
-	meta := service.applySceneDetection(context.Background(), api.PreparedMetadata{})
+	meta, err := service.applySceneDetection(context.Background(), api.PreparedMetadata{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if meta.ExternalIDs.IMDBID != 132245 {
 		t.Fatalf("expected scene imdb backfilled, got %d", meta.ExternalIDs.IMDBID)
 	}
 	// An already-resolved id is not overwritten.
-	meta = service.applySceneDetection(context.Background(), api.PreparedMetadata{ExternalIDs: api.ExternalIDs{IMDBID: 999}})
+	meta, err = service.applySceneDetection(context.Background(), api.PreparedMetadata{ExternalIDs: api.ExternalIDs{IMDBID: 999}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if meta.ExternalIDs.IMDBID != 999 {
 		t.Fatalf("expected resolved imdb preserved, got %d", meta.ExternalIDs.IMDBID)
+	}
+}
+
+func TestApplySceneDetectionPropagatesCancellation(t *testing.T) {
+	t.Parallel()
+
+	// Context cancellation must abort the pipeline, not be swallowed as a soft
+	// srrdb failure that continues into tracker rules.
+	service := NewService(&stubRepo{},
+		WithSceneDetector(staticSceneDetector{err: context.Canceled}),
+	)
+	if _, err := service.applySceneDetection(context.Background(), api.PreparedMetadata{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation propagated, got %v", err)
 	}
 }
 
@@ -358,7 +380,10 @@ func TestApplySceneDetectionAppliesServiceFromNFO(t *testing.T) {
 		WithSceneDetector(staticSceneDetector{result: SceneResult{IsScene: true, Service: "iT", ServiceLongName: "iTunes"}}),
 	)
 
-	meta := service.applySceneDetection(context.Background(), api.PreparedMetadata{})
+	meta, err := service.applySceneDetection(context.Background(), api.PreparedMetadata{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if meta.Service != "iT" {
 		t.Fatalf("expected iT service from scene nfo, got %q", meta.Service)
 	}

--- a/internal/trackers/modified_release.go
+++ b/internal/trackers/modified_release.go
@@ -42,6 +42,19 @@ func isRenamedRelease(meta api.PreparedMetadata) (bool, string) {
 		return false, ""
 	}
 
+	// srrdb scene detection (the imdb: fallback) authoritatively compares the
+	// on-disk basename to the canonical scene media filename and sets this when
+	// they differ. It is the strongest signal (a database match, not a heuristic),
+	// so it is checked first and independent of the release group an *arr rename
+	// may strip.
+	if meta.SceneRenamed {
+		reason := strings.TrimSpace(meta.SceneRenamedReason)
+		if reason == "" {
+			reason = "source renamed from original scene release name"
+		}
+		return true, reason
+	}
+
 	names := candidateReleaseNames(meta)
 
 	// *arr id tokens mark a rename on their own, independent of the release group

--- a/internal/trackers/modified_release.go
+++ b/internal/trackers/modified_release.go
@@ -50,7 +50,7 @@ func isRenamedRelease(meta api.PreparedMetadata) (bool, string) {
 	if meta.SceneRenamed {
 		reason := strings.TrimSpace(meta.SceneRenamedReason)
 		if reason == "" {
-			reason = "source renamed from original scene release name"
+			reason = modifiedReleaseReason
 		}
 		return true, reason
 	}

--- a/internal/trackers/modified_release_test.go
+++ b/internal/trackers/modified_release_test.go
@@ -163,6 +163,35 @@ func TestIsRenamedRelease(t *testing.T) {
 			meta: grouped("/data/movies/Fury 2014 2160p MA WEB-DL DDP5.1 HDR H.265-HHWEB"),
 			want: true,
 		},
+		{
+			name: "srrdb rename signal flags a clean-looking name with no group",
+			// The imdb: fallback authoritatively confirmed a rename that the
+			// heuristics above cannot see (no group tag, no *arr token, no spaces).
+			meta: api.PreparedMetadata{
+				SourcePath:         "/data/movies/Fury.2014.1080p.BluRay.x264",
+				SceneRenamed:       true,
+				SceneRenamedReason: "source appears renamed or modified from its original release name; verify the file hash and source provenance",
+			},
+			want: true,
+		},
+		{
+			name: "srrdb rename signal is exempt for personal release",
+			meta: api.PreparedMetadata{
+				SourcePath:      "/data/movies/Fury.2014.1080p.BluRay.x264",
+				PersonalRelease: true,
+				SceneRenamed:    true,
+			},
+			want: false,
+		},
+		{
+			name: "srrdb rename signal is exempt for disc source",
+			meta: api.PreparedMetadata{
+				SourcePath:   "/data/movies/Fury.2014.1080p.BluRay.x264",
+				DiscType:     "BDMV",
+				SceneRenamed: true,
+			},
+			want: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -109,6 +109,8 @@ type PreparedMetadata struct {
 	SceneMALID                  int
 	SceneNFOPath                string
 	SceneNFONew                 bool
+	SceneRenamed                bool
+	SceneRenamedReason          string
 	Mode                        Mode
 	DescriptionGroups           []DescriptionBuilderGroup
 	Trackers                    []string


### PR DESCRIPTION
Closes #173

Upgrades srrdb scene detection from the brittle exact `search/r:<name>` lookup to an IMDb‑keyed fallback with canonical‑name matching, so renamed/modified scene releases are detected as scene **and** flagged as renamed before a tracker rejects them. Follow‑up to the `{tmdb-/imdb-/tvdb-}` *arr‑token check (#157).

> **Stacked on #157 (Phase 1).** This targets `feat/detect-renamed-release` because Phase 2 feeds the `modified_release` rule introduced there. Once #157 merges to `main`, retarget to `main`.

## Approach
- When `r:` misses **and** an IMDb id is already known (source‑lookup URL, prior persisted resolution, or Arr), fall back to `search/imdb:<id>` — the full release list for the title, independent of the on‑disk filename. Paginated (`order:date/page:N`), bounded to 5 pages with truncation logged.
- **Local candidate scoring** (`scene_scoring.go`): resolution / year / group / source / codec / edition, foreign‑dub aware. A candidate is eligible only with **≥2 strong signals** (resolution‑matched, year‑matched, group‑matched) — the primary false‑positive guard.
- Fetch `details/<release>`, extend `srrdbDetailsResponse` with `archived-files[]` (`name`/`crc`/`size`), and compare the canonical media basename to the on‑disk basename (case‑tolerant, like `r:`). A mismatch ⇒ renamed.

## Renamed signal → rule (field‑vs‑rule‑path decision)
New internal `PreparedMetadata.SceneRenamed` / `SceneRenamedReason` carry the verdict from the metadata layer to `isRenamedRelease` in the trackers package (added as the first, highest‑signal case; personal/disc exempt; overridable via `IgnoreTrackerRuleFailuresFor`). The **user‑visible artifact is the existing `modified_release` `RuleFailure`** — identical to Phase 1 — so no CLI/Wails/web/TS entrypoint needs to surface the new fields. Not persisted to the DB row (no migration); recomputed via the existing on‑disk cache.

## Config gate
`main_settings.scene_detection` (default **on**), mirroring `use_favicons` end‑to‑end (config default‑true, `example.yaml`, settings toggle). When off, the srrdb detector isn't constructed → **zero** srrdb requests (covers `r:` and `imdb:`).

## Operational
- Strictly **soft‑fail on every srrdb network/decode path** (both `r:` and `imdb:`): srrdb being slow/down never blocks or fails an upload; context cancellation still propagates.
- Descriptive `User-Agent` on every srrdb request (previously none).
- IMDb URL built from a validated int (no SSRF surface); details URL uses `url.PathEscape`; archive names handled as slash‑data via pure string ops.

## Tests → acceptance criteria
- Renamed scene (dots→spaces) + known IMDb id → imdb: fallback match + `SceneRenamed` + `modified_release` failure (**AC#1**)
- Unmodified scene still matches via `r:`; matching canonical name is **not** flagged (**AC#2**)
- Non‑scene / wrong‑resolution / year‑only candidates not matched (**AC#3**)
- srrdb 5xx, network outage, malformed body, empty‑200 → no error / no block (**AC#4**)
- Pagination across >40 results (**AC#5**)
- Scoring fixtures: foreign‑dub (incl. WEB‑DL not misclassified), multi‑edition, season pack (**AC#6**)
- Rule: `SceneRenamed` → `modified_release`; personal/disc exempt

## Verification
- `go test -race ./internal/metadata ./internal/trackers ./internal/core ./pkg/api ./internal/config`
- Frontend `typecheck` + unit tests
- `gofmt`, `go vet`, `make logpolicy`, `make pathpolicy`, `git diff --check`
- `golangci-lint` on changed packages: 0 issues

## Follow‑up
v1 fires the fallback only when an IMDb id is already on `meta` at Prepare time. A first‑ever upload of a renamed scene with no id source won't trigger it until a later run persists the id; closing that fully means running the fallback after `ResolveExternalIDs` (deferred to keep this PR scoped).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scene detection setting in settings (enabled by default).
  * Scene detection can now determine whether a match appears renamed and includes a user-facing rename reason.
* **Bug Fixes**
  * Scene detection now runs at the correct stage after external IDs and release naming are resolved, improving tracker/release check outcomes.
  * Improved SRRDB scene matching and IMDb-based fallback (including pagination) with more robust handling of partial failures.
  * Rename signals are now propagated to release modification detection for more accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->