### PR TITLE
fix: reduce bad service insertition

### DIFF
--- a/internal/metadata/service_resolve.go
+++ b/internal/metadata/service_resolve.go
@@ -4,19 +4,32 @@
 package metadata
 
 import (
+	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+// serviceAlias carries a configured service alias and its normalized token span
+// for deterministic filename matching.
+type serviceAlias struct {
+	name    string
+	service string
+	tokens  []string
+}
+
+// resolveService returns the normalized service token, display name, and source
+// filename for metadata naming. Existing metadata service values win over
+// filename-derived matches.
 func resolveService(meta api.PreparedMetadata) (string, string, string) {
 	services := serviceCodeMap()
 	filename := strings.TrimSpace(meta.Filename)
 	if filename == "" {
 		filename = pathutil.Base(meta.SourcePath)
 	}
-	cleaned := strings.NewReplacer(".", " ", "(", " ", ")", " ").Replace(filename)
+	cleaned := filename
 	if tag := strings.TrimSpace(meta.Tag); tag != "" {
 		cleaned = strings.ReplaceAll(cleaned, tag, "")
 	}
@@ -24,16 +37,10 @@ func resolveService(meta api.PreparedMetadata) (string, string, string) {
 		cleaned = strings.ReplaceAll(cleaned, "DTS-HD.MA.", "")
 		cleaned = strings.ReplaceAll(cleaned, "DTS-HD MA ", "")
 	}
-	cleanedLower := " " + strings.ToLower(cleaned) + " "
 
 	service := strings.TrimSpace(meta.Service)
 	if service == "" {
-		for key, value := range services {
-			needle := " " + strings.ToLower(strings.TrimSpace(key)) + " "
-			if needle != "  " && strings.Contains(cleanedLower, needle) {
-				service = value
-			}
-		}
+		service = resolveFilenameService(cleaned, services)
 	}
 
 	longName := ""
@@ -53,6 +60,35 @@ func resolveService(meta api.PreparedMetadata) (string, string, string) {
 	return service, longName, filename
 }
 
+// resolveFilenameService finds a service alias only when it is immediately
+// before a WEB source marker, matching release-name service position and
+// avoiding title or episode-name words.
+func resolveFilenameService(filename string, services map[string]string) string {
+	tokens := serviceMatchTokens(filename)
+	if len(tokens) == 0 {
+		return ""
+	}
+
+	aliases := orderedServiceAliases(services)
+	for idx := range tokens {
+		if !isWebSourceTokenAt(tokens, idx) {
+			continue
+		}
+		for _, alias := range aliases {
+			start := idx - len(alias.tokens)
+			if start < 0 {
+				continue
+			}
+			if matchTokenSpan(tokens[start:idx], alias.tokens) {
+				return alias.service
+			}
+		}
+	}
+	return ""
+}
+
+// resolveServiceValue normalizes an exact service alias or service token from
+// trusted metadata such as an NFO field.
 func resolveServiceValue(value string) (string, string) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -73,6 +109,95 @@ func resolveServiceValue(value string) (string, string) {
 	return "", ""
 }
 
+// orderedServiceAliases returns deterministic alias candidates, preferring more
+// specific aliases before shorter aliases that share the same suffix position.
+func orderedServiceAliases(services map[string]string) []serviceAlias {
+	aliases := make([]serviceAlias, 0, len(services))
+	for name, service := range services {
+		tokens := serviceMatchTokens(name)
+		if len(tokens) == 0 {
+			continue
+		}
+		aliases = append(aliases, serviceAlias{name: name, service: service, tokens: tokens})
+	}
+	sort.Slice(aliases, func(i, j int) bool {
+		iWeight := serviceAliasTokenWeight(aliases[i])
+		jWeight := serviceAliasTokenWeight(aliases[j])
+		if iWeight != jWeight {
+			return iWeight > jWeight
+		}
+		if len(aliases[i].tokens) != len(aliases[j].tokens) {
+			return len(aliases[i].tokens) > len(aliases[j].tokens)
+		}
+		if len(aliases[i].name) != len(aliases[j].name) {
+			return len(aliases[i].name) > len(aliases[j].name)
+		}
+		return aliases[i].name < aliases[j].name
+	})
+	return aliases
+}
+
+// serviceAliasTokenWeight measures alias specificity by normalized token
+// length, keeping multi-character service names ahead of shorter overlaps.
+func serviceAliasTokenWeight(alias serviceAlias) int {
+	weight := 0
+	for _, token := range alias.tokens {
+		weight += len(token)
+	}
+	return weight
+}
+
+// serviceMatchTokens lowercases value and splits it on release-name separators
+// while preserving service-significant characters such as plus and ampersand.
+func serviceMatchTokens(value string) []string {
+	fields := strings.FieldsFunc(strings.ToLower(strings.TrimSpace(value)), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '+' && r != '&'
+	})
+	tokens := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if field == "" {
+			continue
+		}
+		tokens = append(tokens, field)
+	}
+	return tokens
+}
+
+// isWebSourceTokenAt reports whether tokens at idx form a WEB-DL or WEBRip
+// marker, including compact and split filename forms.
+func isWebSourceTokenAt(tokens []string, idx int) bool {
+	if idx < 0 || idx >= len(tokens) {
+		return false
+	}
+	switch tokens[idx] {
+	case "webdl", "webrip":
+		return true
+	case "web":
+		if idx+1 >= len(tokens) {
+			return false
+		}
+		return tokens[idx+1] == "dl" || tokens[idx+1] == "rip"
+	default:
+		return false
+	}
+}
+
+// matchTokenSpan reports whether a candidate filename token span exactly equals
+// an alias token span.
+func matchTokenSpan(got []string, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for idx := range want {
+		if got[idx] != want[idx] {
+			return false
+		}
+	}
+	return true
+}
+
+// serviceLongName returns the longest configured alias for a service token,
+// using lexical order to break equal-length ties deterministically.
 func serviceLongName(service string, services map[string]string) string {
 	longName := ""
 	for key, value := range services {

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -371,31 +371,52 @@ func TestResolveServiceIgnoresTitleServiceTokens(t *testing.T) {
 func TestResolveServiceUsesAliasAdjacentToWebSource(t *testing.T) {
 	t.Parallel()
 
-	service, longName, filename := resolveService(api.PreparedMetadata{
-		SourcePath: `/releases/Netflix.Documentary.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-GRP.mkv`,
-	})
-	if service != "AMZN" {
-		t.Fatalf("expected AMZN adjacent to WEB-DL, got %q", service)
+	tests := []struct {
+		name       string
+		sourcePath string
+	}{
+		{
+			name:       "web dl with separator",
+			sourcePath: `/releases/Netflix.Documentary.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-GRP.mkv`,
+		},
+		{
+			name:       "split web dl",
+			sourcePath: `/releases/Netflix.Documentary.2026.1080p.AMZN WEB DL DDP5.1 H.264-GRP.mkv`,
+		},
+		{
+			name:       "split web rip",
+			sourcePath: `/releases/Netflix.Documentary.2026.1080p.AMZN WEB RIP DDP5.1 H.264-GRP.mkv`,
+		},
+		{
+			name:       "compact webrip",
+			sourcePath: `/releases/Netflix.Documentary.2026.1080p.AMZN.WEBRip.DDP5.1.H.264-GRP.mkv`,
+		},
 	}
-	if longName != "Amazon Prime" {
-		t.Fatalf("expected Amazon Prime long name, got %q", longName)
-	}
-	if filename == "" {
-		t.Fatalf("expected filename to be preserved")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertResolvedService(t, tt.sourcePath, "AMZN", "Amazon Prime")
+		})
 	}
 }
 
 func TestResolveServicePrefersLongestAdjacentAlias(t *testing.T) {
 	t.Parallel()
 
+	assertResolvedService(t, `/releases/Example.Movie.2026.1080p.Apple.TV+.WEB-DL.DDP5.1.H.264-GRP.mkv`, "ATVP", "Apple TV+")
+}
+
+func assertResolvedService(t *testing.T, sourcePath, wantService, wantLongName string) {
+	t.Helper()
+
 	service, longName, filename := resolveService(api.PreparedMetadata{
-		SourcePath: `/releases/Example.Movie.2026.1080p.Apple.TV+.WEB-DL.DDP5.1.H.264-GRP.mkv`,
+		SourcePath: sourcePath,
 	})
-	if service != "ATVP" {
-		t.Fatalf("expected ATVP service, got %q", service)
+	if service != wantService {
+		t.Fatalf("expected %s service, got %q", wantService, service)
 	}
-	if longName != "Apple TV+" {
-		t.Fatalf("expected Apple TV+ long name, got %q", longName)
+	if longName != wantLongName {
+		t.Fatalf("expected %s long name, got %q", wantLongName, longName)
 	}
 	if filename == "" {
 		t.Fatalf("expected filename to be preserved")

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -351,6 +351,57 @@ func TestResolveServiceMGMPlus(t *testing.T) {
 	}
 }
 
+func TestResolveServiceIgnoresTitleServiceTokens(t *testing.T) {
+	t.Parallel()
+
+	service, longName, filename := resolveService(api.PreparedMetadata{
+		SourcePath: `/releases/Example.Show.S01E01.Netflix.and.Chill.1080p.WEB-DL.DDP5.1.H.264-GRP.mkv`,
+	})
+	if service != "" {
+		t.Fatalf("expected no service from episode title, got %q", service)
+	}
+	if longName != "" {
+		t.Fatalf("expected no long name from episode title, got %q", longName)
+	}
+	if filename == "" {
+		t.Fatalf("expected filename to be preserved")
+	}
+}
+
+func TestResolveServiceUsesAliasAdjacentToWebSource(t *testing.T) {
+	t.Parallel()
+
+	service, longName, filename := resolveService(api.PreparedMetadata{
+		SourcePath: `/releases/Netflix.Documentary.2026.1080p.AMZN.WEB-DL.DDP5.1.H.264-GRP.mkv`,
+	})
+	if service != "AMZN" {
+		t.Fatalf("expected AMZN adjacent to WEB-DL, got %q", service)
+	}
+	if longName != "Amazon Prime" {
+		t.Fatalf("expected Amazon Prime long name, got %q", longName)
+	}
+	if filename == "" {
+		t.Fatalf("expected filename to be preserved")
+	}
+}
+
+func TestResolveServicePrefersLongestAdjacentAlias(t *testing.T) {
+	t.Parallel()
+
+	service, longName, filename := resolveService(api.PreparedMetadata{
+		SourcePath: `/releases/Example.Movie.2026.1080p.Apple.TV+.WEB-DL.DDP5.1.H.264-GRP.mkv`,
+	})
+	if service != "ATVP" {
+		t.Fatalf("expected ATVP service, got %q", service)
+	}
+	if longName != "Apple TV+" {
+		t.Fatalf("expected Apple TV+ long name, got %q", longName)
+	}
+	if filename == "" {
+		t.Fatalf("expected filename to be preserved")
+	}
+}
+
 func TestResolveServiceValue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service detection when service metadata is missing by deriving it more reliably from the release name.
  * Enhanced recognition of WEB-DL/WEBRip variants and matching of service aliases positioned near those markers.
  * Improves accuracy by preferring the best (including longest) adjacent alias and reducing false matches from title text.

* **Tests**
  * Added unit tests covering ignoring title-only service-like tokens, matching aliases adjacent to WEB sources, and selecting the longest valid alias.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->