### PR TITLE
fix(docker): install fontconfig + dejavu font for screenshot overlays

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,10 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM alpine:3.23
 
-RUN apk add --no-cache ca-certificates ffmpeg mesa-vulkan-swrast vulkan-loader
+# fontconfig + a font are required by ffmpeg's drawtext filter (screenshot frame
+# overlays); without them capture fails with "Cannot find a valid font for the
+# family Sans". See issue #180.
+RUN apk add --no-cache ca-certificates ffmpeg fontconfig font-dejavu mesa-vulkan-swrast vulkan-loader
 
 # Run as a non-root user and give it a writable config dir. chown happens before
 # VOLUME so anonymous/named volumes inherit the ownership.


### PR DESCRIPTION
## Problem

When the **Frame Overlay** screenshot option is enabled, ffmpeg's `drawtext` filter renders the frame number/type labels using the fontconfig `Sans` family (`internal/services/screenshots/ffmpeg.go`). The Alpine base image shipped neither fontconfig nor any font, so capture failed at runtime:

```
Cannot find a valid font for the family Sans
```

Reported in #180.

## Fix

Add `fontconfig` and `font-dejavu` to the final image's `apk add` line.

## Verification

In `alpine:3.23` (the base image), after installing the packages:

```
$ fc-match Sans
DejaVuSans.ttf: "DejaVu Sans" "Book"
```

`Sans` now resolves to a concrete font, which is exactly what the default `drawtext` family needs.

Fixes #180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot overlay support by adding required font-related runtime components.
  * Text rendered in video/image overlays should now display correctly in environments using the lightweight runtime image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->