### PR TITLE
fix(cli): if no dupes are found don't display all search results

### DIFF
--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -1331,9 +1331,6 @@ func printDupeResult(result api.DupeCheckResult) {
 		fmt.Printf("- %s\n", note)
 	}
 	entries := result.Filtered
-	if len(entries) == 0 {
-		entries = result.Raw
-	}
 	for _, entry := range entries {
 		if entry.Name == "" {
 			continue


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated duplicate-result output so only filtered entries are shown.
  * When no filtered entries are available, no entry lines are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->