### PR TITLE
fix: clarify the lacking metadata message

### DIFF
--- a/gui/frontend/src/app.test.ts
+++ b/gui/frontend/src/app.test.ts
@@ -63,6 +63,8 @@ type FetchPreparation = (
   ignoreDupesFor: string[],
 ) => Promise<unknown>;
 type DetectDiscType = (sourcePath: string) => Promise<string>;
+type StartDupeCheck = (...args: unknown[]) => Promise<string>;
+type GetDupeCheckSnapshot = (jobID: string) => Promise<DupeCheckSnapshot>;
 type StartTrackerUpload = (...args: unknown[]) => Promise<string>;
 type RetryFailedTrackerUpload = (jobID: string) => Promise<string>;
 type CancelTrackerUpload = (jobID: string) => Promise<void>;
@@ -268,7 +270,8 @@ const installAppBridge = (
     fetchDescriptionBuilder?: FetchDescriptionBuilder;
     fetchPreparation?: FetchPreparation;
     browseFolder?: () => Promise<string>;
-    getDupeCheckSnapshot?: () => Promise<DupeCheckSnapshot>;
+    startDupeCheck?: StartDupeCheck;
+    getDupeCheckSnapshot?: GetDupeCheckSnapshot;
     detectDiscType?: DetectDiscType;
     startTrackerUpload?: StartTrackerUpload;
     retryFailedTrackerUpload?: RetryFailedTrackerUpload;
@@ -333,7 +336,7 @@ const installAppBridge = (
           },
         ],
         SavePlaylistSelection: async () => undefined,
-        StartDupeCheck: async () => "dupe-job-1",
+        StartDupeCheck: options.startDupeCheck ?? (async () => "dupe-job-1"),
         GetDupeCheckSnapshot: options.getDupeCheckSnapshot ?? (async () => dupeCheckSnapshot()),
         StartTrackerUpload: options.startTrackerUpload ?? (async () => "upload-job-1"),
         RetryFailedTrackerUpload: options.retryFailedTrackerUpload ?? (async () => "upload-job-2"),
@@ -865,6 +868,58 @@ describe("metadata tracker payloads", () => {
     await waitFor(() => expect(fetchPreparation).toHaveBeenCalledTimes(1));
     expect(fetchPreparation.mock.calls[0][3]).toEqual(["AITHER"]);
     expect(fetchPreparation.mock.calls[0][4]).toEqual([]);
+  });
+});
+
+describe("dupe check job tracking", () => {
+  it("shows metadata preview guidance when dupe job creation is blocked", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const startDupeCheck = vi.fn<StartDupeCheck>(async () => {
+      throw new Error("dupe check requires metadata preview");
+    });
+    installAppBridge(fetchMetadata, { startDupeCheck });
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+    await screen.findByText("2/2");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+
+    await waitFor(() => expect(startDupeCheck).toHaveBeenCalledTimes(1));
+    await screen.findByText("Fetch metadata first to cache a preview before checking dupes.");
+  });
+
+  it("shows metadata preview guidance when an existing dupe job reports a cache miss", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const getDupeCheckSnapshot = vi.fn<GetDupeCheckSnapshot>(async () => ({
+      ...dupeCheckSnapshot(),
+      status: "failed",
+      summary: { SourcePath: "C:\\media\\Example", Results: [], Notes: [] },
+      error: "core: dupe check requires metadata preview",
+      finishedAt: "2026-06-17T00:00:01Z",
+    }));
+    installAppBridge(fetchMetadata, { getDupeCheckSnapshot });
+
+    render(createElement(App));
+
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledTimes(1));
+    await screen.findByText("2/2");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+
+    await waitFor(() => expect(getDupeCheckSnapshot).toHaveBeenCalledWith("dupe-job-1"));
+    await screen.findByText("Fetch metadata first to cache a preview before checking dupes.");
   });
 });
 

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -247,6 +247,7 @@ const dupeResultsFromSnapshot = (snapshot: DupeCheckSnapshot | null) =>
     .map(dupeResultFromTrackerState)
     .filter((result): result is DupeCheckResult => Boolean(result));
 
+/** Maps backend metadata-cache misses to the same actionable dupe-check guidance. */
 const dupeCheckErrorMessage = (message: string) =>
   message.includes("dupe check requires metadata preview")
     ? "Fetch metadata first to cache a preview before checking dupes."

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -247,6 +247,11 @@ const dupeResultsFromSnapshot = (snapshot: DupeCheckSnapshot | null) =>
     .map(dupeResultFromTrackerState)
     .filter((result): result is DupeCheckResult => Boolean(result));
 
+const dupeCheckErrorMessage = (message: string) =>
+  message.includes("dupe check requires metadata preview")
+    ? "Fetch metadata first to cache a preview before checking dupes."
+    : message;
+
 const emptyDescriptionBuilder: DescriptionBuilderPreview = {
   SourcePath: "",
   Groups: [],
@@ -3036,7 +3041,7 @@ export default function App() {
       setDupeError(snapshot.error || "One or more tracker dupe checks failed.");
     } else if (normalized === "failed" || normalized === "canceled") {
       setDupeChecked(false);
-      setDupeError(snapshot.error || "Dupe check failed.");
+      setDupeError(snapshot.error ? dupeCheckErrorMessage(snapshot.error) : "Dupe check failed.");
     }
   }, []);
 
@@ -3079,11 +3084,7 @@ export default function App() {
       setDupeCheckJobID("");
       setDupeCheckSnapshot(null);
       setDupeChecked(false);
-      if (message.includes("dupe check requires metadata preview")) {
-        setDupeError("Fetch metadata first to cache a preview before checking dupes.");
-      } else {
-        setDupeError(message);
-      }
+      setDupeError(dupeCheckErrorMessage(message));
       return;
     }
     setDupeCheckJobID(jobID);

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -60,6 +60,7 @@ type App struct {
 	streams     map[string]*logStreamSession
 	dupeMu      sync.Mutex
 	dupes       map[string]*dupeCheckJob
+	dupeWG      sync.WaitGroup
 	uploadMu    sync.Mutex
 	uploads     map[string]*trackerUploadJob
 	uploadWG    sync.WaitGroup

--- a/internal/guiapp/dupe_jobs.go
+++ b/internal/guiapp/dupe_jobs.go
@@ -23,6 +23,8 @@ import (
 const dupeCheckEventPrefix = "dupe:job:"
 const errDupeCheckRequiresMetadataPreview = "dupe check requires metadata preview"
 
+// DupeCheckTrackerState reports Wails-visible state for one tracker in a dupe
+// check job.
 type DupeCheckTrackerState struct {
 	Tracker    string              `json:"tracker"`
 	Status     string              `json:"status"`
@@ -32,6 +34,7 @@ type DupeCheckTrackerState struct {
 	FinishedAt string              `json:"finishedAt"`
 }
 
+// DupeCheckSnapshot reports Wails-visible state for a dupe check job.
 type DupeCheckSnapshot struct {
 	JobID          string                  `json:"jobID"`
 	SourcePath     string                  `json:"sourcePath"`
@@ -47,8 +50,12 @@ type DupeCheckSnapshot struct {
 
 type dupeCheckJob struct {
 	mu             sync.Mutex
+	cleanupOnce    sync.Once
 	id             string
 	sourcePath     string
+	uploadOptions  api.UploadOptions
+	core           api.Core
+	logger         interface{ Close() error }
 	overrides      api.ExternalIDOverrides
 	nameOverrides  api.ReleaseNameOverrides
 	trackers       []string
@@ -63,9 +70,15 @@ type dupeCheckJob struct {
 	cancel         context.CancelFunc
 }
 
+// StartDupeCheck starts a background dupe check for selected trackers and
+// returns the job ID. When the active core exposes the GUI prepared-metadata
+// cache, the matching metadata preview must already exist before a durable job
+// is created. The job captures a runtime snapshot so later config/core swaps do
+// not change the cache proof or execution core.
 func (a *App) StartDupeCheck(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string) (string, error) {
-	if a == nil || a.currentCore() == nil {
-		return "", errors.New("app not initialized")
+	rt, err := a.requireRuntime()
+	if err != nil {
+		return "", err
 	}
 	trimmedPath := strings.TrimSpace(path)
 	if trimmedPath == "" {
@@ -80,18 +93,41 @@ func (a *App) StartDupeCheck(path string, overrides api.ExternalIDOverrides, nam
 		Paths:    []string{trimmedPath},
 		Mode:     api.ModeGUI,
 		Trackers: resolvedTrackers,
-		Options:  a.baseUploadOptions(),
+		Options:  rt.baseUploadOptions(),
 
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
-	if exporter, ok := a.currentCore().(guishared.PreparedMetaExporter); ok {
-		_, found, err := exporter.ExportGUICachedPreparedMeta(a.runtimeContext(), req)
+	baseCtx := a.runtimeContext()
+	var preparedMeta api.PreparedMetadata
+	preparedMetaFound := false
+	if exporter, ok := rt.core.(guishared.PreparedMetaExporter); ok {
+		var found bool
+		preparedMeta, found, err = exporter.ExportGUICachedPreparedMeta(baseCtx, req)
 		if err != nil {
 			return "", fmt.Errorf("dupe check metadata preview cache: %w", err)
 		}
 		if !found {
 			return "", errors.New(errDupeCheckRequiresMetadataPreview)
+		}
+		preparedMetaFound = true
+	}
+
+	runCore, runLogger, err := a.buildRunCoreFromSnapshot(rt, runOptions{})
+	if err != nil {
+		return "", err
+	}
+	if preparedMetaFound {
+		importer, ok := runCore.(guishared.PreparedMetaImporter)
+		if !ok {
+			_ = runCore.Close()
+			_ = runLogger.Close()
+			return "", errors.New("dupe check metadata preview cache: run core cannot import prepared metadata")
+		}
+		if err := importer.ImportPreparedMetadataForGUI(baseCtx, req, preparedMeta); err != nil {
+			_ = runCore.Close()
+			_ = runLogger.Close()
+			return "", fmt.Errorf("dupe check metadata preview cache: %w", err)
 		}
 	}
 
@@ -108,6 +144,9 @@ func (a *App) StartDupeCheck(path string, overrides api.ExternalIDOverrides, nam
 	job := &dupeCheckJob{
 		id:            jobID,
 		sourcePath:    trimmedPath,
+		uploadOptions: req.Options,
+		core:          runCore,
+		logger:        runLogger,
 		overrides:     overrides,
 		nameOverrides: nameOverrides,
 		trackers:      resolvedTrackers,
@@ -118,16 +157,13 @@ func (a *App) StartDupeCheck(path string, overrides api.ExternalIDOverrides, nam
 		startedAt:     time.Now().UTC(),
 	}
 
-	baseCtx := a.runtimeContext()
 	jobCtx, cancel := context.WithCancel(baseCtx)
 	job.cancel = cancel
 
-	a.dupeMu.Lock()
-	a.dupes[jobID] = job
-	a.dupeMu.Unlock()
-
+	a.publishDupeCheckJob(job)
 	a.emitDupeCheckSnapshot(baseCtx, job)
 	go func() {
+		defer a.dupeWG.Done()
 		defer cancel()
 		a.runDupeCheckJob(jobCtx, baseCtx, job)
 	}()
@@ -135,6 +171,7 @@ func (a *App) StartDupeCheck(path string, overrides api.ExternalIDOverrides, nam
 	return jobID, nil
 }
 
+// GetDupeCheckSnapshot returns the current state for an existing dupe check job.
 func (a *App) GetDupeCheckSnapshot(jobID string) (DupeCheckSnapshot, error) {
 	if a == nil {
 		return DupeCheckSnapshot{}, errors.New("app not initialized")
@@ -152,6 +189,7 @@ func (a *App) GetDupeCheckSnapshot(jobID string) (DupeCheckSnapshot, error) {
 	return buildDupeCheckSnapshot(job), nil
 }
 
+// CancelDupeCheck requests cancellation for an existing dupe check job.
 func (a *App) CancelDupeCheck(jobID string) error {
 	if a == nil {
 		return errors.New("app not initialized")
@@ -176,7 +214,12 @@ func (a *App) CancelDupeCheck(jobID string) error {
 }
 
 func (a *App) runDupeCheckJob(ctx context.Context, eventCtx context.Context, job *dupeCheckJob) {
-	if a == nil || a.currentCore() == nil || job == nil {
+	if job != nil {
+		defer func() {
+			_ = job.closeResources()
+		}()
+	}
+	if a == nil || job == nil || job.core == nil {
 		return
 	}
 
@@ -193,13 +236,13 @@ func (a *App) runDupeCheckJob(ctx context.Context, eventCtx context.Context, job
 		Paths:    []string{job.sourcePath},
 		Mode:     api.ModeGUI,
 		Trackers: job.trackers,
-		Options:  a.baseUploadOptions(),
+		Options:  job.uploadOptions,
 
 		ExternalIDOverrides:  job.overrides,
 		ReleaseNameOverrides: job.nameOverrides,
 	}
 
-	summary, err := a.currentCore().CheckDupes(progressCtx, req)
+	summary, err := job.core.CheckDupes(progressCtx, req)
 
 	job.mu.Lock()
 	job.finishedAt = time.Now().UTC()
@@ -402,9 +445,12 @@ func resultMessage(result api.DupeCheckResult) string {
 }
 
 func (a *App) emitDupeCheckSnapshot(ctx context.Context, job *dupeCheckJob) {
-	if a == nil || ctx == nil || job == nil {
+	if a == nil || ctx == nil || job == nil || ctx.Value("events") == nil {
 		return
 	}
+	defer func() {
+		_ = recover()
+	}()
 	snapshot := buildDupeCheckSnapshot(job)
 	runtime.EventsEmit(ctx, dupeCheckEventPrefix+job.id, snapshot)
 }
@@ -463,6 +509,37 @@ func (a *App) getDupeCheckJob(jobID string) *dupeCheckJob {
 	return a.dupes[jobID]
 }
 
+func (a *App) publishDupeCheckJob(job *dupeCheckJob) {
+	a.dupeMu.Lock()
+	a.dupeWG.Add(1)
+	a.dupes[job.id] = job
+	a.dupeMu.Unlock()
+}
+
+func (j *dupeCheckJob) closeResources() error {
+	if j == nil {
+		return nil
+	}
+
+	var closeErr error
+	j.cleanupOnce.Do(func() {
+		j.mu.Lock()
+		coreSvc := j.core
+		logger := j.logger
+		j.core = nil
+		j.logger = nil
+		j.mu.Unlock()
+
+		if coreSvc != nil {
+			closeErr = errors.Join(closeErr, closeTrackerUploadResource("core", coreSvc))
+		}
+		if logger != nil {
+			closeErr = errors.Join(closeErr, closeTrackerUploadResource("logger", logger))
+		}
+	})
+	return closeErr
+}
+
 func (a *App) stopAllDupeJobs() {
 	if a == nil {
 		return
@@ -483,6 +560,12 @@ func (a *App) stopAllDupeJobs() {
 		job.mu.Unlock()
 		if cancel != nil {
 			cancel()
+		}
+	}
+	a.dupeWG.Wait()
+	for _, job := range jobs {
+		if job != nil {
+			_ = job.closeResources()
 		}
 	}
 }

--- a/internal/guiapp/dupe_jobs.go
+++ b/internal/guiapp/dupe_jobs.go
@@ -16,10 +16,12 @@ import (
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 
+	"github.com/autobrr/upbrr/internal/guishared"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
 const dupeCheckEventPrefix = "dupe:job:"
+const errDupeCheckRequiresMetadataPreview = "dupe check requires metadata preview"
 
 type DupeCheckTrackerState struct {
 	Tracker    string              `json:"tracker"`
@@ -72,6 +74,25 @@ func (a *App) StartDupeCheck(path string, overrides api.ExternalIDOverrides, nam
 	resolvedTrackers := normalizeTrackerList(trackers)
 	if len(resolvedTrackers) == 0 {
 		return "", errors.New("at least one tracker must be selected")
+	}
+
+	req := api.Request{
+		Paths:    []string{trimmedPath},
+		Mode:     api.ModeGUI,
+		Trackers: resolvedTrackers,
+		Options:  a.baseUploadOptions(),
+
+		ExternalIDOverrides:  overrides,
+		ReleaseNameOverrides: nameOverrides,
+	}
+	if exporter, ok := a.currentCore().(guishared.PreparedMetaExporter); ok {
+		_, found, err := exporter.ExportGUICachedPreparedMeta(a.runtimeContext(), req)
+		if err != nil {
+			return "", fmt.Errorf("dupe check metadata preview cache: %w", err)
+		}
+		if !found {
+			return "", errors.New(errDupeCheckRequiresMetadataPreview)
+		}
 	}
 
 	jobID := randomJobID()

--- a/internal/guiapp/run_options_test.go
+++ b/internal/guiapp/run_options_test.go
@@ -6,7 +6,10 @@ package guiapp
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -36,15 +39,17 @@ func (c *closeCounter) Close() error {
 
 type closeCounterCore struct {
 	closeCounter
-	exportedMeta api.PreparedMetadata
-	exportFound  bool
-	exportErr    error
-	importedMeta api.PreparedMetadata
-	importedReq  api.Request
-	fetchReq     api.Request
-	dupeSummary  api.DupeCheckSummary
-	uploads      []uploadPreparedResponse
-	uploadCalls  int
+	exportedMeta      api.PreparedMetadata
+	exportFound       bool
+	exportErr         error
+	expectedExportReq *api.Request
+	importedMeta      api.PreparedMetadata
+	importedReq       api.Request
+	fetchReq          api.Request
+	dupeSummary       api.DupeCheckSummary
+	dupeCalls         atomic.Int32
+	uploads           []uploadPreparedResponse
+	uploadCalls       int
 }
 
 type uploadPreparedResponse struct {
@@ -91,6 +96,7 @@ func (c *closeCounterCore) FetchTrackerDryRunPreview(context.Context, api.Reques
 }
 
 func (c *closeCounterCore) CheckDupes(context.Context, api.Request) (api.DupeCheckSummary, error) {
+	c.dupeCalls.Add(1)
 	return c.dupeSummary, nil
 }
 
@@ -182,7 +188,10 @@ func (c *closeCounterCore) SaveDescriptionOverride(context.Context, api.Request,
 	return api.DescriptionBuilderGroup{}, nil
 }
 
-func (c *closeCounterCore) ExportGUICachedPreparedMeta(context.Context, api.Request) (api.PreparedMetadata, bool, error) {
+func (c *closeCounterCore) ExportGUICachedPreparedMeta(_ context.Context, req api.Request) (api.PreparedMetadata, bool, error) {
+	if err := assertPreparedMetaExportRequest(req, c.expectedExportReq); err != nil {
+		return api.PreparedMetadata{}, false, err
+	}
 	return c.exportedMeta, c.exportFound, c.exportErr
 }
 
@@ -586,7 +595,8 @@ func TestRunDupeCheckJobSplitsGroupedPathedResultsIntoTrackerStates(t *testing.T
 		},
 	}}
 	job := newDupeCheckJobTestJob(coreSvc.dupeSummary.SourcePath, []string{"AITHER", "BLU", "RF"})
-	app := &App{core: coreSvc}
+	job.core = coreSvc
+	app := &App{}
 
 	app.runDupeCheckJob(context.Background(), nil, job)
 
@@ -604,6 +614,35 @@ func TestRunDupeCheckJobSplitsGroupedPathedResultsIntoTrackerStates(t *testing.T
 		if got := state.Result.Tracker; got != tracker {
 			t.Fatalf("expected %s result tracker, got %q", tracker, got)
 		}
+	}
+}
+
+func TestRunDupeCheckJobUsesJobCoreSnapshot(t *testing.T) {
+	t.Parallel()
+
+	jobCore := &closeCounterCore{dupeSummary: api.DupeCheckSummary{
+		SourcePath: `C:\Media\Movie.mkv`,
+		Results:    []api.DupeCheckResult{{Tracker: "AITHER", Status: "completed"}},
+	}}
+	currentCore := &closeCounterCore{dupeSummary: api.DupeCheckSummary{
+		SourcePath: `C:\Media\Other.mkv`,
+		Results:    []api.DupeCheckResult{{Tracker: "AITHER", Status: "failed"}},
+	}}
+	job := newDupeCheckJobTestJob(jobCore.dupeSummary.SourcePath, []string{"AITHER"})
+	job.core = jobCore
+	job.uploadOptions = api.UploadOptions{Screens: 1}
+	app := &App{core: currentCore}
+
+	app.runDupeCheckJob(context.Background(), nil, job)
+
+	if got := jobCore.dupeCalls.Load(); got != 1 {
+		t.Fatalf("expected job-owned core to run once, got %d", got)
+	}
+	if got := currentCore.dupeCalls.Load(); got != 0 {
+		t.Fatalf("expected current runtime core not to run, got %d", got)
+	}
+	if got := job.states["AITHER"].Status; got != "completed" {
+		t.Fatalf("expected result from job-owned core, got %q", got)
 	}
 }
 
@@ -625,6 +664,106 @@ func TestStartDupeCheckRequiresMetadataPreviewCache(t *testing.T) {
 	}
 	if len(app.dupes) != 0 {
 		t.Fatalf("expected no durable dupe job after cache miss, got %d", len(app.dupes))
+	}
+}
+
+func TestStartDupeCheckUsesMetadataPreviewCache(t *testing.T) {
+	t.Parallel()
+
+	app, sourcePath := newDupeCheckStartTestApp(t)
+	tmdbID := 1234567
+	releaseType := "movie"
+	overrides := api.ExternalIDOverrides{TMDBID: &tmdbID}
+	nameOverrides := api.ReleaseNameOverrides{Type: &releaseType}
+	coreSvc := &closeCounterCore{
+		exportFound:  true,
+		exportedMeta: api.PreparedMetadata{SourcePath: sourcePath},
+		expectedExportReq: &api.Request{
+			Paths:                []string{sourcePath},
+			Mode:                 api.ModeGUI,
+			Trackers:             []string{"AITHER"},
+			ExternalIDOverrides:  overrides,
+			ReleaseNameOverrides: nameOverrides,
+		},
+	}
+	app.core = coreSvc
+
+	jobID, err := app.StartDupeCheck(sourcePath, overrides, nameOverrides, []string{"AITHER"})
+	if err != nil {
+		t.Fatalf("start dupe check: %v", err)
+	}
+	if strings.TrimSpace(jobID) == "" {
+		t.Fatal("expected job id")
+	}
+	if len(app.dupes) != 1 {
+		t.Fatalf("expected durable dupe job, got %d", len(app.dupes))
+	}
+}
+
+func TestStartDupeCheckFailsOnMetadataPreviewCacheRequestMismatch(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		expected    func(string) api.Request
+		overrides   api.ExternalIDOverrides
+		wantMessage string
+	}{
+		{
+			name: "path",
+			expected: func(sourcePath string) api.Request {
+				return api.Request{Paths: []string{sourcePath + ".other"}, Mode: api.ModeGUI, Trackers: []string{"AITHER"}}
+			},
+			wantMessage: "metadata preview cache request paths",
+		},
+		{
+			name: "tracker",
+			expected: func(sourcePath string) api.Request {
+				return api.Request{Paths: []string{sourcePath}, Mode: api.ModeGUI, Trackers: []string{"BLU"}}
+			},
+			wantMessage: "metadata preview cache request trackers",
+		},
+		{
+			name: "external id override",
+			expected: func(sourcePath string) api.Request {
+				tmdbID := 7654321
+				return api.Request{
+					Paths:               []string{sourcePath},
+					Mode:                api.ModeGUI,
+					Trackers:            []string{"AITHER"},
+					ExternalIDOverrides: api.ExternalIDOverrides{TMDBID: &tmdbID},
+				}
+			},
+			overrides: func() api.ExternalIDOverrides {
+				tmdbID := 1234567
+				return api.ExternalIDOverrides{TMDBID: &tmdbID}
+			}(),
+			wantMessage: "metadata preview cache request external overrides",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			app, sourcePath := newDupeCheckStartTestApp(t)
+			expected := tt.expected(sourcePath)
+			coreSvc := &closeCounterCore{
+				exportFound:       true,
+				exportedMeta:      api.PreparedMetadata{SourcePath: sourcePath},
+				expectedExportReq: &expected,
+			}
+			app.core = coreSvc
+
+			_, err := app.StartDupeCheck(sourcePath, tt.overrides, api.ReleaseNameOverrides{}, []string{"AITHER"})
+			if err == nil {
+				t.Fatal("expected metadata preview cache request mismatch to fail")
+			}
+			if !strings.Contains(err.Error(), tt.wantMessage) {
+				t.Fatalf("expected mismatch error %q, got %v", tt.wantMessage, err)
+			}
+			if len(app.dupes) != 0 {
+				t.Fatalf("expected no durable dupe job after cache request mismatch, got %d", len(app.dupes))
+			}
+		})
 	}
 }
 
@@ -766,6 +905,61 @@ func newDupeCheckJobTestJob(sourcePath string, trackers []string) *dupeCheckJob 
 		job.states[tracker] = DupeCheckTrackerState{Tracker: tracker, Status: "queued", Message: "queued"}
 	}
 	return job
+}
+
+func newDupeCheckStartTestApp(t *testing.T) (*App, string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	sourcePath := filepath.Join(tempDir, "Example.Release.2026.1080p-GRP.mkv")
+	if err := os.WriteFile(sourcePath, []byte("example"), 0o600); err != nil {
+		t.Fatalf("write source fixture: %v", err)
+	}
+	repoPath := filepath.Join(tempDir, "upbrr.db")
+	repo, err := db.OpenWithLogger(repoPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	if err := repo.Migrate(); err != nil {
+		_ = repo.Close()
+		t.Fatalf("migrate repo: %v", err)
+	}
+
+	app := &App{
+		cfg: config.Config{
+			MainSettings:       config.MainSettingsConfig{DBPath: repoPath, TMDBAPI: "x"},
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+		},
+		repo:  repo,
+		dupes: make(map[string]*dupeCheckJob),
+	}
+	t.Cleanup(func() {
+		app.stopAllDupeJobs()
+		_ = repo.Close()
+	})
+	return app, sourcePath
+}
+
+func assertPreparedMetaExportRequest(req api.Request, expected *api.Request) error {
+	if expected == nil {
+		return nil
+	}
+	if !reflect.DeepEqual(req.Paths, expected.Paths) {
+		return fmt.Errorf("metadata preview cache request paths: got %#v want %#v", req.Paths, expected.Paths)
+	}
+	if req.Mode != expected.Mode {
+		return fmt.Errorf("metadata preview cache request mode: got %q want %q", req.Mode, expected.Mode)
+	}
+	if !reflect.DeepEqual(req.Trackers, expected.Trackers) {
+		return fmt.Errorf("metadata preview cache request trackers: got %#v want %#v", req.Trackers, expected.Trackers)
+	}
+	if !reflect.DeepEqual(req.ExternalIDOverrides, expected.ExternalIDOverrides) {
+		return fmt.Errorf("metadata preview cache request external overrides: got %#v want %#v", req.ExternalIDOverrides, expected.ExternalIDOverrides)
+	}
+	if !reflect.DeepEqual(req.ReleaseNameOverrides, expected.ReleaseNameOverrides) {
+		return fmt.Errorf("metadata preview cache request name overrides: got %#v want %#v", req.ReleaseNameOverrides, expected.ReleaseNameOverrides)
+	}
+	return nil
 }
 
 func TestSeedRunCorePreparedMetaCopiesPreparedMetadata(t *testing.T) {

--- a/internal/guiapp/run_options_test.go
+++ b/internal/guiapp/run_options_test.go
@@ -607,6 +607,27 @@ func TestRunDupeCheckJobSplitsGroupedPathedResultsIntoTrackerStates(t *testing.T
 	}
 }
 
+func TestStartDupeCheckRequiresMetadataPreviewCache(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &closeCounterCore{}
+	app := &App{
+		core: coreSvc,
+		cfg:  config.Config{ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+	}
+
+	_, err := app.StartDupeCheck(`C:\Media\Example.mkv`, api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, []string{"AITHER"})
+	if err == nil {
+		t.Fatal("expected missing metadata preview cache to block dupe check start")
+	}
+	if !strings.Contains(err.Error(), "dupe check requires metadata preview") {
+		t.Fatalf("expected metadata preview error, got %v", err)
+	}
+	if len(app.dupes) != 0 {
+		t.Fatalf("expected no durable dupe job after cache miss, got %d", len(app.dupes))
+	}
+}
+
 func TestRunTrackerUploadJobIgnoresNegativeUploadedCount(t *testing.T) {
 	app := &App{}
 	coreSvc := &closeCounterCore{uploads: []uploadPreparedResponse{

--- a/internal/webserver/app_routes.go
+++ b/internal/webserver/app_routes.go
@@ -910,7 +910,7 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		value, err := s.backend.StartDupeCheck(current.ID, req.Path, req.Overrides, req.NameOverrides, req.Trackers)
+		value, err := s.backend.StartDupeCheck(r.Context(), current.ID, req.Path, req.Overrides, req.NameOverrides, req.Trackers)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return

--- a/internal/webserver/jobs.go
+++ b/internal/webserver/jobs.go
@@ -30,6 +30,8 @@ const (
 
 const errDupeCheckRequiresMetadataPreview = "dupe check requires metadata preview"
 
+// DupeCheckTrackerState reports frontend-visible state for one tracker in a
+// dupe check job.
 type DupeCheckTrackerState struct {
 	Tracker    string              `json:"tracker"`
 	Status     string              `json:"status"`
@@ -39,6 +41,7 @@ type DupeCheckTrackerState struct {
 	FinishedAt string              `json:"finishedAt"`
 }
 
+// DupeCheckSnapshot reports frontend-visible state for a dupe check job.
 type DupeCheckSnapshot struct {
 	JobID          string                  `json:"jobID"`
 	SourcePath     string                  `json:"sourcePath"`
@@ -54,9 +57,13 @@ type DupeCheckSnapshot struct {
 
 type dupeCheckJob struct {
 	mu             sync.Mutex
+	cleanupOnce    sync.Once
 	sessionID      string
 	id             string
 	sourcePath     string
+	uploadOptions  api.UploadOptions
+	core           api.Core
+	logger         interface{ Close() error }
 	overrides      api.ExternalIDOverrides
 	nameOverrides  api.ReleaseNameOverrides
 	trackers       []string
@@ -221,9 +228,18 @@ func randomJobID() string {
 	return fmt.Sprintf("%d-%x", time.Now().UnixNano(), value.Uint64())
 }
 
-func (b *Backend) StartDupeCheck(sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string) (string, error) {
-	if err := b.requireCore(); err != nil {
+// StartDupeCheck starts a dupe check job owned by sessionID and returns its job
+// ID. The request context controls the pre-job metadata cache export/import
+// work; after the job is accepted, cancellation is detached and callers must use
+// CancelDupeCheck. When the active core exposes the GUI prepared-metadata cache,
+// the matching preview must exist before a durable job is created.
+func (b *Backend) StartDupeCheck(ctx context.Context, sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, trackers []string) (string, error) {
+	rt, err := b.requireRuntime()
+	if err != nil {
 		return "", err
+	}
+	if ctx == nil {
+		return "", errors.New("request context is required")
 	}
 	trimmedPath := strings.TrimSpace(path)
 	if trimmedPath == "" {
@@ -238,17 +254,48 @@ func (b *Backend) StartDupeCheck(sessionID string, path string, overrides api.Ex
 		Paths:                []string{trimmedPath},
 		Mode:                 api.ModeGUI,
 		Trackers:             resolvedTrackers,
-		Options:              b.baseUploadOptions(),
+		Options:              rt.baseUploadOptions(),
 		ExternalIDOverrides:  overrides,
 		ReleaseNameOverrides: nameOverrides,
 	}
-	if exporter, ok := b.currentCore().(guishared.PreparedMetaExporter); ok {
-		_, found, err := exporter.ExportGUICachedPreparedMeta(context.Background(), req)
+	var preparedMeta api.PreparedMetadata
+	preparedMetaFound := false
+	if exporter, ok := rt.core.(guishared.PreparedMetaExporter); ok {
+		var found bool
+		preparedMeta, found, err = exporter.ExportGUICachedPreparedMeta(ctx, req)
 		if err != nil {
 			return "", fmt.Errorf("dupe check metadata preview cache: %w", err)
 		}
 		if !found {
 			return "", errors.New(errDupeCheckRequiresMetadataPreview)
+		}
+		preparedMetaFound = true
+	}
+
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("dupe check metadata preview cache: %w", err)
+	}
+	//nolint:contextcheck // Per-run core construction has no context-aware API; request context is checked before and after setup.
+	runCore, runLogger, err := b.buildRunCoreFromSnapshot(rt, runOptions{})
+	if err != nil {
+		return "", err
+	}
+	if err := ctx.Err(); err != nil {
+		_ = runCore.Close()
+		_ = runLogger.Close()
+		return "", fmt.Errorf("dupe check metadata preview cache: %w", err)
+	}
+	if preparedMetaFound {
+		importer, ok := runCore.(guishared.PreparedMetaImporter)
+		if !ok {
+			_ = runCore.Close()
+			_ = runLogger.Close()
+			return "", errors.New("dupe check metadata preview cache: run core cannot import prepared metadata")
+		}
+		if err := importer.ImportPreparedMetadataForGUI(ctx, req, preparedMeta); err != nil {
+			_ = runCore.Close()
+			_ = runLogger.Close()
+			return "", fmt.Errorf("dupe check metadata preview cache: %w", err)
 		}
 	}
 
@@ -262,6 +309,9 @@ func (b *Backend) StartDupeCheck(sessionID string, path string, overrides api.Ex
 		sessionID:     sessionID,
 		id:            jobID,
 		sourcePath:    trimmedPath,
+		uploadOptions: req.Options,
+		core:          runCore,
+		logger:        runLogger,
 		overrides:     overrides,
 		nameOverrides: nameOverrides,
 		trackers:      resolvedTrackers,
@@ -272,7 +322,7 @@ func (b *Backend) StartDupeCheck(sessionID string, path string, overrides api.Ex
 		startedAt:     time.Now().UTC(),
 	}
 
-	jobCtx, cancel := context.WithCancel(context.Background())
+	jobCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	job.cancel = cancel
 
 	b.dupeMu.Lock()
@@ -316,6 +366,9 @@ func (b *Backend) CancelDupeCheck(sessionID string, jobID string) error {
 
 func (b *Backend) runDupeCheckJob(ctx context.Context, job *dupeCheckJob) {
 	defer b.dupeWG.Done()
+	defer func() {
+		job.closeResources()
+	}()
 
 	job.mu.Lock()
 	job.status = "running"
@@ -330,12 +383,25 @@ func (b *Backend) runDupeCheckJob(ctx context.Context, job *dupeCheckJob) {
 		Paths:                []string{job.sourcePath},
 		Mode:                 api.ModeGUI,
 		Trackers:             job.trackers,
-		Options:              b.baseUploadOptions(),
+		Options:              job.uploadOptions,
 		ExternalIDOverrides:  job.overrides,
 		ReleaseNameOverrides: job.nameOverrides,
 	}
 
-	summary, err := b.currentCore().CheckDupes(progressCtx, req)
+	if job.core == nil {
+		err := errors.New("core not initialized")
+		job.mu.Lock()
+		job.finishedAt = time.Now().UTC()
+		job.cancel = nil
+		job.status = "failed"
+		job.errorMessage = err.Error()
+		job.mu.Unlock()
+		b.emitDupeCheckSnapshot(job)
+		b.scheduleDupeJobCleanup(job)
+		return
+	}
+
+	summary, err := job.core.CheckDupes(progressCtx, req)
 	job.mu.Lock()
 	job.finishedAt = time.Now().UTC()
 	job.cancel = nil
@@ -420,6 +486,26 @@ func (b *Backend) applyDupeProgress(job *dupeCheckJob, update api.DupeProgressUp
 }
 
 func (j *trackerUploadJob) closeResources() {
+	if j == nil {
+		return
+	}
+	j.cleanupOnce.Do(func() {
+		j.mu.Lock()
+		coreSvc := j.core
+		logger := j.logger
+		j.core = nil
+		j.logger = nil
+		j.mu.Unlock()
+		if coreSvc != nil {
+			_ = coreSvc.Close()
+		}
+		if logger != nil {
+			_ = logger.Close()
+		}
+	})
+}
+
+func (j *dupeCheckJob) closeResources() {
 	if j == nil {
 		return
 	}

--- a/internal/webserver/jobs.go
+++ b/internal/webserver/jobs.go
@@ -28,6 +28,8 @@ const (
 	trackerUploadProgressEvent = "upload:progress"
 )
 
+const errDupeCheckRequiresMetadataPreview = "dupe check requires metadata preview"
+
 type DupeCheckTrackerState struct {
 	Tracker    string              `json:"tracker"`
 	Status     string              `json:"status"`
@@ -230,6 +232,24 @@ func (b *Backend) StartDupeCheck(sessionID string, path string, overrides api.Ex
 	resolvedTrackers := normalizeTrackerList(trackers)
 	if len(resolvedTrackers) == 0 {
 		return "", errors.New("at least one tracker must be selected")
+	}
+
+	req := api.Request{
+		Paths:                []string{trimmedPath},
+		Mode:                 api.ModeGUI,
+		Trackers:             resolvedTrackers,
+		Options:              b.baseUploadOptions(),
+		ExternalIDOverrides:  overrides,
+		ReleaseNameOverrides: nameOverrides,
+	}
+	if exporter, ok := b.currentCore().(guishared.PreparedMetaExporter); ok {
+		_, found, err := exporter.ExportGUICachedPreparedMeta(context.Background(), req)
+		if err != nil {
+			return "", fmt.Errorf("dupe check metadata preview cache: %w", err)
+		}
+		if !found {
+			return "", errors.New(errDupeCheckRequiresMetadataPreview)
+		}
 	}
 
 	jobID := randomJobID()

--- a/internal/webserver/jobs_test.go
+++ b/internal/webserver/jobs_test.go
@@ -252,8 +252,8 @@ func TestStartDupeCheckRequiresMetadataPreviewCache(t *testing.T) {
 	if !strings.Contains(err.Error(), "dupe check requires metadata preview") {
 		t.Fatalf("expected metadata preview error, got %v", err)
 	}
-	if len(backend.dupes) != 0 {
-		t.Fatalf("expected no durable dupe job after cache miss, got %d", len(backend.dupes))
+	if count := dupeJobCount(backend); count != 0 {
+		t.Fatalf("expected no durable dupe job after cache miss, got %d", count)
 	}
 }
 
@@ -285,8 +285,8 @@ func TestStartDupeCheckUsesMetadataPreviewCache(t *testing.T) {
 	if strings.TrimSpace(jobID) == "" {
 		t.Fatal("expected job id")
 	}
-	if len(backend.dupes) != 1 {
-		t.Fatalf("expected durable dupe job, got %d", len(backend.dupes))
+	if count := dupeJobCount(backend); count != 1 {
+		t.Fatalf("expected durable dupe job, got %d", count)
 	}
 }
 
@@ -350,8 +350,8 @@ func TestStartDupeCheckFailsOnMetadataPreviewCacheRequestMismatch(t *testing.T) 
 			if !strings.Contains(err.Error(), tt.wantMessage) {
 				t.Fatalf("expected mismatch error %q, got %v", tt.wantMessage, err)
 			}
-			if len(backend.dupes) != 0 {
-				t.Fatalf("expected no durable dupe job after cache request mismatch, got %d", len(backend.dupes))
+			if count := dupeJobCount(backend); count != 0 {
+				t.Fatalf("expected no durable dupe job after cache request mismatch, got %d", count)
 			}
 		})
 	}
@@ -391,8 +391,8 @@ func TestStartDupeCheckStopsPreJobExportOnRequestCancel(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("expected start to return after request cancellation")
 	}
-	if len(backend.dupes) != 0 {
-		t.Fatalf("expected no durable dupe job after canceled export, got %d", len(backend.dupes))
+	if count := dupeJobCount(backend); count != 0 {
+		t.Fatalf("expected no durable dupe job after canceled export, got %d", count)
 	}
 }
 
@@ -958,6 +958,12 @@ func newDupeCheckStartTestBackend(t *testing.T) (*Backend, string) {
 		_ = repo.Close()
 	})
 	return backend, sourcePath
+}
+
+func dupeJobCount(backend *Backend) int {
+	backend.dupeMu.Lock()
+	defer backend.dupeMu.Unlock()
+	return len(backend.dupes)
 }
 
 func assertPreparedMetaExportRequest(req api.Request, expected *api.Request) error {

--- a/internal/webserver/jobs_test.go
+++ b/internal/webserver/jobs_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -202,6 +203,49 @@ func TestPruneCompletedDupeJobsLockedKeepsNewestCompleted(t *testing.T) {
 	}
 	if _, ok := backend.dupes[active.id]; !ok {
 		t.Fatal("expected active dupe job to remain")
+	}
+}
+
+func TestStartDupeCheckRequiresMetadataPreviewCache(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &preparedMetaTestCore{}
+	backend := &Backend{
+		core:  coreSvc,
+		dupes: make(map[string]*dupeCheckJob),
+	}
+
+	_, err := backend.StartDupeCheck("session", `C:\Media\Example.mkv`, api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, []string{"AITHER"})
+	if err == nil {
+		t.Fatal("expected missing metadata preview cache to block dupe check start")
+	}
+	if !strings.Contains(err.Error(), "dupe check requires metadata preview") {
+		t.Fatalf("expected metadata preview error, got %v", err)
+	}
+	if len(backend.dupes) != 0 {
+		t.Fatalf("expected no durable dupe job after cache miss, got %d", len(backend.dupes))
+	}
+}
+
+func TestStartDupeCheckUsesMetadataPreviewCache(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &preparedMetaTestCore{exportFound: true}
+	backend := &Backend{
+		core:  coreSvc,
+		dupes: make(map[string]*dupeCheckJob),
+		hub:   newEventHub(),
+	}
+
+	jobID, err := backend.StartDupeCheck("session", `C:\Media\Example.mkv`, api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, []string{"AITHER"})
+	if err != nil {
+		t.Fatalf("start dupe check: %v", err)
+	}
+	if strings.TrimSpace(jobID) == "" {
+		t.Fatal("expected job id")
+	}
+	if len(backend.dupes) != 1 {
+		t.Fatalf("expected durable dupe job, got %d", len(backend.dupes))
 	}
 }
 

--- a/internal/webserver/jobs_test.go
+++ b/internal/webserver/jobs_test.go
@@ -7,24 +7,35 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/guishared"
+	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
 type preparedMetaTestCore struct {
-	exportedMeta api.PreparedMetadata
-	exportFound  bool
-	exportErr    error
-	importedMeta api.PreparedMetadata
-	importedReq  api.Request
-	fetchReq     api.Request
-	dupeSummary  api.DupeCheckSummary
-	uploads      []uploadPreparedResponse
-	uploadCalls  int
+	exportedMeta      api.PreparedMetadata
+	exportFound       bool
+	exportErr         error
+	exportStarted     chan struct{}
+	exportContinue    chan struct{}
+	exportStartedOnce sync.Once
+	expectedExportReq *api.Request
+	importedMeta      api.PreparedMetadata
+	importedReq       api.Request
+	fetchReq          api.Request
+	dupeSummary       api.DupeCheckSummary
+	dupeCalls         int
+	uploads           []uploadPreparedResponse
+	uploadCalls       int
 }
 
 type uploadPreparedResponse struct {
@@ -67,6 +78,7 @@ func (c *preparedMetaTestCore) FetchTrackerDryRunPreview(context.Context, api.Re
 }
 
 func (c *preparedMetaTestCore) CheckDupes(context.Context, api.Request) (api.DupeCheckSummary, error) {
+	c.dupeCalls++
 	return c.dupeSummary, nil
 }
 
@@ -162,7 +174,25 @@ func (c *preparedMetaTestCore) Close() error {
 	return nil
 }
 
-func (c *preparedMetaTestCore) ExportGUICachedPreparedMeta(context.Context, api.Request) (api.PreparedMetadata, bool, error) {
+func (c *preparedMetaTestCore) ExportGUICachedPreparedMeta(ctx context.Context, req api.Request) (api.PreparedMetadata, bool, error) {
+	if c.exportStarted != nil {
+		c.exportStartedOnce.Do(func() {
+			close(c.exportStarted)
+		})
+	}
+	if err := assertPreparedMetaExportRequest(req, c.expectedExportReq); err != nil {
+		return api.PreparedMetadata{}, false, err
+	}
+	if c.exportContinue != nil {
+		select {
+		case <-ctx.Done():
+			return api.PreparedMetadata{}, false, fmt.Errorf("export canceled: %w", ctx.Err())
+		case <-c.exportContinue:
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return api.PreparedMetadata{}, false, fmt.Errorf("export canceled: %w", err)
+	}
 	return c.exportedMeta, c.exportFound, c.exportErr
 }
 
@@ -215,7 +245,7 @@ func TestStartDupeCheckRequiresMetadataPreviewCache(t *testing.T) {
 		dupes: make(map[string]*dupeCheckJob),
 	}
 
-	_, err := backend.StartDupeCheck("session", `C:\Media\Example.mkv`, api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, []string{"AITHER"})
+	_, err := backend.StartDupeCheck(context.Background(), "session", `C:\Media\Example.mkv`, api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, []string{"AITHER"})
 	if err == nil {
 		t.Fatal("expected missing metadata preview cache to block dupe check start")
 	}
@@ -230,14 +260,25 @@ func TestStartDupeCheckRequiresMetadataPreviewCache(t *testing.T) {
 func TestStartDupeCheckUsesMetadataPreviewCache(t *testing.T) {
 	t.Parallel()
 
-	coreSvc := &preparedMetaTestCore{exportFound: true}
-	backend := &Backend{
-		core:  coreSvc,
-		dupes: make(map[string]*dupeCheckJob),
-		hub:   newEventHub(),
+	backend, sourcePath := newDupeCheckStartTestBackend(t)
+	tmdbID := 1234567
+	releaseType := "movie"
+	overrides := api.ExternalIDOverrides{TMDBID: &tmdbID}
+	nameOverrides := api.ReleaseNameOverrides{Type: &releaseType}
+	coreSvc := &preparedMetaTestCore{
+		exportFound:  true,
+		exportedMeta: api.PreparedMetadata{SourcePath: sourcePath},
+		expectedExportReq: &api.Request{
+			Paths:                []string{sourcePath},
+			Mode:                 api.ModeGUI,
+			Trackers:             []string{"AITHER"},
+			ExternalIDOverrides:  overrides,
+			ReleaseNameOverrides: nameOverrides,
+		},
 	}
+	backend.core = coreSvc
 
-	jobID, err := backend.StartDupeCheck("session", `C:\Media\Example.mkv`, api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, []string{"AITHER"})
+	jobID, err := backend.StartDupeCheck(context.Background(), "session", sourcePath, overrides, nameOverrides, []string{"AITHER"})
 	if err != nil {
 		t.Fatalf("start dupe check: %v", err)
 	}
@@ -246,6 +287,112 @@ func TestStartDupeCheckUsesMetadataPreviewCache(t *testing.T) {
 	}
 	if len(backend.dupes) != 1 {
 		t.Fatalf("expected durable dupe job, got %d", len(backend.dupes))
+	}
+}
+
+func TestStartDupeCheckFailsOnMetadataPreviewCacheRequestMismatch(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		expected    func(string) api.Request
+		overrides   api.ExternalIDOverrides
+		wantMessage string
+	}{
+		{
+			name: "path",
+			expected: func(sourcePath string) api.Request {
+				return api.Request{Paths: []string{sourcePath + ".other"}, Mode: api.ModeGUI, Trackers: []string{"AITHER"}}
+			},
+			wantMessage: "metadata preview cache request paths",
+		},
+		{
+			name: "tracker",
+			expected: func(sourcePath string) api.Request {
+				return api.Request{Paths: []string{sourcePath}, Mode: api.ModeGUI, Trackers: []string{"BLU"}}
+			},
+			wantMessage: "metadata preview cache request trackers",
+		},
+		{
+			name: "external id override",
+			expected: func(sourcePath string) api.Request {
+				tmdbID := 7654321
+				return api.Request{
+					Paths:               []string{sourcePath},
+					Mode:                api.ModeGUI,
+					Trackers:            []string{"AITHER"},
+					ExternalIDOverrides: api.ExternalIDOverrides{TMDBID: &tmdbID},
+				}
+			},
+			overrides: func() api.ExternalIDOverrides {
+				tmdbID := 1234567
+				return api.ExternalIDOverrides{TMDBID: &tmdbID}
+			}(),
+			wantMessage: "metadata preview cache request external overrides",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			backend, sourcePath := newDupeCheckStartTestBackend(t)
+			expected := tt.expected(sourcePath)
+			coreSvc := &preparedMetaTestCore{
+				exportFound:       true,
+				exportedMeta:      api.PreparedMetadata{SourcePath: sourcePath},
+				expectedExportReq: &expected,
+			}
+			backend.core = coreSvc
+
+			_, err := backend.StartDupeCheck(context.Background(), "session", sourcePath, tt.overrides, api.ReleaseNameOverrides{}, []string{"AITHER"})
+			if err == nil {
+				t.Fatal("expected metadata preview cache request mismatch to fail")
+			}
+			if !strings.Contains(err.Error(), tt.wantMessage) {
+				t.Fatalf("expected mismatch error %q, got %v", tt.wantMessage, err)
+			}
+			if len(backend.dupes) != 0 {
+				t.Fatalf("expected no durable dupe job after cache request mismatch, got %d", len(backend.dupes))
+			}
+		})
+	}
+}
+
+func TestStartDupeCheckStopsPreJobExportOnRequestCancel(t *testing.T) {
+	t.Parallel()
+
+	backend, sourcePath := newDupeCheckStartTestBackend(t)
+	coreSvc := &preparedMetaTestCore{
+		exportFound:    true,
+		exportedMeta:   api.PreparedMetadata{SourcePath: sourcePath},
+		exportStarted:  make(chan struct{}),
+		exportContinue: make(chan struct{}),
+	}
+	backend.core = coreSvc
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := backend.StartDupeCheck(ctx, "session", sourcePath, api.ExternalIDOverrides{}, api.ReleaseNameOverrides{}, []string{"AITHER"})
+		errCh <- err
+	}()
+
+	select {
+	case <-coreSvc.exportStarted:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("expected metadata cache export to start")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected canceled export error, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected start to return after request cancellation")
+	}
+	if len(backend.dupes) != 0 {
+		t.Fatalf("expected no durable dupe job after canceled export, got %d", len(backend.dupes))
 	}
 }
 
@@ -424,7 +571,8 @@ func TestRunDupeCheckJobSplitsGroupedPathedResultsIntoTrackerStates(t *testing.T
 		},
 	}}
 	job := newDupeCheckJobTestJob("session-a", coreSvc.dupeSummary.SourcePath, []string{"AITHER", "BLU", "RF"})
-	backend := &Backend{core: coreSvc, hub: newEventHub()}
+	job.core = coreSvc
+	backend := &Backend{hub: newEventHub()}
 	backend.dupeWG.Add(1)
 
 	backend.runDupeCheckJob(context.Background(), job)
@@ -443,6 +591,36 @@ func TestRunDupeCheckJobSplitsGroupedPathedResultsIntoTrackerStates(t *testing.T
 		if got := state.Result.Tracker; got != tracker {
 			t.Fatalf("expected %s result tracker, got %q", tracker, got)
 		}
+	}
+}
+
+func TestRunDupeCheckJobUsesJobCoreSnapshot(t *testing.T) {
+	t.Parallel()
+
+	jobCore := &preparedMetaTestCore{dupeSummary: api.DupeCheckSummary{
+		SourcePath: `C:\Media\Movie.mkv`,
+		Results:    []api.DupeCheckResult{{Tracker: "AITHER", Status: "completed"}},
+	}}
+	currentCore := &preparedMetaTestCore{dupeSummary: api.DupeCheckSummary{
+		SourcePath: `C:\Media\Other.mkv`,
+		Results:    []api.DupeCheckResult{{Tracker: "AITHER", Status: "failed"}},
+	}}
+	job := newDupeCheckJobTestJob("session-a", jobCore.dupeSummary.SourcePath, []string{"AITHER"})
+	job.core = jobCore
+	job.uploadOptions = api.UploadOptions{Screens: 1}
+	backend := &Backend{core: currentCore, hub: newEventHub()}
+	backend.dupeWG.Add(1)
+
+	backend.runDupeCheckJob(context.Background(), job)
+
+	if got := jobCore.dupeCalls; got != 1 {
+		t.Fatalf("expected job-owned core to run once, got %d", got)
+	}
+	if got := currentCore.dupeCalls; got != 0 {
+		t.Fatalf("expected current runtime core not to run, got %d", got)
+	}
+	if got := job.states["AITHER"].Status; got != "completed" {
+		t.Fatalf("expected result from job-owned core, got %q", got)
 	}
 }
 
@@ -746,6 +924,62 @@ func newDupeCheckJobTestJob(sessionID string, sourcePath string, trackers []stri
 		job.states[tracker] = DupeCheckTrackerState{Tracker: tracker, Status: "queued", Message: "queued"}
 	}
 	return job
+}
+
+func newDupeCheckStartTestBackend(t *testing.T) (*Backend, string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	sourcePath := filepath.Join(tempDir, "Example.Release.2026.1080p-GRP.mkv")
+	if err := os.WriteFile(sourcePath, []byte("example"), 0o600); err != nil {
+		t.Fatalf("write source fixture: %v", err)
+	}
+	repoPath := filepath.Join(tempDir, "upbrr.db")
+	repo, err := db.OpenWithLogger(repoPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	if err := repo.Migrate(); err != nil {
+		_ = repo.Close()
+		t.Fatalf("migrate repo: %v", err)
+	}
+
+	backend := &Backend{
+		cfg: config.Config{
+			MainSettings:       config.MainSettingsConfig{DBPath: repoPath, TMDBAPI: "x"},
+			ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1},
+		},
+		repo:  repo,
+		dupes: make(map[string]*dupeCheckJob),
+		hub:   newEventHub(),
+	}
+	t.Cleanup(func() {
+		backend.stopAllDupeJobs()
+		_ = repo.Close()
+	})
+	return backend, sourcePath
+}
+
+func assertPreparedMetaExportRequest(req api.Request, expected *api.Request) error {
+	if expected == nil {
+		return nil
+	}
+	if !reflect.DeepEqual(req.Paths, expected.Paths) {
+		return fmt.Errorf("metadata preview cache request paths: got %#v want %#v", req.Paths, expected.Paths)
+	}
+	if req.Mode != expected.Mode {
+		return fmt.Errorf("metadata preview cache request mode: got %q want %q", req.Mode, expected.Mode)
+	}
+	if !reflect.DeepEqual(req.Trackers, expected.Trackers) {
+		return fmt.Errorf("metadata preview cache request trackers: got %#v want %#v", req.Trackers, expected.Trackers)
+	}
+	if !reflect.DeepEqual(req.ExternalIDOverrides, expected.ExternalIDOverrides) {
+		return fmt.Errorf("metadata preview cache request external overrides: got %#v want %#v", req.ExternalIDOverrides, expected.ExternalIDOverrides)
+	}
+	if !reflect.DeepEqual(req.ReleaseNameOverrides, expected.ReleaseNameOverrides) {
+		return fmt.Errorf("metadata preview cache request name overrides: got %#v want %#v", req.ReleaseNameOverrides, expected.ReleaseNameOverrides)
+	}
+	return nil
 }
 
 func assertSnapshotHasNoActiveTrackerStates(t *testing.T, snapshot TrackerUploadSnapshot) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dupe check now uses a metadata preview workflow before starting, ensuring results are generated from the latest prepared data.
  * Improved dupe-check job tracking so in-progress work is handled more reliably during shutdown.
* **Bug Fixes**
  * Clearer, consistent user guidance is shown when metadata preview is missing or when dupe-check metadata can’t be fetched.
  * Dupe-check runs now use the correct captured job state, reducing inconsistent results and startup failures.
* **Tests**
  * Expanded coverage for metadata preview cache behavior and dupe-check job tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->