### PR TITLE
fix(btn): always override origin

### DIFF
--- a/cmd/upbrr/cli_options_test.go
+++ b/cmd/upbrr/cli_options_test.go
@@ -1069,6 +1069,54 @@ func TestPrintDryRunDetails(t *testing.T) {
 			name:  "empty details print nothing",
 			entry: api.TrackerDryRunEntry{},
 		},
+		{
+			name: "prints debug sections with redacted endpoint and payload",
+			entry: api.TrackerDryRunEntry{
+				DebugSections: []api.TrackerDryRunDebugSection{
+					{
+						Title:    "BTN autofill request",
+						Endpoint: "https://tracker.test/upload.php?passkey=secret-pass",
+						Payload: map[string]string{
+							"auto_season": "5",
+							"auto_series": "12345",
+							"scene_yesno": "No",
+							"type":        "Season",
+						},
+					},
+					{
+						Title:    "BTN final upload payload after autofill",
+						Endpoint: "https://tracker.test/upload.php?api_key=secret-key",
+						Files: []api.TrackerDryRunFile{
+							{Field: "file_input", Path: "C:\\Users\\Tester\\.upbrr\\tmp\\file.torrent", Present: true},
+						},
+						Payload: map[string]string{
+							"artist":       "Example Show",
+							"release_desc": "line 1\nline 2",
+							"type":         "Season",
+						},
+					},
+				},
+			},
+			contains: []string{
+				"Debug sections:",
+				"BTN autofill request:",
+				"Endpoint: https://tracker.test/upload.php?passkey=[REDACTED]",
+				"- auto_season: 5",
+				"- auto_series: 12345",
+				"BTN final upload payload after autofill:",
+				"Endpoint: https://tracker.test/upload.php?api_key=[REDACTED]",
+				"- file_input [present]: .upbrr/tmp/file.torrent",
+				"- artist: Example Show",
+				"- release_desc: [13 bytes, 2 lines omitted]",
+				"- type: Season",
+			},
+			notContains: []string{
+				"secret-pass",
+				"secret-key",
+				"C:\\Users\\Tester",
+				"line 1\nline 2",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -570,15 +570,33 @@ func cliTrackerAuthReady(status api.TrackerAuthStatus) bool {
 	}
 }
 
-// cliTrackerAuthStatusMessage selects and redacts the safest user-visible status
-// detail available for CLI prompts and errors.
+// cliTrackerAuthStatusMessage renders the tracker auth status display contract:
+// Message is the stable summary and LastError is redacted detail displayed when
+// distinct, matching GUI/web auth cards.
 func cliTrackerAuthStatusMessage(status api.TrackerAuthStatus) string {
-	for _, value := range []string{status.Message, status.LastError, status.State} {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return cliAuthLogField(trimmed)
-		}
+	message := cliTrackerAuthDisplayField(status.Message)
+	detail := cliTrackerAuthDisplayField(status.LastError)
+	if message != "" && detail != "" && !strings.EqualFold(message, detail) {
+		return message + ": " + detail
+	}
+	if message != "" {
+		return message
+	}
+	if detail != "" {
+		return detail
+	}
+	if state := cliTrackerAuthDisplayField(status.State); state != "" {
+		return state
 	}
 	return "auth not ready"
+}
+
+func cliTrackerAuthDisplayField(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	return redaction.RedactValue(trimmed, nil)
 }
 
 func matchedPreviewTrackers(preview api.MetadataPreview) []string {

--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -1474,29 +1474,67 @@ func printDryRunDetails(entry api.TrackerDryRunEntry) {
 // writeDryRunDetails writes redacted dry-run files, payload fields, and
 // description summaries to an arbitrary writer.
 func writeDryRunDetails(w io.Writer, entry api.TrackerDryRunEntry) {
-	if len(entry.Files) > 0 {
-		fmt.Fprintln(w, "Files:")
-		for _, file := range entry.Files {
-			status := "missing"
-			if file.Present {
-				status = "present"
-			}
-			fmt.Fprintf(w, "- %s [%s]: %s\n", file.Field, status, formatDryRunFilePath(file.Path))
+	if len(entry.DebugSections) > 0 {
+		writeDryRunDebugSections(w, entry.DebugSections)
+	} else {
+		if len(entry.Files) > 0 {
+			writeDryRunFiles(w, entry.Files)
 		}
-	}
-	if len(entry.Payload) > 0 {
-		fmt.Fprintln(w, "Payload:")
-		keys := make([]string, 0, len(entry.Payload))
-		for key := range entry.Payload {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-		for _, key := range keys {
-			fmt.Fprintf(w, "- %s: %s\n", key, formatDryRunPayloadValue(key, entry.Payload[key]))
+		if len(entry.Payload) > 0 {
+			writeDryRunPayload(w, entry.Payload)
 		}
 	}
 	if message := strings.TrimSpace(entry.Description); message != "" && !payloadIncludesDescription(entry.Payload) {
 		fmt.Fprintf(w, "Description: %s\n", summarizeDryRunBody(message))
+	}
+}
+
+// writeDryRunDebugSections renders staged tracker diagnostics instead of the
+// top-level dry-run payload so debug output can show intermediate request data
+// without duplicating the final payload.
+func writeDryRunDebugSections(w io.Writer, sections []api.TrackerDryRunDebugSection) {
+	if len(sections) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "Debug sections:")
+	for _, section := range sections {
+		title := strings.TrimSpace(section.Title)
+		if title == "" {
+			title = "debug section"
+		}
+		fmt.Fprintf(w, "%s:\n", title)
+		if endpoint := strings.TrimSpace(section.Endpoint); endpoint != "" {
+			fmt.Fprintf(w, "Endpoint: %s\n", formatDryRunPayloadValue("endpoint", endpoint))
+		}
+		if len(section.Files) > 0 {
+			writeDryRunFiles(w, section.Files)
+		}
+		if len(section.Payload) > 0 {
+			writeDryRunPayload(w, section.Payload)
+		}
+	}
+}
+
+func writeDryRunFiles(w io.Writer, files []api.TrackerDryRunFile) {
+	fmt.Fprintln(w, "Files:")
+	for _, file := range files {
+		status := "missing"
+		if file.Present {
+			status = "present"
+		}
+		fmt.Fprintf(w, "- %s [%s]: %s\n", file.Field, status, formatDryRunFilePath(file.Path))
+	}
+}
+
+func writeDryRunPayload(w io.Writer, payload map[string]string) {
+	fmt.Fprintln(w, "Payload:")
+	keys := make([]string, 0, len(payload))
+	for key := range payload {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		fmt.Fprintf(w, "- %s: %s\n", key, formatDryRunPayloadValue(key, payload[key]))
 	}
 }
 

--- a/cmd/upbrr/interactive_test.go
+++ b/cmd/upbrr/interactive_test.go
@@ -723,6 +723,27 @@ func TestCLITrackerAuthStatusMessageRedactsUserVisibleStatusText(t *testing.T) {
 	}
 }
 
+func TestCLITrackerAuthStatusMessageIncludesDistinctFailureDetail(t *testing.T) {
+	t.Parallel()
+
+	got := cliTrackerAuthStatusMessage(api.TrackerAuthStatus{
+		Message:   "stored session expired or invalid",
+		LastError: `remote validation failed: {"api_key":"secret-token"}`,
+	})
+	if !strings.Contains(got, "stored session expired or invalid") {
+		t.Fatal("status message omitted auth summary")
+	}
+	if !strings.Contains(got, "remote validation failed") {
+		t.Fatal("status message omitted auth failure detail")
+	}
+	if strings.Contains(got, "secret-token") {
+		t.Fatal("status message leaked secret")
+	}
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Fatal("status message omitted redaction marker")
+	}
+}
+
 func TestEnsureCLITrackerAuthBeforeDupeCheckPromptsForManual2FA(t *testing.T) {
 	t.Parallel()
 

--- a/gui/frontend/src/pages/settings/index.test.tsx
+++ b/gui/frontend/src/pages/settings/index.test.tsx
@@ -360,6 +360,61 @@ describe("SettingsPage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders tracker auth failure summary with distinct remote detail", async () => {
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: vi.fn().mockResolvedValue([trackerAuthCapability]),
+          GetTrackerAuthStatus: vi.fn().mockResolvedValue({
+            ...trackerAuthStatus("stored session expired or invalid"),
+            state: "login_required",
+            lastError: "remote auth test failed status=401",
+          }),
+        },
+      },
+    });
+
+    render(
+      <SettingsPage {...baseProps} settingsSection="tracker_auth" setSettingsSection={vi.fn()} />,
+    );
+
+    const title = await screen.findByText("MTV");
+    const card = title.closest(".tracker-auth-card");
+    expect(card).not.toBeNull();
+    expect(
+      within(card as HTMLElement).getByText("stored session expired or invalid"),
+    ).toBeInTheDocument();
+    expect(
+      within(card as HTMLElement).getByText("remote auth test failed status=401"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render duplicate tracker auth failure detail", async () => {
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          ListTrackerAuthCapabilities: vi.fn().mockResolvedValue([trackerAuthCapability]),
+          GetTrackerAuthStatus: vi.fn().mockResolvedValue({
+            ...trackerAuthStatus("stored session expired or invalid"),
+            state: "login_required",
+            lastError: "stored session expired or invalid",
+          }),
+        },
+      },
+    });
+
+    render(
+      <SettingsPage {...baseProps} settingsSection="tracker_auth" setSettingsSection={vi.fn()} />,
+    );
+
+    const title = await screen.findByText("MTV");
+    const card = title.closest(".tracker-auth-card");
+    expect(card).not.toBeNull();
+    expect(
+      within(card as HTMLElement).getAllByText("stored session expired or invalid"),
+    ).toHaveLength(1);
+  });
+
   it("renders fast tracker auth statuses before slow statuses resolve", async () => {
     let resolveSlow: (value: unknown) => void = () => undefined;
     const slowStatus = new Promise((resolve) => {

--- a/gui/frontend/src/pages/settings/index.tsx
+++ b/gui/frontend/src/pages/settings/index.tsx
@@ -71,6 +71,16 @@ const isManagedTrackerAuthCapability = (capability: TrackerAuthCapability) => {
   );
 };
 
+/** Returns tracker auth summary/detail text using the shared API display contract. */
+const trackerAuthStatusDisplay = (status?: TrackerAuthStatus) => {
+  const message = status?.message.trim() ?? "";
+  const lastError = status?.lastError.trim() ?? "";
+  return {
+    message,
+    lastError: lastError && lastError !== message ? lastError : "",
+  };
+};
+
 type ConfigOpStatus = {
   type: "success" | "error" | "warning";
   title: string;
@@ -480,6 +490,7 @@ export default function SettingsPage(props: Props) {
             const busy = trackerAuthActions[capability.trackerID] || "";
             const actionError = trackerAuthActionErrors[capability.trackerID] || "";
             const code = trackerAuthCodes[capability.trackerID] || "";
+            const statusDisplay = trackerAuthStatusDisplay(status);
             const canTestAuth = remoteAuthValidationTrackers.has(
               capability.trackerID.trim().toUpperCase(),
             );
@@ -532,11 +543,11 @@ export default function SettingsPage(props: Props) {
                     Storage: {status?.encryptedStorage ? "encrypted" : "unavailable"}
                   </p>
                 </div>
-                {status?.message ? (
-                  <p className="helper [overflow-wrap:anywhere]">{status.message}</p>
+                {statusDisplay.message ? (
+                  <p className="helper [overflow-wrap:anywhere]">{statusDisplay.message}</p>
                 ) : null}
-                {status?.lastError ? (
-                  <p className="error [overflow-wrap:anywhere]">{status.lastError}</p>
+                {statusDisplay.lastError ? (
+                  <p className="error [overflow-wrap:anywhere]">{statusDisplay.lastError}</p>
                 ) : null}
                 {actionError ? <p className="error">{actionError}</p> : null}
                 {(capability.notes ?? []).map((note) => (

--- a/gui/frontend/src/pages/tracker_upload/index.test.tsx
+++ b/gui/frontend/src/pages/tracker_upload/index.test.tsx
@@ -209,4 +209,99 @@ describe("TrackerUploadPage", () => {
     expect(onRunDryRun).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
   });
+
+  it("redacts debug dry-run endpoints, payloads, and local file paths", () => {
+    render(
+      <TrackerUploadPage
+        {...baseProps}
+        dryRunPreview={{
+          ...dryRunPreview,
+          Trackers: [
+            {
+              ...dryRunPreview.Trackers[0],
+              DebugSections: [
+                {
+                  Title: "Tracker request",
+                  Endpoint:
+                    "https://tracker.example/upload?api_key=debug-value&name=Example.Release.2026.1080p-GRP",
+                  Files: [
+                    {
+                      Field: "torrent",
+                      Path: "C:\\path\\to\\Example.Release.2026.1080p-GRP.torrent",
+                      Present: true,
+                    },
+                  ],
+                  Payload: {
+                    api_key: "debug-value",
+                    description: "line 1\nline 2",
+                    name: "Example.Release.2026.1080p-GRP",
+                  },
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "https://tracker.example/upload?api_key=[REDACTED]&name=Example.Release.2026.1080p-GRP",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("[local path]")).toBeTruthy();
+    expect(screen.getByText("[13 bytes, 2 lines omitted]")).toBeTruthy();
+    expect(screen.getAllByText("[REDACTED]").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders blocked debug dry-run top-level payload and files", () => {
+    render(
+      <TrackerUploadPage
+        {...baseProps}
+        dryRunPreview={{
+          ...dryRunPreview,
+          Trackers: [
+            {
+              ...dryRunPreview.Trackers[0],
+              Status: "blocked",
+              Message: "Manual confirmation required",
+              Payload: {
+                upload_name: "top-level-payload",
+              },
+              Files: [
+                {
+                  Field: "torrent",
+                  Path: ".upbrr/tmp/top-level.torrent",
+                  Present: true,
+                },
+              ],
+              DebugSections: [
+                {
+                  Title: "Debug payload",
+                  Endpoint: "",
+                  Files: [
+                    {
+                      Field: "torrent",
+                      Path: ".upbrr/tmp/debug.torrent",
+                      Present: true,
+                    },
+                  ],
+                  Payload: {
+                    upload_name: "debug-payload",
+                  },
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("blocked")).toBeTruthy();
+    expect(screen.getByText("Manual confirmation required")).toBeTruthy();
+    expect(screen.getByText("top-level-payload")).toBeTruthy();
+    expect(screen.getByText(".upbrr/tmp/top-level.torrent")).toBeTruthy();
+    expect(screen.getByText("debug-payload")).toBeTruthy();
+    expect(screen.getByText(".upbrr/tmp/debug.torrent")).toBeTruthy();
+  });
 });

--- a/gui/frontend/src/pages/tracker_upload/index.tsx
+++ b/gui/frontend/src/pages/tracker_upload/index.tsx
@@ -640,7 +640,45 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
                             <p className="value mono">{dryRun.Endpoint}</p>
                           </div>
                         ) : null}
-                        {dryRun.Files?.length ? (
+                        {dryRun.DebugSections?.length ? (
+                          <div className="grid gap-1.5">
+                            <p className="label">Debug sections</p>
+                            {dryRun.DebugSections.map((section, sectionIndex) => (
+                              <div
+                                className={subtleBox}
+                                key={`${section.Title || "debug"}-${sectionIndex}`}
+                              >
+                                <p className="label">{section.Title || "Debug section"}</p>
+                                {section.Endpoint ? (
+                                  <p className="value mono">{section.Endpoint}</p>
+                                ) : null}
+                                {section.Files?.length ? (
+                                  <div className="mt-1 grid gap-1">
+                                    {section.Files.map((file) => (
+                                      <div key={`${file.Field}-${file.Path}`}>
+                                        <p className="label">File · {file.Field}</p>
+                                        <p className="value mono">{file.Path || "(missing)"}</p>
+                                      </div>
+                                    ))}
+                                  </div>
+                                ) : null}
+                                {Object.keys(section.Payload || {}).length ? (
+                                  <div className="mt-1 grid gap-1">
+                                    {Object.entries(section.Payload)
+                                      .sort(([left], [right]) => left.localeCompare(right))
+                                      .map(([key, value]) => (
+                                        <div key={key}>
+                                          <p className="label">{key}</p>
+                                          <p className="value mono">{String(value)}</p>
+                                        </div>
+                                      ))}
+                                  </div>
+                                ) : null}
+                              </div>
+                            ))}
+                          </div>
+                        ) : null}
+                        {(dryRun.DebugSections?.length || 0) === 0 && dryRun.Files?.length ? (
                           <div className="grid gap-1.5">
                             {dryRun.Files.map((file) => (
                               <div className={subtleBox} key={`${file.Field}-${file.Path}`}>
@@ -650,7 +688,8 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
                             ))}
                           </div>
                         ) : null}
-                        {Object.keys(dryRun.Payload || {}).length ? (
+                        {(dryRun.DebugSections?.length || 0) === 0 &&
+                        Object.keys(dryRun.Payload || {}).length ? (
                           <div className="grid gap-1.5">
                             {Object.entries(dryRun.Payload)
                               .sort(([left], [right]) => left.localeCompare(right))

--- a/gui/frontend/src/pages/tracker_upload/index.tsx
+++ b/gui/frontend/src/pages/tracker_upload/index.tsx
@@ -11,6 +11,7 @@ import type { TrackerIconCache } from "../../hooks/useTrackerIcons";
 import { trackerIconFor } from "../../hooks/useTrackerIcons";
 import type {
   MetadataPreview,
+  TrackerDryRunFile,
   TrackerDryRunPreview,
   TrackerUploadItem,
   TrackerUploadSnapshot,
@@ -69,6 +70,116 @@ const blockReasonClass =
   "inline-flex h-5 items-center rounded border border-red-400/30 bg-red-500/10 px-1.5 text-[11px] font-semibold leading-none text-red-700 dark:text-red-100";
 const formatStatusText = (value: string) => value.replaceAll("_", " ");
 const trimName = (value: unknown) => String(value || "").trim();
+const dryRunPayloadPreviewLimit = 240;
+
+const sensitiveDryRunPayloadKeys = new Set([
+  "anticsrftoken",
+  "accesstoken",
+  "apikey",
+  "apitoken",
+  "auth",
+  "authorization",
+  "authkey",
+  "authtoken",
+  "cookie",
+  "csrf",
+  "email",
+  "infohash",
+  "key",
+  "passkey",
+  "password",
+  "passwordconfirm",
+  "passwordconfirmation",
+  "popcron",
+  "refreshtoken",
+  "rsskey",
+  "secret",
+  "secretkey",
+  "sessionkey",
+  "sessiontoken",
+  "token",
+  "torrentpass",
+  "torrentpasskey",
+  "uid",
+  "user",
+  "userid",
+  "username",
+]);
+
+const normalizedDryRunPayloadKey = (key: string) => key.trim().toLowerCase();
+
+const normalizedSensitiveDryRunPayloadKey = (key: string) =>
+  key
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+
+const isSensitiveDryRunPayloadField = (key: string) =>
+  sensitiveDryRunPayloadKeys.has(normalizedSensitiveDryRunPayloadKey(key));
+
+const isDryRunBodyPayloadField = (key: string) =>
+  new Set([
+    "description",
+    "desc",
+    "descr",
+    "release_desc",
+    "album_desc",
+    "mediainfo",
+    "mediainfo[]",
+    "media_info",
+    "bdinfo",
+    "bd_info",
+    "techinfo",
+    "technical_info",
+    "technicaldetails",
+  ]).has(normalizedDryRunPayloadKey(key));
+
+const redactDryRunSecretFragments = (value: string) =>
+  value
+    .replace(/([?&])([^=&#\s]+)=([^&#\s]*)/g, (match, separator, key) =>
+      isSensitiveDryRunPayloadField(String(key)) ? `${separator}${key}=[REDACTED]` : match,
+    )
+    .replace(
+      /(^|[\s,{])([A-Za-z][A-Za-z0-9_-]*(?:key|token|pass|password|cookie|auth|secret|csrf|uid|user))\s*[:=]\s*[^\s,;}]+/gi,
+      (_match, prefix, key) =>
+        isSensitiveDryRunPayloadField(String(key)) ? `${prefix}${key}=[REDACTED]` : _match,
+    );
+
+const summarizeDryRunBody = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  const lines = trimmed.split(/\r\n|\r|\n/).length;
+  return `[${trimmed.length} bytes, ${lines} lines omitted]`;
+};
+
+const formatDryRunPayloadValue = (key: string, value: unknown) => {
+  const trimmed = String(value ?? "").trim();
+  if (!trimmed) return "";
+  if (isSensitiveDryRunPayloadField(key)) return "[REDACTED]";
+
+  const redacted = redactDryRunSecretFragments(trimmed);
+  if (isDryRunBodyPayloadField(key)) return summarizeDryRunBody(redacted);
+
+  const compact = redacted.replace(/\s+/g, " ");
+  if (compact.length <= dryRunPayloadPreviewLimit) return compact;
+  return `${compact.slice(0, dryRunPayloadPreviewLimit)}... [${redacted.length} bytes total]`;
+};
+
+const formatDryRunFilePath = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed) return "(none)";
+
+  const normalized = trimmed.replaceAll("\\", "/").toLowerCase();
+  const original = trimmed.replaceAll("\\", "/");
+  for (const marker of [".upbrr/tmp/", ".upbrr/cache/", ".upbrr/logs/"]) {
+    if (normalized.startsWith(marker)) return original;
+    const index = normalized.indexOf(`/${marker}`);
+    if (index >= 0) return original.slice(index + 1);
+  }
+  return "[local path]";
+};
+
+const dryRunFileKey = (file: TrackerDryRunFile) => `${file.Field}-${file.Path}`;
 
 export default function TrackerUploadPage(props: Readonly<Props>) {
   const {
@@ -637,7 +748,9 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
                         {dryRun.Endpoint ? (
                           <div>
                             <p className="label">Endpoint</p>
-                            <p className="value mono">{dryRun.Endpoint}</p>
+                            <p className="value mono">
+                              {formatDryRunPayloadValue("endpoint", dryRun.Endpoint)}
+                            </p>
                           </div>
                         ) : null}
                         {dryRun.DebugSections?.length ? (
@@ -650,14 +763,18 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
                               >
                                 <p className="label">{section.Title || "Debug section"}</p>
                                 {section.Endpoint ? (
-                                  <p className="value mono">{section.Endpoint}</p>
+                                  <p className="value mono">
+                                    {formatDryRunPayloadValue("endpoint", section.Endpoint)}
+                                  </p>
                                 ) : null}
                                 {section.Files?.length ? (
                                   <div className="mt-1 grid gap-1">
                                     {section.Files.map((file) => (
-                                      <div key={`${file.Field}-${file.Path}`}>
+                                      <div key={dryRunFileKey(file)}>
                                         <p className="label">File · {file.Field}</p>
-                                        <p className="value mono">{file.Path || "(missing)"}</p>
+                                        <p className="value mono">
+                                          {formatDryRunFilePath(file.Path)}
+                                        </p>
                                       </div>
                                     ))}
                                   </div>
@@ -669,7 +786,9 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
                                       .map(([key, value]) => (
                                         <div key={key}>
                                           <p className="label">{key}</p>
-                                          <p className="value mono">{String(value)}</p>
+                                          <p className="value mono">
+                                            {formatDryRunPayloadValue(key, value)}
+                                          </p>
                                         </div>
                                       ))}
                                   </div>
@@ -678,25 +797,26 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
                             ))}
                           </div>
                         ) : null}
-                        {(dryRun.DebugSections?.length || 0) === 0 && dryRun.Files?.length ? (
+                        {dryRun.Files?.length ? (
                           <div className="grid gap-1.5">
                             {dryRun.Files.map((file) => (
-                              <div className={subtleBox} key={`${file.Field}-${file.Path}`}>
+                              <div className={subtleBox} key={dryRunFileKey(file)}>
                                 <p className="label">File · {file.Field}</p>
-                                <p className="value mono">{file.Path || "(missing)"}</p>
+                                <p className="value mono">{formatDryRunFilePath(file.Path)}</p>
                               </div>
                             ))}
                           </div>
                         ) : null}
-                        {(dryRun.DebugSections?.length || 0) === 0 &&
-                        Object.keys(dryRun.Payload || {}).length ? (
+                        {Object.keys(dryRun.Payload || {}).length ? (
                           <div className="grid gap-1.5">
                             {Object.entries(dryRun.Payload)
                               .sort(([left], [right]) => left.localeCompare(right))
                               .map(([key, value]) => (
                                 <div className={subtleBox} key={key}>
                                   <p className="label">{key}</p>
-                                  <p className="value mono">{String(value)}</p>
+                                  <p className="value mono">
+                                    {formatDryRunPayloadValue(key, value)}
+                                  </p>
                                 </div>
                               ))}
                           </div>

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -235,6 +235,25 @@ export type TVDBMetadata = {
   EpisodeOverview: string;
   EpisodeOverviewEnglish: string;
   EpisodeAired: string;
+  /** Selected episode image URL when TVDB returned one. */
+  EpisodeImage: string;
+  /** Fetched TVDB episode entries, usually for the selected season. */
+  Episodes: TVDBEpisodeMetadata[];
+};
+
+/** One TVDB episode entry used by tracker descriptions. */
+export type TVDBEpisodeMetadata = {
+  ID: number;
+  SeasonNumber: number;
+  EpisodeNumber: number;
+  EpisodeName: string;
+  EpisodeNameEnglish: string;
+  EpisodeOverview: string;
+  EpisodeOverviewEnglish: string;
+  /** TVDB air date string used in tracker descriptions. */
+  EpisodeAired: string;
+  /** Episode image URL when TVDB returned one. */
+  EpisodeImage: string;
 };
 
 export type TVmazeMetadata = {

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -886,8 +886,18 @@ export type TrackerDryRunEntry = {
   Endpoint: string;
   Payload: Record<string, string>;
   Files: TrackerDryRunFile[];
+  /** Optional staged diagnostics for trackers that expose intermediate dry-run payloads. */
+  DebugSections?: TrackerDryRunDebugSection[] | null;
   Questionnaire?: TrackerQuestionnaire | null;
   ImageHost: ImageHostFeedback;
+};
+
+/** One named diagnostic payload rendered inside a tracker dry-run preview. */
+export type TrackerDryRunDebugSection = {
+  Title: string;
+  Endpoint: string;
+  Payload: Record<string, string>;
+  Files: TrackerDryRunFile[];
 };
 
 export type TrackerDryRunPreview = {

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -336,12 +336,13 @@ export type TrackerAuthStatus = {
   cookieCount: number;
   /** RFC3339 UTC timestamp generated when the backend evaluated the status. */
   lastCheckedAt: string;
-  /** Redacted failure text from the most recent local or remote auth check. */
+  /** Redacted failure detail from the most recent local or remote auth check. */
   lastError: string;
   encryptedStorage: boolean;
   needs2FA: boolean;
   /** Opaque manual-2FA continuation token; empty unless needs2FA is true. */
   challengeID: string;
+  /** Stable user-facing status summary or next step. */
   message: string;
 };
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -3582,6 +3582,7 @@ func deepCopyTVDBMetadata(metadata *api.TVDBMetadata) *api.TVDBMetadata {
 	}
 	cloned := *metadata
 	cloned.Aliases = append([]string(nil), metadata.Aliases...)
+	cloned.Episodes = append([]api.TVDBEpisodeMetadata(nil), metadata.Episodes...)
 	return &cloned
 }
 

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -1591,6 +1591,46 @@ func mapTVDBMetadata(tvdbID int, fallbackName string, details tvdb.SeriesMetadat
 	}
 }
 
+// mapTVDBEpisodes copies TVDB client episode data into the persisted external
+// metadata shape used by tracker payload builders.
+func mapTVDBEpisodes(values []tvdb.Episode) []api.TVDBEpisodeMetadata {
+	if len(values) == 0 {
+		return nil
+	}
+	result := make([]api.TVDBEpisodeMetadata, 0, len(values))
+	for _, value := range values {
+		result = append(result, api.TVDBEpisodeMetadata{
+			ID:              value.ID,
+			SeasonNumber:    value.SeasonNumber,
+			EpisodeNumber:   value.Number,
+			EpisodeName:     strings.TrimSpace(value.Name),
+			EpisodeOverview: strings.TrimSpace(value.Overview),
+			EpisodeAired:    strings.TrimSpace(value.Aired),
+			EpisodeImage:    strings.TrimSpace(value.Image),
+		})
+	}
+	return result
+}
+
+// applySelectedTVDBEpisodeText mirrors translated selected-episode text back
+// into the matching stored episode entry.
+func applySelectedTVDBEpisodeText(metadata *api.TVDBMetadata, episodeID int) {
+	if metadata == nil || episodeID == 0 {
+		return
+	}
+	for idx := range metadata.Episodes {
+		if metadata.Episodes[idx].ID != episodeID {
+			continue
+		}
+		metadata.Episodes[idx].EpisodeNameEnglish = strings.TrimSpace(metadata.EpisodeNameEnglish)
+		metadata.Episodes[idx].EpisodeOverviewEnglish = strings.TrimSpace(metadata.EpisodeOverviewEnglish)
+		if strings.TrimSpace(metadata.Episodes[idx].EpisodeImage) == "" {
+			metadata.Episodes[idx].EpisodeImage = strings.TrimSpace(metadata.EpisodeImage)
+		}
+		return
+	}
+}
+
 // mergeTVDBMetadata fills missing stored TVDB fields from newer metadata and
 // refreshes alias-year provenance when TVDB title evidence changes.
 func mergeTVDBMetadata(target *api.TVDBMetadata, incoming *api.TVDBMetadata) {
@@ -1663,6 +1703,9 @@ func mergeTVDBMetadata(target *api.TVDBMetadata, incoming *api.TVDBMetadata) {
 	}
 	if len(target.Aliases) == 0 && len(incoming.Aliases) > 0 {
 		target.Aliases = append([]string{}, incoming.Aliases...)
+	}
+	if len(target.Episodes) == 0 && len(incoming.Episodes) > 0 {
+		target.Episodes = append([]api.TVDBEpisodeMetadata(nil), incoming.Episodes...)
 	}
 	target.HasEnglish = tvdbHasEnglishContent(target)
 }
@@ -1859,6 +1902,12 @@ func (s *Service) applyTVEpisodeMetadata(
 			meta.TVDBAirsTime = strings.TrimSpace(episodes.AirsTime)
 			meta.TVDBAirsTimezone = strings.TrimSpace(episodes.AirsTimezone)
 			meta.TVDBAirsTimezoneSource = strings.TrimSpace(episodes.AirsTimezoneSource)
+			if external != nil {
+				if external.TVDB == nil {
+					external.TVDB = &api.TVDBMetadata{TVDBID: ids.TVDBID}
+				}
+				external.TVDB.Episodes = mapTVDBEpisodes(episodes.Episodes)
+			}
 			if external != nil && shouldApplyTVDBSpecificAlias(specificAlias) {
 				if aliasName, aliasYear, ok := parseTVDBAliasNameYear(specificAlias); ok {
 					if external.TVDB == nil {
@@ -1900,6 +1949,7 @@ func (s *Service) applyTVEpisodeMetadata(
 						external.TVDB.EpisodeName = strings.TrimSpace(match.EpisodeName)
 						external.TVDB.EpisodeOverview = strings.TrimSpace(match.Overview)
 						external.TVDB.EpisodeAired = metautil.FirstNonEmptyTrimmed(match.Aired, query.AiredDate)
+						external.TVDB.EpisodeImage = strings.TrimSpace(match.Image)
 						if isEnglishLanguage(external.TVDB.OriginalLanguage) {
 							external.TVDB.EpisodeNameEnglish = strings.TrimSpace(match.EpisodeName)
 							external.TVDB.EpisodeOverviewEnglish = strings.TrimSpace(match.Overview)
@@ -1914,6 +1964,7 @@ func (s *Service) applyTVEpisodeMetadata(
 								external.TVDB.EpisodeOverviewEnglish = metautil.FirstNonEmptyTrimmed(translated.Overview, external.TVDB.EpisodeOverviewEnglish)
 							}
 						}
+						applySelectedTVDBEpisodeText(external.TVDB, match.EpisodeID)
 						external.TVDB.HasEnglish = tvdbHasEnglishContent(external.TVDB)
 						englishTVDBEpisodeTitle = strings.TrimSpace(external.TVDB.EpisodeNameEnglish)
 						englishTVDBEpisodeOverview = strings.TrimSpace(external.TVDB.EpisodeOverviewEnglish)

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -1888,6 +1888,8 @@ func TestApplyTVEpisodeMetadataTVDBEpisodeTranslationApplied(t *testing.T) {
 			Number:       2,
 			Name:         "第2話 / Episode 2",
 			Overview:     "日本語概要",
+			Aired:        "2026-01-02",
+			Image:        "https://img.example/tvdb-episode-2.jpg",
 		}}},
 		episodeTranslate: tvdb.EpisodeTranslation{
 			Name:     "Episode 2",
@@ -1919,6 +1921,16 @@ func TestApplyTVEpisodeMetadataTVDBEpisodeTranslationApplied(t *testing.T) {
 	if external.TVDB.EpisodeOverviewEnglish != "English episode overview" {
 		t.Fatalf("expected english episode overview from translation, got %q", external.TVDB.EpisodeOverviewEnglish)
 	}
+	if external.TVDB.EpisodeImage != "https://img.example/tvdb-episode-2.jpg" {
+		t.Fatalf("expected episode image from TVDB, got %q", external.TVDB.EpisodeImage)
+	}
+	if len(external.TVDB.Episodes) != 1 {
+		t.Fatalf("expected one stored TVDB episode, got %#v", external.TVDB.Episodes)
+	}
+	storedEpisode := external.TVDB.Episodes[0]
+	if storedEpisode.EpisodeNameEnglish != "Episode 2" || storedEpisode.EpisodeOverviewEnglish != "English episode overview" || storedEpisode.EpisodeImage != "https://img.example/tvdb-episode-2.jpg" {
+		t.Fatalf("expected stored TVDB episode to include translated text and image, got %#v", storedEpisode)
+	}
 	if !external.TVDB.HasEnglish {
 		t.Fatalf("expected HasEnglish true when english episode fields are populated")
 	}
@@ -1927,6 +1939,55 @@ func TestApplyTVEpisodeMetadataTVDBEpisodeTranslationApplied(t *testing.T) {
 	}
 	if updated.EpisodeOverview != "English episode overview" {
 		t.Fatalf("expected english episode overview, got %q", updated.EpisodeOverview)
+	}
+}
+
+func TestApplyTVEpisodeMetadataStoresTVDBSeasonEpisodesForPack(t *testing.T) {
+	svc := NewService(&fakeRepo{})
+	tmdbClient := &stubTMDB{}
+	tvdbClient := &stubTVDB{
+		episodes: tvdb.EpisodesData{Episodes: []tvdb.Episode{
+			{
+				ID:           201,
+				SeasonNumber: 2,
+				Number:       1,
+				Name:         "Example Episode One",
+				Overview:     "Example overview one.",
+				Aired:        "2026-04-23",
+				Image:        "https://img.example/tvdb-episode-1.jpg",
+			},
+			{
+				ID:           202,
+				SeasonNumber: 2,
+				Number:       2,
+				Name:         "Example Episode Two",
+				Overview:     "Example overview two.",
+				Aired:        "2026-04-30",
+				Image:        "https://img.example/tvdb-episode-2.jpg",
+			},
+		}},
+	}
+
+	meta := api.PreparedMetadata{
+		SourcePath: "/media/Example.Show.S02.mkv",
+		SeasonInt:  2,
+		TVPack:     true,
+	}
+	ids := &api.ExternalIDs{
+		TVDBID:   200,
+		Category: "TV",
+	}
+	external := &api.ExternalMetadata{
+		TVDB: &api.TVDBMetadata{TVDBID: 200, OriginalLanguage: "eng"},
+	}
+
+	_ = svc.applyTVEpisodeMetadata(context.Background(), meta, ids, external, tmdbClient, tvdbClient, &stubTVmaze{})
+
+	if len(external.TVDB.Episodes) != 2 {
+		t.Fatalf("expected stored TVDB season episodes, got %#v", external.TVDB.Episodes)
+	}
+	if external.TVDB.Episodes[0].EpisodeImage != "https://img.example/tvdb-episode-1.jpg" || external.TVDB.Episodes[1].EpisodeAired != "2026-04-30" {
+		t.Fatalf("unexpected stored TVDB season episodes: %#v", external.TVDB.Episodes)
 	}
 }
 

--- a/internal/metadata/tvdb/client.go
+++ b/internal/metadata/tvdb/client.go
@@ -1106,6 +1106,7 @@ func episodeFromResponse(item episodeResponse) Episode {
 		Overview:       item.Overview,
 		Year:           int(item.Year),
 		Aired:          item.Aired,
+		Image:          item.Image,
 	}
 }
 
@@ -1335,6 +1336,7 @@ func toMatch(ep Episode) EpisodeMatch {
 		Year:          ep.Year,
 		EpisodeID:     ep.ID,
 		Aired:         ep.Aired,
+		Image:         ep.Image,
 	}
 }
 
@@ -1673,6 +1675,7 @@ type episodeResponse struct {
 	Overview       string      `json:"overview"`
 	Year           intOrString `json:"year"`
 	Aired          string      `json:"aired"`
+	Image          string      `json:"image"`
 }
 
 type intOrString int

--- a/internal/metadata/tvdb/types.go
+++ b/internal/metadata/tvdb/types.go
@@ -65,6 +65,8 @@ type Episode struct {
 	Overview       string
 	Year           int
 	Aired          string
+	// Image is the episode image URL returned by TVDB.
+	Image string
 }
 
 type EpisodeQuery struct {
@@ -85,6 +87,8 @@ type EpisodeMatch struct {
 	Year          int
 	EpisodeID     int
 	Aired         string
+	// Image is the matched episode image URL returned by TVDB.
+	Image string
 }
 
 type EpisodeTranslation struct {

--- a/internal/trackers/impl/btn/definition.go
+++ b/internal/trackers/impl/btn/definition.go
@@ -67,3 +67,33 @@ func validateBTNRequest(req trackers.UploadRequest) error {
 	}
 	return nil
 }
+
+var btnInternalGroups = []string{
+	"BTW",
+	"ESPNtb",
+	"HiSD",
+	"HRiP",
+	"iPRiP",
+	"iT00NZ",
+	"JJ",
+	"LoTV",
+	"NTb",
+	"PreBS",
+	"RAWR",
+	"TTVa",
+	"TVSmash",
+}
+
+func isBTNInternalGroup(meta api.PreparedMetadata) bool {
+	if strings.TrimSpace(meta.Tag) == "" {
+		return false
+	}
+
+	group := strings.ToLower(strings.TrimPrefix(meta.Tag, "-"))
+	for _, value := range btnInternalGroups {
+		if strings.ToLower(value) == group {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/trackers/impl/btn/definition_test.go
+++ b/internal/trackers/impl/btn/definition_test.go
@@ -754,12 +754,12 @@ func TestBTNUploadPayloadUsesCanonicalSeasonEpisodeOnly(t *testing.T) {
 		t.Fatalf("expected upload type Season without canonical episode, got %q", got)
 	}
 	desc := buildAlbumDesc(meta, nil)
-	for _, value := range []string{"Season: 0", "Episode: 0"} {
+	for _, value := range []string{"[b]Season:[/b] 0", "[b]Episode:[/b] 0"} {
 		if !strings.Contains(desc, value) {
 			t.Fatalf("expected album description to contain %q, got %q", value, desc)
 		}
 	}
-	if strings.Contains(desc, "Season: 4") || strings.Contains(desc, "Episode: 9") {
+	if strings.Contains(desc, "[b]Season:[/b] 4") || strings.Contains(desc, "[b]Episode:[/b] 9") {
 		t.Fatalf("album description used parsed fallback values: %q", desc)
 	}
 	if got := btnTVPayloadMetadataMessage(meta); got != "canonical TV season/episode missing; BTN upload requires TVDB or metadata season/episode ints and ignores parsed season/episode fallback; refresh metadata or correct canonical season/episode before upload" {
@@ -861,9 +861,116 @@ func TestBuildAlbumDescFallsBackToIMDBEpisodeMetadata(t *testing.T) {
 	}
 
 	desc := buildAlbumDesc(meta, nil)
-	for _, value := range []string{"IMDb Episode", "Season: 2", "Episode: 7", "Aired: 2026-03-04", "IMDb overview"} {
+	for _, value := range []string{"[b]Episode Name:[/b] IMDb Episode", "[b]Season:[/b] 2", "[b]Episode:[/b] 7", "[b]Aired:[/b] 2026-03-04", "[b]Episode overview:[/b]\nIMDb overview"} {
 		if !strings.Contains(desc, value) {
 			t.Fatalf("expected album_desc to contain %q, got %q", value, desc)
+		}
+	}
+}
+
+func TestBuildAlbumDescUsesSingleTVDBEpisodeBlock(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		SeasonInt:   2,
+		EpisodeInt:  1,
+		ExternalMetadata: api.ExternalMetadata{
+			TVDB: &api.TVDBMetadata{
+				Episodes: []api.TVDBEpisodeMetadata{
+					{
+						SeasonNumber:    2,
+						EpisodeNumber:   1,
+						EpisodeName:     "Example Episode One",
+						EpisodeOverview: "Example overview one.",
+						EpisodeAired:    "2026-04-23",
+						EpisodeImage:    "https://img.example/tvdb-episode-1.jpg",
+					},
+					{
+						SeasonNumber:    2,
+						EpisodeNumber:   2,
+						EpisodeName:     "Example Episode Two",
+						EpisodeOverview: "Example overview two.",
+						EpisodeAired:    "2026-04-30",
+						EpisodeImage:    "https://img.example/tvdb-episode-2.jpg",
+					},
+				},
+			},
+		},
+	}
+
+	desc := buildAlbumDesc(meta, nil)
+	want := "[b]Episode Name:[/b] Example Episode One\n" +
+		"[b]Season:[/b] 2\n" +
+		"[b]Episode:[/b] 1\n" +
+		"[b]Aired:[/b] 2026-04-23\n\n" +
+		"[b]Episode overview:[/b]\n" +
+		"Example overview one.\n\n" +
+		"[b]Episode image:[/b]\n" +
+		"[img=https://img.example/tvdb-episode-1.jpg]"
+	if desc != want {
+		t.Fatalf("unexpected single episode album_desc:\n%s", desc)
+	}
+	if strings.Contains(desc, "Example Episode Two") {
+		t.Fatalf("single episode album_desc included another episode: %q", desc)
+	}
+}
+
+func TestBuildAlbumDescUsesTVDBSeasonEpisodeBlocks(t *testing.T) {
+	t.Parallel()
+
+	meta := api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		SeasonInt:   2,
+		TVPack:      true,
+		ExternalMetadata: api.ExternalMetadata{
+			TVDB: &api.TVDBMetadata{
+				Episodes: []api.TVDBEpisodeMetadata{
+					{
+						SeasonNumber:    2,
+						EpisodeNumber:   2,
+						EpisodeName:     "Example Episode Two",
+						EpisodeOverview: "Example overview two.",
+						EpisodeAired:    "2026-04-30",
+						EpisodeImage:    "https://img.example/tvdb-episode-2.jpg",
+					},
+					{
+						SeasonNumber:    1,
+						EpisodeNumber:   1,
+						EpisodeName:     "Wrong Season",
+						EpisodeOverview: "Wrong season overview.",
+						EpisodeAired:    "2025-04-23",
+					},
+					{
+						SeasonNumber:    2,
+						EpisodeNumber:   1,
+						EpisodeName:     "Example Episode One",
+						EpisodeOverview: "Example overview one.",
+						EpisodeAired:    "2026-04-23",
+						EpisodeImage:    "https://img.example/tvdb-episode-1.jpg",
+					},
+				},
+			},
+		},
+	}
+
+	desc := buildAlbumDesc(meta, nil)
+	if strings.Contains(desc, "Wrong Season") {
+		t.Fatalf("season pack album_desc included another season: %q", desc)
+	}
+	first := strings.Index(desc, "Example Episode One")
+	second := strings.Index(desc, "Example Episode Two")
+	if first < 0 || second < 0 || first > second {
+		t.Fatalf("season pack album_desc did not include sorted season episodes: %q", desc)
+	}
+	for _, value := range []string{
+		"[b]Episode Name:[/b] Example Episode One",
+		"[b]Episode image:[/b]\n[img=https://img.example/tvdb-episode-1.jpg]",
+		"[b]Episode Name:[/b] Example Episode Two",
+		"[b]Episode image:[/b]\n[img=https://img.example/tvdb-episode-2.jpg]",
+	} {
+		if !strings.Contains(desc, value) {
+			t.Fatalf("expected season pack album_desc to contain %q, got %q", value, desc)
 		}
 	}
 }

--- a/internal/trackers/impl/btn/definition_test.go
+++ b/internal/trackers/impl/btn/definition_test.go
@@ -222,21 +222,9 @@ func TestResolveOrigin(t *testing.T) {
 	tests := []struct {
 		name     string
 		meta     api.PreparedMetadata
-		fields   map[string]string
+		username string
 		expected string
 	}{
-		{
-			name:     "BTN autofill origin wins",
-			meta:     api.PreparedMetadata{Scene: true},
-			fields:   map[string]string{"origin": "P2P"},
-			expected: "P2P",
-		},
-		{
-			name:     "invalid BTN autofill origin ignored",
-			meta:     api.PreparedMetadata{Scene: true},
-			fields:   map[string]string{"origin": "Internal"},
-			expected: "Scene",
-		},
 		{
 			name:     "scene metadata",
 			meta:     api.PreparedMetadata{Scene: true},
@@ -284,11 +272,26 @@ func TestResolveOrigin(t *testing.T) {
 			},
 			expected: "P2P",
 		},
+		{
+			name: "none origin for no group tag",
+			meta: api.PreparedMetadata{
+				Release: api.ReleaseInfo{Group: "nogrp"},
+			},
+			expected: "None",
+		},
+		{
+			name: "user origin when username matches group",
+			meta: api.PreparedMetadata{
+				Release: api.ReleaseInfo{Group: "MyGroup"},
+			},
+			username: "mygroup",
+			expected: "User",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := resolveOrigin(tc.meta, tc.fields); got != tc.expected {
+			if got := resolveOrigin(tc.meta, tc.username); got != tc.expected {
 				t.Fatalf("expected origin %q, got %q", tc.expected, got)
 			}
 		})

--- a/internal/trackers/impl/btn/definition_test.go
+++ b/internal/trackers/impl/btn/definition_test.go
@@ -753,7 +753,7 @@ func TestBTNUploadPayloadUsesCanonicalSeasonEpisodeOnly(t *testing.T) {
 	if got := resolveUploadType(meta); got != "Season" {
 		t.Fatalf("expected upload type Season without canonical episode, got %q", got)
 	}
-	desc := buildAlbumDesc(meta, map[string]string{"album_desc": "fallback overview"})
+	desc := buildAlbumDesc(meta, nil)
 	for _, value := range []string{"Season: 0", "Episode: 0"} {
 		if !strings.Contains(desc, value) {
 			t.Fatalf("expected album description to contain %q, got %q", value, desc)
@@ -856,7 +856,11 @@ func TestBuildAlbumDescFallsBackToIMDBEpisodeMetadata(t *testing.T) {
 		},
 	}
 
-	desc := buildAlbumDesc(meta, map[string]string{"album_desc": "Autofill overview"})
+	if desc := buildAlbumDesc(meta, map[string]string{"album_desc": "Autofill overview"}); desc != "Autofill overview" {
+		t.Fatalf("expected BTN autofill album_desc to win, got %q", desc)
+	}
+
+	desc := buildAlbumDesc(meta, nil)
 	for _, value := range []string{"IMDb Episode", "Season: 2", "Episode: 7", "Aired: 2026-03-04", "IMDb overview"} {
 		if !strings.Contains(desc, value) {
 			t.Fatalf("expected album_desc to contain %q, got %q", value, desc)

--- a/internal/trackers/impl/btn/definition_test.go
+++ b/internal/trackers/impl/btn/definition_test.go
@@ -222,7 +222,6 @@ func TestResolveOrigin(t *testing.T) {
 	tests := []struct {
 		name     string
 		meta     api.PreparedMetadata
-		username string
 		expected string
 	}{
 		{
@@ -279,19 +278,11 @@ func TestResolveOrigin(t *testing.T) {
 			},
 			expected: "None",
 		},
-		{
-			name: "user origin when username matches group",
-			meta: api.PreparedMetadata{
-				Release: api.ReleaseInfo{Group: "MyGroup"},
-			},
-			username: "mygroup",
-			expected: "User",
-		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := resolveOrigin(tc.meta, tc.username); got != tc.expected {
+			if got := resolveOrigin(tc.meta); got != tc.expected {
 				t.Fatalf("expected origin %q, got %q", tc.expected, got)
 			}
 		})

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -1179,8 +1179,8 @@ func btnTVPayloadMetadataMessage(meta api.PreparedMetadata) string {
 	return message
 }
 
-// resolveOrigin preserves BTN autofill origin when available, then derives the
-// closest BTN origin from prepared scene and season-pack metadata.
+// resolveOrigin derives the origin from
+// prepared scene and season-pack metadata, group tag and username
 func resolveOrigin(meta api.PreparedMetadata, username string) string {
 	group := strings.TrimSpace(meta.Release.Group)
 	if metadata.DetectSeasonPackGroupTags(meta).Mixed {

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -390,7 +390,7 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 		"submit":       "true",
 		"type":         resolveUploadType(req.Meta),
 		"scenename":    resolveUploadName(req.Meta),
-		"origin":       resolveOrigin(req.Meta, nil),
+		"origin":       resolveOrigin(req.Meta, req.TrackerConfig.Username),
 		"release_desc": strings.TrimSpace(req.Meta.DescriptionOverride),
 		"tvdb":         "autofilled",
 	}
@@ -750,7 +750,7 @@ func prepareUploadData(ctx context.Context, req trackers.UploadRequest, uploadCt
 		"artist":       metautil.FirstNonEmptyTrimmed(fields["artist"]),
 		"title":        title,
 		"actors":       metautil.FirstNonEmptyTrimmed(fields["actors"]),
-		"origin":       resolveOrigin(req.Meta, fields),
+		"origin":       resolveOrigin(req.Meta, req.TrackerConfig.Username),
 		"year":         metautil.FirstNonEmptyTrimmed(fields["year"]),
 		"tags":         resolveBTNTags(req.Meta, fields),
 		"image":        resolveBTNImage(req.Meta, fields),
@@ -1181,28 +1181,21 @@ func btnTVPayloadMetadataMessage(meta api.PreparedMetadata) string {
 
 // resolveOrigin preserves BTN autofill origin when available, then derives the
 // closest BTN origin from prepared scene and season-pack metadata.
-func resolveOrigin(meta api.PreparedMetadata, fields map[string]string) string {
-	if origin := strings.TrimSpace(fields["origin"]); validBTNOrigin(origin) {
-		return origin
-	}
+func resolveOrigin(meta api.PreparedMetadata, username string) string {
+	group := strings.TrimSpace(meta.Release.Group)
 	if metadata.DetectSeasonPackGroupTags(meta).Mixed {
 		return "Mixed"
 	}
 	if isBTNSceneRelease(meta) {
 		return "Scene"
 	}
-	return "P2P"
-}
-
-// validBTNOrigin reports whether value is one of BTN's supported origin
-// dropdown values.
-func validBTNOrigin(value string) bool {
-	switch strings.TrimSpace(value) {
-	case "None", "Scene", "P2P", "User", "Mixed":
-		return true
-	default:
-		return false
+	if group != "" && isNoGroupTag(group) {
+		return "None"
 	}
+	if username != "" && group != "" && strings.EqualFold(group, strings.TrimSpace(username)) {
+		return "User"
+	}
+	return "P2P"
 }
 
 // stripEpisodeTitle removes generated episode-title text from BTN upload names

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -250,6 +250,10 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	}
 	uploadCtx.client = client
 
+	if err := checkBTNSeasonPackReservation(ctx, uploadCtx, req); err != nil {
+		return api.UploadSummary{}, err
+	}
+
 	data, err := prepareUploadData(ctx, req, uploadCtx)
 	if err != nil {
 		return api.UploadSummary{}, err
@@ -2550,4 +2554,119 @@ func (origin *btnAPIDownloadOrigin) sameOrigin(parsed *url.URL) bool {
 	return strings.EqualFold(origin.scheme, parsed.Scheme) &&
 		strings.EqualFold(origin.host, parsed.Host) &&
 		origin.host != ""
+}
+
+func checkBTNSeasonPackReservation(ctx context.Context, uploadCtx uploadContext, req trackers.UploadRequest) error {
+	if resolveUploadType(req.Meta) != "Season" {
+		return nil
+	}
+	// The 2-hour reservation ONLY applies to season packs made of internal releases.
+	if !isBTNInternalGroup(req.Meta) {
+		return nil
+	}
+
+	tvdbID := req.Meta.ExternalIDs.TVDBID
+	if tvdbID == 0 {
+		return nil
+	}
+
+	group := strings.TrimPrefix(req.Meta.Tag, "-")
+	if group == "" {
+		return nil
+	}
+
+	filter := map[string]any{
+		"tvdb":     strconv.Itoa(tvdbID),
+		"category": "Episode",
+		"group":    group,
+	}
+
+	// We only need the most recent episodes to check the 2-hour window
+	torrentsMap, err := btnAPISearchTorrents(ctx, uploadCtx.apiURL, uploadCtx.apiToken, filter, 50)
+	if err != nil {
+		return err
+	}
+
+	seasonPrefix := ""
+	if req.Meta.SeasonInt > 0 {
+		seasonPrefix = fmt.Sprintf("S%02dE", req.Meta.SeasonInt)
+	}
+
+	var newestInternal time.Time
+	for _, t := range torrentsMap {
+		name, _ := t["ReleaseName"].(string)
+		if seasonPrefix != "" && !strings.Contains(strings.ToUpper(name), seasonPrefix) {
+			continue
+		}
+
+		tTime := parseBTNTimestamp(t["Time"])
+		if tTime.After(newestInternal) {
+			newestInternal = tTime
+		}
+	}
+
+	if !newestInternal.IsZero() && time.Since(newestInternal) < 2*time.Hour {
+		return errors.New("trackers: BTN 2-hour reservation period for internal season packs has not expired")
+	}
+
+	return nil
+}
+
+func btnAPISearchTorrents(ctx context.Context, apiURL, apiToken string, filter map[string]any, limit int) (map[string]map[string]any, error) {
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "ua-btn-upload-check",
+		"method":  "getTorrentsSearch",
+		"params":  []any{apiToken, filter, limit},
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("trackers: BTN API check encode: %w", err)
+	}
+	apiReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(encoded))
+	if err != nil {
+		return nil, fmt.Errorf("trackers: BTN API check request build: %w", err)
+	}
+	apiReq.Header.Set("Content-Type", "application/json")
+	apiResp, err := (&http.Client{Timeout: 30 * time.Second}).Do(apiReq)
+	if err != nil {
+		return nil, fmt.Errorf("trackers: BTN API check request: %w", err)
+	}
+	defer apiResp.Body.Close()
+	if apiResp.StatusCode < 200 || apiResp.StatusCode >= 300 {
+		return nil, fmt.Errorf("trackers: BTN API check failed status=%d", apiResp.StatusCode)
+	}
+
+	var response struct {
+		Result struct {
+			Torrents json.RawMessage `json:"torrents"`
+		} `json:"result"`
+	}
+	if err := decodeBTNAPIJSON(apiResp.Body, &response); err != nil {
+		return nil, fmt.Errorf("trackers: BTN decode torrent check response: %w", err)
+	}
+
+	if len(response.Result.Torrents) == 0 || string(response.Result.Torrents) == "false" || string(response.Result.Torrents) == "[]" {
+		return nil, nil
+	}
+
+	var torrentsMap map[string]map[string]any
+	if err := json.Unmarshal(response.Result.Torrents, &torrentsMap); err != nil {
+		return nil, nil
+	}
+	return torrentsMap, nil
+}
+
+func parseBTNTimestamp(val any) time.Time {
+	var epoch int64
+	switch v := val.(type) {
+	case string:
+		epoch, _ = strconv.ParseInt(v, 10, 64)
+	case float64:
+		epoch = int64(v)
+	}
+	if epoch > 0 {
+		return time.Unix(epoch, 0)
+	}
+	return time.Time{}
 }

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -29,6 +29,7 @@ import (
 	"time"
 	"unicode"
 
+	xhtml "golang.org/x/net/html"
 	"golang.org/x/text/runes"
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
@@ -39,6 +40,7 @@ import (
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	"github.com/autobrr/upbrr/internal/paths"
 	"github.com/autobrr/upbrr/internal/pathutil"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
@@ -51,17 +53,16 @@ const (
 	btnLoginPath       = "/login.php"
 	btnAPIRPCURL       = "https://api.broadcasthe.net/"
 	btnAPIJSONMaxBytes = 1024 * 1024
+	btnTorrentMaxBytes = 8 * 1024 * 1024
 )
 
 var (
-	btnInputPattern        = regexp.MustCompile(`(?is)<input[^>]*name=["']([^"']+)["'][^>]*value=["']([^"']*)["'][^>]*>`)
-	btnTextAreaPattern     = regexp.MustCompile(`(?is)<textarea[^>]*name=["']album_desc["'][^>]*>(.*?)</textarea>`)
-	btnSelectPattern       = regexp.MustCompile(`(?is)<select[^>]*name=["']([^"']+)["'][^>]*>(.*?)</select>`)
-	btnSelectedOptionRegex = regexp.MustCompile(`(?is)<option[^>]*selected[^>]*value=["']([^"']+)["']`)
-	btnOptionValueRegex    = regexp.MustCompile(`(?is)<option[^>]*value=["']([^"']+)["']`)
-	btnSuccessURLPattern   = regexp.MustCompile(`torrents\.php\?id=(\d+)(?:&torrentid=(\d+))?`)
-	btnHTMLURLAttrPattern  = regexp.MustCompile(`(?is)\b(?:href|action)=["']([^"']+)["']`)
-	btnIMDBEpisodePattern  = regexp.MustCompile(`(?i)(?:^|\bE|episode\s*)(\d{1,4})(?:\b|$)`)
+	btnInputPattern       = regexp.MustCompile(`(?is)<input[^>]*name=["']([^"']+)["'][^>]*value=["']([^"']*)["'][^>]*>`)
+	btnTextAreaPattern    = regexp.MustCompile(`(?is)<textarea[^>]*name=["']album_desc["'][^>]*>(.*?)</textarea>`)
+	btnSelectPattern      = regexp.MustCompile(`(?is)<select[^>]*name=["']([^"']+)["'][^>]*>(.*?)</select>`)
+	btnSuccessURLPattern  = regexp.MustCompile(`torrents\.php\?id=(\d+)(?:&torrentid=(\d+))?`)
+	btnHTMLURLAttrPattern = regexp.MustCompile(`(?is)\b(?:href|action)=["']([^"']+)["']`)
+	btnIMDBEpisodePattern = regexp.MustCompile(`(?i)(?:^|\bE|episode\s*)(\d{1,4})(?:\b|$)`)
 	// btnCountryMap maps normalized BTN country option labels and exact
 	// metadata-source country codes to BTN's country select values.
 	btnCountryMap = map[string]string{
@@ -381,12 +382,12 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 	if err := validateBTNRequest(req); err != nil {
 		return api.TrackerDryRunEntry{}, err
 	}
-	if err := validateBTNDryRunUploadAuth(ctx, req); err != nil {
-		return api.TrackerDryRunEntry{}, err
-	}
 
 	uploadCtx, err := newUploadContext(ctx, req)
 	if err != nil {
+		return api.TrackerDryRunEntry{}, err
+	}
+	if err := validateBTNDryRunUploadAuth(ctx, req, uploadCtx); err != nil {
 		return api.TrackerDryRunEntry{}, err
 	}
 
@@ -460,14 +461,24 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 	}, nil
 }
 
-// validateBTNDryRunUploadAuth checks only local auth prerequisites needed before
-// an upload can authenticate. It does not perform remote login or persist cookies
-// during dry-run, and it preserves storage/decrypt failures instead of treating
-// them as missing cookies.
-func validateBTNDryRunUploadAuth(ctx context.Context, req trackers.UploadRequest) error {
+// validateBTNDryRunUploadAuth checks auth prerequisites needed before an upload
+// can authenticate. Stored cookies must pass the same upload-page session gate
+// as live upload; credential fallback remains local-only and does not log in or
+// persist cookies during dry-run.
+func validateBTNDryRunUploadAuth(ctx context.Context, req trackers.UploadRequest, uploadCtx uploadContext) error {
 	values, cookieErr := loadBTNCookies(ctx, req.AppConfig.MainSettings.DBPath)
 	if cookieErr == nil && len(values) > 0 {
-		return nil
+		client, err := newBTNClientWithCookies(uploadCtx.baseURL, values)
+		if err != nil {
+			return err
+		}
+		if err := validateBTNClientSession(ctx, client, uploadCtx.baseURL); err == nil {
+			return nil
+		} else if !errors.Is(err, errBTNSessionConfirmedInvalid) {
+			return err
+		} else if strings.TrimSpace(req.TrackerConfig.Username) == "" || strings.TrimSpace(req.TrackerConfig.Password) == "" {
+			return err
+		}
 	}
 	if cookieErr != nil && !errors.Is(cookieErr, errBTNCookiesMissing) {
 		return cookieErr
@@ -1023,15 +1034,51 @@ func extractAutofillFields(htmlRaw string) map[string]string {
 		}
 		name := strings.ToLower(strings.TrimSpace(selectMatch[1]))
 		body := selectMatch[2]
-		if selected := btnSelectedOptionRegex.FindStringSubmatch(body); len(selected) > 1 {
-			fields[name] = html.UnescapeString(strings.TrimSpace(selected[1]))
-			continue
-		}
-		if first := btnOptionValueRegex.FindStringSubmatch(body); len(first) > 1 {
-			fields[name] = html.UnescapeString(strings.TrimSpace(first[1]))
+		if value := selectedBTNAutofillOptionValue(body); value != "" {
+			fields[name] = value
 		}
 	}
 	return fields
+}
+
+// selectedBTNAutofillOptionValue returns the selected option value regardless
+// of attribute order, falling back to the first option value when no option is
+// marked selected.
+func selectedBTNAutofillOptionValue(body string) string {
+	tokenizer := xhtml.NewTokenizer(strings.NewReader(body))
+	firstValue := ""
+	for {
+		switch tokenizer.Next() {
+		case xhtml.ErrorToken:
+			return firstValue
+		case xhtml.StartTagToken, xhtml.SelfClosingTagToken:
+			token := tokenizer.Token()
+			if !strings.EqualFold(token.Data, "option") {
+				continue
+			}
+			value := ""
+			selected := false
+			for _, attr := range token.Attr {
+				switch {
+				case strings.EqualFold(attr.Key, "value"):
+					value = html.UnescapeString(strings.TrimSpace(attr.Val))
+				case strings.EqualFold(attr.Key, "selected"):
+					selected = true
+				}
+			}
+			if value == "" {
+				continue
+			}
+			if firstValue == "" {
+				firstValue = value
+			}
+			if selected {
+				return value
+			}
+		case xhtml.TextToken, xhtml.EndTagToken, xhtml.CommentToken, xhtml.DoctypeToken:
+			continue
+		}
+	}
 }
 
 // validateAutofill reports whether BTN returned the minimum autofill fields
@@ -1992,7 +2039,7 @@ func resolveAndDownloadViaAPI(ctx context.Context, apiURL string, apiToken strin
 	if dlResp.StatusCode < 200 || dlResp.StatusCode >= 300 {
 		return "", "", fmt.Errorf("trackers: BTN API download fetch failed status=%d", dlResp.StatusCode)
 	}
-	body, err := io.ReadAll(io.LimitReader(dlResp.Body, 8*1024*1024))
+	body, err := readBTNTorrentResponseBody(dlResp.Body)
 	if err != nil {
 		return "", "", fmt.Errorf("trackers: BTN API read torrent response: %w", err)
 	}
@@ -2006,6 +2053,19 @@ func resolveAndDownloadViaAPI(ctx context.Context, apiURL string, apiToken strin
 		return "", "", fmt.Errorf("trackers: BTN API write torrent output: %w", err)
 	}
 	return selection.ID, selection.GroupID, nil
+}
+
+// readBTNTorrentResponseBody rejects bodies beyond BTN's accepted torrent
+// response cap before callers validate or persist the payload.
+func readBTNTorrentResponseBody(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, btnTorrentMaxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read torrent response: %w", err)
+	}
+	if len(body) > btnTorrentMaxBytes {
+		return nil, fmt.Errorf("torrent response exceeds %d bytes", btnTorrentMaxBytes)
+	}
+	return body, nil
 }
 
 // loadBTNCookiesIntoJar best-effort seeds an upload client with persisted BTN
@@ -2700,6 +2760,9 @@ func (origin *btnAPIDownloadOrigin) sameOrigin(parsed *url.URL) bool {
 		origin.host != ""
 }
 
+// checkBTNSeasonPackReservation enforces BTN's 2-hour internal season-pack
+// reservation using the same canonical season source as the final upload
+// payload, including TVDB/IMDb translated episode metadata.
 func checkBTNSeasonPackReservation(ctx context.Context, uploadCtx uploadContext, req trackers.UploadRequest) error {
 	if resolveUploadType(req.Meta) != "Season" {
 		return nil
@@ -2732,8 +2795,9 @@ func checkBTNSeasonPackReservation(ctx context.Context, uploadCtx uploadContext,
 	}
 
 	seasonPrefix := ""
-	if req.Meta.SeasonInt > 0 {
-		seasonPrefix = fmt.Sprintf("S%02dE", req.Meta.SeasonInt)
+	season, _ := resolveBTNTVSeasonEpisode(req.Meta)
+	if season > 0 {
+		seasonPrefix = fmt.Sprintf("S%02dE", season)
 	}
 
 	var newestInternal time.Time
@@ -2772,7 +2836,7 @@ func btnAPISearchTorrents(ctx context.Context, apiURL, apiToken string, filter m
 
 	var torrentsMap map[string]map[string]any
 	if err := json.Unmarshal(response.Result.Torrents, &torrentsMap); err != nil {
-		return nil, nil
+		return nil, fmt.Errorf("trackers: BTN API parse torrents search response: %s", redaction.RedactValue(err.Error(), nil))
 	}
 	return torrentsMap, nil
 }

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -405,7 +405,7 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 		"type":         uploadType,
 		"scenename":    resolveUploadName(req.Meta),
 		"origin":       resolveOrigin(req.Meta),
-		"release_desc": strings.TrimSpace(req.Meta.DescriptionOverride),
+		"release_desc": resolveBTNReleaseDesc(req.Meta),
 		"tvdb":         "autofilled",
 	}
 	if resolveFastTorrent(req.TrackerConfig) {
@@ -767,18 +767,10 @@ func requestBTNAutofillFields(ctx context.Context, uploadCtx uploadContext, auto
 }
 
 // buildBTNUploadPayload merges BTN autofill fields with local metadata for the
-// final upload form. BTN text fields such as album_desc are retained, while
-// local MediaInfo-derived dropdown mappings win when both sources provide a
-// BTN-supported value.
+// final upload form. BTN text fields such as album_desc are retained, release_desc
+// is populated only from MediaInfo text, and local MediaInfo-derived dropdown
+// mappings win when both sources provide a BTN-supported value.
 func buildBTNUploadPayload(req trackers.UploadRequest, fields map[string]string) (map[string]string, error) {
-	description := strings.TrimSpace(req.Meta.DescriptionOverride)
-	if description == "" {
-		description = commonhttp.ReadOptionalFile(req.Meta.MediaInfoTextPath)
-	}
-	if description == "" {
-		description = "No description provided."
-	}
-
 	format := mapContainer(req.Meta, fields)
 	bitrate := mapCodec(req.Meta, fields)
 	media := mapSource(req.Meta, fields)
@@ -822,7 +814,7 @@ func buildBTNUploadPayload(req trackers.UploadRequest, fields map[string]string)
 		"bitrate":      bitrate,
 		"media":        media,
 		"resolution":   resolution,
-		"release_desc": description,
+		"release_desc": resolveBTNReleaseDesc(req.Meta),
 		"tvdb":         "autofilled",
 	}
 	if resolveFastTorrent(req.TrackerConfig) {
@@ -836,12 +828,18 @@ func buildBTNUploadPayload(req trackers.UploadRequest, fields map[string]string)
 	}
 	clean := make(map[string]string, len(payload))
 	for key, value := range payload {
-		if strings.TrimSpace(value) == "" {
+		if key != "release_desc" && strings.TrimSpace(value) == "" {
 			continue
 		}
 		clean[key] = value
 	}
 	return clean, nil
+}
+
+// resolveBTNReleaseDesc returns the MediaInfo text BTN expects in release_desc.
+// Description overrides are intentionally ignored for this field.
+func resolveBTNReleaseDesc(meta api.PreparedMetadata) string {
+	return strings.TrimSpace(commonhttp.ReadOptionalFile(meta.MediaInfoTextPath))
 }
 
 // urlValuesToPayloadMap flattens form values for debug display; BTN autofill

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -737,7 +737,7 @@ func buildBTNAutofillPayload(meta api.PreparedMetadata) (url.Values, string) {
 		if uploadType == "Episode" {
 			autofillPayload.Set("auto_title", fmt.Sprintf("S%02dE%02d", season, episode))
 		} else {
-			autofillPayload.Set("auto_season", strconv.Itoa(season))
+			autofillPayload.Set("auto_season", fmt.Sprintf("S%02d", season))
 		}
 	} else {
 		autofillPayload.Set("scene_yesno", "Yes")

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -390,9 +390,19 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 		return api.TrackerDryRunEntry{}, err
 	}
 
+	autofillPayload, uploadType := buildBTNAutofillPayload(req.Meta)
+	debugSections := make([]api.TrackerDryRunDebugSection, 0, 2)
+	if req.Meta.Options.Debug {
+		debugSections = append(debugSections, api.TrackerDryRunDebugSection{
+			Title:    "BTN autofill request",
+			Endpoint: uploadCtx.uploadURL,
+			Payload:  urlValuesToPayloadMap(autofillPayload),
+		})
+	}
+
 	payload := map[string]string{
 		"submit":       "true",
-		"type":         resolveUploadType(req.Meta),
+		"type":         uploadType,
 		"scenename":    resolveUploadName(req.Meta),
 		"origin":       resolveOrigin(req.Meta),
 		"release_desc": strings.TrimSpace(req.Meta.DescriptionOverride),
@@ -413,6 +423,28 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 		message += "; " + metadataMessage
 		status = "blocked"
 	}
+	if req.Meta.Options.Debug && status == "ready" {
+		client, err := ensureBTNUploadSession(ctx, req.TrackerConfig, req.AppConfig.MainSettings.DBPath, uploadCtx)
+		if err != nil {
+			return api.TrackerDryRunEntry{}, err
+		}
+		uploadCtx.client = client
+		fields, err := requestBTNAutofillFields(ctx, uploadCtx, autofillPayload, uploadType)
+		if err != nil {
+			return api.TrackerDryRunEntry{}, err
+		}
+		payload, err = buildBTNUploadPayload(req, fields)
+		if err != nil {
+			return api.TrackerDryRunEntry{}, err
+		}
+		message += "; BTN autofill debug completed"
+		debugSections = append(debugSections, api.TrackerDryRunDebugSection{
+			Title:    "BTN final upload payload after autofill",
+			Endpoint: uploadCtx.uploadURL,
+			Payload:  payload,
+			Files:    resolveBTNDryRunFiles(req.Meta, torrentPath),
+		})
+	}
 
 	return api.TrackerDryRunEntry{
 		Tracker:          "BTN",
@@ -424,6 +456,7 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 		Endpoint:         uploadCtx.uploadURL,
 		Payload:          payload,
 		Files:            resolveBTNDryRunFiles(req.Meta, torrentPath),
+		DebugSections:    debugSections,
 	}, nil
 }
 
@@ -668,15 +701,27 @@ func prepareUploadData(ctx context.Context, req trackers.UploadRequest, uploadCt
 		return nil, err
 	}
 
+	autofillPayload, uploadType := buildBTNAutofillPayload(req.Meta)
+	fields, err := requestBTNAutofillFields(ctx, uploadCtx, autofillPayload, uploadType)
+	if err != nil {
+		return nil, err
+	}
+	return buildBTNUploadPayload(req, fields)
+}
+
+// buildBTNAutofillPayload returns the form fields for BTN's first upload.php
+// POST. TVDB-backed uploads submit the series id plus season or episode token;
+// scene-name autofill is used only when no TVDB series id is available.
+func buildBTNAutofillPayload(meta api.PreparedMetadata) (url.Values, string) {
 	autofillPayload := url.Values{}
-	uploadType := resolveUploadType(req.Meta)
-	season, episode := resolveBTNTVSeasonEpisode(req.Meta)
+	uploadType := resolveUploadType(meta)
+	season, episode := resolveBTNTVSeasonEpisode(meta)
 	autofillPayload.Set("type", uploadType)
 	autofillPayload.Set("tvdb", "Get Info")
 
-	if req.Meta.ExternalMetadata.TVDB != nil && req.Meta.ExternalMetadata.TVDB.TVDBID > 0 {
+	if meta.ExternalMetadata.TVDB != nil && meta.ExternalMetadata.TVDB.TVDBID > 0 {
 		autofillPayload.Set("scene_yesno", "No")
-		autofillPayload.Set("auto_series", strconv.Itoa(req.Meta.ExternalMetadata.TVDB.TVDBID))
+		autofillPayload.Set("auto_series", strconv.Itoa(meta.ExternalMetadata.TVDB.TVDBID))
 
 		if uploadType == "Episode" {
 			autofillPayload.Set("auto_title", fmt.Sprintf("S%02dE%02d", season, episode))
@@ -685,9 +730,16 @@ func prepareUploadData(ctx context.Context, req trackers.UploadRequest, uploadCt
 		}
 	} else {
 		autofillPayload.Set("scene_yesno", "Yes")
-		autofillPayload.Set("autofill", resolveUploadName(req.Meta))
+		autofillPayload.Set("autofill", resolveUploadName(meta))
 	}
 
+	return autofillPayload, uploadType
+}
+
+// requestBTNAutofillFields performs BTN's autofill POST and extracts the form
+// values returned for the final upload payload. A validation failure means BTN
+// did not return enough series/title data for the requested upload type.
+func requestBTNAutofillFields(ctx context.Context, uploadCtx uploadContext, autofillPayload url.Values, uploadType string) (map[string]string, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadCtx.uploadURL, strings.NewReader(autofillPayload.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("trackers: BTN autofill request build: %w", err)
@@ -711,7 +763,13 @@ func prepareUploadData(ctx context.Context, req trackers.UploadRequest, uploadCt
 	if !validateAutofill(fields, uploadType) {
 		return nil, errors.New("trackers: BTN autofill validation failed")
 	}
+	return fields, nil
+}
 
+// buildBTNUploadPayload merges BTN autofill fields with local metadata for the
+// final upload form. Local MediaInfo-derived dropdown mappings win over BTN
+// autofill values when both are available.
+func buildBTNUploadPayload(req trackers.UploadRequest, fields map[string]string) (map[string]string, error) {
 	description := strings.TrimSpace(req.Meta.DescriptionOverride)
 	if description == "" {
 		description = commonhttp.ReadOptionalFile(req.Meta.MediaInfoTextPath)
@@ -783,6 +841,19 @@ func prepareUploadData(ctx context.Context, req trackers.UploadRequest, uploadCt
 		clean[key] = value
 	}
 	return clean, nil
+}
+
+// urlValuesToPayloadMap flattens form values for debug display; BTN autofill
+// fields are single-valued, so later values are intentionally ignored.
+func urlValuesToPayloadMap(values url.Values) map[string]string {
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		if len(value) == 0 {
+			continue
+		}
+		out[key] = value[0]
+	}
+	return out
 }
 
 // logBTNAutofillMismatch records when BTN autofill selected a different

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -1645,6 +1645,36 @@ func decodeBTNAPIJSON(r io.Reader, dest any) error {
 	return nil
 }
 
+func callBTNAPI(ctx context.Context, apiURL, id, method string, params []any, dest any) error {
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  params,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("trackers: BTN API %s encode: %w", method, err)
+	}
+	apiReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(encoded))
+	if err != nil {
+		return fmt.Errorf("trackers: BTN API %s request build: %w", method, err)
+	}
+	apiReq.Header.Set("Content-Type", "application/json")
+	apiResp, err := (&http.Client{Timeout: 30 * time.Second}).Do(apiReq)
+	if err != nil {
+		return fmt.Errorf("trackers: BTN API %s request: %w", method, err)
+	}
+	defer apiResp.Body.Close()
+	if apiResp.StatusCode < 200 || apiResp.StatusCode >= 300 {
+		return fmt.Errorf("trackers: BTN API %s failed status=%d", method, apiResp.StatusCode)
+	}
+	if err := decodeBTNAPIJSON(apiResp.Body, dest); err != nil {
+		return fmt.Errorf("trackers: BTN API decode %s response: %w", method, err)
+	}
+	return nil
+}
+
 // validateBTNJSONNoDuplicateObjectNames scans one JSON value before unmarshal
 // so duplicate object names cannot collapse into the last decoded value.
 func validateBTNJSONNoDuplicateObjectNames(payload []byte) error {
@@ -1749,73 +1779,30 @@ func resolveAndDownloadViaAPI(ctx context.Context, apiURL string, apiToken strin
 	if strings.TrimSpace(groupID) != "" {
 		filter["group"] = groupID
 	}
-	payload := map[string]any{
-		"jsonrpc": "2.0",
-		"id":      "ua-btn-upload",
-		"method":  "getTorrentsSearch",
-		"params":  []any{apiToken, filter, 50},
-	}
-	encoded, err := json.Marshal(payload)
-	if err != nil {
-		return "", "", fmt.Errorf("trackers: BTN API search encode: %w", err)
-	}
-	apiReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(encoded))
-	if err != nil {
-		return "", "", fmt.Errorf("trackers: BTN API search request build: %w", err)
-	}
-	apiReq.Header.Set("Content-Type", "application/json")
-	apiResp, err := (&http.Client{Timeout: 30 * time.Second}).Do(apiReq)
-	if err != nil {
-		return "", "", fmt.Errorf("trackers: BTN API search request: %w", err)
-	}
-	defer apiResp.Body.Close()
-	if apiResp.StatusCode < 200 || apiResp.StatusCode >= 300 {
-		return "", "", fmt.Errorf("trackers: BTN API search failed status=%d", apiResp.StatusCode)
-	}
+
 	var response struct {
 		Result struct {
 			Torrents map[string]map[string]any `json:"torrents"`
 		} `json:"result"`
 	}
-	if err := decodeBTNAPIJSON(apiResp.Body, &response); err != nil {
-		return "", "", fmt.Errorf("trackers: BTN decode torrent search response: %w", err)
+	if err := callBTNAPI(ctx, apiURL, "ua-btn-upload", "getTorrentsSearch", []any{apiToken, filter, 50}, &response); err != nil {
+		return "", "", err
 	}
+
 	selection := selectBTNAPITorrent(response.Result.Torrents, releaseName, groupID)
 	if selection.ID == "" {
 		return "", "", errors.New("trackers: BTN API did not return a matching torrent id")
 	}
 
-	downloadPayload := map[string]any{
-		"jsonrpc": "2.0",
-		"id":      "ua-btn-download",
-		"method":  "getTorrentById",
-		"params":  []any{apiToken, selection.ID},
-	}
-	downloadEncoded, err := json.Marshal(downloadPayload)
-	if err != nil {
-		return "", "", fmt.Errorf("trackers: BTN API download encode: %w", err)
-	}
-	downloadReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(downloadEncoded))
-	if err != nil {
-		return "", "", fmt.Errorf("trackers: BTN API download request build: %w", err)
-	}
-	downloadReq.Header.Set("Content-Type", "application/json")
-	downloadResp, err := (&http.Client{Timeout: 30 * time.Second}).Do(downloadReq)
-	if err != nil {
-		return "", "", fmt.Errorf("trackers: BTN API download request: %w", err)
-	}
-	defer downloadResp.Body.Close()
-	if downloadResp.StatusCode < 200 || downloadResp.StatusCode >= 300 {
-		return "", "", fmt.Errorf("trackers: BTN API download failed status=%d", downloadResp.StatusCode)
-	}
 	var downloadResult struct {
 		Result struct {
 			DownloadURL string `json:"DownloadURL"`
 		} `json:"result"`
 	}
-	if err := decodeBTNAPIJSON(downloadResp.Body, &downloadResult); err != nil {
-		return "", "", fmt.Errorf("trackers: BTN API decode download response: %w", err)
+	if err := callBTNAPI(ctx, apiURL, "ua-btn-download", "getTorrentById", []any{apiToken, selection.ID}, &downloadResult); err != nil {
+		return "", "", err
 	}
+
 	if downloadResult.Result.DownloadURL == "" {
 		return "", "", errors.New("trackers: BTN API did not return DownloadURL")
 	}
@@ -2613,37 +2600,13 @@ func checkBTNSeasonPackReservation(ctx context.Context, uploadCtx uploadContext,
 }
 
 func btnAPISearchTorrents(ctx context.Context, apiURL, apiToken string, filter map[string]any, limit int) (map[string]map[string]any, error) {
-	payload := map[string]any{
-		"jsonrpc": "2.0",
-		"id":      "ua-btn-upload-check",
-		"method":  "getTorrentsSearch",
-		"params":  []any{apiToken, filter, limit},
-	}
-	encoded, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("trackers: BTN API check encode: %w", err)
-	}
-	apiReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(encoded))
-	if err != nil {
-		return nil, fmt.Errorf("trackers: BTN API check request build: %w", err)
-	}
-	apiReq.Header.Set("Content-Type", "application/json")
-	apiResp, err := (&http.Client{Timeout: 30 * time.Second}).Do(apiReq)
-	if err != nil {
-		return nil, fmt.Errorf("trackers: BTN API check request: %w", err)
-	}
-	defer apiResp.Body.Close()
-	if apiResp.StatusCode < 200 || apiResp.StatusCode >= 300 {
-		return nil, fmt.Errorf("trackers: BTN API check failed status=%d", apiResp.StatusCode)
-	}
-
 	var response struct {
 		Result struct {
 			Torrents json.RawMessage `json:"torrents"`
 		} `json:"result"`
 	}
-	if err := decodeBTNAPIJSON(apiResp.Body, &response); err != nil {
-		return nil, fmt.Errorf("trackers: BTN decode torrent check response: %w", err)
+	if err := callBTNAPI(ctx, apiURL, "ua-btn-upload-check", "getTorrentsSearch", []any{apiToken, filter, limit}, &response); err != nil {
+		return nil, err
 	}
 
 	if len(response.Result.Torrents) == 0 || string(response.Result.Torrents) == "false" || string(response.Result.Torrents) == "[]" {

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -767,8 +767,9 @@ func requestBTNAutofillFields(ctx context.Context, uploadCtx uploadContext, auto
 }
 
 // buildBTNUploadPayload merges BTN autofill fields with local metadata for the
-// final upload form. Local MediaInfo-derived dropdown mappings win over BTN
-// autofill values when both are available.
+// final upload form. BTN text fields such as album_desc are retained, while
+// local MediaInfo-derived dropdown mappings win when both sources provide a
+// BTN-supported value.
 func buildBTNUploadPayload(req trackers.UploadRequest, fields map[string]string) (map[string]string, error) {
 	description := strings.TrimSpace(req.Meta.DescriptionOverride)
 	if description == "" {
@@ -1004,6 +1005,9 @@ func normalizedBTNGenreContains(normalized string, alias string) bool {
 	return strings.Contains(" "+normalized+" ", " "+alias+" ")
 }
 
+// extractAutofillFields reads BTN's autofilled upload form into the field map
+// consumed by final payload construction. Input values, selected dropdown
+// values, and the album_desc textarea are normalized to lower-case field names.
 func extractAutofillFields(htmlRaw string) map[string]string {
 	fields := map[string]string{}
 	for _, match := range btnInputPattern.FindAllStringSubmatch(htmlRaw, -1) {
@@ -1032,6 +1036,9 @@ func extractAutofillFields(htmlRaw string) map[string]string {
 	return fields
 }
 
+// validateAutofill reports whether BTN returned the minimum autofill fields
+// needed for the requested upload type. Episodes require a title; season packs
+// only require a series artist.
 func validateAutofill(fields map[string]string, uploadType string) bool {
 	artist := strings.TrimSpace(fields["artist"])
 	title := strings.TrimSpace(fields["title"])
@@ -1088,16 +1095,17 @@ func preferredBTNIMDBOverview(imdb *api.IMDBMetadata) string {
 	return strings.TrimSpace(imdb.Plot)
 }
 
-// buildAlbumDesc builds the BTN description block for TV uploads from metadata
-// that BTN does not provide through autofill. TVDB episode metadata wins for
-// title, overview, aired date, season, and episode when present; missing TVDB
-// values fall back through IMDb before local metadata and BTN autofill fields.
+// buildAlbumDesc keeps BTN's autofilled album_desc when available. If BTN did
+// not return one, TV uploads fall back to provider/local episode metadata.
 func buildAlbumDesc(meta api.PreparedMetadata, fields map[string]string) string {
+	if desc := metautil.FirstNonEmptyTrimmed(fields["album_desc"]); desc != "" {
+		return desc
+	}
 	if !strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "TV") {
-		return metautil.FirstNonEmptyTrimmed(fields["album_desc"])
+		return ""
 	}
 	tvdb := meta.ExternalMetadata.TVDB
-	overview := metautil.FirstNonEmptyTrimmed(preferredBTNTVDBOverview(tvdb), preferredBTNIMDBOverview(meta.ExternalMetadata.IMDB), strings.TrimSpace(meta.EpisodeOverview), strings.TrimSpace(fields["album_desc"]))
+	overview := metautil.FirstNonEmptyTrimmed(preferredBTNTVDBOverview(tvdb), preferredBTNIMDBOverview(meta.ExternalMetadata.IMDB), strings.TrimSpace(meta.EpisodeOverview))
 	aired := metautil.FirstNonEmptyTrimmed(btnTVDBEpisodeAired(tvdb), btnIMDBEpisodeAired(meta), strings.TrimSpace(meta.TVDBAiredDate), strings.TrimSpace(meta.DailyEpisodeDate), "TBA")
 	season, episode := resolveBTNTVSeasonEpisode(meta)
 	episodeTitle := metautil.FirstNonEmptyTrimmed(preferredBTNTVDBEpisodeTitle(tvdb), preferredBTNIMDBEpisodeTitle(meta), strings.TrimSpace(meta.EpisodeTitle), "TBA")

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -1189,7 +1189,7 @@ func resolveOrigin(meta api.PreparedMetadata) string {
 	if isBTNSceneRelease(meta) {
 		return "Scene"
 	}
-	if group != "" && isNoGroupTag(group) {
+	if group != "" && isNoGroupTag(group) || isBTNInternalGroup(meta) {
 		return "None"
 	}
 	return "P2P"

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -1096,7 +1096,8 @@ func preferredBTNIMDBOverview(imdb *api.IMDBMetadata) string {
 }
 
 // buildAlbumDesc keeps BTN's autofilled album_desc when available. If BTN did
-// not return one, TV uploads fall back to provider/local episode metadata.
+// not return one, TV uploads fall back to BBCode episode blocks from TVDB or
+// provider/local episode metadata.
 func buildAlbumDesc(meta api.PreparedMetadata, fields map[string]string) string {
 	if desc := metautil.FirstNonEmptyTrimmed(fields["album_desc"]); desc != "" {
 		return desc
@@ -1104,12 +1105,91 @@ func buildAlbumDesc(meta api.PreparedMetadata, fields map[string]string) string 
 	if !strings.EqualFold(strings.TrimSpace(meta.ExternalIDs.Category), "TV") {
 		return ""
 	}
+	if desc := buildTVDBAlbumDesc(meta); desc != "" {
+		return desc
+	}
 	tvdb := meta.ExternalMetadata.TVDB
 	overview := metautil.FirstNonEmptyTrimmed(preferredBTNTVDBOverview(tvdb), preferredBTNIMDBOverview(meta.ExternalMetadata.IMDB), strings.TrimSpace(meta.EpisodeOverview))
 	aired := metautil.FirstNonEmptyTrimmed(btnTVDBEpisodeAired(tvdb), btnIMDBEpisodeAired(meta), strings.TrimSpace(meta.TVDBAiredDate), strings.TrimSpace(meta.DailyEpisodeDate), "TBA")
 	season, episode := resolveBTNTVSeasonEpisode(meta)
 	episodeTitle := metautil.FirstNonEmptyTrimmed(preferredBTNTVDBEpisodeTitle(tvdb), preferredBTNIMDBEpisodeTitle(meta), strings.TrimSpace(meta.EpisodeTitle), "TBA")
-	return strings.TrimSpace(fmt.Sprintf("Episode Name: %s\nEpisode Title: %s\nSeason: %d\nEpisode: %d\nAired: %s\n\nEpisode overview: %s", episodeTitle, episodeTitle, season, episode, aired, overview))
+	return formatBTNEpisodeAlbumDesc([]api.TVDBEpisodeMetadata{{
+		SeasonNumber:    season,
+		EpisodeNumber:   episode,
+		EpisodeName:     episodeTitle,
+		EpisodeOverview: overview,
+		EpisodeAired:    aired,
+	}})
+}
+
+// buildTVDBAlbumDesc builds BTN album_desc from TVDB data only. Episode uploads
+// use the selected episode; season-pack uploads use every fetched episode in
+// the selected season.
+func buildTVDBAlbumDesc(meta api.PreparedMetadata) string {
+	tvdb := meta.ExternalMetadata.TVDB
+	if tvdb == nil {
+		return ""
+	}
+	season, episode := resolveBTNTVSeasonEpisode(meta)
+	if resolveUploadType(meta) == "Season" {
+		episodes := make([]api.TVDBEpisodeMetadata, 0, len(tvdb.Episodes))
+		for _, candidate := range tvdb.Episodes {
+			if candidate.SeasonNumber == season {
+				episodes = append(episodes, candidate)
+			}
+		}
+		sort.SliceStable(episodes, func(i, j int) bool {
+			return episodes[i].EpisodeNumber < episodes[j].EpisodeNumber
+		})
+		return formatBTNEpisodeAlbumDesc(episodes)
+	}
+	for _, candidate := range tvdb.Episodes {
+		if candidate.SeasonNumber == season && candidate.EpisodeNumber == episode {
+			return formatBTNEpisodeAlbumDesc([]api.TVDBEpisodeMetadata{candidate})
+		}
+	}
+	if tvdb.EpisodeSeason > 0 || tvdb.EpisodeNumber > 0 || strings.TrimSpace(tvdb.EpisodeName) != "" || strings.TrimSpace(tvdb.EpisodeOverview) != "" {
+		return formatBTNEpisodeAlbumDesc([]api.TVDBEpisodeMetadata{{
+			SeasonNumber:           tvdb.EpisodeSeason,
+			EpisodeNumber:          tvdb.EpisodeNumber,
+			EpisodeName:            tvdb.EpisodeName,
+			EpisodeNameEnglish:     tvdb.EpisodeNameEnglish,
+			EpisodeOverview:        tvdb.EpisodeOverview,
+			EpisodeOverviewEnglish: tvdb.EpisodeOverviewEnglish,
+			EpisodeAired:           tvdb.EpisodeAired,
+			EpisodeImage:           tvdb.EpisodeImage,
+		}})
+	}
+	return ""
+}
+
+// formatBTNEpisodeAlbumDesc renders each episode as the BBCode block expected
+// by BTN's album_desc field. Empty input returns an empty string.
+func formatBTNEpisodeAlbumDesc(episodes []api.TVDBEpisodeMetadata) string {
+	blocks := make([]string, 0, len(episodes))
+	for _, episode := range episodes {
+		title := metautil.FirstNonEmptyTrimmed(episode.EpisodeNameEnglish, episode.EpisodeName, "TBA")
+		overview := metautil.FirstNonEmptyTrimmed(episode.EpisodeOverviewEnglish, episode.EpisodeOverview)
+		aired := metautil.FirstNonEmptyTrimmed(episode.EpisodeAired, "TBA")
+		var block strings.Builder
+		block.WriteString("[b]Episode Name:[/b] ")
+		block.WriteString(title)
+		block.WriteString("\n[b]Season:[/b] ")
+		block.WriteString(strconv.Itoa(episode.SeasonNumber))
+		block.WriteString("\n[b]Episode:[/b] ")
+		block.WriteString(strconv.Itoa(episode.EpisodeNumber))
+		block.WriteString("\n[b]Aired:[/b] ")
+		block.WriteString(aired)
+		block.WriteString("\n\n[b]Episode overview:[/b]\n")
+		block.WriteString(overview)
+		if image := strings.TrimSpace(episode.EpisodeImage); image != "" {
+			block.WriteString("\n\n[b]Episode image:[/b]\n[img=")
+			block.WriteString(image)
+			block.WriteString("]")
+		}
+		blocks = append(blocks, strings.TrimSpace(block.String()))
+	}
+	return strings.Join(blocks, "\n\n")
 }
 
 // btnTVDBEpisodeAired returns the TVDB episode air date used in BTN-generated

--- a/internal/trackers/impl/btn/upload.go
+++ b/internal/trackers/impl/btn/upload.go
@@ -390,7 +390,7 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 		"submit":       "true",
 		"type":         resolveUploadType(req.Meta),
 		"scenename":    resolveUploadName(req.Meta),
-		"origin":       resolveOrigin(req.Meta, req.TrackerConfig.Username),
+		"origin":       resolveOrigin(req.Meta),
 		"release_desc": strings.TrimSpace(req.Meta.DescriptionOverride),
 		"tvdb":         "autofilled",
 	}
@@ -750,7 +750,7 @@ func prepareUploadData(ctx context.Context, req trackers.UploadRequest, uploadCt
 		"artist":       metautil.FirstNonEmptyTrimmed(fields["artist"]),
 		"title":        title,
 		"actors":       metautil.FirstNonEmptyTrimmed(fields["actors"]),
-		"origin":       resolveOrigin(req.Meta, req.TrackerConfig.Username),
+		"origin":       resolveOrigin(req.Meta),
 		"year":         metautil.FirstNonEmptyTrimmed(fields["year"]),
 		"tags":         resolveBTNTags(req.Meta, fields),
 		"image":        resolveBTNImage(req.Meta, fields),
@@ -1181,7 +1181,7 @@ func btnTVPayloadMetadataMessage(meta api.PreparedMetadata) string {
 
 // resolveOrigin derives the origin from
 // prepared scene and season-pack metadata, group tag and username
-func resolveOrigin(meta api.PreparedMetadata, username string) string {
+func resolveOrigin(meta api.PreparedMetadata) string {
 	group := strings.TrimSpace(meta.Release.Group)
 	if metadata.DetectSeasonPackGroupTags(meta).Mixed {
 		return "Mixed"
@@ -1191,9 +1191,6 @@ func resolveOrigin(meta api.PreparedMetadata, username string) string {
 	}
 	if group != "" && isNoGroupTag(group) {
 		return "None"
-	}
-	if username != "" && group != "" && strings.EqualFold(group, strings.TrimSpace(username)) {
-		return "User"
 	}
 	return "P2P"
 }

--- a/internal/trackers/impl/btn/upload_integration_test.go
+++ b/internal/trackers/impl/btn/upload_integration_test.go
@@ -195,23 +195,26 @@ func TestBTNUploadEndToEndSuccess(t *testing.T) {
 	if err := os.WriteFile(torrentPath, []byte("d8:announce13:https://x.ee"), 0o600); err != nil {
 		t.Fatalf("write torrent: %v", err)
 	}
+	mediaInfoText := "General\nFormat: Matroska\nVideo\nCodec: H.265"
+	mediaInfoPath := writeBTNTestMediaInfo(t, tempDir, mediaInfoText)
 
 	req := trackers.UploadRequest{
 		Tracker: "BTN",
 		Meta: api.PreparedMetadata{
-			SourcePath:      sourcePath,
-			TorrentPath:     torrentPath,
-			ReleaseName:     "Example.Show.S01E01.1080p.WEB-DL.x265-GRP",
-			Type:            "WEBDL",
-			Source:          "WEB-DL",
-			Container:       "MKV",
-			VideoEncode:     "x265",
-			VideoCodec:      "HEVC",
-			SeasonInt:       1,
-			EpisodeInt:      1,
-			EpisodeTitle:    "Episode One",
-			EpisodeOverview: "Overview",
-			TVDBAiredDate:   "2025-01-01",
+			SourcePath:        sourcePath,
+			TorrentPath:       torrentPath,
+			MediaInfoTextPath: mediaInfoPath,
+			ReleaseName:       "Example.Show.S01E01.1080p.WEB-DL.x265-GRP",
+			Type:              "WEBDL",
+			Source:            "WEB-DL",
+			Container:         "MKV",
+			VideoEncode:       "x265",
+			VideoCodec:        "HEVC",
+			SeasonInt:         1,
+			EpisodeInt:        1,
+			EpisodeTitle:      "Episode One",
+			EpisodeOverview:   "Overview",
+			TVDBAiredDate:     "2025-01-01",
 			ExternalIDs: api.ExternalIDs{
 				Category: "TV",
 			},
@@ -296,6 +299,9 @@ func TestBTNUploadEndToEndSuccess(t *testing.T) {
 	}
 	if got := uploadFormValues["origin"]; got != "P2P" {
 		t.Fatalf("expected origin P2P, got %q", got)
+	}
+	if got := uploadFormValues["release_desc"]; got != mediaInfoText {
+		t.Fatalf("expected MediaInfo release_desc, got %q", got)
 	}
 	if got := uploadFormValues["scenename"]; !strings.Contains(got, "H.265") || strings.Contains(got, "x265") {
 		t.Fatalf("expected scenename codec remap to H.265, got %q", got)
@@ -543,6 +549,9 @@ func TestBTNDryRunRequiresUploadAuthPrerequisites(t *testing.T) {
 	if entry.Status != "ready" {
 		t.Fatalf("expected credentials to satisfy dry-run upload auth prerequisites, got %#v", entry)
 	}
+	if desc, ok := entry.Payload["release_desc"]; !ok || desc != "" {
+		t.Fatalf("expected empty dry-run release_desc without MediaInfo, got value=%q present=%t", desc, ok)
+	}
 
 	cookieDBPath := newBTNAuthDB(t)
 	if err := cookies.SaveTrackerCookieMap(context.Background(), cookieDBPath, "BTN", map[string]string{"session": "imported"}); err != nil {
@@ -628,6 +637,7 @@ func TestBTNDryRunDebugRunsBTNAutofillAndReportsBothPayloads(t *testing.T) {
 
 	req := newBTNDryRunTestRequest(t, dbPath)
 	req.TrackerConfig.URL = server.URL
+	req.Meta.MediaInfoTextPath = writeBTNTestMediaInfo(t, filepath.Dir(req.Meta.SourcePath), "General\nFormat: Matroska")
 	req.Meta.Options.Debug = true
 	req.Meta.TVPack = true
 	req.Meta.EpisodeInt = 0
@@ -667,11 +677,17 @@ func TestBTNDryRunDebugRunsBTNAutofillAndReportsBothPayloads(t *testing.T) {
 	if finalSection.Payload["album_desc"] != "Autofill overview" {
 		t.Fatalf("expected final debug payload to keep BTN autofill album_desc, got %q", finalSection.Payload["album_desc"])
 	}
+	if finalSection.Payload["release_desc"] != "General\nFormat: Matroska" {
+		t.Fatalf("expected final debug payload release_desc to use MediaInfo, got %q", finalSection.Payload["release_desc"])
+	}
 	if len(finalSection.Files) == 0 || finalSection.Files[0].Field != "file_input" {
 		t.Fatalf("expected final debug section files, got %#v", finalSection.Files)
 	}
 	if entry.Payload["artist"] != "Example Show" {
 		t.Fatalf("expected top-level debug payload to use autofill result, got %#v", entry.Payload)
+	}
+	if entry.Payload["release_desc"] != "General\nFormat: Matroska" {
+		t.Fatalf("expected top-level debug payload release_desc to use MediaInfo, got %q", entry.Payload["release_desc"])
 	}
 
 	formMu.Lock()
@@ -970,6 +986,9 @@ func TestBTNPrepareUploadDataUsesEpisodeIntForTVDBAutoTitle(t *testing.T) {
 	}
 	if payload["album_desc"] != "Autofill overview" {
 		t.Fatalf("expected BTN autofill album_desc to win, got %q", payload["album_desc"])
+	}
+	if desc, ok := payload["release_desc"]; !ok || desc != "" {
+		t.Fatalf("expected empty release_desc without MediaInfo, got value=%q present=%t", desc, ok)
 	}
 
 	formMu.Lock()
@@ -1736,6 +1755,16 @@ func writeBTNTestTorrent(t *testing.T, torrentPath string) {
 	if err := torrentMeta.Write(file); err != nil {
 		t.Fatalf("write torrent: %v", err)
 	}
+}
+
+func writeBTNTestMediaInfo(t *testing.T, dir string, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, "mediainfo.txt")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write MediaInfo: %v", err)
+	}
+	return path
 }
 
 func newBTNAuthDB(t *testing.T) string {

--- a/internal/trackers/impl/btn/upload_integration_test.go
+++ b/internal/trackers/impl/btn/upload_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -577,6 +578,104 @@ func TestBTNDryRunBlocksMissingCanonicalTVSeasonEpisode(t *testing.T) {
 	}
 	if !strings.Contains(entry.Message, "canonical TV season/episode missing; BTN upload requires TVDB or metadata season/episode ints and ignores parsed season/episode fallback; refresh metadata or correct canonical season/episode before upload") {
 		t.Fatalf("expected canonical metadata message, got %q", entry.Message)
+	}
+}
+
+func TestBTNDryRunDebugRunsBTNAutofillAndReportsBothPayloads(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newBTNAuthDB(t)
+	if err := cookies.SaveTrackerCookieMap(context.Background(), dbPath, "BTN", map[string]string{"session": "imported"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+
+	handlerErrs := newHTTPHandlerErrorRecorder(t)
+	var formMu sync.Mutex
+	autofillForm := map[string]string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/upload.php":
+			_, _ = io.WriteString(w, `<form action="/upload.php"><input name="autofill"></form>`)
+		case r.Method == http.MethodPost && r.URL.Path == "/upload.php":
+			if err := r.ParseForm(); err != nil {
+				handlerErrs.Errorf("parse autofill form: %v", err)
+				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
+				return
+			}
+			formMu.Lock()
+			autofillForm["type"] = r.PostForm.Get("type")
+			autofillForm["scene_yesno"] = r.PostForm.Get("scene_yesno")
+			autofillForm["auto_series"] = r.PostForm.Get("auto_series")
+			autofillForm["auto_season"] = r.PostForm.Get("auto_season")
+			autofillForm["tvdb"] = r.PostForm.Get("tvdb")
+			formMu.Unlock()
+			_, _ = io.WriteString(w, `
+				<input name="artist" value="Example Show">
+				<input name="seriesid" value="12345">
+				<input name="title" value="Season 5">
+				<input name="year" value="2026">
+				<select name="format"><option selected value="MKV">MKV</option></select>
+				<select name="bitrate"><option selected value="H.265">H.265</option></select>
+				<select name="media"><option selected value="WEB-DL">WEB-DL</option></select>
+				<select name="resolution"><option selected value="1080p">1080p</option></select>
+				<textarea name="album_desc">Autofill overview</textarea>
+			`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	req := newBTNDryRunTestRequest(t, dbPath)
+	req.TrackerConfig.URL = server.URL
+	req.Meta.Options.Debug = true
+	req.Meta.TVPack = true
+	req.Meta.EpisodeInt = 0
+	req.Meta.ReleaseName = "Example.Show.S05.1080p.WEB-DL.x265-GRP"
+	req.Meta.SeasonInt = 3
+	req.Meta.ExternalMetadata.TVDB = &api.TVDBMetadata{
+		TVDBID:           12345,
+		EpisodeSeason:    5,
+		OriginalLanguage: "en",
+	}
+
+	entry, err := buildUploadDryRun(context.Background(), req)
+	handlerErrs.Check()
+	if err != nil {
+		t.Fatalf("BuildUploadDryRun: %v", err)
+	}
+	if entry.Status != "ready" {
+		t.Fatalf("expected ready debug dry-run, got %#v", entry)
+	}
+	if len(entry.DebugSections) != 2 {
+		t.Fatalf("expected two debug sections, got %#v", entry.DebugSections)
+	}
+	requestSection := entry.DebugSections[0]
+	if requestSection.Title != "BTN autofill request" {
+		t.Fatalf("expected autofill request section, got %#v", requestSection)
+	}
+	if requestSection.Payload["type"] != "Season" || requestSection.Payload["auto_series"] != "12345" || requestSection.Payload["auto_season"] != "5" || requestSection.Payload["tvdb"] != "Get Info" {
+		t.Fatalf("unexpected autofill request payload %#v", requestSection.Payload)
+	}
+	finalSection := entry.DebugSections[1]
+	if finalSection.Title != "BTN final upload payload after autofill" {
+		t.Fatalf("expected final payload section, got %#v", finalSection)
+	}
+	if finalSection.Payload["type"] != "Season" || finalSection.Payload["seriesid"] != "12345" || finalSection.Payload["artist"] != "Example Show" {
+		t.Fatalf("unexpected final payload %#v", finalSection.Payload)
+	}
+	if len(finalSection.Files) == 0 || finalSection.Files[0].Field != "file_input" {
+		t.Fatalf("expected final debug section files, got %#v", finalSection.Files)
+	}
+	if entry.Payload["artist"] != "Example Show" {
+		t.Fatalf("expected top-level debug payload to use autofill result, got %#v", entry.Payload)
+	}
+
+	formMu.Lock()
+	gotForm := maps.Clone(autofillForm)
+	formMu.Unlock()
+	if gotForm["type"] != "Season" || gotForm["scene_yesno"] != "No" || gotForm["auto_series"] != "12345" || gotForm["auto_season"] != "5" || gotForm["tvdb"] != "Get Info" {
+		t.Fatalf("unexpected submitted autofill form %#v", gotForm)
 	}
 }
 

--- a/internal/trackers/impl/btn/upload_integration_test.go
+++ b/internal/trackers/impl/btn/upload_integration_test.go
@@ -727,7 +727,7 @@ func TestBTNDryRunDebugRunsBTNAutofillAndReportsBothPayloads(t *testing.T) {
 	if requestSection.Title != "BTN autofill request" {
 		t.Fatalf("expected autofill request section, got %#v", requestSection)
 	}
-	if requestSection.Payload["type"] != "Season" || requestSection.Payload["auto_series"] != "12345" || requestSection.Payload["auto_season"] != "5" || requestSection.Payload["tvdb"] != "Get Info" {
+	if requestSection.Payload["type"] != "Season" || requestSection.Payload["auto_series"] != "12345" || requestSection.Payload["auto_season"] != "S05" || requestSection.Payload["tvdb"] != "Get Info" {
 		t.Fatalf("unexpected autofill request payload %#v", requestSection.Payload)
 	}
 	finalSection := entry.DebugSections[1]
@@ -756,7 +756,7 @@ func TestBTNDryRunDebugRunsBTNAutofillAndReportsBothPayloads(t *testing.T) {
 	formMu.Lock()
 	gotForm := maps.Clone(autofillForm)
 	formMu.Unlock()
-	if gotForm["type"] != "Season" || gotForm["scene_yesno"] != "No" || gotForm["auto_series"] != "12345" || gotForm["auto_season"] != "5" || gotForm["tvdb"] != "Get Info" {
+	if gotForm["type"] != "Season" || gotForm["scene_yesno"] != "No" || gotForm["auto_series"] != "12345" || gotForm["auto_season"] != "S05" || gotForm["tvdb"] != "Get Info" {
 		t.Fatalf("unexpected submitted autofill form %#v", gotForm)
 	}
 }

--- a/internal/trackers/impl/btn/upload_integration_test.go
+++ b/internal/trackers/impl/btn/upload_integration_test.go
@@ -4,6 +4,7 @@
 package btn
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -14,10 +15,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/anacrolix/torrent/metainfo"
@@ -557,13 +560,63 @@ func TestBTNDryRunRequiresUploadAuthPrerequisites(t *testing.T) {
 	if err := cookies.SaveTrackerCookieMap(context.Background(), cookieDBPath, "BTN", map[string]string{"session": "imported"}); err != nil {
 		t.Fatalf("SaveTrackerCookieMap: %v", err)
 	}
+	handlerErrs := newHTTPHandlerErrorRecorder(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/upload.php" {
+			http.NotFound(w, r)
+			return
+		}
+		if !strings.Contains(r.Header.Get("Cookie"), "session=imported") {
+			handlerErrs.Errorf("expected imported cookie on dry-run upload validation")
+			http.Error(w, "handler assertion failed", http.StatusInternalServerError)
+			return
+		}
+		_, _ = io.WriteString(w, `<form action="/upload.php"><input name="autofill"></form>`)
+	}))
+	defer server.Close()
 	cookieReq := newBTNDryRunTestRequest(t, cookieDBPath)
+	cookieReq.TrackerConfig.URL = server.URL
 	entry, err = buildUploadDryRun(context.Background(), cookieReq)
+	handlerErrs.Check()
 	if err != nil {
 		t.Fatalf("BuildUploadDryRun with stored cookies: %v", err)
 	}
 	if entry.Status != "ready" {
 		t.Fatalf("expected stored cookies to satisfy dry-run upload auth prerequisites, got %#v", entry)
+	}
+}
+
+func TestBTNDryRunRejectsStaleStoredCookiesWithoutCredentials(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newBTNAuthDB(t)
+	if err := cookies.SaveTrackerCookieMap(context.Background(), dbPath, "BTN", map[string]string{"session": "stale"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+
+	handlerErrs := newHTTPHandlerErrorRecorder(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/upload.php" {
+			http.NotFound(w, r)
+			return
+		}
+		if !strings.Contains(r.Header.Get("Cookie"), "session=stale") {
+			handlerErrs.Errorf("expected stale cookie on dry-run upload validation")
+			http.Error(w, "handler assertion failed", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `<form action="/login.php"><input name="password"></form>`)
+	}))
+	defer server.Close()
+
+	req := newBTNDryRunTestRequest(t, dbPath)
+	req.TrackerConfig.URL = server.URL
+
+	_, err := buildUploadDryRun(context.Background(), req)
+	handlerErrs.Check()
+	if !errors.Is(err, errBTNSessionConfirmedInvalid) {
+		t.Fatalf("expected stale stored cookies to block dry-run readiness, got %v", err)
 	}
 }
 
@@ -604,8 +657,18 @@ func TestBTNDryRunDebugRunsBTNAutofillAndReportsBothPayloads(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/upload.php":
+			if !strings.Contains(r.Header.Get("Cookie"), "session=imported") {
+				handlerErrs.Errorf("expected imported cookie on debug dry-run upload validation")
+				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
+				return
+			}
 			_, _ = io.WriteString(w, `<form action="/upload.php"><input name="autofill"></form>`)
 		case r.Method == http.MethodPost && r.URL.Path == "/upload.php":
+			if !strings.Contains(r.Header.Get("Cookie"), "session=imported") {
+				handlerErrs.Errorf("expected imported cookie on debug dry-run autofill request")
+				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
+				return
+			}
 			if err := r.ParseForm(); err != nil {
 				handlerErrs.Errorf("parse autofill form: %v", err)
 				http.Error(w, "handler assertion failed", http.StatusInternalServerError)
@@ -1229,6 +1292,93 @@ func TestValidateBTNClientSessionRequiresUploadFormStructure(t *testing.T) {
 	}
 }
 
+func TestExtractAutofillFieldsSelectsOptionsOrderIndependently(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "selected before value",
+			body: `<select name="media">
+				<option value="HDTV">HDTV</option>
+				<option selected value="WEB-DL">WEB-DL</option>
+			</select>`,
+			want: "WEB-DL",
+		},
+		{
+			name: "value before selected",
+			body: `<select name="media">
+				<option value="HDTV">HDTV</option>
+				<option value="WEB-DL" selected>WEB-DL</option>
+			</select>`,
+			want: "WEB-DL",
+		},
+		{
+			name: "first value fallback",
+			body: `<select name="media">
+				<option value="HDTV">HDTV</option>
+				<option value="WEB-DL">WEB-DL</option>
+			</select>`,
+			want: "HDTV",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fields := extractAutofillFields(tt.body)
+			if got := fields["media"]; got != tt.want {
+				t.Fatalf("media option = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadBTNTorrentResponseBodySizeLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		size    int
+		wantErr bool
+	}{
+		{
+			name: "limit size accepted",
+			size: btnTorrentMaxBytes,
+		},
+		{
+			name:    "over limit rejected",
+			size:    btnTorrentMaxBytes + 1,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := bytes.Repeat([]byte("d"), tt.size)
+			got, err := readBTNTorrentResponseBody(bytes.NewReader(body))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected oversized torrent response error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readBTNTorrentResponseBody: %v", err)
+			}
+			if len(got) != tt.size {
+				t.Fatalf("torrent response length = %d, want %d", len(got), tt.size)
+			}
+		})
+	}
+}
+
 func TestResolveSessionForTrackerAuthLoginPersistsCookies(t *testing.T) {
 	t.Parallel()
 
@@ -1511,6 +1661,106 @@ func TestBTNUploadFallsBackToAPIResolution(t *testing.T) {
 	}
 	if got, _ := apiDownloadID.Load().(string); got != "779" {
 		t.Fatalf("expected exact API fallback torrent id 779, got %q", got)
+	}
+}
+
+func TestBTNSeasonPackReservationFailsClosedOnMalformedAPISearch(t *testing.T) {
+	t.Parallel()
+
+	var apiSearchCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rpc" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var rpc struct {
+			Method string `json:"method"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&rpc)
+		if rpc.Method != "getTorrentsSearch" {
+			http.NotFound(w, r)
+			return
+		}
+		apiSearchCalls.Add(1)
+		_, _ = w.Write([]byte(`{"result":{"torrents":"api_key=secret-value"}}`))
+	}))
+	defer server.Close()
+
+	req := trackers.UploadRequest{
+		Meta: api.PreparedMetadata{
+			TVPack:    true,
+			SeasonInt: 1,
+			Tag:       "NTb",
+			ExternalIDs: api.ExternalIDs{
+				TVDBID:   123456,
+				Category: "TV",
+			},
+		},
+	}
+
+	err := checkBTNSeasonPackReservation(context.Background(), uploadContext{
+		apiURL:   server.URL + "/rpc",
+		apiToken: strings.Repeat("x", 30),
+	}, req)
+	if err == nil || !strings.Contains(err.Error(), "parse torrents search response") {
+		t.Fatalf("expected malformed BTN API search to fail closed, got %v", err)
+	}
+	if strings.Contains(err.Error(), "secret-value") {
+		t.Fatal("expected malformed BTN API search error to redact provider details")
+	}
+	if apiSearchCalls.Load() != 1 {
+		t.Fatalf("expected one API search call, got %d", apiSearchCalls.Load())
+	}
+}
+
+func TestBTNSeasonPackReservationUsesTranslatedTVDBSeason(t *testing.T) {
+	t.Parallel()
+
+	var apiSearchCalls atomic.Int32
+	now := strconv.FormatInt(time.Now().Unix(), 10)
+	old := strconv.FormatInt(time.Now().Add(-3*time.Hour).Unix(), 10)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rpc" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var rpc struct {
+			Method string `json:"method"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&rpc)
+		if rpc.Method != "getTorrentsSearch" {
+			http.NotFound(w, r)
+			return
+		}
+		apiSearchCalls.Add(1)
+		_, _ = fmt.Fprintf(w, `{"result":{"torrents":{"10":{"ReleaseName":"Example.Show.S05E01.1080p-GRP","Time":%q},"9":{"ReleaseName":"Example.Show.S03E01.1080p-GRP","Time":%q}}}}`, now, old)
+	}))
+	defer server.Close()
+
+	req := trackers.UploadRequest{
+		Meta: api.PreparedMetadata{
+			TVPack:    true,
+			SeasonInt: 3,
+			Tag:       "NTb",
+			ExternalIDs: api.ExternalIDs{
+				TVDBID:   123456,
+				Category: "TV",
+			},
+			ExternalMetadata: api.ExternalMetadata{
+				TVDB: &api.TVDBMetadata{EpisodeSeason: 5},
+			},
+		},
+	}
+
+	err := checkBTNSeasonPackReservation(context.Background(), uploadContext{
+		apiURL:   server.URL + "/rpc",
+		apiToken: strings.Repeat("x", 30),
+	}, req)
+	if err == nil || !strings.Contains(err.Error(), "BTN 2-hour reservation period") {
+		t.Fatalf("expected translated TVDB season reservation to block")
+	}
+	if apiSearchCalls.Load() != 1 {
+		t.Fatalf("expected one API search call, got %d", apiSearchCalls.Load())
 	}
 }
 

--- a/internal/trackers/impl/btn/upload_integration_test.go
+++ b/internal/trackers/impl/btn/upload_integration_test.go
@@ -1156,8 +1156,8 @@ func TestBTNPrepareUploadDataUsesSeasonIntForTVDBSeasonPack(t *testing.T) {
 	if gotAutoSeries != "12345" {
 		t.Fatalf("expected TVDB series id, got %q", gotAutoSeries)
 	}
-	if gotAutoSeason != "5" {
-		t.Fatalf("expected auto_season 5, got %q", gotAutoSeason)
+	if gotAutoSeason != "S05" {
+		t.Fatalf("expected auto_season S05, got %q", gotAutoSeason)
 	}
 }
 

--- a/internal/trackers/impl/btn/upload_integration_test.go
+++ b/internal/trackers/impl/btn/upload_integration_test.go
@@ -664,6 +664,9 @@ func TestBTNDryRunDebugRunsBTNAutofillAndReportsBothPayloads(t *testing.T) {
 	if finalSection.Payload["type"] != "Season" || finalSection.Payload["seriesid"] != "12345" || finalSection.Payload["artist"] != "Example Show" {
 		t.Fatalf("unexpected final payload %#v", finalSection.Payload)
 	}
+	if finalSection.Payload["album_desc"] != "Autofill overview" {
+		t.Fatalf("expected final debug payload to keep BTN autofill album_desc, got %q", finalSection.Payload["album_desc"])
+	}
 	if len(finalSection.Files) == 0 || finalSection.Files[0].Field != "file_input" {
 		t.Fatalf("expected final debug section files, got %#v", finalSection.Files)
 	}
@@ -965,10 +968,8 @@ func TestBTNPrepareUploadDataUsesEpisodeIntForTVDBAutoTitle(t *testing.T) {
 	if !logger.containsInfo(`BTN autofill resolution mismatch metadata_resolution="1080p" autofill_resolution="2160p" decision=metadata`) {
 		t.Fatal("expected resolution mismatch info log")
 	}
-	for _, value := range []string{"English Episode", "Season: 4", "Episode: 12", "Aired: 2026-02-03", "English overview"} {
-		if !strings.Contains(payload["album_desc"], value) {
-			t.Fatalf("expected album_desc to contain %q, got %q", value, payload["album_desc"])
-		}
+	if payload["album_desc"] != "Autofill overview" {
+		t.Fatalf("expected BTN autofill album_desc to win, got %q", payload["album_desc"])
 	}
 
 	formMu.Lock()

--- a/pkg/api/preview.go
+++ b/pkg/api/preview.go
@@ -83,8 +83,21 @@ type TrackerDryRunEntry struct {
 	Endpoint                string
 	Payload                 map[string]string
 	Files                   []TrackerDryRunFile
-	Questionnaire           *TrackerQuestionnaire
-	ImageHost               ImageHostFeedback
+	// DebugSections carries optional staged diagnostics for trackers whose dry-run
+	// preview needs to show more than one request or derived payload.
+	DebugSections []TrackerDryRunDebugSection
+	Questionnaire *TrackerQuestionnaire
+	ImageHost     ImageHostFeedback
+}
+
+// TrackerDryRunDebugSection describes one named diagnostic payload inside a
+// dry-run preview. Payload and files use the same redaction and path-display
+// rules as the top-level dry-run entry.
+type TrackerDryRunDebugSection struct {
+	Title    string
+	Endpoint string
+	Payload  map[string]string
+	Files    []TrackerDryRunFile
 }
 
 type TrackerDryRunFile struct {

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -619,6 +619,24 @@ type IMDBSeasonSummary struct {
 	YearRange string
 }
 
+// TVDBEpisodeMetadata stores one TVDB episode entry for tracker payloads that
+// need single-episode or season-pack episode descriptions.
+type TVDBEpisodeMetadata struct {
+	ID                     int
+	SeasonNumber           int
+	EpisodeNumber          int
+	EpisodeName            string
+	EpisodeNameEnglish     string
+	EpisodeOverview        string
+	EpisodeOverviewEnglish string
+	// EpisodeAired is the TVDB air date string used in tracker descriptions.
+	EpisodeAired string
+	// EpisodeImage is the TVDB episode image URL when the API returned one.
+	EpisodeImage string
+}
+
+// TVDBMetadata stores TVDB series metadata plus the selected episode and any
+// episode list fetched for the selected season.
 type TVDBMetadata struct {
 	TVDBID          int
 	Name            string
@@ -649,6 +667,11 @@ type TVDBMetadata struct {
 	EpisodeOverview        string
 	EpisodeOverviewEnglish string
 	EpisodeAired           string
+	// EpisodeImage is the selected episode image URL when the API returned one.
+	EpisodeImage string
+	// Episodes contains fetched TVDB episode entries, usually the season needed
+	// by a season-pack upload.
+	Episodes []TVDBEpisodeMetadata
 }
 
 type TVmazeMetadata struct {

--- a/pkg/api/tracker_auth.go
+++ b/pkg/api/tracker_auth.go
@@ -29,13 +29,14 @@ type TrackerAuthStatus struct {
 	CookieCount int    `json:"cookieCount"`
 	// LastCheckedAt is an RFC3339 UTC timestamp generated when the status is evaluated.
 	LastCheckedAt string `json:"lastCheckedAt"`
-	// LastError contains redacted failure text when a local or remote auth check failed.
+	// LastError contains redacted failure detail when a local or remote auth check failed; consumers should display it with Message when distinct.
 	LastError        string `json:"lastError"`
 	EncryptedStorage bool   `json:"encryptedStorage"`
 	Needs2FA         bool   `json:"needs2FA"`
 	// ChallengeID is an opaque manual-2FA continuation token; it is empty unless Needs2FA is true.
 	ChallengeID string `json:"challengeID"`
-	Message     string `json:"message"`
+	// Message contains the stable user-facing status summary or next step.
+	Message string `json:"message"`
 }
 
 // TrackerAuthLoginRequest carries optional login data for tracker auth flows.


### PR DESCRIPTION
the autofill origin is always None, so it shouldn't be used
also added detection for noGroup tags -> None and if the username is the group tag -> User

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dry-run previews can now include “Debug sections” in both the UI and CLI for deeper diagnostics.
* **Bug Fixes**
  * BTN uploads now enforce a pre-upload 2-hour reservation gate for internal season packs.
  * BTN payload `origin` is consistently derived from prepared metadata and classified (Mixed/Scene/None/P2P).
  * BTN description generation is more reliable, preserving autofilled `album_desc` and using MediaInfo for `release_desc`.
  * TVDB episode metadata now includes image URLs to improve TVDB-based description building.
  * Improved redaction and distinct auth-status messaging across CLI and UI.
* **Tests**
  * Expanded BTN, TVDB, and dry-run/debug coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->