### PR TITLE
fix(frontend): stop discarding tracker selections and bulk selection …

### DIFF
--- a/gui/frontend/src/app.test.ts
+++ b/gui/frontend/src/app.test.ts
@@ -12,6 +12,8 @@ import type {
   DupeCheckSnapshot,
   DupeEntry,
   DupeMatch,
+  HistoryEntry,
+  HistoryOverview,
   MetadataPreview,
   ScreenshotPlan,
   TrackerUploadSnapshot,
@@ -65,6 +67,9 @@ type StartTrackerUpload = (...args: unknown[]) => Promise<string>;
 type RetryFailedTrackerUpload = (jobID: string) => Promise<string>;
 type CancelTrackerUpload = (jobID: string) => Promise<void>;
 type GetTrackerUploadSnapshot = (jobID: string) => Promise<TrackerUploadSnapshot>;
+type ListHistory = () => Promise<HistoryEntry[]>;
+type GetHistoryOverview = (sourcePath: string) => Promise<HistoryOverview>;
+type DeleteHistoryRelease = (sourcePath: string) => Promise<void>;
 
 const metadataPreview = (sourcePath: string): MetadataPreview => ({
   SourcePath: sourcePath,
@@ -209,6 +214,51 @@ const dupeCheckSnapshot = (sourcePath = "C:\\media\\Example"): DupeCheckSnapshot
   finishedAt: "2026-06-17T00:00:01Z",
 });
 
+const historyEntry = (sourcePath: string): HistoryEntry => ({
+  SourcePath: sourcePath,
+  ReleaseTitle: "Example Release",
+  ReleaseSource: "WEB",
+  ReleaseResolution: "1080p",
+  MetadataUpdatedAt: "2026-06-17T00:00:00Z",
+  LatestUploadStatus: "",
+  LatestUploadAt: "",
+  RuleFailureCount: 0,
+});
+
+const historyOverview = (sourcePath: string): HistoryOverview => ({
+  SourcePath: sourcePath,
+  ReleaseTitle: "Example Release",
+  ReleaseSource: "WEB",
+  ReleaseResolution: "1080p",
+  MetadataUpdatedAt: "2026-06-17T00:00:00Z",
+  LatestUploadStatus: "",
+  LatestUploadAt: "",
+  StatusLabel: "Stored",
+  Metadata: {},
+  ExternalIDs: metadataPreview(sourcePath).ExternalIDs,
+  ExternalMetadata: {},
+  ReleaseNameOverrides: {},
+  DescriptionOverride: {
+    SourcePath: sourcePath,
+    GroupKey: "",
+    Description: "",
+    UpdatedAt: "",
+  },
+  DescriptionOverrides: [],
+  PlaylistSelection: {
+    SourcePath: sourcePath,
+    SelectedPlaylists: [],
+    UseAll: false,
+    UpdatedAt: "",
+  },
+  TrackerMetadata: [],
+  TrackerRuleFailures: [],
+  Screenshots: [],
+  FinalSelections: [],
+  UploadedImages: [],
+  UploadHistory: [],
+});
+
 const installAppBridge = (
   fetchMetadata: FetchMetadata,
   options: {
@@ -224,6 +274,9 @@ const installAppBridge = (
     retryFailedTrackerUpload?: RetryFailedTrackerUpload;
     cancelTrackerUpload?: CancelTrackerUpload;
     getTrackerUploadSnapshot?: GetTrackerUploadSnapshot;
+    listHistory?: ListHistory;
+    getHistoryOverview?: GetHistoryOverview;
+    deleteHistoryRelease?: DeleteHistoryRelease;
   } = {},
 ) => {
   const storage = new Map<string, string>();
@@ -288,6 +341,10 @@ const installAppBridge = (
         GetTrackerUploadSnapshot:
           options.getTrackerUploadSnapshot ??
           (async (jobID: string) => trackerUploadSnapshot(jobID, "completed")),
+        ListHistory: options.listHistory ?? (async () => []),
+        GetHistoryOverview:
+          options.getHistoryOverview ?? (async (sourcePath: string) => historyOverview(sourcePath)),
+        DeleteHistoryRelease: options.deleteHistoryRelease ?? (async () => undefined),
       },
     },
   };
@@ -538,6 +595,47 @@ describe("metadata tracker payloads", () => {
     await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(3));
     expect(fetchMetadata.mock.calls[2][0]).toBe("C:\\media\\Other");
     expect(fetchMetadata.mock.calls[2][4]).toEqual(["BLU"]);
+  });
+
+  it("keeps input tracker selections after deleting the current history release", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const deletedPath = "C:\\media\\Example";
+    const listHistory = vi
+      .fn<ListHistory>()
+      .mockResolvedValueOnce([historyEntry(deletedPath)])
+      .mockResolvedValue([]);
+    const deleteHistoryRelease = vi.fn<DeleteHistoryRelease>(async () => undefined);
+    const confirm = vi.fn(() => true);
+    vi.stubGlobal("confirm", confirm);
+    installAppBridge(fetchMetadata, {
+      listHistory,
+      getHistoryOverview: async (sourcePath) => historyOverview(sourcePath),
+      deleteHistoryRelease,
+    });
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: deletedPath },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+    await screen.findByText("2/2");
+
+    fireEvent.click(screen.getByRole("button", { name: "History" }));
+    await screen.findByRole("button", { name: /Example Release/ });
+    fireEvent.click(await screen.findByRole("button", { name: "Remove from database" }));
+    await waitFor(() => expect(deleteHistoryRelease).toHaveBeenCalledWith(deletedPath));
+
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Other" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(2));
+    expect(fetchMetadata.mock.calls[1][4]).toEqual(["AITHER", "BLU"]);
+    await screen.findByText("2/2");
   });
 
   it("blocks metadata fetch when all selected trackers are filtered out", async () => {

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -1575,6 +1575,12 @@ export default function App() {
     setLiveCaptureLoading(false);
   }, [resetScreenshots, resetUploadState]);
 
+  /**
+   * Clears release-specific workflow state after the loaded release is no longer current.
+   *
+   * Input tracker selections are intentionally preserved so the next metadata fetch keeps the
+   * user's configured/default tracker choices.
+   */
   const resetFreshWorkflowState = useCallback(
     (nextActiveTab = "input") => {
       setPath("");
@@ -1633,7 +1639,6 @@ export default function App() {
       setTrackerDryRunPreview(emptyTrackerDryRun);
       setTrackerDryRunProgress(null);
       setTrackerQuestionnaireAnswers({});
-      setReleasePageTrackerSelection({});
       setRunDebug(false);
       setRunLogLevel(configuredRunLogLevel);
       setRunLogLevelTouched(false);

--- a/gui/frontend/src/pages/input/index.test.tsx
+++ b/gui/frontend/src/pages/input/index.test.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2025-2026, Audionut and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { MetadataPreview, ReleaseNameEditState, ReleaseNameTouchedState } from "../../types";
@@ -123,5 +124,98 @@ describe("InputPage metadata progress", () => {
 
     expect(screen.getByText("Retry tracker data")).toBeInTheDocument();
     expect(screen.getByText("Running")).toBeInTheDocument();
+  });
+});
+
+describe("InputPage tracker selection", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("selects and deselects all configured trackers", () => {
+    function Harness() {
+      const [releasePageTrackerSelection, setReleasePageTrackerSelection] = useState<
+        Record<string, boolean>
+      >({
+        AITHER: true,
+        BLU: false,
+      });
+
+      return (
+        <InputPage
+          path="C:\\media\\Example.mkv"
+          handleSourcePathChange={vi.fn()}
+          sourcePathHistory={[]}
+          handleSourcePathHistorySelect={vi.fn()}
+          sourceLookupURL=""
+          setSourceLookupURL={vi.fn()}
+          browseAvailable={false}
+          handleBrowseFile={vi.fn()}
+          handleBrowseFolder={vi.fn()}
+          handleFetch={vi.fn()}
+          handleRefresh={vi.fn()}
+          handleResetMetadata={vi.fn()}
+          loading={false}
+          metadataResetting={false}
+          metadataProgressActive={false}
+          metadataProgressUpdates={[]}
+          error=""
+          preview={preview}
+          trackerUploadItems={[
+            { name: "AITHER", config: {} },
+            { name: "BLU", config: {} },
+          ]}
+          releasePageTrackerSelection={releasePageTrackerSelection}
+          setReleasePageTrackerSelection={setReleasePageTrackerSelection}
+          idEdits={{ tmdb: "", imdb: "", tvdb: "", tvmaze: "" }}
+          setIdEdits={vi.fn()}
+          releaseEdits={releaseEdits}
+          setReleaseEdits={vi.fn()}
+          markReleaseTouched={vi.fn<(key: keyof ReleaseNameTouchedState) => void>()}
+          idOverrideState={{ overrides: {}, dirty: false, invalid: false }}
+          releaseOverrideState={{ overrides: {}, dirty: false, invalid: false }}
+          showExternalIDInputUI={false}
+          refreshDisabled={false}
+          selectedProvider=""
+          setSelectedProvider={vi.fn()}
+          setLightboxImage={vi.fn()}
+          setLightboxAlt={vi.fn()}
+          runDebug={false}
+          setRunDebug={vi.fn()}
+          runLogLevel=""
+          setRunLogLevel={vi.fn()}
+          runLogLevelTouched={false}
+          setRunLogLevelTouched={vi.fn()}
+          trackerIconSrcByName={{}}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    expect(screen.getByText("1/2")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "AITHER" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByRole("checkbox", { name: "BLU" })).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(screen.getByRole("button", { name: "Select all" }));
+
+    expect(screen.getByText("2/2")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "AITHER" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByRole("checkbox", { name: "BLU" })).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Deselect all" }));
+
+    expect(screen.getByText("0/2")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "AITHER" })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    expect(screen.getByRole("checkbox", { name: "BLU" })).toHaveAttribute("aria-checked", "false");
   });
 });

--- a/gui/frontend/src/pages/input/index.tsx
+++ b/gui/frontend/src/pages/input/index.tsx
@@ -705,6 +705,23 @@ export default function InputPage(props: Props) {
       ),
     [trackerUploadItems, releasePageTrackerSelection],
   );
+  const allTrackersSelected =
+    trackerUploadItems.length > 0 && selectedTrackerCount === trackerUploadItems.length;
+
+  /**
+   * Applies one selection state to every currently configured input tracker.
+   *
+   * Existing selection entries for trackers outside the visible config list are left untouched.
+   */
+  const setAllTrackersSelected = (selected: boolean) => {
+    setReleasePageTrackerSelection((prev) => {
+      const next = { ...prev };
+      trackerUploadItems.forEach((tracker) => {
+        next[tracker.name] = selected;
+      });
+      return next;
+    });
+  };
 
   const discHint = useMemo(() => {
     const trimmed = path.trim();
@@ -1231,33 +1248,51 @@ export default function InputPage(props: Props) {
                   {trackerUploadItems.length === 0 ? (
                     <p className="muted">No configured tracker entries found.</p>
                   ) : (
-                    <div className="tracker-pills">
-                      {trackerUploadItems.map((tracker) => {
-                        const iconSrc = trackerIconFor(trackerIconSrcByName, tracker.name);
-                        return (
-                          <PillCheckbox
-                            aria-label={tracker.name}
-                            key={tracker.name}
-                            checked={Boolean(releasePageTrackerSelection[tracker.name])}
-                            onCheckedChange={(checked) =>
-                              setReleasePageTrackerSelection((prev) => ({
-                                ...prev,
-                                [tracker.name]: checked,
-                              }))
-                            }
-                          >
-                            <span className="flex items-center gap-1.5">
-                              <TrackerIconImage
-                                tracker={tracker.name}
-                                iconSrc={iconSrc}
-                                enabled={useFavicons}
-                              />
-                              {faviconOnly && useFavicons ? null : tracker.name}
-                            </span>
-                          </PillCheckbox>
-                        );
-                      })}
-                    </div>
+                    <>
+                      <div className="mb-2 flex flex-wrap gap-2">
+                        <Button
+                          type="button"
+                          onClick={() => setAllTrackersSelected(true)}
+                          disabled={allTrackersSelected}
+                        >
+                          Select all
+                        </Button>
+                        <Button
+                          type="button"
+                          onClick={() => setAllTrackersSelected(false)}
+                          disabled={selectedTrackerCount === 0}
+                        >
+                          Deselect all
+                        </Button>
+                      </div>
+                      <div className="tracker-pills">
+                        {trackerUploadItems.map((tracker) => {
+                          const iconSrc = trackerIconFor(trackerIconSrcByName, tracker.name);
+                          return (
+                            <PillCheckbox
+                              aria-label={tracker.name}
+                              key={tracker.name}
+                              checked={Boolean(releasePageTrackerSelection[tracker.name])}
+                              onCheckedChange={(checked) =>
+                                setReleasePageTrackerSelection((prev) => ({
+                                  ...prev,
+                                  [tracker.name]: checked,
+                                }))
+                              }
+                            >
+                              <span className="flex items-center gap-1.5">
+                                <TrackerIconImage
+                                  tracker={tracker.name}
+                                  iconSrc={iconSrc}
+                                  enabled={useFavicons}
+                                />
+                                {faviconOnly && useFavicons ? null : tracker.name}
+                              </span>
+                            </PillCheckbox>
+                          );
+                        })}
+                      </div>
+                    </>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
…options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added **Select all** and **Deselect all** options for tracker selection on the Input page.
  * Tracker selections now persist when navigating through the history deletion flow.

* **Bug Fixes**
  * Fixed an issue where selected trackers could be cleared after returning from a loaded release or history-related flow.

* **Tests**
  * Expanded automated coverage for tracker selection behavior and history deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->