### PR TITLE
fix(metadata): reduce srrdb tv scene search fanout

### DIFF
--- a/internal/metadata/scene.go
+++ b/internal/metadata/scene.go
@@ -208,12 +208,18 @@ func (d *srrdbDetector) Detect(ctx context.Context, meta api.PreparedMetadata) (
 	imdbID := sceneIMDbID(meta)
 	d.log().Debugf("metadata: scene detection start imdb=%d folders=%d files=%d media_present=%t", imdbID, len(cands.folders), len(cands.files), strings.TrimSpace(cands.mediaFilename) != "")
 
-	// Detection now runs after external-ID resolution (ApplyMediaDetails), so a
-	// resolved IMDb id is normally available. The IMDb-keyed search returns the
-	// full scene release set for the title regardless of filename, which is the
-	// robust primary path. If it yields no confident match (e.g. truncated results
-	// or srrdb not keying the release to this id), fall through to the exact r:
-	// search, which is also the fallback when no IMDb id is known.
+	// For TV releases, a word:<title SxxEyy|Sxx> search is the cheapest
+	// high-signal path and avoids broad IMDb fan-out on long-running shows. TV
+	// detection deliberately skips the IMDb fallback after the word search and
+	// only tries exact r: names; non-TV releases still use IMDb before r:.
+	if result, err := d.detectViaTVWord(ctx, meta, cands); err != nil {
+		return result, err
+	} else if result.IsScene {
+		return result, nil
+	}
+	if isSRRDBTVCategory(meta) {
+		return d.detectViaR(ctx, cands)
+	}
 	if imdbID > 0 {
 		result, err := d.detectViaIMDB(ctx, meta, cands, imdbID)
 		if err != nil {
@@ -226,12 +232,43 @@ func (d *srrdbDetector) Detect(ctx context.Context, meta api.PreparedMetadata) (
 	return d.detectViaR(ctx, cands)
 }
 
+// detectViaTVWord runs the low-fan-out SRRDB word search for parsed TV releases.
+// It returns no match when the metadata cannot form a title/season query. Network
+// and decode failures are soft unless they are context cancellation.
+func (d *srrdbDetector) detectViaTVWord(ctx context.Context, meta api.PreparedMetadata, cands sceneCandidates) (SceneResult, error) {
+	query := srrdbTVWordQuery(meta)
+	if query == "" {
+		return SceneResult{}, nil
+	}
+	d.log().Tracef("metadata: scene word search start query=%q", query)
+	releases, err := d.searchWord(ctx, query)
+	if err != nil {
+		if isContextError(ctx, err) {
+			return SceneResult{}, err
+		}
+		d.log().Debugf("metadata: scene word search soft-failed query=%q: %v", query, err)
+		return SceneResult{}, nil
+	}
+	if len(releases) == 0 {
+		d.log().Debugf("metadata: scene word search no results query=%q", query)
+		return SceneResult{}, nil
+	}
+	d.log().Debugf("metadata: scene word search results query=%q count=%d", query, len(releases))
+
+	best, source := selectSceneRelease(meta, cands, releases)
+	if best == nil {
+		d.log().Debugf("metadata: scene word no confident candidate query=%q candidates=%d folders=%d files=%d", query, len(releases), len(cands.folders), len(cands.files))
+		return SceneResult{}, nil
+	}
+	return d.finishSceneMatch(ctx, cands, *best, source, "word")
+}
+
 // detectViaIMDB lists every scene release for the title, selects the one matching
 // the local folder/filename, then verifies the media filename. Strictly
 // best-effort: every failure returns a no-match (except context cancellation).
 func (d *srrdbDetector) detectViaIMDB(ctx context.Context, meta api.PreparedMetadata, cands sceneCandidates, imdbID int) (SceneResult, error) {
 	d.log().Tracef("metadata: scene imdb search start imdb=%d", imdbID)
-	releases, err := d.fetchIMDBReleases(ctx, imdbID)
+	releases, err := d.fetchIMDBReleases(ctx, meta, imdbID)
 	if err != nil {
 		if isContextError(ctx, err) {
 			return SceneResult{}, err
@@ -309,6 +346,37 @@ func (d *srrdbDetector) searchExactR(ctx context.Context, name string) (srrdbSea
 	}
 	d.log().Tracef("metadata: scene r search candidate=%q results=%d selected=%q", trimmed, len(payload.Results), payload.Results[0].Release)
 	return payload.Results[0], true, nil
+}
+
+// searchWord performs one SRRDB word:<query> search and returns the raw result
+// list. Non-OK HTTP statuses are treated as no results; request and JSON decode
+// failures are returned so the caller can apply the scene-detection soft-fail
+// policy.
+func (d *srrdbDetector) searchWord(ctx context.Context, query string) ([]srrdbSearchResult, error) {
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" {
+		return nil, nil
+	}
+	endpoint := fmt.Sprintf("%s/v1/search/word:%s", strings.TrimRight(d.baseURL, "/"), url.PathEscape(trimmed))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("scene: build word search request: %w", err)
+	}
+	setSRRDBHeaders(req)
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("scene: word search request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		d.log().Tracef("metadata: scene word search query=%q status=%d", trimmed, resp.StatusCode)
+		return nil, nil
+	}
+	var payload srrdbResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("scene: decode word search: %w", err)
+	}
+	return payload.Results, nil
 }
 
 // selectSceneRelease picks the srrdb release that matches the local names, using
@@ -836,17 +904,45 @@ func sceneIMDbID(meta api.PreparedMetadata) int {
 	return 0
 }
 
+// srrdbTVWordQuery builds the low-fan-out TV query SRRDB accepts after word:.
+// It returns "<title> SxxEyy" when an episode is known and "<title> Sxx" when
+// only the season is known. A normalized TV category, title, and season are
+// required so movie-like releases do not take the TV-only path.
+func srrdbTVWordQuery(meta api.PreparedMetadata) string {
+	if !isSRRDBTVCategory(meta) {
+		return ""
+	}
+	title := strings.Join(strings.Fields(meta.Release.Title), " ")
+	if title == "" {
+		return ""
+	}
+	season, episode := meta.SeasonEpisodeWithParsedFallback()
+	if season <= 0 {
+		return ""
+	}
+	if episode <= 0 {
+		return fmt.Sprintf("%s S%02d", title, season)
+	}
+	return fmt.Sprintf("%s S%02dE%02d", title, season, episode)
+}
+
+// isSRRDBTVCategory reports whether scene detection should use TV-specific SRRDB
+// search behavior for the parsed release category.
+func isSRRDBTVCategory(meta api.PreparedMetadata) bool {
+	return api.NormalizeCategory(meta.Release.Category) == api.CategoryTV
+}
+
 // fetchIMDBReleases lists every scene release for an IMDb id via the imdb:
 // search, paginating up to srrdbIMDBMaxPages. The id is a validated integer, so
 // the URL cannot be influenced by parsed metadata (no SSRF surface).
-func (d *srrdbDetector) fetchIMDBReleases(ctx context.Context, imdbID int) ([]srrdbSearchResult, error) {
+func (d *srrdbDetector) fetchIMDBReleases(ctx context.Context, meta api.PreparedMetadata, imdbID int) ([]srrdbSearchResult, error) {
 	if imdbID <= 0 {
 		return nil, nil
 	}
 	all := make([]srrdbSearchResult, 0, srrdbIMDBPageSize)
 	total := -1
 	for page := 1; page <= srrdbIMDBMaxPages; page++ {
-		payload, err := d.fetchIMDBReleasePage(ctx, imdbID, page)
+		payload, err := d.fetchIMDBReleasePage(ctx, meta, imdbID, page)
 		if err != nil {
 			return all, err
 		}
@@ -866,12 +962,12 @@ func (d *srrdbDetector) fetchIMDBReleases(ctx context.Context, imdbID int) ([]sr
 	return all, nil
 }
 
-func (d *srrdbDetector) fetchIMDBReleasePage(ctx context.Context, imdbID, page int) (srrdbIMDBSearchResponse, error) {
+func (d *srrdbDetector) fetchIMDBReleasePage(ctx context.Context, meta api.PreparedMetadata, imdbID, page int) (srrdbIMDBSearchResponse, error) {
 	imdb := formatSRRDBIMDbID(imdbID)
 	if imdb == "" {
 		return srrdbIMDBSearchResponse{}, nil
 	}
-	endpoint := fmt.Sprintf("%s/v1/search/imdb:%s/order:date/page:%d", strings.TrimRight(d.baseURL, "/"), imdb, page)
+	endpoint := fmt.Sprintf("%s/v1/search/imdb:%s%s/order:date/page:%d", strings.TrimRight(d.baseURL, "/"), imdb, srrdbIMDBForeignFilterPath(meta), page)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return srrdbIMDBSearchResponse{}, fmt.Errorf("scene: build imdb search request: %w", err)
@@ -891,6 +987,23 @@ func (d *srrdbDetector) fetchIMDBReleasePage(ctx context.Context, imdbID, page i
 		return srrdbIMDBSearchResponse{}, fmt.Errorf("scene: decode imdb search: %w", err)
 	}
 	return payload, nil
+}
+
+// srrdbIMDBForeignFilterPath narrows the broad imdb: release listing by the
+// parsed release language. Empty or English-only release names search
+// non-foreign entries; any explicit non-English marker searches foreign entries.
+func srrdbIMDBForeignFilterPath(meta api.PreparedMetadata) string {
+	for _, language := range meta.Release.Language {
+		switch strings.ToLower(strings.TrimSpace(language)) {
+		case "":
+			continue
+		case "english", "en", "eng":
+			continue
+		default:
+			return "/foreign:yes"
+		}
+	}
+	return "/foreign:no"
 }
 
 // sceneMediaExtensions are the archive members treated as the primary media file

--- a/internal/metadata/scene_test.go
+++ b/internal/metadata/scene_test.go
@@ -426,17 +426,34 @@ func TestSceneDetectorSRRDBNFOContextCancellationIsFatal(t *testing.T) {
 // srrdbFallbackHandler routes the srrdb endpoints used by the imdb: fallback so
 // tests can drive scene/rename detection without touching the live service.
 type srrdbFallbackHandler struct {
-	imdbPages map[int]string // page -> JSON body for /v1/search/imdb:<id>/...
-	details   map[string]string
-	rResults  map[string]string // r:<name> -> JSON body (name is the unescaped search term)
-	imdbStat  int               // non-zero overrides the imdb: search status code
-	imdbHits  *atomic.Int32     // when set, counts /v1/search/imdb: requests
+	imdbPages   map[int]string // page -> JSON body for /v1/search/imdb:<id>/...
+	details     map[string]string
+	rResults    map[string]string // r:<name> -> JSON body (name is the unescaped search term)
+	wordResults map[string]string // word:<query> -> JSON body (query is the unescaped search term)
+	imdbStat    int               // non-zero overrides the imdb: search status code
+	imdbHits    *atomic.Int32     // when set, counts /v1/search/imdb: requests
+	imdbPaths   *[]string         // when set, captures /v1/search/imdb: request paths
+	wordHits    *atomic.Int32     // when set, counts /v1/search/word: requests
+	wordPaths   *[]string         // when set, captures escaped /v1/search/word: request paths
 }
 
 func (h srrdbFallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	path := r.URL.Path
 	switch {
+	case strings.Contains(path, "/v1/search/word:"):
+		if h.wordHits != nil {
+			h.wordHits.Add(1)
+		}
+		if h.wordPaths != nil {
+			*h.wordPaths = append(*h.wordPaths, r.URL.EscapedPath())
+		}
+		query := path[strings.Index(path, "/v1/search/word:")+len("/v1/search/word:"):]
+		if body, ok := h.wordResults[query]; ok {
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		_, _ = w.Write([]byte(`{"resultsCount":0,"results":[]}`))
 	case strings.Contains(path, "/v1/search/r:"):
 		name := path[strings.Index(path, "/v1/search/r:")+len("/v1/search/r:"):]
 		if body, ok := h.rResults[name]; ok {
@@ -447,6 +464,9 @@ func (h srrdbFallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	case strings.Contains(path, "/v1/search/imdb:"):
 		if h.imdbHits != nil {
 			h.imdbHits.Add(1)
+		}
+		if h.imdbPaths != nil {
+			*h.imdbPaths = append(*h.imdbPaths, path)
 		}
 		if h.imdbStat != 0 {
 			w.WriteHeader(h.imdbStat)
@@ -650,6 +670,256 @@ func TestSceneDetectorIMDBFallbackPaginates(t *testing.T) {
 	}
 	if !result.IsScene || result.SceneName != "Example.Movie.2026.1080p.BluRay.x264-GRP" {
 		t.Fatalf("expected paginated match, got %#v", result)
+	}
+}
+
+func TestSceneDetectorTVWordSearchRunsBeforeIMDBFallback(t *testing.T) {
+	imdbHits := &atomic.Int32{}
+	wordHits := &atomic.Int32{}
+	var wordPaths []string
+	const release = "Example.Show.S02E03.1080p.WEB.h264-GRP"
+	handler := srrdbFallbackHandler{
+		imdbHits:  imdbHits,
+		wordHits:  wordHits,
+		wordPaths: &wordPaths,
+		wordResults: map[string]string{
+			"Example Show S02E03": `{"resultsCount":1,"results":[{"release":"` + release + `","imdbId":"1234567","hasNFO":"no","isForeign":"no"}]}`,
+		},
+		imdbPages: map[int]string{
+			1: `{"resultsCount":1,"results":[{"release":"Example.Show.S02E03.720p.WEB.h264-ALT","imdbId":"1234567"}]}`,
+		},
+		details: map[string]string{
+			release: `{"archived-files":[{"name":"example.show.s02e03.1080p.web.h264-grp.mkv","size":1000000000}]}`,
+		},
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	meta := api.PreparedMetadata{
+		VideoPath:   "/data/" + release + ".mkv",
+		ExternalIDs: api.ExternalIDs{IMDBID: 1234567},
+		Release: api.ReleaseInfo{
+			Category:   "TV",
+			Title:      "Example Show",
+			Season:     2,
+			Episode:    3,
+			Resolution: "1080p",
+			Source:     "Web",
+			Codec:      []string{"H.264"},
+			Group:      "GRP",
+		},
+	}
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if !result.IsScene || result.SceneName != release {
+		t.Fatalf("expected word search match %q, got %#v", release, result)
+	}
+	if got := wordHits.Load(); got != 1 {
+		t.Fatalf("expected one word search, got %d", got)
+	}
+	if got := imdbHits.Load(); got != 0 {
+		t.Fatalf("expected imdb fallback skipped after word match, got %d", got)
+	}
+	if len(wordPaths) != 1 || !strings.Contains(wordPaths[0], "/v1/search/word:Example%20Show%20S02E03") {
+		t.Fatalf("expected word search path for title and episode")
+	}
+}
+
+func TestSceneDetectorTVWordSearchAllowsSeasonOnly(t *testing.T) {
+	imdbHits := &atomic.Int32{}
+	wordHits := &atomic.Int32{}
+	var wordPaths []string
+	const release = "Example.Show.S02.1080p.WEB.h264-GRP"
+	handler := srrdbFallbackHandler{
+		imdbHits:  imdbHits,
+		wordHits:  wordHits,
+		wordPaths: &wordPaths,
+		wordResults: map[string]string{
+			"Example Show S02": `{"resultsCount":1,"results":[{"release":"` + release + `","imdbId":"1234567","hasNFO":"no","isForeign":"no"}]}`,
+		},
+		details: map[string]string{
+			release: `{"archived-files":[{"name":"example.show.s02e01.1080p.web.h264-grp.mkv","size":1000000000}]}`,
+		},
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	meta := api.PreparedMetadata{
+		VideoPath:   "/data/" + release + ".mkv",
+		ExternalIDs: api.ExternalIDs{IMDBID: 1234567},
+		Release: api.ReleaseInfo{
+			Category:   "TV",
+			Title:      "Example Show",
+			Season:     2,
+			Resolution: "1080p",
+			Source:     "Web",
+			Codec:      []string{"H.264"},
+			Group:      "GRP",
+		},
+	}
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if !result.IsScene || result.SceneName != release {
+		t.Fatalf("expected season-only word search match %q, got %#v", release, result)
+	}
+	if got := wordHits.Load(); got != 1 {
+		t.Fatalf("expected one word search, got %d", got)
+	}
+	if got := imdbHits.Load(); got != 0 {
+		t.Fatalf("expected imdb fallback skipped after season-only word match, got %d", got)
+	}
+	if len(wordPaths) != 1 || !strings.Contains(wordPaths[0], "/v1/search/word:Example%20Show%20S02") {
+		t.Fatalf("expected season-only word search path")
+	}
+}
+
+func TestSceneDetectorTVWordMissSkipsIMDBFallback(t *testing.T) {
+	imdbHits := &atomic.Int32{}
+	wordHits := &atomic.Int32{}
+	const release = "Example.Show.S02E03.1080p.WEB.h264-GRP"
+	handler := srrdbFallbackHandler{
+		imdbHits: imdbHits,
+		wordHits: wordHits,
+		rResults: map[string]string{
+			release: `{"resultsCount":1,"results":[{"release":"` + release + `","imdbId":"1234567","hasNFO":"no","isForeign":"no"}]}`,
+		},
+		imdbPages: map[int]string{
+			1: `{"resultsCount":1,"results":[{"release":"Example.Show.S02E03.720p.WEB.h264-ALT","imdbId":"1234567"}]}`,
+		},
+		details: map[string]string{
+			release: `{"archived-files":[{"name":"example.show.s02e03.1080p.web.h264-grp.mkv","size":1000000000}]}`,
+		},
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	meta := api.PreparedMetadata{
+		VideoPath:   "/data/" + release + ".mkv",
+		ExternalIDs: api.ExternalIDs{IMDBID: 1234567},
+		Release: api.ReleaseInfo{
+			Category:   "TV",
+			Title:      "Example Show",
+			Season:     2,
+			Episode:    3,
+			Resolution: "1080p",
+			Source:     "Web",
+			Codec:      []string{"H.264"},
+			Group:      "GRP",
+		},
+	}
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if !result.IsScene || result.SceneName != release {
+		t.Fatalf("expected r fallback match %q, got %#v", release, result)
+	}
+	if got := wordHits.Load(); got != 1 {
+		t.Fatalf("expected one word search, got %d", got)
+	}
+	if got := imdbHits.Load(); got != 0 {
+		t.Fatalf("expected imdb fallback skipped for tv category, got %d", got)
+	}
+}
+
+func TestSceneDetectorIMDBFallbackFiltersForeignWhenLanguageUnknown(t *testing.T) {
+	var imdbPaths []string
+	handler := srrdbFallbackHandler{
+		imdbPaths: &imdbPaths,
+		imdbPages: map[int]string{
+			1: `{"resultsCount":1,"results":[{"release":"Example.Movie.2026.1080p.BluRay.x264-GRP","imdbId":"1234567","hasNFO":"no","isForeign":"no"}]}`,
+		},
+		details: map[string]string{
+			"Example.Movie.2026.1080p.BluRay.x264-GRP": `{"archived-files":[{"name":"example.movie.2026.1080p.bluray.x264-grp.mkv","size":8000000000}]}`,
+		},
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), renamedSceneMeta("/data/Example Movie 2026 1080p BluRay x264 GRP.mkv"))
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if !result.IsScene {
+		t.Fatalf("expected scene match")
+	}
+	if len(imdbPaths) != 1 {
+		t.Fatalf("expected one imdb request, got %d", len(imdbPaths))
+	}
+	if !strings.Contains(imdbPaths[0], "/v1/search/imdb:tt1234567/foreign:no/order:date/page:1") {
+		t.Fatalf("expected foreign:no imdb search path")
+	}
+}
+
+func TestSceneDetectorIMDBFallbackFiltersForeignNoWhenLanguageEnglish(t *testing.T) {
+	var imdbPaths []string
+	handler := srrdbFallbackHandler{
+		imdbPaths: &imdbPaths,
+		imdbPages: map[int]string{
+			1: `{"resultsCount":1,"results":[{"release":"Example.Movie.2026.English.1080p.BluRay.x264-GRP","imdbId":"1234567","hasNFO":"no","isForeign":"no"}]}`,
+		},
+		details: map[string]string{
+			"Example.Movie.2026.English.1080p.BluRay.x264-GRP": `{"archived-files":[{"name":"example.movie.2026.english.1080p.bluray.x264-grp.mkv","size":8000000000}]}`,
+		},
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	meta := renamedSceneMeta("/data/Example Movie 2026 English 1080p BluRay x264 GRP.mkv")
+	meta.Release.Language = []string{"English"}
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if !result.IsScene {
+		t.Fatalf("expected scene match")
+	}
+	if len(imdbPaths) != 1 {
+		t.Fatalf("expected one imdb request, got %d", len(imdbPaths))
+	}
+	if !strings.Contains(imdbPaths[0], "/v1/search/imdb:tt1234567/foreign:no/order:date/page:1") {
+		t.Fatalf("expected foreign:no imdb search path")
+	}
+}
+
+func TestSceneDetectorIMDBFallbackFiltersForeignYesWhenLanguageNonEnglish(t *testing.T) {
+	var imdbPaths []string
+	handler := srrdbFallbackHandler{
+		imdbPaths: &imdbPaths,
+		imdbPages: map[int]string{
+			1: `{"resultsCount":1,"results":[{"release":"Example.Movie.2026.German.1080p.BluRay.x264-GRP","imdbId":"1234567","hasNFO":"no","isForeign":"yes"}]}`,
+		},
+		details: map[string]string{
+			"Example.Movie.2026.German.1080p.BluRay.x264-GRP": `{"archived-files":[{"name":"example.movie.2026.german.1080p.bluray.x264-grp.mkv","size":8000000000}]}`,
+		},
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	meta := renamedSceneMeta("/data/Example Movie 2026 German 1080p BluRay x264 GRP.mkv")
+	meta.Release.Language = []string{"German"}
+	detector := newSRRDBDetector(server.Client(), server.URL, t.TempDir(), t.TempDir())
+	result, err := detector.Detect(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("Detect error: %v", err)
+	}
+	if !result.IsScene {
+		t.Fatalf("expected scene match")
+	}
+	if len(imdbPaths) != 1 {
+		t.Fatalf("expected one imdb request, got %d", len(imdbPaths))
+	}
+	if !strings.Contains(imdbPaths[0], "/v1/search/imdb:tt1234567/foreign:yes/order:date/page:1") {
+		t.Fatalf("expected foreign:yes imdb search path")
 	}
 }
 


### PR DESCRIPTION
found a case where imdb search simply did not return any recent results for a reasonably long running show.

word:Title SxxExx should be reasonably robust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved TV release detection with an additional search path that can find matches faster and more accurately.
  * Added smarter handling for release-language matching when searching for titles.

* **Bug Fixes**
  * TV releases now avoid unnecessary fallback searches when a direct TV match is available.
  * Search results are now more reliable when language information is missing, English-only, or non-English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->