### PR TITLE
fix: edition cleaning

### DIFF
--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -1935,34 +1935,34 @@ func isAllUpperEditionWord(value string) bool {
 // cleanEditionText normalizes parser-derived edition text and drops filename
 // tokens that are not meaningful release-name editions.
 func cleanEditionText(edition string) string {
-	edition = strings.TrimSpace(strings.ReplaceAll(edition, ",", " "))
-	if edition == "" {
-		return ""
-	}
-	lower := strings.ToLower(edition)
-	if lower == "cut" || lower == "approximate" || len(edition) < 6 {
-		return ""
-	}
-	if strings.Contains(lower, "edition") {
-		edition = editionWordPattern.ReplaceAllString(edition, "")
-	}
-	lower = strings.ToLower(edition)
-	if strings.Contains(lower, "extended") && !strings.Contains(lower, "in1") && !strings.Contains(edition, "/") {
-		edition = "Extended"
-	}
-	edition = editionBadTokenPattern.ReplaceAllString(edition, "")
-	return cleanEditionResidue(edition)
+	return cleanEditionTextWithOptions(edition, cleanEditionTextOptions{
+		shouldDrop: func(edition string) bool {
+			return len(edition) < 6
+		},
+		stripBadTokens: true,
+	})
 }
 
 // cleanIMDbEditionText normalizes IMDb runtime edition attributes while
 // preserving IMDb-specific labels that the parser cleanup would otherwise drop.
 func cleanIMDbEditionText(edition string) string {
+	return cleanEditionTextWithOptions(edition, cleanEditionTextOptions{})
+}
+
+type cleanEditionTextOptions struct {
+	shouldDrop     func(string) bool
+	stripBadTokens bool
+}
+
+// cleanEditionTextWithOptions applies preprocessing shared by parser and IMDb
+// edition normalization before final residue cleanup.
+func cleanEditionTextWithOptions(edition string, opts cleanEditionTextOptions) string {
 	edition = strings.TrimSpace(strings.ReplaceAll(edition, ",", " "))
 	if edition == "" {
 		return ""
 	}
 	lower := strings.ToLower(edition)
-	if lower == "cut" || lower == "approximate" {
+	if lower == "cut" || lower == "approximate" || opts.shouldDrop != nil && opts.shouldDrop(edition) {
 		return ""
 	}
 	if strings.Contains(lower, "edition") {
@@ -1971,6 +1971,9 @@ func cleanIMDbEditionText(edition string) string {
 	lower = strings.ToLower(edition)
 	if strings.Contains(lower, "extended") && !strings.Contains(lower, "in1") && !strings.Contains(edition, "/") {
 		edition = "Extended"
+	}
+	if opts.stripBadTokens {
+		edition = editionBadTokenPattern.ReplaceAllString(edition, "")
 	}
 	return cleanEditionResidue(edition)
 }

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -1932,6 +1932,8 @@ func isAllUpperEditionWord(value string) bool {
 	return hasLetter
 }
 
+// cleanEditionText normalizes parser-derived edition text and drops filename
+// tokens that are not meaningful release-name editions.
 func cleanEditionText(edition string) string {
 	edition = strings.TrimSpace(strings.ReplaceAll(edition, ",", " "))
 	if edition == "" {
@@ -1949,10 +1951,11 @@ func cleanEditionText(edition string) string {
 		edition = "Extended"
 	}
 	edition = editionBadTokenPattern.ReplaceAllString(edition, "")
-	edition = editionWhitespacePattern.ReplaceAllString(edition, " ")
-	return strings.TrimSpace(edition)
+	return cleanEditionResidue(edition)
 }
 
+// cleanIMDbEditionText normalizes IMDb runtime edition attributes while
+// preserving IMDb-specific labels that the parser cleanup would otherwise drop.
 func cleanIMDbEditionText(edition string) string {
 	edition = strings.TrimSpace(strings.ReplaceAll(edition, ",", " "))
 	if edition == "" {
@@ -1969,7 +1972,14 @@ func cleanIMDbEditionText(edition string) string {
 	if strings.Contains(lower, "extended") && !strings.Contains(lower, "in1") && !strings.Contains(edition, "/") {
 		edition = "Extended"
 	}
+	return cleanEditionResidue(edition)
+}
+
+// cleanEditionResidue removes separator-only leftovers after edition token
+// cleanup, such as ". ." from stripped "Limited.Edition" markers.
+func cleanEditionResidue(edition string) string {
 	edition = editionWhitespacePattern.ReplaceAllString(edition, " ")
+	edition = strings.Trim(edition, " ._-+/()[]{}")
 	return strings.TrimSpace(edition)
 }
 

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -277,6 +277,31 @@ func TestEditionFromMetaExtractsRepackAndCleansEdition(t *testing.T) {
 	}
 }
 
+func TestEditionFromMetaDropsPunctuationOnlyEditionResidue(t *testing.T) {
+	meta := api.PreparedMetadata{
+		Release: api.ReleaseInfo{Edition: []string{"Limited.Edition", "Limited.Edition"}},
+	}
+
+	edition, repack := editionFromMeta(meta, mediaInfoDoc{})
+	if edition != "" {
+		t.Fatalf("expected punctuation-only edition residue to be dropped, got %q", edition)
+	}
+	if repack != "" {
+		t.Fatalf("expected no repack, got %q", repack)
+	}
+}
+
+func TestEditionFromMetaTrimsPunctuationAroundKeptEdition(t *testing.T) {
+	meta := api.PreparedMetadata{
+		Release: api.ReleaseInfo{Edition: []string{"Limited.Edition", "Extended.Edition"}},
+	}
+
+	edition, _ := editionFromMeta(meta, mediaInfoDoc{})
+	if edition != "Extended" {
+		t.Fatalf("expected punctuation around kept edition to be trimmed, got %q", edition)
+	}
+}
+
 func TestEditionFromMetaStripsRepackAliasesFromEdition(t *testing.T) {
 	meta := api.PreparedMetadata{
 		Release: api.ReleaseInfo{Edition: []string{"Director's", "Cut", "V3"}},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edition name cleanup by normalizing separators, removing unwanted residue, and trimming leftover punctuation more consistently.
  * Reduced cases where edition labels could end up empty or partially trimmed after cleanup.

* **Tests**
  * Added unit coverage to confirm punctuation-only edition entries are treated as empty.
  * Added unit coverage to ensure editions surrounded by punctuation are properly trimmed and preserved (e.g., “Extended”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->