### PR TITLE
fix(metadata): keep parsed TV episode fallback non-canonical

### DIFF
--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -1726,6 +1726,10 @@ func mapTVmazeMetadata(result tvmaze.SearchResult) *api.TVmazeMetadata {
 	}
 }
 
+// applyTVEpisodeMetadata enriches TV episode fields from provider data.
+// Parsed release season/episode values may seed provider lookups, but only
+// canonical metadata or provider-confirmed mappings are persisted back to
+// SeasonInt and EpisodeInt.
 func (s *Service) applyTVEpisodeMetadata(
 	ctx context.Context,
 	meta api.PreparedMetadata,
@@ -1757,14 +1761,8 @@ func (s *Service) applyTVEpisodeMetadata(
 		ids.Category = "TV"
 	}
 
-	season := meta.SeasonInt
-	if season == 0 {
-		season = meta.Release.Season
-	}
-	episode := meta.EpisodeInt
-	if episode == 0 {
-		episode = meta.Release.Episode
-	}
+	fallbackSeason, fallbackEpisode := meta.SeasonEpisodeWithParsedFallback()
+	season, episode := meta.CanonicalSeasonEpisode()
 	initialSeason := season
 	initialEpisode := episode
 	initialSeasonStr := strings.TrimSpace(meta.SeasonStr)
@@ -1844,9 +1842,11 @@ func (s *Service) applyTVEpisodeMetadata(
 	tmdbEpisodeOverview := ""
 
 	if ids.TVDBID != 0 {
+		querySeason := metautil.FirstInt(season, fallbackSeason)
+		queryEpisode := metautil.FirstInt(episode, fallbackEpisode)
 		query := tvdb.EpisodeQuery{
-			Season:    season,
-			Episode:   episode,
+			Season:    querySeason,
+			Episode:   queryEpisode,
 			AiredDate: dailyDate,
 			Debug:     meta.Options.Debug,
 		}
@@ -1931,10 +1931,10 @@ func (s *Service) applyTVEpisodeMetadata(
 					if episodeYear == 0 {
 						episodeYear = match.Year
 					}
-					if season == 0 && match.SeasonNumber > 0 {
+					if match.SeasonNumber > 0 {
 						season = match.SeasonNumber
 					}
-					if episode == 0 && match.EpisodeNumber > 0 {
+					if match.EpisodeNumber > 0 {
 						episode = match.EpisodeNumber
 					}
 				}
@@ -1949,8 +1949,8 @@ func (s *Service) applyTVEpisodeMetadata(
 		var err error
 		if dailyDate != "" {
 			epData, err = tvmazeClient.GetEpisodeByDate(ctx, ids.TVmazeID, dailyDate)
-		} else if season > 0 && episode > 0 {
-			epData, err = tvmazeClient.GetEpisodeByNumber(ctx, ids.TVmazeID, season, episode, tvmaze.EpisodeLookupContext{
+		} else if lookupSeason, lookupEpisode := metautil.FirstInt(season, fallbackSeason), metautil.FirstInt(episode, fallbackEpisode); lookupSeason > 0 && lookupEpisode > 0 {
+			epData, err = tvmazeClient.GetEpisodeByNumber(ctx, ids.TVmazeID, lookupSeason, lookupEpisode, tvmaze.EpisodeLookupContext{
 				ManualDate: dailyDate,
 				Debug:      meta.Options.Debug,
 			})
@@ -1961,10 +1961,10 @@ func (s *Service) applyTVEpisodeMetadata(
 		if epData != nil {
 			tvmazeEpisodeTitle = strings.TrimSpace(epData.EpisodeName)
 			tvmazeEpisodeOverview = strings.TrimSpace(epData.Overview)
-			if season == 0 && epData.SeasonNumber > 0 {
+			if epData.SeasonNumber > 0 {
 				season = epData.SeasonNumber
 			}
-			if episode == 0 && epData.EpisodeNumber > 0 {
+			if epData.EpisodeNumber > 0 {
 				episode = epData.EpisodeNumber
 			}
 			if episodeYear == 0 {
@@ -1976,10 +1976,18 @@ func (s *Service) applyTVEpisodeMetadata(
 	}
 
 	if ids.TMDBID != 0 {
-		if !meta.TVPack && season > 0 && episode > 0 {
-			if details, err := tmdbClient.GetEpisodeDetails(ctx, ids.TMDBID, season, episode); err == nil {
+		lookupSeason := metautil.FirstInt(season, fallbackSeason)
+		lookupEpisode := metautil.FirstInt(episode, fallbackEpisode)
+		if !meta.TVPack && lookupSeason > 0 && lookupEpisode > 0 {
+			if details, err := tmdbClient.GetEpisodeDetails(ctx, ids.TMDBID, lookupSeason, lookupEpisode); err == nil {
 				tmdbEpisodeTitle = strings.TrimSpace(details.Name)
 				tmdbEpisodeOverview = strings.TrimSpace(details.Overview)
+				if details.SeasonNumber > 0 {
+					season = details.SeasonNumber
+				}
+				if details.EpisodeNumber > 0 {
+					episode = details.EpisodeNumber
+				}
 				if episodeYear == 0 {
 					if parsedYear := parseYearFromDate(details.AirDate); parsedYear > 0 {
 						episodeYear = parsedYear
@@ -1989,8 +1997,11 @@ func (s *Service) applyTVEpisodeMetadata(
 				s.logger.Debugf("metadata: tmdb episode details lookup failed: %v", err)
 			}
 		}
-		if meta.TVPack && season > 0 {
-			if details, err := tmdbClient.GetSeasonDetails(ctx, ids.TMDBID, season); err == nil {
+		if meta.TVPack && lookupSeason > 0 {
+			if details, err := tmdbClient.GetSeasonDetails(ctx, ids.TMDBID, lookupSeason); err == nil {
+				if details.SeasonNumber > 0 {
+					season = details.SeasonNumber
+				}
 				if tmdbEpisodeTitle == "" {
 					tmdbEpisodeTitle = strings.TrimSpace(details.Name)
 				}
@@ -2206,7 +2217,7 @@ func isLikelyTV(meta api.PreparedMetadata) bool {
 	if strings.EqualFold(meta.MediaInfoCategory, "TV") || strings.EqualFold(meta.ExternalIDs.Category, "TV") {
 		return true
 	}
-	if meta.SeasonInt > 0 || meta.EpisodeInt > 0 || meta.Release.Season > 0 || meta.Release.Episode > 0 {
+	if meta.HasTVSeasonEpisodeSignal() {
 		return true
 	}
 	if strings.TrimSpace(meta.DailyEpisodeDate) != "" {

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -1586,6 +1586,37 @@ func TestApplyTVEpisodeMetadataDailyMappingNoMatchDoesNotCoerceEpisode(t *testin
 	}
 }
 
+func TestApplyTVEpisodeMetadataDailyMappingNoMatchDoesNotPersistParsedFallback(t *testing.T) {
+	svc := NewService(&fakeRepo{})
+	tmdbClient := &stubTMDB{}
+
+	meta := api.PreparedMetadata{
+		SourcePath:       "/media/Daily.Show.2024-01-15.mkv",
+		DailyEpisodeDate: "2024-01-15",
+		Release: api.ReleaseInfo{
+			Category: "TV",
+			Season:   2024,
+			Episode:  115,
+		},
+	}
+	ids := &api.ExternalIDs{
+		TMDBID:   100,
+		Category: "TV",
+	}
+
+	updated := svc.applyTVEpisodeMetadata(context.Background(), meta, ids, nil, tmdbClient, &stubTVDB{}, &stubTVmaze{})
+	if updated.SeasonInt != 0 || updated.EpisodeInt != 0 {
+		t.Fatalf("expected parsed fallback not to persist as canonical season/episode, got %d/%d", updated.SeasonInt, updated.EpisodeInt)
+	}
+	if updated.SeasonStr != "" || updated.EpisodeStr != "" {
+		t.Fatalf("expected empty formatted season/episode, got %q/%q", updated.SeasonStr, updated.EpisodeStr)
+	}
+	fallbackSeason, fallbackEpisode := updated.SeasonEpisodeWithParsedFallback()
+	if fallbackSeason != 2024 || fallbackEpisode != 115 {
+		t.Fatalf("expected parsed fallback 2024/115 to remain available, got %d/%d", fallbackSeason, fallbackEpisode)
+	}
+}
+
 func TestApplyTVEpisodeMetadataUseSeasonEpisodePrefersTMDBDateMapping(t *testing.T) {
 	svc := NewService(&fakeRepo{})
 	tmdbClient := &stubTMDB{dailySeason: 2, dailyEpisode: 7}

--- a/internal/metadata/naming.go
+++ b/internal/metadata/naming.go
@@ -539,7 +539,7 @@ func inferCategoryFromMetadata(meta api.PreparedMetadata) string {
 	if meta.ExternalMetadata.TVDB != nil || meta.ExternalMetadata.TVmaze != nil {
 		return "TV"
 	}
-	if meta.SeasonInt > 0 || meta.EpisodeInt > 0 || meta.Release.Season > 0 || meta.Release.Episode > 0 {
+	if meta.HasTVSeasonEpisodeSignal() {
 		return "TV"
 	}
 	if category := normalizeNamingCategory(meta.Release.Category); category != "" {

--- a/internal/metadata/tracker_claims.go
+++ b/internal/metadata/tracker_claims.go
@@ -339,16 +339,14 @@ type trackerClaimMatchTarget struct {
 }
 
 func trackerClaimTarget(meta api.PreparedMetadata) (trackerClaimMatchTarget, bool) {
+	season, _ := meta.SeasonEpisodeWithParsedFallback()
 	target := trackerClaimMatchTarget{
 		tmdbID:     meta.ExternalIDs.TMDBID,
-		season:     meta.SeasonInt,
+		season:     season,
 		category:   trackerdata.CanonicalUnit3DCategory(resolveTrackerClaimCategory(meta)),
 		typeName:   trackerdata.CanonicalUnit3DType(resolveTrackerClaimType(meta)),
 		resolution: trackerdata.CanonicalUnit3DResolution(resolveTrackerClaimResolution(meta)),
 		isTV:       isTVCategory(meta),
-	}
-	if target.season == 0 {
-		target.season = meta.Release.Season
 	}
 	if target.tmdbID == 0 || target.typeName == "" || target.resolution == "" {
 		return trackerClaimMatchTarget{}, false
@@ -612,10 +610,7 @@ func decodeTrackerClaimValue(raw json.RawMessage, namesByID func(string) []strin
 }
 
 func isTVCategory(meta api.PreparedMetadata) bool {
-	return meta.SeasonInt > 0 ||
-		meta.EpisodeInt > 0 ||
-		meta.Release.Season > 0 ||
-		meta.Release.Episode > 0 ||
+	return meta.HasTVSeasonEpisodeSignal() ||
 		meta.TVPack ||
 		strings.TrimSpace(meta.DailyEpisodeDate) != ""
 }

--- a/internal/metadata/tracker_claims.go
+++ b/internal/metadata/tracker_claims.go
@@ -338,8 +338,11 @@ type trackerClaimMatchTarget struct {
 	isTV       bool
 }
 
+// trackerClaimTarget builds the canonical upload identity used to compare
+// tracker-side claim records. TV claim matching requires provider-resolved
+// season metadata and intentionally ignores parsed release fallbacks.
 func trackerClaimTarget(meta api.PreparedMetadata) (trackerClaimMatchTarget, bool) {
-	season, _ := meta.SeasonEpisodeWithParsedFallback()
+	season, _ := meta.CanonicalSeasonEpisode()
 	target := trackerClaimMatchTarget{
 		tmdbID:     meta.ExternalIDs.TMDBID,
 		season:     season,

--- a/internal/metadata/tracker_data_test.go
+++ b/internal/metadata/tracker_data_test.go
@@ -509,6 +509,53 @@ func TestApplyTrackerClaimsDoesNotBlockOnSemanticMismatch(t *testing.T) {
 	}
 }
 
+func TestApplyTrackerClaimsDoesNotUseParsedSeasonFallbackForUploadIdentity(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"data":[
+				{"attributes":{"title":"Example Show","season":2,"tmdb_id":4242,"categories":["2"],"resolutions":["3"],"types":["4"]}}
+			],
+			"meta":{"next_cursor":""}
+		}`))
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	cfg := config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: filepath.Join(tempDir, "db.sqlite")},
+		Trackers: config.TrackersConfig{
+			Trackers: map[string]config.TrackerConfig{
+				"AITHER": {
+					APIKey:      "aither-key",
+					AnnounceURL: server.URL + "/announce",
+				},
+			},
+		},
+	}
+
+	svc := NewService(&fakeRepo{}, WithConfig(cfg))
+	meta := api.PreparedMetadata{
+		SourcePath: "/media/Example.Show.S02E03.mkv",
+		Trackers:   []string{"AITHER"},
+		Type:       "WEBDL",
+		Release:    api.ReleaseInfo{Resolution: "1080p", Season: 2, Episode: 3},
+		ExternalIDs: api.ExternalIDs{
+			TMDBID:   4242,
+			Category: "TV",
+		},
+	}
+
+	result, err := svc.applyTrackerClaims(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("apply tracker claims: %v", err)
+	}
+	if len(result.BlockedTrackers["AITHER"]) != 0 {
+		t.Fatalf("expected parsed-only season not to create claim block, got %#v", result.BlockedTrackers)
+	}
+}
+
 func TestApplyTrackerClaimsUsesRequestedBTNWhenTrackerIDsContainDifferentTracker(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/impl/btn/definition_test.go
+++ b/internal/trackers/impl/btn/definition_test.go
@@ -52,7 +52,7 @@ func TestBTNUploadPayloadUsesCanonicalSeasonEpisodeOnly(t *testing.T) {
 	if strings.Contains(desc, "Season: 4") || strings.Contains(desc, "Episode: 9") {
 		t.Fatalf("album description used parsed fallback values: %q", desc)
 	}
-	if got := btnTVPayloadMetadataMessage(meta); got != "canonical TV season/episode missing; tracker payload uses 0 and ignores parsed season/episode fallback" {
+	if got := btnTVPayloadMetadataMessage(meta); got != "canonical TV season/episode missing; tracker payload uses 0 and ignores parsed season/episode fallback; refresh metadata or correct canonical season/episode before upload" {
 		t.Fatalf("unexpected metadata message %q", got)
 	}
 }

--- a/internal/trackers/impl/btn/definition_test.go
+++ b/internal/trackers/impl/btn/definition_test.go
@@ -3,7 +3,12 @@
 
 package btn
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
 
 func TestDefinitionName(t *testing.T) {
 	t.Parallel()
@@ -24,5 +29,48 @@ func TestApplyBTNNameMapping(t *testing.T) {
 	}
 	if mapped != "Example.Show.S01E01.1080p.WEB-DL.H.265-GRP" {
 		t.Fatalf("unexpected mapped name: %s", mapped)
+	}
+}
+
+func TestBTNUploadPayloadUsesCanonicalSeasonEpisodeOnly(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		Release:     api.ReleaseInfo{Season: 4, Episode: 9},
+	}
+
+	if got := resolveUploadType(meta); got != "Season" {
+		t.Fatalf("expected upload type Season without canonical episode, got %q", got)
+	}
+	desc := buildAlbumDesc(meta, map[string]string{"album_desc": "fallback overview"})
+	for _, value := range []string{"Season: 0", "Episode: 0"} {
+		if !strings.Contains(desc, value) {
+			t.Fatalf("expected album description to contain %q, got %q", value, desc)
+		}
+	}
+	if strings.Contains(desc, "Season: 4") || strings.Contains(desc, "Episode: 9") {
+		t.Fatalf("album description used parsed fallback values: %q", desc)
+	}
+	if got := btnTVPayloadMetadataMessage(meta); got != "canonical TV season/episode missing; tracker payload uses 0 and ignores parsed season/episode fallback" {
+		t.Fatalf("unexpected metadata message %q", got)
+	}
+}
+
+func TestBTNUploadTypeUsesCanonicalEpisode(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		SeasonInt:   4,
+		EpisodeInt:  9,
+		Release:     api.ReleaseInfo{Season: 1, Episode: 2},
+	}
+
+	if got := resolveUploadType(meta); got != "Episode" {
+		t.Fatalf("expected upload type Episode, got %q", got)
+	}
+	if got := btnTVPayloadMetadataMessage(meta); got != "" {
+		t.Fatalf("unexpected metadata message %q", got)
 	}
 }

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -171,6 +171,10 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	}, nil
 }
 
+// buildUploadDryRun returns a BTN preview entry with the exact payload that
+// would be submitted locally. TV payloads that would serialize missing
+// canonical season or episode metadata as zero are returned as blocked so the
+// operator sees the remediation before upload.
 func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.TrackerDryRunEntry, error) {
 	if err := validateBTNRequest(req); err != nil {
 		return api.TrackerDryRunEntry{}, err
@@ -199,13 +203,15 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 	}
 
 	message := "dry-run payload generated"
+	status := "ready"
 	if metadataMessage := btnTVPayloadMetadataMessage(req.Meta); metadataMessage != "" {
 		message += "; " + metadataMessage
+		status = "blocked"
 	}
 
 	return api.TrackerDryRunEntry{
 		Tracker:          "BTN",
-		Status:           "ready",
+		Status:           status,
 		Message:          message,
 		ReleaseName:      resolveUploadName(req.Meta),
 		DescriptionGroup: "btn",
@@ -596,10 +602,10 @@ func resolveUploadType(meta api.PreparedMetadata) string {
 	return "Season"
 }
 
-// btnTVPayloadMetadataMessage returns dry-run/log feedback when BTN will send
-// zero-valued TV season or episode fields because canonical metadata is absent.
-// Parsed release values are reported only as ignored signals and must not feed
-// tracker payload construction.
+// btnTVPayloadMetadataMessage explains when BTN will send zero-valued TV season
+// or episode fields because canonical metadata is absent. Parsed release values
+// are reported only as ignored signals, and the message includes the operator
+// action required by blocked dry-run entries.
 func btnTVPayloadMetadataMessage(meta api.PreparedMetadata) string {
 	if !strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "TV") {
 		return ""
@@ -625,6 +631,7 @@ func btnTVPayloadMetadataMessage(meta api.PreparedMetadata) string {
 	if len(ignored) > 0 {
 		message += " and ignores parsed " + strings.Join(ignored, "/") + " fallback"
 	}
+	message += "; refresh metadata or correct canonical season/episode before upload"
 	return message
 }
 

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -72,6 +72,12 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if err := validateBTNRequest(req); err != nil {
 		return api.UploadSummary{}, err
 	}
+	if message, err := validateBTNTVPayloadMetadata(req.Meta); err != nil {
+		if req.Logger != nil {
+			req.Logger.Warnf("trackers: BTN %s", message)
+		}
+		return api.UploadSummary{}, err
+	}
 
 	torrentPath, err := resolveTorrentPath(req.Meta, req.AppConfig.MainSettings.DBPath)
 	if err != nil {
@@ -91,11 +97,6 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	data, err := prepareUploadData(ctx, req, uploadCtx)
 	if err != nil {
 		return api.UploadSummary{}, err
-	}
-	if req.Logger != nil {
-		if message := btnTVPayloadMetadataMessage(req.Meta); message != "" {
-			req.Logger.Warnf("trackers: BTN %s", message)
-		}
 	}
 
 	body, contentType, err := commonhttp.BuildMultipartPayload(data, []commonhttp.FileField{{FieldName: "file_input", Path: torrentPath, FileName: "torrent.torrent"}})
@@ -204,7 +205,7 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 
 	message := "dry-run payload generated"
 	status := "ready"
-	if metadataMessage := btnTVPayloadMetadataMessage(req.Meta); metadataMessage != "" {
+	if metadataMessage, err := validateBTNTVPayloadMetadata(req.Meta); err != nil {
 		message += "; " + metadataMessage
 		status = "blocked"
 	}
@@ -590,6 +591,17 @@ func buildAlbumDesc(meta api.PreparedMetadata, fields map[string]string) string 
 	season, episode := meta.CanonicalSeasonEpisode()
 	episodeTitle := metautil.FirstNonEmptyTrimmed(strings.TrimSpace(meta.EpisodeTitle), "TBA")
 	return strings.TrimSpace(fmt.Sprintf("Episode Name: %s\nEpisode Title: %s\nSeason: %d\nEpisode: %d\nAired: %s\n\nEpisode overview: %s", episodeTitle, episodeTitle, season, episode, aired, overview))
+}
+
+// validateBTNTVPayloadMetadata returns the shared BTN TV metadata block reason
+// used by live upload and dry-run when canonical season or episode data is
+// missing.
+func validateBTNTVPayloadMetadata(meta api.PreparedMetadata) (string, error) {
+	message := btnTVPayloadMetadataMessage(meta)
+	if message == "" {
+		return "", nil
+	}
+	return message, errors.New("trackers: BTN " + message)
 }
 
 func resolveUploadType(meta api.PreparedMetadata) string {

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -571,14 +571,7 @@ func buildAlbumDesc(meta api.PreparedMetadata, fields map[string]string) string 
 	}
 	overview := metautil.FirstNonEmptyTrimmed(strings.TrimSpace(meta.EpisodeOverview), strings.TrimSpace(fields["album_desc"]))
 	aired := metautil.FirstNonEmptyTrimmed(strings.TrimSpace(meta.TVDBAiredDate), strings.TrimSpace(meta.DailyEpisodeDate), "TBA")
-	season := meta.SeasonInt
-	episode := meta.EpisodeInt
-	if season <= 0 {
-		season = meta.Release.Season
-	}
-	if episode <= 0 {
-		episode = meta.Release.Episode
-	}
+	season, episode := meta.SeasonEpisodeWithParsedFallback()
 	episodeTitle := metautil.FirstNonEmptyTrimmed(strings.TrimSpace(meta.EpisodeTitle), "TBA")
 	return strings.TrimSpace(fmt.Sprintf("Episode Name: %s\nEpisode Title: %s\nSeason: %d\nEpisode: %d\nAired: %s\n\nEpisode overview: %s", episodeTitle, episodeTitle, season, episode, aired, overview))
 }
@@ -587,7 +580,8 @@ func resolveUploadType(meta api.PreparedMetadata) string {
 	if meta.TVPack {
 		return "Season"
 	}
-	if meta.EpisodeInt > 0 || meta.Release.Episode > 0 {
+	_, episode := meta.SeasonEpisodeWithParsedFallback()
+	if episode > 0 {
 		return "Episode"
 	}
 	return "Season"

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -92,6 +92,11 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if err != nil {
 		return api.UploadSummary{}, err
 	}
+	if req.Logger != nil {
+		if message := btnTVPayloadMetadataMessage(req.Meta); message != "" {
+			req.Logger.Warnf("trackers: BTN %s", message)
+		}
+	}
 
 	body, contentType, err := commonhttp.BuildMultipartPayload(data, []commonhttp.FileField{{FieldName: "file_input", Path: torrentPath, FileName: "torrent.torrent"}})
 	if err != nil {
@@ -193,10 +198,15 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 		return api.TrackerDryRunEntry{}, err
 	}
 
+	message := "dry-run payload generated"
+	if metadataMessage := btnTVPayloadMetadataMessage(req.Meta); metadataMessage != "" {
+		message += "; " + metadataMessage
+	}
+
 	return api.TrackerDryRunEntry{
 		Tracker:          "BTN",
 		Status:           "ready",
-		Message:          "dry-run payload generated",
+		Message:          message,
 		ReleaseName:      resolveUploadName(req.Meta),
 		DescriptionGroup: "btn",
 		Description:      payload["release_desc"],
@@ -571,7 +581,7 @@ func buildAlbumDesc(meta api.PreparedMetadata, fields map[string]string) string 
 	}
 	overview := metautil.FirstNonEmptyTrimmed(strings.TrimSpace(meta.EpisodeOverview), strings.TrimSpace(fields["album_desc"]))
 	aired := metautil.FirstNonEmptyTrimmed(strings.TrimSpace(meta.TVDBAiredDate), strings.TrimSpace(meta.DailyEpisodeDate), "TBA")
-	season, episode := meta.SeasonEpisodeWithParsedFallback()
+	season, episode := meta.CanonicalSeasonEpisode()
 	episodeTitle := metautil.FirstNonEmptyTrimmed(strings.TrimSpace(meta.EpisodeTitle), "TBA")
 	return strings.TrimSpace(fmt.Sprintf("Episode Name: %s\nEpisode Title: %s\nSeason: %d\nEpisode: %d\nAired: %s\n\nEpisode overview: %s", episodeTitle, episodeTitle, season, episode, aired, overview))
 }
@@ -580,11 +590,42 @@ func resolveUploadType(meta api.PreparedMetadata) string {
 	if meta.TVPack {
 		return "Season"
 	}
-	_, episode := meta.SeasonEpisodeWithParsedFallback()
-	if episode > 0 {
+	if meta.EpisodeInt > 0 {
 		return "Episode"
 	}
 	return "Season"
+}
+
+// btnTVPayloadMetadataMessage returns dry-run/log feedback when BTN will send
+// zero-valued TV season or episode fields because canonical metadata is absent.
+// Parsed release values are reported only as ignored signals and must not feed
+// tracker payload construction.
+func btnTVPayloadMetadataMessage(meta api.PreparedMetadata) string {
+	if !strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "TV") {
+		return ""
+	}
+	missing := make([]string, 0, 2)
+	ignored := make([]string, 0, 2)
+	if meta.SeasonInt <= 0 {
+		missing = append(missing, "season")
+		if meta.Release.Season > 0 {
+			ignored = append(ignored, "season")
+		}
+	}
+	if meta.EpisodeInt <= 0 && !meta.TVPack {
+		missing = append(missing, "episode")
+		if meta.Release.Episode > 0 {
+			ignored = append(ignored, "episode")
+		}
+	}
+	if len(missing) == 0 {
+		return ""
+	}
+	message := "canonical TV " + strings.Join(missing, "/") + " missing; tracker payload uses 0"
+	if len(ignored) > 0 {
+		message += " and ignores parsed " + strings.Join(ignored, "/") + " fallback"
+	}
+	return message
 }
 
 func resolveOrigin(releaseName string) string {

--- a/internal/trackers/impl/btn/upload_integration_test.go
+++ b/internal/trackers/impl/btn/upload_integration_test.go
@@ -55,6 +55,37 @@ func (r *httpHandlerErrorRecorder) Check() {
 	}
 }
 
+// captureBTNLogger records warning messages from upload paths that may return
+// before reaching the HTTP test server.
+type captureBTNLogger struct {
+	mu       sync.Mutex
+	warnings []string
+}
+
+func (l *captureBTNLogger) Tracef(string, ...any) {}
+func (l *captureBTNLogger) Debugf(string, ...any) {}
+func (l *captureBTNLogger) Infof(string, ...any)  {}
+
+func (l *captureBTNLogger) Warnf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warnings = append(l.warnings, fmt.Sprintf(format, args...))
+}
+
+func (l *captureBTNLogger) Errorf(string, ...any) {}
+
+// containsWarning reports whether any captured warning contains value.
+func (l *captureBTNLogger) containsWarning(value string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, warning := range l.warnings {
+		if strings.Contains(warning, value) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestBTNUploadEndToEndSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -442,6 +473,43 @@ func TestBTNDryRunBlocksMissingCanonicalTVSeasonEpisode(t *testing.T) {
 	}
 	if !strings.Contains(entry.Message, "canonical TV season/episode missing; tracker payload uses 0 and ignores parsed season/episode fallback; refresh metadata or correct canonical season/episode before upload") {
 		t.Fatalf("expected canonical metadata message, got %q", entry.Message)
+	}
+}
+
+func TestBTNUploadBlocksMissingCanonicalTVSeasonEpisode(t *testing.T) {
+	t.Parallel()
+
+	var requestCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCalls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	logger := &captureBTNLogger{}
+	req := newBTNDryRunTestRequest(t, newBTNAuthDB(t))
+	req.TrackerConfig.URL = server.URL
+	req.TrackerConfig.Username = "user"
+	req.TrackerConfig.Password = "pass"
+	req.Logger = logger
+	req.Meta.SeasonInt = 0
+	req.Meta.EpisodeInt = 0
+	req.Meta.Release.Season = 1
+	req.Meta.Release.Episode = 1
+
+	_, err := upload(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected canonical TV metadata gap to block upload")
+	}
+	want := "canonical TV season/episode missing; tracker payload uses 0 and ignores parsed season/episode fallback; refresh metadata or correct canonical season/episode before upload"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected canonical metadata error, got %v", err)
+	}
+	if !logger.containsWarning(want) {
+		t.Fatal("expected canonical metadata warning")
+	}
+	if requestCalls.Load() != 0 {
+		t.Fatalf("expected upload to fail before remote calls, got %d calls", requestCalls.Load())
 	}
 }
 

--- a/internal/trackers/impl/btn/upload_integration_test.go
+++ b/internal/trackers/impl/btn/upload_integration_test.go
@@ -422,6 +422,29 @@ func TestBTNDryRunRequiresUploadAuthPrerequisites(t *testing.T) {
 	}
 }
 
+func TestBTNDryRunBlocksMissingCanonicalTVSeasonEpisode(t *testing.T) {
+	t.Parallel()
+
+	req := newBTNDryRunTestRequest(t, newBTNAuthDB(t))
+	req.TrackerConfig.Username = "user"
+	req.TrackerConfig.Password = "pass"
+	req.Meta.SeasonInt = 0
+	req.Meta.EpisodeInt = 0
+	req.Meta.Release.Season = 1
+	req.Meta.Release.Episode = 1
+
+	entry, err := buildUploadDryRun(context.Background(), req)
+	if err != nil {
+		t.Fatalf("BuildUploadDryRun: %v", err)
+	}
+	if entry.Status != "blocked" {
+		t.Fatalf("expected canonical TV metadata gap to block dry-run, got %#v", entry)
+	}
+	if !strings.Contains(entry.Message, "canonical TV season/episode missing; tracker payload uses 0 and ignores parsed season/episode fallback; refresh metadata or correct canonical season/episode before upload") {
+		t.Fatalf("expected canonical metadata message, got %q", entry.Message)
+	}
+}
+
 func TestResolveSessionForTrackerAuthLoginStorageErrorPreventsLogin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -111,6 +111,9 @@ func uploadUnit3D(ctx context.Context, req trackers.UploadRequest) (api.UploadSu
 		logger.Errorf("trackers: %s failed to build upload data: %v", trackerName, err)
 		return api.UploadSummary{}, err
 	}
+	if message := unit3DTVPayloadMetadataMessage(req.Meta, data); message != "" {
+		logger.Warnf("trackers: %s %s", trackerName, message)
+	}
 	category := resolveUnit3DCategory(req.Meta)
 	_, hasTVDB := data["tvdb"]
 	_, hasSeason := data["season_number"]
@@ -429,10 +432,15 @@ func buildUploadDryRunUnit3D(ctx context.Context, req trackers.UploadRequest) (a
 		files = append(files, api.TrackerDryRunFile{Field: "nfo", Path: nfoPath, Present: true})
 	}
 
+	message := "dry-run payload generated"
+	if metadataMessage := unit3DTVPayloadMetadataMessage(req.Meta, data); metadataMessage != "" {
+		message += "; " + metadataMessage
+	}
+
 	return api.TrackerDryRunEntry{
 		Tracker:          trackerName,
 		Status:           "ready",
-		Message:          "dry-run payload generated",
+		Message:          message,
 		ReleaseName:      name,
 		DescriptionGroup: "unit3d",
 		Description:      description,
@@ -975,44 +983,78 @@ func detectResolution(value string) string {
 	return ""
 }
 
-// resolveSeason returns the Unit3D payload season value. Manual overrides and
-// canonical provider metadata win; parsed release data is only a payload
-// fallback for trackers that require TV fields before provider remapping exists.
+// resolveSeason returns the Unit3D payload season value from SeasonInt only.
 func resolveSeason(meta api.PreparedMetadata) string {
-	if meta.ReleaseNameOverrides.Season != nil {
-		if override := parseSeasonEpisodeToken(*meta.ReleaseNameOverrides.Season, "S"); override > 0 {
-			return formatOptionalInt(override)
-		}
-	}
-	season, _ := meta.SeasonEpisodeWithParsedFallback()
-	if season > 0 {
-		return formatOptionalInt(season)
-	}
-	season, _ = parseSeasonEpisode(meta.ReleaseName)
-	if season == 0 {
+	if meta.SeasonInt <= 0 {
 		return "0"
 	}
-	return formatOptionalInt(season)
+	return formatOptionalInt(meta.SeasonInt)
 }
 
-// resolveEpisode returns the Unit3D payload episode value. Manual overrides and
-// canonical provider metadata win; parsed release data is only a payload
-// fallback for trackers that require TV fields before provider remapping exists.
+// resolveEpisode returns the Unit3D payload episode value from EpisodeInt only.
 func resolveEpisode(meta api.PreparedMetadata) string {
-	if meta.ReleaseNameOverrides.Episode != nil {
-		if override := parseSeasonEpisodeToken(*meta.ReleaseNameOverrides.Episode, "E"); override > 0 {
-			return formatOptionalInt(override)
-		}
-	}
-	_, episode := meta.SeasonEpisodeWithParsedFallback()
-	if episode > 0 {
-		return formatOptionalInt(episode)
-	}
-	_, episode = parseSeasonEpisode(meta.ReleaseName)
-	if episode == 0 {
+	if meta.EpisodeInt <= 0 {
 		return "0"
 	}
-	return formatOptionalInt(episode)
+	return formatOptionalInt(meta.EpisodeInt)
+}
+
+// unit3DTVPayloadMetadataMessage returns dry-run/log feedback when Unit3D TV
+// fields are present but canonical season or episode metadata is missing.
+// Parsed release and manual naming values are reported only as ignored signals
+// and must not feed tracker payload construction.
+func unit3DTVPayloadMetadataMessage(meta api.PreparedMetadata, data map[string]string) string {
+	if _, hasSeason := data["season_number"]; !hasSeason {
+		return ""
+	}
+	if _, hasEpisode := data["episode_number"]; !hasEpisode {
+		return ""
+	}
+
+	missing := make([]string, 0, 2)
+	ignored := make([]string, 0, 2)
+	if meta.SeasonInt <= 0 {
+		missing = append(missing, "season")
+		if hasParsedSeasonSignal(meta) {
+			ignored = append(ignored, "season")
+		}
+	}
+	if meta.EpisodeInt <= 0 && !meta.TVPack {
+		missing = append(missing, "episode")
+		if hasParsedEpisodeSignal(meta) {
+			ignored = append(ignored, "episode")
+		}
+	}
+	if len(missing) == 0 {
+		return ""
+	}
+	message := "canonical TV " + strings.Join(missing, "/") + " missing; tracker payload uses 0"
+	if len(ignored) > 0 {
+		message += " and ignores parsed " + strings.Join(ignored, "/") + " fallback"
+	}
+	return message
+}
+
+func hasParsedSeasonSignal(meta api.PreparedMetadata) bool {
+	if meta.Release.Season > 0 {
+		return true
+	}
+	if meta.ReleaseNameOverrides.Season != nil && parseSeasonEpisodeToken(*meta.ReleaseNameOverrides.Season, "S") > 0 {
+		return true
+	}
+	season, _ := parseSeasonEpisode(meta.ReleaseName)
+	return season > 0
+}
+
+func hasParsedEpisodeSignal(meta api.PreparedMetadata) bool {
+	if meta.Release.Episode > 0 {
+		return true
+	}
+	if meta.ReleaseNameOverrides.Episode != nil && parseSeasonEpisodeToken(*meta.ReleaseNameOverrides.Episode, "E") > 0 {
+		return true
+	}
+	_, episode := parseSeasonEpisode(meta.ReleaseName)
+	return episode > 0
 }
 
 var seasonEpisodePattern = regexp.MustCompile(`(?i)S(\d{1,2})(?:E(\d{1,2}))?`)

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -984,13 +984,11 @@ func resolveSeason(meta api.PreparedMetadata) string {
 			return formatOptionalInt(override)
 		}
 	}
-	if meta.SeasonInt > 0 {
-		return formatOptionalInt(meta.SeasonInt)
+	season, _ := meta.SeasonEpisodeWithParsedFallback()
+	if season > 0 {
+		return formatOptionalInt(season)
 	}
-	if meta.Release.Season > 0 {
-		return formatOptionalInt(meta.Release.Season)
-	}
-	season, _ := parseSeasonEpisode(meta.ReleaseName)
+	season, _ = parseSeasonEpisode(meta.ReleaseName)
 	if season == 0 {
 		return "0"
 	}
@@ -1006,13 +1004,11 @@ func resolveEpisode(meta api.PreparedMetadata) string {
 			return formatOptionalInt(override)
 		}
 	}
-	if meta.EpisodeInt > 0 {
-		return formatOptionalInt(meta.EpisodeInt)
+	_, episode := meta.SeasonEpisodeWithParsedFallback()
+	if episode > 0 {
+		return formatOptionalInt(episode)
 	}
-	if meta.Release.Episode > 0 {
-		return formatOptionalInt(meta.Release.Episode)
-	}
-	_, episode := parseSeasonEpisode(meta.ReleaseName)
+	_, episode = parseSeasonEpisode(meta.ReleaseName)
 	if episode == 0 {
 		return "0"
 	}

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -769,7 +769,7 @@ func resolveUnit3DCategory(meta api.PreparedMetadata) string {
 	if category := canonicalUnit3DCategory(meta.Release.Category); category != "" {
 		return category
 	}
-	if meta.SeasonInt > 0 || meta.EpisodeInt > 0 || meta.Release.Season > 0 || meta.Release.Episode > 0 {
+	if meta.HasTVSeasonEpisodeSignal() {
 		return "TV"
 	}
 	if hasSeasonEpisode(meta.ReleaseName) {
@@ -927,7 +927,7 @@ func shouldIncludeUnit3DTVFields(meta api.PreparedMetadata, category string) boo
 	if strings.EqualFold(strings.TrimSpace(meta.MediaInfoCategory), "TV") {
 		return true
 	}
-	if meta.SeasonInt > 0 || meta.EpisodeInt > 0 || meta.Release.Season > 0 || meta.Release.Episode > 0 {
+	if meta.HasTVSeasonEpisodeSignal() {
 		return true
 	}
 
@@ -975,6 +975,9 @@ func detectResolution(value string) string {
 	return ""
 }
 
+// resolveSeason returns the Unit3D payload season value. Manual overrides and
+// canonical provider metadata win; parsed release data is only a payload
+// fallback for trackers that require TV fields before provider remapping exists.
 func resolveSeason(meta api.PreparedMetadata) string {
 	if meta.ReleaseNameOverrides.Season != nil {
 		if override := parseSeasonEpisodeToken(*meta.ReleaseNameOverrides.Season, "S"); override > 0 {
@@ -984,6 +987,9 @@ func resolveSeason(meta api.PreparedMetadata) string {
 	if meta.SeasonInt > 0 {
 		return formatOptionalInt(meta.SeasonInt)
 	}
+	if meta.Release.Season > 0 {
+		return formatOptionalInt(meta.Release.Season)
+	}
 	season, _ := parseSeasonEpisode(meta.ReleaseName)
 	if season == 0 {
 		return "0"
@@ -991,6 +997,9 @@ func resolveSeason(meta api.PreparedMetadata) string {
 	return formatOptionalInt(season)
 }
 
+// resolveEpisode returns the Unit3D payload episode value. Manual overrides and
+// canonical provider metadata win; parsed release data is only a payload
+// fallback for trackers that require TV fields before provider remapping exists.
 func resolveEpisode(meta api.PreparedMetadata) string {
 	if meta.ReleaseNameOverrides.Episode != nil {
 		if override := parseSeasonEpisodeToken(*meta.ReleaseNameOverrides.Episode, "E"); override > 0 {
@@ -999,6 +1008,9 @@ func resolveEpisode(meta api.PreparedMetadata) string {
 	}
 	if meta.EpisodeInt > 0 {
 		return formatOptionalInt(meta.EpisodeInt)
+	}
+	if meta.Release.Episode > 0 {
+		return formatOptionalInt(meta.Release.Episode)
 	}
 	_, episode := parseSeasonEpisode(meta.ReleaseName)
 	if episode == 0 {

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -345,6 +345,10 @@ func isNumericID(value string) bool {
 	return true
 }
 
+// buildUploadDryRunUnit3D returns a Unit3D preview entry with the payload,
+// files, and endpoint that would be used locally. TV payloads with zero-valued
+// canonical season or episode metadata are returned as blocked because the
+// payload no longer satisfies upload prerequisites.
 func buildUploadDryRunUnit3D(ctx context.Context, req trackers.UploadRequest) (api.TrackerDryRunEntry, error) {
 	select {
 	case <-ctx.Done():
@@ -433,13 +437,15 @@ func buildUploadDryRunUnit3D(ctx context.Context, req trackers.UploadRequest) (a
 	}
 
 	message := "dry-run payload generated"
+	status := "ready"
 	if metadataMessage := unit3DTVPayloadMetadataMessage(req.Meta, data); metadataMessage != "" {
 		message += "; " + metadataMessage
+		status = "blocked"
 	}
 
 	return api.TrackerDryRunEntry{
 		Tracker:          trackerName,
-		Status:           "ready",
+		Status:           status,
 		Message:          message,
 		ReleaseName:      name,
 		DescriptionGroup: "unit3d",
@@ -999,10 +1005,10 @@ func resolveEpisode(meta api.PreparedMetadata) string {
 	return formatOptionalInt(meta.EpisodeInt)
 }
 
-// unit3DTVPayloadMetadataMessage returns dry-run/log feedback when Unit3D TV
-// fields are present but canonical season or episode metadata is missing.
-// Parsed release and manual naming values are reported only as ignored signals
-// and must not feed tracker payload construction.
+// unit3DTVPayloadMetadataMessage explains when Unit3D TV fields are present but
+// canonical season or episode metadata is missing. Parsed release and manual
+// naming values are reported only as ignored signals, and the message includes
+// the operator action required by blocked dry-run entries.
 func unit3DTVPayloadMetadataMessage(meta api.PreparedMetadata, data map[string]string) string {
 	if _, hasSeason := data["season_number"]; !hasSeason {
 		return ""
@@ -1032,6 +1038,7 @@ func unit3DTVPayloadMetadataMessage(meta api.PreparedMetadata, data map[string]s
 	if len(ignored) > 0 {
 		message += " and ignores parsed " + strings.Join(ignored, "/") + " fallback"
 	}
+	message += "; refresh metadata or correct canonical season/episode before upload"
 	return message
 }
 

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -111,8 +111,9 @@ func uploadUnit3D(ctx context.Context, req trackers.UploadRequest) (api.UploadSu
 		logger.Errorf("trackers: %s failed to build upload data: %v", trackerName, err)
 		return api.UploadSummary{}, err
 	}
-	if message := unit3DTVPayloadMetadataMessage(req.Meta, data); message != "" {
+	if message, err := validateUnit3DTVPayloadMetadata(trackerName, req.Meta, data); err != nil {
 		logger.Warnf("trackers: %s %s", trackerName, message)
+		return api.UploadSummary{}, err
 	}
 	category := resolveUnit3DCategory(req.Meta)
 	_, hasTVDB := data["tvdb"]
@@ -438,7 +439,7 @@ func buildUploadDryRunUnit3D(ctx context.Context, req trackers.UploadRequest) (a
 
 	message := "dry-run payload generated"
 	status := "ready"
-	if metadataMessage := unit3DTVPayloadMetadataMessage(req.Meta, data); metadataMessage != "" {
+	if metadataMessage, err := validateUnit3DTVPayloadMetadata(trackerName, req.Meta, data); err != nil {
 		message += "; " + metadataMessage
 		status = "blocked"
 	}
@@ -1003,6 +1004,17 @@ func resolveEpisode(meta api.PreparedMetadata) string {
 		return "0"
 	}
 	return formatOptionalInt(meta.EpisodeInt)
+}
+
+// validateUnit3DTVPayloadMetadata returns the shared Unit3D TV metadata block
+// reason used by live upload and dry-run when canonical season or episode data
+// is missing from payload fields that would otherwise be submitted as zero.
+func validateUnit3DTVPayloadMetadata(trackerName string, meta api.PreparedMetadata, data map[string]string) (string, error) {
+	message := unit3DTVPayloadMetadataMessage(meta, data)
+	if message == "" {
+		return "", nil
+	}
+	return message, fmt.Errorf("trackers: %s %s", trackerName, message)
 }
 
 // unit3DTVPayloadMetadataMessage explains when Unit3D TV fields are present but

--- a/internal/trackers/impl/unit3d/upload_test.go
+++ b/internal/trackers/impl/unit3d/upload_test.go
@@ -381,8 +381,57 @@ func TestBuildUnit3DDataTVOmitsParsedReleaseSeasonEpisodeFallback(t *testing.T) 
 	if got := data["tvdb"]; got != "789" {
 		t.Fatalf("expected tvdb=789, got %q", got)
 	}
-	if got := unit3DTVPayloadMetadataMessage(req.Meta, data); got != "canonical TV season/episode missing; tracker payload uses 0 and ignores parsed season/episode fallback" {
+	if got := unit3DTVPayloadMetadataMessage(req.Meta, data); got != "canonical TV season/episode missing; tracker payload uses 0 and ignores parsed season/episode fallback; refresh metadata or correct canonical season/episode before upload" {
 		t.Fatalf("unexpected metadata message %q", got)
+	}
+}
+
+func TestBuildUnit3DDryRunBlocksMissingCanonicalTVSeasonEpisode(t *testing.T) {
+	tempDir := t.TempDir()
+	mediaInfoPath := filepath.Join(tempDir, "mediainfo.txt")
+	if err := os.WriteFile(mediaInfoPath, []byte("General\nComplete name: show"), 0o600); err != nil {
+		t.Fatalf("write mediainfo: %v", err)
+	}
+	torrentPath := filepath.Join(tempDir, "show.torrent")
+	if err := os.WriteFile(torrentPath, []byte("d8:announce13:https://x.ee"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+
+	entry, err := buildUploadDryRunUnit3D(context.Background(), trackers.UploadRequest{
+		Tracker: "AITHER",
+		TrackerConfig: config.TrackerConfig{
+			APIKey: "test-key",
+		},
+		Meta: api.PreparedMetadata{
+			ReleaseName:            "Daily.Show.2025.07.01.1080p.WEB-DL-GRP",
+			TorrentPath:            torrentPath,
+			MediaInfoTextPath:      mediaInfoPath,
+			ValidMediaInfoSettings: true,
+			ExternalIDs: api.ExternalIDs{
+				Category: "TV",
+				TVDBID:   789,
+			},
+			Type: "WEBDL",
+			Release: api.ReleaseInfo{
+				Category:   "TV",
+				Season:     2025,
+				Episode:    701,
+				Resolution: "1080p",
+			},
+		},
+		Assets: &trackers.DescriptionAssets{
+			Description: "description",
+			Final:       true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("build Unit3D dry-run: %v", err)
+	}
+	if entry.Status != "blocked" {
+		t.Fatalf("expected canonical TV metadata gap to block dry-run, got %#v", entry)
+	}
+	if !strings.Contains(entry.Message, "canonical TV season/episode missing; tracker payload uses 0 and ignores parsed season/episode fallback; refresh metadata or correct canonical season/episode before upload") {
+		t.Fatalf("expected canonical metadata message, got %q", entry.Message)
 	}
 }
 

--- a/internal/trackers/impl/unit3d/upload_test.go
+++ b/internal/trackers/impl/unit3d/upload_test.go
@@ -5,9 +5,14 @@ package unit3d
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/config"
@@ -15,6 +20,37 @@ import (
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
+
+// captureUnit3DLogger records warning messages from upload paths that may
+// return before reaching the HTTP test server.
+type captureUnit3DLogger struct {
+	mu       sync.Mutex
+	warnings []string
+}
+
+func (l *captureUnit3DLogger) Tracef(string, ...any) {}
+func (l *captureUnit3DLogger) Debugf(string, ...any) {}
+func (l *captureUnit3DLogger) Infof(string, ...any)  {}
+
+func (l *captureUnit3DLogger) Warnf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warnings = append(l.warnings, fmt.Sprintf(format, args...))
+}
+
+func (l *captureUnit3DLogger) Errorf(string, ...any) {}
+
+// containsWarning reports whether any captured warning contains value.
+func (l *captureUnit3DLogger) containsWarning(value string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, warning := range l.warnings {
+		if strings.Contains(warning, value) {
+			return true
+		}
+	}
+	return false
+}
 
 func TestResolveUnit3DCategory(t *testing.T) {
 	tests := []struct {
@@ -432,6 +468,69 @@ func TestBuildUnit3DDryRunBlocksMissingCanonicalTVSeasonEpisode(t *testing.T) {
 	}
 	if !strings.Contains(entry.Message, "canonical TV season/episode missing; tracker payload uses 0 and ignores parsed season/episode fallback; refresh metadata or correct canonical season/episode before upload") {
 		t.Fatalf("expected canonical metadata message, got %q", entry.Message)
+	}
+}
+
+func TestUploadUnit3DBlocksMissingCanonicalTVSeasonEpisode(t *testing.T) {
+	tempDir := t.TempDir()
+	mediaInfoPath := filepath.Join(tempDir, "mediainfo.txt")
+	if err := os.WriteFile(mediaInfoPath, []byte("General\nComplete name: show"), 0o600); err != nil {
+		t.Fatalf("write mediainfo: %v", err)
+	}
+	torrentPath := filepath.Join(tempDir, "show.torrent")
+	if err := os.WriteFile(torrentPath, []byte("d8:announce13:https://x.ee"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+
+	var requestCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCalls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	logger := &captureUnit3DLogger{}
+	_, err := uploadUnit3D(context.Background(), trackers.UploadRequest{
+		Tracker: "AITHER",
+		TrackerConfig: config.TrackerConfig{
+			URL:    server.URL,
+			APIKey: "test-key",
+		},
+		Logger: logger,
+		Meta: api.PreparedMetadata{
+			ReleaseName:            "Daily.Show.2025.07.01.1080p.WEB-DL-GRP",
+			TorrentPath:            torrentPath,
+			MediaInfoTextPath:      mediaInfoPath,
+			ValidMediaInfoSettings: true,
+			ExternalIDs: api.ExternalIDs{
+				Category: "TV",
+				TVDBID:   789,
+			},
+			Type: "WEBDL",
+			Release: api.ReleaseInfo{
+				Category:   "TV",
+				Season:     2025,
+				Episode:    701,
+				Resolution: "1080p",
+			},
+		},
+		Assets: &trackers.DescriptionAssets{
+			Description: "description",
+			Final:       true,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected canonical TV metadata gap to block upload")
+	}
+	want := "canonical TV season/episode missing; tracker payload uses 0 and ignores parsed season/episode fallback; refresh metadata or correct canonical season/episode before upload"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected canonical metadata error, got %v", err)
+	}
+	if !logger.containsWarning(want) {
+		t.Fatal("expected canonical metadata warning")
+	}
+	if requestCalls.Load() != 0 {
+		t.Fatalf("expected upload to fail before remote calls, got %d calls", requestCalls.Load())
 	}
 }
 

--- a/internal/trackers/impl/unit3d/upload_test.go
+++ b/internal/trackers/impl/unit3d/upload_test.go
@@ -348,6 +348,41 @@ func TestBuildUnit3DDataTVIncludesTVOnlyFields(t *testing.T) {
 	}
 }
 
+func TestBuildUnit3DDataTVUsesParsedReleaseSeasonEpisodeFallback(t *testing.T) {
+	req := trackers.UploadRequest{
+		Tracker: "AITHER",
+		Meta: api.PreparedMetadata{
+			ReleaseName: "Daily.Show.2025.07.01.1080p.WEB-DL-GRP",
+			ExternalIDs: api.ExternalIDs{
+				Category: "TV",
+				TVDBID:   789,
+			},
+			Type: "WEBDL",
+			Release: api.ReleaseInfo{
+				Category:   "TV",
+				Season:     2025,
+				Episode:    701,
+				Resolution: "1080p",
+			},
+		},
+	}
+
+	data, err := buildUnit3DData(req, "name", "desc", "mi", "")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if got := data["season_number"]; got != "2025" {
+		t.Fatalf("expected season_number=2025, got %q", got)
+	}
+	if got := data["episode_number"]; got != "701" {
+		t.Fatalf("expected episode_number=701, got %q", got)
+	}
+	if got := data["tvdb"]; got != "789" {
+		t.Fatalf("expected tvdb=789, got %q", got)
+	}
+}
+
 func TestBuildUnit3DDataFailsOnUnknownType(t *testing.T) {
 	req := trackers.UploadRequest{
 		Tracker: "AITHER",

--- a/internal/trackers/impl/unit3d/upload_test.go
+++ b/internal/trackers/impl/unit3d/upload_test.go
@@ -348,7 +348,7 @@ func TestBuildUnit3DDataTVIncludesTVOnlyFields(t *testing.T) {
 	}
 }
 
-func TestBuildUnit3DDataTVUsesParsedReleaseSeasonEpisodeFallback(t *testing.T) {
+func TestBuildUnit3DDataTVOmitsParsedReleaseSeasonEpisodeFallback(t *testing.T) {
 	req := trackers.UploadRequest{
 		Tracker: "AITHER",
 		Meta: api.PreparedMetadata{
@@ -372,14 +372,17 @@ func TestBuildUnit3DDataTVUsesParsedReleaseSeasonEpisodeFallback(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if got := data["season_number"]; got != "2025" {
-		t.Fatalf("expected season_number=2025, got %q", got)
+	if got := data["season_number"]; got != "0" {
+		t.Fatalf("expected season_number=0, got %q", got)
 	}
-	if got := data["episode_number"]; got != "701" {
-		t.Fatalf("expected episode_number=701, got %q", got)
+	if got := data["episode_number"]; got != "0" {
+		t.Fatalf("expected episode_number=0, got %q", got)
 	}
 	if got := data["tvdb"]; got != "789" {
 		t.Fatalf("expected tvdb=789, got %q", got)
+	}
+	if got := unit3DTVPayloadMetadataMessage(req.Meta, data); got != "canonical TV season/episode missing; tracker payload uses 0 and ignores parsed season/episode fallback" {
+		t.Fatalf("unexpected metadata message %q", got)
 	}
 }
 

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -227,9 +227,10 @@ func (m PreparedMetadata) CanonicalSeasonEpisode() (int, int) {
 }
 
 // SeasonEpisodeWithParsedFallback returns canonical season/episode values and
-// falls back to release-name parsed values only when canonical values are
-// unavailable. Use this for TV classification and lookup fallbacks, not for
-// canonical upload naming.
+// falls back to release-name parsed values independently for each missing
+// field. The returned season and episode can come from different sources, so
+// callers must not treat the pair as source-consistent. Use this for TV
+// classification and lookup fallbacks, not for canonical upload naming.
 func (m PreparedMetadata) SeasonEpisodeWithParsedFallback() (int, int) {
 	season, episode := m.CanonicalSeasonEpisode()
 	if season <= 0 {

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -79,6 +79,10 @@ const (
 	TrackerBlockReasonAudio TrackerBlockReason = "audio"
 )
 
+// PreparedMetadata contains the shared metadata snapshot used across CLI, GUI,
+// embedded web, and tracker upload flows. Release preserves parsed release-name
+// data; SeasonInt and EpisodeInt carry canonical TV identity after metadata
+// parsing and provider/date remapping.
 type PreparedMetadata struct {
 	SourcePath                  string
 	SourceLookupURL             string
@@ -214,6 +218,34 @@ type PreparedMetadata struct {
 	IgnoreTrackerRuleFailures   bool
 	TrackerRuleFailures         map[string][]RuleFailure
 	BDInfo                      map[string]any
+}
+
+// CanonicalSeasonEpisode returns the provider-resolved TV season/episode used
+// for upload identity and naming.
+func (m PreparedMetadata) CanonicalSeasonEpisode() (int, int) {
+	return m.SeasonInt, m.EpisodeInt
+}
+
+// SeasonEpisodeWithParsedFallback returns canonical season/episode values and
+// falls back to release-name parsed values only when canonical values are
+// unavailable. Use this for TV classification and lookup fallbacks, not for
+// canonical upload naming.
+func (m PreparedMetadata) SeasonEpisodeWithParsedFallback() (int, int) {
+	season, episode := m.CanonicalSeasonEpisode()
+	if season <= 0 {
+		season = m.Release.Season
+	}
+	if episode <= 0 {
+		episode = m.Release.Episode
+	}
+	return season, episode
+}
+
+// HasTVSeasonEpisodeSignal reports whether either canonical metadata or the
+// parsed release name carries a season/episode hint.
+func (m PreparedMetadata) HasTVSeasonEpisodeSignal() bool {
+	season, episode := m.SeasonEpisodeWithParsedFallback()
+	return season > 0 || episode > 0
 }
 
 type MetadataOverrides struct {
@@ -678,6 +710,8 @@ type TrackerMatch struct {
 	TrackerID string
 }
 
+// ReleaseInfo preserves release-name parser output before provider metadata can
+// remap episode identity.
 type ReleaseInfo struct {
 	Category   string
 	Type       string

--- a/pkg/api/services_test.go
+++ b/pkg/api/services_test.go
@@ -8,6 +8,29 @@ import (
 	"testing"
 )
 
+func TestPreparedMetadataSeasonEpisodeHelpers(t *testing.T) {
+	meta := PreparedMetadata{
+		SeasonInt: 9,
+		Release: ReleaseInfo{
+			Season:  1,
+			Episode: 2,
+		},
+	}
+
+	canonicalSeason, canonicalEpisode := meta.CanonicalSeasonEpisode()
+	if canonicalSeason != 9 || canonicalEpisode != 0 {
+		t.Fatalf("canonical season/episode = %d/%d, want 9/0", canonicalSeason, canonicalEpisode)
+	}
+
+	fallbackSeason, fallbackEpisode := meta.SeasonEpisodeWithParsedFallback()
+	if fallbackSeason != 9 || fallbackEpisode != 2 {
+		t.Fatalf("fallback season/episode = %d/%d, want 9/2", fallbackSeason, fallbackEpisode)
+	}
+	if !meta.HasTVSeasonEpisodeSignal() {
+		t.Fatalf("expected parsed release episode to provide TV signal")
+	}
+}
+
 func TestTMDBMetadataMarshalLocalizedTitlesAsObject(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved TV season/episode identification by prioritizing canonical metadata, using parsed release-name values only as temporary fallback during provider lookups.

* **Bug Fixes**
  * TV metadata now updates season/episode from provider-returned details when available.
  * Parsed fallback season/episode is no longer persisted as canonical TV identity, preventing incorrect matching/uploads.

* **Improvements**
  * BTN and Unit3D uploads (and dry-runs) now warn and block when canonical TV season/episode is missing, and ignore parsed fallback for payload fields.

* **Tests**
  * Added unit/integration coverage for canonical-metadata gaps and expected payload/dry-run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->