### PR TITLE
fix(renames): add jellyfin style

### DIFF
--- a/internal/trackers/modified_release.go
+++ b/internal/trackers/modified_release.go
@@ -15,11 +15,11 @@ import (
 // ([Modified Release] Renamed), so detecting it lets us skip the upload before it
 // is rejected. Two independent, deliberately high-signal cases are checked:
 //
-//   - *arr id tokens: Radarr/Sonarr inject "{tmdb-…}", "{imdb-…}", or "{tvdb-…}"
-//     into renamed names (e.g. "Example Release (2026) {imdb-tt1234567}"). These
-//     never occur in an original scene/P2P name, so their presence alone marks a
-//     rename. This is independent of the release group, which an *arr rename
-//     often strips.
+//   - *arr id tokens: Radarr/Sonarr inject "{tmdb-…}", "{imdb-…}", "{tvdb-…}",
+//     jellyfin "[tmdb" style, or bracket/paren variants into renamed names
+//     (e.g. "Example Release (2026) {imdb-tt1234567}"). These never occur in an
+//     original scene/P2P name, so their presence alone marks a rename. This is
+//     independent of the release group, which an *arr rename often strips.
 //
 //   - whitespace renames: a grouped release (a trailing "-GROUP" tag, which
 //     scene/P2P releases always dot-delimit) whose on-disk name has had its dots
@@ -107,7 +107,12 @@ func skipsStandardRenameCheck(group string) bool {
 // arrReleaseIDTokens are the Radarr/Sonarr id-injection tokens that appear in
 // renamed filenames (e.g. "Example Release (2026) {imdb-tt1234567}") and never
 // in an original scene/P2P release name.
-var arrReleaseIDTokens = []string{"{tmdb-", "{imdb-", "{tvdb-"}
+var arrReleaseIDTokens = []string{
+	"{tmdb-", "{imdb-", "{tvdb-",
+	"[tmdb", "(tmdb",
+	"[imdb", "(imdb",
+	"[tvdb", "(tvdb",
+}
 
 // arrRenameToken returns the first *arr id-injection token present in name
 // (case-insensitive), or "" when none is found.

--- a/internal/trackers/modified_release_test.go
+++ b/internal/trackers/modified_release_test.go
@@ -86,6 +86,36 @@ func TestIsRenamedRelease(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "tmdb bracket token is flagged",
+			meta: api.PreparedMetadata{SourcePath: "/data/movies/Example Movie (2026) [tmdb-12345]"},
+			want: true,
+		},
+		{
+			name: "tmdb paren token is flagged",
+			meta: api.PreparedMetadata{SourcePath: "/data/movies/Example Movie (2026) (tmdb-12345)"},
+			want: true,
+		},
+		{
+			name: "imdb bracket token is flagged",
+			meta: api.PreparedMetadata{SourcePath: "/data/movies/Example Movie (2026) [imdb-tt1234567]"},
+			want: true,
+		},
+		{
+			name: "imdb paren token is flagged",
+			meta: api.PreparedMetadata{SourcePath: "/data/movies/Example Movie (2026) (imdb-tt1234567)"},
+			want: true,
+		},
+		{
+			name: "tvdb bracket token is flagged",
+			meta: api.PreparedMetadata{SourcePath: "/data/tv/Example Show (2026) [tvdb-12345]"},
+			want: true,
+		},
+		{
+			name: "tvdb paren token is flagged",
+			meta: api.PreparedMetadata{SourcePath: "/data/tv/Example Show (2026) (tvdb-12345)"},
+			want: true,
+		},
+		{
 			name: "standard rename check skipped for configured group",
 			meta: api.PreparedMetadata{
 				SourcePath: "/data/movies/Example Release 2026 2160p MA WEB-DL DDP5 1 HDR H 265-HiDt",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release detection for renamed or modified items by recognizing more ID-token patterns, including bracketed and parenthesized forms.
  * Reduced false negatives when releases contain injected metadata-style tokens in their names.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->