### PR TITLE
fix(gui) : remove duplicate "v" in the application version

### DIFF
--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -4092,7 +4092,7 @@ export default function App() {
               <div className="grid min-w-0 gap-0.5">
                 {applicationInfo?.version ? (
                   <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-semibold text-[var(--text)]">
-                    v{applicationInfo.version}
+                    {applicationInfo.version}
                   </span>
                 ) : null}
                 <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">


### PR DESCRIPTION
Right now it says vv0.2.2 instead of just v0.2.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app version display in the sidebar to show the version exactly as provided, removing the extra `v` prefix when a version is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->