### PR TITLE
fix(metadata): harden hdr detection

### DIFF
--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -1369,9 +1369,11 @@ func uhdFromMeta(meta api.PreparedMetadata) string {
 	return ""
 }
 
-// hdrFromMedia prefers BDInfo and MediaInfo HDR evidence, normalizing bare PQ
-// transfer metadata to HDR for tracker naming, then falls back to normalized
-// filename tokens from the current source path or parsed release.
+// hdrFromMedia prefers BDInfo and MediaInfo HDR evidence, including Dolby
+// Vision HDR10/HDR10+ compatibility markers, then falls back to normalized
+// filename tokens from the current source path or parsed release. Bare PQ
+// transfer metadata is normalized to HDR only when BT.2020 primaries confirm
+// the HDR color space.
 func hdrFromMedia(doc mediaInfoDoc, bdinfo *discparse.BDInfo, meta api.PreparedMetadata) string {
 	if bdinfo != nil && len(bdinfo.Video) > 0 {
 		hdr := ""
@@ -1401,31 +1403,31 @@ func hdrFromMedia(doc mediaInfoDoc, bdinfo *discparse.BDInfo, meta api.PreparedM
 	primariesUpper := strings.ToUpper(primaries)
 	hdr := ""
 	dv := ""
-	if primariesUpper == "BT.2020" || primariesUpper == "REC.2020" {
-		compat := trackString(track, "HDR_Format_Compatibility")
-		formatStr := trackString(track, "HDR_Format_String")
-		format := trackString(track, "HDR_Format")
-		hdrFormat := metautil.FirstNonEmptyTrimmed(compat, formatStr, format)
-		upperFormat := strings.ToUpper(hdrFormat)
-		switch {
-		case strings.Contains(upperFormat, "HDR10+"):
-			hdr = "HDR10+"
-		case strings.Contains(upperFormat, "HDR10") || strings.Contains(upperFormat, "SMPTE ST 2094"):
-			hdr = "HDR"
-		}
-		if strings.Contains(upperFormat, "HLG") {
-			hdr = strings.TrimSpace(hdr + " HLG")
-		}
-		transfer := trackString(track, "transfer_characteristics", "transfer_characteristics_Original")
-		if hdrFormat == "" && strings.Contains(strings.ToUpper(transfer), "PQ") {
-			hdr = "HDR"
-		}
-		if strings.Contains(strings.ToUpper(transfer), "HLG") {
-			hdr = "HLG"
-		}
-		if hdr != "HLG" && strings.Contains(strings.ToUpper(transfer), "BT.2020 (10-BIT)") {
-			hdr = "WCG"
-		}
+	formatEvidence := strings.Join([]string{
+		trackString(track, "HDR_Format_Compatibility"),
+		trackString(track, "HDR_Format_String"),
+		trackString(track, "HDR_Format"),
+	}, " ")
+	upperFormat := strings.ToUpper(formatEvidence)
+	switch {
+	case strings.Contains(upperFormat, "HDR10+"):
+		hdr = "HDR10+"
+	case strings.Contains(upperFormat, "HDR10") || strings.Contains(upperFormat, "SMPTE ST 2094"):
+		hdr = "HDR"
+	}
+	if strings.Contains(upperFormat, "HLG") {
+		hdr = strings.TrimSpace(hdr + " HLG")
+	}
+	transfer := trackString(track, "transfer_characteristics", "transfer_characteristics_Original")
+	transferUpper := strings.ToUpper(transfer)
+	if (primariesUpper == "BT.2020" || primariesUpper == "REC.2020") && strings.TrimSpace(formatEvidence) == "" && strings.Contains(transferUpper, "PQ") {
+		hdr = "HDR"
+	}
+	if strings.Contains(transferUpper, "HLG") {
+		hdr = "HLG"
+	}
+	if hdr != "HLG" && strings.Contains(transferUpper, "BT.2020 (10-BIT)") {
+		hdr = "WCG"
 	}
 	if strings.Contains(trackString(track, "HDR_Format"), "Dolby Vision") || strings.Contains(trackString(track, "HDR_Format_String"), "Dolby Vision") {
 		dv = "DV"

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -544,6 +544,90 @@ func TestHDRFromMediaNormalizesPQTransferToHDR(t *testing.T) {
 	}
 }
 
+func TestHDRFromMediaDetectsDolbyVisionHDR10Compatibility(t *testing.T) {
+	doc, err := loadMediaInfoDocFromJSONPayload(`{"media":{"track":[{"@type":"General"},{"@type":"Video","HDR_Format":"Dolby Vision","HDR_Format_String":"Dolby Vision, Version 1.0, Profile 8.1, dvhe.08.06, BL+RPU, no metadata compression, HDR10 compatible"}]}}`)
+	if err != nil {
+		t.Fatalf("parse mediainfo: %v", err)
+	}
+
+	got := hdrFromMedia(doc, nil, api.PreparedMetadata{})
+	if got != "DV HDR" {
+		t.Fatalf("expected Dolby Vision HDR10 compatibility to normalize to DV HDR, got %q", got)
+	}
+}
+
+func TestHDRFromMediaDetectsDolbyVisionHDR10PlusCompatibility(t *testing.T) {
+	doc, err := loadMediaInfoDocFromJSONPayload(`{"media":{"track":[{"@type":"General"},{"@type":"Video","HDR_Format":"Dolby Vision","HDR_Format_String":"Dolby Vision, Version 1.0, Profile 8.1, dvhe.08.06, BL+RPU, no metadata compression, HDR10 compatible / SMPTE ST 2094 App 4, Version 1, HDR10+ Profile B compatible"}]}}`)
+	if err != nil {
+		t.Fatalf("parse mediainfo: %v", err)
+	}
+
+	got := hdrFromMedia(doc, nil, api.PreparedMetadata{})
+	if got != "DV HDR10+" {
+		t.Fatalf("expected Dolby Vision HDR10+ compatibility to normalize to DV HDR10+, got %q", got)
+	}
+}
+
+func TestHDRFromMediaDetectsDolbyVisionOnly(t *testing.T) {
+	doc, err := loadMediaInfoDocFromJSONPayload(`{"media":{"track":[{"@type":"General"},{"@type":"Video","HDR_Format_String":"Dolby Vision, Version 1.0, Profile 5"}]}}`)
+	if err != nil {
+		t.Fatalf("parse mediainfo: %v", err)
+	}
+
+	got := hdrFromMedia(doc, nil, api.PreparedMetadata{})
+	if got != "DV" {
+		t.Fatalf("expected Dolby Vision metadata to normalize to DV, got %q", got)
+	}
+}
+
+func TestHDRFromMediaDetectsSMPTE2094AsHDR(t *testing.T) {
+	doc, err := loadMediaInfoDocFromJSONPayload(`{"media":{"track":[{"@type":"General"},{"@type":"Video","colour_primaries":"BT.2020","HDR_Format_String":"SMPTE ST 2094 App 4, Version 1"}]}}`)
+	if err != nil {
+		t.Fatalf("parse mediainfo: %v", err)
+	}
+
+	got := hdrFromMedia(doc, nil, api.PreparedMetadata{})
+	if got != "HDR" {
+		t.Fatalf("expected SMPTE ST 2094 metadata to normalize to HDR, got %q", got)
+	}
+}
+
+func TestHDRFromMediaDetectsHLGFormat(t *testing.T) {
+	doc, err := loadMediaInfoDocFromJSONPayload(`{"media":{"track":[{"@type":"General"},{"@type":"Video","colour_primaries":"BT.2020","HDR_Format_String":"HLG"}]}}`)
+	if err != nil {
+		t.Fatalf("parse mediainfo: %v", err)
+	}
+
+	got := hdrFromMedia(doc, nil, api.PreparedMetadata{})
+	if got != "HLG" {
+		t.Fatalf("expected HLG format metadata to normalize to HLG, got %q", got)
+	}
+}
+
+func TestHDRFromMediaDetectsHLGTransfer(t *testing.T) {
+	doc, err := loadMediaInfoDocFromJSONPayload(`{"media":{"track":[{"@type":"General"},{"@type":"Video","colour_primaries":"BT.2020","transfer_characteristics":"HLG"}]}}`)
+	if err != nil {
+		t.Fatalf("parse mediainfo: %v", err)
+	}
+
+	got := hdrFromMedia(doc, nil, api.PreparedMetadata{})
+	if got != "HLG" {
+		t.Fatalf("expected HLG transfer metadata to normalize to HLG, got %q", got)
+	}
+}
+
+func TestHDRFromMediaDetectsBT2020TransferAsWCG(t *testing.T) {
+	doc, err := loadMediaInfoDocFromJSONPayload(`{"media":{"track":[{"@type":"General"},{"@type":"Video","colour_primaries":"BT.2020","transfer_characteristics_Original":"BT.2020 (10-bit)"}]}}`)
+	if err != nil {
+		t.Fatalf("parse mediainfo: %v", err)
+	}
+
+	got := hdrFromMedia(doc, nil, api.PreparedMetadata{})
+	if got != "WCG" {
+		t.Fatalf("expected BT.2020 transfer metadata to normalize to WCG, got %q", got)
+	}
+}
+
 func TestHDRFromMediaPrefersBDInfoOverFilenameHDR(t *testing.T) {
 	got := hdrFromMedia(mediaInfoDoc{}, &discparse.BDInfo{
 		Video: []discparse.BDVideo{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HDR detection for video files, making metadata more accurate for Dolby Vision, HDR10+, HLG, and other HDR formats.
  * Better handling of color and transfer metadata now helps distinguish HDR from wide-color-gamut content more reliably.

* **Tests**
  * Added coverage for several HDR and color-format cases to help prevent regressions in media metadata detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->