### PR TITLE
fix: dvd screens handling with menus functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Have these ready:
 - image host credentials
 - torrent client details or watch-folder paths
 - existing Upload Assistant `config.py`, if migrating
-- ffmpeg installed on your system for screenshot generation
-    - On Windows, ffmpeg must be added to PATH (https://windowsloop.com/install-ffmpeg-windows-10/)
+- FFmpeg installed on your system for screenshot generation
+    - On Windows, FFmpeg must be added to `PATH`
     - On Linux, install it from your distribution package manager
     - On macOS, install it with Homebrew:
 
@@ -40,6 +40,7 @@ Have these ready:
       ```
 
       The CLI can find ffmpeg when your shell PATH includes Homebrew. If you start the GUI from Finder, macOS may not pass your shell PATH to the app, so the GUI may not see Homebrew's ffmpeg. Start the GUI from Terminal, or make ffmpeg available in the environment used to launch the app.
+    - Automatic DVD menu screenshots need an FFmpeg build whose `dvdvideo` demuxer exposes `menu`, `menu_lu`, `menu_vts`, `pgc`, and `pg`. A version number alone does not prove this capability. upbrr checks the selected FFmpeg at runtime; see [FFmpeg's dvdvideo documentation](https://ffmpeg.org/ffmpeg-formats.html#dvdvideo).
 
 By default, upbrr stores its database at:
 
@@ -233,6 +234,22 @@ Useful CLI checks:
 ```
 
 NOTE: with cli `--debug` works as expected. Additionally, the printed feedback (even with debug) can be adjusted with `--log-level`. See `upbrr.exe --help`
+
+### Automatic DVD Menu Screenshots
+
+Automatic DVD menu capture is opt-in. It accepts an extracted DVD directory containing `VIDEO_TS`, or the `VIDEO_TS` directory itself. ISO images, optical drives, and Blu-ray menus are not automatic-capture inputs in this version.
+
+CLI example:
+
+```powershell
+.\upbrr.exe --get-dvd-menus "D:\releases\Example.Release.2026.DVD-GRP"
+```
+
+In the GUI or web UI, fetch DVD metadata, then open **Disc Menus** and start automatic capture. Manual Disc Menu image import remains available for DVD, BDMV, and HDDVD sources. `screenshot_handling.max_menu_items` controls the maximum stored automatic menu images; the default is `6` and the supported range is `1` to `32`.
+
+The FFmpeg capability check must find the `dvdvideo` demuxer and all required menu-coordinate options. If it does not, capture stops with an explicit capability error instead of sampling menu VOB files. Application Details shows the embedded Go DVD engine version, FFmpeg version, and menu-capability status without exposing local executable paths.
+
+upbrr does not include CSS decryption or bundle `libdvdcss`. Encrypted/protected, unreadable, region-restricted, or corrupt inputs may fail. Use only media you are legally permitted to process; extract/decrypt it outside upbrr where allowed.
 
 ### Run with Docker Compose
 

--- a/cmd/upbrr/cli_options.go
+++ b/cmd/upbrr/cli_options.go
@@ -111,6 +111,7 @@ type cliOptions struct {
 	Comparison            string
 	ComparisonIndex       int
 	MenuImages            string
+	GetDVDMenus           bool
 	InfoHash              string
 	MaxPieceSize          int
 	NoHash                bool
@@ -256,6 +257,7 @@ func parseCLIOptions(args []string) (cliOptions, map[string]bool, []string, erro
 	fs.IntVar(&opts.ComparisonIndex, "comparison_index", 0, "Primary comparison index")
 	fs.IntVar(&opts.ComparisonIndex, "comps_index", 0, "Primary comparison index")
 	fs.StringVar(&opts.MenuImages, "menu-images", "", "Path to manually captured disc menu screenshots (Disc releases only)")
+	fs.BoolVar(&opts.GetDVDMenus, "get-dvd-menus", false, "Capture distinct menus from an extracted DVD VIDEO_TS (requires compatible FFmpeg)")
 	fs.StringVar(&opts.InfoHash, "torrenthash", "", "Reuse an existing torrent info hash")
 	fs.StringVar(&opts.InfoHash, "th", "", "Reuse an existing torrent info hash")
 	fs.StringVar(&opts.InfoHash, "infohash", "", "Override v1 info hash")
@@ -621,7 +623,7 @@ func cliHelpSections(name string) []helpSection {
 			"commentary", "personalrelease", "stream", "webdv", "not-anime", "anon", "draft", "modq", "channel",
 		}},
 		{title: "Screenshots and Images", names: []string{
-			"screens", "manual_frames", "comparison", "comparison_index", "menu-images", "imghost", "skip-imagehost-upload",
+			"screens", "manual_frames", "comparison", "comparison_index", "menu-images", "get-dvd-menus", "imghost", "skip-imagehost-upload",
 			"descfile", "desclink",
 		}},
 		{title: "Client and Torrent", names: []string{
@@ -731,6 +733,7 @@ func buildCLIRequest(opts cliOptions, visited map[string]bool, paths []string, s
 			SkipAutoTorrent: opts.SkipAutoTorrent,
 			KeepFolder:      opts.KeepFolder,
 			OnlyID:          opts.OnlyID,
+			CaptureDVDMenus: opts.GetDVDMenus,
 			InteractionMode: opts.interactionMode(),
 		},
 		ReleaseNameOverrides: buildReleaseNameOverrides(visited, releaseOverrideInput{

--- a/cmd/upbrr/cli_options_test.go
+++ b/cmd/upbrr/cli_options_test.go
@@ -615,6 +615,23 @@ func TestBuildCLIRequestSkipAutoTorrent(t *testing.T) {
 	}
 }
 
+func TestBuildCLIRequestCaptureDVDMenus(t *testing.T) {
+	opts, visited, paths, err := parseCLIOptions([]string{"--get-dvd-menus", "Example.Release.2026.1080p-GRP"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !visited["get-dvd-menus"] {
+		t.Fatalf("expected get-dvd-menus visited, got %#v", visited)
+	}
+	req, err := buildCLIRequest(opts, visited, paths, 4)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if !req.Options.CaptureDVDMenus {
+		t.Fatalf("expected capture option, got %#v", req.Options)
+	}
+}
+
 func TestBuildCLIRequestKeepFolder(t *testing.T) {
 	opts, visited, paths, err := parseCLIOptions([]string{"-kf", "movie-folder"})
 	if err != nil {

--- a/cmd/upbrr/cli_tracker_auth_default.go
+++ b/cmd/upbrr/cli_tracker_auth_default.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build !e2e
+
+package main
+
+import (
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackerauth"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+// newCLITrackerAuthService returns the production tracker-auth implementation.
+func newCLITrackerAuthService(cfg config.Config, logger api.Logger) cliTrackerAuthService {
+	return trackerauth.NewServiceWithLogger(cfg, logger)
+}

--- a/cmd/upbrr/cli_tracker_auth_e2e.go
+++ b/cmd/upbrr/cli_tracker_auth_e2e.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build e2e
+
+package main
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackerauth"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+const cliE2EFakeServicesEnv = "UPBRR_E2E_FAKE_SERVICES"
+
+// newCLITrackerAuthService returns the network-free auth seam only when the
+// e2e build and fake-services environment gate are both active.
+func newCLITrackerAuthService(cfg config.Config, logger api.Logger) cliTrackerAuthService {
+	value := strings.TrimSpace(os.Getenv(cliE2EFakeServicesEnv))
+	if value == "1" || strings.EqualFold(value, "true") {
+		return e2eCLITrackerAuthService{}
+	}
+	return trackerauth.NewServiceWithLogger(cfg, logger)
+}
+
+// e2eCLITrackerAuthService treats tracker auth as configured without network IO.
+type e2eCLITrackerAuthService struct{}
+
+// Capabilities exposes no managed tracker-auth workflows to fake-services E2E runs.
+func (e2eCLITrackerAuthService) Capabilities(context.Context) ([]api.TrackerAuthCapability, error) {
+	return nil, nil
+}
+
+// Validate returns configured state without contacting the tracker.
+func (e2eCLITrackerAuthService) Validate(_ context.Context, trackerID string) (api.TrackerAuthStatus, error) {
+	return api.TrackerAuthStatus{TrackerID: strings.ToUpper(strings.TrimSpace(trackerID)), State: trackerauth.StateConfigured}, nil
+}
+
+// Submit2FA completes the fake challenge without external IO.
+func (e2eCLITrackerAuthService) Submit2FA(context.Context, string, string) (api.TrackerAuthStatus, error) {
+	return api.TrackerAuthStatus{State: trackerauth.StateConfigured}, nil
+}

--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -193,7 +193,7 @@ func runInteractiveCLIPathWithInputAndLogger(ctx context.Context, coreSvc api.Co
 			return err
 		}
 	}
-	if err := prepareCLIImages(ctx, coreSvc, req, logger); err != nil {
+	if err := prepareCLIImages(ctx, coreSvc, req, logger, false); err != nil {
 		return err
 	}
 

--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -193,6 +193,9 @@ func runInteractiveCLIPathWithInputAndLogger(ctx context.Context, coreSvc api.Co
 			return err
 		}
 	}
+	if err := prepareCLIImages(ctx, coreSvc, req, logger); err != nil {
+		return err
+	}
 
 	review, err := coreSvc.BuildUploadReview(ctx, req)
 	if err != nil {
@@ -332,7 +335,7 @@ func ensureCLITrackerAuthBeforeDupeCheckWithLogger(ctx context.Context, reader *
 		return trackerNames, nil
 	}
 	logger = cliAuthLogger(logger)
-	return ensureCLITrackerAuthBeforeDupeCheckWithServiceAndLogger(ctx, reader, trackerauth.NewServiceWithLogger(cfg, logger), req, trackerNames, preview, logger)
+	return ensureCLITrackerAuthBeforeDupeCheckWithServiceAndLogger(ctx, reader, newCLITrackerAuthService(cfg, logger), req, trackerNames, preview, logger)
 }
 
 // ensureCLITrackerAuthBeforeDupeCheckWithService is the injectable form of

--- a/cmd/upbrr/interactive_test.go
+++ b/cmd/upbrr/interactive_test.go
@@ -21,6 +21,25 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+var errSyntheticDVDMenuCapture = errors.New("synthetic DVD menu capture failure")
+
+func assertDVDMenuCaptureError(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected DVD menu capture failure")
+	}
+	if !strings.Contains(err.Error(), "upbrr: capture DVD menus") {
+		t.Fatal("DVD menu capture error is missing operation context")
+	}
+	if !strings.Contains(err.Error(), errSyntheticDVDMenuCapture.Error()) {
+		t.Fatal("DVD menu capture error is missing the underlying cause")
+	}
+	if !errors.Is(err, errSyntheticDVDMenuCapture) {
+		t.Fatal("DVD menu capture error does not wrap the underlying cause")
+	}
+}
+
 func TestRunInteractiveCLIPathReturnsNilAfterSuccessfulUpload(t *testing.T) {
 	t.Parallel()
 
@@ -61,6 +80,100 @@ func TestRunInteractiveCLIPathHandlesScreenshotsBeforeReview(t *testing.T) {
 	}
 	if len(coreSvc.savedFinalImages) != 1 || coreSvc.savedFinalImages[0].Path != "screen1.png" {
 		t.Fatalf("expected generated final screenshot saved, got %#v", coreSvc.savedFinalImages)
+	}
+}
+
+func TestRunInteractiveCLIPathCapturesDVDMenusBeforeReview(t *testing.T) {
+	t.Parallel()
+
+	discRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(discRoot, "VIDEO_TS"), 0o700); err != nil {
+		t.Fatalf("create VIDEO_TS: %v", err)
+	}
+	coreSvc := &cliCoreForTest{
+		dvdMenuResult: api.DVDMenuCaptureResult{
+			Images:   []api.DVDMenuCaptureImage{{ScreenshotImage: api.ScreenshotImage{Path: "dvd-menu.png", Purpose: api.ScreenshotPurposeMenu}}},
+			Complete: true,
+		},
+		review: api.UploadReview{Trackers: []api.TrackerReview{{Tracker: "BLU"}}},
+	}
+	err := runInteractiveCLIPath(context.Background(), coreSvc, cliOptions{Unattended: true, GetDVDMenus: true}, map[string]bool{}, discRoot, config.Config{
+		Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+	})
+	if err != nil {
+		t.Fatalf("runInteractiveCLIPath: %v", err)
+	}
+	if got := strings.Join(coreSvc.callOrder, ","); got != "preview,dupes,screenshot-plan,capture-dvd-menus,review" {
+		t.Fatalf("capture order = %s", got)
+	}
+	if coreSvc.dvdMenuCaptureCalls != 1 {
+		t.Fatalf("capture calls = %d, want 1", coreSvc.dvdMenuCaptureCalls)
+	}
+}
+
+func TestRunInteractiveCLIPathDVDMenuCaptureFailureStopsBeforeReview(t *testing.T) {
+	t.Parallel()
+
+	discRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(discRoot, "VIDEO_TS"), 0o700); err != nil {
+		t.Fatalf("create VIDEO_TS: %v", err)
+	}
+	coreSvc := &cliCoreForTest{
+		dvdMenuErr: errSyntheticDVDMenuCapture,
+		review:     api.UploadReview{Trackers: []api.TrackerReview{{Tracker: "BLU"}}},
+	}
+	err := runInteractiveCLIPath(context.Background(), coreSvc, cliOptions{Unattended: true, GetDVDMenus: true}, map[string]bool{}, discRoot, config.Config{
+		Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+	})
+
+	assertDVDMenuCaptureError(t, err)
+	if got := strings.Join(coreSvc.callOrder, ","); got != "preview,dupes,screenshot-plan,capture-dvd-menus" {
+		t.Fatalf("capture failure call order = %s", got)
+	}
+	if coreSvc.runUploadPreparedCalls != 0 {
+		t.Fatalf("upload calls after capture failure = %d, want 0", coreSvc.runUploadPreparedCalls)
+	}
+}
+
+func TestRunInteractiveCLIPathExplicitDryRunCapturesDVDMenus(t *testing.T) {
+	t.Parallel()
+
+	discRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(discRoot, "VIDEO_TS"), 0o700); err != nil {
+		t.Fatalf("create VIDEO_TS: %v", err)
+	}
+	coreSvc := &cliCoreForTest{
+		dvdMenuResult: api.DVDMenuCaptureResult{
+			Images: []api.DVDMenuCaptureImage{{ScreenshotImage: api.ScreenshotImage{Path: "dvd-menu.png", Purpose: api.ScreenshotPurposeMenu}}},
+		},
+		review: api.UploadReview{Trackers: []api.TrackerReview{{Tracker: "BLU"}}},
+	}
+	err := runInteractiveCLIPath(context.Background(), coreSvc, cliOptions{Unattended: true, DryRun: true, GetDVDMenus: true}, map[string]bool{}, discRoot, config.Config{
+		Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+	})
+	if err != nil {
+		t.Fatalf("runInteractiveCLIPath: %v", err)
+	}
+	if got := strings.Join(coreSvc.callOrder, ","); got != "preview,dupes,capture-dvd-menus,review" {
+		t.Fatalf("dry-run capture order = %s", got)
+	}
+}
+
+func TestRunInteractiveCLIPathSkipsNonDVDMenuCapture(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &cliCoreForTest{review: api.UploadReview{Trackers: []api.TrackerReview{{Tracker: "BLU"}}}}
+	err := runInteractiveCLIPath(context.Background(), coreSvc, cliOptions{Unattended: true, GetDVDMenus: true}, map[string]bool{}, t.TempDir(), config.Config{
+		Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"BLU"}},
+	})
+	if err != nil {
+		t.Fatalf("runInteractiveCLIPath: %v", err)
+	}
+	if coreSvc.dvdMenuCaptureCalls != 0 {
+		t.Fatalf("non-DVD capture calls = %d", coreSvc.dvdMenuCaptureCalls)
+	}
+	if got := strings.Join(coreSvc.callOrder, ","); got != "preview,dupes,screenshot-plan,review" {
+		t.Fatalf("non-DVD call order = %s", got)
 	}
 }
 
@@ -1807,6 +1920,10 @@ type cliCoreForTest struct {
 	screenshotPlan         api.ScreenshotPlan
 	screenshotResult       api.ScreenshotResult
 	savedFinalImages       []api.ScreenshotImage
+	dvdMenuResult          api.DVDMenuCaptureResult
+	dvdMenuErr             error
+	dvdMenuCaptureCalls    int
+	importMenuCalls        int
 	playlistSelectionErr   error
 	playlists              []api.PlaylistInfo
 	savedPlaylists         []string
@@ -2020,7 +2137,25 @@ func (c *cliCoreForTest) DeleteUploadedImage(context.Context, api.Request, strin
 	return nil
 }
 
-func (c *cliCoreForTest) ImportMenuImages(context.Context, api.Request, []string) error {
+func (c *cliCoreForTest) ImportMenuImages(_ context.Context, req api.Request, _ []string) error {
+	c.callOrder = append(c.callOrder, "import-menu-images")
+	c.recordRequest("import-menu-images", req)
+	c.importMenuCalls++
+	return nil
+}
+
+func (c *cliCoreForTest) CaptureDVDMenus(_ context.Context, req api.Request) (api.DVDMenuCaptureResult, error) {
+	c.callOrder = append(c.callOrder, "capture-dvd-menus")
+	c.recordRequest("capture-dvd-menus", req)
+	c.dvdMenuCaptureCalls++
+	return c.dvdMenuResult, c.dvdMenuErr
+}
+
+func (c *cliCoreForTest) ListDVDMenuScreenshots(context.Context, api.Request) ([]api.ScreenshotImage, error) {
+	return nil, nil
+}
+
+func (c *cliCoreForTest) DeleteDVDMenuScreenshot(context.Context, api.Request, string) error {
 	return nil
 }
 

--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -339,7 +339,7 @@ func runCLIUploadOnlyBatch(ctx context.Context, coreSvc api.Core, uploadReq api.
 	if err != nil {
 		return exitError(1, err)
 	}
-	if err := prepareCLIImages(uploadCtx, coreSvc, preparedReq, logger); err != nil {
+	if err := prepareCLIImages(uploadCtx, coreSvc, preparedReq, logger, true); err != nil {
 		return exitError(1, err)
 	}
 	if debug {
@@ -372,7 +372,7 @@ func runCLIUploadOnlyQueue(ctx context.Context, coreSvc api.Core, uploadReq api.
 		if err != nil {
 			return err
 		}
-		if err := prepareCLIImages(itemCtx, coreSvc, preparedReq, logger); err != nil {
+		if err := prepareCLIImages(itemCtx, coreSvc, preparedReq, logger, false); err != nil {
 			return err
 		}
 		if debug {
@@ -415,8 +415,9 @@ func runCLIUploadOnlyQueue(ctx context.Context, coreSvc api.Core, uploadReq api.
 
 // prepareCLIImages imports manual menu paths and optionally captures automatic
 // DVD menus for each request path before review or upload. Non-DVD paths are
-// skipped without invoking capture.
-func prepareCLIImages(ctx context.Context, coreSvc api.Core, req api.Request, logger api.Logger) error {
+// skipped without invoking capture. Batch callers can continue after an empty
+// successful capture while retaining errors from CaptureDVDMenus.
+func prepareCLIImages(ctx context.Context, coreSvc api.Core, req api.Request, logger api.Logger, continueOnEmptyCapture bool) error {
 	if coreSvc == nil {
 		return errors.New("upbrr: core service is required")
 	}
@@ -458,7 +459,14 @@ func prepareCLIImages(ctx context.Context, coreSvc api.Core, req api.Request, lo
 			return fmt.Errorf("upbrr: capture DVD menus: %w", err)
 		}
 		if len(result.Images) == 0 {
-			return errors.New("upbrr: capture DVD menus: no menu images captured")
+			if !continueOnEmptyCapture {
+				return errors.New("upbrr: capture DVD menus: no menu images captured")
+			}
+			logger.Errorf(
+				"DVD menus: capture failed source=%s decision=continue reason=no_images",
+				formatPathLabel(sourcePath),
+			)
+			continue
 		}
 		if result.Partial {
 			logger.Warnf(

--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -314,7 +314,7 @@ func run() error {
 		if queueMode {
 			return runCLIUploadOnlyQueue(ctx, coreSvc, uploadReq, paths, opts.Debug, logger)
 		}
-		return runCLIUploadOnlyBatch(ctx, coreSvc, uploadReq, paths, opts.Debug)
+		return runCLIUploadOnlyBatch(ctx, coreSvc, uploadReq, paths, opts.Debug, logger)
 	}
 
 	queueMode := strings.TrimSpace(opts.QueueName) != ""
@@ -331,12 +331,15 @@ func run() error {
 // semantics) under a deadline budgeted by item count but capped at
 // cliUploadOnlyTimeoutCap items so a large path list cannot create an
 // effectively unbounded run-wide timeout.
-func runCLIUploadOnlyBatch(ctx context.Context, coreSvc api.Core, uploadReq api.Request, paths []string, debug bool) error {
+func runCLIUploadOnlyBatch(ctx context.Context, coreSvc api.Core, uploadReq api.Request, paths []string, debug bool, logger api.Logger) error {
 	budgetItems := min(max(1, len(paths)), cliUploadOnlyTimeoutCap)
 	uploadCtx, uploadCancel := context.WithTimeout(ctx, time.Duration(budgetItems)*cliItemTimeout)
 	defer uploadCancel()
 	preparedReq, err := prepareCLIUploadMetadata(uploadCtx, coreSvc, uploadReq)
 	if err != nil {
+		return exitError(1, err)
+	}
+	if err := prepareCLIImages(uploadCtx, coreSvc, preparedReq, logger); err != nil {
 		return exitError(1, err)
 	}
 	if debug {
@@ -367,6 +370,9 @@ func runCLIUploadOnlyQueue(ctx context.Context, coreSvc api.Core, uploadReq api.
 		itemReq.Paths = []string{sourcePath}
 		preparedReq, err := prepareCLIUploadMetadata(itemCtx, coreSvc, itemReq)
 		if err != nil {
+			return err
+		}
+		if err := prepareCLIImages(itemCtx, coreSvc, preparedReq, logger); err != nil {
 			return err
 		}
 		if debug {
@@ -405,6 +411,72 @@ func runCLIUploadOnlyQueue(ctx context.Context, coreSvc api.Core, uploadReq api.
 		logger.Infof("queue: upload-only completed, %d tracker upload(s) accepted", uploaded)
 	}
 	return err
+}
+
+// prepareCLIImages imports manual menu paths and optionally captures automatic
+// DVD menus for each request path before review or upload. Non-DVD paths are
+// skipped without invoking capture.
+func prepareCLIImages(ctx context.Context, coreSvc api.Core, req api.Request, logger api.Logger) error {
+	if coreSvc == nil {
+		return errors.New("upbrr: core service is required")
+	}
+	if logger == nil {
+		logger = api.NopLogger{}
+	}
+	if len(req.Paths) == 0 {
+		return internalerrors.ErrInvalidInput
+	}
+
+	for _, sourcePath := range req.Paths {
+		singleReq := req
+		singleReq.Paths = []string{sourcePath}
+		if len(singleReq.ScreenshotOverrides.MenuPaths) > 0 {
+			if err := coreSvc.ImportMenuImages(ctx, singleReq, singleReq.ScreenshotOverrides.MenuPaths); err != nil {
+				return fmt.Errorf("upbrr: import menu images: %w", err)
+			}
+		}
+		if !singleReq.Options.CaptureDVDMenus {
+			continue
+		}
+
+		discType, err := filesystem.DetectDiscType(ctx, sourcePath)
+		if err != nil {
+			return fmt.Errorf("upbrr: detect DVD menu source: %w", err)
+		}
+		if !strings.EqualFold(strings.TrimSpace(discType), "DVD") {
+			label := strings.TrimSpace(discType)
+			if label == "" {
+				label = "none"
+			}
+			logger.Infof("DVD menus: capture skipped disc_type=%s decision=skip", label)
+			fmt.Printf("DVD menu capture skipped: %s is not a DVD\n", formatPathLabel(sourcePath))
+			continue
+		}
+
+		result, err := coreSvc.CaptureDVDMenus(ctx, singleReq)
+		if err != nil {
+			return fmt.Errorf("upbrr: capture DVD menus: %w", err)
+		}
+		if len(result.Images) == 0 {
+			return errors.New("upbrr: capture DVD menus: no menu images captured")
+		}
+		if result.Partial {
+			logger.Warnf(
+				"DVD menus: capture incomplete captured=%d warnings=%d truncated=%t",
+				len(result.Images),
+				len(result.Warnings),
+				result.Truncated,
+			)
+			fmt.Printf("DVD menus ready: %d (capture incomplete)\n", len(result.Images))
+			continue
+		}
+		if result.Truncated {
+			fmt.Printf("DVD menus ready: %d (maximum reached)\n", len(result.Images))
+			continue
+		}
+		fmt.Printf("DVD menus ready: %d\n", len(result.Images))
+	}
+	return nil
 }
 
 // processCLIPaths runs process for each input path under its own itemTimeout. In

--- a/cmd/upbrr/main_test.go
+++ b/cmd/upbrr/main_test.go
@@ -879,6 +879,52 @@ func TestRunCLIUploadOnlyQueueSumsUploadedCounts(t *testing.T) {
 	}
 }
 
+func TestRunCLIUploadOnlyQueueCapturesOnlyDVDItems(t *testing.T) {
+	t.Parallel()
+
+	dvdRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dvdRoot, "VIDEO_TS"), 0o700); err != nil {
+		t.Fatalf("create VIDEO_TS: %v", err)
+	}
+	nonDiscRoot := t.TempDir()
+	coreSvc := &cliCoreForTest{dvdMenuResult: api.DVDMenuCaptureResult{
+		Images: []api.DVDMenuCaptureImage{{ScreenshotImage: api.ScreenshotImage{Path: "dvd-menu.png", Purpose: api.ScreenshotPurposeMenu}}},
+	}}
+	err := runCLIUploadOnlyQueue(context.Background(), coreSvc, api.Request{
+		Options: api.UploadOptions{CaptureDVDMenus: true},
+	}, []string{dvdRoot, nonDiscRoot}, false, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("upload-only queue: %v", err)
+	}
+	if coreSvc.dvdMenuCaptureCalls != 1 {
+		t.Fatalf("capture calls = %d, want 1", coreSvc.dvdMenuCaptureCalls)
+	}
+	if coreSvc.runUploadPreparedCalls != 2 {
+		t.Fatalf("upload calls = %d, want 2", coreSvc.runUploadPreparedCalls)
+	}
+}
+
+func TestRunCLIUploadOnlyQueueDVDMenuCaptureFailureStopsUpload(t *testing.T) {
+	t.Parallel()
+
+	dvdRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dvdRoot, "VIDEO_TS"), 0o700); err != nil {
+		t.Fatalf("create VIDEO_TS: %v", err)
+	}
+	coreSvc := &cliCoreForTest{dvdMenuErr: errSyntheticDVDMenuCapture}
+	err := runCLIUploadOnlyQueue(context.Background(), coreSvc, api.Request{
+		Options: api.UploadOptions{CaptureDVDMenus: true},
+	}, []string{dvdRoot}, false, api.NopLogger{})
+
+	assertDVDMenuCaptureError(t, err)
+	if got := strings.Join(coreSvc.callOrder, ","); got != "preview,capture-dvd-menus" {
+		t.Fatalf("queue capture failure call order = %s", got)
+	}
+	if coreSvc.runUploadPreparedCalls != 0 {
+		t.Fatalf("queue upload calls after capture failure = %d, want 0", coreSvc.runUploadPreparedCalls)
+	}
+}
+
 func TestRunCLIUploadOnlyBatchBoundsTimeoutByItemCap(t *testing.T) {
 	t.Parallel()
 
@@ -897,7 +943,7 @@ func TestRunCLIUploadOnlyBatchBoundsTimeoutByItemCap(t *testing.T) {
 	for i := range paths {
 		paths[i] = "p" + strconv.Itoa(i)
 	}
-	if err := runCLIUploadOnlyBatch(context.Background(), coreSvc, api.Request{Paths: paths}, paths, false); err != nil {
+	if err := runCLIUploadOnlyBatch(context.Background(), coreSvc, api.Request{Paths: paths}, paths, false, api.NopLogger{}); err != nil {
 		t.Fatalf("runCLIUploadOnlyBatch: %v", err)
 	}
 	if !sawDeadline {
@@ -930,7 +976,7 @@ func TestRunCLIUploadOnlyBatchSinglePathTimeout(t *testing.T) {
 		},
 	}
 	paths := []string{"only"}
-	if err := runCLIUploadOnlyBatch(context.Background(), coreSvc, api.Request{Paths: paths}, paths, false); err != nil {
+	if err := runCLIUploadOnlyBatch(context.Background(), coreSvc, api.Request{Paths: paths}, paths, false, api.NopLogger{}); err != nil {
 		t.Fatalf("runCLIUploadOnlyBatch: %v", err)
 	}
 	if !sawDeadline {
@@ -941,6 +987,54 @@ func TestRunCLIUploadOnlyBatchSinglePathTimeout(t *testing.T) {
 	}
 	if coreSvc.runUploadPreparedCalls != 1 {
 		t.Fatalf("expected a single RunUploadPrepared call, got %d", coreSvc.runUploadPreparedCalls)
+	}
+}
+
+func TestRunCLIUploadOnlyBatchCapturesBeforeDebugReviews(t *testing.T) {
+	t.Parallel()
+
+	dvdRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dvdRoot, "VIDEO_TS"), 0o700); err != nil {
+		t.Fatalf("create VIDEO_TS: %v", err)
+	}
+	coreSvc := &cliCoreForTest{
+		dvdMenuResult: api.DVDMenuCaptureResult{
+			Images: []api.DVDMenuCaptureImage{{ScreenshotImage: api.ScreenshotImage{Path: "dvd-menu.png", Purpose: api.ScreenshotPurposeMenu}}},
+		},
+		review: api.UploadReview{Trackers: []api.TrackerReview{{Tracker: "BLU"}}},
+	}
+	paths := []string{dvdRoot}
+	if err := runCLIUploadOnlyBatch(context.Background(), coreSvc, api.Request{
+		Paths:   paths,
+		Options: api.UploadOptions{CaptureDVDMenus: true},
+	}, paths, true, api.NopLogger{}); err != nil {
+		t.Fatalf("upload-only batch: %v", err)
+	}
+	if got := strings.Join(coreSvc.callOrder, ","); got != "preview,capture-dvd-menus,review" {
+		t.Fatalf("batch call order = %s", got)
+	}
+}
+
+func TestRunCLIUploadOnlyBatchDVDMenuCaptureFailureStopsReviewAndUpload(t *testing.T) {
+	t.Parallel()
+
+	dvdRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dvdRoot, "VIDEO_TS"), 0o700); err != nil {
+		t.Fatalf("create VIDEO_TS: %v", err)
+	}
+	coreSvc := &cliCoreForTest{dvdMenuErr: errSyntheticDVDMenuCapture}
+	paths := []string{dvdRoot}
+	err := runCLIUploadOnlyBatch(context.Background(), coreSvc, api.Request{
+		Paths:   paths,
+		Options: api.UploadOptions{CaptureDVDMenus: true},
+	}, paths, true, api.NopLogger{})
+
+	assertDVDMenuCaptureError(t, err)
+	if got := strings.Join(coreSvc.callOrder, ","); got != "preview,capture-dvd-menus" {
+		t.Fatalf("batch capture failure call order = %s", got)
+	}
+	if coreSvc.runUploadPreparedCalls != 0 {
+		t.Fatalf("batch upload calls after capture failure = %d, want 0", coreSvc.runUploadPreparedCalls)
 	}
 }
 

--- a/cmd/upbrr/main_test.go
+++ b/cmd/upbrr/main_test.go
@@ -925,6 +925,30 @@ func TestRunCLIUploadOnlyQueueDVDMenuCaptureFailureStopsUpload(t *testing.T) {
 	}
 }
 
+func TestRunCLIUploadOnlyQueueRecordsEachEmptyDVDMenuCapture(t *testing.T) {
+	t.Parallel()
+
+	paths := []string{t.TempDir(), t.TempDir()}
+	for _, path := range paths {
+		if err := os.Mkdir(filepath.Join(path, "VIDEO_TS"), 0o700); err != nil {
+			t.Fatalf("create VIDEO_TS: %v", err)
+		}
+	}
+	coreSvc := &cliCoreForTest{}
+	err := runCLIUploadOnlyQueue(context.Background(), coreSvc, api.Request{
+		Options: api.UploadOptions{CaptureDVDMenus: true},
+	}, paths, false, api.NopLogger{})
+	if err == nil {
+		t.Fatal("expected queue summary error for empty DVD menu captures")
+	}
+	if coreSvc.dvdMenuCaptureCalls != len(paths) {
+		t.Fatalf("capture calls = %d, want %d", coreSvc.dvdMenuCaptureCalls, len(paths))
+	}
+	if coreSvc.runUploadPreparedCalls != 0 {
+		t.Fatalf("upload calls = %d, want 0", coreSvc.runUploadPreparedCalls)
+	}
+}
+
 func TestRunCLIUploadOnlyBatchBoundsTimeoutByItemCap(t *testing.T) {
 	t.Parallel()
 
@@ -1015,6 +1039,34 @@ func TestRunCLIUploadOnlyBatchCapturesBeforeDebugReviews(t *testing.T) {
 	}
 }
 
+func TestRunCLIUploadOnlyBatchContinuesAfterEmptyDVDMenuCapture(t *testing.T) {
+	t.Parallel()
+
+	paths := []string{t.TempDir(), t.TempDir()}
+	for _, path := range paths {
+		if err := os.Mkdir(filepath.Join(path, "VIDEO_TS"), 0o700); err != nil {
+			t.Fatalf("create VIDEO_TS: %v", err)
+		}
+	}
+	coreSvc := &cliCoreForTest{}
+	logger := &cliErrorCountingLogger{}
+	if err := runCLIUploadOnlyBatch(context.Background(), coreSvc, api.Request{
+		Paths:   paths,
+		Options: api.UploadOptions{CaptureDVDMenus: true},
+	}, paths, false, logger); err != nil {
+		t.Fatalf("upload-only batch: %v", err)
+	}
+	if coreSvc.dvdMenuCaptureCalls != len(paths) {
+		t.Fatalf("capture calls = %d, want %d", coreSvc.dvdMenuCaptureCalls, len(paths))
+	}
+	if logger.errors != len(paths) {
+		t.Fatalf("recorded capture failures = %d, want %d", logger.errors, len(paths))
+	}
+	if coreSvc.runUploadPreparedCalls != 1 {
+		t.Fatalf("upload calls = %d, want 1", coreSvc.runUploadPreparedCalls)
+	}
+}
+
 func TestRunCLIUploadOnlyBatchDVDMenuCaptureFailureStopsReviewAndUpload(t *testing.T) {
 	t.Parallel()
 
@@ -1036,6 +1088,15 @@ func TestRunCLIUploadOnlyBatchDVDMenuCaptureFailureStopsReviewAndUpload(t *testi
 	if coreSvc.runUploadPreparedCalls != 0 {
 		t.Fatalf("batch upload calls after capture failure = %d, want 0", coreSvc.runUploadPreparedCalls)
 	}
+}
+
+type cliErrorCountingLogger struct {
+	api.NopLogger
+	errors int
+}
+
+func (l *cliErrorCountingLogger) Errorf(string, ...any) {
+	l.errors++
 }
 
 // --- GROUP C: BDMV setup cancellation is surfaced, not swallowed ---

--- a/gui/frontend/src/app.test.ts
+++ b/gui/frontend/src/app.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { createElement } from "react";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import App, { hasExplicitEmptyReleaseTrackerSelection, ruleBlockingTrackerLabels } from "./app";
@@ -75,6 +75,14 @@ type GetHistoryOverview = (sourcePath: string) => Promise<HistoryOverview>;
 type DeleteHistoryRelease = (sourcePath: string) => Promise<void>;
 type StartDVDMenuCapture = (...args: unknown[]) => Promise<string>;
 type GetDVDMenuCaptureSnapshot = (jobID: string) => Promise<DVDMenuCaptureSnapshot>;
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
 
 const metadataPreview = (sourcePath: string): MetadataPreview => ({
   SourcePath: sourcePath,
@@ -613,6 +621,74 @@ describe("metadata tracker payloads", () => {
     fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
     await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
 
+    expect(screen.queryByRole("button", { name: "Menu Images" })).not.toBeInTheDocument();
+  });
+
+  it("ignores a fetch disc detection after the source path changes", async () => {
+    const detection = createDeferred<string>();
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const detectDiscType = vi.fn<DetectDiscType>(() => detection.promise);
+    installAppBridge(fetchMetadata, { detectDiscType });
+
+    render(createElement(App));
+    const sourcePath = screen.getByLabelText("Source path");
+    fireEvent.change(sourcePath, { target: { value: "C:\\media\\First" } });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(detectDiscType).toHaveBeenCalledWith("C:\\media\\First"));
+
+    fireEvent.change(sourcePath, { target: { value: "C:\\media\\Second.mkv" } });
+    await act(async () => detection.resolve("BDMV"));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledOnce());
+    await screen.findByText("2/2");
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    expect(screen.queryByRole("button", { name: "Menu Images" })).not.toBeInTheDocument();
+  });
+
+  it("ignores an older browse disc detection after a newer path selection", async () => {
+    const firstDetection = createDeferred<string>();
+    const secondDetection = createDeferred<string>();
+    const firstPath = "C:\\media\\First";
+    const secondPath = "C:\\media\\Second";
+    const browseFolder = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce(firstPath)
+      .mockResolvedValueOnce(secondPath);
+    const detectDiscType = vi.fn<DetectDiscType>((sourcePath) => {
+      if (sourcePath === firstPath) {
+        return firstDetection.promise;
+      }
+      if (sourcePath === secondPath) {
+        return secondDetection.promise;
+      }
+      return Promise.resolve("");
+    });
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    installAppBridge(fetchMetadata, { browseFolder, detectDiscType });
+
+    render(createElement(App));
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example.mkv" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledOnce());
+    await screen.findByText("2/2");
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Input" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Browse folder" }));
+    await waitFor(() => expect(detectDiscType).toHaveBeenCalledWith(firstPath));
+    fireEvent.click(screen.getByRole("button", { name: "Browse folder" }));
+    await waitFor(() => expect(detectDiscType).toHaveBeenCalledWith(secondPath));
+
+    await act(async () => secondDetection.resolve(""));
+    await act(async () => firstDetection.resolve("BDMV"));
+
+    expect(screen.getByLabelText("Source path")).toHaveValue(secondPath);
     expect(screen.queryByRole("button", { name: "Menu Images" })).not.toBeInTheDocument();
   });
 

--- a/gui/frontend/src/app.test.ts
+++ b/gui/frontend/src/app.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import App, { hasExplicitEmptyReleaseTrackerSelection, ruleBlockingTrackerLabels } from "./app";
 import type {
   DescriptionBuilderPreview,
+  DVDMenuCaptureSnapshot,
   DupeCheckResult,
   DupeCheckSnapshot,
   DupeEntry,
@@ -72,6 +73,8 @@ type GetTrackerUploadSnapshot = (jobID: string) => Promise<TrackerUploadSnapshot
 type ListHistory = () => Promise<HistoryEntry[]>;
 type GetHistoryOverview = (sourcePath: string) => Promise<HistoryOverview>;
 type DeleteHistoryRelease = (sourcePath: string) => Promise<void>;
+type StartDVDMenuCapture = (...args: unknown[]) => Promise<string>;
+type GetDVDMenuCaptureSnapshot = (jobID: string) => Promise<DVDMenuCaptureSnapshot>;
 
 const metadataPreview = (sourcePath: string): MetadataPreview => ({
   SourcePath: sourcePath,
@@ -218,6 +221,44 @@ const dupeCheckSnapshot = (sourcePath = "C:\\media\\Example"): DupeCheckSnapshot
   finishedAt: "2026-06-17T00:00:01Z",
 });
 
+const dvdMenuCaptureSnapshot = (): DVDMenuCaptureSnapshot => ({
+  jobID: "dvd-job-1",
+  sourcePath: "C:\\media\\Example",
+  status: "completed",
+  phase: "complete",
+  message: "DVD menu capture finished.",
+  discoveredMenus: 1,
+  visitedStates: 2,
+  visitedButtons: 1,
+  capturedCount: 1,
+  warningCount: 0,
+  result: {
+    SourcePath: "C:\\media\\Example",
+    Images: [],
+    SelectedLanguage: "en",
+    Region: 0,
+    DiscoveredMenus: 1,
+    VisitedStates: 2,
+    VisitedButtons: 1,
+    MaxItems: 6,
+    Complete: true,
+    Partial: false,
+    Truncated: false,
+    Warnings: [],
+    Engine: {
+      EngineVersion: "phase0a-1",
+      SchemaVersion: 1,
+      SupportedFeatures: [],
+      FFmpegVersion: "8.0",
+      FFmpegDVDVideo: true,
+      MissingFFmpegOptions: [],
+    },
+  },
+  error: "",
+  startedAt: "2026-07-10T00:00:00Z",
+  finishedAt: "2026-07-10T00:00:01Z",
+});
+
 const historyEntry = (sourcePath: string): HistoryEntry => ({
   SourcePath: sourcePath,
   ReleaseTitle: "Example Release",
@@ -282,6 +323,8 @@ const installAppBridge = (
     listHistory?: ListHistory;
     getHistoryOverview?: GetHistoryOverview;
     deleteHistoryRelease?: DeleteHistoryRelease;
+    startDVDMenuCapture?: StartDVDMenuCapture;
+    getDVDMenuCaptureSnapshot?: GetDVDMenuCaptureSnapshot;
   } = {},
 ) => {
   const storage = new Map<string, string>();
@@ -312,6 +355,7 @@ const installAppBridge = (
             },
             ScreenshotHandling: {
               ProcessLimit: 1,
+              MaxMenuItems: 6,
             },
           }),
         BrowseFolder: options.browseFolder ?? (async () => "C:\\media\\Example\\BDMV"),
@@ -328,6 +372,14 @@ const installAppBridge = (
           (async (sourcePath: string) => descriptionBuilderPreview(sourcePath)),
         FetchPreparation: options.fetchPreparation ?? (async () => ({})),
         ListUploadedImages: async () => [],
+        ListDVDMenuScreenshots: async () => [],
+        ReadScreenshotImage: async () => "data:image/png;base64,example",
+        StartDVDMenuCapture: options.startDVDMenuCapture ?? (async () => "dvd-job-1"),
+        GetDVDMenuCaptureSnapshot:
+          options.getDVDMenuCaptureSnapshot ?? (async () => dvdMenuCaptureSnapshot()),
+        CancelDVDMenuCapture: async () => undefined,
+        DeleteDVDMenuScreenshot: async () => undefined,
+        ImportMenuImages: async () => undefined,
         DiscoverPlaylists: async () => [
           {
             file: "00001.mpls",
@@ -546,6 +598,58 @@ describe("hasFilteredEmptyUploadTrackerSelection", () => {
 });
 
 describe("metadata tracker payloads", () => {
+  it("gates Disc Menus by detected disc type", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    installAppBridge(fetchMetadata, { detectDiscType: async () => "" });
+
+    render(createElement(App));
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example.mkv" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledOnce());
+    await screen.findByText("2/2");
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    expect(screen.queryByRole("button", { name: "Menu Images" })).not.toBeInTheDocument();
+  });
+
+  it("invalidates Description Builder after DVD menu capture without auto-navigation", async () => {
+    const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
+    const fetchDescriptionBuilder = vi.fn<FetchDescriptionBuilder>(async (sourcePath) =>
+      descriptionBuilderPreview(sourcePath),
+    );
+    installAppBridge(fetchMetadata, {
+      detectDiscType: async () => "DVD",
+      fetchDescriptionBuilder,
+      startDVDMenuCapture: async () => "dvd-job-1",
+      getDVDMenuCaptureSnapshot: async () => dvdMenuCaptureSnapshot(),
+    });
+
+    render(createElement(App));
+    fireEvent.change(screen.getByLabelText("Source path"), {
+      target: { value: "C:\\media\\Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Fetch metadata" }));
+    await waitFor(() => expect(fetchMetadata).toHaveBeenCalledOnce());
+    await screen.findByText("2/2");
+    fireEvent.click(await screen.findByRole("button", { name: "Dupe Checking" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run dupe check" }));
+    await waitFor(() => expect(screen.getByText("1 blocked.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Description Builder" }));
+    await waitFor(() => expect(fetchDescriptionBuilder).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole("button", { name: "Menu Images" }));
+    fireEvent.click(screen.getByRole("button", { name: "Capture DVD menus" }));
+    expect(await screen.findByText("Captured 1 DVD menu image.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Menu Images" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Description Builder" }));
+    await waitFor(() => expect(fetchDescriptionBuilder).toHaveBeenCalledTimes(2));
+  });
+
   it("excludes dupe-blocked upload targets from metadata fetches", async () => {
     const fetchMetadata = vi.fn<FetchMetadata>(async (sourcePath) => metadataPreview(sourcePath));
     installAppBridge(fetchMetadata);

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -35,6 +35,7 @@ import type {
   ApplicationInfo,
   BrowseDirectoryResponse,
   DescriptionBuilderPreview,
+  DVDMenuCaptureSnapshot,
   DupeCheckResult,
   DupeCheckSnapshot,
   DupeCheckSummary,
@@ -512,6 +513,29 @@ declare global {
               nameOverrides: ReleaseNameOverrides,
               paths: string[],
             ) => Promise<void>;
+            /** Starts background capture from prepared metadata and resolves to an opaque job ID. */
+            StartDVDMenuCapture: (
+              path: string,
+              overrides: ExternalIDOverrides,
+              nameOverrides: ReleaseNameOverrides,
+            ) => Promise<string>;
+            /** Returns the latest state for a background DVD menu capture job. */
+            GetDVDMenuCaptureSnapshot: (jobID: string) => Promise<DVDMenuCaptureSnapshot>;
+            /** Requests asynchronous cancellation of a background DVD menu capture job. */
+            CancelDVDMenuCapture: (jobID: string) => Promise<void>;
+            /** Lists persisted manual and automatic menu images for a prepared source path. */
+            ListDVDMenuScreenshots: (
+              path: string,
+              overrides: ExternalIDOverrides,
+              nameOverrides: ReleaseNameOverrides,
+            ) => Promise<ScreenshotImage[]>;
+            /** Removes one managed menu image and its local records. */
+            DeleteDVDMenuScreenshot: (
+              path: string,
+              overrides: ExternalIDOverrides,
+              nameOverrides: ReleaseNameOverrides,
+              imagePath: string,
+            ) => Promise<void>;
             ReadScreenshotImage: (path: string) => Promise<string>;
             ListUploadCandidates: (
               path: string,
@@ -751,6 +775,7 @@ export default function App() {
   });
   const [sourcePathMode, setSourcePathMode] = useState<SourcePathMode | undefined>();
   const [currentDiscType, setCurrentDiscType] = useState("");
+  const [imageAssetsRevision, setImageAssetsRevision] = useState(0);
   const [sourceLookupURL, setSourceLookupURL] = useState("");
   const [loading, setLoading] = useState(false);
   const [metadataResetting, setMetadataResetting] = useState(false);
@@ -932,6 +957,10 @@ export default function App() {
       null) as ConfigMap | null;
     return typeof mainSettings?.FaviconOnly === "boolean" ? mainSettings.FaviconOnly : false;
   }, [configData]);
+  const maxMenuItems = useMemo(() => {
+    const value = screenshotConfig?.MaxMenuItems;
+    return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 6;
+  }, [screenshotConfig]);
 
   const persistSourcePathHistory = useCallback((entries: SourcePathHistoryEntry[]) => {
     try {
@@ -1601,6 +1630,8 @@ export default function App() {
     setUploadSelections,
     setUploadHost,
     uploadHost,
+    handleUploadImages: uploadSelectedImages,
+    handleDeleteUploadedImage: deleteUploadedImage,
   } = uploadImages;
 
   // Tracker image URL handling
@@ -1640,6 +1671,26 @@ export default function App() {
     );
   }, [screenshots.uploadCandidates]);
 
+  const markImageAssetsChanged = useCallback(() => {
+    setImageAssetsRevision((revision) => revision + 1);
+  }, []);
+
+  const handleUploadImagesWithRevision = useCallback(
+    async (selected: ScreenshotPreviewImage[]) => {
+      await uploadSelectedImages(selected);
+      markImageAssetsChanged();
+    },
+    [markImageAssetsChanged, uploadSelectedImages],
+  );
+
+  const handleDeleteUploadedImageWithRevision = useCallback(
+    async (imagePath: string, host: string) => {
+      await deleteUploadedImage(imagePath, host);
+      markImageAssetsChanged();
+    },
+    [deleteUploadedImage, markImageAssetsChanged],
+  );
+
   const resetScreenshotState = useCallback(() => {
     resetScreenshots();
     resetUploadState();
@@ -1658,6 +1709,8 @@ export default function App() {
     (nextActiveTab = "input") => {
       setPath("");
       setSourcePathMode(undefined);
+      setCurrentDiscType("");
+      setImageAssetsRevision(0);
       setSourceLookupURL("");
       setLoading(false);
       setMetadataResetting(false);
@@ -2364,6 +2417,7 @@ export default function App() {
     setMetadataProgressActive(true);
     setLoading(true);
     try {
+      setCurrentDiscType(await detectDiscType(targetPath));
       const result = await fetcher(
         targetPath,
         sourceLookupURL.trim(),
@@ -3235,6 +3289,8 @@ export default function App() {
   }, [applyDupeCheckSnapshot, dupeCheckJobID, dupeCheckSnapshot?.status, dupeLoading]);
 
   useEffect(() => {
+    setCurrentDiscType("");
+    setImageAssetsRevision(0);
     setDupeChecked(false);
     setDupeCheckJobID("");
     setDupeCheckSnapshot(null);
@@ -3278,6 +3334,7 @@ export default function App() {
       path: normalizedPath,
       external: normalizeOverrides(idOverrideState?.overrides || {}),
       release: normalizeReleaseOverrides(releaseOverrideState?.overrides || {}),
+      imageAssetsRevision,
     });
     if (builderAutoRequestKey === requestKey) return;
     setBuilderAutoRequestKey(requestKey);
@@ -3292,6 +3349,7 @@ export default function App() {
     idOverrideState,
     releaseOverrideState,
     builderAutoRequestKey,
+    imageAssetsRevision,
     runDescriptionBuilder,
   ]);
 
@@ -3368,6 +3426,7 @@ export default function App() {
     setExistingImages,
     readScreenshotImage,
     refreshUploadedImages,
+    imageAssetsRevision,
   ]);
 
   /**
@@ -4401,10 +4460,13 @@ export default function App() {
               path={path}
               overrides={idOverrideState?.overrides || {}}
               nameOverrides={releaseOverrideState?.overrides || {}}
+              currentDiscType={currentDiscType}
+              maxMenuItems={maxMenuItems}
               browseAvailable={browserNativeBrowseAvailable}
-              onImportComplete={() => {
-                setActiveTab("upload_images");
-              }}
+              onImagesChanged={markImageAssetsChanged}
+              onContinue={() => setActiveTab("upload_images")}
+              setLightboxImage={setLightboxImage}
+              setLightboxAlt={setLightboxAlt}
             />
           ) : activeTab === "upload_images" ? (
             <UploadImagesPage
@@ -4416,7 +4478,7 @@ export default function App() {
               uploadImagesLoading={uploadImages.uploadImagesLoading}
               uploadProgress={uploadImages.uploadProgress}
               setAllUploadSelections={uploadImages.setAllUploadSelections}
-              handleUploadImages={uploadImages.handleUploadImages}
+              handleUploadImages={handleUploadImagesWithRevision}
               uploadImagesError={uploadImages.uploadImagesError}
               uploadImageFailures={uploadImages.uploadImageFailures}
               uploadCandidates={screenshots.uploadCandidates}
@@ -4429,7 +4491,7 @@ export default function App() {
               uploadedImageRecords={uploadImages.uploadedImageRecords}
               trackerImageLinks={screenshots.trackerImageLinks}
               trackerImageURLs={trackerImageURLs}
-              handleDeleteUploadedImage={uploadImages.handleDeleteUploadedImage}
+              handleDeleteUploadedImage={handleDeleteUploadedImageWithRevision}
               handleDeleteTrackerImage={screenshots.handleDeleteTrackerImage}
             />
           ) : activeTab === "bluray" ? (

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -819,6 +819,7 @@ export default function App() {
   // same tick as a fetch/reset request are not dropped by a stale React closure.
   const metadataProgressActiveRef = useRef(false);
   const metadataProgressTargetRef = useRef("");
+  const discTypeRequestTokenRef = useRef(0);
   const [dupeSummary, setDupeSummary] = useState<DupeCheckSummary>(emptyDupeSummary);
   const [dupeLoading, setDupeLoading] = useState(false);
   const [dupeError, setDupeError] = useState("");
@@ -992,8 +993,10 @@ export default function App() {
   );
 
   const handleSourcePathChange = useCallback((value: string) => {
+    discTypeRequestTokenRef.current += 1;
     setPath(value);
     setSourcePathMode(undefined);
+    setCurrentDiscType("");
   }, []);
 
   useEffect(() => {
@@ -1707,6 +1710,7 @@ export default function App() {
    */
   const resetFreshWorkflowState = useCallback(
     (nextActiveTab = "input") => {
+      discTypeRequestTokenRef.current += 1;
       setPath("");
       setSourcePathMode(undefined);
       setCurrentDiscType("");
@@ -2273,6 +2277,16 @@ export default function App() {
     return "";
   };
 
+  const updateCurrentDiscType = async (selectedPath: string): Promise<string | null> => {
+    const requestToken = ++discTypeRequestTokenRef.current;
+    const discType = await detectDiscType(selectedPath);
+    if (requestToken !== discTypeRequestTokenRef.current) {
+      return null;
+    }
+    setCurrentDiscType(discType);
+    return discType;
+  };
+
   // Auto-detect BDMV and show playlist selection
   const handlePathSelected = async (
     selectedPath: string,
@@ -2286,8 +2300,10 @@ export default function App() {
     setPath(trimmedPath);
     setSourcePathMode(selectedMode);
     rememberSourcePath(trimmedPath, selectedMode);
-    const discType = await detectDiscType(trimmedPath);
-    setCurrentDiscType(discType);
+    const discType = await updateCurrentDiscType(trimmedPath);
+    if (discType === null) {
+      return null;
+    }
     setShowExternalIDInputUI(true);
     setPlaylistPreparationError("");
     setBdinfoProgressLines([]);
@@ -2417,7 +2433,7 @@ export default function App() {
     setMetadataProgressActive(true);
     setLoading(true);
     try {
-      setCurrentDiscType(await detectDiscType(targetPath));
+      await updateCurrentDiscType(targetPath);
       const result = await fetcher(
         targetPath,
         sourceLookupURL.trim(),

--- a/gui/frontend/src/hooks/useSettingsState.test.ts
+++ b/gui/frontend/src/hooks/useSettingsState.test.ts
@@ -192,6 +192,25 @@ function ImageHostingHarness() {
   );
 }
 
+function ScreenshotSettingsHarness() {
+  const state = useSettingsState({ activeTab: "settings" });
+  const config = state.screenshotConfig;
+  if (!config) {
+    return createElement("div");
+  }
+  return createElement(
+    "div",
+    null,
+    state.renderField(
+      "MaxMenuItems",
+      config.MaxMenuItems,
+      ["ScreenshotHandling", "MaxMenuItems"],
+      state.sectionFieldMeta.ScreenshotHandling?.MaxMenuItems,
+    ),
+    createElement(PayloadCapture, { value: state.buildSavePayload() }),
+  );
+}
+
 let latestPayload = "";
 
 /** Captures save payloads without rendering secret-shaped values into DOM snapshots. */
@@ -261,6 +280,30 @@ describe("settings advanced fields", () => {
     expect(advancedBySection.PostUpload).toEqual(["InjectDelay", "MaxConcurrentTrackers"]);
     expect(advancedBySection.TorrentCreation).toEqual([]);
     expect(advancedBySection.TorrentClients).toEqual(["VerifyWebUICertificate"]);
+  });
+});
+
+describe("DVD menu screenshot settings", () => {
+  it("loads the default maximum and preserves edits in the save payload", async () => {
+    (globalThis as typeof globalThis & { go?: any }).go = {
+      guiapp: {
+        App: {
+          GetConfig: async () => JSON.stringify({ ScreenshotHandling: { MaxMenuItems: 6 } }),
+          GetDefaultConfig: async () => JSON.stringify({}),
+          ListKnownTrackers: async () => [],
+          GetImageHostPolicyMetadata: async () => ({}),
+        },
+      },
+    };
+
+    render(createElement(ScreenshotSettingsHarness));
+    const input = await screen.findByLabelText("Maximum DVD menu images");
+    expect(input).toHaveValue(6);
+    fireEvent.change(input, { target: { value: "8" } });
+    await waitFor(() => {
+      const payload = readPayload<{ ScreenshotHandling?: { MaxMenuItems?: number } }>();
+      expect(payload.ScreenshotHandling?.MaxMenuItems).toBe(8);
+    });
   });
 });
 

--- a/gui/frontend/src/hooks/useSettingsState.tsx
+++ b/gui/frontend/src/hooks/useSettingsState.tsx
@@ -766,6 +766,7 @@ const sectionFieldMeta: Record<string, Record<string, FieldMeta>> = {
     CheckPredb: { key: "CheckPredb", advanced: true },
   },
   ScreenshotHandling: {
+    MaxMenuItems: { key: "MaxMenuItems", label: "Maximum DVD menu images", type: "number" },
     ProcessLimit: { key: "ProcessLimit", advanced: true },
     MaxConcurrentUploads: { key: "MaxConcurrentUploads", advanced: true },
     FFmpegLimit: { key: "FFmpegLimit", advanced: true },

--- a/gui/frontend/src/pages/menu_images/index.test.tsx
+++ b/gui/frontend/src/pages/menu_images/index.test.tsx
@@ -324,4 +324,51 @@ describe("MenuImagesPage", () => {
     expect(screen.queryByRole("button", { name: "Remove DVD menu 2" })).not.toBeInTheDocument();
     expect(props.onImagesChanged).toHaveBeenCalledOnce();
   });
+
+  it("keeps every concurrent deletion disabled until its own request completes", async () => {
+    let persisted = [menuImage("menu-1.png", 0), menuImage("menu-2.png", 1)];
+    const firstDelete = deferred<void>();
+    const secondDelete = deferred<void>();
+    const app = installBridge({
+      ListDVDMenuScreenshots: vi.fn(async () => persisted),
+      DeleteDVDMenuScreenshot: vi.fn(
+        async (_path, _overrides, _nameOverrides, imagePath: string) => {
+          if (imagePath === "menu-1.png") await firstDelete.promise;
+          else await secondDelete.promise;
+          persisted = persisted.filter((image) => image.Path !== imagePath);
+        },
+      ),
+    });
+    renderPage();
+
+    const firstButton = await screen.findByRole("button", { name: "Remove DVD menu 1" });
+    const secondButton = screen.getByRole("button", { name: "Remove DVD menu 2" });
+    fireEvent.click(firstButton);
+    fireEvent.click(secondButton);
+
+    expect(app.DeleteDVDMenuScreenshot).toHaveBeenCalledTimes(2);
+    expect(firstButton).toBeDisabled();
+    expect(secondButton).toBeDisabled();
+
+    await act(async () => {
+      secondDelete.resolve();
+      await secondDelete.promise;
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Remove DVD menu 2" })).not.toBeInTheDocument(),
+    );
+    const stillPendingButton = screen.getByRole("button", { name: "Remove DVD menu 1" });
+    expect(stillPendingButton).toBeDisabled();
+    fireEvent.click(stillPendingButton);
+    expect(app.DeleteDVDMenuScreenshot).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      firstDelete.resolve();
+      await firstDelete.promise;
+    });
+
+    expect(await screen.findByText("No saved menu images yet.")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
 });

--- a/gui/frontend/src/pages/menu_images/index.test.tsx
+++ b/gui/frontend/src/pages/menu_images/index.test.tsx
@@ -1,0 +1,327 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
+
+import type { DVDMenuCaptureResult, DVDMenuCaptureSnapshot, ScreenshotImage } from "../../types";
+import MenuImagesPage from "./index";
+
+const menuImage = (path: string, index: number): ScreenshotImage => ({
+  Index: index,
+  TimestampSeconds: 0,
+  Path: path,
+  Purpose: "menu",
+  Width: 720,
+  Height: 480,
+  SizeBytes: 1024,
+});
+
+const captureResult = (overrides: Partial<DVDMenuCaptureResult> = {}): DVDMenuCaptureResult => ({
+  SourcePath: "C:/media/Example/VIDEO_TS",
+  Images: [],
+  SelectedLanguage: "en",
+  Region: 0,
+  DiscoveredMenus: 2,
+  VisitedStates: 4,
+  VisitedButtons: 3,
+  MaxItems: 6,
+  Complete: true,
+  Partial: false,
+  Truncated: false,
+  Warnings: [],
+  Engine: {
+    EngineVersion: "phase0a-1",
+    SchemaVersion: 1,
+    SupportedFeatures: [],
+    FFmpegVersion: "8.0",
+    FFmpegDVDVideo: true,
+    MissingFFmpegOptions: [],
+  },
+  ...overrides,
+});
+
+const captureSnapshot = (status: string, result = captureResult()): DVDMenuCaptureSnapshot => ({
+  jobID: "dvd-job-1",
+  sourcePath: result.SourcePath,
+  status,
+  phase: status === "completed" ? "complete" : "capturing",
+  message: status === "completed" ? "DVD menu capture finished." : "Rendering menus.",
+  discoveredMenus: result.DiscoveredMenus,
+  visitedStates: result.VisitedStates,
+  visitedButtons: result.VisitedButtons,
+  capturedCount: result.Images.length || 2,
+  warningCount: result.Warnings.length,
+  result,
+  error: "",
+  startedAt: "2026-07-10T00:00:00Z",
+  finishedAt: status === "completed" ? "2026-07-10T00:00:01Z" : "",
+});
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+};
+
+const installBridge = (overrides: Record<string, unknown> = {}) => {
+  const app = {
+    ListDVDMenuScreenshots: vi.fn(async () => [] as ScreenshotImage[]),
+    ReadScreenshotImage: vi.fn(async () => "data:image/png;base64,example"),
+    StartDVDMenuCapture: vi.fn(async () => "dvd-job-1"),
+    GetDVDMenuCaptureSnapshot: vi.fn(async () => captureSnapshot("completed")),
+    CancelDVDMenuCapture: vi.fn(async () => undefined),
+    DeleteDVDMenuScreenshot: vi.fn(async () => undefined),
+    ImportMenuImages: vi.fn(async () => undefined),
+    BrowseImageFiles: vi.fn(async () => [] as string[]),
+    ...overrides,
+  };
+  (globalThis as typeof globalThis & { go?: any }).go = { guiapp: { App: app } };
+  return app;
+};
+
+const pageProps = (
+  overrides: Partial<ComponentProps<typeof MenuImagesPage>> = {},
+): ComponentProps<typeof MenuImagesPage> => ({
+  path: "C:/media/Example/VIDEO_TS",
+  overrides: {},
+  nameOverrides: {},
+  currentDiscType: "DVD",
+  maxMenuItems: 6,
+  browseAvailable: true,
+  onImagesChanged: vi.fn(),
+  onContinue: vi.fn(),
+  setLightboxImage: vi.fn(),
+  setLightboxAlt: vi.fn(),
+  ...overrides,
+});
+
+const renderPage = (overrides: Partial<ComponentProps<typeof MenuImagesPage>> = {}) => {
+  const props = pageProps(overrides);
+  render(<MenuImagesPage {...props} />);
+  return props;
+};
+
+afterEach(() => {
+  cleanup();
+  delete (globalThis as typeof globalThis & { go?: any }).go;
+});
+
+describe("MenuImagesPage", () => {
+  it("loads persisted images and shows DVD-only capture controls with configured maximum", async () => {
+    const app = installBridge({
+      ListDVDMenuScreenshots: vi.fn(async () => [menuImage("menu-1.png", 0)]),
+    });
+    const props = renderPage({ maxMenuItems: 8 });
+
+    expect(screen.getByText("Capture up to 8 distinct DVD menu screens.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Capture DVD menus" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Preview DVD menu 1" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Preview DVD menu 1" }));
+    expect(props.setLightboxAlt).toHaveBeenCalledWith("DVD menu 1");
+    expect(app.ListDVDMenuScreenshots).toHaveBeenCalledOnce();
+  });
+
+  it.each(["BDMV", "HDDVD"])("keeps %s in manual-only mode", (discType) => {
+    installBridge();
+    renderPage({ currentDiscType: discType });
+
+    expect(screen.queryByRole("button", { name: "Capture DVD menus" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add images" })).toBeInTheDocument();
+    expect(
+      screen.getByText(new RegExp(`Manual disc menu import remains available for ${discType}`)),
+    ).toBeInTheDocument();
+  });
+
+  it("shows progress and cancels an active capture", async () => {
+    const app = installBridge({
+      GetDVDMenuCaptureSnapshot: vi.fn(async () => captureSnapshot("running")),
+    });
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Capture DVD menus" }));
+    expect(await screen.findByText("Rendering menus.")).toBeInTheDocument();
+    expect(screen.getByText(/States 4/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(app.CancelDVDMenuCapture).toHaveBeenCalledWith("dvd-job-1"));
+    expect(
+      screen.getByRole("button", { name: "Capture DVD menus" }).closest("section"),
+    ).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("cancels an active capture and ignores its late completion after a source change", async () => {
+    const oldPath = "C:/media/Example.Release.2026/VIDEO_TS";
+    const newPath = "C:/media/Example.Release.2027/VIDEO_TS";
+    const pendingSnapshot = deferred<DVDMenuCaptureSnapshot>();
+    const app = installBridge({
+      StartDVDMenuCapture: vi.fn(async () => "old-dvd-job"),
+      GetDVDMenuCaptureSnapshot: vi.fn(() => pendingSnapshot.promise),
+    });
+    const onImagesChanged = vi.fn();
+    const props = pageProps({ path: oldPath, onImagesChanged });
+    const view = render(<MenuImagesPage {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Capture DVD menus" }));
+    await waitFor(() => expect(app.GetDVDMenuCaptureSnapshot).toHaveBeenCalledWith("old-dvd-job"));
+
+    view.rerender(<MenuImagesPage {...props} path={newPath} />);
+    await waitFor(() => expect(app.CancelDVDMenuCapture).toHaveBeenCalledWith("old-dvd-job"));
+
+    await act(async () => {
+      pendingSnapshot.resolve(captureSnapshot("completed", captureResult({ SourcePath: oldPath })));
+      await pendingSnapshot.promise;
+    });
+
+    expect(screen.queryByText("DVD menu capture finished.")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Capture DVD menus" })).toBeEnabled();
+    expect(onImagesChanged).not.toHaveBeenCalled();
+  });
+
+  it("gates duplicate starts synchronously and clears the pending state on rejection", async () => {
+    const pendingStart = deferred<string>();
+    const app = installBridge({
+      StartDVDMenuCapture: vi.fn(() => pendingStart.promise),
+    });
+    renderPage();
+
+    const captureButton = screen.getByRole("button", { name: "Capture DVD menus" });
+    fireEvent.click(captureButton);
+    fireEvent.click(captureButton);
+
+    expect(app.StartDVDMenuCapture).toHaveBeenCalledOnce();
+    expect(screen.getByRole("button", { name: "Starting..." })).toBeDisabled();
+
+    await act(async () => {
+      pendingStart.reject(new Error("DVD capture start failed"));
+      await pendingStart.promise.catch(() => undefined);
+    });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("DVD capture start failed");
+    expect(screen.getByRole("button", { name: "Capture DVD menus" })).toBeEnabled();
+  });
+
+  it.each([
+    {
+      name: "partial",
+      result: captureResult({
+        Complete: false,
+        Partial: true,
+        Warnings: [{ Code: "frame_decode", Message: "One menu could not be rendered." }],
+      }),
+      text: "Captured 2 DVD menu images.",
+    },
+    {
+      name: "truncated",
+      result: captureResult({ Complete: false, Truncated: true, MaxItems: 2 }),
+      text: "Maximum reached",
+    },
+  ])("shows $name completion state without navigating", async ({ result, text }) => {
+    installBridge({
+      GetDVDMenuCaptureSnapshot: vi.fn(async () => captureSnapshot("completed", result)),
+    });
+    const props = renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Capture DVD menus" }));
+    expect(await screen.findByText(text)).toBeInTheDocument();
+    expect(props.onImagesChanged).toHaveBeenCalledOnce();
+    expect(props.onContinue).not.toHaveBeenCalled();
+  });
+
+  it("hides internal navigation warnings while keeping basic capture feedback", async () => {
+    const hiddenWarnings = [
+      {
+        Code: "unsupported_post_link",
+        Message: "menu post-command target was not resolved",
+      },
+      {
+        Code: "structural_state",
+        Message: "structural menu candidate could not be classified",
+      },
+      {
+        Code: "structural_only",
+        Message: "visible menu was not reached through navigation",
+      },
+      {
+        Code: "nav_scan_limit",
+        Message: "menu NAV/SPU sector scan limit reached",
+      },
+      {
+        Code: "structural_discovery",
+        Message:
+          "Some menu screens were found through structural inventory rather than reachable navigation.",
+      },
+    ];
+    installBridge({
+      GetDVDMenuCaptureSnapshot: vi.fn(async () =>
+        captureSnapshot(
+          "completed",
+          captureResult({ Complete: false, Partial: true, Warnings: hiddenWarnings }),
+        ),
+      ),
+    });
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Capture DVD menus" }));
+    expect(await screen.findByText("Captured 2 DVD menu images.")).toBeInTheDocument();
+    for (const warning of hiddenWarnings) {
+      expect(screen.queryByText(warning.Message)).not.toBeInTheDocument();
+    }
+    expect(screen.queryByText(/Warnings \d+/)).not.toBeInTheDocument();
+  });
+
+  it("shows hard capture failures in an alert region", async () => {
+    installBridge({
+      StartDVDMenuCapture: vi.fn(async () => {
+        throw new Error("Compatible FFmpeg DVD menu support is required");
+      }),
+    });
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Capture DVD menus" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Compatible FFmpeg DVD menu support is required",
+    );
+  });
+
+  it("imports without automatic navigation and exposes explicit continue", async () => {
+    const app = installBridge({
+      BrowseImageFiles: vi.fn(async () => ["C:/images/menu.png"]),
+    });
+    const props = renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add images" }));
+    expect(await screen.findByText("C:/images/menu.png")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Import images" }));
+    await waitFor(() => expect(app.ImportMenuImages).toHaveBeenCalledOnce());
+    expect(props.onImagesChanged).toHaveBeenCalledOnce();
+    expect(props.onContinue).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue to Upload Images" }));
+    expect(props.onContinue).toHaveBeenCalledOnce();
+  });
+
+  it("removes one persisted image, preserves order, and focuses the next removal", async () => {
+    let persisted = [menuImage("menu-1.png", 0), menuImage("menu-2.png", 1)];
+    const app = installBridge({
+      ListDVDMenuScreenshots: vi.fn(async () => persisted),
+      DeleteDVDMenuScreenshot: vi.fn(async (_path, _overrides, _nameOverrides, imagePath) => {
+        persisted = persisted.filter((image) => image.Path !== imagePath);
+      }),
+    });
+    const props = renderPage();
+
+    expect(await screen.findByRole("button", { name: "Remove DVD menu 2" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Remove DVD menu 1" }));
+    await waitFor(() => expect(app.DeleteDVDMenuScreenshot).toHaveBeenCalledOnce());
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Remove DVD menu 1" })).toHaveFocus(),
+    );
+    expect(screen.queryByRole("button", { name: "Remove DVD menu 2" })).not.toBeInTheDocument();
+    expect(props.onImagesChanged).toHaveBeenCalledOnce();
+  });
+});

--- a/gui/frontend/src/pages/menu_images/index.tsx
+++ b/gui/frontend/src/pages/menu_images/index.tsx
@@ -1,168 +1,508 @@
 // Copyright (c) 2025-2026, Audionut and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState } from "react";
-import type { ExternalIDOverrides, ReleaseNameOverrides } from "../../types";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  DVDMenuCaptureSnapshot,
+  ExternalIDOverrides,
+  ReleaseNameOverrides,
+  ScreenshotImage,
+} from "../../types";
 
 type Props = Readonly<{
   path: string;
   overrides: ExternalIDOverrides;
   nameOverrides: ReleaseNameOverrides;
+  currentDiscType: string;
+  maxMenuItems: number;
   browseAvailable: boolean;
-  onImportComplete: () => void;
+  onImagesChanged: () => void;
+  onContinue: () => void;
+  setLightboxImage: (value: string) => void;
+  setLightboxAlt: (value: string) => void;
 }>;
 
+type MenuPreview = {
+  image: ScreenshotImage;
+  dataURI: string;
+};
+
+type CaptureJob = Readonly<{
+  id: string;
+  sourcePath: string;
+}>;
+
+type CaptureStart = Readonly<{
+  sourcePath: string;
+}>;
+
+type CaptureStatus = Readonly<{
+  sourcePath: string;
+  snapshot: DVDMenuCaptureSnapshot;
+}>;
+
+const terminalStatuses = new Set(["completed", "failed", "canceled"]);
+const hiddenCaptureWarningCodes = new Set([
+  "unsupported_post_link",
+  "structural_state",
+  "structural_only",
+  "nav_scan_limit",
+  "structural_discovery",
+]);
+
+const errorText = (error: unknown) =>
+  error instanceof Error && error.message ? error.message : String(error);
+
+/**
+ * Manages manual disc-menu imports and background DVD menu capture for the
+ * current prepared source. Persisted images can be previewed or deleted before
+ * continuing to image-host selection.
+ */
 export default function MenuImagesPage(props: Props) {
-  const { path, overrides, nameOverrides, browseAvailable, onImportComplete } = props;
+  const {
+    path,
+    overrides,
+    nameOverrides,
+    currentDiscType,
+    maxMenuItems,
+    browseAvailable,
+    onImagesChanged,
+    onContinue,
+    setLightboxImage,
+    setLightboxAlt,
+  } = props;
 
   const [menuPaths, setMenuPaths] = useState<string[]>([]);
+  const [images, setImages] = useState<MenuPreview[]>([]);
+  const [listLoading, setListLoading] = useState(false);
   const [importing, setImporting] = useState(false);
+  const [deletingPath, setDeletingPath] = useState("");
+  const [captureJob, setCaptureJob] = useState<CaptureJob | null>(null);
+  const [captureStart, setCaptureStart] = useState<CaptureStart | null>(null);
+  const [captureStatus, setCaptureStatus] = useState<CaptureStatus | null>(null);
   const [error, setError] = useState("");
-  const [success, setSuccess] = useState(false);
+  const [notice, setNotice] = useState("");
+  const removeButtonRefs = useRef(new Map<string, HTMLButtonElement>());
+  const captureButtonRef = useRef<HTMLButtonElement>(null);
+  const focusAfterRemovalRef = useRef<number | null>(null);
+  const captureJobRef = useRef<CaptureJob | null>(null);
+  const captureStartRef = useRef<CaptureStart | null>(null);
+  const previousSourcePathRef = useRef(path.trim());
+  const refreshRequestRef = useRef(0);
+
+  const sourcePath = path.trim();
+  const resolvedMaxMenuItems =
+    Number.isFinite(maxMenuItems) && maxMenuItems > 0 ? Math.trunc(maxMenuItems) : 6;
+  const automaticCaptureAvailable = currentDiscType.toUpperCase() === "DVD";
+  const currentCaptureJob = captureJob?.sourcePath === sourcePath ? captureJob : null;
+  const captureStarting = captureStart?.sourcePath === sourcePath;
+  const visibleSnapshot = captureStatus?.sourcePath === sourcePath ? captureStatus.snapshot : null;
+  const captureActive =
+    captureStarting ||
+    (currentCaptureJob !== null &&
+      (!visibleSnapshot ||
+        visibleSnapshot.status === "queued" ||
+        visibleSnapshot.status === "running"));
+
+  const refreshImages = useCallback(async () => {
+    const requestID = ++refreshRequestRef.current;
+    const app = globalThis.go?.guiapp?.App;
+    if (!app?.ListDVDMenuScreenshots || !sourcePath) {
+      setImages([]);
+      setListLoading(false);
+      return;
+    }
+    setListLoading(true);
+    try {
+      const persisted = await app.ListDVDMenuScreenshots(sourcePath, overrides, nameOverrides);
+      const previews = await Promise.all(
+        (persisted || []).map(async (image): Promise<MenuPreview | null> => {
+          if (!image.Path || !app.ReadScreenshotImage) return null;
+          try {
+            return { image, dataURI: await app.ReadScreenshotImage(image.Path) };
+          } catch {
+            return null;
+          }
+        }),
+      );
+      if (refreshRequestRef.current !== requestID) return;
+      setImages(previews.filter((item): item is MenuPreview => item !== null));
+    } catch (loadError) {
+      if (refreshRequestRef.current === requestID) setError(errorText(loadError));
+    } finally {
+      if (refreshRequestRef.current === requestID) setListLoading(false);
+    }
+  }, [nameOverrides, overrides, sourcePath]);
+
+  useEffect(() => {
+    void refreshImages();
+  }, [refreshImages]);
+
+  useEffect(() => {
+    const previousSourcePath = previousSourcePathRef.current;
+    if (previousSourcePath === sourcePath) return;
+    previousSourcePathRef.current = sourcePath;
+
+    setCaptureStatus(null);
+    setError("");
+    setNotice("");
+
+    const staleStart = captureStartRef.current;
+    if (staleStart && staleStart.sourcePath !== sourcePath) {
+      captureStartRef.current = null;
+      setCaptureStart((current) => (current === staleStart ? null : current));
+    }
+
+    const staleJob = captureJobRef.current;
+    if (staleJob && staleJob.sourcePath !== sourcePath) {
+      captureJobRef.current = null;
+      setCaptureJob((current) => (current === staleJob ? null : current));
+      const cancel = globalThis.go?.guiapp?.App?.CancelDVDMenuCapture;
+      if (cancel) void cancel(staleJob.id).catch(() => undefined);
+    }
+  }, [sourcePath]);
+
+  useEffect(() => {
+    const targetIndex = focusAfterRemovalRef.current;
+    if (targetIndex === null) return;
+    focusAfterRemovalRef.current = null;
+    const target = images[Math.min(targetIndex, Math.max(images.length - 1, 0))];
+    window.requestAnimationFrame(() => {
+      if (target?.image.Path) {
+        removeButtonRefs.current.get(target.image.Path)?.focus();
+      } else {
+        captureButtonRef.current?.focus();
+      }
+    });
+  }, [images]);
+
+  useEffect(() => {
+    if (!currentCaptureJob) return;
+    let disposed = false;
+    let timer: number | undefined;
+
+    const poll = async () => {
+      try {
+        const loader = globalThis.go?.guiapp?.App?.GetDVDMenuCaptureSnapshot;
+        if (!loader) throw new Error("DVD menu capture status is unavailable");
+        const next = await loader(currentCaptureJob.id);
+        if (disposed) return;
+        setCaptureStatus({ sourcePath: currentCaptureJob.sourcePath, snapshot: next });
+        if (terminalStatuses.has(next.status)) {
+          if (next.status === "completed") {
+            await refreshImages();
+            if (disposed) return;
+            onImagesChanged();
+          } else if (next.error) {
+            setError(next.error);
+          }
+          if (captureJobRef.current === currentCaptureJob) captureJobRef.current = null;
+          setCaptureJob((current) => (current === currentCaptureJob ? null : current));
+          return;
+        }
+        timer = window.setTimeout(poll, 300);
+      } catch (pollError) {
+        if (!disposed) {
+          if (captureJobRef.current === currentCaptureJob) captureJobRef.current = null;
+          setCaptureJob((current) => (current === currentCaptureJob ? null : current));
+          setError(errorText(pollError));
+        }
+      }
+    };
+
+    void poll();
+    return () => {
+      disposed = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, [currentCaptureJob, onImagesChanged, refreshImages]);
 
   const handleBrowseImages = async () => {
+    setError("");
     try {
       const app = globalThis.go?.guiapp?.App;
       if (!app) return;
-
-      // Prefer the image-specific picker, then fall back to older local builds.
-      if (app.BrowseImageFiles || app.BrowseFiles) {
-        const selected = await (app.BrowseImageFiles || app.BrowseFiles)?.();
-        if (selected && selected.length > 0) {
-          const valid = selected.filter((s) => s.trim() !== "");
-          if (valid.length > 0) {
-            setMenuPaths((prev) => Array.from(new Set([...prev, ...valid])));
-            setSuccess(false);
-          }
-        }
-      } else if (app.BrowseFile) {
-        const selected = await app.BrowseFile();
-        if (selected && selected.trim() !== "") {
-          setMenuPaths((prev) => Array.from(new Set([...prev, selected.trim()])));
-          setSuccess(false);
-        }
+      const selected = app.BrowseImageFiles
+        ? await app.BrowseImageFiles()
+        : app.BrowseFiles
+          ? await app.BrowseFiles()
+          : app.BrowseFile
+            ? [await app.BrowseFile()]
+            : [];
+      const valid = selected.map((value) => value.trim()).filter(Boolean);
+      if (valid.length > 0) {
+        setMenuPaths((previous) => Array.from(new Set([...previous, ...valid])));
+        setNotice("");
       }
-    } catch (err) {
-      console.error(err);
+    } catch (browseError) {
+      setError(errorText(browseError));
     }
-  };
-
-  const handleRemoveItem = (itemToRemove: string) => {
-    setMenuPaths((prev) => prev.filter((p) => p !== itemToRemove));
   };
 
   const handleImport = async () => {
     if (menuPaths.length === 0) return;
     setImporting(true);
     setError("");
-    setSuccess(false);
+    setNotice("");
     try {
-      const importFn = globalThis.go?.guiapp?.App?.ImportMenuImages;
-      if (!importFn) throw new Error("Import function not available");
-      await importFn(path, overrides, nameOverrides, menuPaths);
-      setSuccess(true);
+      const importImages = globalThis.go?.guiapp?.App?.ImportMenuImages;
+      if (!importImages) throw new Error("Menu image import is unavailable");
+      await importImages(path, overrides, nameOverrides, menuPaths);
       setMenuPaths([]);
-      onImportComplete();
-    } catch (err: any) {
-      setError(err?.message || String(err));
+      setNotice("Menu images imported successfully.");
+      await refreshImages();
+      onImagesChanged();
+    } catch (importError) {
+      setError(errorText(importError));
     } finally {
       setImporting(false);
     }
   };
 
+  const handleCapture = async () => {
+    if (!sourcePath || captureStartRef.current?.sourcePath === sourcePath) return;
+    if (captureJobRef.current?.sourcePath === sourcePath) return;
+
+    const request: CaptureStart = { sourcePath };
+    captureStartRef.current = request;
+    setCaptureStart(request);
+    setError("");
+    setNotice("");
+    setCaptureStatus(null);
+    try {
+      const start = globalThis.go?.guiapp?.App?.StartDVDMenuCapture;
+      if (!start) throw new Error("DVD menu capture is unavailable");
+      const nextJobID = await start(sourcePath, overrides, nameOverrides);
+      if (captureStartRef.current !== request) {
+        const cancel = globalThis.go?.guiapp?.App?.CancelDVDMenuCapture;
+        if (cancel) await cancel(nextJobID).catch(() => undefined);
+        return;
+      }
+      const nextJob: CaptureJob = { id: nextJobID, sourcePath };
+      captureJobRef.current = nextJob;
+      setCaptureJob(nextJob);
+    } catch (captureError) {
+      if (captureStartRef.current === request) setError(errorText(captureError));
+    } finally {
+      if (captureStartRef.current === request) {
+        captureStartRef.current = null;
+        setCaptureStart(null);
+      }
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!currentCaptureJob) return;
+    try {
+      const cancel = globalThis.go?.guiapp?.App?.CancelDVDMenuCapture;
+      if (!cancel) throw new Error("DVD menu capture cancellation is unavailable");
+      await cancel(currentCaptureJob.id);
+    } catch (cancelError) {
+      setError(errorText(cancelError));
+    }
+  };
+
+  const handleDelete = async (imagePath: string, index: number) => {
+    setDeletingPath(imagePath);
+    setError("");
+    try {
+      const remove = globalThis.go?.guiapp?.App?.DeleteDVDMenuScreenshot;
+      if (!remove) throw new Error("DVD menu image removal is unavailable");
+      await remove(path, overrides, nameOverrides, imagePath);
+      focusAfterRemovalRef.current = index;
+      await refreshImages();
+      onImagesChanged();
+      setNotice("Menu image removed.");
+    } catch (deleteError) {
+      setError(errorText(deleteError));
+    } finally {
+      setDeletingPath("");
+    }
+  };
+
+  const completionMessage = useMemo(() => {
+    if (visibleSnapshot?.status !== "completed") return "";
+    if (visibleSnapshot.result.Truncated) return "Maximum reached";
+    return `Captured ${visibleSnapshot.capturedCount} DVD menu image${visibleSnapshot.capturedCount === 1 ? "" : "s"}.`;
+  }, [visibleSnapshot]);
+  const visibleCaptureWarnings =
+    visibleSnapshot?.result.Warnings?.filter(
+      (warning) => !hiddenCaptureWarningCodes.has(warning.Code),
+    ) ?? [];
+
   return (
-    <section className="menu-images-panel">
-      <header className="menu-images-header">
+    <section className="grid gap-4">
+      <header>
         <p className="eyebrow">Disc Menus</p>
         <h1>Menu Images</h1>
         <p className="subtitle">
-          Select existing menu images from your computer to be uploaded alongside your screenshots.
+          Capture DVD menus or import existing disc menu images for upload and descriptions.
         </p>
       </header>
 
-      <section className="panel menu-images-controls">
-        <div>
-          <p className="label">Source path</p>
-          <p className="value dupe-path">{path || "No path selected"}</p>
-        </div>
-
-        <div className="upload-images-actions" style={{ marginTop: "1rem" }}>
-          {browseAvailable ? (
-            <>
-              <button
-                className="ghost"
-                type="button"
-                onClick={handleBrowseImages}
-                disabled={importing}
-              >
-                Add images
+      {automaticCaptureAvailable ? (
+        <section className="panel grid gap-3" aria-busy={captureActive}>
+          <div>
+            <h2>Automatic DVD capture</h2>
+            <p className="muted">Capture up to {resolvedMaxMenuItems} distinct DVD menu screens.</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              ref={captureButtonRef}
+              className="primary"
+              type="button"
+              onClick={handleCapture}
+              disabled={captureActive || importing || !path.trim()}
+            >
+              {captureStarting ? "Starting..." : "Capture DVD menus"}
+            </button>
+            {captureActive ? (
+              <button className="ghost" type="button" onClick={handleCancel}>
+                Cancel
               </button>
-            </>
+            ) : null}
+          </div>
+          {visibleSnapshot ? (
+            <div className="grid gap-1" role="status" aria-live="polite">
+              <p className="m-0 font-medium">{visibleSnapshot.message || visibleSnapshot.phase}</p>
+              <p className="muted m-0">
+                Menus {visibleSnapshot.discoveredMenus} · States {visibleSnapshot.visitedStates} ·
+                Buttons {visibleSnapshot.visitedButtons} · Captured {visibleSnapshot.capturedCount}
+                {visibleCaptureWarnings.length > 0
+                  ? ` · Warnings ${visibleCaptureWarnings.length}`
+                  : ""}
+              </p>
+              {completionMessage ? <p className="success m-0">{completionMessage}</p> : null}
+              {visibleSnapshot.result.Truncated ? (
+                <p className="muted m-0">Configured maximum: {visibleSnapshot.result.MaxItems}.</p>
+              ) : null}
+              {visibleCaptureWarnings.map((warning) => (
+                <p className="muted m-0" key={warning.Code}>
+                  {warning.Message}
+                </p>
+              ))}
+            </div>
+          ) : null}
+        </section>
+      ) : (
+        <section className="panel">
+          <p className="muted">
+            Automatic capture is available for DVD sources. Manual disc menu import remains
+            available for {currentDiscType || "this source"}.
+          </p>
+        </section>
+      )}
+
+      <section className="panel grid gap-3">
+        <div>
+          <h2>Import menu images</h2>
+          <p className="muted">Select PNG, JPEG, or WebP menu images from this computer.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {browseAvailable ? (
+            <button
+              className="ghost"
+              type="button"
+              onClick={handleBrowseImages}
+              disabled={importing}
+            >
+              Add images
+            </button>
           ) : (
             <p className="muted">Native file browsing is only available locally.</p>
           )}
-
           <button
             className="primary"
             type="button"
             onClick={handleImport}
-            disabled={importing || menuPaths.length === 0}
+            disabled={importing || menuPaths.length === 0 || captureActive}
           >
-            {importing ? "Importing..." : "Import Images"}
+            {importing ? "Importing..." : "Import images"}
           </button>
         </div>
-
-        {error ? (
-          <p className="error" style={{ marginTop: "1rem" }}>
-            {error}
-          </p>
-        ) : null}
-        {success ? (
-          <p
-            className="success"
-            style={{ marginTop: "1rem", color: "var(--success-color, #22c55e)" }}
-          >
-            Images imported successfully! They will appear in the Upload Images tab.
-          </p>
-        ) : null}
-
         {menuPaths.length > 0 ? (
-          <div style={{ marginTop: "1.5rem" }}>
-            <p className="label" style={{ marginBottom: "0.5rem" }}>
-              Selected files for import:
-            </p>
-            <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
-              {menuPaths.map((p) => (
-                <li
-                  key={p}
-                  style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    padding: "0.5rem",
-                    background: "var(--bg-secondary)",
-                    marginBottom: "0.25rem",
-                    borderRadius: "4px",
-                  }}
+          <ul className="m-0 grid list-none gap-1 p-0">
+            {menuPaths.map((selectedPath) => (
+              <li
+                className="flex items-center justify-between gap-2 rounded border border-white/10 bg-white/5 p-2"
+                key={selectedPath}
+              >
+                <span className="min-w-0 break-all">{selectedPath}</span>
+                <button
+                  className="ghost"
+                  type="button"
+                  onClick={() =>
+                    setMenuPaths((previous) => previous.filter((item) => item !== selectedPath))
+                  }
                 >
-                  <span style={{ wordBreak: "break-all" }}>{p}</span>
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </section>
+
+      {error ? (
+        <p className="error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      {notice ? (
+        <p className="success" role="status" aria-live="polite">
+          {notice}
+        </p>
+      ) : null}
+
+      <section className="panel grid gap-3">
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <h2>Saved menu images</h2>
+          <p className="muted">{listLoading ? "Loading..." : `${images.length} saved`}</p>
+        </div>
+        {images.length > 0 ? (
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-3">
+            {images.map((item, index) => {
+              const itemNumber = index + 1;
+              return (
+                <article className="grid gap-2" key={item.image.Path}>
                   <button
-                    className="ghost"
+                    className="screens-thumb"
                     type="button"
-                    onClick={() => handleRemoveItem(p)}
-                    style={{ padding: "0.25rem 0.5rem", height: "auto", minHeight: "0" }}
+                    aria-label={`Preview DVD menu ${itemNumber}`}
+                    onClick={() => {
+                      setLightboxImage(item.dataURI);
+                      setLightboxAlt(`DVD menu ${itemNumber}`);
+                    }}
                   >
-                    Remove
+                    <img src={item.dataURI} alt="" />
                   </button>
-                </li>
-              ))}
-            </ul>
+                  <button
+                    ref={(element) => {
+                      if (element) removeButtonRefs.current.set(item.image.Path, element);
+                      else removeButtonRefs.current.delete(item.image.Path);
+                    }}
+                    className="danger"
+                    type="button"
+                    aria-label={`Remove DVD menu ${itemNumber}`}
+                    disabled={deletingPath === item.image.Path || captureActive}
+                    onClick={() => handleDelete(item.image.Path, index)}
+                  >
+                    {deletingPath === item.image.Path ? "Removing..." : "Remove"}
+                  </button>
+                </article>
+              );
+            })}
           </div>
         ) : (
-          <p className="muted" style={{ marginTop: "1.5rem" }}>
-            No images selected yet.
-          </p>
+          <p className="muted">No saved menu images yet.</p>
         )}
       </section>
+
+      <div className="flex justify-end">
+        <button className="primary" type="button" onClick={onContinue}>
+          Continue to Upload Images
+        </button>
+      </div>
     </section>
   );
 }

--- a/gui/frontend/src/pages/menu_images/index.tsx
+++ b/gui/frontend/src/pages/menu_images/index.tsx
@@ -56,7 +56,8 @@ const errorText = (error: unknown) =>
 /**
  * Manages manual disc-menu imports and background DVD menu capture for the
  * current prepared source. Persisted images can be previewed or deleted before
- * continuing to image-host selection.
+ * continuing to image-host selection. Concurrent deletions keep each affected
+ * control pending until its own request settles.
  */
 export default function MenuImagesPage(props: Props) {
   const {
@@ -76,13 +77,14 @@ export default function MenuImagesPage(props: Props) {
   const [images, setImages] = useState<MenuPreview[]>([]);
   const [listLoading, setListLoading] = useState(false);
   const [importing, setImporting] = useState(false);
-  const [deletingPath, setDeletingPath] = useState("");
+  const [deletingPaths, setDeletingPaths] = useState<ReadonlySet<string>>(() => new Set());
   const [captureJob, setCaptureJob] = useState<CaptureJob | null>(null);
   const [captureStart, setCaptureStart] = useState<CaptureStart | null>(null);
   const [captureStatus, setCaptureStatus] = useState<CaptureStatus | null>(null);
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
   const removeButtonRefs = useRef(new Map<string, HTMLButtonElement>());
+  const deletingPathsRef = useRef(new Set<string>());
   const captureButtonRef = useRef<HTMLButtonElement>(null);
   const focusAfterRemovalRef = useRef<number | null>(null);
   const captureJobRef = useRef<CaptureJob | null>(null);
@@ -303,7 +305,9 @@ export default function MenuImagesPage(props: Props) {
   };
 
   const handleDelete = async (imagePath: string, index: number) => {
-    setDeletingPath(imagePath);
+    if (deletingPathsRef.current.has(imagePath)) return;
+    deletingPathsRef.current.add(imagePath);
+    setDeletingPaths(new Set(deletingPathsRef.current));
     setError("");
     try {
       const remove = globalThis.go?.guiapp?.App?.DeleteDVDMenuScreenshot;
@@ -316,7 +320,8 @@ export default function MenuImagesPage(props: Props) {
     } catch (deleteError) {
       setError(errorText(deleteError));
     } finally {
-      setDeletingPath("");
+      deletingPathsRef.current.delete(imagePath);
+      setDeletingPaths(new Set(deletingPathsRef.current));
     }
   };
 
@@ -463,6 +468,7 @@ export default function MenuImagesPage(props: Props) {
           <div className="grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-3">
             {images.map((item, index) => {
               const itemNumber = index + 1;
+              const deleting = deletingPaths.has(item.image.Path);
               return (
                 <article className="grid gap-2" key={item.image.Path}>
                   <button
@@ -484,10 +490,10 @@ export default function MenuImagesPage(props: Props) {
                     className="danger"
                     type="button"
                     aria-label={`Remove DVD menu ${itemNumber}`}
-                    disabled={deletingPath === item.image.Path || captureActive}
+                    disabled={deleting || captureActive}
                     onClick={() => handleDelete(item.image.Path, index)}
                   >
-                    {deletingPath === item.image.Path ? "Removing..." : "Remove"}
+                    {deleting ? "Removing..." : "Remove"}
                   </button>
                 </article>
               );

--- a/gui/frontend/src/pages/settings/index.test.tsx
+++ b/gui/frontend/src/pages/settings/index.test.tsx
@@ -148,6 +148,49 @@ describe("SettingsPage", () => {
     expect(screen.queryByText("Copyright (c) 2026 autobrr")).not.toBeInTheDocument();
   });
 
+  it("shows path-free DVD engine and FFmpeg capability diagnostics", async () => {
+    vi.stubGlobal("go", {
+      guiapp: {
+        App: {
+          GetApplicationInfo: vi.fn().mockResolvedValue({
+            version: "dev",
+            buildIdentifier: "example-build",
+            goVersion: "go1.26.4",
+            goos: "windows",
+            goarch: "amd64",
+            uptime: "1s",
+            uptimeSeconds: 1,
+            dvdMenuEngine: {
+              EngineVersion: "phase0a-1",
+              SchemaVersion: 1,
+              SupportedFeatures: ["ifo_inventory"],
+              FFmpegVersion: "ffmpeg version example",
+              FFmpegDVDVideo: true,
+              MissingFFmpegOptions: [],
+            },
+            dvdMenuCapabilityStatus: "available",
+            dvdMenuCapabilityMessage: "Compatible FFmpeg dvdvideo menu support detected.",
+          }),
+        },
+      },
+    });
+
+    render(
+      <SettingsPage
+        {...baseProps}
+        settingsSection="application_details"
+        setSettingsSection={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("phase0a-1")).toBeInTheDocument());
+    expect(screen.getByText("Available")).toBeInTheDocument();
+    expect(screen.getByText("ffmpeg version example")).toBeInTheDocument();
+    expect(
+      screen.getByText("Compatible FFmpeg dvdvideo menu support detected."),
+    ).toBeInTheDocument();
+  });
+
   it("renders tracker auth as the bottom tab", async () => {
     const setSettingsSection = vi.fn();
     vi.stubGlobal("go", {

--- a/gui/frontend/src/pages/settings/index.tsx
+++ b/gui/frontend/src/pages/settings/index.tsx
@@ -678,6 +678,29 @@ export default function SettingsPage(props: Props) {
               <p className="settings-detail-card__value mono">{applicationInfo.goVersion}</p>
             </div>
             <div className="settings-detail-card">
+              <p className="settings-detail-card__label">DVD Menu Engine</p>
+              <p className="settings-detail-card__value mono">
+                {applicationInfo.dvdMenuEngine.EngineVersion || "Unavailable"}
+              </p>
+            </div>
+            <div className="settings-detail-card">
+              <p className="settings-detail-card__label">FFmpeg DVD Menus</p>
+              <p className="settings-detail-card__value mono">
+                {applicationInfo.dvdMenuCapabilityStatus === "available"
+                  ? "Available"
+                  : applicationInfo.dvdMenuCapabilityStatus === "incompatible"
+                    ? "Incompatible"
+                    : "Unavailable"}
+              </p>
+              <p className="helper">{applicationInfo.dvdMenuCapabilityMessage}</p>
+            </div>
+            <div className="settings-detail-card">
+              <p className="settings-detail-card__label">FFmpeg Version</p>
+              <p className="settings-detail-card__value mono">
+                {applicationInfo.dvdMenuEngine.FFmpegVersion || "Unavailable"}
+              </p>
+            </div>
+            <div className="settings-detail-card">
               <p className="settings-detail-card__label">Platform</p>
               <p className="settings-detail-card__value mono">
                 {applicationInfo.goos}/{applicationInfo.goarch}

--- a/gui/frontend/src/pages/upload_images/index.test.tsx
+++ b/gui/frontend/src/pages/upload_images/index.test.tsx
@@ -45,4 +45,49 @@ describe("UploadImagesPage", () => {
     expect(screen.getByText(trackerImageURL)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Raw URL" })).toHaveAttribute("href", trackerImageURL);
   });
+
+  it("labels menu-purpose upload candidates", () => {
+    render(
+      <UploadImagesPage
+        path="C:/media/Example"
+        uploadHost="imgbb"
+        setUploadHost={vi.fn()}
+        configuredImageHosts={["imgbb"]}
+        resolveImageHostLabel={(value) => value}
+        uploadImagesLoading={false}
+        uploadProgress={{ current: 0, total: 0 }}
+        setAllUploadSelections={vi.fn()}
+        handleUploadImages={vi.fn()}
+        uploadImagesError=""
+        uploadImageFailures={[]}
+        uploadCandidates={[
+          {
+            image: {
+              Index: 0,
+              TimestampSeconds: 0,
+              Path: "C:/managed/menu.png",
+              Purpose: "menu",
+              Width: 720,
+              Height: 480,
+              SizeBytes: 1024,
+            },
+            dataUri: "data:image/png;base64,example",
+          },
+        ]}
+        uploadSelections={{}}
+        toggleUploadSelection={vi.fn()}
+        setLightboxImage={vi.fn()}
+        setLightboxAlt={vi.fn()}
+        uploadedRecordByPath={new Map()}
+        uploadedImages={[]}
+        uploadedImageRecords={[]}
+        trackerImageLinks={[]}
+        trackerImageURLs={[]}
+        handleDeleteUploadedImage={vi.fn()}
+        handleDeleteTrackerImage={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Disc menu")).toBeInTheDocument();
+  });
 });

--- a/gui/frontend/src/pages/upload_images/index.tsx
+++ b/gui/frontend/src/pages/upload_images/index.tsx
@@ -301,6 +301,11 @@ export default function UploadImagesPage(props: Props) {
                         Uploaded {hostLabel}
                       </span>
                     ) : null}
+                    {item.image.Purpose === "menu" ? (
+                      <span className="pointer-events-none absolute bottom-1.5 left-1.5 rounded bg-sky-900 px-1.5 py-1 text-xs font-semibold text-sky-50">
+                        Disc menu
+                      </span>
+                    ) : null}
                   </button>
                   <Button
                     className={cn(

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -415,6 +415,7 @@ export type WebAuthStatus = {
   message: string;
 };
 
+/** Running build metadata plus path-free DVD menu capability diagnostics. */
 export type ApplicationInfo = {
   version: string;
   buildIdentifier: string;
@@ -423,6 +424,12 @@ export type ApplicationInfo = {
   goarch: string;
   uptime: string;
   uptimeSeconds: number;
+  /** Pure-Go engine and FFmpeg dvdvideo probe metadata. */
+  dvdMenuEngine: DVDMenuEngineInfo;
+  /** Stable capability state shown by settings diagnostics. */
+  dvdMenuCapabilityStatus: "available" | "incompatible" | "unavailable";
+  /** User-facing reason for dvdMenuCapabilityStatus. */
+  dvdMenuCapabilityMessage: string;
 };
 
 /** Tracker auth support metadata returned by the app bridge. */
@@ -761,7 +768,8 @@ export type DescriptionBuilderPreview = {
   Groups: DescriptionBuilderGroup[];
 };
 
-export type ScreenshotPurpose = "preview" | "final";
+/** Image category shared by capture, selection, upload, and menu workflows. */
+export type ScreenshotPurpose = "preview" | "final" | "menu";
 
 export type ScreenshotSelection = {
   Index: number;
@@ -774,6 +782,8 @@ export type ScreenshotImage = {
   Index: number;
   TimestampSeconds: number;
   Path: string;
+  /** Distinguishes preview, normal final, and disc-menu images. */
+  Purpose: ScreenshotPurpose;
   Width: number;
   Height: number;
   SizeBytes: number;
@@ -782,6 +792,101 @@ export type ScreenshotImage = {
   RawURL?: string;
   WebURL?: string;
   UploadedAt?: string;
+};
+
+/** How the DVD navigation engine found a selected menu screen. */
+export type DVDMenuDiscovery = "reachable" | "structural";
+
+/** Stable, redacted diagnostic for incomplete DVD menu coverage. */
+export type DVDMenuCaptureWarning = {
+  /** Machine-readable warning identifier. */
+  Code: string;
+  /** User-facing path-free warning text. */
+  Message: string;
+};
+
+/** Path-free pure-Go engine and FFmpeg dvdvideo capability metadata. */
+export type DVDMenuEngineInfo = {
+  /** Bundled pure-Go engine implementation version. */
+  EngineVersion: string;
+  /** Capture metadata contract version. */
+  SchemaVersion: number;
+  /** Engine stages available in this build. */
+  SupportedFeatures: string[];
+  /** Bounded first line of FFmpeg version output. */
+  FFmpegVersion: string;
+  /** Whether FFmpeg exposes the required dvdvideo menu options. */
+  FFmpegDVDVideo: boolean;
+  /** Required dvdvideo options absent from the capability probe. */
+  MissingFFmpegOptions: string[];
+};
+
+/** Persisted menu image plus its navigation discovery source. */
+export type DVDMenuCaptureImage = ScreenshotImage & {
+  /** Whether navigation or structural inventory found the screen. */
+  Discovery: DVDMenuDiscovery;
+};
+
+/** Final or partial result of one bounded automatic DVD menu capture. */
+export type DVDMenuCaptureResult = {
+  /** Host filesystem path of the prepared DVD source. */
+  SourcePath: string;
+  /** Persisted automatic captures in display order. */
+  Images: DVDMenuCaptureImage[];
+  /** Menu language requested from the engine. */
+  SelectedLanguage: string;
+  /** DVD region override; zero means none. */
+  Region: number;
+  /** Number of structurally inventoried menu programs. */
+  DiscoveredMenus: number;
+  /** Number of distinct VM states evaluated. */
+  VisitedStates: number;
+  /** Number of authored button commands evaluated. */
+  VisitedButtons: number;
+  /** Configured upper bound on automatic captures. */
+  MaxItems: number;
+  /** True when every selected screen was captured without coverage warnings. */
+  Complete: boolean;
+  /** True when warnings prevented complete navigation or rendering coverage. */
+  Partial: boolean;
+  /** True when MaxItems excluded eligible screens. */
+  Truncated: boolean;
+  /** Deduplicated coverage diagnostics. */
+  Warnings: DVDMenuCaptureWarning[];
+  /** Engine and FFmpeg capability used for capture. */
+  Engine: DVDMenuEngineInfo;
+};
+
+/** Pollable frontend state for one background DVD menu capture job. */
+export type DVDMenuCaptureSnapshot = {
+  /** Opaque identifier used for polling and cancellation. */
+  jobID: string;
+  /** Host filesystem path associated with the prepared metadata. */
+  sourcePath: string;
+  /** Job lifecycle state: queued, running, completed, failed, or canceled. */
+  status: string;
+  /** Current capture stage within status. */
+  phase: string;
+  /** User-facing progress or terminal summary. */
+  message: string;
+  /** Latest structural inventory count. */
+  discoveredMenus: number;
+  /** Latest evaluated VM-state count. */
+  visitedStates: number;
+  /** Latest evaluated button-command count. */
+  visitedButtons: number;
+  /** Latest rendered or persisted image count. */
+  capturedCount: number;
+  /** Latest distinct coverage-warning count. */
+  warningCount: number;
+  /** Final or partial capture result when available. */
+  result: DVDMenuCaptureResult;
+  /** Terminal failure text; empty for successful jobs. */
+  error: string;
+  /** RFC3339 UTC job start time. */
+  startedAt: string;
+  /** RFC3339 UTC finish time, or empty while active. */
+  finishedAt: string;
 };
 
 export type ScreenshotError = {

--- a/gui/frontend/src/utils/runtime.test.ts
+++ b/gui/frontend/src/utils/runtime.test.ts
@@ -71,6 +71,77 @@ describe("browser runtime bridge", () => {
     );
   });
 
+  it("uses exact DVD menu capture and lifecycle payloads", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse("dvd-job-1"))
+      .mockResolvedValueOnce(jsonResponse({ jobID: "dvd-job-1", status: "running" }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }))
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { initializeBrowserBridge } = await import("./runtime");
+    initializeBrowserBridge("csrf-token", true);
+    const app = (globalThis as any).go.guiapp.App;
+
+    await app.StartDVDMenuCapture("C:/media/Example", { TMDBID: 1 }, { Category: "MOVIE" });
+    await app.GetDVDMenuCaptureSnapshot("dvd-job-1");
+    await app.CancelDVDMenuCapture("dvd-job-1");
+    await app.ListDVDMenuScreenshots("C:/media/Example", { TMDBID: 1 }, { Category: "MOVIE" });
+    await app.DeleteDVDMenuScreenshot(
+      "C:/media/Example",
+      { TMDBID: 1 },
+      { Category: "MOVIE" },
+      "C:/managed/menu.png",
+    );
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/app/StartDVDMenuCapture",
+      expect.objectContaining({
+        body: JSON.stringify({
+          Path: "C:/media/Example",
+          Overrides: { TMDBID: 1 },
+          NameOverrides: { Category: "MOVIE" },
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/app/GetDVDMenuCaptureSnapshot",
+      expect.objectContaining({ body: JSON.stringify({ JobID: "dvd-job-1" }) }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "/api/app/CancelDVDMenuCapture",
+      expect.objectContaining({ body: JSON.stringify({ JobID: "dvd-job-1" }) }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "/api/app/ListDVDMenuScreenshots",
+      expect.objectContaining({
+        body: JSON.stringify({
+          Path: "C:/media/Example",
+          Overrides: { TMDBID: 1 },
+          NameOverrides: { Category: "MOVIE" },
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
+      "/api/app/DeleteDVDMenuScreenshot",
+      expect.objectContaining({
+        body: JSON.stringify({
+          Path: "C:/media/Example",
+          Overrides: { TMDBID: 1 },
+          NameOverrides: { Category: "MOVIE" },
+          ImagePath: "C:/managed/menu.png",
+        }),
+      }),
+    );
+  });
+
   it("preserves tracker auth status fields from browser app routes", async () => {
     const status: TrackerAuthStatus = {
       trackerID: "MTV",

--- a/gui/frontend/src/utils/runtime.ts
+++ b/gui/frontend/src/utils/runtime.ts
@@ -495,6 +495,33 @@ export const initializeBrowserBridge = (
             NameOverrides: nameOverrides,
             Paths: paths,
           }),
+        StartDVDMenuCapture: (path: string, overrides: unknown, nameOverrides: unknown) =>
+          call("StartDVDMenuCapture", {
+            Path: path,
+            Overrides: overrides,
+            NameOverrides: nameOverrides,
+          }),
+        GetDVDMenuCaptureSnapshot: (jobID: string) =>
+          call("GetDVDMenuCaptureSnapshot", { JobID: jobID }),
+        CancelDVDMenuCapture: (jobID: string) => call("CancelDVDMenuCapture", { JobID: jobID }),
+        ListDVDMenuScreenshots: (path: string, overrides: unknown, nameOverrides: unknown) =>
+          call("ListDVDMenuScreenshots", {
+            Path: path,
+            Overrides: overrides,
+            NameOverrides: nameOverrides,
+          }),
+        DeleteDVDMenuScreenshot: (
+          path: string,
+          overrides: unknown,
+          nameOverrides: unknown,
+          imagePath: string,
+        ) =>
+          call("DeleteDVDMenuScreenshot", {
+            Path: path,
+            Overrides: overrides,
+            NameOverrides: nameOverrides,
+            ImagePath: imagePath,
+          }),
         ReadScreenshotImage: (path: string) => call("ReadScreenshotImage", { Path: path }),
         ListUploadCandidates: (path: string, overrides: unknown, nameOverrides: unknown) =>
           call("ListUploadCandidates", {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,7 +39,14 @@ type Config struct {
 	secretReencryptionRequired bool
 }
 
-const DefaultInputHistoryLimit = 20
+const (
+	// DefaultInputHistoryLimit is the default number of retained input paths.
+	DefaultInputHistoryLimit = 20
+	// DefaultDVDMenuItems is the default automatic DVD menu capture limit.
+	DefaultDVDMenuItems = 6
+	// MaxDVDMenuItems is the largest accepted automatic DVD menu capture limit.
+	MaxDVDMenuItems = 32
+)
 
 type MainSettingsConfig struct {
 	UpdateNotification  bool   `yaml:"update_notification"`
@@ -118,7 +125,9 @@ type MetadataConfig struct {
 }
 
 type ScreenshotHandlingConfig struct {
-	Screens              int     `yaml:"screens"`
+	Screens int `yaml:"screens"`
+	// MaxMenuItems bounds automatic DVD menu captures; zero resolves to DefaultDVDMenuItems.
+	MaxMenuItems         int     `yaml:"max_menu_items"`
 	MinSuccessfulUploads int     `yaml:"min_successful_image_uploads"`
 	CutoffScreens        int     `yaml:"cutoff_screens"`
 	FrameOverlay         bool    `yaml:"frame_overlay"`
@@ -131,6 +140,47 @@ type ScreenshotHandlingConfig struct {
 	FFmpegCompression    int     `yaml:"ffmpeg_compression"`
 	TonemapAlgorithm     string  `yaml:"algorithm"`
 	Desat                float64 `yaml:"desat"`
+}
+
+type screenshotHandlingConfigAlias ScreenshotHandlingConfig
+
+// UnmarshalYAML preserves the default menu limit when legacy YAML omits or
+// explicitly zeroes max_menu_items.
+func (c *ScreenshotHandlingConfig) UnmarshalYAML(value *yaml.Node) error {
+	var raw screenshotHandlingConfigAlias
+	raw.MaxMenuItems = DefaultDVDMenuItems
+	if err := value.Decode(&raw); err != nil {
+		return fmt.Errorf("config: decode screenshot handling yaml: %w", err)
+	}
+	if raw.MaxMenuItems == 0 {
+		raw.MaxMenuItems = DefaultDVDMenuItems
+	}
+	*c = ScreenshotHandlingConfig(raw)
+	return nil
+}
+
+// UnmarshalJSON preserves the default menu limit when legacy JSON omits or
+// explicitly zeroes MaxMenuItems.
+func (c *ScreenshotHandlingConfig) UnmarshalJSON(data []byte) error {
+	var raw screenshotHandlingConfigAlias
+	raw.MaxMenuItems = DefaultDVDMenuItems
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("config: decode screenshot handling json: %w", err)
+	}
+	if raw.MaxMenuItems == 0 {
+		raw.MaxMenuItems = DefaultDVDMenuItems
+	}
+	*c = ScreenshotHandlingConfig(raw)
+	return nil
+}
+
+// ResolvedMaxMenuItems returns the configured DVD menu capture limit. Zero in
+// legacy or programmatic configs uses the embedded default.
+func (c *ScreenshotHandlingConfig) ResolvedMaxMenuItems() int {
+	if c.MaxMenuItems == 0 {
+		return DefaultDVDMenuItems
+	}
+	return c.MaxMenuItems
 }
 
 type DescriptionSettingsConfig struct {
@@ -832,6 +882,12 @@ func (c Config) Validate() error {
 	}
 	if c.ScreenshotHandling.Screens <= 0 {
 		return errors.New("config: screenshot_handling.screens must be greater than zero")
+	}
+	if c.ScreenshotHandling.MaxMenuItems < 0 {
+		return errors.New("config: screenshot_handling.max_menu_items must be zero or greater")
+	}
+	if c.ScreenshotHandling.MaxMenuItems > MaxDVDMenuItems {
+		return fmt.Errorf("config: screenshot_handling.max_menu_items must not exceed %d", MaxDVDMenuItems)
 	}
 	if c.PostUpload.MaxConcurrentTrackers < 0 {
 		return errors.New("config: post_upload.max_concurrent_tracker_uploads must be zero or greater")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -366,6 +366,64 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+func TestScreenshotHandlingMaxMenuItemsDefaultsAndValidation(t *testing.T) {
+	t.Parallel()
+
+	for name, payload := range map[string]string{
+		"yaml omitted": "screens: 1\n",
+		"yaml zero":    "screens: 1\nmax_menu_items: 0\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			var cfg ScreenshotHandlingConfig
+			if err := yaml.Unmarshal([]byte(payload), &cfg); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if cfg.MaxMenuItems != DefaultDVDMenuItems {
+				t.Fatalf("MaxMenuItems = %d, want %d", cfg.MaxMenuItems, DefaultDVDMenuItems)
+			}
+		})
+	}
+
+	var jsonCfg ScreenshotHandlingConfig
+	if err := json.Unmarshal([]byte(`{"Screens":1}`), &jsonCfg); err != nil {
+		t.Fatalf("unmarshal json: %v", err)
+	}
+	if jsonCfg.MaxMenuItems != DefaultDVDMenuItems {
+		t.Fatalf("JSON MaxMenuItems = %d, want %d", jsonCfg.MaxMenuItems, DefaultDVDMenuItems)
+	}
+
+	base := Config{
+		MainSettings:       MainSettingsConfig{TMDBAPI: "test-key"},
+		ScreenshotHandling: ScreenshotHandlingConfig{Screens: 1},
+	}
+	if err := base.Validate(); err != nil {
+		t.Fatalf("zero legacy value should resolve to default: %v", err)
+	}
+	if got := base.ScreenshotHandling.ResolvedMaxMenuItems(); got != DefaultDVDMenuItems {
+		t.Fatalf("resolved zero = %d, want %d", got, DefaultDVDMenuItems)
+	}
+	base.ScreenshotHandling.MaxMenuItems = -1
+	if err := base.Validate(); err == nil || !strings.Contains(err.Error(), "max_menu_items") {
+		t.Fatalf("negative validation error = %v", err)
+	}
+	base.ScreenshotHandling.MaxMenuItems = MaxDVDMenuItems + 1
+	if err := base.Validate(); err == nil || !strings.Contains(err.Error(), "max_menu_items") {
+		t.Fatalf("over-limit validation error = %v", err)
+	}
+}
+
+func TestEmbeddedDefaultMaxMenuItems(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := LoadEmbeddedDefaultConfig()
+	if err != nil {
+		t.Fatalf("LoadEmbeddedDefaultConfig: %v", err)
+	}
+	if cfg.ScreenshotHandling.MaxMenuItems != DefaultDVDMenuItems {
+		t.Fatalf("MaxMenuItems = %d, want %d", cfg.ScreenshotHandling.MaxMenuItems, DefaultDVDMenuItems)
+	}
+}
+
 func TestMainSettingsInputHistoryLimitDefaultsWhenMissing(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/defaults/example.yaml
+++ b/internal/config/defaults/example.yaml
@@ -45,6 +45,8 @@ metadata:
 
 screenshot_handling:
   screens: 4
+  # Automatic DVD menu capture is opt-in. This caps stored distinct menu screens (1-32).
+  max_menu_items: 6
   min_successful_image_uploads: 3
   cutoff_screens: 1
   frame_overlay: false

--- a/internal/config/importer/importer_test.go
+++ b/internal/config/importer/importer_test.go
@@ -185,6 +185,12 @@ func TestImportFromContentRejectsNestedUnknownKeys(t *testing.T) {
 			wantKey: "MainSettings.tmdbapi",
 		},
 		{
+			name:    "yaml-max-menu-items-noncanonical",
+			file:    "config.yaml",
+			payload: []byte("screenshot_handling:\n  maxMenuItems: 6\n"),
+			wantKey: "screenshot_handling.maxMenuItems",
+		},
+		{
 			name:    "yaml-torrent-client-typo",
 			file:    "config.yaml",
 			payload: []byte("torrent_clients:\n  watch-client:\n    type: watch\n    watch_folder_typo: C:/Watch\n"),

--- a/internal/config/persistence_test.go
+++ b/internal/config/persistence_test.go
@@ -294,6 +294,7 @@ func TestYAMLRoundTrip(t *testing.T) {
 		},
 		ScreenshotHandling: ScreenshotHandlingConfig{
 			Screens:              4,
+			MaxMenuItems:         DefaultDVDMenuItems,
 			MinSuccessfulUploads: 3,
 			CutoffScreens:        2,
 			FrameOverlay:         true,
@@ -709,6 +710,32 @@ func TestLoadFromDatabaseWithDefaultBackfillIgnoresExplicitZeroDefaultKey(t *tes
 	}
 	if backfilledDefaults {
 		t.Fatalf("expected explicit zero-value key to avoid default backfill")
+	}
+}
+
+func TestLoadFromDatabaseBackfillsMaxMenuItems(t *testing.T) {
+	t.Parallel()
+
+	for name, mutate := range map[string]func(map[string]any){
+		"missing": func(section map[string]any) { delete(section, "MaxMenuItems") },
+		"zero":    func(section map[string]any) { section["MaxMenuItems"] = float64(0) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			raw := defaultDatabaseConfigMap(t)
+			section, ok := raw["ScreenshotHandling"].(map[string]any)
+			if !ok {
+				t.Fatal("expected ScreenshotHandling defaults map")
+			}
+			mutate(section)
+
+			loaded, _, err := LoadFromDatabaseWithDefaultBackfill(context.Background(), &rawConfigRepo{raw: raw})
+			if err != nil {
+				t.Fatalf("LoadFromDatabaseWithDefaultBackfill: %v", err)
+			}
+			if loaded.ScreenshotHandling.MaxMenuItems != DefaultDVDMenuItems {
+				t.Fatalf("MaxMenuItems = %d, want %d", loaded.ScreenshotHandling.MaxMenuItems, DefaultDVDMenuItems)
+			}
+		})
 	}
 }
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -1292,6 +1292,10 @@ func (c *Core) ListUploadedImages(ctx context.Context, req api.Request) ([]api.U
 	return wrapCoreResult(c.repo.ListUploadedImagesByPath(ctx, uniquePaths[0]))
 }
 
+// UploadImages uploads one source's selected images to the requested global
+// host and any additional hosts required by its eligible trackers. Host uploads
+// run concurrently, tracker-owned hosts use tracker-scoped records, and
+// recoverable host failures are returned in [api.UploadImagesResult].
 func (c *Core) UploadImages(ctx context.Context, req api.Request, host string, images []api.ScreenshotImage) (api.UploadImagesResult, error) {
 	if len(req.Paths) == 0 {
 		return api.UploadImagesResult{}, internalerrors.ErrInvalidInput
@@ -1679,7 +1683,12 @@ func (c *Core) uploadImagesToTargets(ctx context.Context, meta api.PreparedMetad
 				Message:    uploadFailureMessage(result.err),
 			}
 			failures = append(failures, failure)
-			failureMessages = append(failureMessages, fmt.Sprintf("%s: %v", result.target.Host, result.err))
+			failureMessages = append(failureMessages, fmt.Sprintf(
+				"host=%s trackers=%v err=%s",
+				result.target.Host,
+				result.target.Trackers,
+				redaction.RedactValue(failure.Message, nil),
+			))
 		}
 	}
 	if len(failures) == 0 {
@@ -1720,7 +1729,7 @@ func (c *Core) uploadImagesToTarget(ctx context.Context, meta api.PreparedMetada
 	target.Host = strings.ToLower(strings.TrimSpace(target.Host))
 	target.UsageScope = normalizeImageUploadUsageScope(target.UsageScope)
 	if c.repo == nil {
-		c.logger.Debugf("core: uploading images host=%s scope=%s trackers=%v count=%d", target.Host, target.UsageScope, target.Trackers, len(images))
+		c.logger.Tracef("core: uploading images host=%s tracker=%s scope=%s trackers=%v count=%d", target.Host, imageHostOwnerLogValue(target.Host), target.UsageScope, target.Trackers, len(images))
 		return wrapCoreResult(c.services.Images.Upload(ctx, meta, target.Host, target.UsageScope, images))
 	}
 
@@ -1744,11 +1753,11 @@ func (c *Core) uploadImagesToTarget(ctx context.Context, meta api.PreparedMetada
 		missing = append(missing, image)
 	}
 	if len(missing) == 0 {
-		c.logger.Debugf("core: reusing uploaded images host=%s scope=%s trackers=%v count=%d", target.Host, target.UsageScope, target.Trackers, len(results))
+		c.logger.Tracef("core: reusing uploaded images host=%s tracker=%s scope=%s trackers=%v count=%d", target.Host, imageHostOwnerLogValue(target.Host), target.UsageScope, target.Trackers, len(results))
 		return results, nil
 	}
 
-	c.logger.Debugf("core: uploading missing images host=%s scope=%s trackers=%v missing=%d reused=%d", target.Host, target.UsageScope, target.Trackers, len(missing), len(results))
+	c.logger.Debugf("core: uploading missing images host=%s tracker=%s scope=%s trackers=%v missing=%d reused=%d", target.Host, imageHostOwnerLogValue(target.Host), target.UsageScope, target.Trackers, len(missing), len(results))
 	uploaded, err := c.services.Images.Upload(ctx, meta, target.Host, target.UsageScope, missing)
 	results = append(results, uploaded...)
 	if err != nil {
@@ -1812,6 +1821,14 @@ func normalizeImageUploadUsageScope(scope string) string {
 	return trimmed
 }
 
+// imageHostOwnerLogValue identifies tracker-owned hosts in core upload logs.
+func imageHostOwnerLogValue(host string) string {
+	if tracker := trackers.TrackerForOwnedImageHost(host); tracker != "" {
+		return tracker
+	}
+	return "shared"
+}
+
 func (c *Core) DeleteUploadedImage(ctx context.Context, req api.Request, imagePath string, host string) error {
 	if len(req.Paths) == 0 {
 		return internalerrors.ErrInvalidInput
@@ -1843,7 +1860,7 @@ func (c *Core) DeleteUploadedImage(ctx context.Context, req api.Request, imagePa
 		return internalerrors.ErrInvalidInput
 	}
 
-	c.logger.Debugf("core: deleting uploaded image path=%s host=%s", imagePath, host)
+	c.logger.Debugf("core: deleting uploaded image path=%s host=%s tracker=%s", imagePath, host, imageHostOwnerLogValue(host))
 	return wrapCoreError(c.repo.DeleteUploadedImage(ctx, uniquePaths[0], imagePath, host))
 }
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -35,6 +36,7 @@ import (
 	"github.com/autobrr/upbrr/internal/services/bdinfo"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/services/description"
+	"github.com/autobrr/upbrr/internal/services/dvdmenus"
 	"github.com/autobrr/upbrr/internal/services/imagehosting"
 	"github.com/autobrr/upbrr/internal/services/screenshots"
 	"github.com/autobrr/upbrr/internal/torrent"
@@ -157,6 +159,13 @@ func newCore(ctx context.Context, deps api.CoreDependencies) (*Core, error) {
 			return nil, fmt.Errorf("core: tmp dir: %w", err)
 		}
 		services.Screenshots = screenshots.NewServiceWithRepo(cfg, logger, tmpDir, nil, repo)
+	}
+	if services.DVDMenus == nil {
+		tmpDir, err := db.Subdir(cfg.MainSettings.DBPath, "tmp")
+		if err != nil {
+			return nil, fmt.Errorf("core: tmp dir: %w", err)
+		}
+		services.DVDMenus = dvdmenus.NewService(logger, tmpDir, repo)
 	}
 	if services.Images == nil {
 		services.Images = imagehosting.NewService(cfg, logger, repo)
@@ -1014,12 +1023,25 @@ func (c *Core) SaveFinalScreenshotSelections(ctx context.Context, req api.Reques
 	return wrapCoreError(c.services.Screenshots.SaveFinalSelections(ctx, meta, images))
 }
 
+// ImportMenuImages copies supported image files from host filesystem paths into
+// one prepared release's managed temp directory. Content-addressed names dedupe
+// repeated imports, and DB records/selections are appended atomically.
 func (c *Core) ImportMenuImages(ctx context.Context, req api.Request, importPaths []string) error {
 	if len(req.Paths) == 0 {
 		return internalerrors.ErrInvalidInput
 	}
 	if len(importPaths) == 0 {
 		return nil
+	}
+	if c.repo == nil {
+		return errors.New("core: repository not configured")
+	}
+	if c.services.Filesystem == nil {
+		return errors.New("core: filesystem service not configured")
+	}
+	lifecycle, ok := c.repo.(api.ScreenshotLifecycleRepository)
+	if !ok {
+		return errors.New("core: screenshot lifecycle repository not configured")
 	}
 	normalizedPaths, err := c.services.Filesystem.ValidatePaths(ctx, req.Paths)
 	if err != nil {
@@ -1039,17 +1061,6 @@ func (c *Core) ImportMenuImages(ctx context.Context, req api.Request, importPath
 	}
 	sourcePath := uniquePaths[0]
 
-	existing, err := c.repo.ListFinalSelections(ctx, sourcePath)
-	if err != nil && !errors.Is(err, internalerrors.ErrNotFound) {
-		return fmt.Errorf("core: list menu selections: %w", err)
-	}
-	maxOrder := -1
-	for _, sel := range existing {
-		if sel.Order > maxOrder {
-			maxOrder = sel.Order
-		}
-	}
-
 	var expandedPaths []string
 	for _, p := range importPaths {
 		p = strings.TrimSpace(p)
@@ -1068,14 +1079,14 @@ func (c *Core) ImportMenuImages(ctx context.Context, req api.Request, importPath
 			for _, entry := range entries {
 				if !entry.IsDir() {
 					ext := strings.ToLower(filepath.Ext(entry.Name()))
-					if ext == ".png" || ext == ".jpg" || ext == ".jpeg" {
+					if isMenuImageExtension(ext) {
 						expandedPaths = append(expandedPaths, filepath.Join(p, entry.Name()))
 					}
 				}
 			}
 		} else {
 			ext := strings.ToLower(filepath.Ext(p))
-			if ext == ".png" || ext == ".jpg" || ext == ".jpeg" {
+			if isMenuImageExtension(ext) {
 				expandedPaths = append(expandedPaths, p)
 			}
 		}
@@ -1091,28 +1102,115 @@ func (c *Core) ImportMenuImages(ctx context.Context, req api.Request, importPath
 		return fmt.Errorf("core: create release tmp dir: %w", err)
 	}
 
-	for idx, p := range expandedPaths {
-		destPath := filepath.Join(tmpDir, filepath.Base(p))
+	if len(expandedPaths) == 0 {
+		return nil
+	}
 
-		// Copy file to release tmp dir
-		if err := filesystem.CopyFile(p, destPath); err != nil {
-			return fmt.Errorf("core: copy menu image %s: %w", p, err)
+	now := time.Now().UTC()
+	records := make([]api.Screenshot, 0, len(expandedPaths))
+	selections := make([]api.ScreenshotFinalSelection, 0, len(expandedPaths))
+	created := make([]string, 0, len(expandedPaths))
+	seen := make(map[string]struct{}, len(expandedPaths))
+	for _, sourceImage := range expandedPaths {
+		destPath, wasCreated, err := copyManagedMenuImage(tmpDir, sourceImage)
+		if err != nil {
+			removeMenuImportFiles(created)
+			return err
 		}
-
-		existing = append(existing, api.ScreenshotFinalSelection{
+		if _, exists := seen[destPath]; exists {
+			continue
+		}
+		seen[destPath] = struct{}{}
+		if wasCreated {
+			created = append(created, destPath)
+		}
+		records = append(records, api.Screenshot{
 			SourcePath: sourcePath,
 			ImagePath:  destPath,
-			Order:      maxOrder + 1 + idx,
-			Source:     string(api.ScreenshotPurposeMenu),
-			SelectedAt: time.Now().UTC(),
+			Purpose:    api.ScreenshotPurposeMenu,
+			CapturedAt: now,
+		})
+		selections = append(selections, api.ScreenshotFinalSelection{
+			SourcePath: sourcePath,
+			ImagePath:  destPath,
+			Order:      len(selections),
+			Source:     api.ScreenshotSelectionSourceMenu,
+			SelectedAt: now,
 		})
 	}
-	if err := c.repo.SaveFinalSelections(ctx, sourcePath, existing); err != nil {
+	if err := lifecycle.AppendManualMenuScreenshots(ctx, sourcePath, records, selections); err != nil {
+		removeMenuImportFiles(created)
 		return fmt.Errorf("core: save menu selections: %w", err)
 	}
 	return nil
 }
 
+func isMenuImageExtension(extension string) bool {
+	switch strings.ToLower(strings.TrimSpace(extension)) {
+	case ".png", ".jpg", ".jpeg", ".webp":
+		return true
+	default:
+		return false
+	}
+}
+
+// copyManagedMenuImage stages one import and assigns a content-addressed managed
+// name. The boolean result reports whether this call created the destination.
+func copyManagedMenuImage(tmpDir string, sourcePath string) (string, bool, error) {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return "", false, fmt.Errorf("core: open menu image: %w", err)
+	}
+	defer source.Close()
+
+	staged, err := os.CreateTemp(tmpDir, ".manual-dvd-menu-*.partial")
+	if err != nil {
+		return "", false, fmt.Errorf("core: stage menu image: %w", err)
+	}
+	stagedPath := staged.Name()
+	cleanupStaged := true
+	defer func() {
+		if cleanupStaged {
+			_ = os.Remove(stagedPath)
+		}
+	}()
+
+	hash := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(staged, hash), source); err != nil {
+		_ = staged.Close()
+		return "", false, fmt.Errorf("core: copy menu image: %w", err)
+	}
+	if err := staged.Close(); err != nil {
+		return "", false, fmt.Errorf("core: close staged menu image: %w", err)
+	}
+	extension := strings.ToLower(filepath.Ext(sourcePath))
+	destPath := filepath.Join(tmpDir, fmt.Sprintf("manual-dvd-menu-%x%s", hash.Sum(nil)[:8], extension))
+	if info, err := os.Stat(destPath); err == nil {
+		if info.IsDir() {
+			return "", false, internalerrors.ErrInvalidInput
+		}
+		return destPath, false, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", false, fmt.Errorf("core: inspect managed menu image: %w", err)
+	}
+	if err := os.Rename(stagedPath, destPath); err != nil {
+		if info, statErr := os.Stat(destPath); statErr == nil && !info.IsDir() {
+			return destPath, false, nil
+		}
+		return "", false, fmt.Errorf("core: finalize menu image: %w", err)
+	}
+	cleanupStaged = false
+	return destPath, true, nil
+}
+
+func removeMenuImportFiles(paths []string) {
+	for _, pathValue := range paths {
+		_ = os.Remove(pathValue)
+	}
+}
+
+// ListUploadCandidates returns persisted normal and disc-menu images eligible
+// for image-host upload for one prepared release.
 func (c *Core) ListUploadCandidates(ctx context.Context, req api.Request) ([]api.ScreenshotImage, error) {
 	if len(req.Paths) == 0 {
 		return nil, internalerrors.ErrInvalidInput

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -6,6 +6,7 @@ package core
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -419,6 +420,10 @@ func TestRunUploadPreparedReturnsAccumulatedCountWhenLaterMenuImportFails(t *tes
 
 	tracker := &stubTrackers{}
 	repo := &menuImportRepo{failListOnCall: 2}
+	menuDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(menuDir, "menu.png"), []byte("synthetic menu image"), 0o600); err != nil {
+		t.Fatalf("write menu image: %v", err)
+	}
 	core, err := New(api.CoreDependencies{
 		Config: config.Config{
 			MainSettings:       config.MainSettingsConfig{TMDBAPI: "x", DBPath: t.TempDir()},
@@ -443,7 +448,7 @@ func TestRunUploadPreparedReturnsAccumulatedCountWhenLaterMenuImportFails(t *tes
 		Paths: []string{"/tmp/a", "/tmp/b"},
 		Mode:  api.ModeGUI,
 		ScreenshotOverrides: api.ScreenshotOverrides{
-			MenuPaths: []string{t.TempDir()},
+			MenuPaths: []string{menuDir},
 		},
 	})
 	if err == nil || !strings.Contains(err.Error(), "import menu images failed") {
@@ -4077,6 +4082,26 @@ func (r *menuImportRepo) ListFinalSelections(context.Context, string) ([]db.Scre
 
 func (r *menuImportRepo) SaveFinalSelections(context.Context, string, []db.ScreenshotFinalSelection) error {
 	return nil
+}
+
+func (r *menuImportRepo) ReplaceNormalFinalSelections(context.Context, string, []db.ScreenshotFinalSelection) error {
+	return nil
+}
+
+func (r *menuImportRepo) AppendManualMenuScreenshots(context.Context, string, []db.Screenshot, []db.ScreenshotFinalSelection) error {
+	r.listCalls++
+	if r.failListOnCall > 0 && r.listCalls == r.failListOnCall {
+		return errors.New("menu import append failed")
+	}
+	return nil
+}
+
+func (r *menuImportRepo) ReplaceDVDMenuScreenshots(context.Context, string, []db.Screenshot, []db.ScreenshotFinalSelection) ([]string, error) {
+	return nil, nil
+}
+
+func (r *menuImportRepo) DeleteDiscMenuScreenshot(context.Context, string, string) (api.DiscMenuDeleteResult, error) {
+	return api.DiscMenuDeleteResult{}, nil
 }
 
 type dryRunPreviewRepo struct {

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -4104,6 +4104,10 @@ func (r *menuImportRepo) DeleteDiscMenuScreenshot(context.Context, string, strin
 	return api.DiscMenuDeleteResult{}, nil
 }
 
+func (r *menuImportRepo) RestoreDiscMenuScreenshot(context.Context, string, api.DiscMenuDeleteResult) error {
+	return nil
+}
+
 type dryRunPreviewRepo struct {
 	stubRepo
 }

--- a/internal/core/dvd_menus.go
+++ b/internal/core/dvd_menus.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+// DVDMenuCapability reports the pure-Go engine version and the external
+// FFmpeg dvdvideo menu capability without returning executable paths.
+func (c *Core) DVDMenuCapability(ctx context.Context) (api.DVDMenuEngineInfo, error) {
+	if c == nil || c.services.DVDMenus == nil {
+		return api.DVDMenuEngineInfo{}, errors.New("core: DVD menu service not configured")
+	}
+	return wrapCoreResult(c.services.DVDMenus.Capability(ctx))
+}
+
+// CaptureDVDMenus captures and persists bounded menu screenshots for one DVD.
+// GUI requests require a prepared metadata cache; CLI requests prepare metadata
+// directly. Existing automatic captures are replaced only after rendering.
+func (c *Core) CaptureDVDMenus(ctx context.Context, req api.Request) (api.DVDMenuCaptureResult, error) {
+	if c.services.DVDMenus == nil {
+		return api.DVDMenuCaptureResult{}, errors.New("core: DVD menu service not configured")
+	}
+	meta, err := c.resolveDVDMenuMetadata(ctx, req)
+	if err != nil {
+		return api.DVDMenuCaptureResult{}, err
+	}
+	return wrapCoreResult(c.services.DVDMenus.Capture(ctx, meta, c.cfg.ScreenshotHandling.ResolvedMaxMenuItems()))
+}
+
+// ListDVDMenuScreenshots lists persisted manual and generated menu screenshots
+// for one prepared release.
+func (c *Core) ListDVDMenuScreenshots(ctx context.Context, req api.Request) ([]api.ScreenshotImage, error) {
+	if c.services.DVDMenus == nil {
+		return nil, errors.New("core: DVD menu service not configured")
+	}
+	meta, err := c.resolveDVDMenuMetadata(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return wrapCoreResult(c.services.DVDMenus.List(ctx, meta))
+}
+
+// DeleteDVDMenuScreenshot removes one owned menu screenshot and its local
+// records for a prepared release. Remote-host assets are not deleted.
+func (c *Core) DeleteDVDMenuScreenshot(ctx context.Context, req api.Request, imagePath string) error {
+	if c.services.DVDMenus == nil {
+		return errors.New("core: DVD menu service not configured")
+	}
+	if strings.TrimSpace(imagePath) == "" {
+		return internalerrors.ErrInvalidInput
+	}
+	meta, err := c.resolveDVDMenuMetadata(ctx, req)
+	if err != nil {
+		return err
+	}
+	return wrapCoreError(c.services.DVDMenus.Delete(ctx, meta, imagePath))
+}
+
+// resolveDVDMenuMetadata requires exactly one prepared source. GUI requests use
+// the preview cache; non-GUI requests prepare metadata through the service.
+func (c *Core) resolveDVDMenuMetadata(ctx context.Context, req api.Request) (api.PreparedMetadata, error) {
+	path, err := c.resolveSinglePreparedMetaPath(ctx, req.Paths)
+	if err != nil {
+		return api.PreparedMetadata{}, err
+	}
+	if req.Mode == api.ModeGUI {
+		if cached, ok, cacheErr := c.resolveGUICachedPreparedMeta(ctx, req, path); cacheErr != nil {
+			return api.PreparedMetadata{}, cacheErr
+		} else if ok {
+			return cached, nil
+		}
+		return api.PreparedMetadata{}, errors.New("core: DVD menu operation requires metadata preview")
+	}
+	if c.services.Metadata == nil {
+		return api.PreparedMetadata{}, errors.New("core: metadata service not configured")
+	}
+	options, err := c.applyDefaultOptions(req.Options)
+	if err != nil {
+		return api.PreparedMetadata{}, err
+	}
+	singleReq := req
+	singleReq.Paths = []string{path}
+	singleReq.Options = options
+	meta, err := c.services.Metadata.Prepare(ctx, singleReq)
+	if err != nil {
+		return api.PreparedMetadata{}, fmt.Errorf("core: %w", err)
+	}
+	return meta, nil
+}

--- a/internal/core/dvd_menus_test.go
+++ b/internal/core/dvd_menus_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package core
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+type recordingDVDMenuService struct {
+	meta       api.PreparedMetadata
+	maxItems   int
+	deleted    string
+	listed     bool
+	capability api.DVDMenuEngineInfo
+	probed     bool
+}
+
+func TestImportMenuImagesPersistsPurposeAndDeduplicatesManagedCopy(t *testing.T) {
+	t.Parallel()
+
+	repo, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open repository: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repository: %v", err)
+	}
+
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "db.sqlite")
+	sourcePath := filepath.Join(root, "Example.Release.2026.DVD-GRP")
+	originalPath := filepath.Join(t.TempDir(), "manual-menu.png")
+	if err := os.WriteFile(originalPath, []byte("synthetic menu image"), 0o600); err != nil {
+		t.Fatalf("write original menu: %v", err)
+	}
+	now := time.Now().UTC()
+	if err := repo.SaveFinalSelections(context.Background(), sourcePath, []api.ScreenshotFinalSelection{
+		{SourcePath: sourcePath, ImagePath: filepath.Join(root, "auto.png"), Order: 0, Source: api.ScreenshotSelectionSourceDVDMenu, SelectedAt: now},
+		{SourcePath: sourcePath, ImagePath: filepath.Join(root, "normal.png"), Order: 1, Source: "generated", SelectedAt: now},
+	}); err != nil {
+		t.Fatalf("seed selections: %v", err)
+	}
+	coreSvc := &Core{
+		cfg:      config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}},
+		services: api.ServiceSet{Filesystem: stubFS{}},
+		repo:     repo,
+	}
+	req := api.Request{Paths: []string{sourcePath}, Mode: api.ModeCLI}
+	for range 2 {
+		if err := coreSvc.ImportMenuImages(context.Background(), req, []string{originalPath}); err != nil {
+			t.Fatalf("import menu images: %v", err)
+		}
+	}
+
+	selections, err := repo.ListFinalSelections(context.Background(), sourcePath)
+	if err != nil {
+		t.Fatalf("list selections: %v", err)
+	}
+	if len(selections) != 3 {
+		t.Fatalf("selections = %#v, want auto/manual/normal", selections)
+	}
+	if selections[0].Source != api.ScreenshotSelectionSourceDVDMenu || selections[1].Source != api.ScreenshotSelectionSourceMenu || selections[2].Source != "generated" {
+		t.Fatalf("selection category order = %#v", selections)
+	}
+	if selections[1].ImagePath == originalPath {
+		t.Fatal("manual selection retained arbitrary original path")
+	}
+	if _, err := os.Stat(selections[1].ImagePath); err != nil {
+		t.Fatalf("managed menu copy missing: %v", err)
+	}
+	if _, err := os.Stat(originalPath); err != nil {
+		t.Fatalf("original menu changed: %v", err)
+	}
+	records, err := repo.ListScreenshotsByPath(context.Background(), sourcePath)
+	if err != nil {
+		t.Fatalf("list screenshots: %v", err)
+	}
+	if len(records) != 1 || records[0].ImagePath != selections[1].ImagePath || records[0].Purpose != api.ScreenshotPurposeMenu {
+		t.Fatalf("manual screenshot record = %#v", records)
+	}
+}
+
+func (s *recordingDVDMenuService) Capture(_ context.Context, meta api.PreparedMetadata, maxItems int) (api.DVDMenuCaptureResult, error) {
+	s.meta = meta
+	s.maxItems = maxItems
+	return api.DVDMenuCaptureResult{SourcePath: meta.SourcePath, MaxItems: maxItems}, nil
+}
+
+func (s *recordingDVDMenuService) List(_ context.Context, meta api.PreparedMetadata) ([]api.ScreenshotImage, error) {
+	s.meta = meta
+	s.listed = true
+	return []api.ScreenshotImage{{Path: "dvd-menu-01.png", Purpose: api.ScreenshotPurposeMenu}}, nil
+}
+
+func (s *recordingDVDMenuService) Delete(_ context.Context, meta api.PreparedMetadata, imagePath string) error {
+	s.meta = meta
+	s.deleted = imagePath
+	return nil
+}
+
+func (s *recordingDVDMenuService) Capability(context.Context) (api.DVDMenuEngineInfo, error) {
+	s.probed = true
+	return s.capability, nil
+}
+
+func TestDVDMenuCapabilityUsesConfiguredService(t *testing.T) {
+	t.Parallel()
+
+	menus := &recordingDVDMenuService{capability: api.DVDMenuEngineInfo{
+		EngineVersion:  "phase0a-1",
+		FFmpegDVDVideo: true,
+	}}
+	coreSvc := &Core{services: api.ServiceSet{DVDMenus: menus}}
+	info, err := coreSvc.DVDMenuCapability(context.Background())
+	if err != nil {
+		t.Fatalf("DVDMenuCapability: %v", err)
+	}
+	if !menus.probed || info.EngineVersion != "phase0a-1" || !info.FFmpegDVDVideo {
+		t.Fatalf("capability info = %#v probed=%t", info, menus.probed)
+	}
+}
+
+func TestDVDMenuCoreMethodsUsePreparedMetadataAndResolvedLimit(t *testing.T) {
+	t.Parallel()
+
+	menus := &recordingDVDMenuService{}
+	coreSvc := &Core{
+		cfg: config.Config{ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		services: api.ServiceSet{
+			Filesystem: stubFS{},
+			Metadata:   &stubMeta{},
+			DVDMenus:   menus,
+		},
+	}
+	req := api.Request{Paths: []string{"Example.Release.2026.1080p-GRP"}, Mode: api.ModeCLI}
+
+	result, err := coreSvc.CaptureDVDMenus(context.Background(), req)
+	if err != nil {
+		t.Fatalf("CaptureDVDMenus: %v", err)
+	}
+	if result.SourcePath != req.Paths[0] || menus.meta.SourcePath != req.Paths[0] {
+		t.Fatalf("prepared source result=%q service=%q", result.SourcePath, menus.meta.SourcePath)
+	}
+	if result.MaxItems != config.DefaultDVDMenuItems || menus.maxItems != config.DefaultDVDMenuItems {
+		t.Fatalf("resolved max result=%d service=%d", result.MaxItems, menus.maxItems)
+	}
+
+	images, err := coreSvc.ListDVDMenuScreenshots(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ListDVDMenuScreenshots: %v", err)
+	}
+	if !menus.listed || len(images) != 1 || images[0].Purpose != api.ScreenshotPurposeMenu {
+		t.Fatalf("list result = %+v", images)
+	}
+
+	if err := coreSvc.DeleteDVDMenuScreenshot(context.Background(), req, images[0].Path); err != nil {
+		t.Fatalf("DeleteDVDMenuScreenshot: %v", err)
+	}
+	if menus.deleted != images[0].Path {
+		t.Fatalf("deleted = %q, want %q", menus.deleted, images[0].Path)
+	}
+}

--- a/internal/core/e2e_enabled.go
+++ b/internal/core/e2e_enabled.go
@@ -493,6 +493,7 @@ func (s e2eScreenshotService) Capture(_ context.Context, meta api.PreparedMetada
 	if err != nil {
 		return api.ScreenshotResult{}, err
 	}
+	shot.Purpose = purpose
 	return api.ScreenshotResult{SourcePath: meta.SourcePath, Purpose: purpose, Images: []api.ScreenshotImage{shot}}, nil
 }
 
@@ -525,6 +526,9 @@ func (s e2eScreenshotService) SaveFinalSelections(ctx context.Context, meta api.
 			Source:     string(api.ScreenshotPurposeFinal),
 			SelectedAt: time.Now().UTC(),
 		})
+	}
+	if lifecycle, ok := s.repo.(api.ScreenshotLifecycleRepository); ok {
+		return lifecycle.ReplaceNormalFinalSelections(ctx, meta.SourcePath, selections)
 	}
 	return s.repo.SaveFinalSelections(ctx, meta.SourcePath, selections)
 }
@@ -570,7 +574,7 @@ func e2eManagedScreenshot(shotPath string, tmpRoot string, meta api.PreparedMeta
 	if err != nil {
 		return api.ScreenshotImage{}, fmt.Errorf("e2e screenshots: stat managed screenshot: %w", err)
 	}
-	return api.ScreenshotImage{Index: 1, TimestampSeconds: 10, Path: managedPath, Width: 320, Height: 180, SizeBytes: info.Size()}, nil
+	return api.ScreenshotImage{Index: 1, TimestampSeconds: 10, Path: managedPath, Purpose: api.ScreenshotPurposeFinal, Width: 320, Height: 180, SizeBytes: info.Size()}, nil
 }
 
 func writeJSONE2E(w io.Writer, value any) error {

--- a/internal/core/upload_images_test.go
+++ b/internal/core/upload_images_test.go
@@ -220,6 +220,65 @@ func TestUploadImagesUploadsApplicableTrackerHosts(t *testing.T) {
 	}
 }
 
+func TestUploadImagesIncludesRequiredHDBRehost(t *testing.T) {
+	t.Parallel()
+
+	images := []api.ScreenshotImage{{Path: "/tmp/menu.png", Purpose: api.ScreenshotPurposeMenu}}
+	imageService := &stubImageHosting{
+		uploadFn: func(_ context.Context, meta api.PreparedMetadata, host string, usageScope string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
+			return uploadedImageLinksForHost(meta, host, usageScope, images), nil
+		},
+	}
+	core := &Core{
+		logger: api.NopLogger{},
+		cfg: config.Config{
+			ImageHosting: config.ImageHostingConfig{Host1: "imgbox"},
+			Trackers: config.TrackersConfig{
+				Trackers: map[string]config.TrackerConfig{
+					"HDB": {ImgRehost: true},
+					"STC": {},
+				},
+			},
+		},
+		services: api.ServiceSet{
+			Filesystem: stubFilesystem{paths: []string{"/tmp/source"}},
+			Images:     imageService,
+		},
+		dupeCache: make(map[string]dupeCacheEntry),
+	}
+
+	result, err := core.UploadImages(context.Background(), api.Request{
+		Paths:    []string{"/tmp/source"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"HDB", "STC"},
+	}, "imgbox", images)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(imageService.calls) != 2 {
+		t.Fatalf("expected global and HDB uploads, got %d calls: %#v", len(imageService.calls), imageService.calls)
+	}
+	calledHosts := map[string]string{}
+	for _, call := range imageService.calls {
+		calledHosts[call.host] = call.usageScope
+	}
+	if calledHosts["imgbox"] != "global" {
+		t.Fatalf("expected selected global host, got %#v", imageService.calls)
+	}
+	if calledHosts["hdb"] != "tracker:HDB" {
+		t.Fatalf("expected tracker-scoped HDB rehost, got %#v", imageService.calls)
+	}
+	for _, call := range imageService.calls {
+		if call.host == "hdb" && (len(call.images) != 1 || call.images[0].Purpose != api.ScreenshotPurposeMenu) {
+			t.Fatalf("expected HDB upload to preserve menu purpose, got %#v", call.images)
+		}
+	}
+	if len(result.Links) != 2 {
+		t.Fatalf("expected results from both hosts, got %#v", result)
+	}
+}
+
 func TestUploadImagesUsesConfiguredHostPriorityWhenSelectedHostIsNotApproved(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dvdvideo/engine/engine.go
+++ b/internal/dvdvideo/engine/engine.go
@@ -1,0 +1,409 @@
+// Package engine coordinates bounded DVD menu inventory, navigation-state
+// discovery, exact FFmpeg background decoding, and Go subpicture composition.
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"image/draw"
+	"strings"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/dvdvideo/graph"
+	"github.com/autobrr/upbrr/internal/dvdvideo/ifo"
+	"github.com/autobrr/upbrr/internal/dvdvideo/nav"
+	"github.com/autobrr/upbrr/internal/dvdvideo/render"
+	"github.com/autobrr/upbrr/internal/dvdvideo/spu"
+)
+
+const (
+	// Version identifies the bundled pure-Go DVD menu engine implementation.
+	Version = "phase0a-1"
+	// DefaultMaxMenuItems is the default selected-screen limit.
+	DefaultMaxMenuItems = graph.DefaultMaxItems
+	// DefaultProcessTimeout bounds each FFmpeg probe or frame operation.
+	DefaultProcessTimeout = 30 * time.Second
+	blackPixelThreshold   = 3
+)
+
+// ErrCapture identifies invalid setup or a failed DVD menu capture stage.
+var ErrCapture = errors.New("DVD menu capture failed")
+
+// Options bound traversal, menu-VOB scanning, and each FFmpeg operation.
+type Options struct {
+	// Traversal controls deterministic graph discovery and selection limits.
+	Traversal graph.Options
+	// Scan controls bounded NAV and subpicture reads for each menu cell.
+	Scan nav.CellScanOptions
+	// ProcessTimeout bounds each FFmpeg probe and frame decode; zero uses the default.
+	ProcessTimeout time.Duration
+	// Deinterlace enables frame deinterlacing before SPU composition.
+	Deinterlace bool
+	// Capability reuses a prior successful FFmpeg probe when non-nil.
+	Capability *render.Capability
+	// Progress receives synchronous path-free phase and counter updates.
+	Progress func(Progress)
+	// Logger receives optional path-free discovery and rendering diagnostics.
+	Logger graph.Logger
+}
+
+// Progress reports the current engine phase and bounded capture counters.
+type Progress struct {
+	// Phase is discovering or capturing.
+	Phase string
+	// Inventoried is the number of structural menu programs.
+	Inventoried int
+	// VisitedStates is the number of distinct VM states evaluated.
+	VisitedStates int
+	// VisitedButtons is the number of button commands evaluated.
+	VisitedButtons int
+	// Captured is the number of composed non-black frames retained.
+	Captured int
+	// Warnings is the number of distinct coverage warnings.
+	Warnings int
+}
+
+// Capture is one composed, non-black menu screen and its engine coordinate.
+type Capture struct {
+	// Coordinate is the exact inventory location rendered by FFmpeg.
+	Coordinate graph.Coordinate
+	// Discovery records whether navigation or structural inventory found the screen.
+	Discovery graph.Discovery
+	// Image is the owned composed menu frame.
+	Image *image.NRGBA
+	// HasOverlay reports that decoded SPU state was composited.
+	HasOverlay bool
+	// HasHighlight reports that a selected-button highlight was composited.
+	HasHighlight bool
+}
+
+// Result reports capture output and bounded coverage state without local paths.
+type Result struct {
+	// EngineVersion identifies the engine implementation that produced the result.
+	EngineVersion string
+	// Capability is the successful path-free FFmpeg probe result.
+	Capability render.Capability
+	// Captures contains composed non-black menu frames in selection order.
+	Captures []Capture
+	// Inventoried is the number of structural menu programs.
+	Inventoried int
+	// Selected is the number of distinct screens selected for rendering.
+	Selected int
+	// VisitedStates is the number of distinct VM states evaluated.
+	VisitedStates int
+	// VisitedButtons is the number of button commands evaluated.
+	VisitedButtons int
+	// Complete reports that every selected screen rendered without coverage warnings.
+	Complete bool
+	// Partial reports incomplete discovery, live-state, or rendering coverage.
+	Partial bool
+	// Truncated reports that the traversal item limit excluded eligible screens.
+	Truncated bool
+	// Warnings contains deduplicated path-free coverage diagnostics.
+	Warnings []graph.Warning
+}
+
+// CaptureDirectory inventories and captures menus from an extracted VIDEO_TS
+// directory. The caller controls the FFmpeg executable and process runner.
+// It returns partial counters and warnings when discovery or rendering fails.
+func CaptureDirectory(ctx context.Context, root string, runner render.Runner, executable string, opts Options) (Result, error) {
+	if strings.TrimSpace(root) == "" {
+		return Result{}, fmt.Errorf("%w: empty VIDEO_TS source", ErrCapture)
+	}
+	if runner == nil || strings.TrimSpace(executable) == "" {
+		return Result{}, fmt.Errorf("%w: FFmpeg unavailable", ErrCapture)
+	}
+	if opts.ProcessTimeout == 0 {
+		opts.ProcessTimeout = DefaultProcessTimeout
+	}
+	if opts.ProcessTimeout < 0 {
+		return Result{}, fmt.Errorf("%w: negative process timeout", ErrCapture)
+	}
+	if opts.Traversal.MaxItems == 0 {
+		opts.Traversal.MaxItems = DefaultMaxMenuItems
+	}
+	if opts.Traversal.MaxItems < 0 || opts.Traversal.MaxItems > graph.MaxMenuItems {
+		return Result{}, fmt.Errorf("%w: menu item limit must be between 1 and %d", ErrCapture, graph.MaxMenuItems)
+	}
+	if opts.Logger != nil {
+		opts.Logger.Debugf("DVD menus: engine preflight started engine_version=%s max_items=%d process_timeout_ms=%d deinterlace=%t", Version, opts.Traversal.MaxItems, opts.ProcessTimeout.Milliseconds(), opts.Deinterlace)
+	}
+
+	disc, err := ifo.InspectDirectory(root)
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: DVD inventory unavailable", ErrCapture)
+	}
+	if opts.Logger != nil {
+		recovered := 0
+		if disc.Manager.Recovered {
+			recovered++
+		}
+		for _, titleSet := range disc.TitleSets {
+			if titleSet.Recovered {
+				recovered++
+			}
+		}
+		opts.Logger.Debugf("DVD menus: inventory ready manager=%t title_sets=%d recovered_ifos=%d", disc.Manager.Kind == ifo.KindManager, len(disc.TitleSets), recovered)
+	}
+	var capability render.Capability
+	if opts.Capability != nil {
+		capability = *opts.Capability
+		if !capability.Available {
+			return Result{}, fmt.Errorf("%w: %w", ErrCapture, render.ErrCapability)
+		}
+	} else {
+		probeCtx, cancelProbe := context.WithTimeout(ctx, opts.ProcessTimeout)
+		capability, err = render.Probe(probeCtx, runner, executable)
+		cancelProbe()
+		if err != nil {
+			return Result{}, fmt.Errorf("%w: %w", ErrCapture, err)
+		}
+	}
+	if opts.Logger != nil {
+		opts.Logger.Debugf("DVD menus: FFmpeg capability ready dvdvideo=%t options=%d", capability.Available, len(capability.Options))
+	}
+	resolver, err := newDirectoryResolver(root, opts.Scan)
+	if err != nil {
+		return Result{}, fmt.Errorf("%w: menu source unavailable", ErrCapture)
+	}
+	if opts.Logger != nil {
+		opts.Logger.Debugf("DVD menus: menu sources ready vob_sets=%d", len(resolver.files))
+	}
+	return captureDisc(ctx, root, disc, resolver, runner, executable, capability, opts)
+}
+
+// captureDisc resolves selected graph screens again, decodes their exact
+// background frames, composites live SPU state, and retains non-black output.
+func captureDisc(ctx context.Context, root string, disc ifo.Disc, resolver *directoryResolver, runner render.Runner, executable string, capability render.Capability, opts Options) (Result, error) {
+	opts.Traversal.Logger = opts.Logger
+	opts.Traversal.Progress = func(update graph.Progress) {
+		reportProgress(opts.Progress, Progress{
+			Phase:          "discovering",
+			Inventoried:    update.Inventoried,
+			VisitedStates:  update.VisitedStates,
+			VisitedButtons: update.VisitedButtons,
+			Warnings:       update.Warnings,
+		})
+	}
+	discovered, err := graph.Discover(ctx, disc, resolver, opts.Traversal)
+	result := Result{
+		EngineVersion:  Version,
+		Capability:     capability,
+		Inventoried:    discovered.Inventoried,
+		Selected:       len(discovered.Screens),
+		VisitedStates:  discovered.VisitedStates,
+		VisitedButtons: discovered.VisitedButtons,
+		Partial:        discovered.Partial,
+		Truncated:      discovered.Truncated,
+		Warnings:       append([]graph.Warning(nil), discovered.Warnings...),
+	}
+	if err != nil {
+		return result, fmt.Errorf("%w: menu discovery", ErrCapture)
+	}
+	if opts.Logger != nil {
+		opts.Logger.Debugf("DVD menus: rendering started selected=%d inventoried=%d states=%d buttons=%d", len(discovered.Screens), discovered.Inventoried, discovered.VisitedStates, discovered.VisitedButtons)
+	}
+	reportEngineProgress(opts.Progress, result)
+
+	for index, screen := range discovered.Screens {
+		if err := ctx.Err(); err != nil {
+			return result, fmt.Errorf("%w: %w", ErrCapture, err)
+		}
+		if opts.Logger != nil {
+			opts.Logger.Debugf(
+				"DVD menus: render started index=%d discovery=%s domain=%s vts=%d language_unit=%d menu_id=%d pgc=%d pg=%d cell=%d buttons=%d",
+				index+1,
+				screen.Discovery,
+				engineDomainLabel(screen.Coordinate.Kind),
+				screen.Coordinate.VTS,
+				screen.Coordinate.LanguageUnit,
+				screen.Coordinate.MenuID,
+				screen.Coordinate.PGC,
+				screen.Coordinate.Program,
+				screen.Coordinate.Cell,
+				len(screen.Live.Buttons),
+			)
+		}
+		detail, resolveErr := resolver.resolve(ctx, screen.Coordinate, resolver.programChain(screen.Coordinate), screen.Registers)
+		if resolveErr != nil {
+			if markPartial(&result, "live_state", "menu NAV/SPU state could not be resolved") {
+				logEngineWarning(opts.Logger, "live_state", screen.Coordinate)
+			}
+			reportEngineProgress(opts.Progress, result)
+			continue
+		}
+		if detail.scanTruncated {
+			if markPartial(&result, "nav_scan_limit", "menu NAV/SPU sector scan limit reached") {
+				logEngineWarning(opts.Logger, "nav_scan_limit", screen.Coordinate)
+			}
+		}
+		if opts.Logger != nil {
+			opts.Logger.Tracef("DVD menus: render state index=%d target_ms=%d scan_truncated=%t overlay=%t highlight=%t buttons=%d", index+1, detail.target.Milliseconds(), detail.scanTruncated, detail.hasOverlay, detail.highlight != nil, len(detail.buttons))
+		}
+
+		frameCtx, cancelFrame := context.WithTimeout(ctx, opts.ProcessTimeout)
+		background, frameErr := render.DecodeFrame(frameCtx, runner, executable, render.FrameRequest{
+			SourcePath:   root,
+			VTS:          screen.Coordinate.VTS,
+			LanguageUnit: screen.Coordinate.LanguageUnit,
+			PGC:          screen.Coordinate.PGC,
+			Program:      screen.Coordinate.Program,
+			Target:       detail.target,
+			Deinterlace:  opts.Deinterlace,
+		})
+		cancelFrame()
+		if frameErr != nil {
+			if markPartial(&result, "frame_decode", "inventory-selected menu frame could not be decoded") {
+				logEngineWarning(opts.Logger, "frame_decode", screen.Coordinate)
+			}
+			reportEngineProgress(opts.Progress, result)
+			continue
+		}
+		if opts.Logger != nil {
+			bounds := background.Bounds()
+			opts.Logger.Debugf("DVD menus: frame decoded index=%d width=%d height=%d target_ms=%d", index+1, bounds.Dx(), bounds.Dy(), detail.target.Milliseconds())
+		}
+
+		composed := copyImage(background)
+		if detail.hasOverlay {
+			composed = spu.Composite(background, detail.overlay, detail.palette, detail.highlight)
+		} else if markPartial(&result, "spu_unavailable", "menu subpicture state was not available") {
+			logEngineWarning(opts.Logger, "spu_unavailable", screen.Coordinate)
+		}
+		if len(detail.buttons) != 0 && detail.highlight == nil {
+			if markPartial(&result, "highlight_unavailable", "default menu highlight state was not available") {
+				logEngineWarning(opts.Logger, "highlight_unavailable", screen.Coordinate)
+			}
+		}
+		if imageIsBlack(composed) {
+			if markPartial(&result, "black_frame", "decoded menu frame was black") {
+				logEngineWarning(opts.Logger, "black_frame", screen.Coordinate)
+			}
+			reportEngineProgress(opts.Progress, result)
+			continue
+		}
+		result.Captures = append(result.Captures, Capture{
+			Coordinate:   screen.Coordinate,
+			Discovery:    screen.Discovery,
+			Image:        composed,
+			HasOverlay:   detail.hasOverlay,
+			HasHighlight: detail.highlight != nil,
+		})
+		if opts.Logger != nil {
+			opts.Logger.Debugf("DVD menus: capture stored index=%d discovery=%s overlay=%t highlight=%t captured=%d", index+1, screen.Discovery, detail.hasOverlay, detail.highlight != nil, len(result.Captures))
+		}
+		reportEngineProgress(opts.Progress, result)
+	}
+
+	result.Complete = discovered.Complete && !result.Partial && !result.Truncated && len(result.Captures) == len(discovered.Screens)
+	if opts.Logger != nil {
+		opts.Logger.Debugf("DVD menus: rendering complete selected=%d captured=%d partial=%t truncated=%t warnings=%d", len(discovered.Screens), len(result.Captures), result.Partial, result.Truncated, len(result.Warnings))
+	}
+	if len(result.Captures) == 0 {
+		return result, fmt.Errorf("%w: no menu frames captured", ErrCapture)
+	}
+	return result, nil
+}
+
+func reportEngineProgress(reporter func(Progress), result Result) {
+	reportProgress(reporter, Progress{
+		Phase:          "capturing",
+		Inventoried:    result.Inventoried,
+		VisitedStates:  result.VisitedStates,
+		VisitedButtons: result.VisitedButtons,
+		Captured:       len(result.Captures),
+		Warnings:       len(result.Warnings),
+	})
+}
+
+func reportProgress(reporter func(Progress), update Progress) {
+	if reporter != nil {
+		reporter(update)
+	}
+}
+
+func copyImage(source image.Image) *image.NRGBA {
+	bounds := source.Bounds()
+	result := image.NewNRGBA(bounds)
+	draw.Draw(result, bounds, source, bounds.Min, draw.Src)
+	return result
+}
+
+// imageIsBlack reports whether every non-transparent pixel stays within the
+// engine's near-black threshold.
+func imageIsBlack(source image.Image) bool {
+	bounds := source.Bounds()
+	if bounds.Empty() {
+		return true
+	}
+	threshold := uint32(blackPixelThreshold * 257)
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			r, g, b, a := source.At(x, y).RGBA()
+			if a != 0 && (r > threshold || g > threshold || b > threshold) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// markPartial records one warning code and reports whether it was newly added.
+func markPartial(result *Result, code, message string) bool {
+	result.Partial = true
+	result.Complete = false
+	for _, warning := range result.Warnings {
+		if warning.Code == code {
+			return false
+		}
+	}
+	result.Warnings = append(result.Warnings, graph.Warning{Code: code, Message: message})
+	return true
+}
+
+func logEngineWarning(logger graph.Logger, code string, coordinate graph.Coordinate) {
+	if logger == nil {
+		return
+	}
+	logger.Warnf(
+		"DVD menus: render warning code=%s detail=%q domain=%s vts=%d language_unit=%d pgc=%d pg=%d cell=%d",
+		code,
+		renderWarningDetail(code),
+		engineDomainLabel(coordinate.Kind),
+		coordinate.VTS,
+		coordinate.LanguageUnit,
+		coordinate.PGC,
+		coordinate.Program,
+		coordinate.Cell,
+	)
+}
+
+func renderWarningDetail(code string) string {
+	switch code {
+	case "live_state":
+		return "menu NAV/SPU state could not be resolved"
+	case "nav_scan_limit":
+		return "menu NAV/SPU sector scan limit reached"
+	case "frame_decode":
+		return "inventory-selected menu frame could not be decoded"
+	case "spu_unavailable":
+		return "menu subpicture state was not available"
+	case "highlight_unavailable":
+		return "default menu highlight state was not available"
+	case "black_frame":
+		return "decoded menu frame was black"
+	}
+	return "DVD menu render warning"
+}
+
+func engineDomainLabel(kind ifo.Kind) string {
+	switch kind {
+	case ifo.KindManager:
+		return "vmg"
+	case ifo.KindTitleSet:
+		return "vtsm"
+	}
+	return "unknown"
+}

--- a/internal/dvdvideo/engine/engine_test.go
+++ b/internal/dvdvideo/engine/engine_test.go
@@ -1,0 +1,467 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/dvdvideo/graph"
+	"github.com/autobrr/upbrr/internal/dvdvideo/ifo"
+	"github.com/autobrr/upbrr/internal/dvdvideo/nav"
+	"github.com/autobrr/upbrr/internal/dvdvideo/render"
+)
+
+func TestCaptureDirectoryUsesInventoryCoordinatesAndComposesMenu(t *testing.T) {
+	root := writeSyntheticDVD(t, true)
+	runner := newFakeRunner(t)
+	logger := &engineTestLogger{}
+
+	result, err := CaptureDirectory(context.Background(), root, runner, "ffmpeg", Options{Traversal: graph.Options{MaxItems: 1}, Logger: logger})
+	if err != nil {
+		t.Fatalf("CaptureDirectory: %v", err)
+	}
+	if len(result.Captures) != 1 || !result.Complete || result.Partial || result.Truncated {
+		t.Fatalf("result = %+v", result)
+	}
+	capture := result.Captures[0]
+	if capture.Coordinate.Kind != ifo.KindManager || capture.Coordinate.VTS != 0 || capture.Coordinate.LanguageUnit != 1 || capture.Coordinate.PGC != 1 || capture.Coordinate.Program != 1 || capture.Coordinate.Cell != 1 {
+		t.Fatalf("coordinate = %+v", capture.Coordinate)
+	}
+	if !capture.HasOverlay || !capture.HasHighlight || imageIsBlack(capture.Image) {
+		t.Fatalf("capture state overlay=%t highlight=%t black=%t", capture.HasOverlay, capture.HasHighlight, imageIsBlack(capture.Image))
+	}
+
+	wantPrefix := []string{"-hide_banner", "-loglevel", "error", "-f", "dvdvideo", "-menu", "1", "-menu_vts", "0", "-menu_lu", "1", "-pgc", "1", "-pg", "1", "-i", root}
+	frameArgs := runner.calls[2].args
+	if !reflect.DeepEqual(frameArgs[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("frame args prefix = %q, want %q", frameArgs[:len(wantPrefix)], wantPrefix)
+	}
+	for _, expected := range []string{
+		"DEBUG DVD menus: inventory ready",
+		"DEBUG DVD menus: discovery started",
+		"TRACE DVD menus: state visiting domain=vmg",
+		"DEBUG DVD menus: state resolved domain=vmg",
+		"DEBUG DVD menus: render started index=1",
+		"DEBUG DVD menus: frame decoded index=1",
+		"DEBUG DVD menus: capture stored index=1",
+		"DEBUG DVD menus: rendering complete",
+	} {
+		if !logger.Contains(expected) {
+			t.Fatalf("missing DVD engine log event %q", expected)
+		}
+	}
+	if logger.Contains(root) {
+		t.Fatal("DVD engine logs exposed the source path")
+	}
+}
+
+type engineTestLogger struct {
+	entries []string
+}
+
+func (l *engineTestLogger) add(level, format string, args ...any) {
+	l.entries = append(l.entries, level+" "+fmt.Sprintf(format, args...))
+}
+
+func (l *engineTestLogger) Tracef(format string, args ...any) {
+	l.add("TRACE", format, args...)
+}
+
+func (l *engineTestLogger) Debugf(format string, args ...any) {
+	l.add("DEBUG", format, args...)
+}
+
+func (l *engineTestLogger) Infof(format string, args ...any) {
+	l.add("INFO", format, args...)
+}
+
+func (l *engineTestLogger) Warnf(format string, args ...any) {
+	l.add("WARN", format, args...)
+}
+
+func (l *engineTestLogger) Contains(expected string) bool {
+	for _, entry := range l.entries {
+		if strings.Contains(entry, expected) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCaptureDirectoryRejectsItemLimitOverSafetyMaximum(t *testing.T) {
+	t.Parallel()
+
+	_, err := CaptureDirectory(context.Background(), t.TempDir(), newFakeRunner(t), "ffmpeg", Options{
+		Traversal: graph.Options{MaxItems: graph.MaxMenuItems + 1},
+	})
+	if !errors.Is(err, ErrCapture) {
+		t.Fatalf("CaptureDirectory error = %v, want ErrCapture", err)
+	}
+}
+
+func TestVisibleMenuStateRequiresAuthoredMenuEvidence(t *testing.T) {
+	t.Parallel()
+
+	base := ifo.ProgramChain{Programs: 2, Cells: 1, CellPlayback: []ifo.CellPlayback{{}}}
+	withPGCStill := base
+	withPGCStill.StillTime = 0xff
+	withCellStill := base
+	withCellStill.CellPlayback = []ifo.CellPlayback{{StillTime: 5}}
+	entry := base
+	entry.EntryID = 0x80
+	tests := []struct {
+		name       string
+		pgc        ifo.ProgramChain
+		coordinate graph.Coordinate
+		buttons    []nav.Button
+		overlay    bool
+		highlight  bool
+		want       bool
+	}{
+		{name: "button", pgc: base, coordinate: graph.Coordinate{Program: 1, Cell: 1}, buttons: []nav.Button{{Number: 1}}, want: true},
+		{name: "overlay", pgc: base, coordinate: graph.Coordinate{Program: 1, Cell: 1}, overlay: true, want: true},
+		{name: "highlight", pgc: base, coordinate: graph.Coordinate{Program: 1, Cell: 1}, highlight: true, want: true},
+		{name: "pgc still", pgc: withPGCStill, coordinate: graph.Coordinate{Program: 1, Cell: 1}, want: true},
+		{name: "cell still", pgc: withCellStill, coordinate: graph.Coordinate{Program: 1, Cell: 1}, want: true},
+		{name: "entry program", pgc: entry, coordinate: graph.Coordinate{Program: 1, Cell: 1}, want: true},
+		{name: "entry transition program", pgc: entry, coordinate: graph.Coordinate{Program: 2, Cell: 1}},
+		{name: "plain transition", pgc: base, coordinate: graph.Coordinate{Program: 1, Cell: 1}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := visibleMenuState(tt.pgc, tt.coordinate, tt.buttons, tt.overlay, tt.highlight); got != tt.want {
+				t.Fatalf("visibleMenuState() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCaptureDirectoryCapturesManagerAndTitleSetCoordinates(t *testing.T) {
+	root := writeSyntheticDVD(t, true)
+	if err := os.WriteFile(filepath.Join(root, "VTS_01_0.IFO"), syntheticTitleSetIFO(), 0o600); err != nil {
+		t.Fatalf("write synthetic title-set IFO: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "VTS_01_0.VOB"), syntheticMenuVOB(true), 0o600); err != nil {
+		t.Fatalf("write synthetic title-set menu VOB: %v", err)
+	}
+	runner := newFakeRunner(t)
+	runner.outputs = append(runner.outputs, runner.outputs[2])
+
+	result, err := CaptureDirectory(context.Background(), root, runner, "ffmpeg", Options{Traversal: graph.Options{MaxItems: 2}})
+	if err != nil {
+		t.Fatalf("CaptureDirectory: %v", err)
+	}
+	if len(result.Captures) != 2 || !result.Complete || result.Partial || result.Truncated {
+		t.Fatalf("result = %+v", result)
+	}
+	manager, titleSet := result.Captures[0].Coordinate, result.Captures[1].Coordinate
+	if manager.Kind != ifo.KindManager || manager.VTS != 0 || titleSet.Kind != ifo.KindTitleSet || titleSet.VTS != 1 {
+		t.Fatalf("capture coordinates = manager:%+v title_set:%+v", manager, titleSet)
+	}
+	if got := runner.calls[2].args[7:9]; !reflect.DeepEqual(got, []string{"-menu_vts", "0"}) {
+		t.Fatalf("manager FFmpeg coordinate = %q", got)
+	}
+	if got := runner.calls[3].args[7:9]; !reflect.DeepEqual(got, []string{"-menu_vts", "1"}) {
+		t.Fatalf("title-set FFmpeg coordinate = %q", got)
+	}
+}
+
+func TestCaptureDirectoryReportsMissingSPUAsPartial(t *testing.T) {
+	root := writeSyntheticDVD(t, false)
+	runner := newFakeRunner(t)
+	logger := &engineTestLogger{}
+
+	result, err := CaptureDirectory(context.Background(), root, runner, "ffmpeg", Options{Traversal: graph.Options{MaxItems: 1}, Logger: logger})
+	if err != nil {
+		t.Fatalf("CaptureDirectory: %v", err)
+	}
+	if len(result.Captures) != 1 || !result.Partial || result.Complete || result.Captures[0].HasOverlay {
+		t.Fatalf("result = %+v", result)
+	}
+	if !hasWarning(result.Warnings, "spu_unavailable") {
+		t.Fatalf("warnings = %+v", result.Warnings)
+	}
+	if !logger.Contains(`WARN DVD menus: render warning code=spu_unavailable detail="menu subpicture state was not available" domain=vmg`) {
+		t.Fatal("missing DVD render warning log")
+	}
+}
+
+func TestCaptureDirectoryReturnsFatalWhenEveryFrameFails(t *testing.T) {
+	root := writeSyntheticDVD(t, true)
+	runner := newFakeRunner(t)
+	runner.errors = []error{nil, nil, errors.New("synthetic process failure")}
+
+	result, err := CaptureDirectory(context.Background(), root, runner, "ffmpeg", Options{Traversal: graph.Options{MaxItems: 1}})
+	if !errors.Is(err, ErrCapture) {
+		t.Fatalf("CaptureDirectory error = %v, want ErrCapture", err)
+	}
+	if len(result.Captures) != 0 || !result.Partial || !hasWarning(result.Warnings, "frame_decode") {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestCaptureDiscPreservesSuccessfulFramesAfterLaterDecodeFailure(t *testing.T) {
+	root := writeSyntheticDVD(t, true)
+	resolver, err := newDirectoryResolver(root, nav.CellScanOptions{})
+	if err != nil {
+		t.Fatalf("newDirectoryResolver: %v", err)
+	}
+	base := syntheticProgramChain(1)
+	second := syntheticProgramChain(2)
+	second.EntryID = 0x85
+	second.MenuID = 5
+	disc := ifo.Disc{Manager: ifo.File{
+		Kind:      ifo.KindManager,
+		Languages: []ifo.LanguageUnit{{Code: "en", ProgramChains: []ifo.ProgramChain{base, second}}},
+	}}
+	frameRunner := newFakeRunner(t)
+	runner := &fakeRunner{
+		outputs: []render.Output{frameRunner.outputs[2], {}},
+		errors:  []error{nil, errors.New("synthetic later frame failure")},
+	}
+	result, err := captureDisc(context.Background(), root, disc, resolver, runner, "ffmpeg", render.Capability{Available: true}, Options{
+		Traversal:      graph.Options{MaxItems: 2},
+		ProcessTimeout: DefaultProcessTimeout,
+	})
+	if err != nil {
+		t.Fatalf("captureDisc: %v", err)
+	}
+	if len(result.Captures) != 1 || !result.Partial || result.Complete || !hasWarning(result.Warnings, "frame_decode") {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func hasWarning(warnings []graph.Warning, code string) bool {
+	for _, warning := range warnings {
+		if warning.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func writeSyntheticDVD(t *testing.T, withSPU bool) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "VIDEO_TS.IFO"), syntheticManagerIFO(), 0o600); err != nil {
+		t.Fatalf("write synthetic IFO: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "VIDEO_TS.VOB"), syntheticMenuVOB(withSPU), 0o600); err != nil {
+		t.Fatalf("write synthetic menu VOB: %v", err)
+	}
+	return root
+}
+
+func syntheticManagerIFO() []byte {
+	data := make([]byte, nav.SectorSize*2)
+	copy(data, "DVDVIDEO-VMG")
+	binary.BigEndian.PutUint32(data[200:204], 1)
+
+	pgci := nav.SectorSize
+	binary.BigEndian.PutUint16(data[pgci:pgci+2], 1)
+	binary.BigEndian.PutUint32(data[pgci+4:pgci+8], 296)
+	copy(data[pgci+8:pgci+10], "en")
+	data[pgci+11] = 0x80
+	binary.BigEndian.PutUint32(data[pgci+12:pgci+16], 16)
+
+	pgcit := pgci + 16
+	binary.BigEndian.PutUint16(data[pgcit:pgcit+2], 1)
+	binary.BigEndian.PutUint32(data[pgcit+4:pgcit+8], 280)
+	data[pgcit+8] = 0x83
+	binary.BigEndian.PutUint32(data[pgcit+12:pgcit+16], 16)
+
+	pgc := pgcit + 16
+	data[pgc+2] = 1
+	data[pgc+3] = 1
+	binary.BigEndian.PutUint32(data[pgc+28:pgc+32], 0x8000_0000)
+	binary.BigEndian.PutUint32(data[pgc+164+4:pgc+164+8], 0x0080_8080)
+	binary.BigEndian.PutUint32(data[pgc+164+8:pgc+164+12], 0x00c0_8080)
+	binary.BigEndian.PutUint32(data[pgc+164+12:pgc+164+16], 0x00ff_8080)
+	binary.BigEndian.PutUint16(data[pgc+230:pgc+232], 236)
+	binary.BigEndian.PutUint16(data[pgc+232:pgc+234], 237)
+	binary.BigEndian.PutUint16(data[pgc+234:pgc+236], 261)
+	data[pgc+236] = 1
+
+	cell := pgc + 237
+	binary.BigEndian.PutUint32(data[cell+8:cell+12], 0)
+	binary.BigEndian.PutUint32(data[cell+12:cell+16], 0)
+	binary.BigEndian.PutUint32(data[cell+16:cell+20], 0)
+	binary.BigEndian.PutUint32(data[cell+20:cell+24], 0)
+	position := pgc + 261
+	binary.BigEndian.PutUint16(data[position:position+2], 2)
+	data[position+3] = 1
+	return data
+}
+
+func syntheticTitleSetIFO() []byte {
+	data := syntheticManagerIFO()
+	copy(data, "DVDVIDEO-VTS")
+	binary.BigEndian.PutUint32(data[200:204], 0)
+	binary.BigEndian.PutUint32(data[208:212], 1)
+	return data
+}
+
+func syntheticProgramChain(number int) ifo.ProgramChain {
+	chain := ifo.ProgramChain{
+		Number:        number,
+		EntryID:       0x83,
+		MenuID:        3,
+		Programs:      1,
+		Cells:         1,
+		ProgramMap:    []uint8{1},
+		CellPlayback:  []ifo.CellPlayback{{FirstSector: 0, LastSector: 0}},
+		CellPositions: []ifo.CellPosition{{VOBID: 2, CellID: 1}},
+	}
+	chain.SubpictureControl[0] = 0x8000_0000
+	chain.Palette[1] = 0x0080_8080
+	chain.Palette[2] = 0x00c0_8080
+	chain.Palette[3] = 0x00ff_8080
+	return chain
+}
+
+func syntheticMenuVOB(withSPU bool) []byte {
+	sector := make([]byte, nav.SectorSize)
+	copy(sector, []byte{0, 0, 1, 0xba})
+	sector[4] = 0x40
+	offset := 14
+
+	pci := make([]byte, nav.PCIPayloadSize)
+	binary.BigEndian.PutUint32(pci[12:16], 90_000)
+	binary.BigEndian.PutUint32(pci[16:20], 180_000)
+	binary.BigEndian.PutUint16(pci[96:98], 1)
+	binary.BigEndian.PutUint32(pci[98:102], 90_000)
+	pci[110] = 0x10
+	pci[113] = 1
+	pci[114] = 1
+	pci[116] = 1
+	pci[117] = 1
+	binary.BigEndian.PutUint32(pci[118:122], 0x3333_ffff)
+	put24(pci[142:145], 1<<22|0<<12|1)
+	put24(pci[145:148], 1<<22|0<<12|1)
+	pci[148] = 1
+	pci[149] = 1
+	pci[150] = 1
+	pci[151] = 1
+	writePrivateStream2(sector, offset, 0, pci)
+	offset += 7 + len(pci)
+
+	dsi := make([]byte, 32)
+	binary.BigEndian.PutUint16(dsi[24:26], 2)
+	dsi[27] = 1
+	writePrivateStream2(sector, offset, 1, dsi)
+	offset += 7 + len(dsi)
+	if !withSPU {
+		return sector
+	}
+
+	packet := syntheticSPUPacket()
+	payload := append([]byte{0x80, 0, 0, 0x20}, packet...)
+	copy(sector[offset:], []byte{0, 0, 1, 0xbd})
+	binary.BigEndian.PutUint16(sector[offset+4:offset+6], uint16(len(payload)))
+	copy(sector[offset+6:], payload)
+	return sector
+}
+
+func syntheticSPUPacket() []byte {
+	packet := make([]byte, 31)
+	binary.BigEndian.PutUint16(packet[0:2], uint16(len(packet)))
+	binary.BigEndian.PutUint16(packet[2:4], 6)
+	packet[4] = 0x90
+	packet[5] = 0xa0
+	binary.BigEndian.PutUint16(packet[8:10], 6)
+	position := 10
+	packet[position] = 0x00
+	position++
+	packet[position] = 0x01
+	position++
+	packet[position] = 0x03
+	packet[position+1] = 0x32
+	packet[position+2] = 0x10
+	position += 3
+	packet[position] = 0x04
+	packet[position+1] = 0xff
+	packet[position+2] = 0xff
+	position += 3
+	packet[position] = 0x05
+	packet[position+1] = 0
+	packet[position+2] = 0
+	packet[position+3] = 1
+	packet[position+4] = 0
+	packet[position+5] = 0
+	packet[position+6] = 1
+	position += 7
+	packet[position] = 0x06
+	binary.BigEndian.PutUint16(packet[position+1:position+3], 4)
+	binary.BigEndian.PutUint16(packet[position+3:position+5], 5)
+	position += 5
+	packet[position] = 0xff
+	return packet
+}
+
+func writePrivateStream2(target []byte, offset int, streamID byte, payload []byte) {
+	copy(target[offset:], []byte{0, 0, 1, 0xbf})
+	binary.BigEndian.PutUint16(target[offset+4:offset+6], uint16(len(payload)+1))
+	target[offset+6] = streamID
+	copy(target[offset+7:], payload)
+}
+
+func put24(target []byte, value uint32) {
+	target[0] = byte(value >> 16)
+	target[1] = byte(value >> 8)
+	target[2] = byte(value)
+}
+
+type runnerCall struct {
+	executable string
+	args       []string
+	limit      int
+}
+
+type fakeRunner struct {
+	outputs []render.Output
+	errors  []error
+	calls   []runnerCall
+}
+
+func newFakeRunner(t *testing.T) *fakeRunner {
+	t.Helper()
+	var frame bytes.Buffer
+	background := image.NewNRGBA(image.Rect(0, 0, 2, 2))
+	for y := range 2 {
+		for x := range 2 {
+			background.SetNRGBA(x, y, color.NRGBA{R: 16, G: 32, B: 48, A: 0xff})
+		}
+	}
+	if err := png.Encode(&frame, background); err != nil {
+		t.Fatalf("encode background: %v", err)
+	}
+	return &fakeRunner{outputs: []render.Output{
+		{Stdout: []byte("Demuxer dvdvideo\n-menu -menu_lu -menu_vts -pgc -pg\n")},
+		{Stdout: []byte("ffmpeg version synthetic\n")},
+		{Stdout: frame.Bytes()},
+	}}
+}
+
+func (r *fakeRunner) Run(_ context.Context, executable string, args []string, limit int) (render.Output, error) {
+	index := len(r.calls)
+	r.calls = append(r.calls, runnerCall{executable: executable, args: append([]string(nil), args...), limit: limit})
+	var output render.Output
+	var err error
+	if index < len(r.outputs) {
+		output = r.outputs[index]
+	}
+	if index < len(r.errors) {
+		err = r.errors[index]
+	}
+	return output, err
+}

--- a/internal/dvdvideo/engine/integration_test.go
+++ b/internal/dvdvideo/engine/integration_test.go
@@ -1,0 +1,60 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/dvdvideo/graph"
+	"github.com/autobrr/upbrr/internal/dvdvideo/ifo"
+	"github.com/autobrr/upbrr/internal/dvdvideo/render"
+)
+
+func TestExternalDVDInventoryDerivedCapture(t *testing.T) {
+	root := os.Getenv("UPBRR_TEST_DVD_VIDEO_TS")
+	if root == "" {
+		t.Skip("set UPBRR_TEST_DVD_VIDEO_TS to run the external read-only DVD proof")
+	}
+	executable := os.Getenv("UPBRR_TEST_FFMPEG")
+	if executable == "" {
+		executable = "ffmpeg"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	result, err := CaptureDirectory(ctx, root, render.ExecRunner{}, executable, Options{
+		Traversal:      graph.Options{Language: "en", MaxItems: DefaultMaxMenuItems},
+		ProcessTimeout: time.Minute,
+		Deinterlace:    true,
+	})
+	if err != nil {
+		t.Fatalf("CaptureDirectory: %v", err)
+	}
+	t.Logf("external DVD capture summary inventoried=%d selected=%d captured=%d states=%d buttons=%d partial=%t truncated=%t warnings=%d", result.Inventoried, result.Selected, len(result.Captures), result.VisitedStates, result.VisitedButtons, result.Partial, result.Truncated, len(result.Warnings))
+	for _, warning := range result.Warnings {
+		t.Logf("external DVD capture warning code=%s", warning.Code)
+	}
+	var manager, titleSet bool
+	var overlay, highlight bool
+	for index, capture := range result.Captures {
+		t.Logf("external DVD capture index=%d discovery=%s domain=%d vts=%d language_unit=%d menu_id=%d pgc=%d pg=%d cell=%d overlay=%t highlight=%t", index+1, capture.Discovery, capture.Coordinate.Kind, capture.Coordinate.VTS, capture.Coordinate.LanguageUnit, capture.Coordinate.MenuID, capture.Coordinate.PGC, capture.Coordinate.Program, capture.Coordinate.Cell, capture.HasOverlay, capture.HasHighlight)
+		if imageIsBlack(capture.Image) {
+			t.Fatal("inventory-derived capture produced a black composed frame")
+		}
+		overlay = overlay || capture.HasOverlay
+		highlight = highlight || capture.HasHighlight
+		switch capture.Coordinate.Kind {
+		case ifo.KindManager:
+			manager = true
+		case ifo.KindTitleSet:
+			titleSet = true
+		}
+	}
+	t.Logf("external DVD capture domains manager=%t title_set=%t", manager, titleSet)
+	if !overlay || !highlight {
+		t.Fatalf("composed state overlay=%t highlight=%t captures=%d", overlay, highlight, len(result.Captures))
+	}
+	if !result.Capability.Available {
+		t.Fatal("capture completed without the required FFmpeg DVD menu capability")
+	}
+}

--- a/internal/dvdvideo/engine/resolver.go
+++ b/internal/dvdvideo/engine/resolver.go
@@ -1,0 +1,409 @@
+package engine
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"image"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/dvdvideo/graph"
+	"github.com/autobrr/upbrr/internal/dvdvideo/ifo"
+	"github.com/autobrr/upbrr/internal/dvdvideo/nav"
+	"github.com/autobrr/upbrr/internal/dvdvideo/spu"
+	"github.com/autobrr/upbrr/internal/dvdvideo/vm"
+)
+
+// ErrLiveState identifies missing, invalid, or unresolvable menu VOB/NAV/SPU state.
+var ErrLiveState = errors.New("DVD menu live state unavailable")
+
+type resolverKey struct {
+	coordinate graph.Coordinate
+	registers  vm.Registers
+}
+
+type resolvedState struct {
+	live          graph.LiveState
+	buttons       []nav.Button
+	overlay       spu.Overlay
+	hasOverlay    bool
+	highlight     *spu.Highlight
+	palette       [16]uint32
+	target        time.Duration
+	scanTruncated bool
+}
+
+// directoryResolver maps validated graph coordinates to manager/title-set menu
+// VOBs and caches resolved live state by coordinate and register snapshot.
+type directoryResolver struct {
+	files  map[int]string
+	scan   nav.CellScanOptions
+	cache  map[resolverKey]resolvedState
+	chains map[coordinateKey]ifo.ProgramChain
+}
+
+type coordinateKey struct {
+	kind     ifo.Kind
+	vts      int
+	language int
+	pgc      int
+}
+
+// newDirectoryResolver inventories manager and title-set menu VOB paths beneath
+// one extracted VIDEO_TS directory and rejects duplicate or symlinked entries.
+func newDirectoryResolver(root string, scan nav.CellScanOptions) (*directoryResolver, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("%w: read VIDEO_TS directory", ErrLiveState)
+	}
+	files := make(map[int]string)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		upper := strings.ToUpper(entry.Name())
+		if entry.Type()&os.ModeSymlink != 0 && (upper == "VIDEO_TS.VOB" || len(upper) == len("VTS_01_0.VOB") && strings.HasPrefix(upper, "VTS_") && strings.HasSuffix(upper, "_0.VOB")) {
+			return nil, fmt.Errorf("%w: menu VOB symlink", ErrLiveState)
+		}
+		switch {
+		case upper == "VIDEO_TS.VOB":
+			if _, duplicate := files[0]; duplicate {
+				return nil, fmt.Errorf("%w: duplicate VMG menu VOB", ErrLiveState)
+			}
+			files[0] = filepath.Join(root, entry.Name())
+		case len(upper) == len("VTS_01_0.VOB") && strings.HasPrefix(upper, "VTS_") && strings.HasSuffix(upper, "_0.VOB"):
+			vts, parseErr := strconv.Atoi(upper[4:6])
+			if parseErr == nil && vts >= 1 && vts <= 99 {
+				if _, duplicate := files[vts]; duplicate {
+					return nil, fmt.Errorf("%w: duplicate VTS menu VOB", ErrLiveState)
+				}
+				files[vts] = filepath.Join(root, entry.Name())
+			}
+		}
+	}
+	return &directoryResolver{
+		files:  files,
+		scan:   scan,
+		cache:  make(map[resolverKey]resolvedState),
+		chains: make(map[coordinateKey]ifo.ProgramChain),
+	}, nil
+}
+
+// Resolve returns cached or freshly scanned live state for an inventory-validated
+// graph coordinate and VM register snapshot.
+func (r *directoryResolver) Resolve(ctx context.Context, coordinate graph.Coordinate, pgc ifo.ProgramChain, registers vm.Registers) (graph.LiveState, error) {
+	detail, err := r.resolve(ctx, coordinate, pgc, registers)
+	if err != nil {
+		return graph.LiveState{}, err
+	}
+	r.chains[coordinateLookupKey(coordinate)] = pgc
+	return detail.live, nil
+}
+
+func (r *directoryResolver) programChain(coordinate graph.Coordinate) ifo.ProgramChain {
+	return r.chains[coordinateLookupKey(coordinate)]
+}
+
+func coordinateLookupKey(coordinate graph.Coordinate) coordinateKey {
+	return coordinateKey{kind: coordinate.Kind, vts: coordinate.VTS, language: coordinate.LanguageUnit, pgc: coordinate.PGC}
+}
+
+// resolve scans one authored cell, selects live NAV/SPU/highlight state, and
+// computes the exact program-relative frame target.
+func (r *directoryResolver) resolve(ctx context.Context, coordinate graph.Coordinate, pgc ifo.ProgramChain, registers vm.Registers) (resolvedState, error) {
+	if err := ctx.Err(); err != nil {
+		return resolvedState{}, fmt.Errorf("%w: %w", ErrLiveState, err)
+	}
+	key := resolverKey{coordinate: coordinate, registers: registers}
+	if cached, ok := r.cache[key]; ok {
+		return cached, nil
+	}
+	if coordinate.Cell < 1 || coordinate.Cell > len(pgc.CellPlayback) || coordinate.Cell > len(pgc.CellPositions) {
+		return resolvedState{}, fmt.Errorf("%w: invalid cell coordinate", ErrLiveState)
+	}
+	menuVOB, ok := r.files[coordinate.VTS]
+	if !ok {
+		return resolvedState{}, fmt.Errorf("%w: menu VOB missing vts=%d", ErrLiveState, coordinate.VTS)
+	}
+	file, err := os.Open(menuVOB)
+	if err != nil {
+		return resolvedState{}, fmt.Errorf("%w: open menu VOB", ErrLiveState)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return resolvedState{}, fmt.Errorf("%w: inspect menu VOB", ErrLiveState)
+	}
+	if info.IsDir() || info.Size() <= 0 {
+		return resolvedState{}, fmt.Errorf("%w: invalid menu VOB", ErrLiveState)
+	}
+	cell := pgc.CellPlayback[coordinate.Cell-1]
+	scan, err := nav.ScanCell(file, info.Size(), cell.FirstSector, cell.LastSector, r.scan)
+	if err != nil {
+		return resolvedState{}, fmt.Errorf("%w: scan menu cell", ErrLiveState)
+	}
+	packet, firstPTS, err := selectNAVPacket(scan.Packets, pgc.CellPositions[coordinate.Cell-1])
+	if err != nil {
+		return resolvedState{}, err
+	}
+	buttons := selectButtonGroup(packet.PCI)
+	highlight := selectHighlight(packet.PCI, buttons, registers)
+	targetPTS := packet.PCI.HighlightStartPTS
+	if targetPTS == 0 {
+		targetPTS = packet.PCI.VOBUStartPTS
+	}
+	overlay, hasOverlay := selectOverlay(scan.SPUFragments, pgc, registers, uint64(targetPTS))
+	target, err := targetDuration(pgc, coordinate, firstPTS, packet.PCI.VOBUStartPTS)
+	if err != nil {
+		return resolvedState{}, err
+	}
+	fingerprint := liveFingerprint(packet, overlay, hasOverlay)
+	authoredStill := authoredStillState(pgc, coordinate)
+	authoredEntry := pgc.EntryID&0x80 != 0 && coordinate.Program == 1
+	visible := visibleMenuState(pgc, coordinate, buttons, hasOverlay, highlight != nil)
+	detail := resolvedState{
+		live: graph.LiveState{
+			Visible:       visible,
+			Buttons:       buttons,
+			Fingerprint:   fingerprint,
+			HasOverlay:    hasOverlay,
+			HasHighlight:  highlight != nil,
+			AuthoredStill: authoredStill,
+			AuthoredEntry: authoredEntry,
+		},
+		buttons:       buttons,
+		overlay:       overlay,
+		hasOverlay:    hasOverlay,
+		highlight:     highlight,
+		palette:       pgc.Palette,
+		target:        target,
+		scanTruncated: scan.Truncated,
+	}
+	r.cache[key] = detail
+	return detail, nil
+}
+
+// visibleMenuState accepts live controls/SPU evidence plus authored still or
+// entry evidence used for reachable zero-button menu screens.
+func visibleMenuState(pgc ifo.ProgramChain, coordinate graph.Coordinate, buttons []nav.Button, hasOverlay, hasHighlight bool) bool {
+	if len(buttons) != 0 || hasOverlay || hasHighlight {
+		return true
+	}
+	if authoredStillState(pgc, coordinate) {
+		return true
+	}
+	return pgc.EntryID&0x80 != 0 && coordinate.Program == 1
+}
+
+func authoredStillState(pgc ifo.ProgramChain, coordinate graph.Coordinate) bool {
+	if pgc.StillTime != 0 {
+		return true
+	}
+	return coordinate.Cell > 0 && coordinate.Cell <= len(pgc.CellPlayback) && pgc.CellPlayback[coordinate.Cell-1].StillTime != 0
+}
+
+// selectNAVPacket filters packets to the authored VOB/cell position and returns
+// the earliest packet plus its PTS baseline.
+func selectNAVPacket(packets []nav.Packet, position ifo.CellPosition) (nav.Packet, uint32, error) {
+	var matches []nav.Packet
+	for _, packet := range packets {
+		if position.VOBID != 0 && packet.DSI.VOBID != 0 && packet.DSI.VOBID != position.VOBID {
+			continue
+		}
+		if position.CellID != 0 && packet.DSI.CellID != 0 && packet.DSI.CellID != position.CellID {
+			continue
+		}
+		matches = append(matches, packet)
+	}
+	if len(matches) == 0 {
+		return nav.Packet{}, 0, fmt.Errorf("%w: no matching NAV packet", ErrLiveState)
+	}
+	selected := matches[0]
+	for _, packet := range matches {
+		if packet.PCI.HighlightStatus != 0 || packet.PCI.ButtonCount != 0 {
+			selected = packet
+			break
+		}
+	}
+	return selected, matches[0].PCI.VOBUStartPTS, nil
+}
+
+func selectButtonGroup(pci nav.PCI) []nav.Button {
+	for _, group := range pci.ButtonGroups {
+		if len(group) != 0 {
+			return append([]nav.Button(nil), group...)
+		}
+	}
+	return nil
+}
+
+// selectHighlight resolves the selected button from SPRM 8, forced selection,
+// or the first live button, then applies its authored display-group palette.
+func selectHighlight(pci nav.PCI, buttons []nav.Button, registers vm.Registers) *spu.Highlight {
+	if len(buttons) == 0 {
+		return nil
+	}
+	buttonNumber := pci.ForcedSelectButton & 0x3f
+	if buttonNumber == 0 {
+		buttonNumber = uint8(registers.System[8] & 0x3f)
+	}
+	if buttonNumber == 0 {
+		buttonNumber = buttons[0].Number
+	}
+	for _, button := range buttons {
+		if button.Number != buttonNumber || button.ColorGroup == 0 || button.ColorGroup > nav.MaxButtonGroups {
+			continue
+		}
+		palette := pci.ButtonColors[button.ColorGroup-1][0]
+		return &spu.Highlight{
+			Bounds:  image.Rect(int(button.XStart), int(button.YStart), int(button.XEnd)+1, int(button.YEnd)+1),
+			Palette: palette,
+		}
+	}
+	return nil
+}
+
+type timedSPUPacket struct {
+	packet spu.Packet
+	pts    uint64
+	hasPTS bool
+}
+
+// selectOverlay reassembles preferred subpicture streams and selects the latest
+// decodable menu overlay active at targetPTS.
+func selectOverlay(fragments []nav.SPUFragment, pgc ifo.ProgramChain, registers vm.Registers, targetPTS uint64) (spu.Overlay, bool) {
+	var reassembler spu.Reassembler
+	var streamPTS [32]uint64
+	var streamHasPTS [32]bool
+	var packets []timedSPUPacket
+	for _, fragment := range fragments {
+		index := fragment.StreamID - 0x20
+		if fragment.HasPTS {
+			streamPTS[index] = fragment.PTS
+			streamHasPTS[index] = true
+		}
+		complete, err := reassembler.Push(fragment.StreamID, fragment.Data)
+		if err != nil {
+			continue
+		}
+		for _, packet := range complete {
+			packets = append(packets, timedSPUPacket{packet: packet, pts: streamPTS[index], hasPTS: streamHasPTS[index]})
+			streamHasPTS[index] = false
+		}
+	}
+	allowed := preferredSPUStreams(pgc, registers)
+	for _, streamID := range allowed {
+		for _, packet := range packets {
+			if packet.packet.StreamID != streamID {
+				continue
+			}
+			date := ^uint16(0)
+			if packet.hasPTS {
+				date = 0
+				if targetPTS >= packet.pts {
+					delta := (targetPTS - packet.pts) / 1024
+					date = boundedControlDate(delta)
+				}
+			}
+			overlay, err := spu.Decode(packet.packet.Data, pgc.Palette, date)
+			if err == nil {
+				return overlay, true
+			}
+		}
+	}
+	return spu.Overlay{}, false
+}
+
+func preferredSPUStreams(pgc ifo.ProgramChain, registers vm.Registers) []uint8 {
+	logical := int(registers.System[2] & 0x1f)
+	order := make([]int, 0, len(pgc.SubpictureControl))
+	if logical < len(pgc.SubpictureControl) {
+		order = append(order, logical)
+	}
+	for index := range pgc.SubpictureControl {
+		if index != logical {
+			order = append(order, index)
+		}
+	}
+	var streams []uint8
+	seen := make(map[uint8]struct{})
+	for _, index := range order {
+		control := pgc.SubpictureControl[index]
+		if control&0x8000_0000 == 0 {
+			continue
+		}
+		for _, shift := range []uint{24, 16, 8, 0} {
+			streamID := uint8(0x20 + (control>>shift)&0x1f)
+			if _, ok := seen[streamID]; ok {
+				continue
+			}
+			seen[streamID] = struct{}{}
+			streams = append(streams, streamID)
+		}
+	}
+	if len(streams) == 0 {
+		for streamID := uint8(0x20); streamID <= 0x3f; streamID++ {
+			streams = append(streams, streamID)
+		}
+	}
+	return streams
+}
+
+func boundedControlDate(value uint64) uint16 {
+	if value > math.MaxUint16 {
+		return math.MaxUint16
+	}
+	return uint16(value)
+}
+
+// targetDuration converts preceding cell durations and the selected NAV PTS
+// delta into an FFmpeg seek offset within the chosen program.
+func targetDuration(pgc ifo.ProgramChain, coordinate graph.Coordinate, firstPTS, selectedPTS uint32) (time.Duration, error) {
+	if coordinate.Program < 1 || coordinate.Program > int(pgc.Programs) || coordinate.Cell < 1 || coordinate.Cell > int(pgc.Cells) {
+		return 0, fmt.Errorf("%w: invalid program or cell", ErrLiveState)
+	}
+	firstCell := coordinate.Program
+	if coordinate.Program <= len(pgc.ProgramMap) {
+		firstCell = int(pgc.ProgramMap[coordinate.Program-1])
+	}
+	if firstCell < 1 || firstCell > coordinate.Cell {
+		return 0, fmt.Errorf("%w: invalid program cell mapping", ErrLiveState)
+	}
+	var target time.Duration
+	for cell := firstCell; cell < coordinate.Cell; cell++ {
+		duration, err := pgc.CellPlayback[cell-1].PlaybackTime.Duration()
+		if err != nil {
+			return 0, fmt.Errorf("%w: invalid cell duration", ErrLiveState)
+		}
+		target += duration
+	}
+	if selectedPTS >= firstPTS {
+		target += time.Duration(selectedPTS-firstPTS) * time.Second / 90_000
+	}
+	return target, nil
+}
+
+// liveFingerprint hashes NAV timing/selection state and available overlay
+// pixels without incorporating local paths or disc-identifying text.
+func liveFingerprint(packet nav.Packet, overlay spu.Overlay, hasOverlay bool) []byte {
+	hash := sha256.New()
+	var data [16]byte
+	binary.BigEndian.PutUint32(data[0:4], packet.PCI.VOBUStartPTS)
+	binary.BigEndian.PutUint32(data[4:8], packet.PCI.HighlightStartPTS)
+	binary.BigEndian.PutUint16(data[8:10], packet.DSI.VOBID)
+	data[10] = packet.DSI.CellID
+	data[11] = packet.PCI.ForcedSelectButton
+	_, _ = hash.Write(data[:12])
+	if hasOverlay {
+		_, _ = hash.Write(overlay.Pixels)
+		_, _ = hash.Write([]byte(overlay.Bounds.String()))
+	}
+	return hash.Sum(nil)
+}

--- a/internal/dvdvideo/graph/graph.go
+++ b/internal/dvdvideo/graph/graph.go
@@ -1,0 +1,1008 @@
+// Package graph performs deterministic, bounded DVD menu discovery over cloned
+// pure-Go VM state and reconciles reachable results with the IFO inventory.
+package graph
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/autobrr/upbrr/internal/dvdvideo/ifo"
+	"github.com/autobrr/upbrr/internal/dvdvideo/nav"
+	"github.com/autobrr/upbrr/internal/dvdvideo/vm"
+)
+
+const (
+	// DefaultMaxItems is the default maximum number of selected menu screens.
+	DefaultMaxItems = 6
+	// DefaultMaxStates is the default bound on distinct VM states.
+	DefaultMaxStates = 4096
+	// DefaultMaxDepth is the default bound on one navigation branch.
+	DefaultMaxDepth = 64
+	// DefaultMaxButtons is the default bound on evaluated button commands.
+	DefaultMaxButtons = 16_384
+	// MaxMenuItems is the hard upper bound on selected menu screens.
+	MaxMenuItems = 32
+)
+
+// ErrDiscovery identifies invalid options or incomplete DVD menu graph setup.
+var ErrDiscovery = errors.New("DVD menu discovery failed")
+
+// Discovery identifies how a visible menu was found.
+type Discovery string
+
+// Menu discovery sources emitted in [Screen] values.
+const (
+	// DiscoveryReachable marks a screen reached through deterministic VM navigation.
+	DiscoveryReachable Discovery = "reachable"
+	// DiscoveryStructural marks an interactive screen found only in the IFO inventory.
+	DiscoveryStructural Discovery = "structural"
+)
+
+// Coordinate is one exact FFmpeg-addressable menu location.
+type Coordinate struct {
+	// Kind selects the manager or title-set menu domain.
+	Kind ifo.Kind
+	// VTS is zero for the manager domain or the one-based title-set number.
+	VTS int
+	// LanguageUnit is the one-based menu language-unit index.
+	LanguageUnit int
+	// PGC is the one-based menu program-chain index.
+	PGC int
+	// Program is the one-based program index within PGC.
+	Program int
+	// Cell is the one-based cell containing Program.
+	Cell int
+	// MenuID is the authored low-nibble menu identifier.
+	MenuID uint8
+}
+
+// LiveState is NAV/SPU state resolved for one coordinate and VM checkpoint.
+type LiveState struct {
+	// Visible reports that button, SPU, highlight, still, or entry evidence identifies a menu screen.
+	Visible bool
+	// Buttons contains the selected live PCI display group's authored controls.
+	Buttons []nav.Button
+	// Fingerprint hashes live NAV timing and available SPU pixels for deduplication.
+	Fingerprint []byte
+	// HasOverlay reports that active menu subpicture state was decoded.
+	HasOverlay bool
+	// HasHighlight reports that a default selected-button highlight was resolved.
+	HasHighlight bool
+	// AuthoredStill reports that the PGC or selected cell has nonzero still time.
+	AuthoredStill bool
+	// AuthoredEntry reports that the first program is an authored entry PGC.
+	AuthoredEntry bool
+}
+
+// Resolver reads live NAV/SPU state without controlling traversal.
+type Resolver interface {
+	// Resolve returns live state for one inventory-validated coordinate and register snapshot.
+	Resolve(ctx context.Context, coordinate Coordinate, pgc ifo.ProgramChain, registers vm.Registers) (LiveState, error)
+}
+
+// Logger receives path-free traversal diagnostics. It intentionally mirrors
+// only the log levels used by the DVD engine.
+type Logger interface {
+	// Tracef records near-complete VM action flow.
+	Tracef(format string, args ...any)
+	// Debugf records inventory, classification, branch, and deduplication decisions.
+	Debugf(format string, args ...any)
+	// Infof records top-level progress when used by an embedding service.
+	Infof(format string, args ...any)
+	// Warnf records distinct incomplete-coverage conditions.
+	Warnf(format string, args ...any)
+}
+
+// Options are independent deterministic traversal/storage budgets.
+type Options struct {
+	// Language selects the preferred two-byte DVD language code.
+	Language string
+	// MaxItems bounds selected screens; zero uses DefaultMaxItems.
+	MaxItems int
+	// MaxStates bounds distinct VM states; zero uses DefaultMaxStates.
+	MaxStates int
+	// MaxDepth bounds one traversal branch; zero uses DefaultMaxDepth.
+	MaxDepth int
+	// MaxButtons bounds evaluated button commands; zero uses DefaultMaxButtons.
+	MaxButtons int
+	// Registers is cloned as the initial VM state for every seed.
+	Registers vm.Registers
+	// VM controls deterministic command execution for traversal.
+	VM vm.Options
+	// Progress receives synchronous path-free counter snapshots when non-nil.
+	Progress func(Progress)
+	// Logger receives optional path-free diagnostics.
+	Logger Logger
+}
+
+// Progress reports bounded discovery counters without disc-identifying data.
+type Progress struct {
+	// Inventoried is the number of structural menu programs.
+	Inventoried int
+	// VisitedStates is the number of distinct VM states evaluated.
+	VisitedStates int
+	// VisitedButtons is the number of button commands evaluated.
+	VisitedButtons int
+	// Screens is the number of distinct menu screens selected.
+	Screens int
+	// Warnings is the number of distinct coverage warnings.
+	Warnings int
+}
+
+// Warning is a stable graph coverage warning.
+type Warning struct {
+	// Code is a stable machine-readable coverage identifier.
+	Code string
+	// Message is a path-free user-facing description.
+	Message string
+}
+
+// Screen is one semantically distinct visible authored menu state.
+type Screen struct {
+	// Coordinate is the exact inventory location used for frame rendering.
+	Coordinate Coordinate
+	// Discovery records whether navigation or structural inventory found the screen.
+	Discovery Discovery
+	// Identity is the deterministic semantic screen fingerprint.
+	Identity [32]byte
+	// Registers is the cloned VM checkpoint used to resolve live state again.
+	Registers vm.Registers
+	// Live is the state used to classify and deduplicate the screen.
+	Live LiveState
+}
+
+// Result reports bounded discovery and structural reconciliation.
+type Result struct {
+	// Screens contains distinct selected screens in deterministic discovery order.
+	Screens []Screen
+	// Inventoried is the number of structural menu programs.
+	Inventoried int
+	// VisitedStates is the number of distinct VM states evaluated.
+	VisitedStates int
+	// VisitedButtons is the number of button commands evaluated.
+	VisitedButtons int
+	// Complete reports full traversal without warnings or item truncation.
+	Complete bool
+	// Partial reports incomplete traversal or live-state classification coverage.
+	Partial bool
+	// Truncated reports that MaxItems excluded one or more eligible screens.
+	Truncated bool
+	// Warnings contains deduplicated path-free coverage diagnostics.
+	Warnings []Warning
+}
+
+type node struct {
+	coordinate Coordinate
+	pgc        ifo.ProgramChain
+}
+
+type state struct {
+	node      node
+	registers vm.Registers
+	depth     int
+	runPre    bool
+	utility   bool
+}
+
+// Discover traverses reachable entry PGCs first, then classifies visible
+// unreached inventory entries as structural coverage. Progress callbacks run
+// synchronously, and cancellation returns the counters accumulated so far.
+func Discover(ctx context.Context, disc ifo.Disc, resolver Resolver, opts Options) (Result, error) {
+	if resolver == nil {
+		return Result{}, fmt.Errorf("%w: nil live-state resolver", ErrDiscovery)
+	}
+	if opts.MaxItems == 0 {
+		opts.MaxItems = DefaultMaxItems
+	}
+	if opts.MaxItems < 0 || opts.MaxItems > MaxMenuItems {
+		return Result{}, fmt.Errorf("%w: item limit must be between 1 and %d", ErrDiscovery, MaxMenuItems)
+	}
+	if opts.MaxStates == 0 {
+		opts.MaxStates = DefaultMaxStates
+	}
+	if opts.MaxDepth == 0 {
+		opts.MaxDepth = DefaultMaxDepth
+	}
+	if opts.MaxButtons == 0 {
+		opts.MaxButtons = DefaultMaxButtons
+	}
+	if opts.MaxStates < 0 || opts.MaxDepth < 0 || opts.MaxButtons < 0 {
+		return Result{}, fmt.Errorf("%w: negative traversal limit", ErrDiscovery)
+	}
+
+	nodes, seeds := inventory(disc, opts.Language)
+	result := Result{Inventoried: len(nodes)}
+	if opts.Logger != nil {
+		opts.Logger.Debugf(
+			"DVD menus: discovery started language=%s inventoried=%d seeds=%d max_items=%d max_states=%d max_depth=%d max_buttons=%d",
+			opts.Language,
+			len(nodes),
+			len(seeds),
+			opts.MaxItems,
+			opts.MaxStates,
+			opts.MaxDepth,
+			opts.MaxButtons,
+		)
+	}
+	reportProgress(opts.Progress, result)
+	if len(nodes) == 0 {
+		return result, fmt.Errorf("%w: no menu program chains", ErrDiscovery)
+	}
+	lookup := make(map[nodeKey]node, len(nodes))
+	for _, item := range nodes {
+		if _, exists := lookup[key(item.coordinate)]; !exists {
+			lookup[key(item.coordinate)] = item
+		}
+	}
+	queue := make([]state, 0, len(seeds))
+	fallbackSeed := len(seeds) == 1 && seeds[0].pgc.EntryID&0x80 == 0
+	for _, seed := range seeds {
+		queue = append(queue, state{
+			node:      seed,
+			registers: opts.Registers.Clone(),
+			runPre:    true,
+			utility:   fallbackSeed && seed.coordinate.Kind == ifo.KindManager && seed.coordinate.MenuID == 0,
+		})
+	}
+	seen := make(map[[32]byte]struct{})
+	reachedCoordinates := make(map[Coordinate]struct{})
+	classifiedCoordinates := make(map[Coordinate]struct{})
+	screenIDs := make(map[[32]byte]struct{})
+	controlLayouts := make(map[[32]byte][][]nav.Button)
+	limitSkipped := 0
+	utilityScreens := 0
+	structuralTransitions := 0
+	structuralNonInteractive := 0
+	structuralDuplicates := 0
+	structuralVisible := 0
+	structuralFailures := 0
+
+	for len(queue) > 0 {
+		if err := ctx.Err(); err != nil {
+			return Result{}, fmt.Errorf("%w: %w", ErrDiscovery, err)
+		}
+		current := queue[0]
+		queue = queue[1:]
+		if current.depth > opts.MaxDepth {
+			if markPartial(&result, "depth_limit", "menu branch depth limit reached") {
+				logTraversalWarning(opts.Logger, "depth_limit", current.node.coordinate)
+			}
+			continue
+		}
+		identity := traversalIdentity(current.node.coordinate, current.registers, current.runPre)
+		if _, ok := seen[identity]; ok {
+			if opts.Logger != nil {
+				opts.Logger.Debugf(
+					"DVD menus: state skipped decision=dedupe reason=state_identity domain=%s vts=%d language_unit=%d menu_id=%d pgc=%d pg=%d cell=%d state=%x",
+					domainLabel(current.node.coordinate.Kind),
+					current.node.coordinate.VTS,
+					current.node.coordinate.LanguageUnit,
+					current.node.coordinate.MenuID,
+					current.node.coordinate.PGC,
+					current.node.coordinate.Program,
+					current.node.coordinate.Cell,
+					identity[:6],
+				)
+			}
+			continue
+		}
+		if len(seen) >= opts.MaxStates {
+			if markPartial(&result, "state_limit", "menu state limit reached") {
+				logTraversalWarning(opts.Logger, "state_limit", current.node.coordinate)
+			}
+			break
+		}
+		seen[identity] = struct{}{}
+		result.VisitedStates++
+		if opts.Logger != nil {
+			opts.Logger.Tracef(
+				"DVD menus: state visiting domain=%s vts=%d language_unit=%d menu_id=%d pgc=%d pg=%d cell=%d depth=%d run_pre=%t state=%x queue=%d",
+				domainLabel(current.node.coordinate.Kind),
+				current.node.coordinate.VTS,
+				current.node.coordinate.LanguageUnit,
+				current.node.coordinate.MenuID,
+				current.node.coordinate.PGC,
+				current.node.coordinate.Program,
+				current.node.coordinate.Cell,
+				current.depth,
+				current.runPre,
+				identity[:6],
+				len(queue),
+			)
+		}
+		reportProgress(opts.Progress, result)
+
+		registers := current.registers.Clone()
+		if current.runPre {
+			preResult, err := vm.Execute(current.node.pgc.PreCommands, &registers, opts.VM)
+			if err != nil {
+				if markPartial(&result, "pre_command", "menu pre-command failed") {
+					logTraversalWarning(opts.Logger, "pre_command", current.node.coordinate)
+				}
+				continue
+			}
+			if opts.Logger != nil {
+				opts.Logger.Tracef(
+					"DVD menus: action evaluated action=pre commands=%d executed=%d has_link=%t link=%d",
+					len(current.node.pgc.PreCommands),
+					preResult.Executed,
+					preResult.HasLink,
+					preResult.Link.Command,
+				)
+			}
+			if preResult.HasLink {
+				target, terminal, ok := resolveLink(current.node, preResult.Link, lookup)
+				if ok {
+					if opts.Logger != nil {
+						opts.Logger.Debugf("DVD menus: branch queued action=pre decision=follow link=%d target_domain=%s target_vts=%d target_pgc=%d target_pg=%d", preResult.Link.Command, domainLabel(target.coordinate.Kind), target.coordinate.VTS, target.coordinate.PGC, target.coordinate.Program)
+					}
+					queue = append(queue, transition(current, target, registers))
+					continue
+				}
+				if !terminal {
+					if markPartial(&result, "unsupported_pre_link", "menu pre-command target was not resolved") {
+						logTraversalWarning(opts.Logger, "unsupported_pre_link", current.node.coordinate)
+					}
+				} else if opts.Logger != nil {
+					opts.Logger.Debugf("DVD menus: branch stopped action=pre decision=terminal link=%d", preResult.Link.Command)
+				}
+				continue
+			}
+		}
+
+		live, err := resolver.Resolve(ctx, current.node.coordinate, current.node.pgc, registers.Clone())
+		if err != nil {
+			if markPartial(&result, "live_state", "menu NAV/SPU state could not be resolved") {
+				logTraversalWarning(opts.Logger, "live_state", current.node.coordinate)
+			}
+			continue
+		}
+		if opts.Logger != nil {
+			opts.Logger.Debugf(
+				"DVD menus: state resolved domain=%s vts=%d language_unit=%d menu_id=%d pgc=%d pg=%d cell=%d visible=%t buttons=%d overlay=%t highlight=%t authored_still=%t authored_entry=%t fingerprint=%s",
+				domainLabel(current.node.coordinate.Kind),
+				current.node.coordinate.VTS,
+				current.node.coordinate.LanguageUnit,
+				current.node.coordinate.MenuID,
+				current.node.coordinate.PGC,
+				current.node.coordinate.Program,
+				current.node.coordinate.Cell,
+				live.Visible,
+				len(live.Buttons),
+				live.HasOverlay,
+				live.HasHighlight,
+				live.AuthoredStill,
+				live.AuthoredEntry,
+				fingerprintPrefix(live.Fingerprint),
+			)
+		}
+		reachedCoordinates[current.node.coordinate] = struct{}{}
+		classifiedCoordinates[current.node.coordinate] = struct{}{}
+		if live.Visible && !current.utility {
+			screenID := semanticIdentity(current.node.coordinate, registers, live)
+			controlID, hasControls := controlIdentity(current.node.coordinate, live)
+			_, duplicateScreen := screenIDs[screenID]
+			duplicateControls := hasEquivalentControls(controlLayouts, controlID, live.Buttons)
+			switch {
+			case duplicateScreen:
+				if opts.Logger != nil {
+					opts.Logger.Debugf("DVD menus: screen skipped decision=dedupe reason=semantic_identity domain=%s vts=%d pgc=%d pg=%d screen=%x", domainLabel(current.node.coordinate.Kind), current.node.coordinate.VTS, current.node.coordinate.PGC, current.node.coordinate.Program, screenID[:6])
+				}
+			case hasControls && duplicateControls:
+				if opts.Logger != nil {
+					opts.Logger.Debugf("DVD menus: screen skipped decision=dedupe reason=control_identity domain=%s vts=%d pgc=%d pg=%d controls=%x", domainLabel(current.node.coordinate.Kind), current.node.coordinate.VTS, current.node.coordinate.PGC, current.node.coordinate.Program, controlID[:6])
+				}
+			default:
+				if opts.MaxItems > 0 && len(result.Screens) >= opts.MaxItems {
+					result.Truncated = true
+					limitSkipped++
+				} else {
+					screenIDs[screenID] = struct{}{}
+					if hasControls {
+						rememberControlLayout(controlLayouts, controlID, live.Buttons)
+					}
+					result.Screens = append(result.Screens, Screen{Coordinate: current.node.coordinate, Discovery: DiscoveryReachable, Identity: screenID, Registers: registers.Clone(), Live: live})
+					if opts.Logger != nil {
+						opts.Logger.Debugf("DVD menus: screen selected discovery=reachable domain=%s vts=%d language_unit=%d menu_id=%d pgc=%d pg=%d cell=%d buttons=%d screen=%x stored=%d", domainLabel(current.node.coordinate.Kind), current.node.coordinate.VTS, current.node.coordinate.LanguageUnit, current.node.coordinate.MenuID, current.node.coordinate.PGC, current.node.coordinate.Program, current.node.coordinate.Cell, len(live.Buttons), screenID[:6], len(result.Screens))
+					}
+				}
+			}
+		} else if live.Visible {
+			utilityScreens++
+		}
+
+		for _, button := range live.Buttons {
+			if result.VisitedButtons >= opts.MaxButtons {
+				if markPartial(&result, "button_limit", "menu button limit reached") {
+					logTraversalWarning(opts.Logger, "button_limit", current.node.coordinate)
+				}
+				break
+			}
+			result.VisitedButtons++
+			branchRegisters := registers.Clone()
+			buttonResult, buttonErr := vm.Execute([]vm.Command{button.Command}, &branchRegisters, opts.VM)
+			if buttonErr != nil {
+				if markPartial(&result, "button_command", "menu button command failed") {
+					logTraversalWarning(opts.Logger, "button_command", current.node.coordinate)
+				}
+				continue
+			}
+			if opts.Logger != nil {
+				opts.Logger.Tracef("DVD menus: action evaluated action=button button=%d executed=%d has_link=%t link=%d registers_changed=%t", button.Number, buttonResult.Executed, buttonResult.HasLink, buttonResult.Link.Command, branchRegisters != registers)
+			}
+			if buttonResult.HasLink {
+				target, terminal, ok := resolveLink(current.node, buttonResult.Link, lookup)
+				switch {
+				case ok:
+					if opts.Logger != nil {
+						opts.Logger.Debugf("DVD menus: branch queued action=button button=%d decision=follow link=%d target_domain=%s target_vts=%d target_pgc=%d target_pg=%d", button.Number, buttonResult.Link.Command, domainLabel(target.coordinate.Kind), target.coordinate.VTS, target.coordinate.PGC, target.coordinate.Program)
+					}
+					queue = append(queue, transition(current, target, branchRegisters))
+				case !terminal:
+					if markPartial(&result, "unsupported_button_link", "menu button target was not resolved") {
+						logTraversalWarning(opts.Logger, "unsupported_button_link", current.node.coordinate)
+					}
+				case opts.Logger != nil:
+					opts.Logger.Debugf("DVD menus: branch stopped action=button button=%d decision=terminal link=%d", button.Number, buttonResult.Link.Command)
+				}
+				continue
+			}
+			if branchRegisters != registers {
+				queue = append(queue, state{node: current.node, registers: branchRegisters, depth: current.depth + 1, utility: current.utility})
+			}
+		}
+		reportProgress(opts.Progress, result)
+
+		postRegisters := registers.Clone()
+		postResult, postErr := vm.Execute(current.node.pgc.PostCommands, &postRegisters, opts.VM)
+		if postErr == nil && opts.Logger != nil {
+			opts.Logger.Tracef("DVD menus: action evaluated action=post commands=%d executed=%d has_link=%t link=%d", len(current.node.pgc.PostCommands), postResult.Executed, postResult.HasLink, postResult.Link.Command)
+		}
+		switch {
+		case postErr != nil:
+			if markPartial(&result, "post_command", "menu post-command failed") {
+				logTraversalWarning(opts.Logger, "post_command", current.node.coordinate)
+			}
+		case postResult.HasLink:
+			target, terminal, ok := resolveLink(current.node, postResult.Link, lookup)
+			switch {
+			case ok:
+				if opts.Logger != nil {
+					opts.Logger.Debugf("DVD menus: branch queued action=post decision=follow link=%d target_domain=%s target_vts=%d target_pgc=%d target_pg=%d", postResult.Link.Command, domainLabel(target.coordinate.Kind), target.coordinate.VTS, target.coordinate.PGC, target.coordinate.Program)
+				}
+				queue = append(queue, transition(current, target, postRegisters))
+			case !terminal:
+				if markPartial(&result, "unsupported_post_link", "menu post-command target was not resolved") {
+					logTraversalWarning(opts.Logger, "unsupported_post_link", current.node.coordinate)
+				}
+			case opts.Logger != nil:
+				opts.Logger.Debugf("DVD menus: branch stopped action=post decision=terminal link=%d", postResult.Link.Command)
+			}
+		case current.node.pgc.Next != 0:
+			if target, ok := lookup[nodeKey{kind: current.node.coordinate.Kind, vts: current.node.coordinate.VTS, language: current.node.coordinate.LanguageUnit, pgc: int(current.node.pgc.Next)}]; ok {
+				if opts.Logger != nil {
+					opts.Logger.Debugf("DVD menus: branch queued action=next_pgc decision=follow target_domain=%s target_vts=%d target_pgc=%d", domainLabel(target.coordinate.Kind), target.coordinate.VTS, target.coordinate.PGC)
+				}
+				queue = append(queue, state{node: target, registers: postRegisters, depth: current.depth + 1, runPre: true})
+			}
+		}
+	}
+
+	for _, item := range nodes {
+		if _, ok := reachedCoordinates[item.coordinate]; ok {
+			continue
+		}
+		live, err := resolver.Resolve(ctx, item.coordinate, item.pgc, opts.Registers.Clone())
+		if err != nil {
+			structuralFailures++
+			if markPartial(&result, "structural_state", "structural menu candidate could not be classified") {
+				logTraversalWarning(opts.Logger, "structural_state", item.coordinate)
+			}
+			continue
+		}
+		classifiedCoordinates[item.coordinate] = struct{}{}
+		if !live.Visible {
+			structuralTransitions++
+			continue
+		}
+		// A zero-button screen is valid only when navigation actually reaches it.
+		// Structural still/entry/SPU metadata alone also describes transitions,
+		// warnings, and other authored non-menu video.
+		if len(live.Buttons) == 0 {
+			structuralNonInteractive++
+			continue
+		}
+		screenID := semanticIdentity(item.coordinate, opts.Registers, live)
+		if _, ok := screenIDs[screenID]; ok {
+			structuralDuplicates++
+			continue
+		}
+		controlID, hasControls := controlIdentity(item.coordinate, live)
+		if hasControls && hasEquivalentControls(controlLayouts, controlID, live.Buttons) {
+			structuralDuplicates++
+			if opts.Logger != nil {
+				opts.Logger.Debugf("DVD menus: screen skipped decision=dedupe reason=control_identity domain=%s vts=%d pgc=%d pg=%d controls=%x", domainLabel(item.coordinate.Kind), item.coordinate.VTS, item.coordinate.PGC, item.coordinate.Program, controlID[:6])
+			}
+			continue
+		}
+		structuralVisible++
+		if markPartial(&result, "structural_only", "visible menu was not reached through navigation") {
+			logTraversalWarning(opts.Logger, "structural_only", item.coordinate)
+		}
+		if opts.MaxItems > 0 && len(result.Screens) >= opts.MaxItems {
+			result.Truncated = true
+			limitSkipped++
+			continue
+		}
+		screenIDs[screenID] = struct{}{}
+		if hasControls {
+			rememberControlLayout(controlLayouts, controlID, live.Buttons)
+		}
+		result.Screens = append(result.Screens, Screen{Coordinate: item.coordinate, Discovery: DiscoveryStructural, Identity: screenID, Registers: opts.Registers.Clone(), Live: live})
+		if opts.Logger != nil {
+			opts.Logger.Debugf("DVD menus: screen selected discovery=structural domain=%s vts=%d language_unit=%d menu_id=%d pgc=%d pg=%d cell=%d buttons=%d screen=%x stored=%d", domainLabel(item.coordinate.Kind), item.coordinate.VTS, item.coordinate.LanguageUnit, item.coordinate.MenuID, item.coordinate.PGC, item.coordinate.Program, item.coordinate.Cell, len(live.Buttons), screenID[:6], len(result.Screens))
+		}
+		reportProgress(opts.Progress, result)
+	}
+	result.Complete = !result.Partial && !result.Truncated && len(classifiedCoordinates) == len(nodes)
+	if opts.Logger != nil {
+		opts.Logger.Debugf("DVD menus: structural reconciliation complete classified=%d transitions=%d noninteractive=%d utility=%d duplicates=%d visible_unreached=%d failures=%d", len(classifiedCoordinates), structuralTransitions, structuralNonInteractive, utilityScreens, structuralDuplicates, structuralVisible, structuralFailures)
+		if limitSkipped > 0 {
+			opts.Logger.Debugf("DVD menus: storage limit applied max_items=%d additional_menu_candidates=%d", opts.MaxItems, limitSkipped)
+		}
+		opts.Logger.Debugf("DVD menus: discovery complete inventoried=%d classified=%d reached=%d states=%d buttons=%d screens=%d partial=%t truncated=%t warnings=%d", result.Inventoried, len(classifiedCoordinates), len(reachedCoordinates), result.VisitedStates, result.VisitedButtons, len(result.Screens), result.Partial, result.Truncated, len(result.Warnings))
+	}
+	reportProgress(opts.Progress, result)
+	if len(result.Screens) == 0 {
+		return result, fmt.Errorf("%w: no visible menu screens", ErrDiscovery)
+	}
+	return result, nil
+}
+
+func reportProgress(reporter func(Progress), result Result) {
+	if reporter == nil {
+		return
+	}
+	reporter(Progress{
+		Inventoried:    result.Inventoried,
+		VisitedStates:  result.VisitedStates,
+		VisitedButtons: result.VisitedButtons,
+		Screens:        len(result.Screens),
+		Warnings:       len(result.Warnings),
+	})
+}
+
+// transition advances a branch and preserves utility filtering only while it
+// remains within the same PGC.
+func transition(current state, target node, registers vm.Registers) state {
+	return state{
+		node:      target,
+		registers: registers,
+		depth:     current.depth + 1,
+		runPre:    key(current.node.coordinate) != key(target.coordinate),
+		utility:   current.utility && key(current.node.coordinate) == key(target.coordinate),
+	}
+}
+
+// inventory returns deterministic program-level graph nodes and authored entry
+// seeds for the selected manager/title-set language units.
+func inventory(disc ifo.Disc, language string) ([]node, []node) {
+	files := append([]ifo.File{disc.Manager}, disc.TitleSets...)
+	var nodes []node
+	var seeds []node
+	for _, file := range files {
+		languageIndex := selectLanguage(file.Languages, language)
+		if languageIndex < 0 {
+			continue
+		}
+		unit := file.Languages[languageIndex]
+		for _, pgc := range unit.ProgramChains {
+			if pgc.Programs == 0 || pgc.Cells == 0 {
+				continue
+			}
+			for program := 1; program <= int(pgc.Programs); program++ {
+				item := node{coordinate: Coordinate{Kind: file.Kind, VTS: file.VTS, LanguageUnit: languageIndex + 1, PGC: pgc.Number, Program: program, Cell: cellForProgram(pgc, program), MenuID: pgc.MenuID}, pgc: pgc}
+				nodes = append(nodes, item)
+				if program == 1 && pgc.EntryID&0x80 != 0 {
+					seeds = append(seeds, item)
+				}
+			}
+		}
+	}
+	sort.SliceStable(seeds, func(i, j int) bool {
+		left, right := menuPriority(seeds[i].coordinate.MenuID), menuPriority(seeds[j].coordinate.MenuID)
+		if left != right {
+			return left < right
+		}
+		if seeds[i].coordinate.VTS != seeds[j].coordinate.VTS {
+			return seeds[i].coordinate.VTS < seeds[j].coordinate.VTS
+		}
+		return seeds[i].coordinate.PGC < seeds[j].coordinate.PGC
+	})
+	if len(seeds) == 0 && len(nodes) != 0 {
+		seeds = append(seeds, nodes[0])
+	}
+	return nodes, seeds
+}
+
+func selectLanguage(units []ifo.LanguageUnit, requested string) int {
+	for index := range units {
+		if requested != "" && units[index].Code == requested {
+			return index
+		}
+	}
+	for index := range units {
+		if units[index].Code == "en" {
+			return index
+		}
+	}
+	if len(units) != 0 {
+		return 0
+	}
+	return -1
+}
+
+func menuPriority(menuID uint8) int {
+	switch menuID {
+	case 2: // Title
+		return 0
+	case 3: // Root
+		return 1
+	case 7: // Part/chapter
+		return 2
+	case 5: // Audio
+		return 3
+	case 4: // Subpicture
+		return 4
+	case 6: // Angle
+		return 5
+	default:
+		return 6
+	}
+}
+
+type nodeKey struct {
+	kind     ifo.Kind
+	vts      int
+	language int
+	pgc      int
+}
+
+func key(coordinate Coordinate) nodeKey {
+	return nodeKey{kind: coordinate.Kind, vts: coordinate.VTS, language: coordinate.LanguageUnit, pgc: coordinate.PGC}
+}
+
+// resolveLink maps a VM transition to an inventoried node. The second result
+// reports a terminal command; the third reports a resolved target.
+func resolveLink(current node, link vm.Link, lookup map[nodeKey]node) (node, bool, bool) {
+	coordinate := current.coordinate
+	var targetPGC int
+	switch link.Command {
+	case vm.LinkNoLink:
+		return current, false, false
+	case vm.LinkPGCN:
+		targetPGC = int(link.Data1)
+	case vm.LinkNextPGC:
+		targetPGC = int(current.pgc.Next)
+	case vm.LinkPreviousPGC:
+		targetPGC = int(current.pgc.Previous)
+	case vm.LinkGoUpPGC:
+		targetPGC = int(current.pgc.GoUp)
+	case vm.LinkTopCell:
+		return current, false, true
+	case vm.LinkTopProgram:
+		coordinate.Cell = cellForProgram(current.pgc, coordinate.Program)
+		return node{coordinate: coordinate, pgc: current.pgc}, false, true
+	case vm.LinkTopPGC:
+		coordinate.Program = 1
+		coordinate.Cell = cellForProgram(current.pgc, 1)
+		return node{coordinate: coordinate, pgc: current.pgc}, false, true
+	case vm.LinkNextCell:
+		coordinate.Cell++
+		coordinate.Program = programForCell(current.pgc, coordinate.Cell)
+		return node{coordinate: coordinate, pgc: current.pgc}, false, coordinate.Cell <= int(current.pgc.Cells)
+	case vm.LinkPreviousCell:
+		coordinate.Cell--
+		coordinate.Program = programForCell(current.pgc, coordinate.Cell)
+		return node{coordinate: coordinate, pgc: current.pgc}, false, coordinate.Cell > 0
+	case vm.LinkNextProgram:
+		coordinate.Program++
+		coordinate.Cell = cellForProgram(current.pgc, coordinate.Program)
+		return node{coordinate: coordinate, pgc: current.pgc}, false, coordinate.Program <= int(current.pgc.Programs)
+	case vm.LinkPreviousProgram:
+		coordinate.Program--
+		coordinate.Cell = cellForProgram(current.pgc, coordinate.Program)
+		return node{coordinate: coordinate, pgc: current.pgc}, false, coordinate.Program > 0
+	case vm.LinkPGN:
+		coordinate.Program = int(link.Data1)
+		coordinate.Cell = cellForProgram(current.pgc, coordinate.Program)
+		return node{coordinate: coordinate, pgc: current.pgc}, false, coordinate.Program > 0 && coordinate.Program <= int(current.pgc.Programs)
+	case vm.LinkCN:
+		coordinate.Cell = int(link.Data1)
+		coordinate.Program = programForCell(current.pgc, coordinate.Cell)
+		return node{coordinate: coordinate, pgc: current.pgc}, false, coordinate.Cell > 0 && coordinate.Cell <= int(current.pgc.Cells)
+	case vm.JumpVMGMMenu, vm.CallVMGMMenu:
+		return findMenu(lookup, ifo.KindManager, 0, int(link.Data1))
+	case vm.JumpVTSM:
+		return findMenu(lookup, ifo.KindTitleSet, int(link.Data1), int(link.Data3))
+	case vm.CallVTSM:
+		return findMenu(lookup, ifo.KindTitleSet, current.coordinate.VTS, int(link.Data1))
+	case vm.JumpVMGMPGC, vm.CallVMGMPGC:
+		coordinate.Kind = ifo.KindManager
+		coordinate.VTS = 0
+		targetPGC = int(link.Data1)
+	case vm.Exit, vm.JumpTT, vm.JumpVTSTT, vm.JumpVTSPTT, vm.JumpFirstPlay, vm.CallFirstPlay, vm.LinkResume, vm.LinkPTTN, vm.LinkTailPGC:
+		return node{}, true, false
+	case vm.LinkReserved4, vm.LinkReserved8, vm.LinkReserved14, vm.LinkReserved15:
+		return node{}, false, false
+	default:
+		return node{}, false, false
+	}
+	if targetPGC == 0 {
+		return node{}, false, false
+	}
+	coordinate.PGC = targetPGC
+	target, ok := lookup[key(coordinate)]
+	return target, false, ok
+}
+
+func cellForProgram(pgc ifo.ProgramChain, program int) int {
+	if program > 0 && program <= len(pgc.ProgramMap) && pgc.ProgramMap[program-1] != 0 {
+		return int(pgc.ProgramMap[program-1])
+	}
+	return max(program, 1)
+}
+
+func programForCell(pgc ifo.ProgramChain, cell int) int {
+	program := 1
+	for index, firstCell := range pgc.ProgramMap {
+		if int(firstCell) > cell {
+			break
+		}
+		program = index + 1
+	}
+	return program
+}
+
+func findMenu(lookup map[nodeKey]node, kind ifo.Kind, vts, menuID int) (node, bool, bool) {
+	var matches []node
+	for _, item := range lookup {
+		if item.coordinate.Kind == kind && item.coordinate.VTS == vts && int(item.coordinate.MenuID) == menuID {
+			matches = append(matches, item)
+		}
+	}
+	if len(matches) == 0 {
+		return node{}, false, false
+	}
+	sort.Slice(matches, func(i, j int) bool { return matches[i].coordinate.PGC < matches[j].coordinate.PGC })
+	return matches[0], false, true
+}
+
+func stateIdentity(coordinate Coordinate, registers vm.Registers) [32]byte {
+	hash := sha256.New()
+	writeCoordinate(hash, coordinate)
+	var buffer [2]byte
+	for _, value := range registers.General {
+		binary.BigEndian.PutUint16(buffer[:], value)
+		hash.Write(buffer[:])
+	}
+	for _, value := range registers.System {
+		binary.BigEndian.PutUint16(buffer[:], value)
+		hash.Write(buffer[:])
+	}
+	for _, mode := range registers.CounterMode {
+		if mode {
+			hash.Write([]byte{1})
+		} else {
+			hash.Write([]byte{0})
+		}
+	}
+	var result [32]byte
+	copy(result[:], hash.Sum(nil))
+	return result
+}
+
+func traversalIdentity(coordinate Coordinate, registers vm.Registers, runPre bool) [32]byte {
+	state := stateIdentity(coordinate, registers)
+	hash := sha256.New()
+	hash.Write(state[:])
+	if runPre {
+		hash.Write([]byte{1})
+	} else {
+		hash.Write([]byte{0})
+	}
+	var result [32]byte
+	copy(result[:], hash.Sum(nil))
+	return result
+}
+
+// semanticIdentity hashes coordinate/register/live state for exact screen
+// deduplication within deterministic traversal.
+func semanticIdentity(coordinate Coordinate, registers vm.Registers, live LiveState) [32]byte {
+	state := stateIdentity(coordinate, registers)
+	hash := sha256.New()
+	hash.Write(state[:])
+	hash.Write(live.Fingerprint)
+	for _, button := range live.Buttons {
+		hash.Write(button.Command[:])
+		var data [12]byte
+		binary.BigEndian.PutUint16(data[0:2], button.XStart)
+		binary.BigEndian.PutUint16(data[2:4], button.YStart)
+		binary.BigEndian.PutUint16(data[4:6], button.XEnd)
+		binary.BigEndian.PutUint16(data[6:8], button.YEnd)
+		data[8], data[9], data[10], data[11] = button.Up, button.Down, button.Left, button.Right
+		hash.Write(data[:])
+	}
+	var result [32]byte
+	copy(result[:], hash.Sum(nil))
+	return result
+}
+
+// controlIdentity hashes menu scope plus button commands/navigation while
+// deliberately excluding background fingerprints and exact rectangles.
+func controlIdentity(coordinate Coordinate, live LiveState) ([32]byte, bool) {
+	if len(live.Buttons) == 0 {
+		return [32]byte{}, false
+	}
+	hash := sha256.New()
+	var scope [14]byte
+	scope[0] = byte(coordinate.Kind)
+	binary.BigEndian.PutUint32(scope[1:5], coordinateValue(coordinate.VTS))
+	binary.BigEndian.PutUint32(scope[5:9], coordinateValue(coordinate.LanguageUnit))
+	scope[9] = coordinate.MenuID
+	binary.BigEndian.PutUint32(scope[10:14], coordinateValue(len(live.Buttons)))
+	hash.Write(scope[:])
+	for _, button := range live.Buttons {
+		hash.Write(button.Command[:])
+		var data [7]byte
+		data[0] = button.Number
+		data[1] = button.ColorGroup
+		if button.AutoAction {
+			data[2] = 1
+		}
+		data[3], data[4], data[5], data[6] = button.Up, button.Down, button.Left, button.Right
+		hash.Write(data[:])
+	}
+	var result [32]byte
+	copy(result[:], hash.Sum(nil))
+	return result, true
+}
+
+func hasEquivalentControls(layouts map[[32]byte][][]nav.Button, identity [32]byte, buttons []nav.Button) bool {
+	for _, known := range layouts[identity] {
+		if buttonLayoutsClose(known, buttons) {
+			return true
+		}
+	}
+	return false
+}
+
+func rememberControlLayout(layouts map[[32]byte][][]nav.Button, identity [32]byte, buttons []nav.Button) {
+	layouts[identity] = append(layouts[identity], append([]nav.Button(nil), buttons...))
+}
+
+// buttonLayoutsClose accepts equivalent ordered button rectangles shifted by
+// at most eight pixels on each edge.
+func buttonLayoutsClose(left, right []nav.Button) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if coordinateDistance(left[index].XStart, right[index].XStart) > 8 ||
+			coordinateDistance(left[index].YStart, right[index].YStart) > 8 ||
+			coordinateDistance(left[index].XEnd, right[index].XEnd) > 8 ||
+			coordinateDistance(left[index].YEnd, right[index].YEnd) > 8 {
+			return false
+		}
+	}
+	return true
+}
+
+func coordinateDistance(left, right uint16) uint16 {
+	if left >= right {
+		return left - right
+	}
+	return right - left
+}
+
+type hashWriter interface{ Write([]byte) (int, error) }
+
+func writeCoordinate(hash hashWriter, coordinate Coordinate) {
+	var data [24]byte
+	data[0] = byte(coordinate.Kind)
+	binary.BigEndian.PutUint32(data[1:5], coordinateValue(coordinate.VTS))
+	binary.BigEndian.PutUint32(data[5:9], coordinateValue(coordinate.LanguageUnit))
+	binary.BigEndian.PutUint32(data[9:13], coordinateValue(coordinate.PGC))
+	binary.BigEndian.PutUint32(data[13:17], coordinateValue(coordinate.Program))
+	binary.BigEndian.PutUint32(data[17:21], coordinateValue(coordinate.Cell))
+	data[21] = coordinate.MenuID
+	_, _ = hash.Write(data[:22])
+}
+
+func coordinateValue(value int) uint32 {
+	if value < 0 || uint64(value) > math.MaxUint32 {
+		panic("DVD menu coordinate outside uint32 range")
+	}
+	return uint32(value)
+}
+
+func markPartial(result *Result, code, message string) bool {
+	result.Partial = true
+	for _, warning := range result.Warnings {
+		if warning.Code == code {
+			return false
+		}
+	}
+	result.Warnings = append(result.Warnings, Warning{Code: code, Message: message})
+	return true
+}
+
+func logTraversalWarning(logger Logger, code string, coordinate Coordinate) {
+	if logger == nil {
+		return
+	}
+	logger.Warnf(
+		"DVD menus: traversal warning code=%s detail=%q domain=%s vts=%d language_unit=%d pgc=%d pg=%d cell=%d",
+		code,
+		traversalWarningDetail(code),
+		domainLabel(coordinate.Kind),
+		coordinate.VTS,
+		coordinate.LanguageUnit,
+		coordinate.PGC,
+		coordinate.Program,
+		coordinate.Cell,
+	)
+}
+
+func traversalWarningDetail(code string) string {
+	switch code {
+	case "depth_limit":
+		return "menu branch depth limit reached"
+	case "state_limit":
+		return "menu state limit reached"
+	case "pre_command":
+		return "menu pre-command failed"
+	case "unsupported_pre_link":
+		return "menu pre-command target was not resolved"
+	case "live_state":
+		return "menu NAV/SPU state could not be resolved"
+	case "button_limit":
+		return "menu button limit reached"
+	case "button_command":
+		return "menu button command failed"
+	case "unsupported_button_link":
+		return "menu button target was not resolved"
+	case "post_command":
+		return "menu post-command failed"
+	case "unsupported_post_link":
+		return "menu post-command target was not resolved"
+	case "structural_only":
+		return "visible menu was not reached through navigation"
+	case "structural_state":
+		return "structural menu candidate could not be classified"
+	}
+	return "DVD menu traversal warning"
+}
+
+func domainLabel(kind ifo.Kind) string {
+	switch kind {
+	case ifo.KindManager:
+		return "vmg"
+	case ifo.KindTitleSet:
+		return "vtsm"
+	}
+	return "unknown"
+}
+
+func fingerprintPrefix(value []byte) string {
+	if len(value) > 6 {
+		value = value[:6]
+	}
+	return hex.EncodeToString(value)
+}

--- a/internal/dvdvideo/graph/graph_test.go
+++ b/internal/dvdvideo/graph/graph_test.go
@@ -1,0 +1,328 @@
+package graph
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/dvdvideo/ifo"
+	"github.com/autobrr/upbrr/internal/dvdvideo/nav"
+	"github.com/autobrr/upbrr/internal/dvdvideo/vm"
+)
+
+func TestDiscoverReachableAndStructuralMenus(t *testing.T) {
+	logger := &graphTestLogger{}
+	root := ifo.ProgramChain{Number: 1, EntryID: 0x83, MenuID: 3, Programs: 1, Cells: 1}
+	chapter := ifo.ProgramChain{Number: 2, EntryID: 0x07, MenuID: 7, Programs: 1, Cells: 1}
+	audio := ifo.ProgramChain{Number: 3, EntryID: 0x05, MenuID: 5, Programs: 1, Cells: 1}
+	disc := ifo.Disc{Manager: ifo.File{
+		Kind:      ifo.KindManager,
+		Languages: []ifo.LanguageUnit{{Code: "en", ProgramChains: []ifo.ProgramChain{root, chapter, audio}}},
+	}}
+	resolver := fakeResolver{live: map[int]LiveState{
+		1: {Visible: true, Fingerprint: []byte("root"), Buttons: []nav.Button{{Command: linkPGCN(2)}}},
+		2: {Visible: true, Fingerprint: []byte("chapter")},
+		3: {Visible: true, Fingerprint: []byte("audio"), Buttons: []nav.Button{{Number: 1}}},
+	}}
+	result, err := Discover(context.Background(), disc, resolver, Options{MaxItems: 6, Logger: logger})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(result.Screens) != 3 || result.Screens[0].Discovery != DiscoveryReachable || result.Screens[1].Discovery != DiscoveryReachable || result.Screens[2].Discovery != DiscoveryStructural {
+		t.Fatalf("screens = %+v", result.Screens)
+	}
+	if !result.Partial || result.Complete {
+		t.Fatalf("coverage = complete:%t partial:%t", result.Complete, result.Partial)
+	}
+	if result.VisitedButtons != 1 {
+		t.Fatalf("visited buttons = %d, want 1", result.VisitedButtons)
+	}
+	for _, expected := range []string{
+		"DEBUG DVD menus: discovery started language= inventoried=3 seeds=1",
+		"DEBUG DVD menus: branch queued action=button",
+		"DEBUG DVD menus: screen selected discovery=structural",
+		`WARN DVD menus: traversal warning code=structural_only detail="visible menu was not reached through navigation" domain=vmg`,
+		"DEBUG DVD menus: structural reconciliation complete classified=3 transitions=0 noninteractive=0 utility=0 duplicates=0 visible_unreached=1 failures=0",
+		"DEBUG DVD menus: discovery complete inventoried=3 classified=3 reached=2",
+	} {
+		if !logger.Contains(expected) {
+			t.Fatalf("missing DVD graph log event %q", expected)
+		}
+	}
+}
+
+type graphTestLogger struct {
+	entries []string
+}
+
+func (l *graphTestLogger) add(level, format string, args ...any) {
+	l.entries = append(l.entries, level+" "+fmt.Sprintf(format, args...))
+}
+
+func (l *graphTestLogger) Tracef(format string, args ...any) {
+	l.add("TRACE", format, args...)
+}
+
+func (l *graphTestLogger) Debugf(format string, args ...any) {
+	l.add("DEBUG", format, args...)
+}
+
+func (l *graphTestLogger) Infof(format string, args ...any) {
+	l.add("INFO", format, args...)
+}
+
+func (l *graphTestLogger) Warnf(format string, args ...any) {
+	l.add("WARN", format, args...)
+}
+
+func (l *graphTestLogger) Contains(expected string) bool {
+	for _, entry := range l.entries {
+		if strings.Contains(entry, expected) {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *graphTestLogger) Count(expected string) int {
+	count := 0
+	for _, entry := range l.entries {
+		if strings.Contains(entry, expected) {
+			count++
+		}
+	}
+	return count
+}
+
+func TestDiscoverTruncatesStoredScreens(t *testing.T) {
+	logger := &graphTestLogger{}
+	chains := []ifo.ProgramChain{
+		{Number: 1, EntryID: 0x83, MenuID: 3, Programs: 1, Cells: 1},
+		{Number: 2, EntryID: 0x85, MenuID: 5, Programs: 1, Cells: 1},
+	}
+	disc := ifo.Disc{Manager: ifo.File{Kind: ifo.KindManager, Languages: []ifo.LanguageUnit{{Code: "en", ProgramChains: chains}}}}
+	resolver := fakeResolver{live: map[int]LiveState{
+		1: {Visible: true, Fingerprint: []byte("one")},
+		2: {Visible: true, Fingerprint: []byte("two"), Buttons: []nav.Button{{Number: 1}}},
+	}}
+	result, err := Discover(context.Background(), disc, resolver, Options{MaxItems: 1, Logger: logger})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(result.Screens) != 1 || !result.Truncated || result.Complete {
+		t.Fatalf("result = %+v", result)
+	}
+	if logger.Count("DVD menus: storage limit applied") != 1 {
+		t.Fatal("expected one aggregated storage-limit log")
+	}
+	if logger.Count("decision=truncate") != 0 {
+		t.Fatal("unexpected per-candidate truncation log")
+	}
+}
+
+func TestDiscoverClassifiesInvisibleStructuralProgramsWithoutCapturingThem(t *testing.T) {
+	t.Parallel()
+
+	root := ifo.ProgramChain{Number: 1, EntryID: 0x83, MenuID: 3, Programs: 1, Cells: 1}
+	transition := ifo.ProgramChain{Number: 2, Programs: 1, Cells: 1}
+	disc := ifo.Disc{Manager: ifo.File{
+		Kind:      ifo.KindManager,
+		Languages: []ifo.LanguageUnit{{Code: "en", ProgramChains: []ifo.ProgramChain{root, transition}}},
+	}}
+	resolver := fakeResolver{live: map[int]LiveState{
+		1: {Visible: true, Fingerprint: []byte("root")},
+		2: {Visible: false, Fingerprint: []byte("transition")},
+	}}
+	result, err := Discover(context.Background(), disc, resolver, Options{MaxItems: 1})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(result.Screens) != 1 || result.Screens[0].Coordinate.PGC != 1 {
+		t.Fatalf("screens = %+v", result.Screens)
+	}
+	if result.Partial || result.Truncated || !result.Complete {
+		t.Fatalf("coverage = complete:%t partial:%t truncated:%t", result.Complete, result.Partial, result.Truncated)
+	}
+}
+
+func TestDiscoverDoesNotCaptureUnreachedZeroButtonScreens(t *testing.T) {
+	t.Parallel()
+
+	root := ifo.ProgramChain{Number: 1, EntryID: 0x83, MenuID: 3, Programs: 1, Cells: 1}
+	nonInteractive := ifo.ProgramChain{Number: 2, Programs: 1, Cells: 1, StillTime: 0xff}
+	disc := ifo.Disc{Manager: ifo.File{
+		Kind:      ifo.KindManager,
+		Languages: []ifo.LanguageUnit{{Code: "en", ProgramChains: []ifo.ProgramChain{root, nonInteractive}}},
+	}}
+	resolver := fakeResolver{live: map[int]LiveState{
+		1: {Visible: true, Fingerprint: []byte("root")},
+		2: {Visible: true, Fingerprint: []byte("non-menu"), AuthoredStill: true, AuthoredEntry: true},
+	}}
+	result, err := Discover(context.Background(), disc, resolver, Options{MaxItems: 2})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(result.Screens) != 1 || result.Screens[0].Coordinate.PGC != 1 {
+		t.Fatalf("screens = %+v", result.Screens)
+	}
+	if result.Partial || result.Truncated || !result.Complete {
+		t.Fatalf("coverage = complete:%t partial:%t truncated:%t", result.Complete, result.Partial, result.Truncated)
+	}
+}
+
+func TestDiscoverDeduplicatesEquivalentControlsAcrossBackgrounds(t *testing.T) {
+	t.Parallel()
+
+	logger := &graphTestLogger{}
+	root := ifo.ProgramChain{Number: 1, EntryID: 0x83, MenuID: 3, Programs: 1, Cells: 1}
+	alternate := ifo.ProgramChain{Number: 2, MenuID: 3, Programs: 1, Cells: 1}
+	disc := ifo.Disc{Manager: ifo.File{
+		Kind:      ifo.KindManager,
+		Languages: []ifo.LanguageUnit{{Code: "en", ProgramChains: []ifo.ProgramChain{root, alternate}}},
+	}}
+	button := nav.Button{Number: 1, ColorGroup: 1, XStart: 10, YStart: 20, XEnd: 100, YEnd: 80}
+	alternateButton := button
+	alternateButton.XStart += 7
+	alternateButton.YEnd += 8
+	resolver := fakeResolver{live: map[int]LiveState{
+		1: {Visible: true, Fingerprint: []byte("first-background"), Buttons: []nav.Button{button}, AuthoredEntry: true},
+		2: {Visible: true, Fingerprint: []byte("alternate-background"), Buttons: []nav.Button{alternateButton}},
+	}}
+	result, err := Discover(context.Background(), disc, resolver, Options{MaxItems: 2, Logger: logger})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(result.Screens) != 1 || result.Screens[0].Coordinate.PGC != 1 {
+		t.Fatalf("screens = %+v", result.Screens)
+	}
+	if result.Partial || result.Truncated || !result.Complete {
+		t.Fatalf("coverage = complete:%t partial:%t truncated:%t", result.Complete, result.Partial, result.Truncated)
+	}
+	if !logger.Contains("screen skipped decision=dedupe reason=control_identity") {
+		t.Fatal("missing control-identity dedupe log")
+	}
+}
+
+func TestDiscoverPreservesSameLayoutWithDifferentCommands(t *testing.T) {
+	t.Parallel()
+
+	root := ifo.ProgramChain{Number: 1, EntryID: 0x83, MenuID: 3, Programs: 1, Cells: 1}
+	different := ifo.ProgramChain{Number: 2, MenuID: 3, Programs: 1, Cells: 1}
+	disc := ifo.Disc{Manager: ifo.File{
+		Kind:      ifo.KindManager,
+		Languages: []ifo.LanguageUnit{{Code: "en", ProgramChains: []ifo.ProgramChain{root, different}}},
+	}}
+	baseButton := nav.Button{Number: 1, XStart: 10, YStart: 20, XEnd: 100, YEnd: 80}
+	differentButton := baseButton
+	differentButton.Command = linkPGCN(1)
+	resolver := fakeResolver{live: map[int]LiveState{
+		1: {Visible: true, Fingerprint: []byte("first"), Buttons: []nav.Button{baseButton}, AuthoredEntry: true},
+		2: {Visible: true, Fingerprint: []byte("second"), Buttons: []nav.Button{differentButton}},
+	}}
+	result, err := Discover(context.Background(), disc, resolver, Options{MaxItems: 2})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(result.Screens) != 2 {
+		t.Fatalf("screens = %+v", result.Screens)
+	}
+}
+
+func TestDiscoverTraversesButDoesNotCaptureManagerUtilityScreen(t *testing.T) {
+	t.Parallel()
+
+	logger := &graphTestLogger{}
+	utility := ifo.ProgramChain{Number: 1, Programs: 1, Cells: 1}
+	root := ifo.ProgramChain{Number: 2, MenuID: 3, Programs: 1, Cells: 1}
+	disc := ifo.Disc{Manager: ifo.File{
+		Kind:      ifo.KindManager,
+		Languages: []ifo.LanguageUnit{{Code: "en", ProgramChains: []ifo.ProgramChain{utility, root}}},
+	}}
+	resolver := fakeResolver{live: map[int]LiveState{
+		1: {Visible: true, Fingerprint: []byte("utility"), Buttons: []nav.Button{{Number: 1, Command: linkPGCN(2)}}},
+		2: {Visible: true, Fingerprint: []byte("root"), Buttons: []nav.Button{{Number: 1}}},
+	}}
+	result, err := Discover(context.Background(), disc, resolver, Options{MaxItems: 2, Logger: logger})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(result.Screens) != 1 || result.Screens[0].Coordinate.PGC != 2 {
+		t.Fatalf("screens = %+v", result.Screens)
+	}
+	if result.VisitedButtons != 2 {
+		t.Fatalf("visited buttons = %d, want 2", result.VisitedButtons)
+	}
+	if !logger.Contains("utility=1") {
+		t.Fatal("missing manager utility classification summary")
+	}
+}
+
+func TestDiscoverRejectsItemLimitOverSafetyMaximum(t *testing.T) {
+	t.Parallel()
+
+	_, err := Discover(context.Background(), ifo.Disc{}, fakeResolver{}, Options{MaxItems: MaxMenuItems + 1})
+	if err == nil {
+		t.Fatal("expected item limit error")
+	}
+}
+
+func TestDiscoverMapsProgramToAuthoredCell(t *testing.T) {
+	chain := ifo.ProgramChain{Number: 1, EntryID: 0x83, MenuID: 3, Programs: 2, Cells: 3, ProgramMap: []uint8{1, 3}}
+	chain.PreCommands = []vm.Command{linkPGN(2)}
+	disc := ifo.Disc{Manager: ifo.File{Kind: ifo.KindManager, Languages: []ifo.LanguageUnit{{Code: "en", ProgramChains: []ifo.ProgramChain{chain}}}}}
+	resolver := &coordinateResolver{}
+	result, err := Discover(context.Background(), disc, resolver, Options{MaxItems: 2})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if !resolver.saw(2, 3) {
+		t.Fatalf("coordinates = %+v, want program 2 cell 3", resolver.coordinates)
+	}
+	if result.Inventoried != 2 {
+		t.Fatalf("inventoried = %d, want 2 program coordinates", result.Inventoried)
+	}
+}
+
+type fakeResolver struct{ live map[int]LiveState }
+
+func (r fakeResolver) Resolve(_ context.Context, coordinate Coordinate, _ ifo.ProgramChain, _ vm.Registers) (LiveState, error) {
+	return r.live[coordinate.PGC], nil
+}
+
+type coordinateResolver struct{ coordinates []Coordinate }
+
+func (r *coordinateResolver) Resolve(_ context.Context, coordinate Coordinate, _ ifo.ProgramChain, _ vm.Registers) (LiveState, error) {
+	r.coordinates = append(r.coordinates, coordinate)
+	return LiveState{Visible: true, Fingerprint: []byte("mapped")}, nil
+}
+
+func (r *coordinateResolver) saw(program, cell int) bool {
+	for _, coordinate := range r.coordinates {
+		if coordinate.Program == program && coordinate.Cell == cell {
+			return true
+		}
+	}
+	return false
+}
+
+func linkPGCN(number uint16) vm.Command {
+	var instruction uint64
+	instruction |= 1 << 61
+	instruction |= 4 << 48
+	instruction |= uint64(number) << 0
+	var command vm.Command
+	binary.BigEndian.PutUint64(command[:], instruction)
+	return command
+}
+
+func linkPGN(number uint16) vm.Command {
+	var instruction uint64
+	instruction |= 1 << 61
+	instruction |= 6 << 48
+	instruction |= uint64(number) << 0
+	var command vm.Command
+	binary.BigEndian.PutUint64(command[:], instruction)
+	return command
+}

--- a/internal/dvdvideo/ifo/ifo.go
+++ b/internal/dvdvideo/ifo/ifo.go
@@ -1,0 +1,681 @@
+// Package ifo parses the bounded DVD-Video menu structures needed for menu
+// inventory and VM traversal.
+//
+// Structure layouts are derived from VideoLAN libdvdread 7.0.1
+// src/dvdread/ifo_types.h and src/ifo_read.c (commit
+// c7f373951bae9642e1ce1fbb2cd02f92c09756e0), GPL-2.0-or-later.
+package ifo
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/dvdvideo/vm"
+)
+
+const (
+	sectorSize       = 2048
+	pgcSize          = 236
+	maxIFOBytes      = 64 << 20
+	maxLanguageUnits = 99
+	maxProgramChains = 999
+)
+
+var (
+	// ErrInvalidIFO identifies malformed, inconsistent, or unsupported IFO data.
+	ErrInvalidIFO = errors.New("invalid DVD IFO")
+	// ErrTooLarge identifies an IFO that exceeds the parser's bounded input size.
+	ErrTooLarge = errors.New("DVD IFO exceeds size limit")
+)
+
+// Kind identifies the Video Manager or a Video Title Set IFO.
+type Kind uint8
+
+// IFO domain kinds accepted by [Parse].
+const (
+	// KindManager identifies VIDEO_TS.IFO or its backup.
+	KindManager Kind = iota + 1
+	// KindTitleSet identifies a VTS_nn_0.IFO or its backup.
+	KindTitleSet
+)
+
+// Disc is the structurally inventoried menu metadata from one VIDEO_TS tree.
+type Disc struct {
+	// Manager contains the video-manager menu metadata.
+	Manager File
+	// TitleSets contains parsed title-set menu metadata ordered by VTS number.
+	TitleSets []File
+}
+
+// File contains one IFO's menu language units and program chains.
+type File struct {
+	// Kind identifies whether this file is the manager or a title set.
+	Kind Kind
+	// VTS is zero for the manager and 1 through 99 for a title set.
+	VTS int
+	// Recovered reports that parsing fell back from the IFO to its BUP copy.
+	Recovered bool
+	// FirstPlay is the optional manager first-play program chain.
+	FirstPlay *ProgramChain
+	// Languages contains the authored menu language units.
+	Languages []LanguageUnit
+	// SourceName is the selected IFO or BUP base name, never its local path.
+	SourceName string
+}
+
+// LanguageUnit is one authored menu language table.
+type LanguageUnit struct {
+	// Code is the authored two-byte DVD language code.
+	Code string
+	// Extension is the raw authored language-unit extension byte.
+	Extension uint8
+	// Exists is the raw authored menu-existence mask.
+	Exists uint8
+	// ProgramChains contains the language unit's parsed menu PGCs.
+	ProgramChains []ProgramChain
+}
+
+// DVDTime is the authored four-byte BCD playback time.
+type DVDTime struct {
+	// Hour is the BCD-encoded hour byte.
+	Hour uint8
+	// Minute is the BCD-encoded minute byte.
+	Minute uint8
+	// Second is the BCD-encoded second byte.
+	Second uint8
+	// Frame contains BCD frame count plus the authored frame-rate bits.
+	Frame uint8
+}
+
+// Duration converts DVD BCD time and frame-rate bits into wall-clock time.
+func (value DVDTime) Duration() (time.Duration, error) {
+	hour, err := decodeBCD(value.Hour)
+	if err != nil {
+		return 0, fmt.Errorf("%w: playback hour", ErrInvalidIFO)
+	}
+	minute, err := decodeBCD(value.Minute)
+	if err != nil || minute > 59 {
+		return 0, fmt.Errorf("%w: playback minute", ErrInvalidIFO)
+	}
+	second, err := decodeBCD(value.Second)
+	if err != nil || second > 59 {
+		return 0, fmt.Errorf("%w: playback second", ErrInvalidIFO)
+	}
+	frames, err := decodeBCD(value.Frame & 0x3f)
+	if err != nil {
+		return 0, fmt.Errorf("%w: playback frame", ErrInvalidIFO)
+	}
+
+	duration := time.Duration(hour)*time.Hour + time.Duration(minute)*time.Minute + time.Duration(second)*time.Second
+	switch value.Frame & 0xc0 {
+	case 0:
+		if frames != 0 {
+			return 0, fmt.Errorf("%w: playback frame rate", ErrInvalidIFO)
+		}
+	case 0x40:
+		if frames >= 25 {
+			return 0, fmt.Errorf("%w: PAL playback frame", ErrInvalidIFO)
+		}
+		duration += time.Duration(frames) * time.Second / 25
+	case 0xc0:
+		if frames >= 30 {
+			return 0, fmt.Errorf("%w: NTSC playback frame", ErrInvalidIFO)
+		}
+		duration += time.Duration(frames) * 1001 * time.Second / 30_000
+	default:
+		return 0, fmt.Errorf("%w: playback frame rate", ErrInvalidIFO)
+	}
+	return duration, nil
+}
+
+func decodeBCD(value uint8) (int, error) {
+	if value>>4 > 9 || value&0x0f > 9 {
+		return 0, ErrInvalidIFO
+	}
+	return int(value>>4)*10 + int(value&0x0f), nil
+}
+
+// ProgramChain is the bounded structural data needed by the graph and renderer.
+type ProgramChain struct {
+	// Number is the one-based PGC table index; zero identifies first-play data.
+	Number int
+	// EntryID is the authored entry/menu identifier byte.
+	EntryID uint8
+	// MenuID is the low four bits of EntryID.
+	MenuID uint8
+	// Programs is the authored program count.
+	Programs uint8
+	// Cells is the authored cell count.
+	Cells uint8
+	// PlaybackTime is the PGC's authored duration.
+	PlaybackTime DVDTime
+	// Next is the same-language next-PGC number, or zero when absent.
+	Next uint16
+	// Previous is the same-language previous-PGC number, or zero when absent.
+	Previous uint16
+	// GoUp is the same-language parent-PGC number, or zero when absent.
+	GoUp uint16
+	// PlaybackMode is the raw authored playback-mode byte.
+	PlaybackMode uint8
+	// StillTime is the authored PGC still duration byte.
+	StillTime uint8
+	// AudioControl contains the eight authored audio stream-control words.
+	AudioControl [8]uint16
+	// SubpictureControl contains the 32 authored subpicture stream-control words.
+	SubpictureControl [32]uint32
+	// Palette contains the 16 authored YCrCb subpicture colors.
+	Palette [16]uint32
+	// PreCommands execute before PGC playback during traversal.
+	PreCommands []vm.Command
+	// PostCommands execute after PGC playback during traversal.
+	PostCommands []vm.Command
+	// CellCommands contains the PGC's authored cell command table.
+	CellCommands []vm.Command
+	// ProgramMap maps one-based programs to one-based starting cells.
+	ProgramMap []uint8
+	// CellPlayback contains sector ranges and timing for each cell.
+	CellPlayback []CellPlayback
+	// CellPositions maps each cell to its VOB and cell identifiers.
+	CellPositions []CellPosition
+}
+
+// CellPlayback describes one authored menu cell and its sector bounds.
+type CellPlayback struct {
+	// Flags contains the raw authored cell playback flags.
+	Flags uint16
+	// StillTime is the authored cell still duration byte.
+	StillTime uint8
+	// CommandNumber is the authored cell-command table index.
+	CommandNumber uint8
+	// PlaybackTime is the cell's authored duration.
+	PlaybackTime DVDTime
+	// FirstSector is the cell's inclusive first sector in the menu VOB.
+	FirstSector uint32
+	// FirstILVUEndSector is the authored first interleaved-unit end sector.
+	FirstILVUEndSector uint32
+	// LastVOBUStartSector is the start sector of the cell's final VOBU.
+	LastVOBUStartSector uint32
+	// LastSector is the cell's inclusive final sector in the menu VOB.
+	LastSector uint32
+}
+
+// CellPosition maps a PGC cell to its VOB and cell identifiers.
+type CellPosition struct {
+	// VOBID is the authored VOB identifier.
+	VOBID uint16
+	// CellID is the authored cell identifier within the VOB.
+	CellID uint8
+}
+
+// InspectDirectory inventories VIDEO_TS.IFO and every VTS_nn_0.IFO. A matching
+// BUP is used when the primary IFO is missing, unreadable, or invalid.
+func InspectDirectory(root string) (disc Disc, err error) {
+	defer func() {
+		if recover() != nil {
+			disc = Disc{}
+			err = fmt.Errorf("%w: parser panic", ErrInvalidIFO)
+		}
+	}()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return Disc{}, fmt.Errorf("read VIDEO_TS directory: %w", err)
+	}
+	names := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		upper := strings.ToUpper(entry.Name())
+		if entry.Type()&os.ModeSymlink != 0 {
+			if upper == "VIDEO_TS.IFO" || upper == "VIDEO_TS.BUP" {
+				return Disc{}, fmt.Errorf("%w: manager IFO/BUP symlink", ErrInvalidIFO)
+			}
+			if _, relevant := titleSetNumber(upper); relevant {
+				return Disc{}, fmt.Errorf("%w: title-set IFO/BUP symlink", ErrInvalidIFO)
+			}
+			continue
+		}
+		if _, duplicate := names[upper]; duplicate {
+			return Disc{}, fmt.Errorf("%w: duplicate %s", ErrInvalidIFO, upper)
+		}
+		names[upper] = entry.Name()
+	}
+
+	manager, err := inspectPair(root, names, "VIDEO_TS.IFO", "VIDEO_TS.BUP", KindManager, 0)
+	if err != nil {
+		return Disc{}, err
+	}
+	disc = Disc{Manager: manager}
+	seenTitleSets := make(map[int]struct{})
+	for upperName := range names {
+		vts, ok := titleSetNumber(upperName)
+		if !ok {
+			continue
+		}
+		if _, seen := seenTitleSets[vts]; seen {
+			continue
+		}
+		seenTitleSets[vts] = struct{}{}
+		ifoName := fmt.Sprintf("VTS_%02d_0.IFO", vts)
+		bupName := fmt.Sprintf("VTS_%02d_0.BUP", vts)
+		file, fileErr := inspectPair(root, names, ifoName, bupName, KindTitleSet, vts)
+		if fileErr != nil {
+			return Disc{}, fileErr
+		}
+		disc.TitleSets = append(disc.TitleSets, file)
+	}
+	sort.Slice(disc.TitleSets, func(i, j int) bool { return disc.TitleSets[i].VTS < disc.TitleSets[j].VTS })
+	return disc, nil
+}
+
+func titleSetNumber(name string) (int, bool) {
+	if len(name) != len("VTS_01_0.IFO") || !strings.HasPrefix(name, "VTS_") ||
+		(!strings.HasSuffix(name, "_0.IFO") && !strings.HasSuffix(name, "_0.BUP")) {
+		return 0, false
+	}
+	vts, err := strconv.Atoi(name[4:6])
+	return vts, err == nil && vts > 0 && vts <= 99
+}
+
+func inspectPair(root string, names map[string]string, ifoName, bupName string, kind Kind, vts int) (File, error) {
+	var primaryErr error
+	if primary, ok := names[ifoName]; ok {
+		file, err := parseFile(filepath.Join(root, primary), kind, vts)
+		if err == nil {
+			return file, nil
+		}
+		primaryErr = err
+	} else {
+		primaryErr = fmt.Errorf("%w: missing %s", ErrInvalidIFO, ifoName)
+	}
+	backup, ok := names[bupName]
+	if !ok {
+		return File{}, primaryErr
+	}
+	file, backupErr := parseFile(filepath.Join(root, backup), kind, vts)
+	if backupErr != nil {
+		return File{}, errors.Join(primaryErr, backupErr)
+	}
+	file.Recovered = true
+	return file, nil
+}
+
+func parseFile(path string, kind Kind, vts int) (File, error) {
+	data, err := readBounded(path)
+	if err != nil {
+		return File{}, err
+	}
+	file, err := Parse(data, kind, vts)
+	if err != nil {
+		return File{}, fmt.Errorf("parse %s: %w", filepath.Base(path), err)
+	}
+	file.SourceName = filepath.Base(path)
+	return file, nil
+}
+
+func readBounded(path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open DVD IFO: %w", err)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maxIFOBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read DVD IFO: %w", err)
+	}
+	if len(data) > maxIFOBytes {
+		return nil, ErrTooLarge
+	}
+	return data, nil
+}
+
+// Parse parses a single VMGI or VTSI byte stream without panicking. It rejects
+// invalid kind/VTS combinations, out-of-bounds tables, and oversized input.
+func Parse(data []byte, kind Kind, vts int) (File, error) {
+	if len(data) > maxIFOBytes {
+		return File{}, ErrTooLarge
+	}
+	reader := boundedReader{data: data}
+	file := File{Kind: kind, VTS: vts}
+	var identifier string
+	var pgciSector uint32
+	var err error
+	switch kind {
+	case KindManager:
+		identifier = "DVDVIDEO-VMG"
+		pgciSector, err = reader.u32(200, "VMGM PGCI sector")
+		if err == nil {
+			var firstPlay uint32
+			firstPlay, err = reader.u32(132, "first-play PGC offset")
+			if err == nil && firstPlay != 0 {
+				var pgc ProgramChain
+				pgc, err = reader.programChain(int(firstPlay), 0, 0)
+				file.FirstPlay = &pgc
+			}
+		}
+	case KindTitleSet:
+		if vts <= 0 || vts > 99 {
+			return File{}, fmt.Errorf("%w: VTS number %d", ErrInvalidIFO, vts)
+		}
+		identifier = "DVDVIDEO-VTS"
+		pgciSector, err = reader.u32(208, "VTSM PGCI sector")
+	default:
+		return File{}, fmt.Errorf("%w: unknown IFO kind %d", ErrInvalidIFO, kind)
+	}
+	if err != nil {
+		return File{}, err
+	}
+	header, err := reader.bytes(0, len(identifier), "IFO identifier")
+	if err != nil || !bytes.Equal(header, []byte(identifier)) {
+		return File{}, fmt.Errorf("%w: identifier", ErrInvalidIFO)
+	}
+	if pgciSector == 0 {
+		return file, nil
+	}
+	if pgciSector > maxIFOBytes/sectorSize {
+		return File{}, fmt.Errorf("%w: PGCI sector outside file", ErrInvalidIFO)
+	}
+	sector, err := boundedUint32(pgciSector, "PGCI sector")
+	if err != nil {
+		return File{}, err
+	}
+	base := sector * sectorSize
+	if base > len(data) {
+		return File{}, fmt.Errorf("%w: PGCI sector outside file", ErrInvalidIFO)
+	}
+	file.Languages, err = reader.languageUnits(base)
+	if err != nil {
+		return File{}, err
+	}
+	return file, nil
+}
+
+type boundedReader struct{ data []byte }
+
+func (r boundedReader) bytes(offset, size int, label string) ([]byte, error) {
+	if offset < 0 || size < 0 || uint64(offset)+uint64(size) > uint64(len(r.data)) {
+		return nil, fmt.Errorf("%w: %s outside file", ErrInvalidIFO, label)
+	}
+	return r.data[offset : offset+size], nil
+}
+
+func (r boundedReader) u16(offset int, label string) (uint16, error) {
+	data, err := r.bytes(offset, 2, label)
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint16(data), nil
+}
+
+func (r boundedReader) u32(offset int, label string) (uint32, error) {
+	data, err := r.bytes(offset, 4, label)
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint32(data), nil
+}
+
+func (r boundedReader) languageUnits(base int) ([]LanguageUnit, error) {
+	count, err := r.u16(base, "language-unit count")
+	if err != nil {
+		return nil, err
+	}
+	if count > maxLanguageUnits {
+		return nil, fmt.Errorf("%w: language-unit count %d", ErrInvalidIFO, count)
+	}
+	lastByte, err := r.u32(base+4, "PGCI last byte")
+	if err != nil {
+		return nil, err
+	}
+	lastOffset, err := boundedUint32(lastByte, "PGCI last byte")
+	if err != nil {
+		return nil, err
+	}
+	if lastOffset < 7 || base > len(r.data) || lastOffset >= len(r.data)-base {
+		return nil, fmt.Errorf("%w: language-unit table bounds", ErrInvalidIFO)
+	}
+	end := base + lastOffset + 1
+	if base+8+int(count)*8 > end {
+		return nil, fmt.Errorf("%w: language-unit table bounds", ErrInvalidIFO)
+	}
+	units := make([]LanguageUnit, 0, count)
+	for index := 0; index < int(count); index++ {
+		offset := base + 8 + index*8
+		lang, readErr := r.bytes(offset, 2, "language code")
+		if readErr != nil {
+			return nil, readErr
+		}
+		start, readErr := r.u32(offset+4, "language PGCIT offset")
+		if readErr != nil {
+			return nil, readErr
+		}
+		startOffset, readErr := boundedUint32(start, "language PGCIT offset")
+		if readErr != nil {
+			return nil, readErr
+		}
+		pgcitBase := base + startOffset
+		if startOffset < 8 || pgcitBase >= end {
+			return nil, fmt.Errorf("%w: language PGCIT offset", ErrInvalidIFO)
+		}
+		chains, readErr := r.programChainTable(pgcitBase, end)
+		if readErr != nil {
+			return nil, fmt.Errorf("language unit %d: %w", index+1, readErr)
+		}
+		units = append(units, LanguageUnit{
+			Code:          string(lang),
+			Extension:     r.data[offset+2],
+			Exists:        r.data[offset+3],
+			ProgramChains: chains,
+		})
+	}
+	return units, nil
+}
+
+func (r boundedReader) programChainTable(base, parentEnd int) ([]ProgramChain, error) {
+	count, err := r.u16(base, "PGC count")
+	if err != nil {
+		return nil, err
+	}
+	if count > maxProgramChains {
+		return nil, fmt.Errorf("%w: PGC count %d", ErrInvalidIFO, count)
+	}
+	lastByte, err := r.u32(base+4, "PGCIT last byte")
+	if err != nil {
+		return nil, err
+	}
+	lastOffset, err := boundedUint32(lastByte, "PGCIT last byte")
+	if err != nil {
+		return nil, err
+	}
+	if lastOffset < 7 || base > parentEnd || lastOffset >= parentEnd-base {
+		return nil, fmt.Errorf("%w: PGC table bounds", ErrInvalidIFO)
+	}
+	end := base + lastOffset + 1
+	if base+8+int(count)*8 > end {
+		return nil, fmt.Errorf("%w: PGC table bounds", ErrInvalidIFO)
+	}
+	chains := make([]ProgramChain, 0, count)
+	for index := 0; index < int(count); index++ {
+		offset := base + 8 + index*8
+		entry, readErr := r.bytes(offset, 1, "PGC entry")
+		if readErr != nil {
+			return nil, readErr
+		}
+		start, readErr := r.u32(offset+4, "PGC offset")
+		if readErr != nil {
+			return nil, readErr
+		}
+		startOffset, readErr := boundedUint32(start, "PGC offset")
+		if readErr != nil {
+			return nil, readErr
+		}
+		pgcBase := base + startOffset
+		if startOffset < 8 || pgcBase > end || pgcSize > end-pgcBase {
+			return nil, fmt.Errorf("%w: PGC %d offset", ErrInvalidIFO, index+1)
+		}
+		pgc, readErr := r.programChain(pgcBase, index+1, entry[0])
+		if readErr != nil {
+			return nil, fmt.Errorf("PGC %d: %w", index+1, readErr)
+		}
+		chains = append(chains, pgc)
+	}
+	return chains, nil
+}
+
+func (r boundedReader) programChain(base, number int, entryID uint8) (ProgramChain, error) {
+	fixed, err := r.bytes(base, pgcSize, "PGC header")
+	if err != nil {
+		return ProgramChain{}, err
+	}
+	programs, cells := fixed[2], fixed[3]
+	if programs > cells {
+		return ProgramChain{}, fmt.Errorf("%w: programs=%d cells=%d", ErrInvalidIFO, programs, cells)
+	}
+	pgc := ProgramChain{
+		Number:       number,
+		EntryID:      entryID,
+		MenuID:       entryID & 0x0f,
+		Programs:     programs,
+		Cells:        cells,
+		PlaybackTime: dvdTime(fixed[4:8]),
+		Next:         binary.BigEndian.Uint16(fixed[156:158]),
+		Previous:     binary.BigEndian.Uint16(fixed[158:160]),
+		GoUp:         binary.BigEndian.Uint16(fixed[160:162]),
+		PlaybackMode: fixed[162],
+		StillTime:    fixed[163],
+	}
+	for index := range pgc.AudioControl {
+		pgc.AudioControl[index] = binary.BigEndian.Uint16(fixed[12+index*2 : 14+index*2])
+	}
+	for index := range pgc.SubpictureControl {
+		pgc.SubpictureControl[index] = binary.BigEndian.Uint32(fixed[28+index*4 : 32+index*4])
+	}
+	for index := range pgc.Palette {
+		pgc.Palette[index] = binary.BigEndian.Uint32(fixed[164+index*4 : 168+index*4])
+	}
+	commandOffset := int(binary.BigEndian.Uint16(fixed[228:230]))
+	programOffset := int(binary.BigEndian.Uint16(fixed[230:232]))
+	cellPlaybackOffset := int(binary.BigEndian.Uint16(fixed[232:234]))
+	cellPositionOffset := int(binary.BigEndian.Uint16(fixed[234:236]))
+	if commandOffset != 0 {
+		pgc.PreCommands, pgc.PostCommands, pgc.CellCommands, err = r.commandTable(base + commandOffset)
+		if err != nil {
+			return ProgramChain{}, err
+		}
+	}
+	if programs != 0 {
+		if programOffset < pgcSize {
+			return ProgramChain{}, fmt.Errorf("%w: program map offset", ErrInvalidIFO)
+		}
+		programMap, readErr := r.bytes(base+programOffset, int(programs), "program map")
+		if readErr != nil {
+			return ProgramChain{}, readErr
+		}
+		pgc.ProgramMap = append([]uint8(nil), programMap...)
+		for index, cell := range pgc.ProgramMap {
+			if cell == 0 || cell > cells || index > 0 && cell < pgc.ProgramMap[index-1] {
+				return ProgramChain{}, fmt.Errorf("%w: program %d cell mapping", ErrInvalidIFO, index+1)
+			}
+		}
+	}
+	if cells != 0 {
+		if cellPlaybackOffset < pgcSize || cellPositionOffset < pgcSize {
+			return ProgramChain{}, fmt.Errorf("%w: cell table offset", ErrInvalidIFO)
+		}
+		pgc.CellPlayback, err = r.cellPlayback(base+cellPlaybackOffset, int(cells))
+		if err != nil {
+			return ProgramChain{}, err
+		}
+		pgc.CellPositions, err = r.cellPositions(base+cellPositionOffset, int(cells))
+		if err != nil {
+			return ProgramChain{}, err
+		}
+	}
+	return pgc, nil
+}
+
+func (r boundedReader) commandTable(base int) ([]vm.Command, []vm.Command, []vm.Command, error) {
+	header, err := r.bytes(base, 8, "command table")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	counts := [3]int{
+		int(binary.BigEndian.Uint16(header[0:2])),
+		int(binary.BigEndian.Uint16(header[2:4])),
+		int(binary.BigEndian.Uint16(header[4:6])),
+	}
+	total := counts[0] + counts[1] + counts[2]
+	lastByte := int(binary.BigEndian.Uint16(header[6:8]))
+	if lastByte < 7 || total > (lastByte+1-8)/8 {
+		return nil, nil, nil, fmt.Errorf("%w: command table bounds", ErrInvalidIFO)
+	}
+	data, err := r.bytes(base+8, total*8, "VM commands")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	commands := make([]vm.Command, total)
+	for index := range commands {
+		copy(commands[index][:], data[index*8:(index+1)*8])
+	}
+	preEnd := counts[0]
+	postEnd := preEnd + counts[1]
+	return commands[:preEnd], commands[preEnd:postEnd], commands[postEnd:], nil
+}
+
+func (r boundedReader) cellPlayback(base, count int) ([]CellPlayback, error) {
+	data, err := r.bytes(base, count*24, "cell playback table")
+	if err != nil {
+		return nil, err
+	}
+	cells := make([]CellPlayback, count)
+	for index := range cells {
+		item := data[index*24 : (index+1)*24]
+		cells[index] = CellPlayback{
+			Flags:               binary.BigEndian.Uint16(item[0:2]),
+			StillTime:           item[2],
+			CommandNumber:       item[3],
+			PlaybackTime:        dvdTime(item[4:8]),
+			FirstSector:         binary.BigEndian.Uint32(item[8:12]),
+			FirstILVUEndSector:  binary.BigEndian.Uint32(item[12:16]),
+			LastVOBUStartSector: binary.BigEndian.Uint32(item[16:20]),
+			LastSector:          binary.BigEndian.Uint32(item[20:24]),
+		}
+		if cells[index].FirstSector > cells[index].LastSector || cells[index].LastVOBUStartSector > cells[index].LastSector {
+			return nil, fmt.Errorf("%w: cell %d sector bounds", ErrInvalidIFO, index+1)
+		}
+	}
+	return cells, nil
+}
+
+func (r boundedReader) cellPositions(base, count int) ([]CellPosition, error) {
+	data, err := r.bytes(base, count*4, "cell position table")
+	if err != nil {
+		return nil, err
+	}
+	positions := make([]CellPosition, count)
+	for index := range positions {
+		item := data[index*4 : (index+1)*4]
+		positions[index] = CellPosition{VOBID: binary.BigEndian.Uint16(item[0:2]), CellID: item[3]}
+	}
+	return positions, nil
+}
+
+func dvdTime(data []byte) DVDTime {
+	return DVDTime{Hour: data[0], Minute: data[1], Second: data[2], Frame: data[3]}
+}
+
+func boundedUint32(value uint32, label string) (int, error) {
+	if value > maxIFOBytes {
+		return 0, fmt.Errorf("%w: %s exceeds bounded file size", ErrInvalidIFO, label)
+	}
+	return int(value), nil
+}

--- a/internal/dvdvideo/ifo/ifo_test.go
+++ b/internal/dvdvideo/ifo/ifo_test.go
@@ -1,0 +1,179 @@
+package ifo
+
+import (
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseManagerMenuInventory(t *testing.T) {
+	data := syntheticManagerIFO()
+	file, err := Parse(data, KindManager, 0)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(file.Languages) != 1 || file.Languages[0].Code != "en" {
+		t.Fatalf("languages = %+v, want one English unit", file.Languages)
+	}
+	chains := file.Languages[0].ProgramChains
+	if len(chains) != 1 {
+		t.Fatalf("program chains = %d, want 1", len(chains))
+	}
+	pgc := chains[0]
+	if pgc.MenuID != 3 || pgc.Programs != 1 || pgc.Cells != 1 {
+		t.Fatalf("PGC identity = %+v", pgc)
+	}
+	if len(pgc.PreCommands) != 1 || pgc.PreCommands[0][7] != 1 {
+		t.Fatalf("pre-commands = %x", pgc.PreCommands)
+	}
+	if pgc.CellPlayback[0].LastSector != 11 || pgc.CellPositions[0].VOBID != 2 {
+		t.Fatalf("cell data = %+v %+v", pgc.CellPlayback, pgc.CellPositions)
+	}
+}
+
+func TestParseRejectsTruncatedLanguageTable(t *testing.T) {
+	data := syntheticManagerIFO()
+	data = data[:sectorSize+10]
+	_, err := Parse(data, KindManager, 0)
+	if !errors.Is(err, ErrInvalidIFO) {
+		t.Fatalf("Parse error = %v, want ErrInvalidIFO", err)
+	}
+}
+
+func TestDVDTimeDuration(t *testing.T) {
+	duration, err := (DVDTime{Hour: 0x01, Minute: 0x02, Second: 0x03, Frame: 0x52}).Duration()
+	if err != nil {
+		t.Fatalf("Duration: %v", err)
+	}
+	want := time.Hour + 2*time.Minute + 3*time.Second + 12*time.Second/25
+	if duration != want {
+		t.Fatalf("Duration = %s, want %s", duration, want)
+	}
+}
+
+func TestDVDTimeDurationRejectsInvalidBCD(t *testing.T) {
+	_, err := (DVDTime{Minute: 0x6a}).Duration()
+	if !errors.Is(err, ErrInvalidIFO) {
+		t.Fatalf("Duration error = %v, want ErrInvalidIFO", err)
+	}
+}
+
+func TestParseRejectsProgramCellOutsidePGC(t *testing.T) {
+	data := syntheticManagerIFO()
+	data[sectorSize+16+16+252] = 2
+	_, err := Parse(data, KindManager, 0)
+	if !errors.Is(err, ErrInvalidIFO) {
+		t.Fatalf("Parse error = %v, want ErrInvalidIFO", err)
+	}
+}
+
+func TestInspectDirectoryRecoversMissingManagerIFOFromBUP(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "video_ts.bup"), syntheticManagerIFO(), 0o600); err != nil {
+		t.Fatalf("write manager BUP: %v", err)
+	}
+
+	disc, err := InspectDirectory(root)
+	if err != nil {
+		t.Fatalf("InspectDirectory: %v", err)
+	}
+	if !disc.Manager.Recovered || disc.Manager.SourceName != "video_ts.bup" {
+		t.Fatalf("manager recovery = recovered:%t source:%q", disc.Manager.Recovered, disc.Manager.SourceName)
+	}
+}
+
+func TestInspectDirectoryDiscoversBUPOnlyTitleSet(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "VIDEO_TS.IFO"), syntheticManagerIFO(), 0o600); err != nil {
+		t.Fatalf("write manager IFO: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "vts_02_0.bup"), syntheticTitleSetIFO(), 0o600); err != nil {
+		t.Fatalf("write title-set BUP: %v", err)
+	}
+
+	disc, err := InspectDirectory(root)
+	if err != nil {
+		t.Fatalf("InspectDirectory: %v", err)
+	}
+	if len(disc.TitleSets) != 1 || disc.TitleSets[0].VTS != 2 || !disc.TitleSets[0].Recovered || disc.TitleSets[0].SourceName != "vts_02_0.bup" {
+		t.Fatalf("title sets = %+v", disc.TitleSets)
+	}
+}
+
+func TestInspectDirectoryRejectsManagerIFOSymlink(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "manager-target")
+	if err := os.WriteFile(target, syntheticManagerIFO(), 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "VIDEO_TS.IFO")); err != nil {
+		t.Skipf("file symlinks unavailable: %v", err)
+	}
+
+	_, err := InspectDirectory(root)
+	if !errors.Is(err, ErrInvalidIFO) {
+		t.Fatalf("InspectDirectory error = %v, want ErrInvalidIFO", err)
+	}
+}
+
+func FuzzParse(f *testing.F) {
+	f.Add(syntheticManagerIFO())
+	f.Add([]byte("DVDVIDEO-VMG"))
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		_, _ = Parse(data, KindManager, 0)
+	})
+}
+
+func syntheticManagerIFO() []byte {
+	data := make([]byte, sectorSize*2)
+	copy(data, "DVDVIDEO-VMG")
+	binary.BigEndian.PutUint32(data[200:204], 1)
+
+	pgci := sectorSize
+	binary.BigEndian.PutUint16(data[pgci:pgci+2], 1)
+	binary.BigEndian.PutUint32(data[pgci+4:pgci+8], 312)
+	copy(data[pgci+8:pgci+10], "en")
+	data[pgci+11] = 0x80
+	binary.BigEndian.PutUint32(data[pgci+12:pgci+16], 16)
+
+	pgcit := pgci + 16
+	binary.BigEndian.PutUint16(data[pgcit:pgcit+2], 1)
+	binary.BigEndian.PutUint32(data[pgcit+4:pgcit+8], 296)
+	data[pgcit+8] = 0x83
+	binary.BigEndian.PutUint32(data[pgcit+12:pgcit+16], 16)
+
+	pgc := pgcit + 16
+	data[pgc+2] = 1
+	data[pgc+3] = 1
+	binary.BigEndian.PutUint16(data[pgc+228:pgc+230], 236)
+	binary.BigEndian.PutUint16(data[pgc+230:pgc+232], 252)
+	binary.BigEndian.PutUint16(data[pgc+232:pgc+234], 253)
+	binary.BigEndian.PutUint16(data[pgc+234:pgc+236], 277)
+
+	commands := pgc + 236
+	binary.BigEndian.PutUint16(data[commands:commands+2], 1)
+	binary.BigEndian.PutUint16(data[commands+6:commands+8], 15)
+	data[commands+15] = 1
+	data[pgc+252] = 1
+
+	cell := pgc + 253
+	binary.BigEndian.PutUint32(data[cell+8:cell+12], 10)
+	binary.BigEndian.PutUint32(data[cell+12:cell+16], 10)
+	binary.BigEndian.PutUint32(data[cell+16:cell+20], 11)
+	binary.BigEndian.PutUint32(data[cell+20:cell+24], 11)
+	position := pgc + 277
+	binary.BigEndian.PutUint16(data[position:position+2], 2)
+	data[position+3] = 1
+	return data
+}
+
+func syntheticTitleSetIFO() []byte {
+	data := syntheticManagerIFO()
+	copy(data, "DVDVIDEO-VTS")
+	binary.BigEndian.PutUint32(data[200:204], 0)
+	binary.BigEndian.PutUint32(data[208:212], 1)
+	return data
+}

--- a/internal/dvdvideo/nav/nav.go
+++ b/internal/dvdvideo/nav/nav.go
@@ -568,6 +568,9 @@ func RouteSPUFragments(data []byte, packetLimit, payloadLimit int) ([]SPUFragmen
 			break
 		}
 		offset += index
+		if offset+6 > len(data) {
+			return nil, fmt.Errorf("%w: truncated PES payload", ErrInvalidNAV)
+		}
 		length := int(binary.BigEndian.Uint16(data[offset+4 : offset+6]))
 		end := offset + 6 + length
 		if end > len(data) {

--- a/internal/dvdvideo/nav/nav.go
+++ b/internal/dvdvideo/nav/nav.go
@@ -1,0 +1,675 @@
+// Package nav parses DVD-Video NAV PCI/DSI packets and routes DVD subpicture
+// private-stream payloads.
+//
+// PCI/DSI layouts are derived from VideoLAN libdvdread 7.0.1 nav_types.h and
+// nav_read.c (commit c7f373951bae9642e1ce1fbb2cd02f92c09756e0),
+// GPL-2.0-or-later.
+package nav
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/autobrr/upbrr/internal/dvdvideo/vm"
+)
+
+const (
+	// SectorSize is the fixed byte size of a DVD logical sector.
+	SectorSize = 2048
+	// PCIPayloadSize is the required private-stream-2 PCI payload size.
+	PCIPayloadSize        = 979
+	minimumDSIPayloadSize = 32
+	// MaxButtons is the DVD-Video maximum button count per PCI.
+	MaxButtons = 36
+	// MaxButtonGroups is the DVD-Video maximum display-group count per PCI.
+	MaxButtonGroups     = 3
+	defaultPacketLimit  = 4096
+	defaultPayloadLimit = 16 << 20
+	defaultSectorLimit  = 4096
+)
+
+// ErrInvalidNAV identifies malformed or out-of-bounds NAV/PES data.
+var ErrInvalidNAV = errors.New("invalid DVD NAV data")
+
+// PCI contains presentation timing and authored highlight/button state.
+type PCI struct {
+	// LogicalBlock is the PCI's authored navigation logical-block number.
+	LogicalBlock uint32
+	// VOBUCategory contains the raw authored VOBU category flags.
+	VOBUCategory uint16
+	// VOBUStartPTS is the presentation timestamp at VOBU start.
+	VOBUStartPTS uint32
+	// VOBUEndPTS is the presentation timestamp at VOBU end.
+	VOBUEndPTS uint32
+	// VOBUSequenceEndPTS is the presentation timestamp at sequence end.
+	VOBUSequenceEndPTS uint32
+	// HighlightStatus is the raw authored highlight status.
+	HighlightStatus uint16
+	// HighlightStartPTS is the highlight activation timestamp.
+	HighlightStartPTS uint32
+	// HighlightEndPTS is the highlight end timestamp.
+	HighlightEndPTS uint32
+	// ButtonSelectEndPTS is the final button-selection timestamp.
+	ButtonSelectEndPTS uint32
+	// ButtonGroupCount is the authored display-group count.
+	ButtonGroupCount uint8
+	// ButtonOffset is the authored button table offset selector.
+	ButtonOffset uint8
+	// ButtonCount is the authored button entry count.
+	ButtonCount uint8
+	// SelectableCount is the number of authored selectable buttons.
+	SelectableCount uint8
+	// ForcedSelectButton is the authored default selected button number.
+	ForcedSelectButton uint8
+	// ForcedActionButton is the authored automatically activated button number.
+	ForcedActionButton uint8
+	// ButtonColors contains normal and selected palette words for each display group.
+	ButtonColors [3][2]uint32
+	// ButtonGroups contains parsed buttons indexed by zero-based display group.
+	ButtonGroups [MaxButtonGroups][]Button
+}
+
+// Button is one live PCI button entry for a display group.
+type Button struct {
+	// Number is the one-based authored button number.
+	Number uint8
+	// ColorGroup selects one of PCI.ButtonColors' display groups.
+	ColorGroup uint8
+	// XStart is the inclusive left edge in DVD menu pixels.
+	XStart uint16
+	// YStart is the inclusive top edge in DVD menu pixels.
+	YStart uint16
+	// XEnd is the inclusive right edge in DVD menu pixels.
+	XEnd uint16
+	// YEnd is the inclusive bottom edge in DVD menu pixels.
+	YEnd uint16
+	// AutoAction reports whether selecting the button activates it immediately.
+	AutoAction bool
+	// Up is the neighboring button number for upward navigation.
+	Up uint8
+	// Down is the neighboring button number for downward navigation.
+	Down uint8
+	// Left is the neighboring button number for left navigation.
+	Left uint8
+	// Right is the neighboring button number for right navigation.
+	Right uint8
+	// Command is the VM instruction executed when the button activates.
+	Command vm.Command
+}
+
+// DSI contains the NAV fields used for VOBU/cell timing and discontinuities.
+type DSI struct {
+	// SystemClock is the raw DSI system clock reference.
+	SystemClock uint32
+	// LogicalBlock is the DSI navigation logical-block number.
+	LogicalBlock uint32
+	// VOBUEndAddress is the relative end address of the current VOBU.
+	VOBUEndAddress uint32
+	// FirstReference is the first authored video reference address.
+	FirstReference uint32
+	// SecondReference is the second authored video reference address.
+	SecondReference uint32
+	// ThirdReference is the third authored video reference address.
+	ThirdReference uint32
+	// VOBID is the current VOB identifier.
+	VOBID uint16
+	// CellID is the current cell identifier.
+	CellID uint8
+	// CellElapsedTime is the raw four-byte DVD elapsed-time value.
+	CellElapsedTime [4]uint8
+}
+
+// Packet is one NAV sector's parsed PCI and DSI pair.
+type Packet struct {
+	// PCI is the sector's presentation-control packet.
+	PCI PCI
+	// DSI is the sector's data-search packet.
+	DSI DSI
+}
+
+// SPUFragment is one bounded private-stream-1 DVD subpicture fragment.
+type SPUFragment struct {
+	// StreamID is the DVD subpicture substream identifier from 0x20 through 0x3f.
+	StreamID uint8
+	// Data is an owned fragment of the subpicture payload.
+	Data []byte
+	// PTS is the decoded MPEG presentation timestamp when HasPTS is true.
+	PTS uint64
+	// HasPTS reports whether the PES header supplied a presentation timestamp.
+	HasPTS bool
+}
+
+// CellScanOptions bound independent sector and subpicture work while reading
+// one IFO-selected menu cell.
+type CellScanOptions struct {
+	// MaxSectors bounds sectors read from the cell; zero uses the package default.
+	MaxSectors int
+	// MaxSPUPackets bounds routed subpicture fragments; zero uses the package default.
+	MaxSPUPackets int
+	// MaxSPUBytes bounds aggregate subpicture payload bytes; zero uses the package default.
+	MaxSPUBytes int
+}
+
+// CellScan is the parsed NAV and subpicture state found in one bounded cell
+// prefix. Truncated reports that MaxSectors stopped the scan before LastSector.
+type CellScan struct {
+	// Packets contains every valid NAV sector found in the scanned prefix.
+	Packets []Packet
+	// SPUFragments contains bounded, owned subpicture fragments from that prefix.
+	SPUFragments []SPUFragment
+	// ScannedSectors is the number of whole sectors read.
+	ScannedSectors int
+	// Truncated reports that MaxSectors stopped the scan before lastSector.
+	Truncated bool
+}
+
+// ScanCell reads whole DVD sectors from one IFO-validated cell range. Sector
+// addresses are relative to the already-selected VMG or VTS menu VOB.
+func ScanCell(reader io.ReaderAt, size int64, firstSector, lastSector uint32, opts CellScanOptions) (CellScan, error) {
+	if reader == nil || size < 0 || firstSector > lastSector {
+		return CellScan{}, fmt.Errorf("%w: invalid cell source or sector bounds", ErrInvalidNAV)
+	}
+	maxSectors := opts.MaxSectors
+	if maxSectors == 0 {
+		maxSectors = defaultSectorLimit
+	}
+	packetLimit := opts.MaxSPUPackets
+	if packetLimit == 0 {
+		packetLimit = defaultPacketLimit
+	}
+	payloadLimit := opts.MaxSPUBytes
+	if payloadLimit == 0 {
+		payloadLimit = defaultPayloadLimit
+	}
+	if maxSectors < 0 || packetLimit < 0 || payloadLimit < 0 {
+		return CellScan{}, fmt.Errorf("%w: negative cell scan limit", ErrInvalidNAV)
+	}
+
+	sectorCount := uint64(lastSector) - uint64(firstSector) + 1
+	result := CellScan{}
+	if sectorCount > uint64(maxSectors) {
+		sectorCount = uint64(maxSectors)
+		result.Truncated = true
+	}
+	endByte := (uint64(firstSector) + sectorCount) * SectorSize
+	if endByte > uint64(size) {
+		return CellScan{}, fmt.Errorf("%w: cell sector outside menu VOB", ErrInvalidNAV)
+	}
+
+	sector := make([]byte, SectorSize)
+	spuBytes := 0
+	for index := uint64(0); index < sectorCount; index++ {
+		offset := (uint64(firstSector) + index) * SectorSize
+		if offset > math.MaxInt64 {
+			return CellScan{}, fmt.Errorf("%w: cell byte offset overflow", ErrInvalidNAV)
+		}
+		// DVD sector offsets fit int64 after the file-size bound above.
+		read, err := reader.ReadAt(sector, int64(offset))
+		if err != nil && !errors.Is(err, io.EOF) {
+			return CellScan{}, fmt.Errorf("read DVD menu sector: %w", err)
+		}
+		if read != SectorSize {
+			return CellScan{}, fmt.Errorf("%w: truncated menu sector", ErrInvalidNAV)
+		}
+		result.ScannedSectors++
+
+		if looksLikeNAVSector(sector) {
+			packet, parseErr := ParseNAVSector(sector)
+			if parseErr != nil {
+				return CellScan{}, parseErr
+			}
+			result.Packets = append(result.Packets, packet)
+		}
+		fragments, routeErr := RouteSPUFragments(sector, packetLimit, payloadLimit)
+		if routeErr != nil {
+			return CellScan{}, routeErr
+		}
+		if len(result.SPUFragments)+len(fragments) > packetLimit {
+			return CellScan{}, fmt.Errorf("%w: SPU packet limit", ErrInvalidNAV)
+		}
+		for _, fragment := range fragments {
+			spuBytes += len(fragment.Data)
+			if spuBytes > payloadLimit {
+				return CellScan{}, fmt.Errorf("%w: SPU payload limit", ErrInvalidNAV)
+			}
+			result.SPUFragments = append(result.SPUFragments, fragment)
+		}
+	}
+	return result, nil
+}
+
+// ParsePCI decodes a PCI payload beginning immediately after substream id 0.
+func ParsePCI(data []byte) (PCI, error) {
+	if len(data) < PCIPayloadSize {
+		return PCI{}, fmt.Errorf("%w: PCI payload length %d", ErrInvalidNAV, len(data))
+	}
+	reader := bitReader{data: data[:PCIPayloadSize]}
+	var pci PCI
+	var err error
+	if pci.LogicalBlock, err = reader.u32(); err != nil {
+		return PCI{}, err
+	}
+	if pci.VOBUCategory, err = reader.u16(); err != nil {
+		return PCI{}, err
+	}
+	if err = reader.skip(16 + 32); err != nil { // reserved + prohibited user operations
+		return PCI{}, err
+	}
+	if pci.VOBUStartPTS, err = reader.u32(); err != nil {
+		return PCI{}, err
+	}
+	if pci.VOBUEndPTS, err = reader.u32(); err != nil {
+		return PCI{}, err
+	}
+	if pci.VOBUSequenceEndPTS, err = reader.u32(); err != nil {
+		return PCI{}, err
+	}
+	if err = reader.skip(32 + 32*8 + 9*32); err != nil { // elapsed, ISRC, angle destinations
+		return PCI{}, err
+	}
+	if pci.HighlightStatus, err = reader.u16(); err != nil {
+		return PCI{}, err
+	}
+	if pci.HighlightStartPTS, err = reader.u32(); err != nil {
+		return PCI{}, err
+	}
+	if pci.HighlightEndPTS, err = reader.u32(); err != nil {
+		return PCI{}, err
+	}
+	if pci.ButtonSelectEndPTS, err = reader.u32(); err != nil {
+		return PCI{}, err
+	}
+	if err = reader.skip(2); err != nil {
+		return PCI{}, err
+	}
+	groups, err := reader.u8(2)
+	if err != nil {
+		return PCI{}, err
+	}
+	pci.ButtonGroupCount = groups
+	if err = reader.skip(12); err != nil { // reserved and group display types
+		return PCI{}, err
+	}
+	values := []*uint8{
+		&pci.ButtonOffset,
+		&pci.ButtonCount,
+		&pci.SelectableCount,
+	}
+	for _, target := range values {
+		value, readErr := reader.u8(8)
+		if readErr != nil {
+			return PCI{}, readErr
+		}
+		*target = value
+	}
+	if err = reader.skip(8); err != nil {
+		return PCI{}, err
+	}
+	for _, target := range []*uint8{&pci.ForcedSelectButton, &pci.ForcedActionButton} {
+		value, readErr := reader.u8(8)
+		if readErr != nil {
+			return PCI{}, readErr
+		}
+		*target = value
+	}
+	for group := range pci.ButtonColors {
+		for mode := range pci.ButtonColors[group] {
+			value, readErr := reader.u32()
+			if readErr != nil {
+				return PCI{}, readErr
+			}
+			pci.ButtonColors[group][mode] = value
+		}
+	}
+	if err := validateHeader(pci); err != nil {
+		return PCI{}, err
+	}
+
+	perGroup := MaxButtons
+	if pci.ButtonGroupCount != 0 {
+		perGroup = MaxButtons / int(pci.ButtonGroupCount)
+	}
+	for index := range MaxButtons {
+		button, readErr := readButton(&reader)
+		if readErr != nil {
+			return PCI{}, readErr
+		}
+		if pci.ButtonGroupCount == 0 {
+			continue
+		}
+		group := index / perGroup
+		position := index % perGroup
+		if group >= int(pci.ButtonGroupCount) || position >= int(pci.ButtonCount) {
+			continue
+		}
+		//nolint:gosec // position is bounded by the 36-entry DVD button table.
+		button.Number = uint8(position + 1)
+		if err := validateButton(button, pci.ButtonCount); err != nil {
+			return PCI{}, fmt.Errorf("button group %d item %d: %w", group+1, position+1, err)
+		}
+		pci.ButtonGroups[group] = append(pci.ButtonGroups[group], button)
+	}
+	return pci, nil
+}
+
+func validateHeader(pci PCI) error {
+	if pci.ButtonGroupCount > MaxButtonGroups {
+		return fmt.Errorf("%w: button group count %d", ErrInvalidNAV, pci.ButtonGroupCount)
+	}
+	if pci.ButtonCount > MaxButtons || pci.SelectableCount > pci.ButtonCount {
+		return fmt.Errorf("%w: button counts %d/%d", ErrInvalidNAV, pci.ButtonCount, pci.SelectableCount)
+	}
+	if pci.ButtonGroupCount == 0 {
+		if pci.ButtonCount != 0 {
+			return fmt.Errorf("%w: buttons without display group", ErrInvalidNAV)
+		}
+		return nil
+	}
+	if int(pci.ButtonCount) > MaxButtons/int(pci.ButtonGroupCount) {
+		return fmt.Errorf("%w: %d buttons in %d groups", ErrInvalidNAV, pci.ButtonCount, pci.ButtonGroupCount)
+	}
+	for _, number := range []uint8{pci.ForcedSelectButton & 0x3f, pci.ForcedActionButton & 0x3f} {
+		if number > pci.ButtonCount {
+			return fmt.Errorf("%w: forced button %d", ErrInvalidNAV, number)
+		}
+	}
+	return nil
+}
+
+func readButton(reader *bitReader) (Button, error) {
+	var button Button
+	color, err := reader.u8(2)
+	if err != nil {
+		return Button{}, err
+	}
+	button.ColorGroup = color
+	xStart, err := reader.u16Bits(10)
+	if err != nil {
+		return Button{}, err
+	}
+	button.XStart = xStart
+	if err := reader.skip(2); err != nil {
+		return Button{}, err
+	}
+	xEnd, err := reader.u16Bits(10)
+	if err != nil {
+		return Button{}, err
+	}
+	button.XEnd = xEnd
+	autoAction, err := reader.u8(2)
+	if err != nil {
+		return Button{}, err
+	}
+	button.AutoAction = autoAction != 0
+	yStart, err := reader.u16Bits(10)
+	if err != nil {
+		return Button{}, err
+	}
+	button.YStart = yStart
+	if err := reader.skip(2); err != nil {
+		return Button{}, err
+	}
+	yEnd, err := reader.u16Bits(10)
+	if err != nil {
+		return Button{}, err
+	}
+	button.YEnd = yEnd
+	for _, target := range []*uint8{&button.Up, &button.Down, &button.Left, &button.Right} {
+		if err := reader.skip(2); err != nil {
+			return Button{}, err
+		}
+		value, readErr := reader.u8(6)
+		if readErr != nil {
+			return Button{}, readErr
+		}
+		*target = value
+	}
+	for index := range button.Command {
+		value, readErr := reader.u8(8)
+		if readErr != nil {
+			return Button{}, readErr
+		}
+		button.Command[index] = value
+	}
+	return button, nil
+}
+
+func validateButton(button Button, count uint8) error {
+	if button.ColorGroup > 3 {
+		return fmt.Errorf("%w: color group %d", ErrInvalidNAV, button.ColorGroup)
+	}
+	if button.XStart > button.XEnd || button.YStart > button.YEnd {
+		return fmt.Errorf("%w: inverted rectangle", ErrInvalidNAV)
+	}
+	for _, neighbor := range []uint8{button.Up, button.Down, button.Left, button.Right} {
+		if neighbor > count {
+			return fmt.Errorf("%w: neighbor %d exceeds count %d", ErrInvalidNAV, neighbor, count)
+		}
+	}
+	return nil
+}
+
+// ParseDSI decodes the DSI general-information prefix.
+func ParseDSI(data []byte) (DSI, error) {
+	if len(data) < minimumDSIPayloadSize {
+		return DSI{}, fmt.Errorf("%w: DSI payload length %d", ErrInvalidNAV, len(data))
+	}
+	return DSI{
+		SystemClock:     binary.BigEndian.Uint32(data[0:4]),
+		LogicalBlock:    binary.BigEndian.Uint32(data[4:8]),
+		VOBUEndAddress:  binary.BigEndian.Uint32(data[8:12]),
+		FirstReference:  binary.BigEndian.Uint32(data[12:16]),
+		SecondReference: binary.BigEndian.Uint32(data[16:20]),
+		ThirdReference:  binary.BigEndian.Uint32(data[20:24]),
+		VOBID:           binary.BigEndian.Uint16(data[24:26]),
+		CellID:          data[27],
+		CellElapsedTime: [4]uint8(data[28:32]),
+	}, nil
+}
+
+// ParseNAVSector decodes the paired private-stream-2 PCI and DSI PES packets
+// in one 2048-byte NAV sector.
+func ParseNAVSector(sector []byte) (Packet, error) {
+	if len(sector) != SectorSize || !bytes.Equal(sector[:4], []byte{0, 0, 1, 0xba}) {
+		return Packet{}, fmt.Errorf("%w: NAV sector pack header", ErrInvalidNAV)
+	}
+	offset, err := packEnd(sector, 0)
+	if err != nil {
+		return Packet{}, err
+	}
+	if offset+6 <= len(sector) && bytes.Equal(sector[offset:offset+4], []byte{0, 0, 1, 0xbb}) {
+		length := int(binary.BigEndian.Uint16(sector[offset+4 : offset+6]))
+		offset += 6 + length
+	}
+	pciPayload, next, err := privateStream2(sector, offset, 0)
+	if err != nil {
+		return Packet{}, err
+	}
+	dsiPayload, _, err := privateStream2(sector, next, 1)
+	if err != nil {
+		return Packet{}, err
+	}
+	pci, err := ParsePCI(pciPayload)
+	if err != nil {
+		return Packet{}, err
+	}
+	dsi, err := ParseDSI(dsiPayload)
+	if err != nil {
+		return Packet{}, err
+	}
+	return Packet{PCI: pci, DSI: dsi}, nil
+}
+
+func looksLikeNAVSector(sector []byte) bool {
+	if len(sector) != SectorSize || !bytes.Equal(sector[:4], []byte{0, 0, 1, 0xba}) {
+		return false
+	}
+	offset, err := packEnd(sector, 0)
+	if err != nil {
+		return false
+	}
+	if offset+6 <= len(sector) && bytes.Equal(sector[offset:offset+4], []byte{0, 0, 1, 0xbb}) {
+		length := int(binary.BigEndian.Uint16(sector[offset+4 : offset+6]))
+		offset += 6 + length
+	}
+	return offset+7 <= len(sector) && bytes.Equal(sector[offset:offset+4], []byte{0, 0, 1, 0xbf}) && sector[offset+6] == 0
+}
+
+func privateStream2(data []byte, offset int, substream uint8) ([]byte, int, error) {
+	if offset < 0 || offset+7 > len(data) || !bytes.Equal(data[offset:offset+4], []byte{0, 0, 1, 0xbf}) {
+		return nil, offset, fmt.Errorf("%w: private-stream-2 header", ErrInvalidNAV)
+	}
+	length := int(binary.BigEndian.Uint16(data[offset+4 : offset+6]))
+	end := offset + 6 + length
+	if length < 1 || end > len(data) || data[offset+6] != substream {
+		return nil, offset, fmt.Errorf("%w: private-stream-2 substream %d", ErrInvalidNAV, substream)
+	}
+	return data[offset+7 : end], end, nil
+}
+
+func packEnd(data []byte, offset int) (int, error) {
+	if offset+14 > len(data) {
+		return 0, fmt.Errorf("%w: truncated pack header", ErrInvalidNAV)
+	}
+	if data[offset+4]&0x40 == 0 { // MPEG-1 pack header
+		if offset+12 > len(data) {
+			return 0, fmt.Errorf("%w: truncated MPEG-1 pack", ErrInvalidNAV)
+		}
+		return offset + 12, nil
+	}
+	end := offset + 14 + int(data[offset+13]&0x07)
+	if end > len(data) {
+		return 0, fmt.Errorf("%w: pack stuffing", ErrInvalidNAV)
+	}
+	return end, nil
+}
+
+// RouteSPUFragments returns DVD subpicture payload fragments from MPEG-2
+// private-stream-1 PES packets. Limits are independent of input length.
+func RouteSPUFragments(data []byte, packetLimit, payloadLimit int) ([]SPUFragment, error) {
+	if packetLimit == 0 {
+		packetLimit = defaultPacketLimit
+	}
+	if payloadLimit == 0 {
+		payloadLimit = defaultPayloadLimit
+	}
+	if packetLimit < 0 || payloadLimit < 0 {
+		return nil, fmt.Errorf("%w: negative routing limit", ErrInvalidNAV)
+	}
+	fragments := make([]SPUFragment, 0)
+	total := 0
+	for offset := 0; offset+6 <= len(data); {
+		index := bytes.Index(data[offset:], []byte{0, 0, 1, 0xbd})
+		if index < 0 {
+			break
+		}
+		offset += index
+		length := int(binary.BigEndian.Uint16(data[offset+4 : offset+6]))
+		end := offset + 6 + length
+		if end > len(data) {
+			return nil, fmt.Errorf("%w: truncated PES payload", ErrInvalidNAV)
+		}
+		if length < 4 || offset+9 > end || data[offset+6]&0xc0 != 0x80 {
+			return nil, fmt.Errorf("%w: private-stream-1 header", ErrInvalidNAV)
+		}
+		headerLength := int(data[offset+8])
+		payload := offset + 9 + headerLength
+		if payload >= end {
+			return nil, fmt.Errorf("%w: private-stream-1 payload", ErrInvalidNAV)
+		}
+		substream := data[payload]
+		if substream >= 0x20 && substream <= 0x3f {
+			if len(fragments) >= packetLimit {
+				return nil, fmt.Errorf("%w: SPU packet limit", ErrInvalidNAV)
+			}
+			fragment := data[payload+1 : end]
+			total += len(fragment)
+			if total > payloadLimit {
+				return nil, fmt.Errorf("%w: SPU payload limit", ErrInvalidNAV)
+			}
+			item := SPUFragment{StreamID: substream, Data: append([]byte(nil), fragment...)}
+			if data[offset+7]&0x80 != 0 {
+				if headerLength < 5 {
+					return nil, fmt.Errorf("%w: truncated private-stream-1 PTS", ErrInvalidNAV)
+				}
+				item.PTS = decodePTS(data[offset+9 : offset+14])
+				item.HasPTS = true
+			}
+			fragments = append(fragments, item)
+		}
+		offset = end
+	}
+	return fragments, nil
+}
+
+func decodePTS(data []byte) uint64 {
+	return uint64(data[0]&0x0e)<<29 |
+		uint64(binary.BigEndian.Uint16(data[1:3])>>1)<<15 |
+		uint64(binary.BigEndian.Uint16(data[3:5])>>1)
+}
+
+type bitReader struct {
+	data []byte
+	bit  int
+}
+
+func (r *bitReader) read(count int) (uint64, error) {
+	if count < 0 || count > 64 || r.bit+count > len(r.data)*8 {
+		return 0, fmt.Errorf("%w: bitstream bounds offset=%d count=%d size=%d", ErrInvalidNAV, r.bit, count, len(r.data)*8)
+	}
+	var value uint64
+	for range count {
+		value = value<<1 | uint64(r.data[r.bit/8]>>(7-(r.bit%8))&1)
+		r.bit++
+	}
+	return value, nil
+}
+
+func (r *bitReader) skip(count int) error {
+	if count < 0 || r.bit+count > len(r.data)*8 {
+		return fmt.Errorf("%w: bitstream bounds offset=%d count=%d size=%d", ErrInvalidNAV, r.bit, count, len(r.data)*8)
+	}
+	r.bit += count
+	return nil
+}
+
+func (r *bitReader) u16() (uint16, error) {
+	return r.u16Bits(16)
+}
+
+func (r *bitReader) u32() (uint32, error) {
+	value, err := r.read(32)
+	if err != nil {
+		return 0, err
+	}
+	if value > 0xffff_ffff {
+		return 0, fmt.Errorf("%w: value exceeds 32 bits", ErrInvalidNAV)
+	}
+	return uint32(value), nil
+}
+
+func (r *bitReader) u8(count int) (uint8, error) {
+	value, err := r.read(count)
+	if err != nil {
+		return 0, err
+	}
+	if value > 0xff {
+		return 0, fmt.Errorf("%w: value exceeds 8 bits", ErrInvalidNAV)
+	}
+	return uint8(value), nil
+}
+
+func (r *bitReader) u16Bits(count int) (uint16, error) {
+	value, err := r.read(count)
+	if err != nil {
+		return 0, err
+	}
+	if value > 0xffff {
+		return 0, fmt.Errorf("%w: value exceeds 16 bits", ErrInvalidNAV)
+	}
+	return uint16(value), nil
+}

--- a/internal/dvdvideo/nav/nav_test.go
+++ b/internal/dvdvideo/nav/nav_test.go
@@ -1,0 +1,151 @@
+package nav
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+func TestParsePCIButton(t *testing.T) {
+	data := make([]byte, PCIPayloadSize)
+	binary.BigEndian.PutUint32(data[12:16], 90_000)
+	binary.BigEndian.PutUint32(data[16:20], 180_000)
+	data[110] = 0x10 // one button group
+	data[113] = 1
+	data[114] = 1
+	data[116] = 1
+	data[117] = 1
+	binary.BigEndian.PutUint32(data[118:122], 0x12345678)
+	put24(data[142:145], 1<<22|10<<12|100)
+	put24(data[145:148], 1<<22|20<<12|80)
+	data[148] = 1
+	data[149] = 1
+	data[150] = 1
+	data[151] = 1
+	data[159] = 7
+
+	pci, err := ParsePCI(data)
+	if err != nil {
+		t.Fatalf("ParsePCI: %v", err)
+	}
+	if pci.VOBUStartPTS != 90_000 || pci.VOBUEndPTS != 180_000 {
+		t.Fatalf("PTS = %d..%d", pci.VOBUStartPTS, pci.VOBUEndPTS)
+	}
+	if len(pci.ButtonGroups[0]) != 1 {
+		t.Fatalf("buttons = %+v", pci.ButtonGroups)
+	}
+	button := pci.ButtonGroups[0][0]
+	if button.XStart != 10 || button.XEnd != 100 || button.YStart != 20 || button.YEnd != 80 || !button.AutoAction {
+		t.Fatalf("button = %+v", button)
+	}
+	if button.Command[7] != 7 {
+		t.Fatalf("command = %x", button.Command)
+	}
+}
+
+func TestParsePCIRejectsTooManyButtons(t *testing.T) {
+	data := make([]byte, PCIPayloadSize)
+	data[110] = 0x10
+	data[113] = 37
+	_, err := ParsePCI(data)
+	if !errors.Is(err, ErrInvalidNAV) {
+		t.Fatalf("ParsePCI error = %v, want ErrInvalidNAV", err)
+	}
+}
+
+func TestRouteSPUFragments(t *testing.T) {
+	payload := []byte{0x80, 0, 0, 0x20, 1, 2, 3}
+	packet := append([]byte{0, 0, 1, 0xbd, 0, byte(len(payload))}, payload...)
+	fragments, err := RouteSPUFragments(packet, 1, 3)
+	if err != nil {
+		t.Fatalf("RouteSPUFragments: %v", err)
+	}
+	if len(fragments) != 1 || fragments[0].StreamID != 0x20 || len(fragments[0].Data) != 3 {
+		t.Fatalf("fragments = %+v", fragments)
+	}
+}
+
+func TestRouteSPUFragmentsReadsPTS(t *testing.T) {
+	pts := []byte{0x21, 0, 1, 0, 1}
+	payload := append([]byte{0x80, 0x80, 5}, pts...)
+	payload = append(payload, 0x20, 1, 2, 3)
+	packet := append([]byte{0, 0, 1, 0xbd, 0, byte(len(payload))}, payload...)
+	fragments, err := RouteSPUFragments(packet, 1, 3)
+	if err != nil {
+		t.Fatalf("RouteSPUFragments: %v", err)
+	}
+	if len(fragments) != 1 || !fragments[0].HasPTS || fragments[0].PTS != 0 {
+		t.Fatalf("fragments = %+v", fragments)
+	}
+}
+
+func TestScanCellParsesNAVAndSPU(t *testing.T) {
+	sector := syntheticNAVSector()
+	reader := bytes.NewReader(sector)
+	result, err := ScanCell(reader, int64(len(sector)), 0, 0, CellScanOptions{MaxSectors: 1, MaxSPUPackets: 1, MaxSPUBytes: 3})
+	if err != nil {
+		t.Fatalf("ScanCell: %v", err)
+	}
+	if result.ScannedSectors != 1 || len(result.Packets) != 1 || len(result.SPUFragments) != 1 || result.Truncated {
+		t.Fatalf("scan = %+v", result)
+	}
+}
+
+func TestScanCellReportsTruncation(t *testing.T) {
+	data := make([]byte, SectorSize*2)
+	result, err := ScanCell(bytes.NewReader(data), int64(len(data)), 0, 1, CellScanOptions{MaxSectors: 1})
+	if err != nil {
+		t.Fatalf("ScanCell: %v", err)
+	}
+	if !result.Truncated || result.ScannedSectors != 1 {
+		t.Fatalf("scan = %+v", result)
+	}
+}
+
+func FuzzParsePCI(f *testing.F) {
+	f.Add(make([]byte, PCIPayloadSize))
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		_, _ = ParsePCI(data)
+	})
+}
+
+func FuzzRouteSPUFragments(f *testing.F) {
+	f.Add([]byte{0, 0, 1, 0xbd, 0, 0})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		_, _ = RouteSPUFragments(data, 8, 4096)
+	})
+}
+
+func put24(target []byte, value uint32) {
+	target[0] = byte(value >> 16)
+	target[1] = byte(value >> 8)
+	target[2] = byte(value)
+}
+
+func syntheticNAVSector() []byte {
+	sector := make([]byte, SectorSize)
+	copy(sector, []byte{0, 0, 1, 0xba})
+	sector[4] = 0x40
+	offset := 14
+
+	pci := make([]byte, PCIPayloadSize)
+	writePrivateStream2(sector, offset, 0, pci)
+	offset += 7 + len(pci)
+	dsi := make([]byte, minimumDSIPayloadSize)
+	writePrivateStream2(sector, offset, 1, dsi)
+	offset += 7 + len(dsi)
+
+	payload := []byte{0x80, 0, 0, 0x20, 1, 2, 3}
+	copy(sector[offset:], []byte{0, 0, 1, 0xbd})
+	binary.BigEndian.PutUint16(sector[offset+4:offset+6], uint16(len(payload)))
+	copy(sector[offset+6:], payload)
+	return sector
+}
+
+func writePrivateStream2(target []byte, offset int, streamID byte, payload []byte) {
+	copy(target[offset:], []byte{0, 0, 1, 0xbf})
+	binary.BigEndian.PutUint16(target[offset+4:offset+6], uint16(len(payload)+1))
+	target[offset+6] = streamID
+	copy(target[offset+7:], payload)
+}

--- a/internal/dvdvideo/nav/nav_test.go
+++ b/internal/dvdvideo/nav/nav_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -77,6 +78,14 @@ func TestRouteSPUFragmentsReadsPTS(t *testing.T) {
 	}
 	if len(fragments) != 1 || !fragments[0].HasPTS || fragments[0].PTS != 0 {
 		t.Fatalf("fragments = %+v", fragments)
+	}
+}
+
+func TestRouteSPUFragmentsRejectsTruncatedPESHeader(t *testing.T) {
+	data := append(make([]byte, 6), 0, 0, 1, 0xbd)
+	_, err := RouteSPUFragments(data, 1, 1)
+	if !errors.Is(err, ErrInvalidNAV) || !strings.Contains(err.Error(), "truncated PES payload") {
+		t.Fatalf("RouteSPUFragments error = %v, want truncated ErrInvalidNAV", err)
 	}
 }
 

--- a/internal/dvdvideo/render/integration_test.go
+++ b/internal/dvdvideo/render/integration_test.go
@@ -1,0 +1,21 @@
+package render
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestFFmpegDVDVideoCapability(t *testing.T) {
+	executable := os.Getenv("UPBRR_TEST_FFMPEG")
+	if executable == "" {
+		t.Skip("set UPBRR_TEST_FFMPEG to run the local FFmpeg capability proof")
+	}
+	capability, err := Probe(context.Background(), ExecRunner{}, executable)
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if !capability.Available {
+		t.Fatal("FFmpeg DVD menu capability unavailable")
+	}
+}

--- a/internal/dvdvideo/render/render.go
+++ b/internal/dvdvideo/render/render.go
@@ -1,0 +1,250 @@
+// Package render probes FFmpeg DVD menu capability and decodes exact-coordinate
+// menu background frames selected by the pure-Go engine.
+package render
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// MaxDiagnosticBytes bounds retained FFmpeg diagnostic output.
+	MaxDiagnosticBytes = 64 << 10
+	// MaxFrameBytes bounds retained lossless frame output.
+	MaxFrameBytes = 64 << 20
+	// MaxFrameWidth is the largest accepted decoded frame width.
+	MaxFrameWidth = 4096
+	// MaxFrameHeight is the largest accepted decoded frame height.
+	MaxFrameHeight = 4096
+	// MaxFramePixels bounds decoded frame allocation.
+	MaxFramePixels = 16 << 20
+)
+
+var (
+	// ErrCapability identifies missing or unusable FFmpeg dvdvideo support.
+	ErrCapability = errors.New("FFmpeg lacks required DVD menu capability")
+	// ErrFrame identifies invalid requests or failed DVD menu frame decoding.
+	ErrFrame       = errors.New("FFmpeg DVD menu frame decode failed")
+	errOutputLimit = errors.New("command output limit exceeded")
+)
+
+var requiredOptions = [...]string{"-menu", "-menu_lu", "-menu_vts", "-pgc", "-pg"}
+
+// Output is bounded command output.
+type Output struct {
+	// Stdout contains retained output up to the requested limit.
+	Stdout []byte
+	// Stderr contains retained diagnostics up to MaxDiagnosticBytes.
+	Stderr []byte
+}
+
+// Runner executes FFmpeg without shell interpolation.
+type Runner interface {
+	// Run invokes executable directly with discrete args and bounded output.
+	Run(ctx context.Context, executable string, args []string, stdoutLimit int) (Output, error)
+}
+
+// ExecRunner is the production os/exec implementation.
+type ExecRunner struct{}
+
+// Run resolves executable on PATH, invokes it without a shell, and retains
+// bounded stdout and stderr. Context cancellation terminates the child process.
+func (ExecRunner) Run(ctx context.Context, executable string, args []string, stdoutLimit int) (Output, error) {
+	if stdoutLimit <= 0 {
+		return Output{}, fmt.Errorf("invalid stdout limit %d", stdoutLimit)
+	}
+	stdout := &limitWriter{limit: stdoutLimit}
+	stderr := &limitWriter{limit: MaxDiagnosticBytes}
+	resolved, err := exec.LookPath(executable)
+	if err != nil {
+		return Output{}, fmt.Errorf("resolve FFmpeg executable: %w", err)
+	}
+	//nolint:gosec // executable is resolved with exec.LookPath; args are discrete validated values, never a shell command.
+	command := exec.CommandContext(ctx, resolved, args...)
+	command.Stdout = stdout
+	command.Stderr = stderr
+	err = command.Run()
+	if stdout.exceeded || stderr.exceeded {
+		return Output{Stdout: stdout.data, Stderr: stderr.data}, errOutputLimit
+	}
+	if err != nil {
+		return Output{Stdout: stdout.data, Stderr: stderr.data}, fmt.Errorf("run FFmpeg: %w", err)
+	}
+	return Output{Stdout: stdout.data, Stderr: stderr.data}, nil
+}
+
+type limitWriter struct {
+	data     []byte
+	limit    int
+	exceeded bool
+}
+
+// Write retains data up to the configured limit, records overflow, and reports
+// the full input length so the child process can finish cleanly.
+func (w *limitWriter) Write(data []byte) (int, error) {
+	remaining := w.limit - len(w.data)
+	if remaining <= 0 {
+		w.exceeded = true
+		return len(data), nil
+	}
+	if len(data) > remaining {
+		w.data = append(w.data, data[:remaining]...)
+		w.exceeded = true
+		return len(data), nil
+	}
+	w.data = append(w.data, data...)
+	return len(data), nil
+}
+
+// Capability is safe engine diagnostic metadata without local paths.
+type Capability struct {
+	// Available reports that the dvdvideo demuxer and all required options were found.
+	Available bool
+	// Version is a bounded first line from FFmpeg's version output.
+	Version string
+	// Options contains the required dvdvideo options observed by the probe.
+	Options []string
+}
+
+// Probe verifies the dvdvideo demuxer and every exact-coordinate menu option.
+func Probe(ctx context.Context, runner Runner, executable string) (Capability, error) {
+	if runner == nil || strings.TrimSpace(executable) == "" {
+		return Capability{}, fmt.Errorf("%w: FFmpeg runner unavailable", ErrCapability)
+	}
+	help, err := runner.Run(ctx, executable, []string{"-hide_banner", "-h", "demuxer=dvdvideo"}, MaxDiagnosticBytes)
+	if err != nil {
+		return Capability{}, fmt.Errorf("%w: demuxer probe", ErrCapability)
+	}
+	text := string(append(append([]byte(nil), help.Stdout...), help.Stderr...))
+	fields := strings.Fields(text)
+	available := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		if strings.HasPrefix(field, "-") {
+			available[strings.TrimRight(field, ",:")] = struct{}{}
+		}
+	}
+	options := make([]string, 0, len(requiredOptions))
+	missing := make([]string, 0, len(requiredOptions))
+	for _, option := range requiredOptions {
+		if _, ok := available[option]; !ok {
+			missing = append(missing, option)
+			continue
+		}
+		options = append(options, option)
+	}
+	if len(missing) > 0 {
+		return Capability{}, fmt.Errorf("%w: missing %s", ErrCapability, strings.Join(missing, ", "))
+	}
+	if !strings.Contains(strings.ToLower(text), "dvdvideo") {
+		return Capability{}, fmt.Errorf("%w: dvdvideo demuxer", ErrCapability)
+	}
+	versionOutput, versionErr := runner.Run(ctx, executable, []string{"-hide_banner", "-version"}, MaxDiagnosticBytes)
+	if versionErr != nil {
+		return Capability{}, fmt.Errorf("%w: version probe", ErrCapability)
+	}
+	version := firstLine(string(versionOutput.Stdout))
+	if version == "" {
+		version = firstLine(string(versionOutput.Stderr))
+	}
+	return Capability{Available: true, Version: version, Options: options}, nil
+}
+
+func firstLine(value string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(value), "\n")
+	line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+	if len(line) > 256 {
+		line = line[:256]
+	}
+	return line
+}
+
+// FrameRequest contains inventory-validated FFmpeg dvdvideo coordinates.
+type FrameRequest struct {
+	// SourcePath is the host filesystem path of the extracted VIDEO_TS directory.
+	SourcePath string
+	// VTS selects zero for the manager domain or 1 through 99 for a title set.
+	VTS int
+	// LanguageUnit is the one-based FFmpeg dvdvideo language-unit index.
+	LanguageUnit int
+	// PGC is the one-based menu program-chain index.
+	PGC int
+	// Program is the one-based program index within PGC.
+	Program int
+	// Target is the non-negative seek offset within the selected program.
+	Target time.Duration
+	// Deinterlace enables FFmpeg's bwdif filter before frame extraction.
+	Deinterlace bool
+}
+
+// BuildArgs returns FFmpeg arguments with every dvdvideo input option before
+// -i and no shell-built command string.
+func BuildArgs(request FrameRequest) ([]string, error) {
+	if strings.TrimSpace(request.SourcePath) == "" {
+		return nil, fmt.Errorf("%w: empty source", ErrFrame)
+	}
+	if request.VTS < 0 || request.VTS > 99 || request.LanguageUnit < 1 || request.LanguageUnit > 99 || request.PGC < 1 || request.PGC > 999 || request.Program < 1 || request.Program > 255 || request.Target < 0 {
+		return nil, fmt.Errorf("%w: invalid menu coordinate", ErrFrame)
+	}
+	args := []string{
+		"-hide_banner", "-loglevel", "error",
+		"-f", "dvdvideo",
+		"-menu", "1",
+		"-menu_vts", strconv.Itoa(request.VTS),
+		"-menu_lu", strconv.Itoa(request.LanguageUnit),
+		"-pgc", strconv.Itoa(request.PGC),
+		"-pg", strconv.Itoa(request.Program),
+	}
+	if request.Target > 0 {
+		args = append(args, "-ss", formatDuration(request.Target))
+	}
+	args = append(args, "-i", request.SourcePath, "-map", "0:v:0", "-an", "-sn", "-dn")
+	if request.Deinterlace {
+		args = append(args, "-vf", "bwdif=mode=send_frame:parity=auto:deint=all")
+	}
+	args = append(args, "-frames:v", "1", "-c:v", "png", "-f", "image2pipe", "pipe:1")
+	return args, nil
+}
+
+func formatDuration(value time.Duration) string {
+	seconds := value.Seconds()
+	return strconv.FormatFloat(seconds, 'f', 6, 64)
+}
+
+// DecodeFrame invokes FFmpeg and decodes one lossless background image.
+func DecodeFrame(ctx context.Context, runner Runner, executable string, request FrameRequest) (image.Image, error) {
+	if runner == nil || strings.TrimSpace(executable) == "" {
+		return nil, fmt.Errorf("%w: FFmpeg runner unavailable", ErrFrame)
+	}
+	args, err := BuildArgs(request)
+	if err != nil {
+		return nil, err
+	}
+	output, err := runner.Run(ctx, executable, args, MaxFrameBytes)
+	if err != nil {
+		return nil, fmt.Errorf("%w: process", ErrFrame)
+	}
+	if len(output.Stdout) == 0 {
+		return nil, fmt.Errorf("%w: empty image", ErrFrame)
+	}
+	config, err := png.DecodeConfig(bytes.NewReader(output.Stdout))
+	if err != nil {
+		return nil, fmt.Errorf("%w: image header", ErrFrame)
+	}
+	if config.Width <= 0 || config.Height <= 0 || config.Width > MaxFrameWidth || config.Height > MaxFrameHeight || uint64(config.Width)*uint64(config.Height) > MaxFramePixels {
+		return nil, fmt.Errorf("%w: image dimensions", ErrFrame)
+	}
+	frame, err := png.Decode(io.LimitReader(bytes.NewReader(output.Stdout), MaxFrameBytes))
+	if err != nil {
+		return nil, fmt.Errorf("%w: image decode", ErrFrame)
+	}
+	return frame, nil
+}

--- a/internal/dvdvideo/render/render_test.go
+++ b/internal/dvdvideo/render/render_test.go
@@ -1,0 +1,90 @@
+package render
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"image"
+	"image/png"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProbeRequiresExactMenuOptions(t *testing.T) {
+	runner := &fakeRunner{outputs: []Output{
+		{Stdout: []byte("Demuxer dvdvideo\n-menu -menu_lu -menu_vts -pgc -pg\n")},
+		{Stdout: []byte("ffmpeg version example\n")},
+	}}
+	capability, err := Probe(context.Background(), runner, "ffmpeg")
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if !capability.Available || capability.Version != "ffmpeg version example" {
+		t.Fatalf("capability = %+v", capability)
+	}
+
+	missing := &fakeRunner{outputs: []Output{{Stdout: []byte("Demuxer dvdvideo\n-menu\n")}}}
+	_, err = Probe(context.Background(), missing, "ffmpeg")
+	if !errors.Is(err, ErrCapability) {
+		t.Fatalf("Probe error = %v, want ErrCapability", err)
+	}
+	for _, option := range []string{"-menu_lu", "-menu_vts", "-pgc", "-pg"} {
+		if !strings.Contains(err.Error(), option) {
+			t.Fatalf("Probe error = %v, want missing option %s", err, option)
+		}
+	}
+}
+
+func TestDecodeFrameRejectsOversizedDimensions(t *testing.T) {
+	var payload bytes.Buffer
+	if err := png.Encode(&payload, image.NewNRGBA(image.Rect(0, 0, MaxFrameWidth+1, 1))); err != nil {
+		t.Fatalf("encode PNG: %v", err)
+	}
+	runner := &fakeRunner{outputs: []Output{{Stdout: payload.Bytes()}}}
+	_, err := DecodeFrame(context.Background(), runner, "ffmpeg", FrameRequest{SourcePath: `C:\path\to\VIDEO_TS`, LanguageUnit: 1, PGC: 1, Program: 1})
+	if !errors.Is(err, ErrFrame) {
+		t.Fatalf("DecodeFrame error = %v, want ErrFrame", err)
+	}
+}
+
+func TestBuildArgsPlacesInputOptionsBeforeSource(t *testing.T) {
+	request := FrameRequest{
+		SourcePath:   `C:\path\to\VIDEO_TS`,
+		VTS:          2,
+		LanguageUnit: 1,
+		PGC:          3,
+		Program:      4,
+		Target:       1500 * time.Millisecond,
+		Deinterlace:  true,
+	}
+	args, err := BuildArgs(request)
+	if err != nil {
+		t.Fatalf("BuildArgs: %v", err)
+	}
+	wantPrefix := []string{"-hide_banner", "-loglevel", "error", "-f", "dvdvideo", "-menu", "1", "-menu_vts", "2", "-menu_lu", "1", "-pgc", "3", "-pg", "4", "-ss", "1.500000", "-i", request.SourcePath}
+	if !reflect.DeepEqual(args[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("args prefix = %q, want %q", args[:len(wantPrefix)], wantPrefix)
+	}
+}
+
+type fakeRunner struct {
+	outputs []Output
+	errors  []error
+	calls   int
+}
+
+func (r *fakeRunner) Run(_ context.Context, _ string, _ []string, _ int) (Output, error) {
+	index := r.calls
+	r.calls++
+	var output Output
+	var err error
+	if index < len(r.outputs) {
+		output = r.outputs[index]
+	}
+	if index < len(r.errors) {
+		err = r.errors[index]
+	}
+	return output, err
+}

--- a/internal/dvdvideo/spu/spu.go
+++ b/internal/dvdvideo/spu/spu.go
@@ -1,0 +1,384 @@
+// Package spu reassembles, decodes, and composites DVD subpicture packets.
+//
+// The control and RLE behavior is derived from FFmpeg dvdsubdec.c commit
+// 40ce1513c6a883bc2b96d33d968013b89dfe76af (LGPL-2.1-or-later). The DVD
+// palette/highlight layout also follows VideoLAN libdvdread 7.0.1 nav_types.h
+// (GPL-2.0-or-later). See plans/dvd-menu-engine-proof-adr.md.
+package spu
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+)
+
+const (
+	// MaxPacketBytes is the largest accepted declared subpicture packet size.
+	MaxPacketBytes = 65_535
+	// MaxControlBlocks bounds control-sequence traversal.
+	MaxControlBlocks = 128
+	// MaxOverlayWidth is the largest accepted decoded overlay width.
+	MaxOverlayWidth = 1024
+	// MaxOverlayHeight is the largest accepted decoded overlay height.
+	MaxOverlayHeight = 1024
+	// MaxOverlayPixels bounds decoded overlay allocation.
+	MaxOverlayPixels = 1 << 20
+)
+
+// ErrInvalidSPU identifies malformed, incomplete, or oversized subpicture data.
+var ErrInvalidSPU = errors.New("invalid DVD subpicture")
+
+// Packet is one complete DVD subpicture unit.
+type Packet struct {
+	// StreamID is the DVD subpicture substream identifier.
+	StreamID uint8
+	// Data contains one complete owned subpicture packet.
+	Data []byte
+}
+
+// Reassembler joins bounded private-stream fragments by subpicture stream id.
+type Reassembler struct {
+	streams [32][]byte
+}
+
+// Push appends one fragment and returns any completed packets. It accepts only
+// DVD subpicture stream IDs and retains incomplete data for later calls.
+func (r *Reassembler) Push(streamID uint8, fragment []byte) ([]Packet, error) {
+	if streamID < 0x20 || streamID > 0x3f {
+		return nil, fmt.Errorf("%w: stream id 0x%02x", ErrInvalidSPU, streamID)
+	}
+	index := streamID - 0x20
+	if len(r.streams[index])+len(fragment) > MaxPacketBytes*2 {
+		return nil, fmt.Errorf("%w: reassembly limit", ErrInvalidSPU)
+	}
+	r.streams[index] = append(r.streams[index], fragment...)
+	var packets []Packet
+	for len(r.streams[index]) >= 2 {
+		size := int(binary.BigEndian.Uint16(r.streams[index][:2]))
+		if size < 4 || size > MaxPacketBytes {
+			return nil, fmt.Errorf("%w: packet size %d", ErrInvalidSPU, size)
+		}
+		if len(r.streams[index]) < size {
+			break
+		}
+		data := append([]byte(nil), r.streams[index][:size]...)
+		packets = append(packets, Packet{StreamID: streamID, Data: data})
+		r.streams[index] = append(r.streams[index][:0], r.streams[index][size:]...)
+	}
+	return packets, nil
+}
+
+// Overlay is decoded palette-indexed subpicture state at one control date.
+type Overlay struct {
+	// Bounds is the half-open destination rectangle in DVD menu pixel coordinates.
+	Bounds image.Rectangle
+	// Pixels contains four-entry palette indexes in row-major order.
+	Pixels []uint8
+	// Stride is the number of palette indexes per row.
+	Stride int
+	// Palette contains the decoded NRGBA colors for Pixels.
+	Palette [4]color.NRGBA
+	// ColorMap contains authored indexes into the PGC color lookup table.
+	ColorMap [4]uint8
+	// Alpha contains authored four-bit opacity values.
+	Alpha [4]uint8
+	// StartDate is the selected display-control start date.
+	StartDate uint16
+	// EndDate is the selected display-control end date.
+	EndDate uint16
+	// Menu reports that the packet contains authored menu subpicture state.
+	Menu bool
+}
+
+// Highlight overrides palette entries inside one selected-button rectangle.
+type Highlight struct {
+	// Bounds is the half-open selected-button rectangle.
+	Bounds image.Rectangle
+	// Palette is the authored button color/alpha word.
+	Palette uint32
+}
+
+type controlState struct {
+	menu       bool
+	started    bool
+	startDate  uint16
+	endDate    uint16
+	colorMap   [4]uint8
+	alpha      [4]uint8
+	x1, y1     int
+	x2, y2     int
+	offsetEven int
+	offsetOdd  int
+}
+
+// Decode decodes state active at or immediately before date. Use ^uint16(0)
+// to select the final authored control state.
+func Decode(packet []byte, clut [16]uint32, date uint16) (Overlay, error) {
+	if len(packet) < 10 {
+		return Overlay{}, fmt.Errorf("%w: packet length %d", ErrInvalidSPU, len(packet))
+	}
+	size := int(binary.BigEndian.Uint16(packet[:2]))
+	if size < 4 || size > len(packet) || size > MaxPacketBytes {
+		return Overlay{}, fmt.Errorf("%w: declared size %d", ErrInvalidSPU, size)
+	}
+	packet = packet[:size]
+	commandOffset := int(binary.BigEndian.Uint16(packet[2:4]))
+	if commandOffset < 4 || commandOffset+4 > len(packet) {
+		return Overlay{}, fmt.Errorf("%w: command offset %d", ErrInvalidSPU, commandOffset)
+	}
+	state := controlState{offsetEven: -1, offsetOdd: -1}
+	position := commandOffset
+	seen := make(map[int]struct{})
+	for range MaxControlBlocks {
+		if _, ok := seen[position]; ok {
+			break
+		}
+		seen[position] = struct{}{}
+		if position+4 > len(packet) {
+			return Overlay{}, fmt.Errorf("%w: control block", ErrInvalidSPU)
+		}
+		blockDate := binary.BigEndian.Uint16(packet[position : position+2])
+		next := int(binary.BigEndian.Uint16(packet[position+2 : position+4]))
+		if blockDate > date {
+			break
+		}
+		var err error
+		state, err = parseCommands(packet, position+4, blockDate, state)
+		if err != nil {
+			return Overlay{}, err
+		}
+		if next == position {
+			break
+		}
+		if next < commandOffset || next <= position || next+4 > len(packet) {
+			return Overlay{}, fmt.Errorf("%w: next control offset %d", ErrInvalidSPU, next)
+		}
+		position = next
+	}
+	if state.offsetEven < 0 || state.offsetOdd < 0 || state.x2 < state.x1 || state.y2 < state.y1 {
+		return Overlay{}, fmt.Errorf("%w: incomplete display state", ErrInvalidSPU)
+	}
+	width, height := state.x2-state.x1+1, state.y2-state.y1+1
+	if width <= 0 || height <= 0 || width > MaxOverlayWidth || height > MaxOverlayHeight || width*height > MaxOverlayPixels {
+		return Overlay{}, fmt.Errorf("%w: overlay dimensions %dx%d", ErrInvalidSPU, width, height)
+	}
+	pixels := make([]uint8, width*height)
+	if err := decodeField(packet, state.offsetEven, width, height, 0, pixels); err != nil {
+		return Overlay{}, err
+	}
+	if height > 1 {
+		if err := decodeField(packet, state.offsetOdd, width, height, 1, pixels); err != nil {
+			return Overlay{}, err
+		}
+	}
+	overlay := Overlay{
+		Bounds:    image.Rect(state.x1, state.y1, state.x2+1, state.y2+1),
+		Pixels:    pixels,
+		Stride:    width,
+		ColorMap:  state.colorMap,
+		Alpha:     state.alpha,
+		StartDate: state.startDate,
+		EndDate:   state.endDate,
+		Menu:      state.menu,
+	}
+	for index := range overlay.Palette {
+		overlay.Palette[index] = clutColor(clut[state.colorMap[index]], state.alpha[index]*17)
+	}
+	return overlay, nil
+}
+
+func parseCommands(packet []byte, position int, date uint16, state controlState) (controlState, error) {
+	for position < len(packet) {
+		command := packet[position]
+		position++
+		switch command {
+		case 0x00:
+			state.menu = true
+		case 0x01:
+			state.started = true
+			state.startDate = date
+		case 0x02:
+			state.endDate = date
+		case 0x03:
+			if position+2 > len(packet) {
+				return state, fmt.Errorf("%w: color map", ErrInvalidSPU)
+			}
+			state.colorMap[3] = packet[position] >> 4
+			state.colorMap[2] = packet[position] & 0x0f
+			state.colorMap[1] = packet[position+1] >> 4
+			state.colorMap[0] = packet[position+1] & 0x0f
+			position += 2
+		case 0x04:
+			if position+2 > len(packet) {
+				return state, fmt.Errorf("%w: alpha map", ErrInvalidSPU)
+			}
+			state.alpha[3] = packet[position] >> 4
+			state.alpha[2] = packet[position] & 0x0f
+			state.alpha[1] = packet[position+1] >> 4
+			state.alpha[0] = packet[position+1] & 0x0f
+			position += 2
+		case 0x05:
+			if position+6 > len(packet) {
+				return state, fmt.Errorf("%w: display area", ErrInvalidSPU)
+			}
+			state.x1 = int(packet[position])<<4 | int(packet[position+1]>>4)
+			state.x2 = int(packet[position+1]&0x0f)<<8 | int(packet[position+2])
+			state.y1 = int(packet[position+3])<<4 | int(packet[position+4]>>4)
+			state.y2 = int(packet[position+4]&0x0f)<<8 | int(packet[position+5])
+			position += 6
+		case 0x06:
+			if position+4 > len(packet) {
+				return state, fmt.Errorf("%w: RLE offsets", ErrInvalidSPU)
+			}
+			state.offsetEven = int(binary.BigEndian.Uint16(packet[position : position+2]))
+			state.offsetOdd = int(binary.BigEndian.Uint16(packet[position+2 : position+4]))
+			position += 4
+		case 0xff:
+			return state, nil
+		default:
+			return state, fmt.Errorf("%w: command 0x%02x", ErrInvalidSPU, command)
+		}
+	}
+	return state, fmt.Errorf("%w: unterminated command sequence", ErrInvalidSPU)
+}
+
+func decodeField(packet []byte, offset, width, height, parity int, pixels []uint8) error {
+	if offset < 4 || offset >= len(packet) {
+		return fmt.Errorf("%w: RLE offset %d", ErrInvalidSPU, offset)
+	}
+	reader := nibbleReader{data: packet, nibble: offset * 2}
+	for y := parity; y < height; y += 2 {
+		for x := 0; x < width; {
+			length, value, err := reader.run()
+			if err != nil {
+				return err
+			}
+			if length == 0 {
+				length = width - x
+			}
+			if length > width-x {
+				return fmt.Errorf("%w: RLE crosses scanline", ErrInvalidSPU)
+			}
+			for column := 0; column < length; column++ {
+				pixels[y*width+x+column] = value
+			}
+			x += length
+		}
+		reader.alignByte()
+	}
+	return nil
+}
+
+type nibbleReader struct {
+	data   []byte
+	nibble int
+}
+
+func (r *nibbleReader) read() (uint16, error) {
+	if r.nibble >= len(r.data)*2 {
+		return 0, fmt.Errorf("%w: truncated RLE", ErrInvalidSPU)
+	}
+	value := r.data[r.nibble/2]
+	if r.nibble%2 == 0 {
+		value >>= 4
+	} else {
+		value &= 0x0f
+	}
+	r.nibble++
+	return uint16(value), nil
+}
+
+func (r *nibbleReader) run() (int, uint8, error) {
+	var value uint16
+	for threshold := uint16(1); value < threshold && threshold <= 0x40; threshold <<= 2 {
+		nibble, err := r.read()
+		if err != nil {
+			return 0, 0, err
+		}
+		value = value<<4 | nibble
+	}
+	colorIndex := uint8(value & 3)
+	if value < 4 {
+		return 0, colorIndex, nil
+	}
+	return int(value >> 2), colorIndex, nil
+}
+
+func (r *nibbleReader) alignByte() {
+	if r.nibble%2 != 0 {
+		r.nibble++
+	}
+}
+
+func clutColor(value uint32, alpha uint8) color.NRGBA {
+	y := boundedByte((value >> 16) & 0xff)
+	cr := boundedByte((value >> 8) & 0xff)
+	cb := boundedByte(value & 0xff)
+	r, g, b := color.YCbCrToRGB(y, cb, cr)
+	return color.NRGBA{R: r, G: g, B: b, A: alpha}
+}
+
+// Composite overlays subpicture pixels and an optional selected-button
+// highlight onto a decoded background frame. It returns a new NRGBA image and
+// does not mutate background.
+func Composite(background image.Image, overlay Overlay, clut [16]uint32, highlight *Highlight) *image.NRGBA {
+	bounds := background.Bounds()
+	result := image.NewNRGBA(bounds)
+	draw.Draw(result, bounds, background, bounds.Min, draw.Src)
+	clip := overlay.Bounds.Intersect(bounds)
+	for y := clip.Min.Y; y < clip.Max.Y; y++ {
+		for x := clip.Min.X; x < clip.Max.X; x++ {
+			index := overlay.Pixels[(y-overlay.Bounds.Min.Y)*overlay.Stride+x-overlay.Bounds.Min.X]
+			pixel := overlay.Palette[index]
+			if highlight != nil && image.Pt(x, y).In(highlight.Bounds) {
+				colorIndex, alpha := highlightEntry(highlight.Palette, index)
+				pixel = clutColor(clut[colorIndex], alpha*17)
+			}
+			blendNRGBA(result, x, y, pixel)
+		}
+	}
+	return result
+}
+
+func highlightEntry(palette uint32, index uint8) (uint8, uint8) {
+	shift := index * 4
+	alpha := boundedByte((palette >> shift) & 0x0f)
+	colorIndex := boundedByte((palette >> (16 + shift)) & 0x0f)
+	return colorIndex, alpha
+}
+
+func blendNRGBA(target *image.NRGBA, x, y int, source color.NRGBA) {
+	if source.A == 0 {
+		return
+	}
+	if source.A == 0xff {
+		target.SetNRGBA(x, y, source)
+		return
+	}
+	destination := target.NRGBAAt(x, y)
+	sa := uint32(source.A)
+	da := uint32(destination.A) * (255 - sa) / 255
+	outA := sa + da
+	if outA == 0 {
+		return
+	}
+	blend := func(src, dst uint8) uint8 {
+		return boundedByte((uint32(src)*sa + uint32(dst)*da) / outA)
+	}
+	target.SetNRGBA(x, y, color.NRGBA{
+		R: blend(source.R, destination.R),
+		G: blend(source.G, destination.G),
+		B: blend(source.B, destination.B),
+		A: boundedByte(outA),
+	})
+}
+
+func boundedByte(value uint32) uint8 {
+	if value > 0xff {
+		panic("DVD subpicture byte conversion exceeded 8 bits")
+	}
+	return uint8(value)
+}

--- a/internal/dvdvideo/spu/spu_test.go
+++ b/internal/dvdvideo/spu/spu_test.go
@@ -1,0 +1,124 @@
+package spu
+
+import (
+	"encoding/binary"
+	"image"
+	"image/color"
+	"testing"
+)
+
+func TestDecodeTwoFieldRLE(t *testing.T) {
+	packet := syntheticPacket()
+	var clut [16]uint32
+	clut[1] = 0x00808080
+	clut[2] = 0x00c08080
+	overlay, err := Decode(packet, clut, ^uint16(0))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	want := []uint8{1, 1, 2, 2}
+	for index := range want {
+		if overlay.Pixels[index] != want[index] {
+			t.Fatalf("pixels = %v, want %v", overlay.Pixels, want)
+		}
+	}
+	if !overlay.Menu || overlay.Bounds.Dx() != 2 || overlay.Bounds.Dy() != 2 {
+		t.Fatalf("overlay = %+v", overlay)
+	}
+}
+
+func TestReassemblerJoinsFragments(t *testing.T) {
+	packet := syntheticPacket()
+	var reassembler Reassembler
+	complete, err := reassembler.Push(0x20, packet[:5])
+	if err != nil || len(complete) != 0 {
+		t.Fatalf("first Push = %v, %v", complete, err)
+	}
+	complete, err = reassembler.Push(0x20, packet[5:])
+	if err != nil {
+		t.Fatalf("second Push: %v", err)
+	}
+	if len(complete) != 1 || len(complete[0].Data) != len(packet) {
+		t.Fatalf("complete = %+v", complete)
+	}
+}
+
+func TestCompositeAppliesHighlightPalette(t *testing.T) {
+	packet := syntheticPacket()
+	var clut [16]uint32
+	clut[1] = 0x00808080
+	clut[2] = 0x00c08080
+	clut[3] = 0x00ff8080
+	overlay, err := Decode(packet, clut, ^uint16(0))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	background := color.NRGBA{A: 0xff}
+	image := newSolid(2, 2, background)
+	highlight := Highlight{Bounds: overlay.Bounds, Palette: 0x3333ffff}
+	result := Composite(image, overlay, clut, &highlight)
+	if result.NRGBAAt(0, 0) == overlay.Palette[1] {
+		t.Fatal("highlight palette was not applied")
+	}
+}
+
+func FuzzDecode(f *testing.F) {
+	f.Add(syntheticPacket())
+	f.Add([]byte{0, 4, 0, 4})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		_, _ = Decode(data, [16]uint32{}, ^uint16(0))
+	})
+}
+
+func syntheticPacket() []byte {
+	packet := make([]byte, 31)
+	binary.BigEndian.PutUint16(packet[0:2], uint16(len(packet)))
+	binary.BigEndian.PutUint16(packet[2:4], 6)
+	packet[4] = 0x90
+	packet[5] = 0xa0
+	binary.BigEndian.PutUint16(packet[8:10], 6)
+	position := 10
+	packet[position] = 0x00
+	position++
+	packet[position] = 0x01
+	position++
+	packet[position] = 0x03
+	packet[position+1] = 0x32
+	packet[position+2] = 0x10
+	position += 3
+	packet[position] = 0x04
+	packet[position+1] = 0xff
+	packet[position+2] = 0xff
+	position += 3
+	packet[position] = 0x05
+	packet[position+1] = 0
+	packet[position+2] = 0
+	packet[position+3] = 1
+	packet[position+4] = 0
+	packet[position+5] = 0
+	packet[position+6] = 1
+	position += 7
+	packet[position] = 0x06
+	binary.BigEndian.PutUint16(packet[position+1:position+3], 4)
+	binary.BigEndian.PutUint16(packet[position+3:position+5], 5)
+	position += 5
+	packet[position] = 0xff
+	return packet
+}
+
+type solidImage struct {
+	pixel color.NRGBA
+	rect  imageRectangle
+}
+
+type imageRectangle struct{ maxX, maxY int }
+
+func newSolid(width, height int, pixel color.NRGBA) solidImage {
+	return solidImage{pixel: pixel, rect: imageRectangle{maxX: width, maxY: height}}
+}
+
+func (s solidImage) ColorModel() color.Model { return color.NRGBAModel }
+
+func (s solidImage) Bounds() image.Rectangle { return image.Rect(0, 0, s.rect.maxX, s.rect.maxY) }
+
+func (s solidImage) At(_, _ int) color.Color { return s.pixel }

--- a/internal/dvdvideo/vm/vm.go
+++ b/internal/dvdvideo/vm/vm.go
@@ -1,0 +1,638 @@
+// Package vm decodes and executes DVD-Video virtual-machine commands.
+//
+// The instruction layout and execution behavior in this file are derived from
+// VideoLAN libdvdnav 7.0.0 src/vm/decoder.c (commit
+// 38238caf599dc9405eddf1531c858c725015f776), licensed GPL-2.0-or-later.
+// See plans/dvd-menu-engine-proof-adr.md for provenance and scope.
+package vm
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	// GeneralRegisterCount is the number of DVD general parameter registers.
+	GeneralRegisterCount = 16
+	// SystemRegisterCount is the number of DVD system parameter registers.
+	SystemRegisterCount = 24
+	// DefaultCommandBudget bounds command evaluation when Options omits a limit.
+	DefaultCommandBudget = 100_000
+)
+
+var (
+	// ErrCommandBudget reports that evaluation exhausted its command budget.
+	ErrCommandBudget = errors.New("DVD VM command budget exceeded")
+	// ErrInvalidCommand reports a malformed instruction or invalid VM operand.
+	ErrInvalidCommand = errors.New("invalid DVD VM command")
+)
+
+// Command is one authored eight-byte DVD VM instruction.
+type Command [8]byte
+
+// LinkCommand is a navigation transition produced by a VM instruction.
+type LinkCommand uint8
+
+// LinkCommand values mirror the authored DVD link, jump, call, exit, and
+// resume operations consumed by graph traversal.
+const (
+	// LinkNoLink reports that an instruction emitted no navigation transition.
+	LinkNoLink LinkCommand = iota
+	LinkTopCell
+	LinkNextCell
+	LinkPreviousCell
+	LinkReserved4
+	LinkTopProgram
+	LinkNextProgram
+	LinkPreviousProgram
+	LinkReserved8
+	LinkTopPGC
+	LinkNextPGC
+	LinkPreviousPGC
+	LinkGoUpPGC
+	LinkTailPGC
+	LinkReserved14
+	LinkReserved15
+	LinkResume
+	LinkPGCN
+	LinkPTTN
+	LinkPGN
+	LinkCN
+	Exit
+	JumpTT
+	JumpVTSTT
+	JumpVTSPTT
+	JumpFirstPlay
+	JumpVMGMMenu
+	JumpVTSM
+	JumpVMGMPGC
+	CallFirstPlay
+	CallVMGMMenu
+	CallVTSM
+	CallVMGMPGC
+)
+
+// Link describes the target and operands produced by a link/jump/call.
+type Link struct {
+	// Command identifies the emitted navigation operation.
+	Command LinkCommand
+	// Data1 is the command-specific first operand.
+	Data1 uint16
+	// Data2 is the command-specific second operand.
+	Data2 uint16
+	// Data3 is the command-specific third operand.
+	Data3 uint16
+}
+
+// Registers is cloneable DVD VM register state.
+type Registers struct {
+	// General contains the 16 general parameter register values.
+	General [GeneralRegisterCount]uint16
+	// System contains the 24 system parameter register values.
+	System [SystemRegisterCount]uint16
+	// CounterMode marks general registers that advance from an internal origin time.
+	CounterMode   [GeneralRegisterCount]bool
+	counterOrigin [GeneralRegisterCount]time.Time
+}
+
+// Clone returns independent register state for traversal branching.
+func (r Registers) Clone() Registers { return r }
+
+// Options controls deterministic execution and resource limits.
+type Options struct {
+	// CommandBudget is the maximum number of evaluated rows; zero uses DefaultCommandBudget.
+	CommandBudget int
+	// Now supplies counter-register time; nil uses time.Now.
+	Now func() time.Time
+	// Random returns a value in [1,max]. It must be deterministic during graph
+	// discovery. Nil selects 1, the lowest valid DVD RND result.
+	Random func(upperBound uint16) uint16
+}
+
+// Result records whether command evaluation emitted a navigation transition.
+type Result struct {
+	// Link is the emitted transition when HasLink is true.
+	Link Link
+	// HasLink reports whether command evaluation emitted a transition.
+	HasLink bool
+	// Executed is the number of command rows evaluated.
+	Executed int
+}
+
+type executor struct {
+	registers *Registers
+	now       func() time.Time
+	random    func(uint16) uint16
+}
+
+// Execute evaluates an authored command table and mutates registers in place.
+// It stops at the first navigation transition and rejects nil registers,
+// invalid operands, and exhausted or negative command budgets.
+func Execute(commands []Command, registers *Registers, opts Options) (Result, error) {
+	if registers == nil {
+		return Result{}, fmt.Errorf("%w: nil registers", ErrInvalidCommand)
+	}
+	budget := opts.CommandBudget
+	if budget == 0 {
+		budget = DefaultCommandBudget
+	}
+	if budget < 0 {
+		return Result{}, fmt.Errorf("%w: negative command budget", ErrInvalidCommand)
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	random := opts.Random
+	if random == nil {
+		random = func(upperBound uint16) uint16 {
+			if upperBound == 0 {
+				return 1
+			}
+			return 1
+		}
+	}
+
+	e := executor{registers: registers, now: now, random: random}
+	executed := 0
+	for row := 0; row < len(commands); executed++ {
+		if executed >= budget {
+			return Result{Executed: executed}, ErrCommandBudget
+		}
+		line, link, hasLink, err := e.executeCommand(commands[row])
+		if err != nil {
+			return Result{Executed: executed + 1}, fmt.Errorf("DVD VM row %d: %w", row+1, err)
+		}
+		if hasLink {
+			return Result{Link: link, HasLink: true, Executed: executed + 1}, nil
+		}
+		if line > 0 {
+			if line == 256 {
+				return Result{Executed: executed + 1}, nil
+			}
+			if line > len(commands) {
+				return Result{Executed: executed + 1}, fmt.Errorf("%w: goto row %d outside table", ErrInvalidCommand, line)
+			}
+			row = line - 1
+		} else {
+			row++
+		}
+	}
+	return Result{Executed: executed}, nil
+}
+
+func (e executor) executeCommand(command Command) (int, Link, bool, error) {
+	instruction := binary.BigEndian.Uint64(command[:])
+	typeCode := bits(instruction, 63, 3)
+	var link Link
+
+	switch typeCode {
+	case 0:
+		cond, err := e.condition1(instruction)
+		if err != nil {
+			return 0, link, false, err
+		}
+		if !cond {
+			return 0, link, false, nil
+		}
+		switch bits(instruction, 51, 4) {
+		case 0:
+			return 0, link, false, nil
+		case 1:
+			return bitsInt(instruction, 7, 8), link, false, nil
+		case 2:
+			return 256, link, false, nil
+		case 3:
+			e.registers.System[13] = bits16(instruction, 11, 4)
+			return bitsInt(instruction, 7, 8), link, false, nil
+		default:
+			return 0, link, false, fmt.Errorf("%w: special opcode %d", ErrInvalidCommand, bits(instruction, 51, 4))
+		}
+	case 1:
+		if bits(instruction, 60, 1) != 0 {
+			cond, err := e.condition2(instruction)
+			if err != nil {
+				return 0, link, false, err
+			}
+			link, ok := jumpInstruction(instruction)
+			return 0, link, cond && ok, nil
+		}
+		cond, err := e.condition1(instruction)
+		if err != nil {
+			return 0, link, false, err
+		}
+		link, ok := linkInstruction(instruction)
+		return 0, link, cond && ok, nil
+	case 2:
+		cond, err := e.condition2(instruction)
+		if err != nil {
+			return 0, link, false, err
+		}
+		if err := e.systemSet(instruction, cond); err != nil {
+			return 0, link, false, err
+		}
+		if bits(instruction, 51, 4) != 0 {
+			link, ok := linkInstruction(instruction)
+			return 0, link, cond && ok, nil
+		}
+		return 0, link, false, nil
+	case 3:
+		cond, err := e.condition3(instruction)
+		if err != nil {
+			return 0, link, false, err
+		}
+		if err := e.setVersion1(instruction, cond); err != nil {
+			return 0, link, false, err
+		}
+		if bits(instruction, 51, 4) != 0 {
+			link, ok := linkInstruction(instruction)
+			return 0, link, cond && ok, nil
+		}
+		return 0, link, false, nil
+	case 4, 5, 6:
+		cond := true
+		var err error
+		if typeCode != 4 {
+			cond, err = e.condition4(instruction)
+			if err != nil {
+				return 0, link, false, err
+			}
+		}
+		if err := e.setVersion2(instruction, cond); err != nil {
+			return 0, link, false, err
+		}
+		if typeCode == 4 {
+			cond, err = e.condition4(instruction)
+			if err != nil {
+				return 0, link, false, err
+			}
+		}
+		link, ok := linkSubinstruction(instruction)
+		if typeCode == 6 {
+			cond = true
+		}
+		return 0, link, cond && ok, nil
+	case 7:
+		return 0, link, false, fmt.Errorf("%w: command type 7", ErrInvalidCommand)
+	default:
+		panic("unreachable")
+	}
+}
+
+func bits(instruction uint64, start, count uint) uint64 {
+	if count == 0 {
+		return 0
+	}
+	shift := start + 1 - count
+	mask := uint64(1)<<count - 1
+	return instruction >> shift & mask
+}
+
+func bits16(instruction uint64, start, count uint) uint16 {
+	if count > 16 {
+		panic("DVD VM bits16 width exceeds 16")
+	}
+	//nolint:gosec // bits masks the value to at most 16 bits before conversion.
+	return uint16(bits(instruction, start, count))
+}
+
+func bitsInt(instruction uint64, start, count uint) int {
+	if count > 16 {
+		panic("DVD VM bitsInt width exceeds bounded instruction fields")
+	}
+	//nolint:gosec // bits masks to at most 16 bits, which fits int on every target.
+	return int(bits(instruction, start, count))
+}
+
+func (e executor) general(index uint64) (uint16, error) {
+	if index >= GeneralRegisterCount {
+		return 0, fmt.Errorf("%w: general register %d", ErrInvalidCommand, index)
+	}
+	if e.registers.CounterMode[index] {
+		origin := e.registers.counterOrigin[index]
+		if origin.IsZero() {
+			origin = e.now()
+		}
+		seconds := e.now().Sub(origin) / time.Second
+		//nolint:gosec // DVD counters intentionally retain the low 16 elapsed-second bits.
+		value := uint16(uint64(seconds) & 0xffff)
+		e.registers.General[index] = value
+		return value, nil
+	}
+	return e.registers.General[index], nil
+}
+
+func (e executor) setGeneral(index uint64, value uint16) error {
+	if index >= GeneralRegisterCount {
+		return fmt.Errorf("%w: general register %d", ErrInvalidCommand, index)
+	}
+	if e.registers.CounterMode[index] {
+		e.registers.counterOrigin[index] = e.now().Add(-time.Duration(value) * time.Second)
+	}
+	e.registers.General[index] = value
+	return nil
+}
+
+func (e executor) register(code uint64) (uint16, error) {
+	if code&0x80 != 0 {
+		index := code & 0x1f
+		if index >= SystemRegisterCount {
+			return 0, fmt.Errorf("%w: system register %d", ErrInvalidCommand, index)
+		}
+		return e.registers.System[index], nil
+	}
+	return e.general(code & 0x0f)
+}
+
+func (e executor) registerOrData(instruction uint64, immediate, start uint) (uint16, error) {
+	if bits(instruction, immediate, 1) != 0 {
+		return bits16(instruction, start, 16), nil
+	}
+	return e.register(bits(instruction, start-8, 8))
+}
+
+func (e executor) generalOrData(instruction uint64, immediate, start uint) (uint16, error) {
+	if bits(instruction, immediate, 1) != 0 {
+		return bits16(instruction, start-1, 7), nil
+	}
+	return e.general(bits(instruction, start-4, 4))
+}
+
+func compare(op uint64, left, right uint16) (bool, error) {
+	switch op {
+	case 0:
+		return true, nil
+	case 1:
+		return left&right != 0, nil
+	case 2:
+		return left == right, nil
+	case 3:
+		return left != right, nil
+	case 4:
+		return left >= right, nil
+	case 5:
+		return left > right, nil
+	case 6:
+		return left <= right, nil
+	case 7:
+		return left < right, nil
+	default:
+		return false, fmt.Errorf("%w: comparison opcode %d", ErrInvalidCommand, op)
+	}
+}
+
+func (e executor) condition1(instruction uint64) (bool, error) {
+	op := bits(instruction, 54, 3)
+	if op == 0 {
+		return true, nil
+	}
+	left, err := e.register(bits(instruction, 39, 8))
+	if err != nil {
+		return false, err
+	}
+	right, err := e.registerOrData(instruction, 55, 31)
+	if err != nil {
+		return false, err
+	}
+	return compare(op, left, right)
+}
+
+func (e executor) condition2(instruction uint64) (bool, error) {
+	op := bits(instruction, 54, 3)
+	if op == 0 {
+		return true, nil
+	}
+	left, err := e.register(bits(instruction, 15, 8))
+	if err != nil {
+		return false, err
+	}
+	right, err := e.register(bits(instruction, 7, 8))
+	if err != nil {
+		return false, err
+	}
+	return compare(op, left, right)
+}
+
+func (e executor) condition3(instruction uint64) (bool, error) {
+	op := bits(instruction, 54, 3)
+	if op == 0 {
+		return true, nil
+	}
+	left, err := e.register(bits(instruction, 47, 8))
+	if err != nil {
+		return false, err
+	}
+	right, err := e.registerOrData(instruction, 55, 15)
+	if err != nil {
+		return false, err
+	}
+	return compare(op, left, right)
+}
+
+func (e executor) condition4(instruction uint64) (bool, error) {
+	op := bits(instruction, 54, 3)
+	if op == 0 {
+		return true, nil
+	}
+	left, err := e.register(bits(instruction, 51, 4))
+	if err != nil {
+		return false, err
+	}
+	right, err := e.registerOrData(instruction, 55, 31)
+	if err != nil {
+		return false, err
+	}
+	return compare(op, left, right)
+}
+
+func linkSubinstruction(instruction uint64) (Link, bool) {
+	op := bits(instruction, 4, 5)
+	if op > uint64(LinkResume) {
+		return Link{}, false
+	}
+	return Link{Command: LinkCommand(op), Data1: bits16(instruction, 15, 6)}, op != 0
+}
+
+func linkInstruction(instruction uint64) (Link, bool) {
+	switch bits(instruction, 51, 4) {
+	case 1:
+		return linkSubinstruction(instruction)
+	case 4:
+		return Link{Command: LinkPGCN, Data1: bits16(instruction, 14, 15)}, true
+	case 5:
+		return Link{Command: LinkPTTN, Data1: bits16(instruction, 9, 10), Data2: bits16(instruction, 15, 6)}, true
+	case 6:
+		return Link{Command: LinkPGN, Data1: bits16(instruction, 6, 7), Data2: bits16(instruction, 15, 6)}, true
+	case 7:
+		return Link{Command: LinkCN, Data1: bits16(instruction, 7, 8), Data2: bits16(instruction, 15, 6)}, true
+	default:
+		return Link{}, false
+	}
+}
+
+func jumpInstruction(instruction uint64) (Link, bool) {
+	switch bits(instruction, 51, 4) {
+	case 1:
+		return Link{Command: Exit}, true
+	case 2:
+		return Link{Command: JumpTT, Data1: bits16(instruction, 22, 7)}, true
+	case 3:
+		return Link{Command: JumpVTSTT, Data1: bits16(instruction, 22, 7)}, true
+	case 5:
+		return Link{Command: JumpVTSPTT, Data1: bits16(instruction, 22, 7), Data2: bits16(instruction, 41, 10)}, true
+	case 6:
+		switch bits(instruction, 23, 2) {
+		case 0:
+			return Link{Command: JumpFirstPlay}, true
+		case 1:
+			return Link{Command: JumpVMGMMenu, Data1: bits16(instruction, 19, 4)}, true
+		case 2:
+			return Link{Command: JumpVTSM, Data1: bits16(instruction, 31, 8), Data2: bits16(instruction, 39, 8), Data3: bits16(instruction, 19, 4)}, true
+		case 3:
+			return Link{Command: JumpVMGMPGC, Data1: bits16(instruction, 46, 15)}, true
+		}
+	case 8:
+		resume := bits16(instruction, 31, 8)
+		switch bits(instruction, 23, 2) {
+		case 0:
+			return Link{Command: CallFirstPlay, Data1: resume}, true
+		case 1:
+			return Link{Command: CallVMGMMenu, Data1: bits16(instruction, 19, 4), Data2: resume}, true
+		case 2:
+			return Link{Command: CallVTSM, Data1: bits16(instruction, 19, 4), Data2: resume}, true
+		case 3:
+			return Link{Command: CallVMGMPGC, Data1: bits16(instruction, 46, 15), Data2: resume}, true
+		}
+	}
+	return Link{}, false
+}
+
+func (e executor) systemSet(instruction uint64, cond bool) error {
+	switch bits(instruction, 59, 4) {
+	case 1:
+		for index := uint64(1); index <= 3; index++ {
+			if bits(instruction, uint(63-(2+index)*8), 1) == 0 {
+				continue
+			}
+			value, err := e.generalOrData(instruction, 60, uint(47-index*8))
+			if err != nil {
+				return err
+			}
+			if cond {
+				e.registers.System[index] = value
+			}
+		}
+	case 2:
+		value, err := e.registerOrData(instruction, 60, 47)
+		if err != nil {
+			return err
+		}
+		if cond {
+			e.registers.System[9] = value
+			e.registers.System[10] = bits16(instruction, 23, 8)
+		}
+	case 3:
+		value, err := e.registerOrData(instruction, 60, 47)
+		if err != nil {
+			return err
+		}
+		index := bits(instruction, 19, 4)
+		e.registers.CounterMode[index] = bits(instruction, 23, 1) != 0
+		if cond {
+			return e.setGeneral(index, value)
+		}
+	case 6:
+		value, err := e.registerOrData(instruction, 60, 31)
+		if err != nil {
+			return err
+		}
+		if cond {
+			e.registers.System[8] = value
+		}
+	case 0:
+		return nil
+	default:
+		return fmt.Errorf("%w: system-set opcode %d", ErrInvalidCommand, bits(instruction, 59, 4))
+	}
+	return nil
+}
+
+func (e executor) setVersion1(instruction uint64, cond bool) error {
+	value, err := e.registerOrData(instruction, 60, 31)
+	if err != nil || !cond {
+		return err
+	}
+	return e.setOperation(bits(instruction, 59, 4), bits(instruction, 35, 4), bits(instruction, 19, 4), value)
+}
+
+func (e executor) setVersion2(instruction uint64, cond bool) error {
+	value, err := e.registerOrData(instruction, 60, 47)
+	if err != nil || !cond {
+		return err
+	}
+	return e.setOperation(bits(instruction, 59, 4), bits(instruction, 51, 4), bits(instruction, 35, 4), value)
+}
+
+func (e executor) setOperation(op, register, register2 uint64, data uint16) error {
+	current, err := e.general(register)
+	if err != nil {
+		return err
+	}
+	switch op {
+	case 1:
+		return e.setGeneral(register, data)
+	case 2:
+		if err := e.setGeneral(register2, current); err != nil {
+			return err
+		}
+		return e.setGeneral(register, data)
+	case 3:
+		value := min(uint32(current)+uint32(data), 0xffff)
+		return e.setGeneral(register, boundedUint16(value))
+	case 4:
+		if data > current {
+			return e.setGeneral(register, 0)
+		}
+		return e.setGeneral(register, current-data)
+	case 5:
+		value := min(uint32(current)*uint32(data), 0xffff)
+		return e.setGeneral(register, boundedUint16(value))
+	case 6:
+		if data == 0 {
+			return e.setGeneral(register, 0xffff)
+		}
+		return e.setGeneral(register, current/data)
+	case 7:
+		if data == 0 {
+			return e.setGeneral(register, 0xffff)
+		}
+		return e.setGeneral(register, current%data)
+	case 8:
+		value := e.random(data)
+		if data == 0 {
+			value = 1
+		} else if value == 0 || value > data {
+			return fmt.Errorf("%w: random result %d outside [1,%d]", ErrInvalidCommand, value, data)
+		}
+		return e.setGeneral(register, value)
+	case 9:
+		return e.setGeneral(register, current&data)
+	case 10:
+		return e.setGeneral(register, current|data)
+	case 11:
+		return e.setGeneral(register, current^data)
+	case 0:
+		return nil
+	default:
+		return fmt.Errorf("%w: set opcode %d", ErrInvalidCommand, op)
+	}
+}
+
+func boundedUint16(value uint32) uint16 {
+	if value > 0xffff {
+		panic("DVD VM value outside uint16 range")
+	}
+	return uint16(value)
+}

--- a/internal/dvdvideo/vm/vm.go
+++ b/internal/dvdvideo/vm/vm.go
@@ -313,7 +313,8 @@ func (e executor) general(index uint64) (uint16, error) {
 	if e.registers.CounterMode[index] {
 		origin := e.registers.counterOrigin[index]
 		if origin.IsZero() {
-			origin = e.now()
+			e.registers.counterOrigin[index] = e.now()
+			origin = e.registers.counterOrigin[index]
 		}
 		seconds := e.now().Sub(origin) / time.Second
 		//nolint:gosec // DVD counters intentionally retain the low 16 elapsed-second bits.

--- a/internal/dvdvideo/vm/vm_test.go
+++ b/internal/dvdvideo/vm/vm_test.go
@@ -1,0 +1,90 @@
+package vm
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestExecuteSetAndJump(t *testing.T) {
+	set := makeCommand(
+		field{63, 3, 3},
+		field{60, 1, 1},
+		field{59, 4, 1},
+		field{35, 4, 2},
+		field{31, 16, 42},
+	)
+	jump := makeCommand(
+		field{63, 3, 1},
+		field{60, 1, 1},
+		field{51, 4, 2},
+		field{22, 7, 7},
+	)
+
+	var registers Registers
+	result, err := Execute([]Command{set, jump}, &registers, Options{})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if registers.General[2] != 42 {
+		t.Fatalf("GPRM[2] = %d, want 42", registers.General[2])
+	}
+	if !result.HasLink || result.Link.Command != JumpTT || result.Link.Data1 != 7 {
+		t.Fatalf("result link = %+v, want JumpTT 7", result)
+	}
+}
+
+func TestExecuteGotoBudget(t *testing.T) {
+	loop := makeCommand(field{51, 4, 1}, field{7, 8, 1})
+	var registers Registers
+	result, err := Execute([]Command{loop}, &registers, Options{CommandBudget: 3})
+	if !errors.Is(err, ErrCommandBudget) {
+		t.Fatalf("Execute error = %v, want ErrCommandBudget", err)
+	}
+	if result.Executed != 3 {
+		t.Fatalf("Executed = %d, want 3", result.Executed)
+	}
+}
+
+func TestRegistersCloneIsIndependent(t *testing.T) {
+	registers := Registers{}
+	registers.General[1] = 10
+	clone := registers.Clone()
+	clone.General[1] = 20
+	if registers.General[1] != 10 {
+		t.Fatalf("parent GPRM mutated: %d", registers.General[1])
+	}
+}
+
+func FuzzExecute(f *testing.F) {
+	f.Add([]byte{0, 0, 0, 0, 0, 0, 0, 0})
+	f.Add([]byte{0x30, 0x01, 0, 0, 0, 0, 0, 1})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) != 8 {
+			t.Skip()
+		}
+		var command Command
+		copy(command[:], data)
+		var registers Registers
+		_, _ = Execute([]Command{command}, &registers, Options{CommandBudget: 2})
+	})
+}
+
+type field struct {
+	start uint
+	count uint
+	value uint64
+}
+
+func makeCommand(fields ...field) Command {
+	var instruction uint64
+	for _, item := range fields {
+		shift := item.start + 1 - item.count
+		mask := uint64(1)<<item.count - 1
+		instruction |= item.value & mask << shift
+	}
+	var command Command
+	for index := range command {
+		command[index] = byte(instruction >> (56 - 8*index))
+	}
+	return command
+}

--- a/internal/dvdvideo/vm/vm_test.go
+++ b/internal/dvdvideo/vm/vm_test.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestExecuteSetAndJump(t *testing.T) {
@@ -52,6 +53,33 @@ func TestRegistersCloneIsIndependent(t *testing.T) {
 	clone.General[1] = 20
 	if registers.General[1] != 10 {
 		t.Fatalf("parent GPRM mutated: %d", registers.General[1])
+	}
+}
+
+func TestGeneralCounterPersistsLazyOrigin(t *testing.T) {
+	var registers Registers
+	registers.CounterMode[2] = true
+	current := time.Unix(100, 0)
+	executor := executor{
+		registers: &registers,
+		now:       func() time.Time { return current },
+	}
+
+	first, err := executor.general(2)
+	if err != nil {
+		t.Fatalf("first general read: %v", err)
+	}
+	if first != 0 || !registers.counterOrigin[2].Equal(current) {
+		t.Fatalf("first counter read = %d origin=%v", first, registers.counterOrigin[2])
+	}
+
+	current = current.Add(5 * time.Second)
+	second, err := executor.general(2)
+	if err != nil {
+		t.Fatalf("second general read: %v", err)
+	}
+	if second != 5 || registers.General[2] != 5 {
+		t.Fatalf("second counter read = %d register=%d, want 5", second, registers.General[2])
 	}
 }
 

--- a/internal/guiapp/app.go
+++ b/internal/guiapp/app.go
@@ -64,6 +64,9 @@ type App struct {
 	uploadMu    sync.Mutex
 	uploads     map[string]*trackerUploadJob
 	uploadWG    sync.WaitGroup
+	dvdMenuMu   sync.Mutex
+	dvdMenus    map[string]*dvdMenuCaptureJob
+	dvdMenuWG   sync.WaitGroup
 
 	sharedCookieMigrator func(context.Context, string, api.Logger) error
 }
@@ -136,6 +139,7 @@ func NewAppWithContext(ctx context.Context, configPath string, configProvided bo
 		streams:     make(map[string]*logStreamSession),
 		dupes:       make(map[string]*dupeCheckJob),
 		uploads:     make(map[string]*trackerUploadJob),
+		dvdMenus:    make(map[string]*dvdMenuCaptureJob),
 	}, nil
 }
 
@@ -147,6 +151,7 @@ func (a *App) shutdown(_ context.Context) {
 	a.stopAllLogStreams()
 	a.stopAllDupeJobs()
 	a.stopAllUploadJobs()
+	a.stopAllDVDMenuJobs()
 	rt := a.runtimeSnapshot()
 	if rt.core != nil {
 		_ = rt.core.Close()
@@ -1214,11 +1219,15 @@ func (a *App) GetConfig() (string, error) {
 	return wrapGUIResult(config.ExportToJSON(normalized))
 }
 
+// GetApplicationInfo returns build/runtime metadata plus a bounded, path-free
+// DVD menu capability probe for frontend diagnostics.
 func (a *App) GetApplicationInfo() (api.ApplicationInfo, error) {
 	if a == nil {
 		return api.ApplicationInfo{}, errors.New("app not initialized")
 	}
-	return api.CurrentApplicationInfo(), nil
+	rt := a.runtimeSnapshot()
+	provider, _ := rt.core.(api.DVDMenuCapabilityProvider)
+	return guishared.CurrentApplicationInfo(a.runtimeContext(), provider), nil
 }
 
 func (a *App) GetDefaultConfig() (string, error) {

--- a/internal/guiapp/dvd_menu_jobs.go
+++ b/internal/guiapp/dvd_menu_jobs.go
@@ -15,6 +15,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 
 	"github.com/autobrr/upbrr/internal/guishared"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -245,7 +246,7 @@ func (a *App) runDVDMenuCaptureJob(ctx context.Context, eventCtx context.Context
 			job.status = "failed"
 			job.phase = "failed"
 			job.message = "DVD menu capture failed."
-			job.errorMessage = err.Error()
+			job.errorMessage = redaction.RedactValue(err.Error(), nil)
 		}
 	} else {
 		job.status = "completed"

--- a/internal/guiapp/dvd_menu_jobs.go
+++ b/internal/guiapp/dvd_menu_jobs.go
@@ -1,0 +1,368 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package guiapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+
+	"github.com/autobrr/upbrr/internal/guishared"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+const (
+	dvdMenuCaptureEventPrefix              = "dvdmenu:job:"
+	errDVDMenuCaptureRequiresMetadataCache = "DVD menu capture requires metadata preview"
+	dvdMenuSnapshotThrottle                = 150 * time.Millisecond
+)
+
+// dvdMenuCaptureJob owns one isolated core/logger snapshot and its synchronized
+// frontend-visible progress state.
+type dvdMenuCaptureJob struct {
+	mu             sync.Mutex
+	cleanupOnce    sync.Once
+	id             string
+	sourcePath     string
+	uploadOptions  api.UploadOptions
+	core           api.Core
+	logger         interface{ Close() error }
+	overrides      api.ExternalIDOverrides
+	nameOverrides  api.ReleaseNameOverrides
+	status         string
+	phase          string
+	message        string
+	discovered     int
+	visitedStates  int
+	visitedButtons int
+	captured       int
+	warnings       int
+	result         api.DVDMenuCaptureResult
+	errorMessage   string
+	startedAt      time.Time
+	finishedAt     time.Time
+	lastEmit       time.Time
+	cancel         context.CancelFunc
+}
+
+// StartDVDMenuCapture starts a background capture using the current prepared
+// GUI metadata and returns its job ID. Progress is emitted on
+// dvdmenu:job:<jobID>; setup errors reject the frontend call.
+func (a *App) StartDVDMenuCapture(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) (string, error) {
+	rt, err := a.requireRuntime()
+	if err != nil {
+		return "", err
+	}
+	trimmedPath := strings.TrimSpace(path)
+	if trimmedPath == "" {
+		return "", errors.New("path is required")
+	}
+	req := newDVDMenuRequest(trimmedPath, overrides, nameOverrides, rt.baseUploadOptions())
+	baseCtx := a.runtimeContext()
+
+	var preparedMeta api.PreparedMetadata
+	preparedMetaFound := false
+	if exporter, ok := rt.core.(guishared.PreparedMetaExporter); ok {
+		preparedMeta, preparedMetaFound, err = exporter.ExportGUICachedPreparedMeta(baseCtx, req)
+		if err != nil {
+			return "", fmt.Errorf("DVD menu capture metadata preview cache: %w", err)
+		}
+		if !preparedMetaFound {
+			return "", errors.New(errDVDMenuCaptureRequiresMetadataCache)
+		}
+	}
+
+	runCore, runLogger, err := a.buildRunCoreFromSnapshot(rt, runOptions{})
+	if err != nil {
+		return "", err
+	}
+	if preparedMetaFound {
+		importer, ok := runCore.(guishared.PreparedMetaImporter)
+		if !ok {
+			_ = runCore.Close()
+			_ = runLogger.Close()
+			return "", errors.New("DVD menu capture metadata preview cache: run core cannot import prepared metadata")
+		}
+		if err := importer.ImportPreparedMetadataForGUI(baseCtx, req, preparedMeta); err != nil {
+			_ = runCore.Close()
+			_ = runLogger.Close()
+			return "", fmt.Errorf("DVD menu capture metadata preview cache: %w", err)
+		}
+	}
+
+	job := &dvdMenuCaptureJob{
+		id:            randomJobID(),
+		sourcePath:    trimmedPath,
+		uploadOptions: req.Options,
+		core:          runCore,
+		logger:        runLogger,
+		overrides:     overrides,
+		nameOverrides: nameOverrides,
+		status:        "queued",
+		phase:         "queued",
+		message:       "DVD menu capture queued.",
+		startedAt:     time.Now().UTC(),
+	}
+	jobCtx, cancel := context.WithCancel(baseCtx)
+	job.cancel = cancel
+
+	a.dvdMenuMu.Lock()
+	if a.dvdMenus == nil {
+		a.dvdMenus = make(map[string]*dvdMenuCaptureJob)
+	}
+	a.dvdMenuWG.Add(1)
+	a.dvdMenus[job.id] = job
+	a.dvdMenuMu.Unlock()
+	a.emitDVDMenuCaptureSnapshot(baseCtx, job, true)
+	go func() {
+		defer a.dvdMenuWG.Done()
+		defer cancel()
+		a.runDVDMenuCaptureJob(jobCtx, baseCtx, job)
+	}()
+	return job.id, nil
+}
+
+// GetDVDMenuCaptureSnapshot returns the current capture job state. It rejects
+// unknown or expired job IDs.
+func (a *App) GetDVDMenuCaptureSnapshot(jobID string) (api.DVDMenuCaptureSnapshot, error) {
+	if a == nil {
+		return api.DVDMenuCaptureSnapshot{}, errors.New("app not initialized")
+	}
+	job := a.getDVDMenuCaptureJob(strings.TrimSpace(jobID))
+	if job == nil {
+		return api.DVDMenuCaptureSnapshot{}, errors.New("DVD menu capture job not found")
+	}
+	return buildDVDMenuCaptureSnapshot(job), nil
+}
+
+// CancelDVDMenuCapture requests cancellation for an existing capture job.
+// Completion is asynchronous and is reflected in later snapshots.
+func (a *App) CancelDVDMenuCapture(jobID string) error {
+	if a == nil {
+		return errors.New("app not initialized")
+	}
+	job := a.getDVDMenuCaptureJob(strings.TrimSpace(jobID))
+	if job == nil {
+		return errors.New("DVD menu capture job not found")
+	}
+	job.mu.Lock()
+	cancel := job.cancel
+	job.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	return nil
+}
+
+// ListDVDMenuScreenshots returns persisted manual and automatic menu images for
+// one host filesystem source path. The call requires prepared GUI metadata.
+func (a *App) ListDVDMenuScreenshots(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) ([]api.ScreenshotImage, error) {
+	rt, err := a.requireRuntime()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(a.runtimeContext(), previewTimeout)
+	defer cancel()
+	req := newDVDMenuRequest(path, overrides, nameOverrides, rt.baseUploadOptions())
+	return wrapGUIResult(rt.core.ListDVDMenuScreenshots(ctx, req))
+}
+
+// DeleteDVDMenuScreenshot removes one persisted image from the prepared
+// release's managed directory and local records. Remote-host assets remain.
+func (a *App) DeleteDVDMenuScreenshot(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, imagePath string) error {
+	rt, err := a.requireRuntime()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(a.runtimeContext(), previewTimeout)
+	defer cancel()
+	req := newDVDMenuRequest(path, overrides, nameOverrides, rt.baseUploadOptions())
+	return wrapGUIError(rt.core.DeleteDVDMenuScreenshot(ctx, req, imagePath))
+}
+
+func newDVDMenuRequest(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, options api.UploadOptions) api.Request {
+	return api.Request{
+		Paths:                []string{strings.TrimSpace(path)},
+		Mode:                 api.ModeGUI,
+		Options:              options,
+		ExternalIDOverrides:  overrides,
+		ReleaseNameOverrides: nameOverrides,
+	}
+}
+
+// runDVDMenuCaptureJob owns the queued-to-terminal lifecycle and releases its
+// per-run core/logger resources exactly once.
+func (a *App) runDVDMenuCaptureJob(ctx context.Context, eventCtx context.Context, job *dvdMenuCaptureJob) {
+	if job != nil {
+		defer func() { _ = job.closeResources() }()
+	}
+	if a == nil || job == nil || job.core == nil {
+		return
+	}
+	job.mu.Lock()
+	job.status = "running"
+	job.phase = "preflight"
+	job.message = "Checking DVD menu capture support."
+	job.mu.Unlock()
+	a.emitDVDMenuCaptureSnapshot(eventCtx, job, true)
+
+	progressCtx := api.WithDVDMenuProgressReporter(ctx, func(update api.DVDMenuProgressUpdate) {
+		a.applyDVDMenuCaptureProgress(eventCtx, job, update)
+	})
+	req := newDVDMenuRequest(job.sourcePath, job.overrides, job.nameOverrides, job.uploadOptions)
+	result, err := job.core.CaptureDVDMenus(progressCtx, req)
+
+	job.mu.Lock()
+	job.result = result
+	job.finishedAt = time.Now().UTC()
+	job.cancel = nil
+	job.discovered = result.DiscoveredMenus
+	job.visitedStates = result.VisitedStates
+	job.visitedButtons = result.VisitedButtons
+	job.captured = len(result.Images)
+	job.warnings = len(result.Warnings)
+	if err != nil {
+		if ctx.Err() != nil {
+			job.status = "canceled"
+			job.phase = "canceled"
+			job.message = "DVD menu capture canceled."
+			job.errorMessage = "DVD menu capture canceled"
+		} else {
+			job.status = "failed"
+			job.phase = "failed"
+			job.message = "DVD menu capture failed."
+			job.errorMessage = err.Error()
+		}
+	} else {
+		job.status = "completed"
+		job.phase = "complete"
+		job.message = "DVD menu capture finished."
+		job.errorMessage = ""
+	}
+	job.mu.Unlock()
+	a.emitDVDMenuCaptureSnapshot(eventCtx, job, true)
+}
+
+func (a *App) applyDVDMenuCaptureProgress(ctx context.Context, job *dvdMenuCaptureJob, update api.DVDMenuProgressUpdate) {
+	job.mu.Lock()
+	if strings.TrimSpace(update.Phase) != "" {
+		job.phase = strings.TrimSpace(update.Phase)
+	}
+	if strings.TrimSpace(update.Message) != "" {
+		job.message = strings.TrimSpace(update.Message)
+	}
+	job.discovered = update.DiscoveredMenus
+	job.visitedStates = update.VisitedStates
+	job.visitedButtons = update.VisitedButtons
+	job.captured = update.CapturedCount
+	job.warnings = update.WarningCount
+	job.mu.Unlock()
+	a.emitDVDMenuCaptureSnapshot(ctx, job, false)
+}
+
+// emitDVDMenuCaptureSnapshot publishes a throttled Wails event; force bypasses
+// throttling for queued and terminal transitions.
+func (a *App) emitDVDMenuCaptureSnapshot(ctx context.Context, job *dvdMenuCaptureJob, force bool) {
+	if a == nil || ctx == nil || job == nil || ctx.Value("events") == nil {
+		return
+	}
+	job.mu.Lock()
+	if !force && time.Since(job.lastEmit) < dvdMenuSnapshotThrottle {
+		job.mu.Unlock()
+		return
+	}
+	job.lastEmit = time.Now()
+	job.mu.Unlock()
+	defer func() { _ = recover() }()
+	runtime.EventsEmit(ctx, dvdMenuCaptureEventPrefix+job.id, buildDVDMenuCaptureSnapshot(job))
+}
+
+func buildDVDMenuCaptureSnapshot(job *dvdMenuCaptureJob) api.DVDMenuCaptureSnapshot {
+	job.mu.Lock()
+	defer job.mu.Unlock()
+	return api.DVDMenuCaptureSnapshot{
+		JobID:           job.id,
+		SourcePath:      job.sourcePath,
+		Status:          job.status,
+		Phase:           job.phase,
+		Message:         job.message,
+		DiscoveredMenus: job.discovered,
+		VisitedStates:   job.visitedStates,
+		VisitedButtons:  job.visitedButtons,
+		CapturedCount:   job.captured,
+		WarningCount:    job.warnings,
+		Result:          job.result,
+		Error:           job.errorMessage,
+		StartedAt:       formatDVDMenuTime(job.startedAt),
+		FinishedAt:      formatDVDMenuTime(job.finishedAt),
+	}
+}
+
+func formatDVDMenuTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.Format(time.RFC3339)
+}
+
+func (a *App) getDVDMenuCaptureJob(jobID string) *dvdMenuCaptureJob {
+	if strings.TrimSpace(jobID) == "" {
+		return nil
+	}
+	a.dvdMenuMu.Lock()
+	defer a.dvdMenuMu.Unlock()
+	return a.dvdMenus[jobID]
+}
+
+// closeResources closes the per-run core and logger at most once.
+func (job *dvdMenuCaptureJob) closeResources() error {
+	if job == nil {
+		return nil
+	}
+	var closeErr error
+	job.cleanupOnce.Do(func() {
+		job.mu.Lock()
+		coreSvc := job.core
+		logger := job.logger
+		job.core = nil
+		job.logger = nil
+		job.mu.Unlock()
+		if coreSvc != nil {
+			closeErr = errors.Join(closeErr, closeTrackerUploadResource("core", coreSvc))
+		}
+		if logger != nil {
+			closeErr = errors.Join(closeErr, closeTrackerUploadResource("logger", logger))
+		}
+	})
+	return closeErr
+}
+
+func (a *App) stopAllDVDMenuJobs() {
+	if a == nil {
+		return
+	}
+	a.dvdMenuMu.Lock()
+	jobs := make([]*dvdMenuCaptureJob, 0, len(a.dvdMenus))
+	for _, job := range a.dvdMenus {
+		jobs = append(jobs, job)
+	}
+	a.dvdMenuMu.Unlock()
+	for _, job := range jobs {
+		job.mu.Lock()
+		cancel := job.cancel
+		job.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
+	}
+	a.dvdMenuWG.Wait()
+	for _, job := range jobs {
+		_ = job.closeResources()
+	}
+}

--- a/internal/guiapp/dvd_menu_jobs.go
+++ b/internal/guiapp/dvd_menu_jobs.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -20,7 +21,11 @@ import (
 const (
 	dvdMenuCaptureEventPrefix              = "dvdmenu:job:"
 	errDVDMenuCaptureRequiresMetadataCache = "DVD menu capture requires metadata preview"
-	dvdMenuSnapshotThrottle                = 150 * time.Millisecond
+	// dvdMenuCompletedJobRetention bounds how long terminal snapshots remain queryable.
+	dvdMenuCompletedJobRetention = 24 * time.Hour
+	// maxCompletedDVDMenuJobs bounds retained terminal snapshots across all GUI captures.
+	maxCompletedDVDMenuJobs = 200
+	dvdMenuSnapshotThrottle = 150 * time.Millisecond
 )
 
 // dvdMenuCaptureJob owns one isolated core/logger snapshot and its synchronized
@@ -49,6 +54,7 @@ type dvdMenuCaptureJob struct {
 	finishedAt     time.Time
 	lastEmit       time.Time
 	cancel         context.CancelFunc
+	retentionTimer *time.Timer
 }
 
 // StartDVDMenuCapture starts a background capture using the current prepared
@@ -116,8 +122,9 @@ func (a *App) StartDVDMenuCapture(path string, overrides api.ExternalIDOverrides
 	if a.dvdMenus == nil {
 		a.dvdMenus = make(map[string]*dvdMenuCaptureJob)
 	}
-	a.dvdMenuWG.Add(1)
 	a.dvdMenus[job.id] = job
+	a.pruneCompletedDVDMenuJobsLocked(maxCompletedDVDMenuJobs)
+	a.dvdMenuWG.Add(1)
 	a.dvdMenuMu.Unlock()
 	a.emitDVDMenuCaptureSnapshot(baseCtx, job, true)
 	go func() {
@@ -129,7 +136,8 @@ func (a *App) StartDVDMenuCapture(path string, overrides api.ExternalIDOverrides
 }
 
 // GetDVDMenuCaptureSnapshot returns the current capture job state. It rejects
-// unknown or expired job IDs.
+// unknown or expired job IDs. Terminal snapshots have bounded time and
+// capacity retention, so callers should consume their final state promptly.
 func (a *App) GetDVDMenuCaptureSnapshot(jobID string) (api.DVDMenuCaptureSnapshot, error) {
 	if a == nil {
 		return api.DVDMenuCaptureSnapshot{}, errors.New("app not initialized")
@@ -196,8 +204,8 @@ func newDVDMenuRequest(path string, overrides api.ExternalIDOverrides, nameOverr
 	}
 }
 
-// runDVDMenuCaptureJob owns the queued-to-terminal lifecycle and releases its
-// per-run core/logger resources exactly once.
+// runDVDMenuCaptureJob owns the queued-to-terminal lifecycle, releases its
+// per-run core/logger resources exactly once, and schedules bounded retention.
 func (a *App) runDVDMenuCaptureJob(ctx context.Context, eventCtx context.Context, job *dvdMenuCaptureJob) {
 	if job != nil {
 		defer func() { _ = job.closeResources() }()
@@ -247,6 +255,7 @@ func (a *App) runDVDMenuCaptureJob(ctx context.Context, eventCtx context.Context
 	}
 	job.mu.Unlock()
 	a.emitDVDMenuCaptureSnapshot(eventCtx, job, true)
+	a.scheduleDVDMenuJobCleanup(job)
 }
 
 func (a *App) applyDVDMenuCaptureProgress(ctx context.Context, job *dvdMenuCaptureJob, update api.DVDMenuProgressUpdate) {
@@ -343,6 +352,84 @@ func (job *dvdMenuCaptureJob) closeResources() error {
 	return closeErr
 }
 
+// scheduleDVDMenuJobCleanup retains a registered terminal job for the query
+// window and arranges its eventual removal. Capacity pruning may remove it
+// immediately when newer terminal jobs already fill the retained set.
+func (a *App) scheduleDVDMenuJobCleanup(job *dvdMenuCaptureJob) {
+	if a == nil || job == nil {
+		return
+	}
+	a.dvdMenuMu.Lock()
+	if a.dvdMenus[job.id] != job {
+		a.dvdMenuMu.Unlock()
+		return
+	}
+	a.pruneCompletedDVDMenuJobsLocked(maxCompletedDVDMenuJobs)
+	if a.dvdMenus[job.id] != job {
+		a.dvdMenuMu.Unlock()
+		return
+	}
+	timer := time.AfterFunc(dvdMenuCompletedJobRetention, func() {
+		a.dvdMenuMu.Lock()
+		defer a.dvdMenuMu.Unlock()
+		if current := a.dvdMenus[job.id]; current == job && isDVDMenuJobTerminal(job) {
+			a.deleteDVDMenuJobLocked(job)
+		}
+	})
+	job.mu.Lock()
+	job.retentionTimer = timer
+	job.mu.Unlock()
+	a.dvdMenuMu.Unlock()
+}
+
+// pruneCompletedDVDMenuJobsLocked evicts the oldest terminal jobs until at
+// most maxCompleted remain. The caller must hold a.dvdMenuMu.
+func (a *App) pruneCompletedDVDMenuJobsLocked(maxCompleted int) {
+	if maxCompleted <= 0 {
+		return
+	}
+	completed := make([]*dvdMenuCaptureJob, 0, len(a.dvdMenus))
+	for _, job := range a.dvdMenus {
+		if isDVDMenuJobTerminal(job) {
+			completed = append(completed, job)
+		}
+	}
+	if len(completed) <= maxCompleted {
+		return
+	}
+	sort.Slice(completed, func(i, j int) bool {
+		return completed[i].finishedAt.Before(completed[j].finishedAt)
+	})
+	for _, job := range completed[:len(completed)-maxCompleted] {
+		a.deleteDVDMenuJobLocked(job)
+	}
+}
+
+// deleteDVDMenuJobLocked removes job and stops its retention timer. The caller
+// must hold a.dvdMenuMu.
+func (a *App) deleteDVDMenuJobLocked(job *dvdMenuCaptureJob) {
+	delete(a.dvdMenus, job.id)
+	job.mu.Lock()
+	timer := job.retentionTimer
+	job.retentionTimer = nil
+	job.mu.Unlock()
+	if timer != nil {
+		timer.Stop()
+	}
+}
+
+// isDVDMenuJobTerminal reports whether job has reached a queryable final state.
+func isDVDMenuJobTerminal(job *dvdMenuCaptureJob) bool {
+	if job == nil {
+		return false
+	}
+	job.mu.Lock()
+	defer job.mu.Unlock()
+	return job.status == "completed" || job.status == "failed" || job.status == "canceled"
+}
+
+// stopAllDVDMenuJobs cancels active captures, waits for workers, releases
+// per-job resources, and clears retained snapshots and cleanup timers.
 func (a *App) stopAllDVDMenuJobs() {
 	if a == nil {
 		return
@@ -365,4 +452,9 @@ func (a *App) stopAllDVDMenuJobs() {
 	for _, job := range jobs {
 		_ = job.closeResources()
 	}
+	a.dvdMenuMu.Lock()
+	for _, job := range a.dvdMenus {
+		a.deleteDVDMenuJobLocked(job)
+	}
+	a.dvdMenuMu.Unlock()
 }

--- a/internal/guiapp/dvd_menu_jobs_test.go
+++ b/internal/guiapp/dvd_menu_jobs_test.go
@@ -6,6 +6,7 @@ package guiapp
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -80,6 +81,26 @@ func TestRunDVDMenuCaptureJobClassifiesCancellation(t *testing.T) {
 	snapshot := buildDVDMenuCaptureSnapshot(job)
 	if snapshot.Status != "canceled" || !errors.Is(ctx.Err(), context.Canceled) {
 		t.Fatalf("expected canceled snapshot, got %#v", snapshot)
+	}
+}
+
+func TestRunDVDMenuCaptureJobRedactsFailureMessage(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &closeCounterCore{
+		dvdMenuCapture: func(context.Context, api.Request) (api.DVDMenuCaptureResult, error) {
+			return api.DVDMenuCaptureResult{}, errors.New("provider rejected api_key=secret-value")
+		},
+	}
+	job := &dvdMenuCaptureJob{id: "dvd-job-1", core: coreSvc, status: "queued", startedAt: time.Now().UTC()}
+
+	(&App{}).runDVDMenuCaptureJob(context.Background(), nil, job)
+	snapshot := buildDVDMenuCaptureSnapshot(job)
+	if snapshot.Status != "failed" {
+		t.Fatal("expected failed snapshot")
+	}
+	if strings.Contains(snapshot.Error, "secret-value") || !strings.Contains(snapshot.Error, "[REDACTED]") {
+		t.Fatal("expected redacted DVD menu capture error")
 	}
 }
 

--- a/internal/guiapp/dvd_menu_jobs_test.go
+++ b/internal/guiapp/dvd_menu_jobs_test.go
@@ -82,3 +82,43 @@ func TestRunDVDMenuCaptureJobClassifiesCancellation(t *testing.T) {
 		t.Fatalf("expected canceled snapshot, got %#v", snapshot)
 	}
 }
+
+func TestPruneCompletedDVDMenuJobsKeepsNewestBoundedSet(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	oldest := &dvdMenuCaptureJob{
+		id:             "oldest",
+		status:         "completed",
+		finishedAt:     now.Add(-3 * time.Minute),
+		retentionTimer: time.NewTimer(time.Hour),
+	}
+	middle := &dvdMenuCaptureJob{id: "middle", status: "failed", finishedAt: now.Add(-2 * time.Minute)}
+	newest := &dvdMenuCaptureJob{id: "newest", status: "canceled", finishedAt: now.Add(-time.Minute)}
+	running := &dvdMenuCaptureJob{id: "running", status: "running", startedAt: now}
+	app := &App{dvdMenus: map[string]*dvdMenuCaptureJob{
+		oldest.id:  oldest,
+		middle.id:  middle,
+		newest.id:  newest,
+		running.id: running,
+	}}
+
+	app.dvdMenuMu.Lock()
+	app.pruneCompletedDVDMenuJobsLocked(2)
+	app.dvdMenuMu.Unlock()
+
+	if app.getDVDMenuCaptureJob(oldest.id) != nil {
+		t.Fatal("expected oldest terminal DVD menu job to be evicted")
+	}
+	oldest.mu.Lock()
+	oldestTimer := oldest.retentionTimer
+	oldest.mu.Unlock()
+	if oldestTimer != nil {
+		t.Fatal("expected evicted DVD menu job retention timer to be released")
+	}
+	for _, jobID := range []string{middle.id, newest.id, running.id} {
+		if app.getDVDMenuCaptureJob(jobID) == nil {
+			t.Fatal("expected retained DVD menu job")
+		}
+	}
+}

--- a/internal/guiapp/dvd_menu_jobs_test.go
+++ b/internal/guiapp/dvd_menu_jobs_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package guiapp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestRunDVDMenuCaptureJobPublishesProgressAndResult(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &closeCounterCore{
+		dvdMenuCapture: func(ctx context.Context, _ api.Request) (api.DVDMenuCaptureResult, error) {
+			api.ReportDVDMenuProgress(ctx, api.DVDMenuProgressUpdate{
+				Phase:           "capturing",
+				Message:         "Rendering distinct DVD menu screens.",
+				DiscoveredMenus: 3,
+				VisitedStates:   5,
+				VisitedButtons:  4,
+				CapturedCount:   1,
+				WarningCount:    1,
+			})
+			return api.DVDMenuCaptureResult{
+				SourcePath:      "Example.Release.2026.1080p-GRP",
+				DiscoveredMenus: 3,
+				VisitedStates:   5,
+				VisitedButtons:  4,
+				Partial:         true,
+				Images: []api.DVDMenuCaptureImage{{ScreenshotImage: api.ScreenshotImage{
+					Path:    "menu-1.png",
+					Purpose: api.ScreenshotPurposeMenu,
+				}}},
+				Warnings: []api.DVDMenuCaptureWarning{{Code: "frame_decode", Message: "One menu could not be rendered."}},
+			}, nil
+		},
+	}
+	job := &dvdMenuCaptureJob{
+		id:         "dvd-job-1",
+		sourcePath: "Example.Release.2026.1080p-GRP",
+		core:       coreSvc,
+		status:     "queued",
+		startedAt:  time.Now().UTC(),
+	}
+
+	(&App{}).runDVDMenuCaptureJob(context.Background(), nil, job)
+	snapshot := buildDVDMenuCaptureSnapshot(job)
+	if snapshot.Status != "completed" || snapshot.Phase != "complete" {
+		t.Fatalf("unexpected terminal snapshot: %#v", snapshot)
+	}
+	if snapshot.CapturedCount != 1 || snapshot.WarningCount != 1 || !snapshot.Result.Partial {
+		t.Fatalf("expected partial persisted result, got %#v", snapshot)
+	}
+	if got := coreSvc.dvdMenuCalls.Load(); got != 1 {
+		t.Fatalf("expected one capture call, got %d", got)
+	}
+	if got := coreSvc.count.Load(); got != 1 {
+		t.Fatalf("expected job core close, got %d", got)
+	}
+}
+
+func TestRunDVDMenuCaptureJobClassifiesCancellation(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &closeCounterCore{
+		dvdMenuCapture: func(ctx context.Context, _ api.Request) (api.DVDMenuCaptureResult, error) {
+			return api.DVDMenuCaptureResult{}, ctx.Err()
+		},
+	}
+	job := &dvdMenuCaptureJob{id: "dvd-job-1", core: coreSvc, status: "queued", startedAt: time.Now().UTC()}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	(&App{}).runDVDMenuCaptureJob(ctx, nil, job)
+	snapshot := buildDVDMenuCaptureSnapshot(job)
+	if snapshot.Status != "canceled" || !errors.Is(ctx.Err(), context.Canceled) {
+		t.Fatalf("expected canceled snapshot, got %#v", snapshot)
+	}
+}

--- a/internal/guiapp/run_options_test.go
+++ b/internal/guiapp/run_options_test.go
@@ -48,6 +48,8 @@ type closeCounterCore struct {
 	fetchReq          api.Request
 	dupeSummary       api.DupeCheckSummary
 	dupeCalls         atomic.Int32
+	dvdMenuCapture    func(context.Context, api.Request) (api.DVDMenuCaptureResult, error)
+	dvdMenuCalls      atomic.Int32
 	uploads           []uploadPreparedResponse
 	uploadCalls       int
 }
@@ -129,6 +131,22 @@ func (c *closeCounterCore) SaveFinalScreenshotSelections(context.Context, api.Re
 }
 
 func (c *closeCounterCore) ImportMenuImages(context.Context, api.Request, []string) error {
+	return nil
+}
+
+func (c *closeCounterCore) CaptureDVDMenus(ctx context.Context, req api.Request) (api.DVDMenuCaptureResult, error) {
+	c.dvdMenuCalls.Add(1)
+	if c.dvdMenuCapture != nil {
+		return c.dvdMenuCapture(ctx, req)
+	}
+	return api.DVDMenuCaptureResult{}, nil
+}
+
+func (c *closeCounterCore) ListDVDMenuScreenshots(context.Context, api.Request) ([]api.ScreenshotImage, error) {
+	return nil, nil
+}
+
+func (c *closeCounterCore) DeleteDVDMenuScreenshot(context.Context, api.Request, string) error {
 	return nil
 }
 

--- a/internal/guishared/application_info.go
+++ b/internal/guishared/application_info.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package guishared
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+const applicationInfoCapabilityTimeout = 10 * time.Second
+
+const (
+	// DVDMenuCapabilityAvailable reports compatible FFmpeg dvdvideo support.
+	DVDMenuCapabilityAvailable = "available"
+	// DVDMenuCapabilityIncompatible reports FFmpeg without required dvdvideo support.
+	DVDMenuCapabilityIncompatible = "incompatible"
+	// DVDMenuCapabilityUnavailable reports that capability could not be inspected.
+	DVDMenuCapabilityUnavailable = "unavailable"
+)
+
+// CurrentApplicationInfo adds path-free DVD menu capability diagnostics to
+// the shared application build/runtime information. It bounds the probe to ten
+// seconds and returns unavailable status when ctx or provider is nil.
+func CurrentApplicationInfo(ctx context.Context, provider api.DVDMenuCapabilityProvider) api.ApplicationInfo {
+	info := api.CurrentApplicationInfo()
+	info.DVDMenuCapabilityStatus = DVDMenuCapabilityUnavailable
+	info.DVDMenuCapabilityMessage = "DVD menu capture capability could not be checked."
+	if provider == nil {
+		return info
+	}
+	if ctx == nil {
+		return info
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, applicationInfoCapabilityTimeout)
+	defer cancel()
+
+	capability, err := provider.DVDMenuCapability(probeCtx)
+	info.DVDMenuEngine = capability
+	if err != nil {
+		if len(capability.MissingFFmpegOptions) > 0 {
+			info.DVDMenuCapabilityStatus = DVDMenuCapabilityIncompatible
+			info.DVDMenuCapabilityMessage = "FFmpeg lacks required dvdvideo menu options: " + strings.Join(capability.MissingFFmpegOptions, ", ")
+			return info
+		}
+		info.DVDMenuCapabilityMessage = "FFmpeg was not found or its dvdvideo menu capability could not be inspected."
+		return info
+	}
+	if !capability.FFmpegDVDVideo {
+		info.DVDMenuCapabilityStatus = DVDMenuCapabilityIncompatible
+		info.DVDMenuCapabilityMessage = "FFmpeg lacks required dvdvideo menu support."
+		return info
+	}
+	info.DVDMenuCapabilityStatus = DVDMenuCapabilityAvailable
+	info.DVDMenuCapabilityMessage = "Compatible FFmpeg dvdvideo menu support detected."
+	return info
+}

--- a/internal/guishared/application_info_test.go
+++ b/internal/guishared/application_info_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package guishared
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+type applicationInfoCapabilityProvider struct {
+	info api.DVDMenuEngineInfo
+	err  error
+}
+
+func (p applicationInfoCapabilityProvider) DVDMenuCapability(context.Context) (api.DVDMenuEngineInfo, error) {
+	return p.info, p.err
+}
+
+func TestCurrentApplicationInfoIncludesDVDMenuCapability(t *testing.T) {
+	info := CurrentApplicationInfo(context.Background(), applicationInfoCapabilityProvider{info: api.DVDMenuEngineInfo{
+		EngineVersion:     "phase0a-1",
+		FFmpegVersion:     "ffmpeg version example",
+		FFmpegDVDVideo:    true,
+		SupportedFeatures: []string{"ifo_inventory"},
+	}})
+	if info.DVDMenuCapabilityStatus != DVDMenuCapabilityAvailable || !info.DVDMenuEngine.FFmpegDVDVideo {
+		t.Fatalf("DVD menu diagnostics = %#v", info)
+	}
+	if info.DVDMenuEngine.EngineVersion != "phase0a-1" || info.DVDMenuEngine.FFmpegVersion != "ffmpeg version example" {
+		t.Fatalf("DVD menu engine info = %#v", info.DVDMenuEngine)
+	}
+}
+
+func TestCurrentApplicationInfoReportsPathFreeIncompatibleCapability(t *testing.T) {
+	info := CurrentApplicationInfo(context.Background(), applicationInfoCapabilityProvider{
+		info: api.DVDMenuEngineInfo{
+			EngineVersion:        "phase0a-1",
+			MissingFFmpegOptions: []string{"-menu_vts", "-pgc"},
+		},
+		err: errors.New(`inspect C:\path\to\ffmpeg.exe`),
+	})
+	if info.DVDMenuCapabilityStatus != DVDMenuCapabilityIncompatible {
+		t.Fatalf("capability status = %q", info.DVDMenuCapabilityStatus)
+	}
+	if strings.Contains(info.DVDMenuCapabilityMessage, `C:\path\to`) {
+		t.Fatal("capability diagnostic leaked a local path")
+	}
+	if !strings.Contains(info.DVDMenuCapabilityMessage, "-menu_vts, -pgc") {
+		t.Fatalf("capability message = %q", info.DVDMenuCapabilityMessage)
+	}
+}

--- a/internal/services/db/screenshot_lifecycle_test.go
+++ b/internal/services/db/screenshot_lifecycle_test.go
@@ -114,15 +114,71 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 	}}); err != nil {
 		t.Fatalf("save manual upload: %v", err)
 	}
+	if err := repo.ReplaceScreenshotSlots(ctx, sourcePath, []api.ScreenshotSlot{{
+		SourcePath: sourcePath,
+		SlotOrder:  0,
+		ImagePath:  manualNew,
+		Variants: []api.ScreenshotSlotVariant{{
+			SourcePath: sourcePath,
+			SlotOrder:  0,
+			Host:       "example-host",
+			UsageScope: "global",
+			ImagePath:  manualNew,
+			RawURL:     "https://example.invalid/manual-new.png",
+			UploadedAt: now,
+		}},
+	}}); err != nil {
+		t.Fatalf("save manual screenshot slot: %v", err)
+	}
 	deleted, err := repo.DeleteDiscMenuScreenshot(ctx, sourcePath, manualNew)
 	if err != nil {
 		t.Fatalf("delete manual screenshot: %v", err)
 	}
 	if deleted.Selection.Source != api.ScreenshotSelectionSourceMenu || deleted.UploadedLinks != 1 {
-		t.Fatalf("delete result = %#v", deleted)
+		t.Fatal("delete result metadata is incorrect")
+	}
+	if deleted.Screenshot == nil || deleted.Screenshot.ImagePath != manualNew || len(deleted.UploadedImages) != 1 || len(deleted.ScreenshotSlots) != 1 || len(deleted.ScreenshotSlotVariants) != 1 {
+		t.Fatal("delete result did not retain the compensation snapshot")
 	}
 	assertFinalSelectionPaths(t, repo, sourcePath, []string{autoNew, manualOld, normalNew})
 	assertNoScreenshotReferences(t, repo, sourcePath, manualNew)
+
+	if err := repo.RestoreDiscMenuScreenshot(ctx, sourcePath, deleted); err != nil {
+		t.Fatal("restore deleted menu screenshot records failed")
+	}
+	assertFinalSelectionPaths(t, repo, sourcePath, []string{autoNew, manualOld, manualNew, normalNew})
+	restoredScreenshots, err := repo.ListScreenshotsByPath(ctx, sourcePath)
+	if err != nil {
+		t.Fatal("list restored screenshots failed")
+	}
+	restoredUploads, err := repo.ListUploadedImagesByPath(ctx, sourcePath)
+	if err != nil {
+		t.Fatal("list restored uploads failed")
+	}
+	restoredScreenshot := false
+	for _, screenshot := range restoredScreenshots {
+		if screenshot.ImagePath == manualNew {
+			restoredScreenshot = true
+			break
+		}
+	}
+	restoredUpload := false
+	for _, uploaded := range restoredUploads {
+		if uploaded.ImagePath == manualNew {
+			restoredUpload = true
+			break
+		}
+	}
+	if !restoredScreenshot || !restoredUpload {
+		t.Fatal("restored menu screenshot references are incomplete")
+	}
+	restoredSlots, err := repo.ListScreenshotSlotsByPath(ctx, sourcePath)
+	if err != nil {
+		t.Fatal("list restored screenshot slots failed")
+	}
+	if len(restoredSlots) != 1 || restoredSlots[0].ImagePath != manualNew || len(restoredSlots[0].Variants) != 1 {
+		t.Fatal("restored menu screenshot slot references are incomplete")
+	}
 }
 
 func TestAppendManualMenuScreenshotsRollsBackCrossSourceImageConflict(t *testing.T) {

--- a/internal/services/db/screenshot_lifecycle_test.go
+++ b/internal/services/db/screenshot_lifecycle_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package db
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T) {
+	t.Parallel()
+
+	repo, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	ctx := context.Background()
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "Example.Release.2026.DVD-GRP")
+	autoOld := filepath.Join(root, "auto-old.png")
+	manualOld := filepath.Join(root, "manual-old.png")
+	normalOld := filepath.Join(root, "normal-old.png")
+	normalNew := filepath.Join(root, "normal-new.png")
+	now := time.Now().UTC()
+
+	if err := repo.SaveScreenshot(ctx, api.Screenshot{SourcePath: sourcePath, ImagePath: autoOld, Purpose: api.ScreenshotPurposeMenu, CapturedAt: now}); err != nil {
+		t.Fatalf("save old auto screenshot: %v", err)
+	}
+	if err := repo.SaveScreenshot(ctx, api.Screenshot{SourcePath: sourcePath, ImagePath: manualOld, Purpose: api.ScreenshotPurposeMenu, CapturedAt: now}); err != nil {
+		t.Fatalf("save old manual screenshot: %v", err)
+	}
+	if err := repo.SaveFinalSelections(ctx, sourcePath, []api.ScreenshotFinalSelection{
+		{SourcePath: sourcePath, ImagePath: normalOld, Order: 0, Source: "generated", SelectedAt: now},
+		{SourcePath: sourcePath, ImagePath: manualOld, Order: 1, Source: api.ScreenshotSelectionSourceMenu, SelectedAt: now},
+		{SourcePath: sourcePath, ImagePath: autoOld, Order: 2, Source: api.ScreenshotSelectionSourceDVDMenu, SelectedAt: now},
+	}); err != nil {
+		t.Fatalf("seed final selections: %v", err)
+	}
+
+	if err := repo.ReplaceNormalFinalSelections(ctx, sourcePath, []api.ScreenshotFinalSelection{
+		{SourcePath: sourcePath, ImagePath: normalNew, Order: 0, Source: "generated", SelectedAt: now},
+	}); err != nil {
+		t.Fatalf("replace normal selections: %v", err)
+	}
+	assertFinalSelectionPaths(t, repo, sourcePath, []string{autoOld, manualOld, normalNew})
+
+	manualNew := filepath.Join(root, "manual-new.png")
+	if err := repo.AppendManualMenuScreenshots(ctx, sourcePath,
+		[]api.Screenshot{{SourcePath: sourcePath, ImagePath: manualNew, Purpose: api.ScreenshotPurposeMenu, CapturedAt: now}},
+		[]api.ScreenshotFinalSelection{{SourcePath: sourcePath, ImagePath: manualNew, Source: api.ScreenshotSelectionSourceMenu, SelectedAt: now}},
+	); err != nil {
+		t.Fatalf("append manual screenshot: %v", err)
+	}
+	assertFinalSelectionPaths(t, repo, sourcePath, []string{autoOld, manualOld, manualNew, normalNew})
+
+	if err := repo.SaveUploadedImages(ctx, sourcePath, "example-host", []api.UploadedImageLink{{
+		SourcePath: sourcePath,
+		ImagePath:  autoOld,
+		Host:       "example-host",
+		UsageScope: "global",
+		RawURL:     "https://example.invalid/auto-old.png",
+		UploadedAt: now,
+	}}); err != nil {
+		t.Fatalf("save old auto upload: %v", err)
+	}
+	if err := repo.ReplaceScreenshotSlots(ctx, sourcePath, []api.ScreenshotSlot{{
+		SourcePath: sourcePath,
+		SlotOrder:  0,
+		ImagePath:  autoOld,
+		Variants: []api.ScreenshotSlotVariant{{
+			SourcePath: sourcePath,
+			SlotOrder:  0,
+			Host:       "example-host",
+			UsageScope: "global",
+			ImagePath:  autoOld,
+		}},
+	}}); err != nil {
+		t.Fatalf("save old auto slot: %v", err)
+	}
+
+	autoNew := filepath.Join(root, "auto-new.png")
+	replaced, err := repo.ReplaceDVDMenuScreenshots(ctx, sourcePath,
+		[]api.Screenshot{{SourcePath: sourcePath, ImagePath: autoNew, Purpose: api.ScreenshotPurposeMenu, CapturedAt: now}},
+		[]api.ScreenshotFinalSelection{{SourcePath: sourcePath, ImagePath: autoNew, Source: api.ScreenshotSelectionSourceDVDMenu, SelectedAt: now}},
+	)
+	if err != nil {
+		t.Fatalf("replace auto screenshots: %v", err)
+	}
+	if len(replaced) != 1 || replaced[0] != autoOld {
+		t.Fatalf("replaced = %#v, want old automatic path", replaced)
+	}
+	assertFinalSelectionPaths(t, repo, sourcePath, []string{autoNew, manualOld, manualNew, normalNew})
+	assertNoScreenshotReferences(t, repo, sourcePath, autoOld)
+
+	if err := repo.SaveUploadedImages(ctx, sourcePath, "example-host", []api.UploadedImageLink{{
+		SourcePath: sourcePath,
+		ImagePath:  manualNew,
+		Host:       "example-host",
+		UsageScope: "global",
+		RawURL:     "https://example.invalid/manual-new.png",
+		UploadedAt: now,
+	}}); err != nil {
+		t.Fatalf("save manual upload: %v", err)
+	}
+	deleted, err := repo.DeleteDiscMenuScreenshot(ctx, sourcePath, manualNew)
+	if err != nil {
+		t.Fatalf("delete manual screenshot: %v", err)
+	}
+	if deleted.Selection.Source != api.ScreenshotSelectionSourceMenu || deleted.UploadedLinks != 1 {
+		t.Fatalf("delete result = %#v", deleted)
+	}
+	assertFinalSelectionPaths(t, repo, sourcePath, []string{autoNew, manualOld, normalNew})
+	assertNoScreenshotReferences(t, repo, sourcePath, manualNew)
+}
+
+func TestAppendManualMenuScreenshotsRollsBackCrossSourceImageConflict(t *testing.T) {
+	t.Parallel()
+
+	repo, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	ctx := context.Background()
+	root := t.TempDir()
+	firstSource := filepath.Join(root, "first")
+	secondSource := filepath.Join(root, "second")
+	imagePath := filepath.Join(root, "shared.png")
+	if err := repo.SaveScreenshot(ctx, api.Screenshot{
+		SourcePath: firstSource,
+		ImagePath:  imagePath,
+		Purpose:    api.ScreenshotPurposeFinal,
+		CapturedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed screenshot: %v", err)
+	}
+
+	err = repo.AppendManualMenuScreenshots(ctx, secondSource,
+		[]api.Screenshot{{SourcePath: secondSource, ImagePath: imagePath, Purpose: api.ScreenshotPurposeMenu}},
+		[]api.ScreenshotFinalSelection{{SourcePath: secondSource, ImagePath: imagePath, Source: api.ScreenshotSelectionSourceMenu}},
+	)
+	if !errors.Is(err, internalerrors.ErrInvalidInput) {
+		t.Fatalf("append error = %v, want invalid input", err)
+	}
+	selections, err := repo.ListFinalSelections(ctx, secondSource)
+	if err != nil {
+		t.Fatalf("list rolled-back selections: %v", err)
+	}
+	if len(selections) != 0 {
+		t.Fatalf("rolled-back selections = %#v", selections)
+	}
+	records, err := repo.ListScreenshotsByPath(ctx, firstSource)
+	if err != nil {
+		t.Fatalf("list original screenshots: %v", err)
+	}
+	if len(records) != 1 || records[0].Purpose != api.ScreenshotPurposeFinal {
+		t.Fatalf("original screenshot changed: %#v", records)
+	}
+}
+
+func assertFinalSelectionPaths(t *testing.T, repo *SQLiteRepository, sourcePath string, expected []string) {
+	t.Helper()
+	selections, err := repo.ListFinalSelections(context.Background(), sourcePath)
+	if err != nil {
+		t.Fatalf("list final selections: %v", err)
+	}
+	if len(selections) != len(expected) {
+		t.Fatalf("selection count = %d, want %d: %#v", len(selections), len(expected), selections)
+	}
+	for index, imagePath := range expected {
+		if selections[index].ImagePath != imagePath || selections[index].Order != index {
+			t.Fatalf("selection[%d] = %#v, want path %q order %d", index, selections[index], imagePath, index)
+		}
+	}
+}
+
+func assertNoScreenshotReferences(t *testing.T, repo *SQLiteRepository, sourcePath string, imagePath string) {
+	t.Helper()
+	records, err := repo.ListScreenshotsByPath(context.Background(), sourcePath)
+	if err != nil {
+		t.Fatalf("list screenshots: %v", err)
+	}
+	for _, record := range records {
+		if record.ImagePath == imagePath {
+			t.Fatalf("screenshot record retained for %q", imagePath)
+		}
+	}
+	uploads, err := repo.ListUploadedImagesByPath(context.Background(), sourcePath)
+	if err != nil {
+		t.Fatalf("list uploads: %v", err)
+	}
+	for _, upload := range uploads {
+		if upload.ImagePath == imagePath {
+			t.Fatalf("upload retained for %q", imagePath)
+		}
+	}
+	slots, err := repo.ListScreenshotSlotsByPath(context.Background(), sourcePath)
+	if err != nil {
+		t.Fatalf("list slots: %v", err)
+	}
+	for _, slot := range slots {
+		if slot.ImagePath == imagePath {
+			t.Fatalf("slot retained for %q", imagePath)
+		}
+		for _, variant := range slot.Variants {
+			if variant.ImagePath == imagePath {
+				t.Fatalf("slot variant retained for %q", imagePath)
+			}
+		}
+	}
+}

--- a/internal/services/db/sqlite.go
+++ b/internal/services/db/sqlite.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -2225,8 +2226,9 @@ func (r *SQLiteRepository) ReplaceDVDMenuScreenshots(ctx context.Context, path s
 }
 
 // DeleteDiscMenuScreenshot atomically removes one manual or automatic menu
-// selection, its screenshot row, and local upload records. It rejects normal
-// final selections and reports how many remote-host references were orphaned.
+// selection and all local records tied to it. It rejects normal final
+// selections and returns a complete snapshot suitable for compensation with
+// [SQLiteRepository.RestoreDiscMenuScreenshot]. Remote assets are unchanged.
 func (r *SQLiteRepository) DeleteDiscMenuScreenshot(ctx context.Context, path string, imagePath string) (api.DiscMenuDeleteResult, error) {
 	if r == nil || r.db == nil {
 		return api.DiscMenuDeleteResult{}, errors.New("db: repository not initialized")
@@ -2261,10 +2263,43 @@ func (r *SQLiteRepository) DeleteDiscMenuScreenshot(ctx context.Context, path st
 				deleted.Selection.SelectedAt = parsed
 			}
 		}
-		if err := tx.QueryRowContext(ctx, `
-			SELECT COUNT(*) FROM uploaded_images WHERE source_path = ? AND image_path = ?
-		`, trimmedPath, trimmedImage).Scan(&deleted.UploadedLinks); err != nil {
-			return fmt.Errorf("db delete disc menu screenshot: count uploaded images: %w", err)
+		var screenshot Screenshot
+		var purpose string
+		var capturedAt string
+		err = tx.QueryRowContext(ctx, `
+			SELECT timestamp, frame_number, width, height, purpose, captured_at
+			FROM screenshots
+			WHERE source_path = ? AND image_path = ?
+		`, trimmedPath, trimmedImage).Scan(
+			&screenshot.Timestamp,
+			&screenshot.FrameNumber,
+			&screenshot.Width,
+			&screenshot.Height,
+			&purpose,
+			&capturedAt,
+		)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("db delete disc menu screenshot: load screenshot: %w", err)
+		}
+		if err == nil {
+			screenshot.SourcePath = trimmedPath
+			screenshot.ImagePath = trimmedImage
+			screenshot.Purpose = ScreenshotPurpose(purpose)
+			if capturedAt != "" {
+				if parsed, parseErr := time.Parse(time.RFC3339Nano, capturedAt); parseErr == nil {
+					screenshot.CapturedAt = parsed
+				}
+			}
+			deleted.Screenshot = &screenshot
+		}
+		deleted.UploadedImages, err = listUploadedImagesForImageTx(ctx, tx, trimmedPath, trimmedImage)
+		if err != nil {
+			return err
+		}
+		deleted.UploadedLinks = len(deleted.UploadedImages)
+		deleted.ScreenshotSlots, deleted.ScreenshotSlotVariants, err = listDeletedScreenshotSlotsTx(ctx, tx, trimmedPath, trimmedImage)
+		if err != nil {
+			return err
 		}
 		if err := deleteScreenshotReferencesTx(ctx, tx, trimmedPath, trimmedImage); err != nil {
 			return err
@@ -2285,6 +2320,277 @@ func (r *SQLiteRepository) DeleteDiscMenuScreenshot(ctx context.Context, path st
 		return api.DiscMenuDeleteResult{}, err
 	}
 	return deleted, nil
+}
+
+// RestoreDiscMenuScreenshot atomically compensates a completed local-record
+// deletion when the corresponding filesystem deletion could not be finalized.
+// It rejects snapshots whose source, image, menu purpose, or host data do not
+// match path and the deleted selection.
+func (r *SQLiteRepository) RestoreDiscMenuScreenshot(ctx context.Context, path string, deleted api.DiscMenuDeleteResult) error {
+	if r == nil || r.db == nil {
+		return errors.New("db: repository not initialized")
+	}
+	trimmedPath := strings.TrimSpace(path)
+	selection := deleted.Selection
+	selection.SourcePath = strings.TrimSpace(selection.SourcePath)
+	selection.ImagePath = strings.TrimSpace(selection.ImagePath)
+	if trimmedPath == "" || selection.SourcePath != trimmedPath || selection.ImagePath == "" || !api.IsDiscMenuSelectionSource(strings.TrimSpace(selection.Source)) {
+		return internalerrors.ErrInvalidInput
+	}
+	if deleted.Screenshot != nil {
+		if strings.TrimSpace(deleted.Screenshot.SourcePath) != trimmedPath || strings.TrimSpace(deleted.Screenshot.ImagePath) != selection.ImagePath || deleted.Screenshot.Purpose != api.ScreenshotPurposeMenu {
+			return internalerrors.ErrInvalidInput
+		}
+	}
+	for _, uploaded := range deleted.UploadedImages {
+		if strings.TrimSpace(uploaded.SourcePath) != trimmedPath || strings.TrimSpace(uploaded.ImagePath) != selection.ImagePath || strings.TrimSpace(uploaded.Host) == "" {
+			return internalerrors.ErrInvalidInput
+		}
+	}
+	for _, slot := range deleted.ScreenshotSlots {
+		if strings.TrimSpace(slot.SourcePath) != trimmedPath || strings.TrimSpace(slot.ImagePath) != selection.ImagePath {
+			return internalerrors.ErrInvalidInput
+		}
+	}
+	for _, variant := range deleted.ScreenshotSlotVariants {
+		if strings.TrimSpace(variant.SourcePath) != trimmedPath || strings.TrimSpace(variant.Host) == "" {
+			return internalerrors.ErrInvalidInput
+		}
+	}
+
+	return r.withWriteTx(ctx, "restore disc menu screenshot", func(tx *sql.Tx) error {
+		if deleted.Screenshot != nil {
+			if err := upsertMenuScreenshotsTx(ctx, tx, trimmedPath, []Screenshot{*deleted.Screenshot}); err != nil {
+				return err
+			}
+		}
+		selections, err := listFinalSelectionsTx(ctx, tx, trimmedPath)
+		if err != nil {
+			return err
+		}
+		filtered := selections[:0]
+		for _, current := range selections {
+			if current.ImagePath != selection.ImagePath {
+				filtered = append(filtered, current)
+			}
+		}
+		filtered = append(filtered, selection)
+		if err := rewriteFinalSelectionsTx(ctx, tx, trimmedPath, filtered); err != nil {
+			return err
+		}
+		if err := restoreScreenshotSlotsTx(ctx, tx, trimmedPath, deleted.ScreenshotSlots, deleted.ScreenshotSlotVariants); err != nil {
+			return err
+		}
+		return upsertUploadedImagesTx(ctx, tx, trimmedPath, deleted.UploadedImages)
+	})
+}
+
+// listDeletedScreenshotSlotsTx snapshots slots selected by imagePath and every
+// variant that deletion would remove with those slots or the image itself.
+func listDeletedScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, imagePath string) ([]ScreenshotSlot, []ScreenshotSlotVariant, error) {
+	slotRows, err := tx.QueryContext(ctx, `
+		SELECT slot_order, source_kind, original_key, original_url, original_host, image_path,
+			from_description, tracker, section_kind, render_in_screenshots
+		FROM screenshot_slots
+		WHERE source_path = ? AND image_path = ?
+		ORDER BY slot_order ASC
+	`, path, imagePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("db delete disc menu screenshot: list slots: %w", err)
+	}
+	defer slotRows.Close()
+
+	slots := make([]ScreenshotSlot, 0)
+	for slotRows.Next() {
+		var slot ScreenshotSlot
+		var fromDescription int
+		var renderInScreenshots int
+		if err := slotRows.Scan(
+			&slot.SlotOrder,
+			&slot.SourceKind,
+			&slot.OriginalKey,
+			&slot.OriginalURL,
+			&slot.OriginalHost,
+			&slot.ImagePath,
+			&fromDescription,
+			&slot.Tracker,
+			&slot.SectionKind,
+			&renderInScreenshots,
+		); err != nil {
+			return nil, nil, fmt.Errorf("db delete disc menu screenshot: scan slot: %w", err)
+		}
+		slot.SourcePath = path
+		slot.FromDescription = fromDescription != 0
+		slot.RenderInScreenshots = renderInScreenshots != 0
+		slots = append(slots, slot)
+	}
+	if err := slotRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("db delete disc menu screenshot: iterate slots: %w", err)
+	}
+
+	variantRows, err := tx.QueryContext(ctx, `
+		SELECT slot_order, host, usage_scope, image_path, img_url, raw_url, web_url, uploaded_at
+		FROM screenshot_slot_variants
+		WHERE source_path = ? AND (
+			image_path = ? OR slot_order IN (
+				SELECT slot_order FROM screenshot_slots WHERE source_path = ? AND image_path = ?
+			)
+		)
+		ORDER BY slot_order ASC
+	`, path, imagePath, path, imagePath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("db delete disc menu screenshot: list slot variants: %w", err)
+	}
+	defer variantRows.Close()
+
+	variants := make([]ScreenshotSlotVariant, 0)
+	for variantRows.Next() {
+		var variant ScreenshotSlotVariant
+		var uploadedAt string
+		if err := variantRows.Scan(
+			&variant.SlotOrder,
+			&variant.Host,
+			&variant.UsageScope,
+			&variant.ImagePath,
+			&variant.ImgURL,
+			&variant.RawURL,
+			&variant.WebURL,
+			&uploadedAt,
+		); err != nil {
+			return nil, nil, fmt.Errorf("db delete disc menu screenshot: scan slot variant: %w", err)
+		}
+		variant.SourcePath = path
+		if uploadedAt != "" {
+			if parsed, parseErr := time.Parse(time.RFC3339Nano, uploadedAt); parseErr == nil {
+				variant.UploadedAt = parsed
+			}
+		}
+		variants = append(variants, variant)
+	}
+	if err := variantRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("db delete disc menu screenshot: iterate slot variants: %w", err)
+	}
+	return slots, variants, nil
+}
+
+// restoreScreenshotSlotsTx upserts a compensation snapshot into the caller's
+// transaction, replacing conflicting slot and variant state for path.
+func restoreScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, slots []ScreenshotSlot, variants []ScreenshotSlotVariant) error {
+	if len(slots) > 0 {
+		slotStmt, err := tx.PrepareContext(ctx, `
+			INSERT INTO screenshot_slots (
+				source_path, slot_order, source_kind, original_key, original_url, original_host,
+				image_path, from_description, tracker, section_kind, render_in_screenshots
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(source_path, slot_order) DO UPDATE SET
+				source_kind = excluded.source_kind,
+				original_key = excluded.original_key,
+				original_url = excluded.original_url,
+				original_host = excluded.original_host,
+				image_path = excluded.image_path,
+				from_description = excluded.from_description,
+				tracker = excluded.tracker,
+				section_kind = excluded.section_kind,
+				render_in_screenshots = excluded.render_in_screenshots
+		`)
+		if err != nil {
+			return fmt.Errorf("db restore disc menu screenshot: prepare slots: %w", err)
+		}
+		defer slotStmt.Close()
+		for _, slot := range slots {
+			if _, err := slotStmt.ExecContext(
+				ctx,
+				path,
+				slot.SlotOrder,
+				strings.TrimSpace(slot.SourceKind),
+				strings.TrimSpace(slot.OriginalKey),
+				strings.TrimSpace(slot.OriginalURL),
+				strings.TrimSpace(slot.OriginalHost),
+				strings.TrimSpace(slot.ImagePath),
+				boolToInt(slot.FromDescription),
+				strings.TrimSpace(slot.Tracker),
+				strings.TrimSpace(slot.SectionKind),
+				boolToInt(slot.RenderInScreenshots),
+			); err != nil {
+				return fmt.Errorf("db restore disc menu screenshot: insert slot: %w", err)
+			}
+		}
+	}
+	if len(variants) == 0 {
+		return nil
+	}
+	variantStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO screenshot_slot_variants (
+			source_path, slot_order, host, usage_scope, image_path, img_url, raw_url, web_url, uploaded_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(source_path, slot_order, host, usage_scope) DO UPDATE SET
+			image_path = excluded.image_path,
+			img_url = excluded.img_url,
+			raw_url = excluded.raw_url,
+			web_url = excluded.web_url,
+			uploaded_at = excluded.uploaded_at
+	`)
+	if err != nil {
+		return fmt.Errorf("db restore disc menu screenshot: prepare slot variants: %w", err)
+	}
+	defer variantStmt.Close()
+	for _, variant := range variants {
+		uploadedAt := ""
+		if !variant.UploadedAt.IsZero() {
+			uploadedAt = variant.UploadedAt.UTC().Format(time.RFC3339Nano)
+		}
+		if _, err := variantStmt.ExecContext(
+			ctx,
+			path,
+			variant.SlotOrder,
+			strings.TrimSpace(variant.Host),
+			strings.TrimSpace(variant.UsageScope),
+			strings.TrimSpace(variant.ImagePath),
+			strings.TrimSpace(variant.ImgURL),
+			strings.TrimSpace(variant.RawURL),
+			strings.TrimSpace(variant.WebURL),
+			uploadedAt,
+		); err != nil {
+			return fmt.Errorf("db restore disc menu screenshot: insert slot variant: %w", err)
+		}
+	}
+	return nil
+}
+
+// listUploadedImagesForImageTx snapshots every local upload record associated
+// with one source image. It does not inspect or mutate remote assets.
+func listUploadedImagesForImageTx(ctx context.Context, tx *sql.Tx, path string, imagePath string) ([]UploadedImageLink, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT host, usage_scope, img_url, raw_url, web_url, size_bytes, uploaded_at
+		FROM uploaded_images
+		WHERE source_path = ? AND image_path = ?
+		ORDER BY id ASC
+	`, path, imagePath)
+	if err != nil {
+		return nil, fmt.Errorf("db delete disc menu screenshot: list uploaded images: %w", err)
+	}
+	defer rows.Close()
+
+	images := make([]UploadedImageLink, 0)
+	for rows.Next() {
+		var image UploadedImageLink
+		var uploadedAt string
+		if err := rows.Scan(&image.Host, &image.UsageScope, &image.ImgURL, &image.RawURL, &image.WebURL, &image.SizeBytes, &uploadedAt); err != nil {
+			return nil, fmt.Errorf("db delete disc menu screenshot: scan uploaded image: %w", err)
+		}
+		image.SourcePath = path
+		image.ImagePath = imagePath
+		if uploadedAt != "" {
+			if parsed, parseErr := time.Parse(time.RFC3339Nano, uploadedAt); parseErr == nil {
+				image.UploadedAt = parsed
+			}
+		}
+		images = append(images, image)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db delete disc menu screenshot: iterate uploaded images: %w", err)
+	}
+	return images, nil
 }
 
 func validMenuScreenshotBatch(path string, screenshots []Screenshot, selections []ScreenshotFinalSelection, source string) bool {
@@ -2756,54 +3062,69 @@ func (r *SQLiteRepository) SaveUploadedImages(ctx context.Context, path string, 
 		return fmt.Errorf("db save uploaded images: context canceled: %w", err)
 	}
 
+	normalized := slices.Clone(images)
+	for idx := range normalized {
+		normalized[idx].SourcePath = trimmed
+		normalized[idx].Host = trimmedHost
+	}
 	if err := r.withWriteTx(ctx, "save uploaded images", func(tx *sql.Tx) error {
-		stmt, err := tx.PrepareContext(ctx, `
-			INSERT INTO uploaded_images (
-				source_path, image_path, host, usage_scope, img_url, raw_url, web_url, size_bytes, uploaded_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-			ON CONFLICT(source_path, usage_scope, host, image_path)
-			DO UPDATE SET
-				img_url = excluded.img_url,
-				raw_url = excluded.raw_url,
-				web_url = excluded.web_url,
-				size_bytes = excluded.size_bytes,
-				uploaded_at = excluded.uploaded_at
-		`)
-		if err != nil {
-			return fmt.Errorf("db save uploaded images: prepare: %w", err)
-		}
-		defer stmt.Close()
-
-		for _, image := range images {
-			if strings.TrimSpace(image.ImagePath) == "" {
-				return internalerrors.ErrInvalidInput
-			}
-			usageScope := strings.TrimSpace(image.UsageScope)
-			if usageScope == "" {
-				usageScope = "global"
-			}
-			uploadedAt := image.UploadedAt
-			if uploadedAt.IsZero() {
-				uploadedAt = time.Now().UTC()
-			}
-			if _, err := stmt.ExecContext(
-				ctx,
-				trimmed,
-				image.ImagePath,
-				trimmedHost,
-				usageScope,
-				strings.TrimSpace(image.ImgURL),
-				strings.TrimSpace(image.RawURL),
-				strings.TrimSpace(image.WebURL),
-				image.SizeBytes,
-				uploadedAt.UTC().Format(time.RFC3339Nano),
-			); err != nil {
-				return fmt.Errorf("db save uploaded images: insert: %w", err)
-			}
-		}
-		return nil
+		return upsertUploadedImagesTx(ctx, tx, trimmed, normalized)
 	}); err != nil {
 		return err
+	}
+	return nil
+}
+
+// upsertUploadedImagesTx stores normalized upload records in the caller's
+// transaction. Each record must match path and name a local image and host;
+// empty usage scopes and upload times receive their persistence defaults.
+func upsertUploadedImagesTx(ctx context.Context, tx *sql.Tx, path string, images []UploadedImageLink) error {
+	if len(images) == 0 {
+		return nil
+	}
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO uploaded_images (
+			source_path, image_path, host, usage_scope, img_url, raw_url, web_url, size_bytes, uploaded_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(source_path, usage_scope, host, image_path)
+		DO UPDATE SET
+			img_url = excluded.img_url,
+			raw_url = excluded.raw_url,
+			web_url = excluded.web_url,
+			size_bytes = excluded.size_bytes,
+			uploaded_at = excluded.uploaded_at
+	`)
+	if err != nil {
+		return fmt.Errorf("db save uploaded images: prepare: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, image := range images {
+		if strings.TrimSpace(image.SourcePath) != path || strings.TrimSpace(image.ImagePath) == "" || strings.TrimSpace(image.Host) == "" {
+			return internalerrors.ErrInvalidInput
+		}
+		usageScope := strings.TrimSpace(image.UsageScope)
+		if usageScope == "" {
+			usageScope = "global"
+		}
+		uploadedAt := image.UploadedAt
+		if uploadedAt.IsZero() {
+			uploadedAt = time.Now().UTC()
+		}
+		if _, err := stmt.ExecContext(
+			ctx,
+			path,
+			image.ImagePath,
+			strings.TrimSpace(image.Host),
+			usageScope,
+			strings.TrimSpace(image.ImgURL),
+			strings.TrimSpace(image.RawURL),
+			strings.TrimSpace(image.WebURL),
+			image.SizeBytes,
+			uploadedAt.UTC().Format(time.RFC3339Nano),
+		); err != nil {
+			return fmt.Errorf("db save uploaded images: insert: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/services/db/sqlite.go
+++ b/internal/services/db/sqlite.go
@@ -2119,6 +2119,387 @@ func (r *SQLiteRepository) DeleteFinalSelection(ctx context.Context, imagePath s
 	return nil
 }
 
+// ReplaceNormalFinalSelections atomically replaces non-menu final selections
+// for path while preserving manual and automatic disc-menu selections.
+func (r *SQLiteRepository) ReplaceNormalFinalSelections(ctx context.Context, path string, selections []ScreenshotFinalSelection) error {
+	if r == nil || r.db == nil {
+		return errors.New("db: repository not initialized")
+	}
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return internalerrors.ErrInvalidInput
+	}
+	for _, selection := range selections {
+		if strings.TrimSpace(selection.SourcePath) != trimmed || strings.TrimSpace(selection.ImagePath) == "" || api.IsDiscMenuSelectionSource(strings.TrimSpace(selection.Source)) {
+			return internalerrors.ErrInvalidInput
+		}
+	}
+
+	return r.withWriteTx(ctx, "replace normal final selections", func(tx *sql.Tx) error {
+		existing, err := listFinalSelectionsTx(ctx, tx, trimmed)
+		if err != nil {
+			return err
+		}
+		merged := make([]ScreenshotFinalSelection, 0, len(existing)+len(selections))
+		for _, selection := range existing {
+			if api.IsDiscMenuSelectionSource(strings.TrimSpace(selection.Source)) {
+				merged = append(merged, selection)
+			}
+		}
+		merged = append(merged, selections...)
+		return rewriteFinalSelectionsTx(ctx, tx, trimmed, merged)
+	})
+}
+
+// AppendManualMenuScreenshots atomically upserts manual menu screenshot records
+// and appends their selections after existing manual-menu order values.
+func (r *SQLiteRepository) AppendManualMenuScreenshots(ctx context.Context, path string, screenshots []Screenshot, selections []ScreenshotFinalSelection) error {
+	if r == nil || r.db == nil {
+		return errors.New("db: repository not initialized")
+	}
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" || !validMenuScreenshotBatch(trimmed, screenshots, selections, api.ScreenshotSelectionSourceMenu) {
+		return internalerrors.ErrInvalidInput
+	}
+
+	return r.withWriteTx(ctx, "append manual menu screenshots", func(tx *sql.Tx) error {
+		if err := upsertMenuScreenshotsTx(ctx, tx, trimmed, screenshots); err != nil {
+			return err
+		}
+		existing, err := listFinalSelectionsTx(ctx, tx, trimmed)
+		if err != nil {
+			return err
+		}
+		maxManualOrder := -1
+		for _, selection := range existing {
+			if strings.TrimSpace(selection.Source) == api.ScreenshotSelectionSourceMenu && selection.Order > maxManualOrder {
+				maxManualOrder = selection.Order
+			}
+		}
+		for index := range selections {
+			selections[index].Order = maxManualOrder + 1 + index
+		}
+		return rewriteFinalSelectionsTx(ctx, tx, trimmed, append(existing, selections...))
+	})
+}
+
+// ReplaceDVDMenuScreenshots atomically replaces automatic DVD-menu records and
+// selections while preserving manual menus and normal screenshots. It returns
+// replaced local image paths for caller-owned filesystem cleanup.
+func (r *SQLiteRepository) ReplaceDVDMenuScreenshots(ctx context.Context, path string, screenshots []Screenshot, selections []ScreenshotFinalSelection) ([]string, error) {
+	if r == nil || r.db == nil {
+		return nil, errors.New("db: repository not initialized")
+	}
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" || !validMenuScreenshotBatch(trimmed, screenshots, selections, api.ScreenshotSelectionSourceDVDMenu) {
+		return nil, internalerrors.ErrInvalidInput
+	}
+
+	var replaced []string
+	err := r.withWriteTx(ctx, "replace DVD menu screenshots", func(tx *sql.Tx) error {
+		existing, err := listFinalSelectionsTx(ctx, tx, trimmed)
+		if err != nil {
+			return err
+		}
+		preserved := make([]ScreenshotFinalSelection, 0, len(existing)+len(selections))
+		for _, selection := range existing {
+			if strings.TrimSpace(selection.Source) == api.ScreenshotSelectionSourceDVDMenu {
+				replaced = append(replaced, selection.ImagePath)
+				if err := deleteScreenshotReferencesTx(ctx, tx, trimmed, selection.ImagePath); err != nil {
+					return err
+				}
+				continue
+			}
+			preserved = append(preserved, selection)
+		}
+		if err := upsertMenuScreenshotsTx(ctx, tx, trimmed, screenshots); err != nil {
+			return err
+		}
+		preserved = append(preserved, selections...)
+		return rewriteFinalSelectionsTx(ctx, tx, trimmed, preserved)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return replaced, nil
+}
+
+// DeleteDiscMenuScreenshot atomically removes one manual or automatic menu
+// selection, its screenshot row, and local upload records. It rejects normal
+// final selections and reports how many remote-host references were orphaned.
+func (r *SQLiteRepository) DeleteDiscMenuScreenshot(ctx context.Context, path string, imagePath string) (api.DiscMenuDeleteResult, error) {
+	if r == nil || r.db == nil {
+		return api.DiscMenuDeleteResult{}, errors.New("db: repository not initialized")
+	}
+	trimmedPath := strings.TrimSpace(path)
+	trimmedImage := strings.TrimSpace(imagePath)
+	if trimmedPath == "" || trimmedImage == "" {
+		return api.DiscMenuDeleteResult{}, internalerrors.ErrInvalidInput
+	}
+
+	var deleted api.DiscMenuDeleteResult
+	err := r.withWriteTx(ctx, "delete disc menu screenshot", func(tx *sql.Tx) error {
+		var selectedAt string
+		err := tx.QueryRowContext(ctx, `
+			SELECT sort_order, source, selected_at
+			FROM screenshot_final_selections
+			WHERE source_path = ? AND image_path = ?
+		`, trimmedPath, trimmedImage).Scan(&deleted.Selection.Order, &deleted.Selection.Source, &selectedAt)
+		if errors.Is(err, sql.ErrNoRows) {
+			return internalerrors.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("db delete disc menu screenshot: load selection: %w", err)
+		}
+		if !api.IsDiscMenuSelectionSource(strings.TrimSpace(deleted.Selection.Source)) {
+			return internalerrors.ErrInvalidInput
+		}
+		deleted.Selection.SourcePath = trimmedPath
+		deleted.Selection.ImagePath = trimmedImage
+		if selectedAt != "" {
+			if parsed, parseErr := time.Parse(time.RFC3339Nano, selectedAt); parseErr == nil {
+				deleted.Selection.SelectedAt = parsed
+			}
+		}
+		if err := tx.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM uploaded_images WHERE source_path = ? AND image_path = ?
+		`, trimmedPath, trimmedImage).Scan(&deleted.UploadedLinks); err != nil {
+			return fmt.Errorf("db delete disc menu screenshot: count uploaded images: %w", err)
+		}
+		if err := deleteScreenshotReferencesTx(ctx, tx, trimmedPath, trimmedImage); err != nil {
+			return err
+		}
+		remaining, err := listFinalSelectionsTx(ctx, tx, trimmedPath)
+		if err != nil {
+			return err
+		}
+		filtered := remaining[:0]
+		for _, selection := range remaining {
+			if selection.ImagePath != trimmedImage {
+				filtered = append(filtered, selection)
+			}
+		}
+		return rewriteFinalSelectionsTx(ctx, tx, trimmedPath, filtered)
+	})
+	if err != nil {
+		return api.DiscMenuDeleteResult{}, err
+	}
+	return deleted, nil
+}
+
+func validMenuScreenshotBatch(path string, screenshots []Screenshot, selections []ScreenshotFinalSelection, source string) bool {
+	if len(screenshots) != len(selections) {
+		return false
+	}
+	paths := make(map[string]struct{}, len(screenshots))
+	for _, screenshot := range screenshots {
+		if strings.TrimSpace(screenshot.SourcePath) != path || strings.TrimSpace(screenshot.ImagePath) == "" || screenshot.Purpose != api.ScreenshotPurposeMenu {
+			return false
+		}
+		imagePath := strings.TrimSpace(screenshot.ImagePath)
+		if _, exists := paths[imagePath]; exists {
+			return false
+		}
+		paths[imagePath] = struct{}{}
+	}
+	for _, selection := range selections {
+		if strings.TrimSpace(selection.SourcePath) != path || strings.TrimSpace(selection.ImagePath) == "" || strings.TrimSpace(selection.Source) != source {
+			return false
+		}
+		imagePath := strings.TrimSpace(selection.ImagePath)
+		if _, exists := paths[imagePath]; !exists {
+			return false
+		}
+		delete(paths, imagePath)
+	}
+	return len(paths) == 0
+}
+
+func upsertMenuScreenshotsTx(ctx context.Context, tx *sql.Tx, path string, screenshots []Screenshot) error {
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO screenshots (
+			source_path, image_path, timestamp, frame_number, width, height, purpose, captured_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(image_path) DO UPDATE SET
+			timestamp = excluded.timestamp,
+			frame_number = excluded.frame_number,
+			width = excluded.width,
+			height = excluded.height,
+			purpose = excluded.purpose,
+			captured_at = excluded.captured_at
+		WHERE screenshots.source_path = excluded.source_path
+	`)
+	if err != nil {
+		return fmt.Errorf("db save menu screenshots: prepare: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, screenshot := range screenshots {
+		capturedAt := screenshot.CapturedAt
+		if capturedAt.IsZero() {
+			capturedAt = time.Now().UTC()
+		}
+		result, err := stmt.ExecContext(
+			ctx,
+			path,
+			screenshot.ImagePath,
+			screenshot.Timestamp,
+			screenshot.FrameNumber,
+			screenshot.Width,
+			screenshot.Height,
+			screenshot.Purpose,
+			capturedAt.UTC().Format(time.RFC3339Nano),
+		)
+		if err != nil {
+			return fmt.Errorf("db save menu screenshots: insert: %w", err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("db save menu screenshots: rows affected: %w", err)
+		}
+		if rows == 0 {
+			return internalerrors.ErrInvalidInput
+		}
+	}
+	return nil
+}
+
+func listFinalSelectionsTx(ctx context.Context, tx *sql.Tx, path string) ([]ScreenshotFinalSelection, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT image_path, sort_order, source, selected_at
+		FROM screenshot_final_selections
+		WHERE source_path = ?
+		ORDER BY sort_order ASC
+	`, path)
+	if err != nil {
+		return nil, fmt.Errorf("db list final selections in transaction: %w", err)
+	}
+	defer rows.Close()
+
+	selections := make([]ScreenshotFinalSelection, 0)
+	for rows.Next() {
+		var selection ScreenshotFinalSelection
+		var selectedAt string
+		if err := rows.Scan(&selection.ImagePath, &selection.Order, &selection.Source, &selectedAt); err != nil {
+			return nil, fmt.Errorf("db list final selections in transaction: scan: %w", err)
+		}
+		selection.SourcePath = path
+		if selectedAt != "" {
+			if parsed, parseErr := time.Parse(time.RFC3339Nano, selectedAt); parseErr == nil {
+				selection.SelectedAt = parsed
+			}
+		}
+		selections = append(selections, selection)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db list final selections in transaction: iterate: %w", err)
+	}
+	return selections, nil
+}
+
+func rewriteFinalSelectionsTx(ctx context.Context, tx *sql.Tx, path string, selections []ScreenshotFinalSelection) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM screenshot_final_selections WHERE source_path = ?`, path); err != nil {
+		return fmt.Errorf("db rewrite final selections: clear: %w", err)
+	}
+	ordered := orderFinalSelections(path, selections)
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO screenshot_final_selections (
+			source_path, image_path, sort_order, source, selected_at
+		) VALUES (?, ?, ?, ?, ?)
+	`)
+	if err != nil {
+		return fmt.Errorf("db rewrite final selections: prepare: %w", err)
+	}
+	defer stmt.Close()
+	for _, selection := range ordered {
+		if _, err := stmt.ExecContext(
+			ctx,
+			path,
+			selection.ImagePath,
+			selection.Order,
+			selection.Source,
+			selection.SelectedAt.UTC().Format(time.RFC3339Nano),
+		); err != nil {
+			return fmt.Errorf("db rewrite final selections: insert: %w", err)
+		}
+	}
+	return nil
+}
+
+func orderFinalSelections(path string, selections []ScreenshotFinalSelection) []ScreenshotFinalSelection {
+	groups := [3][]ScreenshotFinalSelection{}
+	for _, selection := range selections {
+		selection.ImagePath = strings.TrimSpace(selection.ImagePath)
+		if selection.ImagePath == "" {
+			continue
+		}
+		selection.Source = strings.TrimSpace(selection.Source)
+		if selection.Source == "" {
+			selection.Source = "unknown"
+		}
+		rank := 2
+		switch selection.Source {
+		case api.ScreenshotSelectionSourceDVDMenu:
+			rank = 0
+		case api.ScreenshotSelectionSourceMenu:
+			rank = 1
+		}
+		groups[rank] = append(groups[rank], selection)
+	}
+	for idx := range groups {
+		sort.SliceStable(groups[idx], func(left, right int) bool {
+			return groups[idx][left].Order < groups[idx][right].Order
+		})
+	}
+
+	ordered := make([]ScreenshotFinalSelection, 0, len(selections))
+	seen := make(map[string]struct{}, len(selections))
+	for _, group := range groups {
+		for _, selection := range group {
+			if _, exists := seen[selection.ImagePath]; exists {
+				continue
+			}
+			seen[selection.ImagePath] = struct{}{}
+			selection.SourcePath = path
+			selection.Order = len(ordered)
+			if selection.SelectedAt.IsZero() {
+				selection.SelectedAt = time.Now().UTC()
+			}
+			ordered = append(ordered, selection)
+		}
+	}
+	return ordered
+}
+
+func deleteScreenshotReferencesTx(ctx context.Context, tx *sql.Tx, path string, imagePath string) error {
+	queries := []string{
+		`DELETE FROM screenshot_slot_variants
+		 WHERE source_path = ? AND (
+			image_path = ? OR slot_order IN (
+				SELECT slot_order FROM screenshot_slots WHERE source_path = ? AND image_path = ?
+			)
+		)`,
+		`DELETE FROM screenshot_slots WHERE source_path = ? AND image_path = ?`,
+		`DELETE FROM uploaded_images WHERE source_path = ? AND image_path = ?`,
+		`DELETE FROM screenshots WHERE source_path = ? AND image_path = ? AND purpose = ?`,
+	}
+	for index, query := range queries {
+		var args []any
+		switch index {
+		case 0:
+			args = []any{path, imagePath, path, imagePath}
+		case 1, 2:
+			args = []any{path, imagePath}
+		case 3:
+			args = []any{path, imagePath, api.ScreenshotPurposeMenu}
+		}
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("db delete screenshot references: %w", err)
+		}
+	}
+	return nil
+}
+
 func (r *SQLiteRepository) ReplaceScreenshotSlots(ctx context.Context, path string, slots []ScreenshotSlot) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")

--- a/internal/services/description/hdb/builder.go
+++ b/internal/services/description/hdb/builder.go
@@ -29,7 +29,11 @@ var (
 	hdbEmptyWrapperTag = regexp.MustCompile(`(?is)\[(?:center|align=center)\]\s*\[/(?:center|align)\]`)
 )
 
-func BuildDescription(ctx context.Context, meta api.PreparedMetadata, appConfig config.Config, keptDescription string, screenshots []api.ScreenshotImage) (string, error) {
+// BuildDescription builds HDB-compatible BBCode from retained description
+// text and resolved image assets. Disc-menu images render in their own section
+// before normal screenshots; cancellation and disc-metadata read failures are
+// returned to the caller.
+func BuildDescription(ctx context.Context, meta api.PreparedMetadata, appConfig config.Config, keptDescription string, menuImages []api.ScreenshotImage, screenshots []api.ScreenshotImage) (string, error) {
 	select {
 	case <-ctx.Done():
 		return "", fmt.Errorf("context canceled: %w", ctx.Err())
@@ -50,8 +54,17 @@ func BuildDescription(ctx context.Context, meta api.PreparedMetadata, appConfig 
 		parts = append(parts, discSection)
 	}
 
-	if transformed := transformBaseDescription(keptDescription, len(screenshots) > 0); strings.TrimSpace(transformed) != "" {
+	if transformed := transformBaseDescription(keptDescription, len(menuImages) > 0 || len(screenshots) > 0); strings.TrimSpace(transformed) != "" {
 		parts = append(parts, transformed)
+	}
+
+	if len(menuImages) > 0 {
+		if header := strings.TrimSpace(appConfig.Description.DiscMenuHeader); header != "" {
+			parts = append(parts, header)
+		}
+		if section := buildScreenshotSection(menuImages, 0); section != "" {
+			parts = append(parts, section)
+		}
 	}
 
 	if section := buildScreenshotSection(screenshots, meta.Options.Screens); section != "" {
@@ -159,10 +172,7 @@ func convertComparisonToCentered(value string, maxWidth int) string {
 		if screensPerLine <= 0 {
 			return match
 		}
-		imgSize := maxWidth / screensPerLine
-		if imgSize > 350 {
-			imgSize = 350
-		}
+		imgSize := min(maxWidth/screensPerLine, 350)
 		rows := make([]string, 0)
 		line := make([]string, 0, screensPerLine)
 		for _, img := range images {

--- a/internal/services/description/hdb/builder_test.go
+++ b/internal/services/description/hdb/builder_test.go
@@ -17,7 +17,7 @@ func TestBuildDescriptionAddsWebDLSource(t *testing.T) {
 		Type:            "WEBDL",
 		ServiceLongName: "Netflix",
 	}
-	description, err := BuildDescription(context.Background(), meta, config.Config{}, "", nil)
+	description, err := BuildDescription(context.Background(), meta, config.Config{}, "", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestBuildDescriptionTransformsBaseAndAddsScreens(t *testing.T) {
 	base := "[code]x[/code]\n[spoiler=Comp][comparison=A, B]https://img/a.jpg https://img/b.jpg[/comparison][/spoiler]\n[size=3][img=300]https://img/x.jpg[/img][/size]"
 	screens := []api.ScreenshotImage{{ImgURL: "https://img/s1.jpg", WebURL: "https://web/s1"}, {ImgURL: "https://img/s2.jpg"}}
 
-	description, err := BuildDescription(context.Background(), meta, config.Config{}, base, screens)
+	description, err := BuildDescription(context.Background(), meta, config.Config{}, base, nil, screens)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -48,6 +48,36 @@ func TestBuildDescriptionTransformsBaseAndAddsScreens(t *testing.T) {
 	}
 	if strings.Contains(description, "https://img/s2.jpg") {
 		t.Fatalf("expected second screenshot omitted by limit, got %q", description)
+	}
+}
+
+func TestBuildDescriptionAddsRehostedMenuImagesSeparately(t *testing.T) {
+	menuImages := []api.ScreenshotImage{{
+		Purpose: api.ScreenshotPurposeMenu,
+		ImgURL:  "https://t.hdbits.org/menu.jpg",
+		WebURL:  "https://img.hdbits.org/menu",
+	}}
+	screens := []api.ScreenshotImage{{
+		Purpose: api.ScreenshotPurposeFinal,
+		ImgURL:  "https://t.hdbits.org/screen.jpg",
+		WebURL:  "https://img.hdbits.org/screen",
+	}}
+	appConfig := config.Config{Description: config.DescriptionSettingsConfig{DiscMenuHeader: "[b]Disc menu[/b]"}}
+
+	description, err := BuildDescription(context.Background(), api.PreparedMetadata{}, appConfig, "", menuImages, screens)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	menuPos := strings.Index(description, "https://t.hdbits.org/menu.jpg")
+	screenPos := strings.Index(description, "https://t.hdbits.org/screen.jpg")
+	if menuPos < 0 || screenPos < 0 {
+		t.Fatalf("expected menu and screenshot sections, got %q", description)
+	}
+	if !strings.Contains(description, "[b]Disc menu[/b]") {
+		t.Fatalf("expected disc menu header, got %q", description)
+	}
+	if menuPos >= screenPos {
+		t.Fatalf("expected menu before screenshots, got %q", description)
 	}
 }
 
@@ -66,7 +96,7 @@ func TestBuildDescriptionReplacesExistingScreenshotBlock(t *testing.T) {
 		{ImgURL: "https://t.hdbits.org/w0S7ltI.jpg", RawURL: "https://img.hdbits.org/w0S7ltI.jpg", WebURL: "https://img.hdbits.org/w0S7ltI"},
 	}
 
-	description, err := BuildDescription(context.Background(), meta, config.Config{}, base, screens)
+	description, err := BuildDescription(context.Background(), meta, config.Config{}, base, nil, screens)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -92,7 +122,7 @@ func TestBuildDescriptionPreservesExistingScreensWhenNoNewScreensProvided(t *tes
 
 [align=right][url=https://github.com/autobrr/upbrr][size=10]upbrr[/size][/url][/align]`
 
-	description, err := BuildDescription(context.Background(), meta, config.Config{}, base, nil)
+	description, err := BuildDescription(context.Background(), meta, config.Config{}, base, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/services/dvdmenus/service.go
+++ b/internal/services/dvdmenus/service.go
@@ -66,6 +66,7 @@ type Service struct {
 	runner            render.Runner
 	resolveExecutable executableResolverFunc
 	captureDirectory  captureDirectoryFunc
+	removeFile        func(string) error
 	capabilityMu      sync.Mutex
 	capabilityCache   capabilityCache
 }
@@ -106,6 +107,7 @@ func newService(
 		runner:            runner,
 		resolveExecutable: resolveExecutable,
 		captureDirectory:  captureDirectory,
+		removeFile:        os.Remove,
 	}
 }
 
@@ -327,7 +329,9 @@ func (s *Service) List(ctx context.Context, meta api.PreparedMetadata) ([]api.Sc
 
 // Delete removes one menu image beneath the prepared release's managed temp
 // directory and atomically deletes its local DB references. Remote image-host
-// assets are not deleted.
+// assets are not deleted. If final removal of the staged file fails, Delete
+// attempts to restore the original file and its local records before returning;
+// compensation failures are joined with the removal error.
 func (s *Service) Delete(ctx context.Context, meta api.PreparedMetadata, imagePath string) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("DVD menus: delete canceled: %w", err)
@@ -372,8 +376,18 @@ func (s *Service) Delete(ctx context.Context, meta api.PreparedMetadata, imagePa
 		return fmt.Errorf("DVD menus: delete records: %w", err)
 	}
 	if renamed {
-		if err := os.Remove(pendingPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("DVD menus: remove staged local image: %w", err)
+		removeFile := s.removeFile
+		if removeFile == nil {
+			removeFile = os.Remove
+		}
+		if removeErr := removeFile(pendingPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			if restoreErr := os.Rename(pendingPath, trimmedPath); restoreErr != nil {
+				return fmt.Errorf("DVD menus: remove staged local image and restore file: %w", errors.Join(removeErr, restoreErr))
+			}
+			if restoreErr := s.lifecycle.RestoreDiscMenuScreenshot(context.WithoutCancel(ctx), meta.SourcePath, deleted); restoreErr != nil {
+				return fmt.Errorf("DVD menus: remove staged local image and restore records: %w", errors.Join(removeErr, restoreErr))
+			}
+			return fmt.Errorf("DVD menus: remove staged local image; deletion rolled back: %w", removeErr)
 		}
 	}
 	if deleted.UploadedLinks > 0 {

--- a/internal/services/dvdmenus/service.go
+++ b/internal/services/dvdmenus/service.go
@@ -1,0 +1,735 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Package dvdmenus captures, persists, lists, and deletes managed DVD menu
+// screenshots while preserving manual and normal screenshot categories.
+package dvdmenus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	_ "image/jpeg" // register JPEG metadata decoding for manual menu imports
+	"image/png"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/dvdvideo/engine"
+	"github.com/autobrr/upbrr/internal/dvdvideo/graph"
+	"github.com/autobrr/upbrr/internal/dvdvideo/render"
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	"github.com/autobrr/upbrr/internal/paths"
+	"github.com/autobrr/upbrr/internal/pathutil"
+	"github.com/autobrr/upbrr/internal/services/screenshots"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+const (
+	engineSchemaVersion       = 1
+	defaultLanguage           = "en"
+	requiredFFmpegMenuOptions = 5
+)
+
+var supportedFeatures = []string{
+	"ifo_inventory",
+	"vm_navigation",
+	"nav_buttons",
+	"spu_composition",
+	"default_highlight",
+}
+
+type captureDirectoryFunc func(context.Context, string, render.Runner, string, engine.Options) (engine.Result, error)
+type executableResolverFunc func() (string, error)
+
+type executableIdentity struct {
+	path    string
+	size    int64
+	modTime int64
+}
+
+type capabilityCache struct {
+	identity   executableIdentity
+	capability render.Capability
+	valid      bool
+}
+
+// Service coordinates bounded DVD menu capture and category-aware persistence.
+type Service struct {
+	logger            api.Logger
+	tmpRoot           string
+	repo              api.MetadataRepository
+	lifecycle         api.ScreenshotLifecycleRepository
+	runner            render.Runner
+	resolveExecutable executableResolverFunc
+	captureDirectory  captureDirectoryFunc
+	capabilityMu      sync.Mutex
+	capabilityCache   capabilityCache
+}
+
+// NewService returns a DVD menu service that shares the screenshot FFmpeg
+// resolver and stores managed images beneath tmpRoot. A nil logger is replaced
+// with [api.NopLogger].
+func NewService(logger api.Logger, tmpRoot string, repo api.MetadataRepository) *Service {
+	return newService(logger, tmpRoot, repo, render.ExecRunner{}, screenshots.ResolveFFmpegExecutable, engine.CaptureDirectory)
+}
+
+func newService(
+	logger api.Logger,
+	tmpRoot string,
+	repo api.MetadataRepository,
+	runner render.Runner,
+	resolveExecutable executableResolverFunc,
+	captureDirectory captureDirectoryFunc,
+) *Service {
+	if logger == nil {
+		logger = api.NopLogger{}
+	}
+	if runner == nil {
+		runner = render.ExecRunner{}
+	}
+	if resolveExecutable == nil {
+		resolveExecutable = screenshots.ResolveFFmpegExecutable
+	}
+	if captureDirectory == nil {
+		captureDirectory = engine.CaptureDirectory
+	}
+	lifecycle, _ := repo.(api.ScreenshotLifecycleRepository)
+	return &Service{
+		logger:            logger,
+		tmpRoot:           tmpRoot,
+		repo:              repo,
+		lifecycle:         lifecycle,
+		runner:            runner,
+		resolveExecutable: resolveExecutable,
+		captureDirectory:  captureDirectory,
+	}
+}
+
+// Capture renders and persists up to maxItems automatic menu images for one
+// prepared DVD. It atomically replaces earlier automatic captures, preserves
+// manual menus and normal screenshots, and reports partial coverage in result.
+func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, maxItems int) (api.DVDMenuCaptureResult, error) {
+	result := api.DVDMenuCaptureResult{SourcePath: meta.SourcePath, MaxItems: maxItems}
+	if s != nil && s.logger != nil {
+		s.logger.Debugf("DVD menus: capture requested disc_type=%s max_items=%d", strings.ToUpper(strings.TrimSpace(meta.DiscType)), maxItems)
+	}
+	api.ReportDVDMenuProgress(ctx, api.DVDMenuProgressUpdate{Phase: "preflight", Message: "Checking DVD menu capture support."})
+	if err := ctx.Err(); err != nil {
+		return result, fmt.Errorf("DVD menus: capture canceled: %w", err)
+	}
+	if s == nil || s.repo == nil || s.lifecycle == nil {
+		return result, errors.New("DVD menus: screenshot lifecycle repository not configured")
+	}
+	if !strings.EqualFold(strings.TrimSpace(meta.DiscType), "DVD") {
+		return result, errors.New("DVD menus: source is not a DVD")
+	}
+	if strings.TrimSpace(meta.SourcePath) == "" || maxItems < 1 || maxItems > graph.MaxMenuItems {
+		return result, internalerrors.ErrInvalidInput
+	}
+
+	videoTS, err := resolveVideoTSDirectory(meta.SourcePath)
+	if err != nil {
+		return result, err
+	}
+	s.logger.Debugf("DVD menus: source ready input=extracted_video_ts")
+	executable, capability, info, err := s.resolveCapability(ctx)
+	result.Engine = info
+	if err != nil {
+		s.logger.Warnf("DVD menus: capture failed stage=capability missing_options=%d", len(info.MissingFFmpegOptions))
+		return result, err
+	}
+
+	s.logger.Infof("DVD menus: capture started language=%s region=%d max_items=%d engine_version=%s ffmpeg_dvdvideo=%t", defaultLanguage, 0, maxItems, info.EngineVersion, info.FFmpegDVDVideo)
+	lastProgress := engine.Progress{}
+	hasProgress := false
+	engineResult, err := s.captureDirectory(ctx, videoTS, s.runner, executable, engine.Options{
+		Traversal:      graph.Options{Language: defaultLanguage, MaxItems: maxItems},
+		ProcessTimeout: engine.DefaultProcessTimeout,
+		Deinterlace:    true,
+		Capability:     &capability,
+		Logger:         s.logger,
+		Progress: func(update engine.Progress) {
+			if !hasProgress || update != lastProgress {
+				s.logger.Debugf("DVD menus: progress phase=%s inventoried=%d states=%d buttons=%d captured=%d warnings=%d", update.Phase, update.Inventoried, update.VisitedStates, update.VisitedButtons, update.Captured, update.Warnings)
+				lastProgress = update
+				hasProgress = true
+			}
+			api.ReportDVDMenuProgress(ctx, api.DVDMenuProgressUpdate{
+				Phase:           update.Phase,
+				Message:         dvdMenuProgressMessage(update.Phase),
+				DiscoveredMenus: update.Inventoried,
+				VisitedStates:   update.VisitedStates,
+				VisitedButtons:  update.VisitedButtons,
+				CapturedCount:   update.Captured,
+				WarningCount:    update.Warnings,
+			})
+		},
+	})
+	result = mapEngineResult(meta.SourcePath, maxItems, engineResult, info)
+	if err != nil {
+		s.logger.Warnf("DVD menus: capture failed stage=engine captured=%d discovered=%d warnings=%d", len(engineResult.Captures), engineResult.Inventoried, len(engineResult.Warnings))
+		return result, fmt.Errorf("DVD menus: %w", err)
+	}
+	if len(engineResult.Captures) == 0 {
+		s.logger.Warnf("DVD menus: capture failed stage=render reason=no_frames")
+		return result, errors.New("DVD menus: no menu images captured")
+	}
+	s.logger.Debugf("DVD menus: engine complete discovered=%d states=%d buttons=%d selected=%d captured=%d partial=%t truncated=%t warnings=%d", result.DiscoveredMenus, result.VisitedStates, result.VisitedButtons, engineResult.Selected, len(engineResult.Captures), result.Partial, result.Truncated, len(result.Warnings))
+	for _, warning := range result.Warnings {
+		s.logger.Debugf("DVD menus: warning recorded code=%s detail=%q", warning.Code, dvdMenuWarningDetail(warning.Code))
+	}
+	s.logger.Debugf("DVD menus: persistence started images=%d", len(engineResult.Captures))
+	api.ReportDVDMenuProgress(ctx, api.DVDMenuProgressUpdate{
+		Phase:           "persisting",
+		Message:         "Saving captured DVD menu images.",
+		DiscoveredMenus: result.DiscoveredMenus,
+		VisitedStates:   result.VisitedStates,
+		VisitedButtons:  result.VisitedButtons,
+		CapturedCount:   len(engineResult.Captures),
+		WarningCount:    len(result.Warnings),
+	})
+
+	tmpDir, base, err := paths.ReleaseTempDir(s.tmpRoot, meta, meta.SourcePath)
+	if err != nil {
+		return result, fmt.Errorf("DVD menus: %w", err)
+	}
+	images, records, selections, created, err := writeCaptureImages(ctx, tmpDir, base, meta.SourcePath, engineResult.Captures)
+	if err != nil {
+		removeCreatedFiles(created)
+		s.logger.Warnf("DVD menus: persistence failed stage=write created=%d", len(created))
+		return result, err
+	}
+	s.logger.Debugf("DVD menus: persistence files ready created=%d", len(created))
+	replaced, err := s.lifecycle.ReplaceDVDMenuScreenshots(ctx, meta.SourcePath, records, selections)
+	if err != nil {
+		removeCreatedFiles(created)
+		s.logger.Warnf("DVD menus: persistence failed stage=database created=%d", len(created))
+		return result, fmt.Errorf("DVD menus: persist capture: %w", err)
+	}
+	result.Images = images
+	s.logger.Debugf("DVD menus: persistence complete stored=%d replaced=%d", len(images), len(replaced))
+
+	cleanupFailed := 0
+	for _, oldPath := range replaced {
+		if !managedChildPath(tmpDir, oldPath) {
+			cleanupFailed++
+			continue
+		}
+		if err := os.Remove(oldPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			cleanupFailed++
+		}
+	}
+	if cleanupFailed > 0 {
+		result.Partial = true
+		result.Complete = false
+		result.Warnings = appendWarning(result.Warnings, api.DVDMenuCaptureWarning{
+			Code:    "cleanup_failed",
+			Message: "Some replaced local DVD menu files could not be removed.",
+		})
+		s.logger.Warnf("DVD menus: replaced file cleanup incomplete count=%d", cleanupFailed)
+	}
+	if result.Partial || result.Truncated {
+		s.logger.Warnf("DVD menus: capture incomplete captured=%d discovered=%d states=%d buttons=%d partial=%t truncated=%t warnings=%d", len(result.Images), result.DiscoveredMenus, result.VisitedStates, result.VisitedButtons, result.Partial, result.Truncated, len(result.Warnings))
+	}
+	s.logger.Infof(
+		"DVD menus: capture complete captured=%d discovered=%d states=%d buttons=%d complete=%t partial=%t truncated=%t warnings=%d",
+		len(result.Images),
+		result.DiscoveredMenus,
+		result.VisitedStates,
+		result.VisitedButtons,
+		result.Complete,
+		result.Partial,
+		result.Truncated,
+		len(result.Warnings),
+	)
+	api.ReportDVDMenuProgress(ctx, api.DVDMenuProgressUpdate{
+		Phase:           "complete",
+		Message:         "DVD menu capture finished.",
+		DiscoveredMenus: result.DiscoveredMenus,
+		VisitedStates:   result.VisitedStates,
+		VisitedButtons:  result.VisitedButtons,
+		CapturedCount:   len(result.Images),
+		WarningCount:    len(result.Warnings),
+	})
+	return result, nil
+}
+
+func dvdMenuProgressMessage(phase string) string {
+	switch phase {
+	case "discovering":
+		return "Discovering reachable DVD menus."
+	case "capturing":
+		return "Rendering distinct DVD menu screens."
+	case "preflight", "persisting", "complete":
+		return ""
+	default:
+		return "Processing DVD menus."
+	}
+}
+
+// List returns persisted manual and automatic menu images in final-selection
+// order. Missing or directory-valued local image paths are omitted.
+func (s *Service) List(ctx context.Context, meta api.PreparedMetadata) ([]api.ScreenshotImage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("DVD menus: list canceled: %w", err)
+	}
+	if s == nil || s.repo == nil {
+		return nil, errors.New("DVD menus: repository not configured")
+	}
+	if strings.TrimSpace(meta.SourcePath) == "" {
+		return nil, internalerrors.ErrInvalidInput
+	}
+
+	selections, err := s.repo.ListFinalSelections(ctx, meta.SourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("DVD menus: list selections: %w", err)
+	}
+	records, err := s.repo.ListScreenshotsByPath(ctx, meta.SourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("DVD menus: list screenshots: %w", err)
+	}
+	uploaded, err := s.repo.ListUploadedImagesByPath(ctx, meta.SourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("DVD menus: list uploaded images: %w", err)
+	}
+
+	recordByPath := make(map[string]api.Screenshot, len(records))
+	for _, record := range records {
+		if record.Purpose == api.ScreenshotPurposeMenu {
+			recordByPath[strings.TrimSpace(record.ImagePath)] = record
+		}
+	}
+	uploadByPath := make(map[string]api.UploadedImageLink, len(uploaded))
+	for _, link := range uploaded {
+		uploadByPath[strings.TrimSpace(link.ImagePath)] = link
+	}
+
+	images := make([]api.ScreenshotImage, 0)
+	for _, selection := range selections {
+		if !api.IsDiscMenuSelectionSource(selection.Source) {
+			continue
+		}
+		pathValue := strings.TrimSpace(selection.ImagePath)
+		if pathValue == "" {
+			continue
+		}
+		imageValue, ok := screenshotImage(pathValue, len(images), recordByPath[pathValue], uploadByPath[pathValue])
+		if ok {
+			images = append(images, imageValue)
+		}
+	}
+	return images, nil
+}
+
+// Delete removes one menu image beneath the prepared release's managed temp
+// directory and atomically deletes its local DB references. Remote image-host
+// assets are not deleted.
+func (s *Service) Delete(ctx context.Context, meta api.PreparedMetadata, imagePath string) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("DVD menus: delete canceled: %w", err)
+	}
+	if s == nil || s.lifecycle == nil {
+		return errors.New("DVD menus: screenshot lifecycle repository not configured")
+	}
+	trimmedPath := strings.TrimSpace(imagePath)
+	if strings.TrimSpace(meta.SourcePath) == "" || trimmedPath == "" {
+		return internalerrors.ErrInvalidInput
+	}
+	tmpDir, _, err := paths.ReleaseTempDir(s.tmpRoot, meta, meta.SourcePath)
+	if err != nil {
+		return fmt.Errorf("DVD menus: %w", err)
+	}
+	if !managedChildPath(tmpDir, trimmedPath) {
+		return errors.New("DVD menus: image is outside the managed release directory")
+	}
+
+	pendingPath := trimmedPath + fmt.Sprintf(".delete-%d", time.Now().UTC().UnixNano())
+	renamed := false
+	info, statErr := os.Stat(trimmedPath)
+	switch {
+	case statErr == nil && info.IsDir():
+		return internalerrors.ErrInvalidInput
+	case statErr == nil:
+		if err := os.Rename(trimmedPath, pendingPath); err != nil {
+			return fmt.Errorf("DVD menus: stage local delete: %w", err)
+		}
+		renamed = true
+	case !errors.Is(statErr, os.ErrNotExist):
+		return fmt.Errorf("DVD menus: inspect local image: %w", statErr)
+	}
+
+	deleted, err := s.lifecycle.DeleteDiscMenuScreenshot(ctx, meta.SourcePath, trimmedPath)
+	if err != nil {
+		if renamed {
+			if restoreErr := os.Rename(pendingPath, trimmedPath); restoreErr != nil {
+				return fmt.Errorf("DVD menus: delete records and restore local image: %w", errors.Join(err, restoreErr))
+			}
+		}
+		return fmt.Errorf("DVD menus: delete records: %w", err)
+	}
+	if renamed {
+		if err := os.Remove(pendingPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("DVD menus: remove staged local image: %w", err)
+		}
+	}
+	if deleted.UploadedLinks > 0 {
+		s.logger.Warnf("DVD menus: local image removed but remote assets may remain count=%d", deleted.UploadedLinks)
+	}
+	s.logger.Infof("DVD menus: image removed source=%s", deleted.Selection.Source)
+	return nil
+}
+
+// Capability reports path-free engine metadata and FFmpeg dvdvideo support.
+// Successful probes are cached until the resolved executable identity changes.
+func (s *Service) Capability(ctx context.Context) (api.DVDMenuEngineInfo, error) {
+	_, _, info, err := s.resolveCapability(ctx)
+	return info, err
+}
+
+// resolveCapability resolves and probes FFmpeg, reusing a cached successful
+// probe only while executable path, size, and modification time remain equal.
+func (s *Service) resolveCapability(ctx context.Context) (string, render.Capability, api.DVDMenuEngineInfo, error) {
+	info := baseEngineInfo()
+	if s != nil && s.logger != nil {
+		s.logger.Debugf("DVD menus: FFmpeg capability check started required_options=%d", requiredFFmpegMenuOptions)
+	}
+	if err := ctx.Err(); err != nil {
+		return "", render.Capability{}, info, fmt.Errorf("DVD menus: capability canceled: %w", err)
+	}
+	if s == nil || s.resolveExecutable == nil || s.runner == nil {
+		return "", render.Capability{}, info, errors.New("DVD menus: FFmpeg capability unavailable")
+	}
+	executable, err := s.resolveExecutable()
+	if err != nil {
+		s.logger.Debugf("DVD menus: FFmpeg capability unavailable stage=resolve")
+		return "", render.Capability{}, info, fmt.Errorf("DVD menus: resolve FFmpeg: %w", err)
+	}
+	identity, err := inspectExecutable(executable)
+	if err != nil {
+		s.logger.Debugf("DVD menus: FFmpeg capability unavailable stage=inspect")
+		return "", render.Capability{}, info, err
+	}
+
+	s.capabilityMu.Lock()
+	if s.capabilityCache.valid && s.capabilityCache.identity == identity {
+		capability := s.capabilityCache.capability
+		s.capabilityMu.Unlock()
+		s.logger.Debugf("DVD menus: FFmpeg capability cache hit dvdvideo=%t options=%d", capability.Available, len(capability.Options))
+		return executable, capability, engineInfo(capability), nil
+	}
+	s.capabilityMu.Unlock()
+
+	s.logger.Debugf("DVD menus: FFmpeg capability probe started")
+	capability, err := render.Probe(ctx, s.runner, executable)
+	if err != nil {
+		info.MissingFFmpegOptions = missingFFmpegOptions(err)
+		s.logger.Debugf("DVD menus: FFmpeg capability incompatible missing_options=%d", len(info.MissingFFmpegOptions))
+		return "", render.Capability{}, info, fmt.Errorf("DVD menus: FFmpeg capability: %w", err)
+	}
+	s.capabilityMu.Lock()
+	s.capabilityCache = capabilityCache{identity: identity, capability: capability, valid: true}
+	s.capabilityMu.Unlock()
+	s.logger.Debugf("DVD menus: FFmpeg capability probe complete dvdvideo=%t options=%d", capability.Available, len(capability.Options))
+	return executable, capability, engineInfo(capability), nil
+}
+
+func dvdMenuWarningDetail(code string) string {
+	switch code {
+	case "depth_limit":
+		return "menu branch depth limit reached"
+	case "state_limit":
+		return "menu state limit reached"
+	case "pre_command":
+		return "menu pre-command failed"
+	case "unsupported_pre_link":
+		return "menu pre-command target was not resolved"
+	case "live_state":
+		return "menu NAV/SPU state could not be resolved"
+	case "button_limit":
+		return "menu button limit reached"
+	case "button_command":
+		return "menu button command failed"
+	case "unsupported_button_link":
+		return "menu button target was not resolved"
+	case "post_command":
+		return "menu post-command failed"
+	case "unsupported_post_link":
+		return "menu post-command target was not resolved"
+	case "structural_only":
+		return "visible menu was not reached through navigation"
+	case "structural_state":
+		return "structural menu candidate could not be classified"
+	case "nav_scan_limit":
+		return "menu NAV/SPU sector scan limit reached"
+	case "frame_decode":
+		return "inventory-selected menu frame could not be decoded"
+	case "spu_unavailable":
+		return "menu subpicture state was not available"
+	case "highlight_unavailable":
+		return "default menu highlight state was not available"
+	case "black_frame":
+		return "decoded menu frame was black"
+	case "structural_discovery":
+		return "some menu screens were found through structural inventory rather than reachable navigation"
+	case "cleanup_failed":
+		return "some replaced local DVD menu files could not be removed"
+	}
+	return "DVD menu coverage warning"
+}
+
+func inspectExecutable(executable string) (executableIdentity, error) {
+	absPath, err := filepath.Abs(strings.TrimSpace(executable))
+	if err != nil {
+		return executableIdentity{}, fmt.Errorf("DVD menus: resolve FFmpeg identity: %w", err)
+	}
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return executableIdentity{}, fmt.Errorf("DVD menus: inspect FFmpeg identity: %w", err)
+	}
+	if info.IsDir() {
+		return executableIdentity{}, errors.New("DVD menus: FFmpeg executable is a directory")
+	}
+	return executableIdentity{path: absPath, size: info.Size(), modTime: info.ModTime().UnixNano()}, nil
+}
+
+func baseEngineInfo() api.DVDMenuEngineInfo {
+	return api.DVDMenuEngineInfo{
+		EngineVersion:     engine.Version,
+		SchemaVersion:     engineSchemaVersion,
+		SupportedFeatures: append([]string(nil), supportedFeatures...),
+	}
+}
+
+func engineInfo(capability render.Capability) api.DVDMenuEngineInfo {
+	info := baseEngineInfo()
+	info.FFmpegVersion = capability.Version
+	info.FFmpegDVDVideo = capability.Available
+	return info
+}
+
+func missingFFmpegOptions(err error) []string {
+	message := err.Error()
+	required := []string{"-menu", "-menu_lu", "-menu_vts", "-pgc", "-pg"}
+	missing := make([]string, 0)
+	_, reported, ok := strings.Cut(message, "missing ")
+	if !ok {
+		return missing
+	}
+	reportedOptions := make(map[string]struct{})
+	for option := range strings.SplitSeq(reported, ",") {
+		reportedOptions[strings.TrimSpace(option)] = struct{}{}
+	}
+	for _, option := range required {
+		if _, ok := reportedOptions[option]; ok {
+			missing = append(missing, option)
+		}
+	}
+	return missing
+}
+
+func mapEngineResult(sourcePath string, maxItems int, source engine.Result, info api.DVDMenuEngineInfo) api.DVDMenuCaptureResult {
+	result := api.DVDMenuCaptureResult{
+		SourcePath:       sourcePath,
+		SelectedLanguage: defaultLanguage,
+		DiscoveredMenus:  source.Inventoried,
+		VisitedStates:    source.VisitedStates,
+		VisitedButtons:   source.VisitedButtons,
+		MaxItems:         maxItems,
+		Complete:         source.Complete,
+		Partial:          source.Partial,
+		Truncated:        source.Truncated,
+		Engine:           info,
+	}
+	structural := false
+	for _, capture := range source.Captures {
+		if capture.Discovery == graph.DiscoveryStructural {
+			structural = true
+		}
+	}
+	for _, warning := range source.Warnings {
+		result.Warnings = appendWarning(result.Warnings, api.DVDMenuCaptureWarning{Code: warning.Code, Message: warning.Message})
+	}
+	if structural {
+		result.Warnings = appendWarning(result.Warnings, api.DVDMenuCaptureWarning{
+			Code:    "structural_discovery",
+			Message: "Some menu screens were found through structural inventory rather than reachable navigation.",
+		})
+	}
+	return result
+}
+
+func appendWarning(warnings []api.DVDMenuCaptureWarning, warning api.DVDMenuCaptureWarning) []api.DVDMenuCaptureWarning {
+	for _, existing := range warnings {
+		if existing.Code == warning.Code {
+			return warnings
+		}
+	}
+	return append(warnings, warning)
+}
+
+// writeCaptureImages atomically publishes PNG captures and builds matching DB
+// records/selections. The returned created paths remain caller-owned on error.
+func writeCaptureImages(
+	ctx context.Context,
+	tmpDir string,
+	base string,
+	sourcePath string,
+	captures []engine.Capture,
+) ([]api.DVDMenuCaptureImage, []api.Screenshot, []api.ScreenshotFinalSelection, []string, error) {
+	stamp := time.Now().UTC()
+	images := make([]api.DVDMenuCaptureImage, 0, len(captures))
+	records := make([]api.Screenshot, 0, len(captures))
+	selections := make([]api.ScreenshotFinalSelection, 0, len(captures))
+	created := make([]string, 0, len(captures))
+	for index, capture := range captures {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, nil, created, fmt.Errorf("DVD menus: write capture canceled: %w", err)
+		}
+		if capture.Image == nil || capture.Image.Bounds().Empty() {
+			return nil, nil, nil, created, errors.New("DVD menus: capture image is empty")
+		}
+		finalPath := filepath.Join(tmpDir, fmt.Sprintf("%s-dvd-menu-%02d-%d.png", base, index+1, stamp.UnixNano()))
+		partialPath := finalPath + ".partial"
+		file, err := os.OpenFile(partialPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err != nil {
+			return nil, nil, nil, created, fmt.Errorf("DVD menus: create capture file: %w", err)
+		}
+		encodeErr := png.Encode(file, capture.Image)
+		closeErr := file.Close()
+		if encodeErr != nil {
+			_ = os.Remove(partialPath)
+			return nil, nil, nil, created, fmt.Errorf("DVD menus: encode capture: %w", encodeErr)
+		}
+		if closeErr != nil {
+			_ = os.Remove(partialPath)
+			return nil, nil, nil, created, fmt.Errorf("DVD menus: close capture: %w", closeErr)
+		}
+		if err := os.Rename(partialPath, finalPath); err != nil {
+			_ = os.Remove(partialPath)
+			return nil, nil, nil, created, fmt.Errorf("DVD menus: finalize capture: %w", err)
+		}
+		created = append(created, finalPath)
+		stat, err := os.Stat(finalPath)
+		if err != nil {
+			return nil, nil, nil, created, fmt.Errorf("DVD menus: inspect capture: %w", err)
+		}
+		bounds := capture.Image.Bounds()
+		discovery := api.DVDMenuDiscovery(capture.Discovery)
+		images = append(images, api.DVDMenuCaptureImage{
+			ScreenshotImage: api.ScreenshotImage{
+				Index:     index,
+				Path:      finalPath,
+				Purpose:   api.ScreenshotPurposeMenu,
+				Width:     bounds.Dx(),
+				Height:    bounds.Dy(),
+				SizeBytes: stat.Size(),
+			},
+			Discovery: discovery,
+		})
+		records = append(records, api.Screenshot{
+			SourcePath:  sourcePath,
+			ImagePath:   finalPath,
+			FrameNumber: index,
+			Width:       bounds.Dx(),
+			Height:      bounds.Dy(),
+			Purpose:     api.ScreenshotPurposeMenu,
+			CapturedAt:  stamp,
+		})
+		selections = append(selections, api.ScreenshotFinalSelection{
+			SourcePath: sourcePath,
+			ImagePath:  finalPath,
+			Order:      index,
+			Source:     api.ScreenshotSelectionSourceDVDMenu,
+			SelectedAt: stamp,
+		})
+	}
+	return images, records, selections, created, nil
+}
+
+func removeCreatedFiles(paths []string) {
+	for _, pathValue := range paths {
+		_ = os.Remove(pathValue)
+	}
+}
+
+func screenshotImage(pathValue string, index int, record api.Screenshot, upload api.UploadedImageLink) (api.ScreenshotImage, bool) {
+	stat, err := os.Stat(pathValue)
+	if err != nil || stat.IsDir() {
+		return api.ScreenshotImage{}, false
+	}
+	result := api.ScreenshotImage{
+		Index:            index,
+		TimestampSeconds: record.Timestamp,
+		Path:             pathValue,
+		Purpose:          api.ScreenshotPurposeMenu,
+		Width:            record.Width,
+		Height:           record.Height,
+		SizeBytes:        stat.Size(),
+		Host:             upload.Host,
+		ImgURL:           upload.ImgURL,
+		RawURL:           upload.RawURL,
+		WebURL:           upload.WebURL,
+		UploadedAt:       upload.UploadedAt,
+	}
+	if result.Width <= 0 || result.Height <= 0 {
+		file, openErr := os.Open(pathValue)
+		if openErr == nil {
+			config, _, decodeErr := image.DecodeConfig(file)
+			_ = file.Close()
+			if decodeErr == nil {
+				result.Width = config.Width
+				result.Height = config.Height
+			}
+		}
+	}
+	return result, true
+}
+
+// resolveVideoTSDirectory accepts an extracted DVD root or VIDEO_TS directory,
+// resolves the source symlink, and rejects indirect VIDEO_TS symlinks.
+func resolveVideoTSDirectory(sourcePath string) (string, error) {
+	trimmed := strings.TrimSpace(sourcePath)
+	if trimmed == "" {
+		return "", internalerrors.ErrInvalidInput
+	}
+	resolved, err := filepath.EvalSymlinks(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("DVD menus: resolve DVD source: %w", err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("DVD menus: inspect DVD source: %w", err)
+	}
+	if !info.IsDir() {
+		return "", errors.New("DVD menus: DVD source is not a directory")
+	}
+	if strings.EqualFold(filepath.Base(resolved), "VIDEO_TS") {
+		return resolved, nil
+	}
+	entries, err := os.ReadDir(resolved)
+	if err != nil {
+		return "", fmt.Errorf("DVD menus: read DVD source: %w", err)
+	}
+	for _, entry := range entries {
+		if !strings.EqualFold(entry.Name(), "VIDEO_TS") {
+			continue
+		}
+		if entry.Type()&os.ModeSymlink != 0 || !entry.IsDir() {
+			return "", errors.New("DVD menus: VIDEO_TS is not a direct directory")
+		}
+		return filepath.Join(resolved, entry.Name()), nil
+	}
+	return "", errors.New("DVD menus: VIDEO_TS directory not found")
+}
+
+// managedChildPath accepts descendants of root but never root itself.
+func managedChildPath(root string, target string) bool {
+	if pathutil.SamePath(root, target) {
+		return false
+	}
+	return pathutil.IsWithinRoot(root, target)
+}

--- a/internal/services/dvdmenus/service_test.go
+++ b/internal/services/dvdmenus/service_test.go
@@ -331,6 +331,93 @@ func TestDeleteRejectsOriginalOutsideManagedDirectory(t *testing.T) {
 	}
 }
 
+func TestDeleteRestoresFileAndRecordsWhenFinalRemoveFails(t *testing.T) {
+	t.Parallel()
+
+	repo := openTestRepository(t)
+	tmpRoot := t.TempDir()
+	discRoot := t.TempDir()
+	meta := api.PreparedMetadata{SourcePath: discRoot, DiscType: "DVD"}
+	managedDir, _, err := paths.ReleaseTempDir(tmpRoot, meta, meta.SourcePath)
+	if err != nil {
+		t.Fatal("create managed directory failed")
+	}
+	imagePath := filepath.Join(managedDir, "Example.Release.2026-dvd-menu-01.png")
+	writePNG(t, imagePath, color.NRGBA{R: 20, G: 40, B: 60, A: 255})
+	now := time.Now().UTC()
+	if err := repo.AppendManualMenuScreenshots(context.Background(), meta.SourcePath,
+		[]api.Screenshot{{SourcePath: meta.SourcePath, ImagePath: imagePath, Width: 2, Height: 2, Purpose: api.ScreenshotPurposeMenu, CapturedAt: now}},
+		[]api.ScreenshotFinalSelection{{SourcePath: meta.SourcePath, ImagePath: imagePath, Source: api.ScreenshotSelectionSourceMenu, SelectedAt: now}},
+	); err != nil {
+		t.Fatal("seed menu screenshot failed")
+	}
+	if err := repo.SaveUploadedImages(context.Background(), meta.SourcePath, "example-host", []api.UploadedImageLink{{
+		SourcePath: meta.SourcePath,
+		ImagePath:  imagePath,
+		Host:       "example-host",
+		UsageScope: "global",
+		RawURL:     "https://example.invalid/dvd-menu.png",
+		UploadedAt: now,
+	}}); err != nil {
+		t.Fatal("seed menu upload record failed")
+	}
+	if err := repo.ReplaceScreenshotSlots(context.Background(), meta.SourcePath, []api.ScreenshotSlot{{
+		SourcePath: meta.SourcePath,
+		SlotOrder:  0,
+		ImagePath:  imagePath,
+		Variants: []api.ScreenshotSlotVariant{{
+			SourcePath: meta.SourcePath,
+			SlotOrder:  0,
+			Host:       "example-host",
+			UsageScope: "global",
+			ImagePath:  imagePath,
+			RawURL:     "https://example.invalid/dvd-menu.png",
+			UploadedAt: now,
+		}},
+	}}); err != nil {
+		t.Fatal("seed menu screenshot slot failed")
+	}
+
+	service := NewService(api.NopLogger{}, tmpRoot, repo)
+	service.removeFile = func(string) error { return errors.New("synthetic remove failure") }
+	err = service.Delete(context.Background(), meta, imagePath)
+	if err == nil || !strings.Contains(err.Error(), "deletion rolled back") {
+		t.Fatal("expected final remove failure to roll back deletion")
+	}
+	if _, err := os.Stat(imagePath); err != nil {
+		t.Fatal("expected rolled-back image at its original path")
+	}
+	listed, err := service.List(context.Background(), meta)
+	if err != nil {
+		t.Fatal("list rolled-back menu image failed")
+	}
+	if len(listed) != 1 || listed[0].Path != imagePath {
+		t.Fatal("rolled-back image is not recoverable through the menu list")
+	}
+	uploads, err := repo.ListUploadedImagesByPath(context.Background(), meta.SourcePath)
+	if err != nil {
+		t.Fatal("list rolled-back upload association failed")
+	}
+	restoredUpload := false
+	for _, uploaded := range uploads {
+		if uploaded.ImagePath == imagePath {
+			restoredUpload = true
+			break
+		}
+	}
+	if !restoredUpload {
+		t.Fatal("rolled-back upload association was not restored")
+	}
+	slots, err := repo.ListScreenshotSlotsByPath(context.Background(), meta.SourcePath)
+	if err != nil || len(slots) != 1 || slots[0].ImagePath != imagePath || len(slots[0].Variants) != 1 {
+		t.Fatal("rolled-back screenshot slot associations were not restored")
+	}
+	pending, err := filepath.Glob(imagePath + ".delete-*")
+	if err != nil || len(pending) != 0 {
+		t.Fatal("rolled-back delete left a staged image behind")
+	}
+}
+
 func TestCapabilityCacheInvalidatesWhenExecutableIdentityChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/dvdmenus/service_test.go
+++ b/internal/services/dvdmenus/service_test.go
@@ -129,8 +129,16 @@ func TestCaptureRerunListAndDeletePreserveManualMenus(t *testing.T) {
 	logger := &dvdMenuRecordingLogger{}
 	service := newService(logger, tmpRoot, repo, runner, func() (string, error) { return executable, nil },
 		func(_ context.Context, root string, _ render.Runner, _ string, options engine.Options) (engine.Result, error) {
-			if root != videoTS {
-				t.Fatalf("capture root = %q, want %q", root, videoTS)
+			rootInfo, err := os.Stat(root)
+			if err != nil {
+				t.Fatal("capture root is unavailable")
+			}
+			videoTSInfo, err := os.Stat(videoTS)
+			if err != nil {
+				t.Fatal("expected VIDEO_TS directory is unavailable")
+			}
+			if !os.SameFile(rootInfo, videoTSInfo) {
+				t.Fatal("capture root does not identify the expected VIDEO_TS directory")
 			}
 			if options.Capability == nil || !options.Capability.Available {
 				t.Fatal("capture did not receive cached capability")

--- a/internal/services/dvdmenus/service_test.go
+++ b/internal/services/dvdmenus/service_test.go
@@ -1,0 +1,438 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package dvdmenus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/dvdvideo/engine"
+	"github.com/autobrr/upbrr/internal/dvdvideo/graph"
+	"github.com/autobrr/upbrr/internal/dvdvideo/render"
+	"github.com/autobrr/upbrr/internal/paths"
+	"github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+type capabilityRunner struct {
+	calls int
+}
+
+type dvdMenuRecordingLogger struct {
+	entries []string
+}
+
+func (l *dvdMenuRecordingLogger) add(level, format string, args ...any) {
+	l.entries = append(l.entries, level+" "+fmt.Sprintf(format, args...))
+}
+
+func (l *dvdMenuRecordingLogger) Tracef(format string, args ...any) {
+	l.add("TRACE", format, args...)
+}
+
+func (l *dvdMenuRecordingLogger) Debugf(format string, args ...any) {
+	l.add("DEBUG", format, args...)
+}
+
+func (l *dvdMenuRecordingLogger) Infof(format string, args ...any) {
+	l.add("INFO", format, args...)
+}
+
+func (l *dvdMenuRecordingLogger) Warnf(format string, args ...any) {
+	l.add("WARN", format, args...)
+}
+
+func (l *dvdMenuRecordingLogger) Errorf(format string, args ...any) {
+	l.add("ERROR", format, args...)
+}
+
+func (l *dvdMenuRecordingLogger) Contains(expected string) bool {
+	for _, entry := range l.entries {
+		if strings.Contains(entry, expected) {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *dvdMenuRecordingLogger) Count(expected string) int {
+	count := 0
+	for _, entry := range l.entries {
+		if strings.Contains(entry, expected) {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *capabilityRunner) Run(_ context.Context, _ string, args []string, _ int) (render.Output, error) {
+	r.calls++
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "demuxer=dvdvideo") {
+		return render.Output{Stdout: []byte("dvdvideo -menu -menu_lu -menu_vts -pgc -pg")}, nil
+	}
+	if strings.Contains(joined, "-version") {
+		return render.Output{Stdout: []byte("ffmpeg version example\n")}, nil
+	}
+	return render.Output{}, errors.New("unexpected FFmpeg call")
+}
+
+func TestCaptureRerunListAndDeletePreserveManualMenus(t *testing.T) {
+	t.Parallel()
+
+	repo := openTestRepository(t)
+	tmpRoot := t.TempDir()
+	discRoot := t.TempDir()
+	videoTS := filepath.Join(discRoot, "VIDEO_TS")
+	if err := os.Mkdir(videoTS, 0o700); err != nil {
+		t.Fatalf("create VIDEO_TS: %v", err)
+	}
+	executable := filepath.Join(t.TempDir(), "ffmpeg-example")
+	if err := os.WriteFile(executable, []byte("example"), 0o600); err != nil {
+		t.Fatalf("write FFmpeg identity: %v", err)
+	}
+
+	meta := api.PreparedMetadata{SourcePath: discRoot, DiscType: "DVD"}
+	managedDir, _, err := paths.ReleaseTempDir(tmpRoot, meta, meta.SourcePath)
+	if err != nil {
+		t.Fatalf("managed dir: %v", err)
+	}
+	manualPath := filepath.Join(managedDir, "manual-dvd-menu-example.png")
+	writePNG(t, manualPath, color.NRGBA{R: 20, G: 40, B: 60, A: 255})
+	now := time.Now().UTC()
+	if err := repo.AppendManualMenuScreenshots(context.Background(), meta.SourcePath,
+		[]api.Screenshot{{SourcePath: meta.SourcePath, ImagePath: manualPath, Width: 2, Height: 2, Purpose: api.ScreenshotPurposeMenu, CapturedAt: now}},
+		[]api.ScreenshotFinalSelection{{SourcePath: meta.SourcePath, ImagePath: manualPath, Source: api.ScreenshotSelectionSourceMenu, SelectedAt: now}},
+	); err != nil {
+		t.Fatalf("seed manual menu: %v", err)
+	}
+
+	captures := []engine.Capture{
+		{Image: solidImage(color.NRGBA{R: 200, G: 10, B: 10, A: 255}), Discovery: graph.DiscoveryReachable},
+		{Image: solidImage(color.NRGBA{R: 10, G: 200, B: 10, A: 255}), Discovery: graph.DiscoveryStructural},
+	}
+	progressUpdates := make([]api.DVDMenuProgressUpdate, 0)
+	progressCtx := api.WithDVDMenuProgressReporter(context.Background(), func(update api.DVDMenuProgressUpdate) {
+		progressUpdates = append(progressUpdates, update)
+	})
+	runner := &capabilityRunner{}
+	logger := &dvdMenuRecordingLogger{}
+	service := newService(logger, tmpRoot, repo, runner, func() (string, error) { return executable, nil },
+		func(_ context.Context, root string, _ render.Runner, _ string, options engine.Options) (engine.Result, error) {
+			if root != videoTS {
+				t.Fatalf("capture root = %q, want %q", root, videoTS)
+			}
+			if options.Capability == nil || !options.Capability.Available {
+				t.Fatal("capture did not receive cached capability")
+			}
+			if options.Logger == nil {
+				t.Fatal("capture did not receive logger")
+			}
+			if options.Progress != nil {
+				options.Progress(engine.Progress{
+					Phase:          "capturing",
+					Inventoried:    len(captures),
+					VisitedStates:  4,
+					VisitedButtons: 3,
+					Captured:       len(captures),
+				})
+			}
+			return engine.Result{
+				EngineVersion:  engine.Version,
+				Captures:       append([]engine.Capture(nil), captures...),
+				Inventoried:    len(captures),
+				Selected:       len(captures),
+				VisitedStates:  4,
+				VisitedButtons: 3,
+				Partial:        true,
+				Warnings: []graph.Warning{{
+					Code:    "unsupported_pre_link",
+					Message: "menu pre-command target was not resolved",
+				}},
+			}, nil
+		})
+
+	first, err := service.Capture(progressCtx, meta, 6)
+	if err != nil {
+		t.Fatalf("first capture: %v", err)
+	}
+	if len(first.Images) != 2 || first.Images[0].Purpose != api.ScreenshotPurposeMenu || first.Images[1].Discovery != api.DVDMenuDiscoveryStructural {
+		t.Fatalf("first capture result = %#v", first)
+	}
+	if !hasWarning(first.Warnings, "structural_discovery") {
+		t.Fatalf("missing structural warning: %#v", first.Warnings)
+	}
+	for _, expected := range []string{
+		"DEBUG DVD menus: capture requested disc_type=DVD max_items=6",
+		"DEBUG DVD menus: FFmpeg capability probe complete dvdvideo=true options=5",
+		"INFO DVD menus: capture started language=en region=0",
+		"DEBUG DVD menus: progress phase=capturing",
+		`DEBUG DVD menus: warning recorded code=unsupported_pre_link detail="menu pre-command target was not resolved"`,
+		"DEBUG DVD menus: persistence started images=2",
+		"DEBUG DVD menus: persistence complete stored=2",
+		"WARN DVD menus: capture incomplete captured=2",
+		"INFO DVD menus: capture complete captured=2 discovered=2 states=4 buttons=3 complete=false",
+	} {
+		if !logger.Contains(expected) {
+			t.Fatalf("missing DVD menu service log event %q", expected)
+		}
+	}
+	if logger.Contains(discRoot) || logger.Contains(executable) {
+		t.Fatal("DVD menu service logs exposed a local path")
+	}
+	if got := logger.Count("INFO DVD menus:"); got != 2 {
+		t.Fatalf("DVD menu capture INFO logs = %d, want start and completion only", got)
+	}
+	assertProgressPhases(t, progressUpdates, []string{"preflight", "capturing", "persisting", "complete"})
+	firstAutoPaths := []string{first.Images[0].Path, first.Images[1].Path}
+	assertSelectionSources(t, repo, meta.SourcePath, []string{
+		api.ScreenshotSelectionSourceDVDMenu,
+		api.ScreenshotSelectionSourceDVDMenu,
+		api.ScreenshotSelectionSourceMenu,
+	})
+
+	captures = captures[:1]
+	second, err := service.Capture(context.Background(), meta, 6)
+	if err != nil {
+		t.Fatalf("second capture: %v", err)
+	}
+	if len(second.Images) != 1 {
+		t.Fatalf("second images = %d, want 1", len(second.Images))
+	}
+	for _, oldPath := range firstAutoPaths {
+		if _, err := os.Stat(oldPath); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("replaced capture still exists: %v", err)
+		}
+	}
+	if _, err := os.Stat(manualPath); err != nil {
+		t.Fatalf("manual image removed by rerun: %v", err)
+	}
+
+	listed, err := service.List(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(listed) != 2 || listed[0].Path != second.Images[0].Path || listed[1].Path != manualPath {
+		t.Fatalf("listed images = %#v", listed)
+	}
+	for _, listedImage := range listed {
+		if listedImage.Purpose != api.ScreenshotPurposeMenu {
+			t.Fatalf("listed purpose = %q", listedImage.Purpose)
+		}
+	}
+
+	if err := repo.SaveUploadedImages(context.Background(), meta.SourcePath, "example-host", []api.UploadedImageLink{{
+		SourcePath: meta.SourcePath,
+		ImagePath:  second.Images[0].Path,
+		Host:       "example-host",
+		UsageScope: "global",
+		RawURL:     "https://example.invalid/dvd-menu.png",
+		UploadedAt: now,
+	}}); err != nil {
+		t.Fatalf("save upload link: %v", err)
+	}
+	if err := service.Delete(context.Background(), meta, second.Images[0].Path); err != nil {
+		t.Fatalf("delete automatic menu: %v", err)
+	}
+	if _, err := os.Stat(second.Images[0].Path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("deleted image stat = %v", err)
+	}
+	assertSelectionSources(t, repo, meta.SourcePath, []string{api.ScreenshotSelectionSourceMenu})
+}
+
+func assertProgressPhases(t *testing.T, updates []api.DVDMenuProgressUpdate, want []string) {
+	t.Helper()
+	got := make([]string, 0, len(updates))
+	for _, update := range updates {
+		got = append(got, update.Phase)
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("progress phases = %#v, want %#v", got, want)
+	}
+}
+
+func TestCaptureRollsBackCreatedFilesWhenPersistenceFails(t *testing.T) {
+	t.Parallel()
+
+	baseRepo := openTestRepository(t)
+	repo := &failingCaptureRepository{SQLiteRepository: baseRepo}
+	tmpRoot := t.TempDir()
+	discRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(discRoot, "VIDEO_TS"), 0o700); err != nil {
+		t.Fatalf("create VIDEO_TS: %v", err)
+	}
+	executable := filepath.Join(t.TempDir(), "ffmpeg-example")
+	if err := os.WriteFile(executable, []byte("example"), 0o600); err != nil {
+		t.Fatalf("write FFmpeg identity: %v", err)
+	}
+	service := newService(api.NopLogger{}, tmpRoot, repo, &capabilityRunner{}, func() (string, error) { return executable, nil },
+		func(context.Context, string, render.Runner, string, engine.Options) (engine.Result, error) {
+			return engine.Result{Captures: []engine.Capture{{Image: solidImage(color.NRGBA{R: 50, A: 255}), Discovery: graph.DiscoveryReachable}}}, nil
+		})
+
+	_, err := service.Capture(context.Background(), api.PreparedMetadata{SourcePath: discRoot, DiscType: "DVD"}, 1)
+	if err == nil || !strings.Contains(err.Error(), "persist capture") {
+		t.Fatalf("capture error = %v", err)
+	}
+	managedDir, _, err := paths.ReleaseTempDir(tmpRoot, api.PreparedMetadata{}, discRoot)
+	if err != nil {
+		t.Fatalf("managed dir: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(managedDir, "*-dvd-menu-*.png"))
+	if err != nil {
+		t.Fatalf("glob captures: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("rollback retained captures: %#v", matches)
+	}
+}
+
+func TestDeleteRejectsOriginalOutsideManagedDirectory(t *testing.T) {
+	t.Parallel()
+
+	repo := openTestRepository(t)
+	tmpRoot := t.TempDir()
+	discRoot := t.TempDir()
+	original := filepath.Join(t.TempDir(), "original-menu.png")
+	writePNG(t, original, color.NRGBA{B: 200, A: 255})
+	if err := repo.SaveFinalSelections(context.Background(), discRoot, []api.ScreenshotFinalSelection{{
+		SourcePath: discRoot,
+		ImagePath:  original,
+		Source:     api.ScreenshotSelectionSourceMenu,
+		SelectedAt: time.Now().UTC(),
+	}}); err != nil {
+		t.Fatalf("save original selection: %v", err)
+	}
+	service := NewService(api.NopLogger{}, tmpRoot, repo)
+	err := service.Delete(context.Background(), api.PreparedMetadata{SourcePath: discRoot, DiscType: "DVD"}, original)
+	if err == nil || !strings.Contains(err.Error(), "outside the managed release directory") {
+		t.Fatalf("delete error = %v", err)
+	}
+	if _, err := os.Stat(original); err != nil {
+		t.Fatalf("original image changed: %v", err)
+	}
+}
+
+func TestCapabilityCacheInvalidatesWhenExecutableIdentityChanges(t *testing.T) {
+	t.Parallel()
+
+	repo := openTestRepository(t)
+	executable := filepath.Join(t.TempDir(), "ffmpeg-example")
+	if err := os.WriteFile(executable, []byte("first"), 0o600); err != nil {
+		t.Fatalf("write FFmpeg identity: %v", err)
+	}
+	runner := &capabilityRunner{}
+	service := newService(api.NopLogger{}, t.TempDir(), repo, runner, func() (string, error) { return executable, nil }, nil)
+
+	for range 2 {
+		info, err := service.Capability(context.Background())
+		if err != nil {
+			t.Fatalf("capability: %v", err)
+		}
+		if !info.FFmpegDVDVideo || info.FFmpegVersion != "ffmpeg version example" {
+			t.Fatalf("capability info = %#v", info)
+		}
+	}
+	if runner.calls != 2 {
+		t.Fatalf("cached probe calls = %d, want 2", runner.calls)
+	}
+	if err := os.WriteFile(executable, []byte("second identity"), 0o600); err != nil {
+		t.Fatalf("change FFmpeg identity: %v", err)
+	}
+	if _, err := service.Capability(context.Background()); err != nil {
+		t.Fatalf("capability after identity change: %v", err)
+	}
+	if runner.calls != 4 {
+		t.Fatalf("invalidated probe calls = %d, want 4", runner.calls)
+	}
+}
+
+func TestMissingFFmpegOptionsReturnsEveryReportedOption(t *testing.T) {
+	t.Parallel()
+
+	missing := missingFFmpegOptions(errors.New("FFmpeg capability: missing -menu_lu, -menu_vts, -pgc, -pg"))
+	if strings.Join(missing, ",") != "-menu_lu,-menu_vts,-pgc,-pg" {
+		t.Fatalf("missing options = %#v", missing)
+	}
+}
+
+type failingCaptureRepository struct {
+	*db.SQLiteRepository
+}
+
+func (r *failingCaptureRepository) ReplaceDVDMenuScreenshots(context.Context, string, []api.Screenshot, []api.ScreenshotFinalSelection) ([]string, error) {
+	return nil, errors.New("synthetic persistence failure")
+}
+
+func openTestRepository(t *testing.T) *db.SQLiteRepository {
+	t.Helper()
+	repo, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open repository: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repository: %v", err)
+	}
+	return repo
+}
+
+func solidImage(fill color.NRGBA) *image.NRGBA {
+	result := image.NewNRGBA(image.Rect(0, 0, 2, 2))
+	for y := range 2 {
+		for x := range 2 {
+			result.SetNRGBA(x, y, fill)
+		}
+	}
+	return result
+}
+
+func writePNG(t *testing.T, path string, fill color.NRGBA) {
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("create PNG: %v", err)
+	}
+	if err := png.Encode(file, solidImage(fill)); err != nil {
+		_ = file.Close()
+		t.Fatalf("encode PNG: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close PNG: %v", err)
+	}
+}
+
+func assertSelectionSources(t *testing.T, repo *db.SQLiteRepository, sourcePath string, expected []string) {
+	t.Helper()
+	selections, err := repo.ListFinalSelections(context.Background(), sourcePath)
+	if err != nil {
+		t.Fatalf("list final selections: %v", err)
+	}
+	if len(selections) != len(expected) {
+		t.Fatalf("selection count = %d, want %d: %#v", len(selections), len(expected), selections)
+	}
+	for index, source := range expected {
+		if selections[index].Source != source || selections[index].Order != index {
+			t.Fatalf("selection[%d] = %#v, want source %q order %d", index, selections[index], source, index)
+		}
+	}
+}
+
+func hasWarning(warnings []api.DVDMenuCaptureWarning, code string) bool {
+	for _, warning := range warnings {
+		if warning.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/services/imagehosting/service.go
+++ b/internal/services/imagehosting/service.go
@@ -116,7 +116,7 @@ func (s *Service) ListCandidates(ctx context.Context, meta api.PreparedMetadata)
 			img.RawURL = uploadInfo.RawURL
 			img.WebURL = uploadInfo.WebURL
 			img.UploadedAt = uploadInfo.UploadedAt
-			s.logger.Tracef("image hosting: found uploaded image %s (host: %s)", filepath.Base(pathValue), uploadInfo.Host)
+			s.logger.Tracef("image hosting: found uploaded image file=%s host=%s tracker=%s", filepath.Base(pathValue), uploadInfo.Host, imageHostLogTracker(uploadInfo.Host))
 		}
 
 		images = append(images, img)
@@ -158,7 +158,7 @@ func (s *Service) ListCandidates(ctx context.Context, meta api.PreparedMetadata)
 			img.RawURL = uploadInfo.RawURL
 			img.WebURL = uploadInfo.WebURL
 			img.UploadedAt = uploadInfo.UploadedAt
-			s.logger.Tracef("image hosting: found uploaded final selection %s (host: %s)", filepath.Base(pathValue), uploadInfo.Host)
+			s.logger.Tracef("image hosting: found uploaded final selection file=%s host=%s tracker=%s", filepath.Base(pathValue), uploadInfo.Host, imageHostLogTracker(uploadInfo.Host))
 		}
 
 		images = append(images, img)
@@ -192,7 +192,7 @@ func (s *Service) ListCandidates(ctx context.Context, meta api.PreparedMetadata)
 			UploadedAt: upload.UploadedAt,
 		})
 		seenPaths[pathValue] = struct{}{}
-		s.logger.Tracef("image hosting: found uploaded-only image %s (host: %s)", filepath.Base(pathValue), upload.Host)
+		s.logger.Tracef("image hosting: found uploaded-only image file=%s host=%s tracker=%s", filepath.Base(pathValue), upload.Host, imageHostLogTracker(upload.Host))
 	}
 
 	sort.Slice(images, func(i, j int) bool {
@@ -203,6 +203,10 @@ func (s *Service) ListCandidates(ctx context.Context, meta api.PreparedMetadata)
 	return images, nil
 }
 
+// Upload validates and deduplicates local image paths, uploads them to one host,
+// and persists successful links when a repository is configured. Tracker-owned
+// hosts require their matching usage scope; HDB batches keep normal and
+// disc-menu images in separate, non-overlapping galleries.
 func (s *Service) Upload(ctx context.Context, meta api.PreparedMetadata, host string, usageScope string, images []api.ScreenshotImage) ([]api.UploadedImageLink, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("image hosting: upload canceled: %w", err)
@@ -237,9 +241,10 @@ func (s *Service) Upload(ctx context.Context, meta api.PreparedMetadata, host st
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("image hosting: upload canceled: %w", err)
 	}
+	logTracker := imageHostLogTracker(normalizedHost)
 
-	s.logger.Infof("image hosting: uploading images count=%d host=%s", len(images), normalizedHost)
-	s.logger.Debugf("image hosting: source path %s", meta.SourcePath)
+	s.logger.Infof("image hosting: uploading images count=%d host=%s tracker=%s", len(images), normalizedHost, logTracker)
+	s.logger.Debugf("image hosting: upload source path=%s host=%s tracker=%s", meta.SourcePath, normalizedHost, logTracker)
 
 	unique := make([]imageCandidate, 0, len(images))
 	seen := make(map[string]struct{}, len(images))
@@ -256,7 +261,7 @@ func (s *Service) Upload(ctx context.Context, meta api.PreparedMetadata, host st
 			return nil, internalerrors.ErrInvalidInput
 		}
 		if _, exists := seen[absPath]; exists {
-			s.logger.Tracef("image hosting: skipping duplicate %s", filepath.Base(absPath))
+			s.logger.Tracef("image hosting: skipping duplicate file=%s host=%s tracker=%s", filepath.Base(absPath), normalizedHost, logTracker)
 			continue
 		}
 		info, err := os.Stat(absPath)
@@ -267,24 +272,24 @@ func (s *Service) Upload(ctx context.Context, meta api.PreparedMetadata, host st
 			return nil, internalerrors.ErrInvalidInput
 		}
 		seen[absPath] = struct{}{}
-		unique = append(unique, imageCandidate{Path: absPath, SizeBytes: info.Size()})
-		s.logger.Tracef("image hosting: queued %s (%.2f KB)", filepath.Base(absPath), float64(info.Size())/1024.0)
+		unique = append(unique, imageCandidate{Path: absPath, Purpose: image.Purpose, SizeBytes: info.Size()})
+		s.logger.Tracef("image hosting: queued file=%s host=%s tracker=%s size_kb=%.2f", filepath.Base(absPath), normalizedHost, logTracker, float64(info.Size())/1024.0)
 	}
 	if len(unique) == 0 {
 		return nil, internalerrors.ErrInvalidInput
 	}
 
-	s.logger.Debugf("image hosting: prepared %d unique images for upload", len(unique))
+	s.logger.Tracef("image hosting: prepared unique images count=%d host=%s tracker=%s", len(unique), normalizedHost, logTracker)
 
 	if batch, ok := uploader.(batchUploader); ok {
-		paths := make([]string, 0, len(unique))
-		for _, candidate := range unique {
-			paths = append(paths, candidate.Path)
+		if normalizedHost == "hdb" {
+			normalCount, menuCount := imagePurposeCounts(unique)
+			s.logger.Infof("image hosting: HDB gallery upload plan host=%s tracker=%s normal=%d menu=%d", normalizedHost, logTracker, normalCount, menuCount)
 		}
-		s.logger.Debugf("image hosting: starting batch upload to %s", normalizedHost)
-		uploadedResults, err := uploadBatch(ctx, batch, meta, paths)
+		s.logger.Debugf("image hosting: starting batch upload host=%s tracker=%s", normalizedHost, logTracker)
+		uploadedResults, err := uploadBatch(ctx, batch, meta, normalizedHost, unique)
 		if err != nil {
-			s.logger.Errorf("image hosting: batch upload failed: %v", err)
+			s.logger.Errorf("image hosting: batch upload failed host=%s tracker=%s err=%s", normalizedHost, logTracker, redaction.RedactValue(err.Error(), nil))
 			return nil, err
 		}
 		if len(uploadedResults) != len(unique) {
@@ -316,18 +321,19 @@ func (s *Service) Upload(ctx context.Context, meta api.PreparedMetadata, host st
 			}
 		}
 		if s.repo != nil {
-			s.logger.Debugf("image hosting: persisting %d upload records to database", len(results))
+			s.logger.Tracef("image hosting: persisting upload records count=%d host=%s tracker=%s", len(results), normalizedHost, logTracker)
 			if err := s.repo.SaveUploadedImages(ctx, meta.SourcePath, normalizedHost, results); err != nil {
-				s.logger.Errorf("image hosting: failed to save upload records: %v", err)
+				s.logger.Errorf("image hosting: failed to save upload records host=%s tracker=%s err=%s", normalizedHost, logTracker, redaction.RedactValue(err.Error(), nil))
 				return nil, fmt.Errorf("image hosting: %w", err)
 			}
 			summary, err := syncScreenshotSlotVariants(ctx, s.repo, meta.SourcePath, results)
 			if err != nil {
-				s.logger.Warnf("image hosting: failed to sync screenshot slot variants: %v", err)
+				s.logger.Warnf("image hosting: failed to sync screenshot slot variants host=%s tracker=%s err=%s", normalizedHost, logTracker, redaction.RedactValue(err.Error(), nil))
 			} else if summary.FallbackMatched > 0 {
-				s.logger.Debugf("image hosting: applied ordered screenshot slot fallback host=%s matched=%d", normalizedHost, summary.FallbackMatched)
+				s.logger.Debugf("image hosting: applied ordered screenshot slot fallback host=%s tracker=%s matched=%d", normalizedHost, logTracker, summary.FallbackMatched)
 			}
 		}
+		s.logger.Infof("image hosting: completed batch upload count=%d host=%s tracker=%s", len(results), normalizedHost, logTracker)
 		return results, nil
 	}
 
@@ -336,7 +342,7 @@ func (s *Service) Upload(ctx context.Context, meta api.PreparedMetadata, host st
 		limit = 1
 	}
 
-	s.logger.Infof("image hosting: starting concurrent uploads (limit: %d)", limit)
+	s.logger.Infof("image hosting: starting concurrent uploads limit=%d host=%s tracker=%s", limit, normalizedHost, logTracker)
 	uploadStart := time.Now()
 
 	var (
@@ -370,7 +376,7 @@ dispatchLoop:
 				return
 			}
 			fileName := filepath.Base(candidate.Path)
-			s.logger.Debugf("image hosting: uploading image file=%s host=%s size_kb=%.2f", fileName, normalizedHost, float64(candidate.SizeBytes)/1024.0)
+			s.logger.Debugf("image hosting: uploading image file=%s host=%s tracker=%s size_kb=%.2f", fileName, normalizedHost, logTracker, float64(candidate.SizeBytes)/1024.0)
 
 			// Add detailed debug logging for imgbox
 			if normalizedHost == "imgbox" {
@@ -395,25 +401,25 @@ dispatchLoop:
 			}
 
 			if err != nil {
-				s.logger.Warnf("image hosting: upload failed file=%s err=%s", fileName, redaction.RedactValue(err.Error(), nil))
+				s.logger.Warnf("image hosting: upload failed file=%s host=%s tracker=%s err=%s", fileName, normalizedHost, logTracker, redaction.RedactValue(err.Error(), nil))
 				mu.Lock()
 				failures = append(failures, fmt.Sprintf("image upload %s: %v", fileName, err))
 				mu.Unlock()
 				return
 			}
 			if strings.TrimSpace(uploaded.RawURL) == "" {
-				s.logger.Warnf("image hosting: missing raw URL for %s", fileName)
+				s.logger.Warnf("image hosting: missing raw URL file=%s host=%s tracker=%s", fileName, normalizedHost, logTracker)
 				mu.Lock()
 				failures = append(failures, fmt.Sprintf("image upload %s: missing raw url", fileName))
 				mu.Unlock()
 				return
 			}
 			if strings.TrimSpace(uploaded.ImgURL) == "" {
-				s.logger.Tracef("image hosting: using raw URL as img URL for %s", fileName)
+				s.logger.Tracef("image hosting: using raw URL as img URL file=%s host=%s tracker=%s", fileName, normalizedHost, logTracker)
 				uploaded.ImgURL = uploaded.RawURL
 			}
 			if strings.TrimSpace(uploaded.WebURL) == "" {
-				s.logger.Tracef("image hosting: using raw URL as web URL for %s", fileName)
+				s.logger.Tracef("image hosting: using raw URL as web URL file=%s host=%s tracker=%s", fileName, normalizedHost, logTracker)
 				uploaded.WebURL = uploaded.RawURL
 			}
 			mu.Lock()
@@ -432,7 +438,7 @@ dispatchLoop:
 				},
 			})
 			mu.Unlock()
-			s.logger.Debugf("image hosting: successfully uploaded file=%s duration=%v", fileName, uploadDuration)
+			s.logger.Debugf("image hosting: successfully uploaded file=%s host=%s tracker=%s duration=%v", fileName, normalizedHost, logTracker, uploadDuration)
 		})
 	}
 
@@ -444,34 +450,44 @@ dispatchLoop:
 	totalDuration := time.Since(uploadStart)
 	orderedResults := orderedUploadResults(results)
 	if len(orderedResults) > 0 {
-		s.logger.Infof("image hosting: completed uploads count=%d host=%s duration=%v avg=%v", len(orderedResults), normalizedHost, totalDuration, totalDuration/time.Duration(len(orderedResults)))
+		s.logger.Infof("image hosting: completed uploads count=%d host=%s tracker=%s duration=%v avg=%v", len(orderedResults), normalizedHost, logTracker, totalDuration, totalDuration/time.Duration(len(orderedResults)))
 	}
 
 	if s.repo != nil && len(orderedResults) > 0 {
-		s.logger.Debugf("image hosting: persisting %d upload records to database", len(orderedResults))
+		s.logger.Tracef("image hosting: persisting upload records count=%d host=%s tracker=%s", len(orderedResults), normalizedHost, logTracker)
 		if err := s.repo.SaveUploadedImages(ctx, meta.SourcePath, normalizedHost, orderedResults); err != nil {
-			s.logger.Errorf("image hosting: failed to save upload records: %v", err)
+			s.logger.Errorf("image hosting: failed to save upload records host=%s tracker=%s err=%s", normalizedHost, logTracker, redaction.RedactValue(err.Error(), nil))
 			return nil, fmt.Errorf("image hosting: %w", err)
 		}
 		summary, err := syncScreenshotSlotVariants(ctx, s.repo, meta.SourcePath, orderedResults)
 		if err != nil {
-			s.logger.Warnf("image hosting: failed to sync screenshot slot variants: %v", err)
+			s.logger.Warnf("image hosting: failed to sync screenshot slot variants host=%s tracker=%s err=%s", normalizedHost, logTracker, redaction.RedactValue(err.Error(), nil))
 		} else if summary.FallbackMatched > 0 {
-			s.logger.Debugf("image hosting: applied ordered screenshot slot fallback host=%s matched=%d", normalizedHost, summary.FallbackMatched)
+			s.logger.Debugf("image hosting: applied ordered screenshot slot fallback host=%s tracker=%s matched=%d", normalizedHost, logTracker, summary.FallbackMatched)
 		}
-		s.logger.Debugf("image hosting: upload records persisted successfully")
+		s.logger.Debugf("image hosting: upload records persisted successfully host=%s tracker=%s", normalizedHost, logTracker)
 	}
 
 	if len(failures) > 0 {
-		s.logger.Warnf("image hosting: upload batch completed failures=%d successes=%d", len(failures), len(orderedResults))
+		s.logger.Warnf("image hosting: upload batch completed host=%s tracker=%s failures=%d successes=%d", normalizedHost, logTracker, len(failures), len(orderedResults))
 		return orderedResults, fmt.Errorf("image hosting: %d of %d uploads failed: %s", len(failures), len(unique), strings.Join(failures, "; "))
 	}
 
 	return orderedResults, nil
 }
 
-func uploadBatch(ctx context.Context, batch batchUploader, meta api.PreparedMetadata, imagePaths []string) ([]uploadResult, error) {
+// uploadBatch dispatches candidates through the uploader's supported batch
+// contract. Named HDB batches retain image purpose so gallery partitioning can
+// preserve input-to-result ordering.
+func uploadBatch(ctx context.Context, batch batchUploader, meta api.PreparedMetadata, host string, images []imageCandidate) ([]uploadResult, error) {
+	imagePaths := make([]string, 0, len(images))
+	for _, image := range images {
+		imagePaths = append(imagePaths, image.Path)
+	}
 	if named, ok := batch.(namedBatchUploader); ok {
+		if strings.EqualFold(strings.TrimSpace(host), "hdb") {
+			return uploadHDBBatchByPurpose(ctx, named, meta, images)
+		}
 		results, err := named.UploadBatchWithName(ctx, imagePaths, resolveGalleryName(meta))
 		if err != nil {
 			return nil, fmt.Errorf("image hosting: upload named batch: %w", err)
@@ -481,6 +497,57 @@ func uploadBatch(ctx context.Context, batch batchUploader, meta api.PreparedMeta
 	results, err := batch.UploadBatch(ctx, imagePaths)
 	if err != nil {
 		return nil, fmt.Errorf("image hosting: upload batch: %w", err)
+	}
+	return results, nil
+}
+
+// uploadHDBBatchByPurpose uploads normal images to the release gallery and menu
+// images to a suffixed disc-menu gallery. Each candidate is uploaded once, and
+// results are restored to candidate order across both batches.
+func uploadHDBBatchByPurpose(ctx context.Context, batch namedBatchUploader, meta api.PreparedMetadata, images []imageCandidate) ([]uploadResult, error) {
+	type indexedImage struct {
+		index int
+		path  string
+	}
+	normal := make([]indexedImage, 0, len(images))
+	menus := make([]indexedImage, 0, len(images))
+	for idx, image := range images {
+		item := indexedImage{index: idx, path: image.Path}
+		if image.Purpose == api.ScreenshotPurposeMenu {
+			menus = append(menus, item)
+			continue
+		}
+		normal = append(normal, item)
+	}
+
+	results := make([]uploadResult, len(images))
+	uploadGroup := func(group []indexedImage, galleryName string) error {
+		if len(group) == 0 {
+			return nil
+		}
+		paths := make([]string, 0, len(group))
+		for _, image := range group {
+			paths = append(paths, image.path)
+		}
+		uploaded, err := batch.UploadBatchWithName(ctx, paths, galleryName)
+		if err != nil {
+			return fmt.Errorf("image hosting: upload named batch: %w", err)
+		}
+		if len(uploaded) != len(group) {
+			return fmt.Errorf("image hosting: HDB batch returned %d images for %d uploads", len(uploaded), len(group))
+		}
+		for idx, image := range group {
+			results[image.index] = uploaded[idx]
+		}
+		return nil
+	}
+
+	galleryName := resolveGalleryName(meta)
+	if err := uploadGroup(normal, galleryName); err != nil {
+		return nil, err
+	}
+	if err := uploadGroup(menus, galleryName+" Disc Menus"); err != nil {
+		return nil, err
 	}
 	return results, nil
 }
@@ -500,8 +567,32 @@ func resolveGalleryName(meta api.PreparedMetadata) string {
 	return "upbrr"
 }
 
+// imageHostLogTracker returns the tracker that owns a private image host, or
+// "shared" for hosts usable outside one tracker. Logging both host and tracker
+// keeps tracker-owned rehosting identifiable in operator output.
+func imageHostLogTracker(host string) string {
+	if tracker := trackers.TrackerForOwnedImageHost(host); tracker != "" {
+		return tracker
+	}
+	return "shared"
+}
+
+// imagePurposeCounts summarizes the HDB gallery partition without exposing
+// local image paths in operator-visible progress logs.
+func imagePurposeCounts(images []imageCandidate) (normal int, menus int) {
+	for _, image := range images {
+		if image.Purpose == api.ScreenshotPurposeMenu {
+			menus++
+			continue
+		}
+		normal++
+	}
+	return normal, menus
+}
+
 type imageCandidate struct {
 	Path      string
+	Purpose   api.ScreenshotPurpose
 	SizeBytes int64
 }
 

--- a/internal/services/imagehosting/service.go
+++ b/internal/services/imagehosting/service.go
@@ -42,6 +42,9 @@ func NewService(cfg config.Config, logger api.Logger, repo api.MetadataRepositor
 	return service
 }
 
+// ListCandidates returns existing local and uploaded screenshot selections for
+// image hosting, deduplicated by local image path. Disc-menu selections retain
+// [api.ScreenshotPurposeMenu]; all other candidates use final purpose.
 func (s *Service) ListCandidates(ctx context.Context, meta api.PreparedMetadata) ([]api.ScreenshotImage, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("image hosting: list candidates canceled: %w", err)
@@ -63,6 +66,15 @@ func (s *Service) ListCandidates(ctx context.Context, meta api.PreparedMetadata)
 	uploaded, err := s.repo.ListUploadedImagesByPath(ctx, meta.SourcePath)
 	if err != nil {
 		return nil, fmt.Errorf("image hosting: %w", err)
+	}
+	selections, err := s.repo.ListFinalSelections(ctx, meta.SourcePath)
+	if err != nil {
+		s.logger.Debugf("image hosting: final selections unavailable: %v", err)
+		selections = nil
+	}
+	selectionSourceByPath := make(map[string]string, len(selections))
+	for _, selection := range selections {
+		selectionSourceByPath[strings.TrimSpace(selection.ImagePath)] = strings.TrimSpace(selection.Source)
 	}
 
 	// Build a map of uploaded images by path for quick lookup
@@ -86,9 +98,15 @@ func (s *Service) ListCandidates(ctx context.Context, meta api.PreparedMetadata)
 		img := api.ScreenshotImage{
 			Path:             pathValue,
 			TimestampSeconds: shot.Timestamp,
+			Purpose:          shot.Purpose,
 			Width:            shot.Width,
 			Height:           shot.Height,
 			SizeBytes:        info.Size(),
+		}
+		if api.IsDiscMenuSelectionSource(selectionSourceByPath[pathValue]) {
+			img.Purpose = api.ScreenshotPurposeMenu
+		} else if img.Purpose == "" {
+			img.Purpose = api.ScreenshotPurposeFinal
 		}
 
 		// If this image has been uploaded, include the upload info
@@ -109,41 +127,42 @@ func (s *Service) ListCandidates(ctx context.Context, meta api.PreparedMetadata)
 	for _, img := range images {
 		seenPaths[img.Path] = struct{}{}
 	}
-	selections, err := s.repo.ListFinalSelections(ctx, meta.SourcePath)
-	if err == nil {
-		for _, sel := range selections {
-			pathValue := strings.TrimSpace(sel.ImagePath)
-			if pathValue == "" || !isAllowedImageExt(pathValue) {
-				continue
-			}
-			if _, exists := seenPaths[pathValue]; exists {
-				continue
-			}
-			info, statErr := os.Stat(pathValue)
-			if statErr != nil || info.IsDir() {
-				continue
-			}
-
-			img := api.ScreenshotImage{
-				Path:             pathValue,
-				TimestampSeconds: 0, // Fallback since it wasn't a generated frame
-				Width:            0,
-				Height:           0,
-				SizeBytes:        info.Size(),
-			}
-
-			if uploadInfo, exists := uploadedByPath[pathValue]; exists {
-				img.Host = uploadInfo.Host
-				img.ImgURL = uploadInfo.ImgURL
-				img.RawURL = uploadInfo.RawURL
-				img.WebURL = uploadInfo.WebURL
-				img.UploadedAt = uploadInfo.UploadedAt
-				s.logger.Tracef("image hosting: found uploaded final selection %s (host: %s)", filepath.Base(pathValue), uploadInfo.Host)
-			}
-
-			images = append(images, img)
-			seenPaths[pathValue] = struct{}{}
+	for _, sel := range selections {
+		pathValue := strings.TrimSpace(sel.ImagePath)
+		if pathValue == "" || !isAllowedImageExt(pathValue) {
+			continue
 		}
+		if _, exists := seenPaths[pathValue]; exists {
+			continue
+		}
+		info, statErr := os.Stat(pathValue)
+		if statErr != nil || info.IsDir() {
+			continue
+		}
+
+		img := api.ScreenshotImage{
+			Path:             pathValue,
+			TimestampSeconds: 0, // Fallback since it wasn't a generated frame
+			Purpose:          api.ScreenshotPurposeFinal,
+			Width:            0,
+			Height:           0,
+			SizeBytes:        info.Size(),
+		}
+		if api.IsDiscMenuSelectionSource(sel.Source) {
+			img.Purpose = api.ScreenshotPurposeMenu
+		}
+
+		if uploadInfo, exists := uploadedByPath[pathValue]; exists {
+			img.Host = uploadInfo.Host
+			img.ImgURL = uploadInfo.ImgURL
+			img.RawURL = uploadInfo.RawURL
+			img.WebURL = uploadInfo.WebURL
+			img.UploadedAt = uploadInfo.UploadedAt
+			s.logger.Tracef("image hosting: found uploaded final selection %s (host: %s)", filepath.Base(pathValue), uploadInfo.Host)
+		}
+
+		images = append(images, img)
+		seenPaths[pathValue] = struct{}{}
 	}
 
 	for _, upload := range uploaded {
@@ -158,8 +177,13 @@ func (s *Service) ListCandidates(ctx context.Context, meta api.PreparedMetadata)
 		if statErr != nil || info.IsDir() {
 			continue
 		}
+		purpose := api.ScreenshotPurposeFinal
+		if api.IsDiscMenuSelectionSource(selectionSourceByPath[pathValue]) {
+			purpose = api.ScreenshotPurposeMenu
+		}
 		images = append(images, api.ScreenshotImage{
 			Path:       pathValue,
+			Purpose:    purpose,
 			SizeBytes:  info.Size(),
 			Host:       upload.Host,
 			ImgURL:     upload.ImgURL,

--- a/internal/services/imagehosting/service_test.go
+++ b/internal/services/imagehosting/service_test.go
@@ -320,6 +320,44 @@ func TestListCandidatesIncludesUploadedOnlyImages(t *testing.T) {
 	}
 }
 
+func TestListCandidatesPopulatesGeneratedAndManualMenuPurpose(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	generatedPath := filepath.Join(root, "generated-menu.png")
+	manualPath := filepath.Join(root, "manual-menu.png")
+	for _, imagePath := range []string{generatedPath, manualPath} {
+		if err := os.WriteFile(imagePath, []byte("synthetic image"), 0o600); err != nil {
+			t.Fatalf("write image: %v", err)
+		}
+	}
+	repo := &recordingRepo{
+		screens: []api.Screenshot{{
+			SourcePath: "/tmp/source",
+			ImagePath:  generatedPath,
+			Purpose:    api.ScreenshotPurposeMenu,
+		}},
+		selections: []api.ScreenshotFinalSelection{
+			{SourcePath: "/tmp/source", ImagePath: generatedPath, Order: 0, Source: api.ScreenshotSelectionSourceDVDMenu},
+			{SourcePath: "/tmp/source", ImagePath: manualPath, Order: 1, Source: api.ScreenshotSelectionSourceMenu},
+		},
+	}
+	service := &Service{logger: api.NopLogger{}, repo: repo}
+
+	images, err := service.ListCandidates(context.Background(), api.PreparedMetadata{SourcePath: "/tmp/source"})
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(images) != 2 {
+		t.Fatalf("candidate count = %d, want 2", len(images))
+	}
+	for _, imageValue := range images {
+		if imageValue.Purpose != api.ScreenshotPurposeMenu {
+			t.Fatalf("candidate purpose = %q for %q", imageValue.Purpose, filepath.Base(imageValue.Path))
+		}
+	}
+}
+
 func TestUploadImagesUnsupportedHost(t *testing.T) {
 	service := &Service{logger: api.NopLogger{}, uploaders: map[string]uploader{}}
 	meta := api.PreparedMetadata{SourcePath: "source"}

--- a/internal/services/imagehosting/service_test.go
+++ b/internal/services/imagehosting/service_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -192,6 +193,48 @@ type fakeBatchUploader struct {
 	calls        []string
 	batches      [][]string
 	galleryNames []string
+}
+
+type recordingImageHostLogger struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func (l *recordingImageHostLogger) record(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.messages = append(l.messages, fmt.Sprintf(format, args...))
+}
+
+func (l *recordingImageHostLogger) Tracef(format string, args ...any) {
+	l.record(format, args...)
+}
+
+func (l *recordingImageHostLogger) Debugf(format string, args ...any) {
+	l.record(format, args...)
+}
+
+func (l *recordingImageHostLogger) Infof(format string, args ...any) {
+	l.record(format, args...)
+}
+
+func (l *recordingImageHostLogger) Warnf(format string, args ...any) {
+	l.record(format, args...)
+}
+
+func (l *recordingImageHostLogger) Errorf(format string, args ...any) {
+	l.record(format, args...)
+}
+
+func (l *recordingImageHostLogger) contains(value string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, message := range l.messages {
+		if strings.Contains(message, value) {
+			return true
+		}
+	}
+	return false
 }
 
 func (u *fakeBatchUploader) Upload(_ context.Context, imagePath string) (uploadResult, error) {
@@ -453,6 +496,80 @@ func TestUploadImagesUsesBatchUploader(t *testing.T) {
 	}
 	if uploaderStub.galleryNames[0] != "Movie.2026.2160p.WEB-DL" {
 		t.Fatalf("expected content gallery name, got %q", uploaderStub.galleryNames[0])
+	}
+}
+
+func TestUploadImagesSeparatesHDBMenuGalleryWithoutDuplicates(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	firstPath := filepath.Join(tmpDir, "screen-01.png")
+	menuPath := filepath.Join(tmpDir, "menu-01.png")
+	secondPath := filepath.Join(tmpDir, "screen-02.png")
+	for _, imagePath := range []string{firstPath, menuPath, secondPath} {
+		if err := os.WriteFile(imagePath, []byte("testdata"), 0o600); err != nil {
+			t.Fatalf("write temp file: %v", err)
+		}
+	}
+
+	uploaderStub := &fakeBatchUploader{}
+	logger := &recordingImageHostLogger{}
+	service := &Service{
+		cfg:       config.Config{},
+		logger:    logger,
+		repo:      &recordingRepo{},
+		uploaders: map[string]uploader{"hdb": uploaderStub},
+	}
+
+	result, err := service.Upload(context.Background(), api.PreparedMetadata{
+		SourcePath:  filepath.Join(tmpDir, "Example.Release.2026.2160p.WEB-DL-GRP.mkv"),
+		ReleaseName: "Example.Release.2026.2160p.WEB-DL-GRP",
+	}, "hdb", "tracker:HDB", []api.ScreenshotImage{
+		{Path: firstPath, Purpose: api.ScreenshotPurposeFinal},
+		{Path: menuPath, Purpose: api.ScreenshotPurposeMenu},
+		{Path: secondPath, Purpose: api.ScreenshotPurposeFinal},
+	})
+	if err != nil {
+		t.Fatalf("upload images: %v", err)
+	}
+	if len(uploaderStub.batches) != 2 {
+		t.Fatalf("expected normal and menu HDB batches, got %#v", uploaderStub.batches)
+	}
+	if !slices.Equal(uploaderStub.batches[0], []string{firstPath, secondPath}) {
+		t.Fatalf("expected normal gallery to exclude menu image, got %#v", uploaderStub.batches[0])
+	}
+	if !slices.Equal(uploaderStub.batches[1], []string{menuPath}) {
+		t.Fatalf("expected menu gallery to contain only menu image, got %#v", uploaderStub.batches[1])
+	}
+	if !slices.Equal(uploaderStub.galleryNames, []string{
+		"Example.Release.2026.2160p.WEB-DL-GRP",
+		"Example.Release.2026.2160p.WEB-DL-GRP Disc Menus",
+	}) {
+		t.Fatalf("unexpected HDB gallery names: %#v", uploaderStub.galleryNames)
+	}
+	if len(result) != 3 || result[0].ImagePath != firstPath || result[1].ImagePath != menuPath || result[2].ImagePath != secondPath {
+		t.Fatalf("expected upload results in input order, got %#v", result)
+	}
+	if !logger.contains("host=hdb tracker=HDB") {
+		t.Fatal("expected HDB tracker identity in image-host logs")
+	}
+}
+
+func TestImageHostLogTrackerNamesEveryOwnedHost(t *testing.T) {
+	t.Parallel()
+
+	for host, expected := range map[string]string{
+		"hdb":      "HDB",
+		"lostimg":  "LST",
+		"reelflix": "RF",
+		"thr":      "THR",
+	} {
+		if got := imageHostLogTracker(host); got != expected {
+			t.Errorf("host %q tracker = %q, want %q", host, got, expected)
+		}
+	}
+	if got := imageHostLogTracker("imgbox"); got != "shared" {
+		t.Errorf("shared host tracker = %q, want shared", got)
 	}
 }
 

--- a/internal/services/screenshots/ffmpeg.go
+++ b/internal/services/screenshots/ffmpeg.go
@@ -141,6 +141,8 @@ type previewRequest struct {
 
 const ffmpegLogPreviewLimit = 2048
 
+var errFFmpegNoImage = errors.New("ffmpeg produced no image")
+
 // captureFrame writes one PNG frame and returns whether the successful attempt
 // used libplacebo. Libplacebo captures retry once before falling back to the
 // software filter chain so transient Vulkan setup failures remain recoverable.
@@ -158,8 +160,11 @@ func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captur
 	logger.Tracef("screenshots: ffmpeg capture attempt mode=%s timestamp_seconds=%.3f input=%s output=%s filters=%s", ffmpegModeLabel(useLibplacebo), req.Timestamp, req.InputPath, req.OutputPath, ffmpegFilterFromArgs(args))
 	result, err := runner.Run(ctx, cmdPath, args, "")
 	if err == nil && result.ExitCode == 0 {
-		logger.Tracef("screenshots: ffmpeg capture ok mode=%s exit_code=%d", ffmpegModeLabel(useLibplacebo), result.ExitCode)
-		return useLibplacebo, nil
+		if captureOutputHasBytes(req.OutputPath) {
+			logger.Tracef("screenshots: ffmpeg capture ok mode=%s exit_code=%d", ffmpegModeLabel(useLibplacebo), result.ExitCode)
+			return useLibplacebo, nil
+		}
+		err = errFFmpegNoImage
 	}
 
 	if useLibplacebo {
@@ -168,8 +173,11 @@ func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captur
 		logger.Tracef("screenshots: ffmpeg capture attempt mode=%s retry=%t timestamp_seconds=%.3f input=%s output=%s filters=%s", ffmpegModeLabel(true), true, req.Timestamp, req.InputPath, req.OutputPath, ffmpegFilterFromArgs(args))
 		result, err = runner.Run(ctx, cmdPath, args, "")
 		if err == nil && result.ExitCode == 0 {
-			logger.Tracef("screenshots: ffmpeg capture ok mode=%s retry=%t exit_code=%d", ffmpegModeLabel(true), true, result.ExitCode)
-			return true, nil
+			if captureOutputHasBytes(req.OutputPath) {
+				logger.Tracef("screenshots: ffmpeg capture ok mode=%s retry=%t exit_code=%d", ffmpegModeLabel(true), true, result.ExitCode)
+				return true, nil
+			}
+			err = errFFmpegNoImage
 		}
 
 		logger.Debugf("screenshots: ffmpeg capture fallback from_mode=%s to_mode=%s reason=%s", ffmpegModeLabel(true), ffmpegModeLabel(false), ffmpegResultPreview(result, err))
@@ -177,8 +185,11 @@ func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captur
 		logger.Tracef("screenshots: ffmpeg capture attempt mode=%s timestamp_seconds=%.3f input=%s output=%s filters=%s", ffmpegModeLabel(false), req.Timestamp, req.InputPath, req.OutputPath, ffmpegFilterFromArgs(args))
 		result, err = runner.Run(ctx, cmdPath, args, "")
 		if err == nil && result.ExitCode == 0 {
-			logger.Tracef("screenshots: ffmpeg capture ok mode=%s exit_code=%d", ffmpegModeLabel(false), result.ExitCode)
-			return false, nil
+			if captureOutputHasBytes(req.OutputPath) {
+				logger.Tracef("screenshots: ffmpeg capture ok mode=%s exit_code=%d", ffmpegModeLabel(false), result.ExitCode)
+				return false, nil
+			}
+			err = errFFmpegNoImage
 		}
 	}
 
@@ -188,6 +199,11 @@ func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captur
 	}
 	logger.Debugf("screenshots: ffmpeg capture exhausted mode=%s reason=%s", ffmpegModeLabel(useLibplacebo), ffmpegResultPreview(result, err))
 	return useLibplacebo, fmt.Errorf("screenshots: ffmpeg capture failed: %s", stderr)
+}
+
+func captureOutputHasBytes(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir() && info.Size() > 0
 }
 
 // captureFrameBytes returns a single preview frame encoded as PNG bytes from
@@ -207,6 +223,9 @@ func captureFrameBytes(ctx context.Context, runner Runner, cmdPath string, req p
 	if err == nil && result.ExitCode == 0 && len(result.Stdout) > 0 {
 		logger.Tracef("screenshots: ffmpeg preview ok bytes=%d exit_code=%d", len(result.Stdout), result.ExitCode)
 		return result.Stdout, nil
+	}
+	if err == nil && result.ExitCode == 0 {
+		err = errFFmpegNoImage
 	}
 
 	stderr := strings.TrimSpace(string(result.Stderr))

--- a/internal/services/screenshots/ffmpeg.go
+++ b/internal/services/screenshots/ffmpeg.go
@@ -153,6 +153,10 @@ const (
 	blackPixelThreshold = 4
 )
 
+// ffmpegDurationPattern extracts the container duration reported on FFmpeg's
+// stderr.
+var ffmpegDurationPattern = regexp.MustCompile(`(?m)Duration:\s*(\d{2,}:\d{2}:\d{2}(?:\.\d+)?)\s*,`)
+
 // ffmpeg image validation errors are returned after ffmpeg exits successfully
 // but fails to produce a usable screenshot frame.
 var (
@@ -267,6 +271,38 @@ func captureFrameBytes(ctx context.Context, runner Runner, cmdPath string, req p
 	}
 	logger.Debugf("screenshots: ffmpeg preview exhausted reason=%s", ffmpegResultPreview(result, err))
 	return nil, fmt.Errorf("screenshots: ffmpeg preview failed: %s", stderr)
+}
+
+// probeVideoDuration reads FFmpeg's container timing without decoding the VOB.
+// The bundled distribution does not include ffprobe, so FFmpeg performs the
+// equivalent header probe with a zero-length null output. It returns seconds
+// and rejects missing, malformed, or non-positive duration metadata.
+func probeVideoDuration(ctx context.Context, runner Runner, cmdPath, inputPath string) (float64, error) {
+	if strings.TrimSpace(inputPath) == "" {
+		return 0, errors.New("screenshots: duration probe input path required")
+	}
+	args := []string{
+		"-hide_banner",
+		"-loglevel", "info",
+		"-i", inputPath,
+		"-map", "0:v:0",
+		"-t", "0",
+		"-f", "null",
+		"-",
+	}
+	result, err := runner.Run(ctx, cmdPath, args, "")
+	if err != nil || result.ExitCode != 0 {
+		return 0, fmt.Errorf("screenshots: ffmpeg duration probe failed: %s", ffmpegResultPreview(result, err))
+	}
+	match := ffmpegDurationPattern.FindSubmatch(result.Stderr)
+	if len(match) != 2 {
+		return 0, errors.New("screenshots: ffmpeg duration unavailable")
+	}
+	duration := parseDurationSeconds(string(match[1]))
+	if duration <= 0 {
+		return 0, errors.New("screenshots: ffmpeg duration invalid")
+	}
+	return duration, nil
 }
 
 // validateImagePayload rejects empty, undecodable, and all-black image bytes

--- a/internal/services/screenshots/ffmpeg.go
+++ b/internal/services/screenshots/ffmpeg.go
@@ -68,6 +68,12 @@ func resolveFFmpeg() (string, error) {
 	return path, nil
 }
 
+// ResolveFFmpegExecutable returns the existing bundled-or-PATH FFmpeg choice
+// shared by screenshot and DVD-menu capture services.
+func ResolveFFmpegExecutable() (string, error) {
+	return resolveFFmpeg()
+}
+
 func bundledFFmpegPath() string {
 	name := "ffmpeg"
 	folder := osFolder()

--- a/internal/services/screenshots/ffmpeg.go
+++ b/internal/services/screenshots/ffmpeg.go
@@ -16,6 +16,9 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/autobrr/upbrr/internal/redaction"
+	"github.com/autobrr/upbrr/pkg/api"
 )
 
 type Runner interface {
@@ -136,7 +139,13 @@ type previewRequest struct {
 	Timestamp float64
 }
 
-func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captureRequest) (bool, error) {
+const ffmpegLogPreviewLimit = 2048
+
+// captureFrame writes one PNG frame and returns whether the successful attempt
+// used libplacebo. Libplacebo captures retry once before falling back to the
+// software filter chain so transient Vulkan setup failures remain recoverable.
+func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captureRequest, logger api.Logger) (bool, error) {
+	logger = screenshotLogger(logger)
 	if strings.TrimSpace(req.InputPath) == "" {
 		return false, errors.New("screenshots: input path required")
 	}
@@ -146,21 +155,29 @@ func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captur
 
 	useLibplacebo := req.UseLibplacebo && req.ToneMap && !req.FrameOverlay
 	args := buildFFmpegArgs(req, useLibplacebo)
+	logger.Tracef("screenshots: ffmpeg capture attempt mode=%s timestamp_seconds=%.3f input=%s output=%s filters=%s", ffmpegModeLabel(useLibplacebo), req.Timestamp, req.InputPath, req.OutputPath, ffmpegFilterFromArgs(args))
 	result, err := runner.Run(ctx, cmdPath, args, "")
 	if err == nil && result.ExitCode == 0 {
+		logger.Tracef("screenshots: ffmpeg capture ok mode=%s exit_code=%d", ffmpegModeLabel(useLibplacebo), result.ExitCode)
 		return useLibplacebo, nil
 	}
 
 	if useLibplacebo {
+		logger.Debugf("screenshots: ffmpeg capture retry mode=%s reason=%s", ffmpegModeLabel(true), ffmpegResultPreview(result, err))
 		args = buildFFmpegArgs(req, true)
+		logger.Tracef("screenshots: ffmpeg capture attempt mode=%s retry=%t timestamp_seconds=%.3f input=%s output=%s filters=%s", ffmpegModeLabel(true), true, req.Timestamp, req.InputPath, req.OutputPath, ffmpegFilterFromArgs(args))
 		result, err = runner.Run(ctx, cmdPath, args, "")
 		if err == nil && result.ExitCode == 0 {
+			logger.Tracef("screenshots: ffmpeg capture ok mode=%s retry=%t exit_code=%d", ffmpegModeLabel(true), true, result.ExitCode)
 			return true, nil
 		}
 
+		logger.Debugf("screenshots: ffmpeg capture fallback from_mode=%s to_mode=%s reason=%s", ffmpegModeLabel(true), ffmpegModeLabel(false), ffmpegResultPreview(result, err))
 		args = buildFFmpegArgs(req, false)
+		logger.Tracef("screenshots: ffmpeg capture attempt mode=%s timestamp_seconds=%.3f input=%s output=%s filters=%s", ffmpegModeLabel(false), req.Timestamp, req.InputPath, req.OutputPath, ffmpegFilterFromArgs(args))
 		result, err = runner.Run(ctx, cmdPath, args, "")
 		if err == nil && result.ExitCode == 0 {
+			logger.Tracef("screenshots: ffmpeg capture ok mode=%s exit_code=%d", ffmpegModeLabel(false), result.ExitCode)
 			return false, nil
 		}
 	}
@@ -169,10 +186,14 @@ func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captur
 	if stderr == "" && err != nil {
 		stderr = err.Error()
 	}
+	logger.Debugf("screenshots: ffmpeg capture exhausted mode=%s reason=%s", ffmpegModeLabel(useLibplacebo), ffmpegResultPreview(result, err))
 	return useLibplacebo, fmt.Errorf("screenshots: ffmpeg capture failed: %s", stderr)
 }
 
-func captureFrameBytes(ctx context.Context, runner Runner, cmdPath string, req previewRequest) ([]byte, error) {
+// captureFrameBytes returns a single preview frame encoded as PNG bytes from
+// stdout. A zero-length ffmpeg stdout is treated as a failed preview.
+func captureFrameBytes(ctx context.Context, runner Runner, cmdPath string, req previewRequest, logger api.Logger) ([]byte, error) {
+	logger = screenshotLogger(logger)
 	if strings.TrimSpace(req.InputPath) == "" {
 		return nil, errors.New("screenshots: input path required")
 	}
@@ -181,8 +202,10 @@ func captureFrameBytes(ctx context.Context, runner Runner, cmdPath string, req p
 	}
 
 	args := buildFFmpegPreviewArgs(req)
+	logger.Tracef("screenshots: ffmpeg preview attempt timestamp_seconds=%.3f input=%s", req.Timestamp, req.InputPath)
 	result, err := runner.Run(ctx, cmdPath, args, "")
 	if err == nil && result.ExitCode == 0 && len(result.Stdout) > 0 {
+		logger.Tracef("screenshots: ffmpeg preview ok bytes=%d exit_code=%d", len(result.Stdout), result.ExitCode)
 		return result.Stdout, nil
 	}
 
@@ -190,7 +213,40 @@ func captureFrameBytes(ctx context.Context, runner Runner, cmdPath string, req p
 	if stderr == "" && err != nil {
 		stderr = err.Error()
 	}
+	logger.Debugf("screenshots: ffmpeg preview exhausted reason=%s", ffmpegResultPreview(result, err))
 	return nil, fmt.Errorf("screenshots: ffmpeg preview failed: %s", stderr)
+}
+
+func ffmpegModeLabel(useLibplacebo bool) string {
+	if useLibplacebo {
+		return "libplacebo"
+	}
+	return "software"
+}
+
+func ffmpegFilterFromArgs(args []string) string {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-vf" {
+			return args[i+1]
+		}
+	}
+	return "none"
+}
+
+// ffmpegResultPreview returns a bounded, redacted diagnostic string for logs
+// while leaving the caller-owned error text unchanged.
+func ffmpegResultPreview(result CommandResult, err error) string {
+	message := strings.TrimSpace(string(result.Stderr))
+	if message == "" && err != nil {
+		message = err.Error()
+	}
+	if message == "" {
+		message = fmt.Sprintf("exit_code=%d", result.ExitCode)
+	}
+	if len(message) > ffmpegLogPreviewLimit {
+		message = message[:ffmpegLogPreviewLimit] + "...[truncated]"
+	}
+	return redaction.RedactValue(message, nil)
 }
 
 func buildFFmpegPreviewArgs(req previewRequest) []string {

--- a/internal/services/screenshots/ffmpeg.go
+++ b/internal/services/screenshots/ffmpeg.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"image"
 	"math"
 	"os"
 	"os/exec"
@@ -139,9 +140,19 @@ type previewRequest struct {
 	Timestamp float64
 }
 
-const ffmpegLogPreviewLimit = 2048
+const (
+	ffmpegLogPreviewLimit = 2048
+	// blackPixelThreshold is the highest 8-bit RGB channel value still treated
+	// as black when rejecting blank ffmpeg frames.
+	blackPixelThreshold = 4
+)
 
-var errFFmpegNoImage = errors.New("ffmpeg produced no image")
+// ffmpeg image validation errors are returned after ffmpeg exits successfully
+// but fails to produce a usable screenshot frame.
+var (
+	errFFmpegNoImage    = errors.New("ffmpeg produced no image")
+	errFFmpegBlackImage = errors.New("ffmpeg produced black image")
+)
 
 // captureFrame writes one PNG frame and returns whether the successful attempt
 // used libplacebo. Libplacebo captures retry once before falling back to the
@@ -160,11 +171,10 @@ func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captur
 	logger.Tracef("screenshots: ffmpeg capture attempt mode=%s timestamp_seconds=%.3f input=%s output=%s filters=%s", ffmpegModeLabel(useLibplacebo), req.Timestamp, req.InputPath, req.OutputPath, ffmpegFilterFromArgs(args))
 	result, err := runner.Run(ctx, cmdPath, args, "")
 	if err == nil && result.ExitCode == 0 {
-		if captureOutputHasBytes(req.OutputPath) {
+		if err = validateCaptureOutput(req.OutputPath); err == nil {
 			logger.Tracef("screenshots: ffmpeg capture ok mode=%s exit_code=%d", ffmpegModeLabel(useLibplacebo), result.ExitCode)
 			return useLibplacebo, nil
 		}
-		err = errFFmpegNoImage
 	}
 
 	if useLibplacebo {
@@ -173,11 +183,10 @@ func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captur
 		logger.Tracef("screenshots: ffmpeg capture attempt mode=%s retry=%t timestamp_seconds=%.3f input=%s output=%s filters=%s", ffmpegModeLabel(true), true, req.Timestamp, req.InputPath, req.OutputPath, ffmpegFilterFromArgs(args))
 		result, err = runner.Run(ctx, cmdPath, args, "")
 		if err == nil && result.ExitCode == 0 {
-			if captureOutputHasBytes(req.OutputPath) {
+			if err = validateCaptureOutput(req.OutputPath); err == nil {
 				logger.Tracef("screenshots: ffmpeg capture ok mode=%s retry=%t exit_code=%d", ffmpegModeLabel(true), true, result.ExitCode)
 				return true, nil
 			}
-			err = errFFmpegNoImage
 		}
 
 		logger.Debugf("screenshots: ffmpeg capture fallback from_mode=%s to_mode=%s reason=%s", ffmpegModeLabel(true), ffmpegModeLabel(false), ffmpegResultPreview(result, err))
@@ -185,11 +194,10 @@ func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captur
 		logger.Tracef("screenshots: ffmpeg capture attempt mode=%s timestamp_seconds=%.3f input=%s output=%s filters=%s", ffmpegModeLabel(false), req.Timestamp, req.InputPath, req.OutputPath, ffmpegFilterFromArgs(args))
 		result, err = runner.Run(ctx, cmdPath, args, "")
 		if err == nil && result.ExitCode == 0 {
-			if captureOutputHasBytes(req.OutputPath) {
+			if err = validateCaptureOutput(req.OutputPath); err == nil {
 				logger.Tracef("screenshots: ffmpeg capture ok mode=%s exit_code=%d", ffmpegModeLabel(false), result.ExitCode)
 				return false, nil
 			}
-			err = errFFmpegNoImage
 		}
 	}
 
@@ -201,13 +209,28 @@ func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captur
 	return useLibplacebo, fmt.Errorf("screenshots: ffmpeg capture failed: %s", stderr)
 }
 
-func captureOutputHasBytes(path string) bool {
+// validateCaptureOutput verifies that ffmpeg wrote a decodable, non-black
+// image. Invalid or black output files are removed so later fallback attempts
+// can replace the same target path cleanly.
+func validateCaptureOutput(path string) error {
 	info, err := os.Stat(path)
-	return err == nil && !info.IsDir() && info.Size() > 0
+	if err != nil || info.IsDir() || info.Size() <= 0 {
+		return errFFmpegNoImage
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("screenshots: read ffmpeg capture output: %w", err)
+	}
+	if err := validateImagePayload(payload); err != nil {
+		_ = os.Remove(path)
+		return err
+	}
+	return nil
 }
 
-// captureFrameBytes returns a single preview frame encoded as PNG bytes from
-// stdout. A zero-length ffmpeg stdout is treated as a failed preview.
+// captureFrameBytes returns a single non-black preview frame encoded as PNG
+// bytes from stdout. Empty or all-black ffmpeg output is treated as a failed
+// preview so callers can try alternate screenshot inputs.
 func captureFrameBytes(ctx context.Context, runner Runner, cmdPath string, req previewRequest, logger api.Logger) ([]byte, error) {
 	logger = screenshotLogger(logger)
 	if strings.TrimSpace(req.InputPath) == "" {
@@ -221,6 +244,10 @@ func captureFrameBytes(ctx context.Context, runner Runner, cmdPath string, req p
 	logger.Tracef("screenshots: ffmpeg preview attempt timestamp_seconds=%.3f input=%s", req.Timestamp, req.InputPath)
 	result, err := runner.Run(ctx, cmdPath, args, "")
 	if err == nil && result.ExitCode == 0 && len(result.Stdout) > 0 {
+		if err := validateImagePayload(result.Stdout); err != nil {
+			logger.Debugf("screenshots: ffmpeg preview rejected reason=%s", redaction.RedactValue(err.Error(), nil))
+			return nil, fmt.Errorf("screenshots: ffmpeg preview failed: %s", err.Error())
+		}
 		logger.Tracef("screenshots: ffmpeg preview ok bytes=%d exit_code=%d", len(result.Stdout), result.ExitCode)
 		return result.Stdout, nil
 	}
@@ -234,6 +261,48 @@ func captureFrameBytes(ctx context.Context, runner Runner, cmdPath string, req p
 	}
 	logger.Debugf("screenshots: ffmpeg preview exhausted reason=%s", ffmpegResultPreview(result, err))
 	return nil, fmt.Errorf("screenshots: ffmpeg preview failed: %s", stderr)
+}
+
+// validateImagePayload rejects empty, undecodable, and all-black image bytes
+// before callers accept a screenshot or preview as usable.
+func validateImagePayload(payload []byte) error {
+	if len(payload) == 0 {
+		return errFFmpegNoImage
+	}
+	black, err := imagePayloadIsBlack(payload)
+	if err != nil {
+		return fmt.Errorf("screenshots: decode ffmpeg image: %w", err)
+	}
+	if black {
+		return errFFmpegBlackImage
+	}
+	return nil
+}
+
+// imagePayloadIsBlack reports whether every visible pixel is at or below the
+// black threshold. Fully transparent pixels do not make an image usable.
+func imagePayloadIsBlack(payload []byte) (bool, error) {
+	img, _, err := image.Decode(bytes.NewReader(payload))
+	if err != nil {
+		return false, fmt.Errorf("decode image payload: %w", err)
+	}
+	bounds := img.Bounds()
+	if bounds.Empty() {
+		return false, nil
+	}
+	maxChannel := uint32(blackPixelThreshold * 257)
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			r, g, b, a := img.At(x, y).RGBA()
+			if a == 0 {
+				continue
+			}
+			if r > maxChannel || g > maxChannel || b > maxChannel {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
 }
 
 func ffmpegModeLabel(useLibplacebo bool) string {

--- a/internal/services/screenshots/ffmpeg_test.go
+++ b/internal/services/screenshots/ffmpeg_test.go
@@ -4,11 +4,14 @@
 package screenshots
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
 )
 
 func TestBundledFFmpegPathPrefersWorkingDirectory(t *testing.T) {
@@ -82,4 +85,31 @@ func TestRoundToEvenUsesNearestEvenForHalves(t *testing.T) {
 			t.Fatalf("roundToEven(%v) = %d, want %d", input, got, want)
 		}
 	}
+}
+
+func TestCaptureFrameBytesRejectsEmptySuccessfulOutput(t *testing.T) {
+	runner := &singleResultRunner{result: CommandResult{ExitCode: 0}}
+
+	payload, err := captureFrameBytes(context.Background(), runner, "ffmpeg", previewRequest{
+		InputPath: "example.mkv",
+		Timestamp: 1,
+	}, api.NopLogger{})
+	if err == nil {
+		t.Fatal("expected empty ffmpeg stdout to fail")
+	}
+	if payload != nil {
+		t.Fatalf("expected no preview payload, got %d bytes", len(payload))
+	}
+	if !strings.Contains(err.Error(), "ffmpeg produced no image") {
+		t.Fatalf("expected no-image error, got %v", err)
+	}
+}
+
+type singleResultRunner struct {
+	result CommandResult
+	err    error
+}
+
+func (r *singleResultRunner) Run(context.Context, string, []string, string) (CommandResult, error) {
+	return r.result, r.err
 }

--- a/internal/services/screenshots/ffmpeg_test.go
+++ b/internal/services/screenshots/ffmpeg_test.go
@@ -4,7 +4,12 @@
 package screenshots
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -105,6 +110,44 @@ func TestCaptureFrameBytesRejectsEmptySuccessfulOutput(t *testing.T) {
 	}
 }
 
+func TestCaptureFrameBytesRejectsBlackSuccessfulOutput(t *testing.T) {
+	runner := &singleResultRunner{result: CommandResult{Stdout: testPNGBytes(t, color.RGBA{A: 255}), ExitCode: 0}}
+
+	payload, err := captureFrameBytes(context.Background(), runner, "ffmpeg", previewRequest{
+		InputPath: "example.mkv",
+		Timestamp: 1,
+	}, api.NopLogger{})
+	if err == nil {
+		t.Fatal("expected black ffmpeg stdout to fail")
+	}
+	if payload != nil {
+		t.Fatalf("expected no preview payload, got %d bytes", len(payload))
+	}
+	if !strings.Contains(err.Error(), "ffmpeg produced black image") {
+		t.Fatalf("expected black-image error, got %v", err)
+	}
+}
+
+func TestCaptureFrameRejectsBlackOutputFile(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "screen.png")
+	runner := &writeOutputRunner{payload: testPNGBytes(t, color.RGBA{A: 255})}
+
+	_, err := captureFrame(context.Background(), runner, "ffmpeg", captureRequest{
+		InputPath:  "example.mkv",
+		OutputPath: output,
+		Timestamp:  1,
+	}, api.NopLogger{})
+	if err == nil {
+		t.Fatal("expected black ffmpeg output file to fail")
+	}
+	if !strings.Contains(err.Error(), "ffmpeg produced black image") {
+		t.Fatalf("expected black-image error, got %v", err)
+	}
+	if _, statErr := os.Stat(output); !os.IsNotExist(statErr) {
+		t.Fatal("expected rejected black output file to be removed")
+	}
+}
+
 type singleResultRunner struct {
 	result CommandResult
 	err    error
@@ -112,4 +155,36 @@ type singleResultRunner struct {
 
 func (r *singleResultRunner) Run(context.Context, string, []string, string) (CommandResult, error) {
 	return r.result, r.err
+}
+
+type writeOutputRunner struct {
+	payload []byte
+}
+
+// writeOutputRunner emulates ffmpeg's file-output path so capture validation
+// tests exercise the same disk read and cleanup code as production captures.
+func (r *writeOutputRunner) Run(_ context.Context, _ string, args []string, _ string) (CommandResult, error) {
+	if len(args) > 0 {
+		if err := os.WriteFile(args[len(args)-1], r.payload, 0o600); err != nil {
+			return CommandResult{ExitCode: 1}, fmt.Errorf("write ffmpeg output fixture: %w", err)
+		}
+	}
+	return CommandResult{ExitCode: 0}, nil
+}
+
+// testPNGBytes builds tiny decodable PNG frames for black-frame validation
+// tests without depending on fixture files.
+func testPNGBytes(t *testing.T, pixel color.RGBA) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	for y := range 2 {
+		for x := range 2 {
+			img.SetRGBA(x, y, pixel)
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	return buf.Bytes()
 }

--- a/internal/services/screenshots/helpers.go
+++ b/internal/services/screenshots/helpers.go
@@ -42,6 +42,16 @@ type videoSegment struct {
 	DurationSeconds float64
 }
 
+// segmentCandidate records one concrete ffmpeg input attempt for a whole-title
+// timestamp. DVD candidates can include later VOB parts as fallbacks when an
+// early menu segment produces no decodable frame.
+type segmentCandidate struct {
+	SourcePath    string
+	Timestamp     float64
+	SegmentIndex  int
+	FallbackIndex int
+}
+
 type mediaInfoDoc struct {
 	Media struct {
 		Track []map[string]any `json:"track"`
@@ -160,27 +170,86 @@ func resolveVideoInfo(ctx context.Context, meta api.PreparedMetadata, tmpRoot st
 // resolveSegmentTimestamp converts a whole-title timestamp into the concrete
 // segment file and local timestamp ffmpeg should seek within that file.
 func resolveSegmentTimestamp(info videoInfo, timestamp float64) (string, float64) {
-	if len(info.Segments) == 0 || timestamp <= 0 {
+	candidates := resolveSegmentCandidates(info, timestamp)
+	if len(candidates) == 0 {
 		return info.SourcePath, timestamp
 	}
-	for _, segment := range info.Segments {
+	return candidates[0].SourcePath, candidates[0].Timestamp
+}
+
+// resolveSegmentCandidates returns the primary input segment for a whole-title
+// timestamp plus later ordered segments that can be tried if ffmpeg emits no
+// frame from the primary segment.
+func resolveSegmentCandidates(info videoInfo, timestamp float64) []segmentCandidate {
+	if len(info.Segments) == 0 {
+		return []segmentCandidate{{SourcePath: info.SourcePath, Timestamp: timestamp, SegmentIndex: -1}}
+	}
+
+	primaryIndex := 0
+	localTimestamp := timestamp
+	for idx, segment := range info.Segments {
 		if segment.SourcePath == "" || segment.DurationSeconds <= 0 {
 			continue
 		}
+		if timestamp <= 0 {
+			primaryIndex = idx
+			localTimestamp = 0
+			break
+		}
 		if timestamp < segment.StartSeconds+segment.DurationSeconds {
-			local := timestamp - segment.StartSeconds
-			if local < 0 {
-				local = 0
+			primaryIndex = idx
+			localTimestamp = timestamp - segment.StartSeconds
+			if localTimestamp < 0 {
+				localTimestamp = 0
 			}
-			return segment.SourcePath, local
+			break
+		}
+		primaryIndex = idx + 1
+	}
+	if primaryIndex >= len(info.Segments) {
+		primaryIndex = len(info.Segments) - 1
+		last := info.Segments[primaryIndex]
+		localTimestamp = last.DurationSeconds
+		if localTimestamp > 0.5 {
+			localTimestamp -= 0.5
 		}
 	}
-	last := info.Segments[len(info.Segments)-1]
-	local := last.DurationSeconds
-	if local > 0.5 {
-		local -= 0.5
+	if localTimestamp < 0 {
+		localTimestamp = 0
 	}
-	return last.SourcePath, local
+
+	candidates := make([]segmentCandidate, 0, len(info.Segments)-primaryIndex)
+	for idx := primaryIndex; idx < len(info.Segments); idx++ {
+		segment := info.Segments[idx]
+		if segment.SourcePath == "" {
+			continue
+		}
+		candidateTimestamp := localTimestamp
+		if idx != primaryIndex {
+			candidateTimestamp = segmentFallbackTimestamp(segment)
+		}
+		candidates = append(candidates, segmentCandidate{
+			SourcePath:    segment.SourcePath,
+			Timestamp:     candidateTimestamp,
+			SegmentIndex:  idx,
+			FallbackIndex: len(candidates),
+		})
+	}
+	if len(candidates) == 0 {
+		return []segmentCandidate{{SourcePath: info.SourcePath, Timestamp: timestamp, SegmentIndex: -1}}
+	}
+	return candidates
+}
+
+func segmentFallbackTimestamp(segment videoSegment) float64 {
+	switch {
+	case segment.DurationSeconds <= 0:
+		return 0.5
+	case segment.DurationSeconds <= 1:
+		return segment.DurationSeconds / 2
+	default:
+		return 0.5
+	}
 }
 
 // resolveVideoSource applies the same input-file preference as resolveVideoInfo

--- a/internal/services/screenshots/helpers.go
+++ b/internal/services/screenshots/helpers.go
@@ -17,6 +17,8 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/metadata/discparse"
 	"github.com/autobrr/upbrr/internal/paths"
+	"github.com/autobrr/upbrr/internal/pathutil"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -38,7 +40,12 @@ type mediaInfoDoc struct {
 
 var durationTokenPattern = regexp.MustCompile(`(?i)(\d+(?:\.\d+)?)\s*(milliseconds?|msecs?|ms|hours?|hrs?|h|minutes?|mins?|min|seconds?|secs?|sec|s)\b`)
 
-func resolveVideoInfo(ctx context.Context, meta api.PreparedMetadata, tmpRoot string) (videoInfo, error) {
+// resolveVideoInfo selects the ffmpeg input path and timing metadata used for
+// screenshot planning/capture. Disc releases prefer selected playlist items or
+// BDInfo/DVD-derived streams; non-disc releases use VideoPath when present and
+// otherwise SourcePath.
+func resolveVideoInfo(ctx context.Context, meta api.PreparedMetadata, tmpRoot string, logger api.Logger) (videoInfo, error) {
+	logger = screenshotLogger(logger)
 	info := videoInfo{}
 
 	basePath := strings.TrimSpace(meta.VideoPath)
@@ -49,21 +56,45 @@ func resolveVideoInfo(ctx context.Context, meta api.PreparedMetadata, tmpRoot st
 		return info, errors.New("screenshots: source path required")
 	}
 
-	doc, _ := loadMediaInfoDoc(meta.MediaInfoJSONPath)
+	logger.Tracef(
+		"screenshots: video info input kind=%s disc=%s source_path=%s video_path=%s mediainfo_present=%t selected_playlists=%d tvpack=%t",
+		screenshotSourceKind(meta),
+		screenshotLogField(meta.DiscType),
+		meta.SourcePath,
+		meta.VideoPath,
+		strings.TrimSpace(meta.MediaInfoJSONPath) != "",
+		len(meta.SelectedBDMVPlaylists),
+		meta.TVPack,
+	)
+	doc, mediaInfoErr := loadMediaInfoDoc(meta.MediaInfoJSONPath)
+	if mediaInfoErr != nil {
+		logger.Debugf("screenshots: mediainfo timing unavailable err=%s", redaction.RedactValue(mediaInfoErr.Error(), nil))
+	}
 	info.DurationSeconds = mediaInfoDurationSeconds(doc)
 	info.FrameRate = mediaInfoFrameRate(doc)
 	info.Width, info.Height, info.WidthScale, info.HeightScale = mediaInfoVideoGeometry(doc)
 	if info.FrameRate <= 0 {
 		info.FrameRate = 24.0
 	}
+	logger.Tracef(
+		"screenshots: mediainfo timing duration_seconds=%.3f frame_rate=%.3f width=%d height=%d width_scale=%.3f height_scale=%.3f",
+		info.DurationSeconds,
+		info.FrameRate,
+		info.Width,
+		info.Height,
+		info.WidthScale,
+		info.HeightScale,
+	)
 
 	if strings.EqualFold(strings.TrimSpace(meta.DiscType), "BDMV") {
 		if filePath, ok, err := selectBDMVFileFromMetadata(ctx, meta); err != nil {
 			return info, err
 		} else if ok {
 			info.SourcePath = filePath
+			logger.Tracef("screenshots: BDMV source selected method=metadata path=%s", filePath)
 		}
 
+		logger.Tracef("screenshots: BDMV summary lookup tmp_root_present=%t playlist=%s", strings.TrimSpace(tmpRoot) != "", paths.PrimaryBDMVPlaylist(meta))
 		bdinfo, err := loadBDInfo(tmpRoot, meta)
 		if err != nil {
 			return info, err
@@ -79,27 +110,47 @@ func resolveVideoInfo(ctx context.Context, meta api.PreparedMetadata, tmpRoot st
 				filePath, err := selectBDMVFile(ctx, meta.SourcePath, bdinfo)
 				if err == nil {
 					info.SourcePath = filePath
+					logger.Tracef("screenshots: BDMV source selected method=bdinfo path=%s", filePath)
+				} else {
+					logger.Debugf("screenshots: BDMV source selection unavailable err=%s", redaction.RedactValue(err.Error(), nil))
 				}
 			}
+			logger.Tracef("screenshots: BDMV summary applied duration_seconds=%.3f frame_rate=%.3f files=%d", info.DurationSeconds, info.FrameRate, len(bdinfo.Files))
+		} else {
+			logger.Tracef("screenshots: BDMV summary not available")
 		}
 	}
 
 	if strings.EqualFold(strings.TrimSpace(meta.DiscType), "DVD") {
+		logger.Tracef("screenshots: DVD source selection root=%s", meta.SourcePath)
 		vob, err := selectDVDVOB(ctx, meta.SourcePath)
 		if err != nil {
 			return info, err
 		}
 		info.SourcePath = vob
+		logger.Tracef("screenshots: DVD source selected path=%s", vob)
 	}
 
 	if info.SourcePath == "" {
 		info.SourcePath = basePath
+		logger.Tracef("screenshots: video source selected method=base path=%s", info.SourcePath)
 	}
+	logger.Debugf(
+		"screenshots: video info resolved kind=%s disc=%s duration_seconds=%.3f frame_rate=%.3f selected_path=%s",
+		screenshotSourceKind(meta),
+		screenshotLogField(meta.DiscType),
+		info.DurationSeconds,
+		info.FrameRate,
+		info.SourcePath,
+	)
 
 	return info, nil
 }
 
-func resolveVideoSource(ctx context.Context, meta api.PreparedMetadata, tmpRoot string) (string, error) {
+// resolveVideoSource applies the same input-file preference as resolveVideoInfo
+// when callers only need the ffmpeg source path, such as preview generation.
+func resolveVideoSource(ctx context.Context, meta api.PreparedMetadata, tmpRoot string, logger api.Logger) (string, error) {
+	logger = screenshotLogger(logger)
 	basePath := strings.TrimSpace(meta.VideoPath)
 	if basePath == "" {
 		basePath = strings.TrimSpace(meta.SourcePath)
@@ -107,14 +158,24 @@ func resolveVideoSource(ctx context.Context, meta api.PreparedMetadata, tmpRoot 
 	if basePath == "" {
 		return "", errors.New("screenshots: source path required")
 	}
+	logger.Tracef(
+		"screenshots: video source input kind=%s disc=%s source_path=%s video_path=%s selected_playlists=%d",
+		screenshotSourceKind(meta),
+		screenshotLogField(meta.DiscType),
+		meta.SourcePath,
+		meta.VideoPath,
+		len(meta.SelectedBDMVPlaylists),
+	)
 
 	if strings.EqualFold(strings.TrimSpace(meta.DiscType), "BDMV") {
 		if filePath, ok, err := selectBDMVFileFromMetadata(ctx, meta); err != nil {
 			return "", err
 		} else if ok {
+			logger.Tracef("screenshots: video source selected method=bdmv_metadata path=%s", filePath)
 			return filePath, nil
 		}
 
+		logger.Tracef("screenshots: video source BDMV summary lookup tmp_root_present=%t playlist=%s", strings.TrimSpace(tmpRoot) != "", paths.PrimaryBDMVPlaylist(meta))
 		bdinfo, err := loadBDInfo(tmpRoot, meta)
 		if err != nil {
 			return "", err
@@ -124,21 +185,27 @@ func resolveVideoSource(ctx context.Context, meta api.PreparedMetadata, tmpRoot 
 			if err != nil {
 				return "", err
 			}
+			logger.Tracef("screenshots: video source selected method=bdmv_bdinfo path=%s", filePath)
 			return filePath, nil
 		}
 	}
 
 	if strings.EqualFold(strings.TrimSpace(meta.DiscType), "DVD") {
+		logger.Tracef("screenshots: video source DVD selection root=%s", meta.SourcePath)
 		vob, err := selectDVDVOB(ctx, meta.SourcePath)
 		if err != nil {
 			return "", err
 		}
+		logger.Tracef("screenshots: video source selected method=dvd_vob path=%s", vob)
 		return vob, nil
 	}
 
+	logger.Tracef("screenshots: video source selected method=base path=%s", basePath)
 	return basePath, nil
 }
 
+// selectBDMVFileFromMetadata returns a concrete stream path when the prepared
+// metadata already identifies the selected BDMV item or resolved video file.
 func selectBDMVFileFromMetadata(ctx context.Context, meta api.PreparedMetadata) (string, bool, error) {
 	if fileName := largestSelectedBDMVPlaylistItem(meta.SelectedBDMVPlaylists); fileName != "" {
 		if videoPath := strings.TrimSpace(meta.VideoPath); videoPath != "" && strings.EqualFold(filepath.Base(videoPath), fileName) {
@@ -675,6 +742,45 @@ func shouldUseLibplacebo(meta api.PreparedMetadata, cfg config.Config) bool {
 		return false
 	}
 	return true
+}
+
+func screenshotLogger(logger api.Logger) api.Logger {
+	if logger == nil {
+		return api.NopLogger{}
+	}
+	return logger
+}
+
+// screenshotSourceKind classifies the prepared metadata for diagnostic logs
+// without changing screenshot selection behavior.
+func screenshotSourceKind(meta api.PreparedMetadata) string {
+	discType := strings.TrimSpace(meta.DiscType)
+	if discType != "" {
+		return "disc_" + strings.ToLower(sanitizeFilename(discType))
+	}
+	if meta.TVPack {
+		return "season_pack"
+	}
+	if strings.EqualFold(strings.TrimSpace(meta.MediaInfoCategory), "TV") {
+		if meta.EpisodeInt <= 0 && meta.Release.Episode <= 0 {
+			return "season_pack"
+		}
+		return "episode"
+	}
+	videoPath := strings.TrimSpace(meta.VideoPath)
+	sourcePath := strings.TrimSpace(meta.SourcePath)
+	if videoPath != "" && sourcePath != "" && !pathutil.SamePath(videoPath, sourcePath) {
+		return "pack_item"
+	}
+	return "single_file"
+}
+
+func screenshotLogField(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "none"
+	}
+	return sanitizeFilename(trimmed)
 }
 
 func abs(x float64) float64 {

--- a/internal/services/screenshots/helpers.go
+++ b/internal/services/screenshots/helpers.go
@@ -44,7 +44,7 @@ type videoSegment struct {
 
 // segmentCandidate records one concrete ffmpeg input attempt for a whole-title
 // timestamp. DVD candidates can include later VOB parts as fallbacks when an
-// early menu segment produces no decodable frame.
+// early segment produces no decodable frame.
 type segmentCandidate struct {
 	SourcePath    string
 	Timestamp     float64
@@ -672,8 +672,8 @@ func selectDVDVOB(ctx context.Context, root string) (string, error) {
 	return vobs[0].path, nil
 }
 
-// selectDVDVOBs returns the largest DVD title set's VOBs in numeric playback
-// order, including VTS_nn_0.VOB when present.
+// selectDVDVOBs returns the largest DVD title set's content VOBs in numeric
+// playback order. VTS_nn_0.VOB menu files are excluded.
 func selectDVDVOBs(ctx context.Context, root string) ([]dvdTitleVOB, error) {
 	videoTS, err := findVideoTS(ctx, root)
 	if err != nil {
@@ -698,16 +698,14 @@ func selectDVDVOBs(ctx context.Context, root string) ([]dvdTitleVOB, error) {
 			continue
 		}
 		set, index, ok := parseDVDVOBName(upper)
-		if !ok || index < 0 {
+		if !ok || index <= 0 {
 			continue
 		}
 		info, err := entry.Info()
 		if err != nil {
 			continue
 		}
-		if index > 0 {
-			contentSizes[set] += info.Size()
-		}
+		contentSizes[set] += info.Size()
 		vobPaths[set] = append(vobPaths[set], dvdTitleVOB{
 			path:  filepath.Join(videoTS, name),
 			index: index,

--- a/internal/services/screenshots/helpers.go
+++ b/internal/services/screenshots/helpers.go
@@ -603,8 +603,8 @@ func selectDVDVOB(ctx context.Context, root string) (string, error) {
 	return vobs[0].path, nil
 }
 
-// selectDVDVOBs returns the largest DVD title set's content VOBs in playback
-// order. Menu/control files such as VTS_nn_0.VOB are excluded.
+// selectDVDVOBs returns the largest DVD title set's VOBs in numeric playback
+// order, including VTS_nn_0.VOB when present.
 func selectDVDVOBs(ctx context.Context, root string) ([]dvdTitleVOB, error) {
 	videoTS, err := findVideoTS(ctx, root)
 	if err != nil {
@@ -615,7 +615,7 @@ func selectDVDVOBs(ctx context.Context, root string) ([]dvdTitleVOB, error) {
 		return nil, fmt.Errorf("screenshots: read VIDEO_TS directory: %w", err)
 	}
 
-	vobSizes := map[string]int64{}
+	contentSizes := map[string]int64{}
 	vobPaths := map[string][]dvdTitleVOB{}
 	for _, entry := range entries {
 		select {
@@ -629,14 +629,16 @@ func selectDVDVOBs(ctx context.Context, root string) ([]dvdTitleVOB, error) {
 			continue
 		}
 		set, index, ok := parseDVDVOBName(upper)
-		if !ok || index <= 0 {
+		if !ok || index < 0 {
 			continue
 		}
 		info, err := entry.Info()
 		if err != nil {
 			continue
 		}
-		vobSizes[set] += info.Size()
+		if index > 0 {
+			contentSizes[set] += info.Size()
+		}
 		vobPaths[set] = append(vobPaths[set], dvdTitleVOB{
 			path:  filepath.Join(videoTS, name),
 			index: index,
@@ -646,10 +648,22 @@ func selectDVDVOBs(ctx context.Context, root string) ([]dvdTitleVOB, error) {
 
 	bestSet := ""
 	var bestSize int64
-	for set, size := range vobSizes {
+	for set, size := range contentSizes {
 		if size > bestSize {
 			bestSize = size
 			bestSet = set
+		}
+	}
+	if bestSet == "" {
+		for set, paths := range vobPaths {
+			var size int64
+			for _, path := range paths {
+				size += path.size
+			}
+			if size > bestSize {
+				bestSize = size
+				bestSet = set
+			}
 		}
 	}
 	if bestSet == "" {

--- a/internal/services/screenshots/helpers.go
+++ b/internal/services/screenshots/helpers.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -30,6 +31,15 @@ type videoInfo struct {
 	Height          int
 	WidthScale      float64
 	HeightScale     float64
+	Segments        []videoSegment
+}
+
+// videoSegment maps a global disc timestamp window onto one concrete ffmpeg
+// input file. DVD title sets use one segment per ordered VOB part.
+type videoSegment struct {
+	SourcePath      string
+	StartSeconds    float64
+	DurationSeconds float64
 }
 
 type mediaInfoDoc struct {
@@ -40,10 +50,9 @@ type mediaInfoDoc struct {
 
 var durationTokenPattern = regexp.MustCompile(`(?i)(\d+(?:\.\d+)?)\s*(milliseconds?|msecs?|ms|hours?|hrs?|h|minutes?|mins?|min|seconds?|secs?|sec|s)\b`)
 
-// resolveVideoInfo selects the ffmpeg input path and timing metadata used for
-// screenshot planning/capture. Disc releases prefer selected playlist items or
-// BDInfo/DVD-derived streams; non-disc releases use VideoPath when present and
-// otherwise SourcePath.
+// resolveVideoInfo selects timing metadata and the ffmpeg inputs used for
+// screenshot planning/capture. DVD releases keep ordered title-set segments so
+// global screenshot times can be captured from the matching VOB part.
 func resolveVideoInfo(ctx context.Context, meta api.PreparedMetadata, tmpRoot string, logger api.Logger) (videoInfo, error) {
 	logger = screenshotLogger(logger)
 	info := videoInfo{}
@@ -123,12 +132,13 @@ func resolveVideoInfo(ctx context.Context, meta api.PreparedMetadata, tmpRoot st
 
 	if strings.EqualFold(strings.TrimSpace(meta.DiscType), "DVD") {
 		logger.Tracef("screenshots: DVD source selection root=%s", meta.SourcePath)
-		vob, err := selectDVDVOB(ctx, meta.SourcePath)
+		vobs, err := selectDVDVOBs(ctx, meta.SourcePath)
 		if err != nil {
 			return info, err
 		}
-		info.SourcePath = vob
-		logger.Tracef("screenshots: DVD source selected path=%s", vob)
+		info.SourcePath = vobs[0].path
+		info.Segments = buildVideoSegments(vobs, info.DurationSeconds)
+		logger.Tracef("screenshots: DVD source selected path=%s segments=%d", info.SourcePath, len(info.Segments))
 	}
 
 	if info.SourcePath == "" {
@@ -145,6 +155,32 @@ func resolveVideoInfo(ctx context.Context, meta api.PreparedMetadata, tmpRoot st
 	)
 
 	return info, nil
+}
+
+// resolveSegmentTimestamp converts a whole-title timestamp into the concrete
+// segment file and local timestamp ffmpeg should seek within that file.
+func resolveSegmentTimestamp(info videoInfo, timestamp float64) (string, float64) {
+	if len(info.Segments) == 0 || timestamp <= 0 {
+		return info.SourcePath, timestamp
+	}
+	for _, segment := range info.Segments {
+		if segment.SourcePath == "" || segment.DurationSeconds <= 0 {
+			continue
+		}
+		if timestamp < segment.StartSeconds+segment.DurationSeconds {
+			local := timestamp - segment.StartSeconds
+			if local < 0 {
+				local = 0
+			}
+			return segment.SourcePath, local
+		}
+	}
+	last := info.Segments[len(info.Segments)-1]
+	local := last.DurationSeconds
+	if local > 0.5 {
+		local -= 0.5
+	}
+	return last.SourcePath, local
 }
 
 // resolveVideoSource applies the same input-file preference as resolveVideoInfo
@@ -560,21 +596,31 @@ func selectBDMVFile(ctx context.Context, root string, info *discparse.BDInfo) (s
 }
 
 func selectDVDVOB(ctx context.Context, root string) (string, error) {
-	videoTS, err := findVideoTS(ctx, root)
+	vobs, err := selectDVDVOBs(ctx, root)
 	if err != nil {
 		return "", err
 	}
+	return vobs[0].path, nil
+}
+
+// selectDVDVOBs returns the largest DVD title set's content VOBs in playback
+// order. Menu/control files such as VTS_nn_0.VOB are excluded.
+func selectDVDVOBs(ctx context.Context, root string) ([]dvdTitleVOB, error) {
+	videoTS, err := findVideoTS(ctx, root)
+	if err != nil {
+		return nil, err
+	}
 	entries, err := os.ReadDir(videoTS)
 	if err != nil {
-		return "", fmt.Errorf("screenshots: read VIDEO_TS directory: %w", err)
+		return nil, fmt.Errorf("screenshots: read VIDEO_TS directory: %w", err)
 	}
 
 	vobSizes := map[string]int64{}
-	vobPaths := map[string][]string{}
+	vobPaths := map[string][]dvdTitleVOB{}
 	for _, entry := range entries {
 		select {
 		case <-ctx.Done():
-			return "", fmt.Errorf("context canceled: %w", ctx.Err())
+			return nil, fmt.Errorf("context canceled: %w", ctx.Err())
 		default:
 		}
 		name := entry.Name()
@@ -582,14 +628,20 @@ func selectDVDVOB(ctx context.Context, root string) (string, error) {
 		if !strings.HasPrefix(upper, "VTS_") || !strings.HasSuffix(upper, ".VOB") {
 			continue
 		}
-		set := strings.TrimPrefix(strings.TrimSuffix(upper, ".VOB"), "VTS_")
-		set = strings.SplitN(set, "_", 2)[0]
+		set, index, ok := parseDVDVOBName(upper)
+		if !ok || index <= 0 {
+			continue
+		}
 		info, err := entry.Info()
 		if err != nil {
 			continue
 		}
 		vobSizes[set] += info.Size()
-		vobPaths[set] = append(vobPaths[set], filepath.Join(videoTS, name))
+		vobPaths[set] = append(vobPaths[set], dvdTitleVOB{
+			path:  filepath.Join(videoTS, name),
+			index: index,
+			size:  info.Size(),
+		})
 	}
 
 	bestSet := ""
@@ -601,14 +653,81 @@ func selectDVDVOB(ctx context.Context, root string) (string, error) {
 		}
 	}
 	if bestSet == "" {
-		return "", errors.New("screenshots: no dvd vob found")
+		return nil, errors.New("screenshots: no dvd vob found")
 	}
 
 	paths := vobPaths[bestSet]
 	if len(paths) == 0 {
-		return "", errors.New("screenshots: no dvd vob files for set")
+		return nil, errors.New("screenshots: no dvd vob files for set")
 	}
-	return paths[0], nil
+	sort.Slice(paths, func(i, j int) bool {
+		if paths[i].index != paths[j].index {
+			return paths[i].index < paths[j].index
+		}
+		if paths[i].size != paths[j].size {
+			return paths[i].size > paths[j].size
+		}
+		return paths[i].path < paths[j].path
+	})
+	return paths, nil
+}
+
+func parseDVDVOBName(name string) (string, int, bool) {
+	trimmed := strings.TrimSuffix(strings.TrimPrefix(strings.ToUpper(strings.TrimSpace(name)), "VTS_"), ".VOB")
+	parts := strings.Split(trimmed, "_")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", 0, false
+	}
+	index, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", 0, false
+	}
+	return parts[0], index, true
+}
+
+// dvdTitleVOB records the parsed VTS set/index and size used to select and
+// order DVD title segments.
+type dvdTitleVOB struct {
+	path  string
+	index int
+	size  int64
+}
+
+// buildVideoSegments assigns a whole-title runtime window to each ordered DVD
+// VOB, using file size as the best available proxy for per-part duration.
+func buildVideoSegments(vobs []dvdTitleVOB, totalDuration float64) []videoSegment {
+	if len(vobs) == 0 {
+		return nil
+	}
+	segments := make([]videoSegment, 0, len(vobs))
+	if totalDuration <= 0 {
+		for _, vob := range vobs {
+			segments = append(segments, videoSegment{SourcePath: vob.path})
+		}
+		return segments
+	}
+	var totalSize int64
+	for _, vob := range vobs {
+		if vob.size > 0 {
+			totalSize += vob.size
+		}
+	}
+	if totalSize <= 0 {
+		each := totalDuration / float64(len(vobs))
+		start := 0.0
+		for _, vob := range vobs {
+			segments = append(segments, videoSegment{SourcePath: vob.path, StartSeconds: start, DurationSeconds: each})
+			start += each
+		}
+		return segments
+	}
+	start := 0.0
+	for _, vob := range vobs {
+		duration := totalDuration * (float64(vob.size) / float64(totalSize))
+		segments = append(segments, videoSegment{SourcePath: vob.path, StartSeconds: start, DurationSeconds: duration})
+		start += duration
+	}
+	return segments
 }
 
 func findVideoTS(ctx context.Context, root string) (string, error) {

--- a/internal/services/screenshots/helpers.go
+++ b/internal/services/screenshots/helpers.go
@@ -147,7 +147,7 @@ func resolveVideoInfo(ctx context.Context, meta api.PreparedMetadata, tmpRoot st
 			return info, err
 		}
 		info.SourcePath = vobs[0].path
-		info.Segments = buildVideoSegments(vobs, info.DurationSeconds)
+		info.Segments = buildVideoSegments(vobs)
 		logger.Tracef("screenshots: DVD source selected path=%s segments=%d", info.SourcePath, len(info.Segments))
 	}
 
@@ -774,41 +774,50 @@ type dvdTitleVOB struct {
 	size  int64
 }
 
-// buildVideoSegments assigns a whole-title runtime window to each ordered DVD
-// VOB, using file size as the best available proxy for per-part duration.
-func buildVideoSegments(vobs []dvdTitleVOB, totalDuration float64) []videoSegment {
-	if len(vobs) == 0 {
+// buildVideoSegments records ordered DVD VOB inputs that need measured timing.
+// A single VOB needs no segment mapping because its local and title timestamps
+// are identical.
+func buildVideoSegments(vobs []dvdTitleVOB) []videoSegment {
+	if len(vobs) <= 1 {
 		return nil
 	}
 	segments := make([]videoSegment, 0, len(vobs))
-	if totalDuration <= 0 {
-		for _, vob := range vobs {
-			segments = append(segments, videoSegment{SourcePath: vob.path})
-		}
-		return segments
-	}
-	var totalSize int64
 	for _, vob := range vobs {
-		if vob.size > 0 {
-			totalSize += vob.size
-		}
-	}
-	if totalSize <= 0 {
-		each := totalDuration / float64(len(vobs))
-		start := 0.0
-		for _, vob := range vobs {
-			segments = append(segments, videoSegment{SourcePath: vob.path, StartSeconds: start, DurationSeconds: each})
-			start += each
-		}
-		return segments
-	}
-	start := 0.0
-	for _, vob := range vobs {
-		duration := totalDuration * (float64(vob.size) / float64(totalSize))
-		segments = append(segments, videoSegment{SourcePath: vob.path, StartSeconds: start, DurationSeconds: duration})
-		start += duration
+		segments = append(segments, videoSegment{SourcePath: vob.path})
 	}
 	return segments
+}
+
+// resolveDVDVideoSegmentTimings measures each VOB's container duration before
+// mapping whole-title timestamps. File size is not a valid duration proxy for
+// variable-bitrate MPEG program streams. It mutates segments in order and
+// returns an error if any segment lacks a usable duration.
+func resolveDVDVideoSegmentTimings(
+	ctx context.Context,
+	runner Runner,
+	cmdPath string,
+	segments []videoSegment,
+	logger api.Logger,
+) error {
+	logger = screenshotLogger(logger)
+	start := 0.0
+	for idx := range segments {
+		duration, err := probeVideoDuration(ctx, runner, cmdPath, segments[idx].SourcePath)
+		if err != nil {
+			return fmt.Errorf("screenshots: probe DVD segment %d duration: %w", idx+1, err)
+		}
+		segments[idx].StartSeconds = start
+		segments[idx].DurationSeconds = duration
+		start += duration
+		logger.Tracef(
+			"screenshots: DVD segment timing measured segment=%d start_seconds=%.3f duration_seconds=%.3f input=%s",
+			idx,
+			segments[idx].StartSeconds,
+			segments[idx].DurationSeconds,
+			segments[idx].SourcePath,
+		)
+	}
+	return nil
 }
 
 func findVideoTS(ctx context.Context, root string) (string, error) {

--- a/internal/services/screenshots/helpers_test.go
+++ b/internal/services/screenshots/helpers_test.go
@@ -218,6 +218,100 @@ func TestResolveVideoInfoLogsSeasonPackSourceKind(t *testing.T) {
 	}
 }
 
+func TestSelectDVDVOBSkipsMenuVOBAndUsesLargestTitleSet(t *testing.T) {
+	root := t.TempDir()
+	videoTS := filepath.Join(root, "VIDEO_TS")
+	if err := os.MkdirAll(videoTS, 0o700); err != nil {
+		t.Fatalf("mkdir VIDEO_TS: %v", err)
+	}
+	files := map[string]int{
+		"VTS_01_0.VOB": 200,
+		"VTS_01_1.VOB": 10,
+		"VTS_02_0.VOB": 1,
+		"VTS_02_1.VOB": 30,
+		"VTS_02_2.VOB": 20,
+	}
+	for name, size := range files {
+		if err := os.WriteFile(filepath.Join(videoTS, name), make([]byte, size), 0o600); err != nil {
+			t.Fatalf("write VOB fixture: %v", err)
+		}
+	}
+
+	got, err := selectDVDVOB(context.Background(), root)
+	if err != nil {
+		t.Fatalf("select DVD VOB: %v", err)
+	}
+	want := filepath.Join(videoTS, "VTS_02_1.VOB")
+	if got != want {
+		t.Fatalf("expected first title VOB from largest set %q, got %q", want, got)
+	}
+}
+
+func TestResolveVideoInfoBuildsOrderedDVDSegments(t *testing.T) {
+	root := t.TempDir()
+	videoTS := filepath.Join(root, "VIDEO_TS")
+	if err := os.MkdirAll(videoTS, 0o700); err != nil {
+		t.Fatalf("mkdir VIDEO_TS: %v", err)
+	}
+	files := map[string]int{
+		"VTS_02_0.VOB": 1,
+		"VTS_02_2.VOB": 20,
+		"VTS_02_1.VOB": 30,
+	}
+	for name, size := range files {
+		if err := os.WriteFile(filepath.Join(videoTS, name), make([]byte, size), 0o600); err != nil {
+			t.Fatalf("write VOB fixture: %v", err)
+		}
+	}
+	mediaInfoPath := filepath.Join(root, "mediainfo.json")
+	payload := []byte(`{"media":{"track":[{"@type":"General","Duration":"100"},{"@type":"Video","FrameRate":"25.000"}]}}`)
+	if err := os.WriteFile(mediaInfoPath, payload, 0o600); err != nil {
+		t.Fatalf("write mediainfo: %v", err)
+	}
+
+	info, err := resolveVideoInfo(context.Background(), api.PreparedMetadata{
+		SourcePath:        root,
+		DiscType:          "DVD",
+		MediaInfoJSONPath: mediaInfoPath,
+	}, "", api.NopLogger{})
+	if err != nil {
+		t.Fatalf("resolve video info: %v", err)
+	}
+	if len(info.Segments) != 2 {
+		t.Fatalf("expected 2 DVD segments, got %#v", info.Segments)
+	}
+	if info.Segments[0].SourcePath != filepath.Join(videoTS, "VTS_02_1.VOB") {
+		t.Fatalf("expected first segment VTS_02_1.VOB, got %#v", info.Segments)
+	}
+	if info.Segments[1].SourcePath != filepath.Join(videoTS, "VTS_02_2.VOB") {
+		t.Fatalf("expected second segment VTS_02_2.VOB, got %#v", info.Segments)
+	}
+
+	path, timestamp := resolveSegmentTimestamp(info, 70)
+	if path != filepath.Join(videoTS, "VTS_02_2.VOB") {
+		t.Fatalf("expected timestamp after first segment to use VTS_02_2.VOB, got %q", path)
+	}
+	if timestamp < 9.99 || timestamp > 10.01 {
+		t.Fatalf("expected local timestamp near 10s, got %f", timestamp)
+	}
+}
+
+func TestSelectDVDVOBRejectsMenuOnlyDisc(t *testing.T) {
+	root := t.TempDir()
+	videoTS := filepath.Join(root, "VIDEO_TS")
+	if err := os.MkdirAll(videoTS, 0o700); err != nil {
+		t.Fatalf("mkdir VIDEO_TS: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(videoTS, "VTS_01_0.VOB"), []byte("menu"), 0o600); err != nil {
+		t.Fatalf("write menu VOB: %v", err)
+	}
+
+	_, err := selectDVDVOB(context.Background(), root)
+	if err == nil {
+		t.Fatal("expected menu-only DVD to fail source selection")
+	}
+}
+
 func TestMediaInfoVideoGeometryBuildsPARScaleFactors(t *testing.T) {
 	var doc mediaInfoDoc
 	payload := []byte(`{"media":{"track":[{"@type":"Video","Width":"720 pixels","Height":"576 pixels","PixelAspectRatio":"0.750","DisplayAspectRatio":"4:3"}]}}`)

--- a/internal/services/screenshots/helpers_test.go
+++ b/internal/services/screenshots/helpers_test.go
@@ -286,13 +286,48 @@ func TestResolveVideoInfoBuildsOrderedDVDSegments(t *testing.T) {
 	if info.Segments[1].SourcePath != filepath.Join(videoTS, "VTS_02_2.VOB") {
 		t.Fatalf("expected second segment VTS_02_2.VOB, got %#v", info.Segments)
 	}
+	for _, segment := range info.Segments {
+		if segment.StartSeconds != 0 || segment.DurationSeconds != 0 {
+			t.Fatalf("expected unresolved segment timing before ffmpeg probe, got %#v", info.Segments)
+		}
+	}
+}
 
-	path, timestamp := resolveSegmentTimestamp(info, 70)
-	if path != filepath.Join(videoTS, "VTS_02_2.VOB") {
-		t.Fatalf("expected timestamp in final segment to use VTS_02_2.VOB, got %q", path)
+func TestResolveDVDVideoSegmentTimingsUsesMeasuredDurations(t *testing.T) {
+	vobs := []dvdTitleVOB{
+		{path: "VTS_01_1.VOB", size: 900},
+		{path: "VTS_01_2.VOB", size: 100},
+	}
+	segments := buildVideoSegments(vobs)
+	runner := &scriptedRunner{results: []CommandResult{
+		{Stderr: []byte("Duration: 00:00:20.00, start: 0.000000, bitrate: 4000 kb/s\n")},
+		{Stderr: []byte("Duration: 00:01:20.00, start: 0.000000, bitrate: 500 kb/s\n")},
+	}}
+
+	if err := resolveDVDVideoSegmentTimings(context.Background(), runner, "ffmpeg", segments, api.NopLogger{}); err != nil {
+		t.Fatalf("resolve DVD segment timings: %v", err)
+	}
+	info := videoInfo{SourcePath: vobs[0].path, Segments: segments}
+	path, timestamp := resolveSegmentTimestamp(info, 30)
+	if path != vobs[1].path {
+		t.Fatalf("expected measured duration to select second VOB, got %q", path)
 	}
 	if timestamp != 10 {
-		t.Fatalf("expected local timestamp 10s, got %f", timestamp)
+		t.Fatalf("expected measured local timestamp 10s, got %f", timestamp)
+	}
+}
+
+func TestResolveDVDVideoSegmentTimingsRejectsUnknownDuration(t *testing.T) {
+	segments := buildVideoSegments([]dvdTitleVOB{
+		{path: "VTS_01_1.VOB", size: 900},
+		{path: "VTS_01_2.VOB", size: 100},
+	})
+	runner := &scriptedRunner{results: []CommandResult{{
+		Stderr: []byte("Duration: N/A, start: 0.000000, bitrate: N/A\n"),
+	}}}
+
+	if err := resolveDVDVideoSegmentTimings(context.Background(), runner, "ffmpeg", segments, api.NopLogger{}); err == nil {
+		t.Fatal("expected unknown segment duration to fail instead of using file size")
 	}
 }
 

--- a/internal/services/screenshots/helpers_test.go
+++ b/internal/services/screenshots/helpers_test.go
@@ -218,7 +218,7 @@ func TestResolveVideoInfoLogsSeasonPackSourceKind(t *testing.T) {
 	}
 }
 
-func TestSelectDVDVOBSkipsMenuVOBAndUsesLargestTitleSet(t *testing.T) {
+func TestSelectDVDVOBIncludesZeroVOBAndUsesLargestTitleSet(t *testing.T) {
 	root := t.TempDir()
 	videoTS := filepath.Join(root, "VIDEO_TS")
 	if err := os.MkdirAll(videoTS, 0o700); err != nil {
@@ -241,9 +241,9 @@ func TestSelectDVDVOBSkipsMenuVOBAndUsesLargestTitleSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("select DVD VOB: %v", err)
 	}
-	want := filepath.Join(videoTS, "VTS_02_1.VOB")
+	want := filepath.Join(videoTS, "VTS_02_0.VOB")
 	if got != want {
-		t.Fatalf("expected first title VOB from largest set %q, got %q", want, got)
+		t.Fatalf("expected first numeric VOB from largest set %q, got %q", want, got)
 	}
 }
 
@@ -277,26 +277,29 @@ func TestResolveVideoInfoBuildsOrderedDVDSegments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve video info: %v", err)
 	}
-	if len(info.Segments) != 2 {
-		t.Fatalf("expected 2 DVD segments, got %#v", info.Segments)
+	if len(info.Segments) != 3 {
+		t.Fatalf("expected 3 DVD segments, got %#v", info.Segments)
 	}
-	if info.Segments[0].SourcePath != filepath.Join(videoTS, "VTS_02_1.VOB") {
-		t.Fatalf("expected first segment VTS_02_1.VOB, got %#v", info.Segments)
+	if info.Segments[0].SourcePath != filepath.Join(videoTS, "VTS_02_0.VOB") {
+		t.Fatalf("expected first segment VTS_02_0.VOB, got %#v", info.Segments)
 	}
-	if info.Segments[1].SourcePath != filepath.Join(videoTS, "VTS_02_2.VOB") {
-		t.Fatalf("expected second segment VTS_02_2.VOB, got %#v", info.Segments)
+	if info.Segments[1].SourcePath != filepath.Join(videoTS, "VTS_02_1.VOB") {
+		t.Fatalf("expected second segment VTS_02_1.VOB, got %#v", info.Segments)
+	}
+	if info.Segments[2].SourcePath != filepath.Join(videoTS, "VTS_02_2.VOB") {
+		t.Fatalf("expected third segment VTS_02_2.VOB, got %#v", info.Segments)
 	}
 
 	path, timestamp := resolveSegmentTimestamp(info, 70)
 	if path != filepath.Join(videoTS, "VTS_02_2.VOB") {
-		t.Fatalf("expected timestamp after first segment to use VTS_02_2.VOB, got %q", path)
+		t.Fatalf("expected timestamp in final segment to use VTS_02_2.VOB, got %q", path)
 	}
-	if timestamp < 9.99 || timestamp > 10.01 {
-		t.Fatalf("expected local timestamp near 10s, got %f", timestamp)
+	if timestamp < 9.20 || timestamp > 9.23 {
+		t.Fatalf("expected local timestamp near 9.22s, got %f", timestamp)
 	}
 }
 
-func TestSelectDVDVOBRejectsMenuOnlyDisc(t *testing.T) {
+func TestSelectDVDVOBAllowsZeroOnlyDisc(t *testing.T) {
 	root := t.TempDir()
 	videoTS := filepath.Join(root, "VIDEO_TS")
 	if err := os.MkdirAll(videoTS, 0o700); err != nil {
@@ -306,9 +309,13 @@ func TestSelectDVDVOBRejectsMenuOnlyDisc(t *testing.T) {
 		t.Fatalf("write menu VOB: %v", err)
 	}
 
-	_, err := selectDVDVOB(context.Background(), root)
-	if err == nil {
-		t.Fatal("expected menu-only DVD to fail source selection")
+	got, err := selectDVDVOB(context.Background(), root)
+	if err != nil {
+		t.Fatalf("select DVD VOB: %v", err)
+	}
+	want := filepath.Join(videoTS, "VTS_01_0.VOB")
+	if got != want {
+		t.Fatalf("expected zero-only DVD VOB %q, got %q", want, got)
 	}
 }
 

--- a/internal/services/screenshots/helpers_test.go
+++ b/internal/services/screenshots/helpers_test.go
@@ -6,8 +6,10 @@ package screenshots
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/autobrr/upbrr/pkg/api"
@@ -133,12 +135,16 @@ func TestResolveVideoInfoPrefersLargestSelectedBDMVPlaylistFile(t *testing.T) {
 		},
 	}
 
-	info, err := resolveVideoInfo(context.Background(), meta, "")
+	logger := &screenshotRecordingLogger{}
+	info, err := resolveVideoInfo(context.Background(), meta, "", logger)
 	if err != nil {
 		t.Fatalf("resolve video info: %v", err)
 	}
 	if info.SourcePath != large {
 		t.Fatalf("expected largest playlist m2ts %q, got %q", large, info.SourcePath)
+	}
+	if !logger.Contains("kind=disc_bdmv") || !logger.Contains("method=metadata") {
+		t.Fatal("expected BDMV metadata source-selection trace")
 	}
 }
 
@@ -171,12 +177,44 @@ func TestResolveVideoSourcePrefersLargestSelectedBDMVPlaylistFile(t *testing.T) 
 		},
 	}
 
-	got, err := resolveVideoSource(context.Background(), meta, "")
+	logger := &screenshotRecordingLogger{}
+	got, err := resolveVideoSource(context.Background(), meta, "", logger)
 	if err != nil {
 		t.Fatalf("resolve video source: %v", err)
 	}
 	if got != large {
 		t.Fatalf("expected largest playlist m2ts %q, got %q", large, got)
+	}
+	if !logger.Contains("kind=disc_bdmv") || !logger.Contains("method=bdmv_metadata") {
+		t.Fatal("expected BDMV preview source-selection trace")
+	}
+}
+
+func TestResolveVideoInfoLogsSeasonPackSourceKind(t *testing.T) {
+	tmpDir := t.TempDir()
+	mediaInfoPath := filepath.Join(tmpDir, "mediainfo.json")
+	payload := []byte(`{"media":{"track":[{"@type":"General","Duration":"1800"},{"@type":"Video","FrameRate":"24.000"}]}}`)
+	if err := os.WriteFile(mediaInfoPath, payload, 0o600); err != nil {
+		t.Fatalf("write mediainfo: %v", err)
+	}
+
+	logger := &screenshotRecordingLogger{}
+	meta := api.PreparedMetadata{
+		SourcePath:        filepath.Join(tmpDir, "Example.Release.2026.S01"),
+		MediaInfoJSONPath: mediaInfoPath,
+		MediaInfoCategory: "TV",
+		TVPack:            true,
+	}
+
+	info, err := resolveVideoInfo(context.Background(), meta, "", logger)
+	if err != nil {
+		t.Fatalf("resolve video info: %v", err)
+	}
+	if info.SourcePath != meta.SourcePath {
+		t.Fatal("expected base source path")
+	}
+	if !logger.Contains("kind=season_pack") || !logger.Contains("method=base") {
+		t.Fatal("expected season-pack base source trace")
 	}
 }
 
@@ -213,4 +251,37 @@ func TestMediaInfoVideoGeometryScalesWidthForWidePixels(t *testing.T) {
 	if widthScale != 1.185 || heightScale != 1 {
 		t.Fatalf("expected width scale 1.185 and height scale 1, got %f x %f", widthScale, heightScale)
 	}
+}
+
+type screenshotRecordingLogger struct {
+	entries []string
+}
+
+func (l *screenshotRecordingLogger) Tracef(format string, args ...any) {
+	l.entries = append(l.entries, fmt.Sprintf(format, args...))
+}
+
+func (l *screenshotRecordingLogger) Debugf(format string, args ...any) {
+	l.entries = append(l.entries, fmt.Sprintf(format, args...))
+}
+
+func (l *screenshotRecordingLogger) Infof(string, ...any) {
+	// Intentionally no-op.
+}
+
+func (l *screenshotRecordingLogger) Warnf(format string, args ...any) {
+	l.entries = append(l.entries, fmt.Sprintf(format, args...))
+}
+
+func (l *screenshotRecordingLogger) Errorf(format string, args ...any) {
+	l.entries = append(l.entries, fmt.Sprintf(format, args...))
+}
+
+func (l *screenshotRecordingLogger) Contains(needle string) bool {
+	for _, entry := range l.entries {
+		if strings.Contains(entry, needle) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/services/screenshots/helpers_test.go
+++ b/internal/services/screenshots/helpers_test.go
@@ -299,6 +299,48 @@ func TestResolveVideoInfoBuildsOrderedDVDSegments(t *testing.T) {
 	}
 }
 
+func TestResolveSegmentCandidatesFallsForwardFromZeroVOB(t *testing.T) {
+	info := videoInfo{
+		SourcePath: "VTS_01_0.VOB",
+		Segments: []videoSegment{
+			{SourcePath: "VTS_01_0.VOB", StartSeconds: 0, DurationSeconds: 2},
+			{SourcePath: "VTS_01_1.VOB", StartSeconds: 2, DurationSeconds: 98},
+		},
+	}
+
+	candidates := resolveSegmentCandidates(info, 1)
+	if len(candidates) != 2 {
+		t.Fatalf("expected primary plus fallback candidate, got %#v", candidates)
+	}
+	if candidates[0].SourcePath != "VTS_01_0.VOB" || candidates[0].Timestamp != 1 {
+		t.Fatalf("expected primary zero VOB candidate, got %#v", candidates[0])
+	}
+	if candidates[1].SourcePath != "VTS_01_1.VOB" || candidates[1].Timestamp != 0.5 {
+		t.Fatalf("expected fallback content VOB candidate, got %#v", candidates[1])
+	}
+}
+
+func TestResolveSegmentCandidatesFallsForwardWithoutSegmentDurations(t *testing.T) {
+	info := videoInfo{
+		SourcePath: "VTS_01_0.VOB",
+		Segments: []videoSegment{
+			{SourcePath: "VTS_01_0.VOB"},
+			{SourcePath: "VTS_01_1.VOB"},
+		},
+	}
+
+	candidates := resolveSegmentCandidates(info, 12)
+	if len(candidates) != 2 {
+		t.Fatalf("expected durationless DVD segment fallbacks, got %#v", candidates)
+	}
+	if candidates[0].SourcePath != "VTS_01_0.VOB" || candidates[0].Timestamp != 12 {
+		t.Fatalf("expected primary durationless candidate, got %#v", candidates[0])
+	}
+	if candidates[1].SourcePath != "VTS_01_1.VOB" || candidates[1].Timestamp != 0.5 {
+		t.Fatalf("expected fallback durationless candidate, got %#v", candidates[1])
+	}
+}
+
 func TestSelectDVDVOBAllowsZeroOnlyDisc(t *testing.T) {
 	root := t.TempDir()
 	videoTS := filepath.Join(root, "VIDEO_TS")

--- a/internal/services/screenshots/helpers_test.go
+++ b/internal/services/screenshots/helpers_test.go
@@ -218,7 +218,7 @@ func TestResolveVideoInfoLogsSeasonPackSourceKind(t *testing.T) {
 	}
 }
 
-func TestSelectDVDVOBIncludesZeroVOBAndUsesLargestTitleSet(t *testing.T) {
+func TestSelectDVDVOBExcludesMenuVOBAndUsesLargestTitleSet(t *testing.T) {
 	root := t.TempDir()
 	videoTS := filepath.Join(root, "VIDEO_TS")
 	if err := os.MkdirAll(videoTS, 0o700); err != nil {
@@ -241,9 +241,9 @@ func TestSelectDVDVOBIncludesZeroVOBAndUsesLargestTitleSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("select DVD VOB: %v", err)
 	}
-	want := filepath.Join(videoTS, "VTS_02_0.VOB")
+	want := filepath.Join(videoTS, "VTS_02_1.VOB")
 	if got != want {
-		t.Fatalf("expected first numeric VOB from largest set %q, got %q", want, got)
+		t.Fatalf("expected first content VOB from largest set %q, got %q", want, got)
 	}
 }
 
@@ -277,34 +277,31 @@ func TestResolveVideoInfoBuildsOrderedDVDSegments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve video info: %v", err)
 	}
-	if len(info.Segments) != 3 {
-		t.Fatalf("expected 3 DVD segments, got %#v", info.Segments)
+	if len(info.Segments) != 2 {
+		t.Fatalf("expected 2 DVD content segments, got %#v", info.Segments)
 	}
-	if info.Segments[0].SourcePath != filepath.Join(videoTS, "VTS_02_0.VOB") {
-		t.Fatalf("expected first segment VTS_02_0.VOB, got %#v", info.Segments)
+	if info.Segments[0].SourcePath != filepath.Join(videoTS, "VTS_02_1.VOB") {
+		t.Fatalf("expected first segment VTS_02_1.VOB, got %#v", info.Segments)
 	}
-	if info.Segments[1].SourcePath != filepath.Join(videoTS, "VTS_02_1.VOB") {
-		t.Fatalf("expected second segment VTS_02_1.VOB, got %#v", info.Segments)
-	}
-	if info.Segments[2].SourcePath != filepath.Join(videoTS, "VTS_02_2.VOB") {
-		t.Fatalf("expected third segment VTS_02_2.VOB, got %#v", info.Segments)
+	if info.Segments[1].SourcePath != filepath.Join(videoTS, "VTS_02_2.VOB") {
+		t.Fatalf("expected second segment VTS_02_2.VOB, got %#v", info.Segments)
 	}
 
 	path, timestamp := resolveSegmentTimestamp(info, 70)
 	if path != filepath.Join(videoTS, "VTS_02_2.VOB") {
 		t.Fatalf("expected timestamp in final segment to use VTS_02_2.VOB, got %q", path)
 	}
-	if timestamp < 9.20 || timestamp > 9.23 {
-		t.Fatalf("expected local timestamp near 9.22s, got %f", timestamp)
+	if timestamp != 10 {
+		t.Fatalf("expected local timestamp 10s, got %f", timestamp)
 	}
 }
 
-func TestResolveSegmentCandidatesFallsForwardFromZeroVOB(t *testing.T) {
+func TestResolveSegmentCandidatesFallsForwardFromPrimarySegment(t *testing.T) {
 	info := videoInfo{
-		SourcePath: "VTS_01_0.VOB",
+		SourcePath: "VTS_01_1.VOB",
 		Segments: []videoSegment{
-			{SourcePath: "VTS_01_0.VOB", StartSeconds: 0, DurationSeconds: 2},
-			{SourcePath: "VTS_01_1.VOB", StartSeconds: 2, DurationSeconds: 98},
+			{SourcePath: "VTS_01_1.VOB", StartSeconds: 0, DurationSeconds: 2},
+			{SourcePath: "VTS_01_2.VOB", StartSeconds: 2, DurationSeconds: 98},
 		},
 	}
 
@@ -312,20 +309,20 @@ func TestResolveSegmentCandidatesFallsForwardFromZeroVOB(t *testing.T) {
 	if len(candidates) != 2 {
 		t.Fatalf("expected primary plus fallback candidate, got %#v", candidates)
 	}
-	if candidates[0].SourcePath != "VTS_01_0.VOB" || candidates[0].Timestamp != 1 {
-		t.Fatalf("expected primary zero VOB candidate, got %#v", candidates[0])
+	if candidates[0].SourcePath != "VTS_01_1.VOB" || candidates[0].Timestamp != 1 {
+		t.Fatalf("expected primary segment candidate, got %#v", candidates[0])
 	}
-	if candidates[1].SourcePath != "VTS_01_1.VOB" || candidates[1].Timestamp != 0.5 {
+	if candidates[1].SourcePath != "VTS_01_2.VOB" || candidates[1].Timestamp != 0.5 {
 		t.Fatalf("expected fallback content VOB candidate, got %#v", candidates[1])
 	}
 }
 
 func TestResolveSegmentCandidatesFallsForwardWithoutSegmentDurations(t *testing.T) {
 	info := videoInfo{
-		SourcePath: "VTS_01_0.VOB",
+		SourcePath: "VTS_01_1.VOB",
 		Segments: []videoSegment{
-			{SourcePath: "VTS_01_0.VOB"},
 			{SourcePath: "VTS_01_1.VOB"},
+			{SourcePath: "VTS_01_2.VOB"},
 		},
 	}
 
@@ -333,15 +330,15 @@ func TestResolveSegmentCandidatesFallsForwardWithoutSegmentDurations(t *testing.
 	if len(candidates) != 2 {
 		t.Fatalf("expected durationless DVD segment fallbacks, got %#v", candidates)
 	}
-	if candidates[0].SourcePath != "VTS_01_0.VOB" || candidates[0].Timestamp != 12 {
+	if candidates[0].SourcePath != "VTS_01_1.VOB" || candidates[0].Timestamp != 12 {
 		t.Fatalf("expected primary durationless candidate, got %#v", candidates[0])
 	}
-	if candidates[1].SourcePath != "VTS_01_1.VOB" || candidates[1].Timestamp != 0.5 {
+	if candidates[1].SourcePath != "VTS_01_2.VOB" || candidates[1].Timestamp != 0.5 {
 		t.Fatalf("expected fallback durationless candidate, got %#v", candidates[1])
 	}
 }
 
-func TestSelectDVDVOBAllowsZeroOnlyDisc(t *testing.T) {
+func TestSelectDVDVOBRejectsMenuOnlyDisc(t *testing.T) {
 	root := t.TempDir()
 	videoTS := filepath.Join(root, "VIDEO_TS")
 	if err := os.MkdirAll(videoTS, 0o700); err != nil {
@@ -351,13 +348,8 @@ func TestSelectDVDVOBAllowsZeroOnlyDisc(t *testing.T) {
 		t.Fatalf("write menu VOB: %v", err)
 	}
 
-	got, err := selectDVDVOB(context.Background(), root)
-	if err != nil {
-		t.Fatalf("select DVD VOB: %v", err)
-	}
-	want := filepath.Join(videoTS, "VTS_01_0.VOB")
-	if got != want {
-		t.Fatalf("expected zero-only DVD VOB %q, got %q", want, got)
+	if _, err := selectDVDVOB(context.Background(), root); err == nil {
+		t.Fatal("expected menu-only DVD to have no screenshot VOB")
 	}
 }
 

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -88,17 +88,28 @@ func (s *Service) Plan(ctx context.Context, meta api.PreparedMetadata, count int
 		return api.ScreenshotPlan{}, internalerrors.ErrInvalidInput
 	}
 
-	info, err := resolveVideoInfo(ctx, meta, s.tmpRoot)
+	info, err := resolveVideoInfo(ctx, meta, s.tmpRoot, s.logger)
 	if err != nil {
 		return api.ScreenshotPlan{}, err
 	}
 	plan.DurationSeconds = info.DurationSeconds
 	plan.FrameRate = info.FrameRate
 	plan.MetadataTimestamp = time.Now().UTC().Format(time.RFC3339)
+	s.logger.Debugf(
+		"screenshots: plan setup kind=%s disc=%s requested=%d manual_frames=%d duration_seconds=%.3f frame_rate=%.3f selected_path=%s",
+		screenshotSourceKind(meta),
+		screenshotLogField(meta.DiscType),
+		count,
+		len(meta.ScreenshotOverrides.ManualFrames),
+		plan.DurationSeconds,
+		plan.FrameRate,
+		info.SourcePath,
+	)
 
 	manualSelections := buildManualFrameSelections(meta.ScreenshotOverrides.ManualFrames, plan.FrameRate)
 	if len(manualSelections) == 0 && (plan.DurationSeconds <= 0 || plan.FrameRate <= 0) {
 		plan.RequiresManualFrames = true
+		s.logger.Debugf("screenshots: manual frames required reason=missing_timing duration_seconds=%.3f frame_rate=%.3f", plan.DurationSeconds, plan.FrameRate)
 		return plan, nil
 	}
 
@@ -203,6 +214,15 @@ func (s *Service) Plan(ctx context.Context, meta api.PreparedMetadata, count int
 
 	// Automatically include tracker images in final selections
 	plan.FinalSelections = mergeTrackerImagesIntoFinalSelections(plan.FinalSelections, plan.TrackerImageLinks)
+	s.logger.Tracef(
+		"screenshots: plan result baseline=%d suggested=%d existing=%d tracker_links=%d tracker_existing=%d final=%d",
+		len(baselineSelections),
+		len(plan.SuggestedSelections),
+		len(plan.ExistingScreenshots),
+		len(plan.TrackerImageLinks),
+		len(plan.ExistingTrackerScreenshots),
+		len(plan.FinalSelections),
+	)
 
 	return plan, nil
 }
@@ -224,7 +244,7 @@ func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, select
 		return api.ScreenshotResult{}, internalerrors.ErrInvalidInput
 	}
 
-	info, err := resolveVideoInfo(ctx, meta, s.tmpRoot)
+	info, err := resolveVideoInfo(ctx, meta, s.tmpRoot, s.logger)
 	if err != nil {
 		return api.ScreenshotResult{}, err
 	}
@@ -302,6 +322,20 @@ func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, select
 	if limit > len(jobs) {
 		limit = len(jobs)
 	}
+	s.logger.Debugf(
+		"screenshots: capture setup kind=%s disc=%s purpose=%s selections=%d jobs=%d invalid=%d concurrency=%d frame_overlay=%t tonemap=%t libplacebo_requested=%t ffmpeg=%s",
+		screenshotSourceKind(meta),
+		screenshotLogField(meta.DiscType),
+		purpose,
+		len(selections),
+		len(jobs),
+		len(errors),
+		limit,
+		s.cfg.ScreenshotHandling.FrameOverlay,
+		tonemap,
+		shouldUseLibplacebo(meta, s.cfg),
+		cmd,
+	)
 
 	jobCh := make(chan captureJob)
 	var wg sync.WaitGroup
@@ -320,6 +354,7 @@ func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, select
 			ts := job.timestamp
 			outputName := buildScreenshotFilename(base, selection.Index, ts, purpose)
 			output := filepath.Join(tmpDir, outputName)
+			s.logger.Tracef("screenshots: capture queued index=%d timestamp_seconds=%.3f output=%s", selection.Index, ts, output)
 			capture := captureRequest{
 				InputPath:     info.SourcePath,
 				OutputPath:    output,
@@ -340,8 +375,9 @@ func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, select
 				HeightScale:   info.HeightScale,
 			}
 
-			usedLib, captureErr := captureFrame(ctx, s.runner, cmd, capture)
+			usedLib, captureErr := captureFrame(ctx, s.runner, cmd, capture, s.logger)
 			if captureErr != nil {
+				s.logger.Warnf("screenshots: capture frame failed index=%d err=%s", selection.Index, redaction.RedactValue(captureErr.Error(), nil))
 				mu.Lock()
 				errors = append(errors, api.ScreenshotError{Index: selection.Index, Message: captureErr.Error()})
 				mu.Unlock()
@@ -367,6 +403,15 @@ func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, select
 			mu.Lock()
 			images = append(images, img)
 			mu.Unlock()
+			s.logger.Tracef(
+				"screenshots: capture completed index=%d timestamp_seconds=%.3f bytes=%d width=%d height=%d libplacebo=%t",
+				selection.Index,
+				ts,
+				img.SizeBytes,
+				img.Width,
+				img.Height,
+				usedLib,
+			)
 		}
 	}
 
@@ -398,6 +443,7 @@ func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, select
 	result.Images = images
 	result.Errors = errors
 	result.UsedLibplacebo = usedLibplacebo.Load()
+	s.logger.Debugf("screenshots: capture result images=%d errors=%d libplacebo_used=%t", len(result.Images), len(result.Errors), result.UsedLibplacebo)
 
 	if s.repo != nil && len(images) > 0 && purpose != api.ScreenshotPurposePreview {
 		for _, img := range images {
@@ -419,7 +465,13 @@ func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, select
 	return result, nil
 }
 
-func (s *Service) PreviewFrame(ctx context.Context, meta api.PreparedMetadata, timestampSeconds float64) (api.ScreenshotPreview, error) {
+func (s *Service) PreviewFrame(ctx context.Context, meta api.PreparedMetadata, timestampSeconds float64) (preview api.ScreenshotPreview, err error) {
+	defer func() {
+		if err != nil {
+			s.logger.Warnf("screenshots: preview blocked err=%s", redaction.RedactValue(err.Error(), nil))
+		}
+	}()
+
 	select {
 	case <-ctx.Done():
 		return api.ScreenshotPreview{}, fmt.Errorf("context canceled: %w", ctx.Err())
@@ -430,7 +482,7 @@ func (s *Service) PreviewFrame(ctx context.Context, meta api.PreparedMetadata, t
 		return api.ScreenshotPreview{}, internalerrors.ErrInvalidInput
 	}
 
-	sourcePath, err := resolveVideoSource(ctx, meta, s.tmpRoot)
+	sourcePath, err := resolveVideoSource(ctx, meta, s.tmpRoot, s.logger)
 	if err != nil {
 		return api.ScreenshotPreview{}, err
 	}
@@ -440,15 +492,16 @@ func (s *Service) PreviewFrame(ctx context.Context, meta api.PreparedMetadata, t
 		return api.ScreenshotPreview{}, err
 	}
 
+	s.logger.Debugf("screenshots: preview setup kind=%s disc=%s timestamp_seconds=%.3f selected_path=%s ffmpeg=%s", screenshotSourceKind(meta), screenshotLogField(meta.DiscType), timestampSeconds, sourcePath, cmd)
 	payload, err := captureFrameBytes(ctx, s.runner, cmd, previewRequest{
 		InputPath: sourcePath,
 		Timestamp: timestampSeconds,
-	})
+	}, s.logger)
 	if err != nil {
 		return api.ScreenshotPreview{}, err
 	}
 
-	preview := api.ScreenshotPreview{
+	preview = api.ScreenshotPreview{
 		TimestampSeconds: timestampSeconds,
 		ImageBytes:       payload,
 		SizeBytes:        int64(len(payload)),

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -256,6 +256,9 @@ func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, select
 	if err != nil {
 		return api.ScreenshotResult{}, err
 	}
+	if err := resolveDVDVideoSegmentTimings(ctx, s.runner, cmd, info.Segments, s.logger); err != nil {
+		return api.ScreenshotResult{}, err
+	}
 
 	tmpDir, _, err := paths.ReleaseTempDir(s.tmpRoot, meta, meta.SourcePath)
 	if err != nil {
@@ -498,12 +501,15 @@ func (s *Service) PreviewFrame(ctx context.Context, meta api.PreparedMetadata, t
 	if err != nil {
 		return api.ScreenshotPreview{}, err
 	}
-	candidates := resolveSegmentCandidates(info, timestampSeconds)
 
 	cmd, err := resolveFFmpeg()
 	if err != nil {
 		return api.ScreenshotPreview{}, err
 	}
+	if err := resolveDVDVideoSegmentTimings(ctx, s.runner, cmd, info.Segments, s.logger); err != nil {
+		return api.ScreenshotPreview{}, err
+	}
+	candidates := resolveSegmentCandidates(info, timestampSeconds)
 
 	s.logger.Debugf("screenshots: preview setup kind=%s disc=%s timestamp_seconds=%.3f candidates=%d selected_path=%s ffmpeg=%s", screenshotSourceKind(meta), screenshotLogField(meta.DiscType), timestampSeconds, len(candidates), candidates[0].SourcePath, cmd)
 	var payload []byte

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -278,7 +278,8 @@ func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, select
 			if _, exists := frameInfo[ts]; exists {
 				continue
 			}
-			infoResult, infoErr := getFrameInfo(ctx, s.runner, cmd, info.SourcePath, ts)
+			frameSourcePath, frameTimestamp := resolveSegmentTimestamp(info, ts)
+			infoResult, infoErr := getFrameInfo(ctx, s.runner, cmd, frameSourcePath, frameTimestamp)
 			if infoErr != nil {
 				s.logger.Debugf("screenshots: frame info failed: %v", infoErr)
 				continue
@@ -354,11 +355,12 @@ func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, select
 			ts := job.timestamp
 			outputName := buildScreenshotFilename(base, selection.Index, ts, purpose)
 			output := filepath.Join(tmpDir, outputName)
-			s.logger.Tracef("screenshots: capture queued index=%d timestamp_seconds=%.3f output=%s", selection.Index, ts, output)
+			inputPath, inputTimestamp := resolveSegmentTimestamp(info, ts)
+			s.logger.Tracef("screenshots: capture queued index=%d timestamp_seconds=%.3f input_timestamp_seconds=%.3f input=%s output=%s", selection.Index, ts, inputTimestamp, inputPath, output)
 			capture := captureRequest{
-				InputPath:     info.SourcePath,
+				InputPath:     inputPath,
 				OutputPath:    output,
-				Timestamp:     ts,
+				Timestamp:     inputTimestamp,
 				FrameRate:     info.FrameRate,
 				Resolution:    meta.Release.Resolution,
 				UseLibplacebo: shouldUseLibplacebo(meta, s.cfg),
@@ -482,20 +484,21 @@ func (s *Service) PreviewFrame(ctx context.Context, meta api.PreparedMetadata, t
 		return api.ScreenshotPreview{}, internalerrors.ErrInvalidInput
 	}
 
-	sourcePath, err := resolveVideoSource(ctx, meta, s.tmpRoot, s.logger)
+	info, err := resolveVideoInfo(ctx, meta, s.tmpRoot, s.logger)
 	if err != nil {
 		return api.ScreenshotPreview{}, err
 	}
+	sourcePath, inputTimestamp := resolveSegmentTimestamp(info, timestampSeconds)
 
 	cmd, err := resolveFFmpeg()
 	if err != nil {
 		return api.ScreenshotPreview{}, err
 	}
 
-	s.logger.Debugf("screenshots: preview setup kind=%s disc=%s timestamp_seconds=%.3f selected_path=%s ffmpeg=%s", screenshotSourceKind(meta), screenshotLogField(meta.DiscType), timestampSeconds, sourcePath, cmd)
+	s.logger.Debugf("screenshots: preview setup kind=%s disc=%s timestamp_seconds=%.3f input_timestamp_seconds=%.3f selected_path=%s ffmpeg=%s", screenshotSourceKind(meta), screenshotLogField(meta.DiscType), timestampSeconds, inputTimestamp, sourcePath, cmd)
 	payload, err := captureFrameBytes(ctx, s.runner, cmd, previewRequest{
 		InputPath: sourcePath,
-		Timestamp: timestampSeconds,
+		Timestamp: inputTimestamp,
 	}, s.logger)
 	if err != nil {
 		return api.ScreenshotPreview{}, err

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -355,29 +355,36 @@ func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, select
 			ts := job.timestamp
 			outputName := buildScreenshotFilename(base, selection.Index, ts, purpose)
 			output := filepath.Join(tmpDir, outputName)
-			inputPath, inputTimestamp := resolveSegmentTimestamp(info, ts)
-			s.logger.Tracef("screenshots: capture queued index=%d timestamp_seconds=%.3f input_timestamp_seconds=%.3f input=%s output=%s", selection.Index, ts, inputTimestamp, inputPath, output)
-			capture := captureRequest{
-				InputPath:     inputPath,
-				OutputPath:    output,
-				Timestamp:     inputTimestamp,
-				FrameRate:     info.FrameRate,
-				Resolution:    meta.Release.Resolution,
-				UseLibplacebo: shouldUseLibplacebo(meta, s.cfg),
-				ToneMap:       tonemap,
-				Algorithm:     s.cfg.ScreenshotHandling.TonemapAlgorithm,
-				Desat:         s.cfg.ScreenshotHandling.Desat,
-				Compression:   s.cfg.ScreenshotHandling.FFmpegCompression,
-				FrameOverlay:  s.cfg.ScreenshotHandling.FrameOverlay,
-				OverlaySize:   s.cfg.ScreenshotHandling.OverlayTextSize,
-				FrameInfo:     frameInfo[ts],
-				SourceWidth:   info.Width,
-				SourceHeight:  info.Height,
-				WidthScale:    info.WidthScale,
-				HeightScale:   info.HeightScale,
-			}
+			var usedLib bool
+			var captureErr error
+			for _, candidate := range resolveSegmentCandidates(info, ts) {
+				s.logger.Tracef("screenshots: capture queued index=%d timestamp_seconds=%.3f input_timestamp_seconds=%.3f segment=%d fallback=%d input=%s output=%s", selection.Index, ts, candidate.Timestamp, candidate.SegmentIndex, candidate.FallbackIndex, candidate.SourcePath, output)
+				capture := captureRequest{
+					InputPath:     candidate.SourcePath,
+					OutputPath:    output,
+					Timestamp:     candidate.Timestamp,
+					FrameRate:     info.FrameRate,
+					Resolution:    meta.Release.Resolution,
+					UseLibplacebo: shouldUseLibplacebo(meta, s.cfg),
+					ToneMap:       tonemap,
+					Algorithm:     s.cfg.ScreenshotHandling.TonemapAlgorithm,
+					Desat:         s.cfg.ScreenshotHandling.Desat,
+					Compression:   s.cfg.ScreenshotHandling.FFmpegCompression,
+					FrameOverlay:  s.cfg.ScreenshotHandling.FrameOverlay,
+					OverlaySize:   s.cfg.ScreenshotHandling.OverlayTextSize,
+					FrameInfo:     frameInfo[ts],
+					SourceWidth:   info.Width,
+					SourceHeight:  info.Height,
+					WidthScale:    info.WidthScale,
+					HeightScale:   info.HeightScale,
+				}
 
-			usedLib, captureErr := captureFrame(ctx, s.runner, cmd, capture, s.logger)
+				usedLib, captureErr = captureFrame(ctx, s.runner, cmd, capture, s.logger)
+				if captureErr == nil {
+					break
+				}
+				s.logger.Debugf("screenshots: capture segment failed index=%d segment=%d fallback=%d err=%s", selection.Index, candidate.SegmentIndex, candidate.FallbackIndex, redaction.RedactValue(captureErr.Error(), nil))
+			}
 			if captureErr != nil {
 				s.logger.Warnf("screenshots: capture frame failed index=%d err=%s", selection.Index, redaction.RedactValue(captureErr.Error(), nil))
 				mu.Lock()
@@ -488,18 +495,26 @@ func (s *Service) PreviewFrame(ctx context.Context, meta api.PreparedMetadata, t
 	if err != nil {
 		return api.ScreenshotPreview{}, err
 	}
-	sourcePath, inputTimestamp := resolveSegmentTimestamp(info, timestampSeconds)
+	candidates := resolveSegmentCandidates(info, timestampSeconds)
 
 	cmd, err := resolveFFmpeg()
 	if err != nil {
 		return api.ScreenshotPreview{}, err
 	}
 
-	s.logger.Debugf("screenshots: preview setup kind=%s disc=%s timestamp_seconds=%.3f input_timestamp_seconds=%.3f selected_path=%s ffmpeg=%s", screenshotSourceKind(meta), screenshotLogField(meta.DiscType), timestampSeconds, inputTimestamp, sourcePath, cmd)
-	payload, err := captureFrameBytes(ctx, s.runner, cmd, previewRequest{
-		InputPath: sourcePath,
-		Timestamp: inputTimestamp,
-	}, s.logger)
+	s.logger.Debugf("screenshots: preview setup kind=%s disc=%s timestamp_seconds=%.3f candidates=%d selected_path=%s ffmpeg=%s", screenshotSourceKind(meta), screenshotLogField(meta.DiscType), timestampSeconds, len(candidates), candidates[0].SourcePath, cmd)
+	var payload []byte
+	for _, candidate := range candidates {
+		s.logger.Tracef("screenshots: preview queued timestamp_seconds=%.3f input_timestamp_seconds=%.3f segment=%d fallback=%d input=%s", timestampSeconds, candidate.Timestamp, candidate.SegmentIndex, candidate.FallbackIndex, candidate.SourcePath)
+		payload, err = captureFrameBytes(ctx, s.runner, cmd, previewRequest{
+			InputPath: candidate.SourcePath,
+			Timestamp: candidate.Timestamp,
+		}, s.logger)
+		if err == nil {
+			break
+		}
+		s.logger.Debugf("screenshots: preview segment failed segment=%d fallback=%d err=%s", candidate.SegmentIndex, candidate.FallbackIndex, redaction.RedactValue(err.Error(), nil))
+	}
 	if err != nil {
 		return api.ScreenshotPreview{}, err
 	}

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -227,6 +227,9 @@ func (s *Service) Plan(ctx context.Context, meta api.PreparedMetadata, count int
 	return plan, nil
 }
 
+// Capture renders the requested frames into the prepared release's managed temp
+// directory and records each image with purpose. It returns successful images
+// plus per-selection failures and honors context cancellation.
 func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, selections []api.ScreenshotSelection, purpose api.ScreenshotPurpose) (result api.ScreenshotResult, err error) {
 	defer func() {
 		if err != nil {
@@ -397,7 +400,7 @@ func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, select
 				usedLibplacebo.Store(true)
 			}
 
-			img := api.ScreenshotImage{Index: selection.Index, TimestampSeconds: ts, Path: output}
+			img := api.ScreenshotImage{Index: selection.Index, TimestampSeconds: ts, Path: output, Purpose: purpose}
 			if stat, err := os.Stat(output); err == nil {
 				img.SizeBytes = stat.Size()
 			}
@@ -713,6 +716,9 @@ func isSQLiteBusyError(err error) bool {
 	return db.IsBusyError(err)
 }
 
+// SaveFinalSelections replaces normal final selections from images while
+// preserving manual and automatic disc-menu selections. Menu-purpose images in
+// the input are ignored rather than reclassified as normal screenshots.
 func (s *Service) SaveFinalSelections(ctx context.Context, meta api.PreparedMetadata, images []api.ScreenshotImage) error {
 	if s.repo == nil {
 		return nil
@@ -730,6 +736,9 @@ func (s *Service) SaveFinalSelections(ctx context.Context, meta api.PreparedMeta
 
 	selections := make([]api.ScreenshotFinalSelection, 0, len(images))
 	for index, img := range images {
+		if img.Purpose == api.ScreenshotPurposeMenu {
+			continue
+		}
 		pathValue := strings.TrimSpace(img.Path)
 		if pathValue == "" {
 			return internalerrors.ErrInvalidInput
@@ -749,6 +758,12 @@ func (s *Service) SaveFinalSelections(ctx context.Context, meta api.PreparedMeta
 		})
 	}
 
+	if lifecycle, ok := s.repo.(api.ScreenshotLifecycleRepository); ok {
+		if err := lifecycle.ReplaceNormalFinalSelections(ctx, meta.SourcePath, selections); err != nil {
+			return fmt.Errorf("screenshots: replace normal final selections: %w", err)
+		}
+		return nil
+	}
 	if err := s.repo.SaveFinalSelections(ctx, meta.SourcePath, selections); err != nil {
 		return fmt.Errorf("screenshots: save final selections: %w", err)
 	}
@@ -820,6 +835,9 @@ func listExistingScreens(tmpDir, base string) []api.ScreenshotImage {
 		if base != "" && strings.HasPrefix(name, strings.ToLower(base)+"-preview-") {
 			continue
 		}
+		if base != "" && strings.HasPrefix(name, strings.ToLower(base)+"-dvd-menu-") {
+			continue
+		}
 		stat, err := os.Stat(match)
 		if err != nil {
 			continue
@@ -829,6 +847,7 @@ func listExistingScreens(tmpDir, base string) []api.ScreenshotImage {
 			Index:            parseScreenshotIndex(match, base),
 			TimestampSeconds: ts,
 			Path:             match,
+			Purpose:          api.ScreenshotPurposeFinal,
 			SizeBytes:        stat.Size(),
 		})
 	}
@@ -871,7 +890,7 @@ func listTrackerScreens(tmpDir, base string) []api.ScreenshotImage {
 		if infoErr != nil {
 			return nil
 		}
-		results = append(results, api.ScreenshotImage{Path: path, SizeBytes: info.Size()})
+		results = append(results, api.ScreenshotImage{Path: path, Purpose: api.ScreenshotPurposeFinal, SizeBytes: info.Size()})
 		return nil
 	})
 
@@ -907,6 +926,11 @@ func (s *Service) loadFinalSelections(ctx context.Context, meta api.PreparedMeta
 		if !ok {
 			continue
 		}
+		if api.IsDiscMenuSelectionSource(selection.Source) {
+			img.Purpose = api.ScreenshotPurposeMenu
+		} else {
+			img.Purpose = api.ScreenshotPurposeFinal
+		}
 		images = append(images, img)
 	}
 	sort.Slice(images, func(i, j int) bool { return images[i].Index < images[j].Index })
@@ -924,6 +948,7 @@ func buildScreenshotImage(pathValue string, index int) (api.ScreenshotImage, boo
 		Index:            index,
 		TimestampSeconds: ts,
 		Path:             pathValue,
+		Purpose:          api.ScreenshotPurposeFinal,
 		SizeBytes:        stat.Size(),
 	}
 	if f, err := os.Open(pathValue); err == nil {

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -50,6 +50,28 @@ func TestMergeTrackerImagesIntoFinalSelectionsReindexesSparseIndices(t *testing.
 	}
 }
 
+func TestListExistingScreensExcludesDVDMenuAndPreviewFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	base := "Example.Release.2026.DVD-GRP"
+	normalPath := filepath.Join(root, base+"-01-ss_1000.png")
+	for _, imagePath := range []string{
+		normalPath,
+		filepath.Join(root, base+"-dvd-menu-01-123.png"),
+		filepath.Join(root, base+"-preview-01.png"),
+	} {
+		if err := os.WriteFile(imagePath, []byte("synthetic image"), 0o600); err != nil {
+			t.Fatalf("write image: %v", err)
+		}
+	}
+
+	images := listExistingScreens(root, base)
+	if len(images) != 1 || images[0].Path != normalPath || images[0].Purpose != api.ScreenshotPurposeFinal {
+		t.Fatalf("existing screenshots = %#v", images)
+	}
+}
+
 func TestPlanUsesManualFrameOverridesWithoutDuration(t *testing.T) {
 	tmpDir := t.TempDir()
 	mediaInfoPath := filepath.Join(tmpDir, "mediainfo.json")

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -95,7 +95,7 @@ func TestPlanUsesManualFrameOverridesWithoutDuration(t *testing.T) {
 	}
 }
 
-func TestPreviewFrameFallsForwardFromEmptyDVDZeroVOB(t *testing.T) {
+func TestPreviewFrameExcludesDVDMenuVOB(t *testing.T) {
 	root := t.TempDir()
 	videoTS := filepath.Join(root, "VIDEO_TS")
 	if err := os.MkdirAll(videoTS, 0o700); err != nil {
@@ -119,10 +119,10 @@ func TestPreviewFrameFallsForwardFromEmptyDVDZeroVOB(t *testing.T) {
 	}
 	t.Chdir(ffmpegRoot)
 
-	runner := &scriptedRunner{results: []CommandResult{
-		{ExitCode: 0},
-		{Stdout: testPNGBytes(t, color.RGBA{R: 16, G: 16, B: 16, A: 255}), ExitCode: 0},
-	}}
+	runner := &scriptedRunner{results: []CommandResult{{
+		Stdout:   testPNGBytes(t, color.RGBA{R: 16, G: 16, B: 16, A: 255}),
+		ExitCode: 0,
+	}}}
 	service := NewService(config.Config{}, api.NopLogger{}, root, runner)
 	preview, err := service.PreviewFrame(context.Background(), api.PreparedMetadata{
 		SourcePath:        root,
@@ -133,19 +133,16 @@ func TestPreviewFrameFallsForwardFromEmptyDVDZeroVOB(t *testing.T) {
 		t.Fatalf("preview frame: %v", err)
 	}
 	if len(preview.ImageBytes) == 0 {
-		t.Fatal("expected fallback preview payload")
+		t.Fatal("expected preview payload")
 	}
-	if len(runner.calls) != 2 {
-		t.Fatalf("expected primary plus fallback ffmpeg calls, got %#v", runner.calls)
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected one ffmpeg call, got %#v", runner.calls)
 	}
-	if got := ffmpegInputArg(runner.calls[0].args); got != filepath.Join(videoTS, "VTS_01_0.VOB") {
-		t.Fatalf("expected first preview call to use zero VOB, got %q", got)
+	if got := ffmpegInputArg(runner.calls[0].args); got != filepath.Join(videoTS, "VTS_01_1.VOB") {
+		t.Fatalf("expected preview call to use content VOB, got %q", got)
 	}
-	if got := ffmpegInputArg(runner.calls[1].args); got != filepath.Join(videoTS, "VTS_01_1.VOB") {
-		t.Fatalf("expected fallback preview call to use content VOB, got %q", got)
-	}
-	if got := ffmpegValueAfter(runner.calls[1].args, "-ss"); got != "0.500" {
-		t.Fatalf("expected fallback seek at 0.500, got %q", got)
+	if got := ffmpegValueAfter(runner.calls[0].args, "-ss"); got != "0.500" {
+		t.Fatalf("expected content seek at 0.500, got %q", got)
 	}
 }
 

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -6,7 +6,9 @@ package screenshots
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"image/color"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,7 +121,7 @@ func TestPreviewFrameFallsForwardFromEmptyDVDZeroVOB(t *testing.T) {
 
 	runner := &scriptedRunner{results: []CommandResult{
 		{ExitCode: 0},
-		{Stdout: []byte("png"), ExitCode: 0},
+		{Stdout: testPNGBytes(t, color.RGBA{R: 16, G: 16, B: 16, A: 255}), ExitCode: 0},
 	}}
 	service := NewService(config.Config{}, api.NopLogger{}, root, runner)
 	preview, err := service.PreviewFrame(context.Background(), api.PreparedMetadata{
@@ -130,8 +132,8 @@ func TestPreviewFrameFallsForwardFromEmptyDVDZeroVOB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("preview frame: %v", err)
 	}
-	if string(preview.ImageBytes) != "png" {
-		t.Fatalf("expected fallback preview payload, got %q", string(preview.ImageBytes))
+	if len(preview.ImageBytes) == 0 {
+		t.Fatal("expected fallback preview payload")
 	}
 	if len(runner.calls) != 2 {
 		t.Fatalf("expected primary plus fallback ffmpeg calls, got %#v", runner.calls)
@@ -159,7 +161,7 @@ type scriptedRunner struct {
 func (r *scriptedRunner) Run(_ context.Context, _ string, args []string, _ string) (CommandResult, error) {
 	r.calls = append(r.calls, runnerCall{args: append([]string(nil), args...)})
 	if len(r.results) == 0 {
-		return CommandResult{Stdout: []byte("png"), ExitCode: 0}, nil
+		return CommandResult{ExitCode: 1}, errors.New("unexpected ffmpeg runner call")
 	}
 	result := r.results[0]
 	r.results = r.results[1:]

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -6,8 +6,10 @@ package screenshots
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/config"
@@ -89,4 +91,109 @@ func TestPlanUsesManualFrameOverridesWithoutDuration(t *testing.T) {
 	if plan.SuggestedSelections[0].Frame != 120 || plan.SuggestedSelections[0].Source != "manual" {
 		t.Fatalf("expected first manual selection, got %#v", plan.SuggestedSelections[0])
 	}
+}
+
+func TestPreviewFrameFallsForwardFromEmptyDVDZeroVOB(t *testing.T) {
+	root := t.TempDir()
+	videoTS := filepath.Join(root, "VIDEO_TS")
+	if err := os.MkdirAll(videoTS, 0o700); err != nil {
+		t.Fatalf("mkdir VIDEO_TS: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(videoTS, "VTS_01_0.VOB"), []byte("m"), 0o600); err != nil {
+		t.Fatalf("write zero VOB: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(videoTS, "VTS_01_1.VOB"), []byte(strings.Repeat("c", 99)), 0o600); err != nil {
+		t.Fatalf("write content VOB: %v", err)
+	}
+	mediaInfoPath := filepath.Join(root, "mediainfo.json")
+	payload := []byte(`{"media":{"track":[{"@type":"General","Duration":"100"},{"@type":"Video","FrameRate":"25.000"}]}}`)
+	if err := os.WriteFile(mediaInfoPath, payload, 0o600); err != nil {
+		t.Fatalf("write mediainfo: %v", err)
+	}
+
+	ffmpegRoot := t.TempDir()
+	if err := writeTestBundledFFmpeg(ffmpegRoot); err != nil {
+		t.Fatalf("write bundled ffmpeg: %v", err)
+	}
+	t.Chdir(ffmpegRoot)
+
+	runner := &scriptedRunner{results: []CommandResult{
+		{ExitCode: 0},
+		{Stdout: []byte("png"), ExitCode: 0},
+	}}
+	service := NewService(config.Config{}, api.NopLogger{}, root, runner)
+	preview, err := service.PreviewFrame(context.Background(), api.PreparedMetadata{
+		SourcePath:        root,
+		DiscType:          "DVD",
+		MediaInfoJSONPath: mediaInfoPath,
+	}, 0.5)
+	if err != nil {
+		t.Fatalf("preview frame: %v", err)
+	}
+	if string(preview.ImageBytes) != "png" {
+		t.Fatalf("expected fallback preview payload, got %q", string(preview.ImageBytes))
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("expected primary plus fallback ffmpeg calls, got %#v", runner.calls)
+	}
+	if got := ffmpegInputArg(runner.calls[0].args); got != filepath.Join(videoTS, "VTS_01_0.VOB") {
+		t.Fatalf("expected first preview call to use zero VOB, got %q", got)
+	}
+	if got := ffmpegInputArg(runner.calls[1].args); got != filepath.Join(videoTS, "VTS_01_1.VOB") {
+		t.Fatalf("expected fallback preview call to use content VOB, got %q", got)
+	}
+	if got := ffmpegValueAfter(runner.calls[1].args, "-ss"); got != "0.500" {
+		t.Fatalf("expected fallback seek at 0.500, got %q", got)
+	}
+}
+
+type runnerCall struct {
+	args []string
+}
+
+type scriptedRunner struct {
+	results []CommandResult
+	calls   []runnerCall
+}
+
+func (r *scriptedRunner) Run(_ context.Context, _ string, args []string, _ string) (CommandResult, error) {
+	r.calls = append(r.calls, runnerCall{args: append([]string(nil), args...)})
+	if len(r.results) == 0 {
+		return CommandResult{Stdout: []byte("png"), ExitCode: 0}, nil
+	}
+	result := r.results[0]
+	r.results = r.results[1:]
+	return result, nil
+}
+
+func writeTestBundledFFmpeg(root string) error {
+	folder := osFolder()
+	if folder == "" {
+		return nil
+	}
+	name := "ffmpeg"
+	if folder == "windows" {
+		name = "ffmpeg.exe"
+	}
+	path := filepath.Join(root, "bin", "ffmpeg", folder, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("mkdir bundled ffmpeg dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte("test"), 0o600); err != nil {
+		return fmt.Errorf("write bundled ffmpeg: %w", err)
+	}
+	return nil
+}
+
+func ffmpegInputArg(args []string) string {
+	return ffmpegValueAfter(args, "-i")
+}
+
+func ffmpegValueAfter(args []string, key string) string {
+	for idx := 0; idx+1 < len(args); idx++ {
+		if args[idx] == key {
+			return args[idx+1]
+		}
+	}
+	return ""
 }

--- a/internal/trackers/description_assets.go
+++ b/internal/trackers/description_assets.go
@@ -129,6 +129,15 @@ func ResolveDescriptionAssets(ctx context.Context, tracker string, meta api.Prep
 	return resolveDescriptionAssets(ctx, tracker, meta, repo, logger, nil)
 }
 
+// ResolveDescriptionAssetsWithPrepared returns caller-prepared assets when
+// available, preserving image-host resolution performed by the orchestrator.
+func ResolveDescriptionAssetsWithPrepared(ctx context.Context, tracker string, meta api.PreparedMetadata, repo api.MetadataRepository, logger api.Logger, prepared *DescriptionAssets) (DescriptionAssets, error) {
+	if prepared != nil {
+		return *prepared, nil
+	}
+	return ResolveDescriptionAssets(ctx, tracker, meta, repo, logger)
+}
+
 func LogDescriptionAssetResolutionFailure(logger api.Logger, tracker string, err error) {
 	if err == nil || logger == nil {
 		return
@@ -228,7 +237,7 @@ func splitDescriptionScreenshots(ctx context.Context, meta api.PreparedMetadata,
 	}
 	menuPaths := make(map[string]struct{})
 	for _, sel := range selections {
-		if sel.Source == screenshotPurposeMenu && strings.TrimSpace(sel.ImagePath) != "" {
+		if api.IsDiscMenuSelectionSource(sel.Source) && strings.TrimSpace(sel.ImagePath) != "" {
 			menuPaths[strings.TrimSpace(sel.ImagePath)] = struct{}{}
 		}
 	}

--- a/internal/trackers/description_assets_test.go
+++ b/internal/trackers/description_assets_test.go
@@ -18,6 +18,7 @@ import (
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/paths"
 	dbsvc "github.com/autobrr/upbrr/internal/services/db"
+	descriptionunit3d "github.com/autobrr/upbrr/internal/services/description/unit3d"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -286,6 +287,29 @@ func TestResolveDescriptionAssetsPrefersDBDescription(t *testing.T) {
 	}
 }
 
+func TestResolveDescriptionAssetsWithPreparedPreservesCallerAssets(t *testing.T) {
+	t.Parallel()
+
+	prepared := DescriptionAssets{
+		Description: "prepared description",
+		MenuImages:  []api.ScreenshotImage{{Path: filepath.Join(t.TempDir(), "prepared-menu.png")}},
+	}
+	resolved, err := ResolveDescriptionAssetsWithPrepared(
+		context.Background(),
+		"AITHER",
+		api.PreparedMetadata{},
+		&stubRepo{trackerRecordsErr: errors.New("must not query repository")},
+		api.NopLogger{},
+		&prepared,
+	)
+	if err != nil {
+		t.Fatalf("resolve prepared assets: %v", err)
+	}
+	if resolved.Description != prepared.Description || len(resolved.MenuImages) != 1 || resolved.MenuImages[0].Path != prepared.MenuImages[0].Path {
+		t.Fatalf("resolved assets = %#v, want %#v", resolved, prepared)
+	}
+}
+
 func TestResolveDescriptionAssetsDedupesAfterSanitizingBotSignatures(t *testing.T) {
 	repo := &stubRepo{
 		trackerRecords: []api.TrackerMetadata{
@@ -311,7 +335,7 @@ func TestApplyResolvedDescriptionScreenshotsKeepsMenuImagesSeparate(t *testing.T
 	repo := &stubRepo{
 		selections: []api.ScreenshotFinalSelection{
 			{SourcePath: "/tmp/source", ImagePath: "/tmp/screen1.png", Order: 0, Source: string(api.ScreenshotPurposeFinal)},
-			{SourcePath: "/tmp/source", ImagePath: "/tmp/menu1.png", Order: 1, Source: screenshotPurposeMenu},
+			{SourcePath: "/tmp/source", ImagePath: "/tmp/menu1.png", Order: 1, Source: api.ScreenshotSelectionSourceDVDMenu},
 			{SourcePath: "/tmp/source", ImagePath: "/tmp/screen2.png", Order: 2, Source: string(api.ScreenshotPurposeFinal)},
 		},
 	}
@@ -334,6 +358,189 @@ func TestApplyResolvedDescriptionScreenshotsKeepsMenuImagesSeparate(t *testing.T
 		if strings.Contains(shot.ImgURL, "menu1.png") {
 			t.Fatalf("menu image leaked into screenshots: %#v", assets.Screenshots)
 		}
+	}
+}
+
+func TestDescriptionAssetsPreserveMenuClassificationAcrossRehost(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "Example.Release.2026.DVD-GRP")
+	paths := []string{
+		filepath.Join(root, "auto-menu.png"),
+		filepath.Join(root, "manual-menu.png"),
+		filepath.Join(root, "normal-screen.png"),
+	}
+	repo := &stubRepo{selections: []api.ScreenshotFinalSelection{
+		{SourcePath: sourcePath, ImagePath: paths[0], Order: 0, Source: api.ScreenshotSelectionSourceDVDMenu},
+		{SourcePath: sourcePath, ImagePath: paths[1], Order: 1, Source: api.ScreenshotSelectionSourceMenu},
+		{SourcePath: sourcePath, ImagePath: paths[2], Order: 2, Source: string(api.ScreenshotPurposeFinal)},
+	}}
+	images := &stubImageService{repo: repo}
+	meta := api.PreparedMetadata{SourcePath: sourcePath}
+
+	resolution, err := ensureDescriptionImageHost(
+		context.Background(),
+		"PTP",
+		meta,
+		config.Config{},
+		config.TrackerConfig{},
+		repo,
+		images,
+		api.NopLogger{},
+	)
+	if err != nil {
+		t.Fatalf("rehost description assets: %v", err)
+	}
+	if !resolution.feedback.Reuploaded || resolution.feedback.SelectedHost != "pixhost" {
+		t.Fatalf("rehost feedback = %#v", resolution.feedback)
+	}
+
+	assets, err := ResolveDescriptionAssets(context.Background(), "PTP", meta, repo, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("resolve rehosted assets: %v", err)
+	}
+	applyResolvedDescriptionScreenshots(context.Background(), meta, repo, nil, &assets, resolution.screenshots)
+	assertScreenshotPaths(t, assets.MenuImages, paths[:2])
+	assertScreenshotPaths(t, assets.Screenshots, paths[2:])
+	for _, image := range append(append([]api.ScreenshotImage(nil), assets.MenuImages...), assets.Screenshots...) {
+		if image.Host != "pixhost" || strings.TrimSpace(image.RawURL) == "" {
+			t.Fatalf("rehosted image lost hosted variant: %#v", image)
+		}
+	}
+}
+
+func TestPartialMenuRemovalUpdatesResolvedAndRenderedDescription(t *testing.T) {
+	t.Parallel()
+
+	repo, err := dbsvc.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open repository: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repository: %v", err)
+	}
+
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "Example.Release.2026.DVD-GRP")
+	autoFirst := filepath.Join(root, "auto-menu-01.png")
+	autoSecond := filepath.Join(root, "auto-menu-02.png")
+	normal := filepath.Join(root, "normal-screen-01.png")
+	selections := []api.ScreenshotFinalSelection{
+		{SourcePath: sourcePath, ImagePath: autoFirst, Order: 0, Source: api.ScreenshotSelectionSourceDVDMenu},
+		{SourcePath: sourcePath, ImagePath: autoSecond, Order: 1, Source: api.ScreenshotSelectionSourceDVDMenu},
+		{SourcePath: sourcePath, ImagePath: normal, Order: 2, Source: string(api.ScreenshotPurposeFinal)},
+	}
+	if err := repo.SaveFinalSelections(context.Background(), sourcePath, selections); err != nil {
+		t.Fatalf("save selections: %v", err)
+	}
+	uploads := make([]api.UploadedImageLink, 0, len(selections))
+	slots := make([]api.ScreenshotSlot, 0, len(selections))
+	for index, selection := range selections {
+		rawURL := fmt.Sprintf("https://images.example.invalid/%d.png", index)
+		uploads = append(uploads, api.UploadedImageLink{
+			SourcePath: sourcePath,
+			ImagePath:  selection.ImagePath,
+			Host:       "imgbb",
+			UsageScope: globalImageUsageScope,
+			ImgURL:     rawURL,
+			RawURL:     rawURL,
+			WebURL:     rawURL,
+		})
+		slots = append(slots, api.ScreenshotSlot{
+			SourcePath:          sourcePath,
+			SlotOrder:           index,
+			SourceKind:          screenshotSlotSourceSelection,
+			OriginalKey:         selection.ImagePath,
+			ImagePath:           selection.ImagePath,
+			SectionKind:         screenshotSectionWrapped,
+			RenderInScreenshots: true,
+			Variants: []api.ScreenshotSlotVariant{{
+				SourcePath: sourcePath,
+				SlotOrder:  index,
+				Host:       "imgbb",
+				UsageScope: globalImageUsageScope,
+				ImagePath:  selection.ImagePath,
+				ImgURL:     rawURL,
+				RawURL:     rawURL,
+				WebURL:     rawURL,
+			}},
+		})
+	}
+	if err := repo.SaveUploadedImages(context.Background(), sourcePath, "imgbb", uploads); err != nil {
+		t.Fatalf("save uploads: %v", err)
+	}
+	if err := repo.ReplaceScreenshotSlots(context.Background(), sourcePath, slots); err != nil {
+		t.Fatalf("save slots: %v", err)
+	}
+
+	meta := api.PreparedMetadata{SourcePath: sourcePath}
+	before := resolveAssetsForTest(t, meta, repo)
+	if len(before.MenuImages) != 2 || len(before.Screenshots) != 1 {
+		t.Fatalf("assets before removal = %#v", before)
+	}
+
+	if _, err := repo.DeleteDiscMenuScreenshot(context.Background(), sourcePath, autoFirst); err != nil {
+		t.Fatalf("delete first menu: %v", err)
+	}
+	after := resolveAssetsForTest(t, meta, repo)
+	assertScreenshotPaths(t, after.MenuImages, []string{autoSecond})
+	assertScreenshotPaths(t, after.Screenshots, []string{normal})
+
+	description, err := descriptionunit3d.BuildDescription(
+		context.Background(),
+		meta,
+		config.Config{Description: config.DescriptionSettingsConfig{
+			DiscMenuHeader:   "Disc menu token",
+			ScreenshotHeader: "Screenshots token",
+			ThumbnailSize:    300,
+		}},
+		config.TrackerConfig{},
+		api.NopLogger{},
+		"Body token",
+		after.MenuImages,
+		after.Screenshots,
+	)
+	if err != nil {
+		t.Fatalf("render description: %v", err)
+	}
+	assertDescriptionTokensInOrder(t, description, "Body token", "Disc menu token", "1.png", "Screenshots token", "2.png")
+	if strings.Contains(description, "0.png") {
+		t.Fatalf("removed menu remained in description: %q", description)
+	}
+}
+
+func resolveAssetsForTest(t *testing.T, meta api.PreparedMetadata, repo api.MetadataRepository) DescriptionAssets {
+	t.Helper()
+	assets, err := ResolveDescriptionAssets(context.Background(), "AITHER", meta, repo, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("resolve description assets: %v", err)
+	}
+	return assets
+}
+
+func assertScreenshotPaths(t *testing.T, images []api.ScreenshotImage, expected []string) {
+	t.Helper()
+	if len(images) != len(expected) {
+		t.Fatalf("image count = %d, want %d: %#v", len(images), len(expected), images)
+	}
+	for index, pathValue := range expected {
+		if images[index].Path != pathValue {
+			t.Fatalf("image[%d].Path = %q, want %q", index, images[index].Path, pathValue)
+		}
+	}
+}
+
+func assertDescriptionTokensInOrder(t *testing.T, description string, tokens ...string) {
+	t.Helper()
+	previous := -1
+	for _, token := range tokens {
+		position := strings.Index(description, token)
+		if position <= previous {
+			t.Fatalf("description tokens out of order at %q: %q", token, description)
+		}
+		previous = position
 	}
 }
 

--- a/internal/trackers/image_host_policy.go
+++ b/internal/trackers/image_host_policy.go
@@ -282,6 +282,7 @@ func neededImageUploadTargets(appCfg config.Config, trackerNames []string, selec
 
 		policy := policyForTrackerForTarget(name, appCfg, trackerCfg)
 		candidates := imageUploadCandidatesForTracker(appCfg, name, userHosts)
+		candidates = appendOwnedPolicyUploadHosts(candidates, name, policy)
 		flexibleTargets = append(flexibleTargets, imageUploadPolicyTarget{tracker: name, policy: policy, candidates: candidates})
 	}
 
@@ -450,6 +451,18 @@ func imageUploadCandidatesForTracker(appCfg config.Config, tracker string, userH
 	}
 	if reelflixEnabledForTracker(tracker, trackerConfigForImageHostPolicy(appCfg, tracker)) {
 		candidates = appendUniqueHost(candidates, "reelflix")
+	}
+	return candidates
+}
+
+// appendOwnedPolicyUploadHosts adds upload-capable policy hosts owned by the
+// target tracker. Owned hosts are intentionally absent from the global host
+// list and must retain their tracker-scoped upload target.
+func appendOwnedPolicyUploadHosts(candidates []string, tracker string, policy imageHostPolicy) []string {
+	for _, host := range policy.uploadHosts {
+		if owner := trackerForOwnedHost(host); owner != "" && strings.EqualFold(owner, tracker) {
+			candidates = appendUniqueHost(candidates, host)
+		}
 	}
 	return candidates
 }

--- a/internal/trackers/impl/ant/definition.go
+++ b/internal/trackers/impl/ant/definition.go
@@ -37,7 +37,7 @@ func (d *Definition) BuildDescription(ctx context.Context, req trackers.Descript
 	default:
 	}
 
-	assets, err := trackers.ResolveDescriptionAssets(ctx, req.Tracker, req.Meta, req.Repo, req.Logger)
+	assets, err := trackers.ResolveDescriptionAssetsWithPrepared(ctx, req.Tracker, req.Meta, req.Repo, req.Logger, req.Assets)
 	if err != nil {
 		assets = trackers.DescriptionAssets{}
 	}

--- a/internal/trackers/impl/ant/definition_test.go
+++ b/internal/trackers/impl/ant/definition_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -205,10 +206,5 @@ func TestBuildDescriptionRemovesScreenshotOnlyBlockAndDefaultSignature(t *testin
 }
 
 func containsString(values []string, target string) bool {
-	for _, value := range values {
-		if value == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, target)
 }

--- a/internal/trackers/impl/ant/description_assets_test.go
+++ b/internal/trackers/impl/ant/description_assets_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package ant
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackers"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestBuildDescriptionUsesPreparedDiscMenuAssets(t *testing.T) {
+	t.Parallel()
+
+	assets := trackers.DescriptionAssets{
+		Description: "Body token",
+		MenuImages:  []api.ScreenshotImage{{RawURL: "https://images.example.invalid/menu.png"}},
+		Screenshots: []api.ScreenshotImage{{RawURL: "https://images.example.invalid/normal.png"}},
+	}
+	result, err := New().BuildDescription(context.Background(), trackers.DescriptionRequest{
+		Tracker: "ANT",
+		AppConfig: config.Config{Description: config.DescriptionSettingsConfig{
+			DiscMenuHeader: "Disc menu token",
+		}},
+		Assets: &assets,
+	})
+	if err != nil {
+		t.Fatalf("build description: %v", err)
+	}
+	assertDescriptionTokensInOrder(t, result.Description, "Body token", "Disc menu token", "https://images.example.invalid/menu.png")
+	if strings.Contains(result.Description, "normal.png") {
+		t.Fatalf("normal screenshot leaked into ANT description: %q", result.Description)
+	}
+
+	final := trackers.DescriptionAssets{Description: " Authoritative final token ", Final: true, MenuImages: assets.MenuImages}
+	result, err = New().BuildDescription(context.Background(), trackers.DescriptionRequest{Tracker: "ANT", Assets: &final})
+	if err != nil {
+		t.Fatalf("build final description: %v", err)
+	}
+	if result.Description != "Authoritative final token" {
+		t.Fatalf("final description = %q", result.Description)
+	}
+}
+
+func assertDescriptionTokensInOrder(t *testing.T, description string, tokens ...string) {
+	t.Helper()
+	previous := -1
+	for _, token := range tokens {
+		position := strings.Index(description, token)
+		if position <= previous {
+			t.Fatalf("description tokens out of order at %q: %q", token, description)
+		}
+		previous = position
+	}
+}

--- a/internal/trackers/impl/ant/upload.go
+++ b/internal/trackers/impl/ant/upload.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -167,7 +168,7 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest) (upload
 	if err != nil {
 		return uploadState{}, fmt.Errorf("trackers: %w", err)
 	}
-	descriptionAssets, err := trackers.ResolveDescriptionAssets(ctx, req.Tracker, req.Meta, req.Repo, req.Logger)
+	descriptionAssets, err := trackers.ResolveDescriptionAssetsWithPrepared(ctx, req.Tracker, req.Meta, req.Repo, req.Logger, req.Assets)
 	if err != nil {
 		trackers.LogDescriptionAssetResolutionFailure(req.Logger, req.Tracker, err)
 		descriptionAssets = trackers.DescriptionAssets{}
@@ -196,9 +197,7 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest) (upload
 		"release_desc": description,
 		"screenshots":  screenshots,
 	}
-	for key, value := range mediaFields {
-		fields[key] = value
-	}
+	maps.Copy(fields, mediaFields)
 	if len(flags) > 0 {
 		fields["flags[]"] = strings.Join(flags, ",")
 	}
@@ -235,6 +234,9 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest) (upload
 }
 
 func buildDescription(req trackers.UploadRequest, assets trackers.DescriptionAssets) string {
+	if assets.Final {
+		return strings.TrimSpace(assets.Description)
+	}
 	meta := req.Meta
 	var parts []string
 
@@ -670,7 +672,7 @@ func buildMultipartPayload(fields map[string]string, torrentPath string) ([]byte
 	writer := multipart.NewWriter(&body)
 	for key, value := range fields {
 		if key == "flags[]" {
-			for _, item := range strings.Split(value, ",") {
+			for item := range strings.SplitSeq(value, ",") {
 				trimmed := strings.TrimSpace(item)
 				if trimmed == "" {
 					continue

--- a/internal/trackers/impl/gpw/definition.go
+++ b/internal/trackers/impl/gpw/definition.go
@@ -29,7 +29,7 @@ func (definition) BuildUploadDryRun(ctx context.Context, req trackers.UploadRequ
 }
 
 func (definition) BuildDescription(ctx context.Context, req trackers.DescriptionRequest) (trackers.DescriptionResult, error) {
-	assets, err := trackers.ResolveDescriptionAssets(ctx, req.Tracker, req.Meta, req.Repo, req.Logger)
+	assets, err := trackers.ResolveDescriptionAssetsWithPrepared(ctx, req.Tracker, req.Meta, req.Repo, req.Logger, req.Assets)
 	if err != nil {
 		assets = trackers.DescriptionAssets{}
 	}

--- a/internal/trackers/impl/gpw/description_assets_test.go
+++ b/internal/trackers/impl/gpw/description_assets_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package gpw
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackers"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestBuildDescriptionUsesPreparedDiscMenuAssets(t *testing.T) {
+	t.Parallel()
+
+	assets := trackers.DescriptionAssets{
+		Description: "Body token",
+		MenuImages:  []api.ScreenshotImage{{RawURL: "https://images.example.invalid/menu.png"}},
+		Screenshots: []api.ScreenshotImage{{RawURL: "https://images.example.invalid/normal.png"}},
+	}
+	result, err := (definition{}).BuildDescription(context.Background(), trackers.DescriptionRequest{
+		Tracker: "GPW",
+		AppConfig: config.Config{Description: config.DescriptionSettingsConfig{
+			DiscMenuHeader:   "Disc menu token",
+			ScreenshotHeader: "Screenshots token",
+		}},
+		Assets: &assets,
+	})
+	if err != nil {
+		t.Fatalf("build description: %v", err)
+	}
+	assertDescriptionTokensInOrder(t, result.Description, "Body token", "Disc menu token", "menu.png", "Screenshots token", "normal.png")
+
+	final := trackers.DescriptionAssets{Description: " Authoritative final token ", Final: true, MenuImages: assets.MenuImages}
+	result, err = (definition{}).BuildDescription(context.Background(), trackers.DescriptionRequest{Tracker: "GPW", Assets: &final})
+	if err != nil {
+		t.Fatalf("build final description: %v", err)
+	}
+	if result.Description != "Authoritative final token" {
+		t.Fatalf("final description = %q", result.Description)
+	}
+}
+
+func assertDescriptionTokensInOrder(t *testing.T, description string, tokens ...string) {
+	t.Helper()
+	previous := -1
+	for _, token := range tokens {
+		position := strings.Index(description, token)
+		if position <= previous {
+			t.Fatalf("description tokens out of order at %q: %q", token, description)
+		}
+		previous = position
+	}
+}

--- a/internal/trackers/impl/gpw/upload.go
+++ b/internal/trackers/impl/gpw/upload.go
@@ -144,7 +144,7 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest) (upload
 	if err != nil {
 		return uploadState{}, fmt.Errorf("trackers: %w", err)
 	}
-	assets, err := trackers.ResolveDescriptionAssets(ctx, req.Tracker, req.Meta, req.Repo, req.Logger)
+	assets, err := trackers.ResolveDescriptionAssetsWithPrepared(ctx, req.Tracker, req.Meta, req.Repo, req.Logger, req.Assets)
 	if err != nil {
 		trackers.LogDescriptionAssetResolutionFailure(req.Logger, req.Tracker, err)
 		assets = trackers.DescriptionAssets{}
@@ -292,6 +292,9 @@ func validateFields(groupID string, fields map[string]string) string {
 }
 
 func buildDescription(req trackers.UploadRequest, assets trackers.DescriptionAssets) string {
+	if assets.Final {
+		return strings.TrimSpace(assets.Description)
+	}
 	meta := req.Meta
 	parts := make([]string, 0, 3)
 	// custom header

--- a/internal/trackers/impl/hdb/definition.go
+++ b/internal/trackers/impl/hdb/definition.go
@@ -52,7 +52,7 @@ func (d *Definition) BuildDescription(ctx context.Context, req trackers.Descript
 
 	description := strings.TrimSpace(assets.Description)
 	if !assets.Final {
-		description, err = descriptionhdb.BuildDescription(ctx, req.Meta, req.AppConfig, assets.Description, assets.Screenshots)
+		description, err = descriptionhdb.BuildDescription(ctx, req.Meta, req.AppConfig, assets.Description, assets.MenuImages, assets.Screenshots)
 		if err != nil {
 			return trackers.DescriptionResult{}, fmt.Errorf("trackers: HDB description build: %w", err)
 		}

--- a/internal/trackers/impl/hdb/definition_test.go
+++ b/internal/trackers/impl/hdb/definition_test.go
@@ -56,6 +56,28 @@ func TestDefinitionBuildDescriptionUsesProvidedAssets(t *testing.T) {
 	}
 }
 
+func TestDefinitionBuildDescriptionUsesProvidedMenuImages(t *testing.T) {
+	d := New()
+	result, err := d.BuildDescription(context.Background(), trackers.DescriptionRequest{
+		Tracker: "HDB",
+		Meta:    api.PreparedMetadata{},
+		Logger:  api.NopLogger{},
+		Assets: &trackers.DescriptionAssets{
+			MenuImages: []api.ScreenshotImage{{
+				Purpose: api.ScreenshotPurposeMenu,
+				ImgURL:  "https://t.hdbits.org/menu.jpg",
+				WebURL:  "https://img.hdbits.org/menu",
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Description, "https://t.hdbits.org/menu.jpg") {
+		t.Fatalf("expected provided menu image in description, got %q", result.Description)
+	}
+}
+
 func TestDefinitionUploadMissingCredentials(t *testing.T) {
 	d := New()
 	_, err := d.Upload(context.Background(), trackers.UploadRequest{Tracker: "HDB", Logger: api.NopLogger{}})

--- a/internal/trackers/impl/hdb/upload.go
+++ b/internal/trackers/impl/hdb/upload.go
@@ -67,7 +67,7 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	}
 	descriptionText := strings.TrimSpace(assets.Description)
 	if !assets.Final {
-		descriptionText, err = descriptionhdb.BuildDescription(ctx, req.Meta, req.AppConfig, assets.Description, assets.Screenshots)
+		descriptionText, err = descriptionhdb.BuildDescription(ctx, req.Meta, req.AppConfig, assets.Description, assets.MenuImages, assets.Screenshots)
 		if err != nil {
 			return api.UploadSummary{}, fmt.Errorf("trackers: %w", err)
 		}
@@ -176,7 +176,7 @@ func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.Tra
 	}
 	descriptionText := strings.TrimSpace(assets.Description)
 	if !assets.Final {
-		descriptionText, err = descriptionhdb.BuildDescription(ctx, req.Meta, req.AppConfig, assets.Description, assets.Screenshots)
+		descriptionText, err = descriptionhdb.BuildDescription(ctx, req.Meta, req.AppConfig, assets.Description, assets.MenuImages, assets.Screenshots)
 		if err != nil {
 			return api.TrackerDryRunEntry{}, fmt.Errorf("trackers: %w", err)
 		}

--- a/internal/trackers/impl/hds/definition.go
+++ b/internal/trackers/impl/hds/definition.go
@@ -29,7 +29,7 @@ func (definition) BuildUploadDryRun(ctx context.Context, req trackers.UploadRequ
 }
 
 func (definition) BuildDescription(ctx context.Context, req trackers.DescriptionRequest) (trackers.DescriptionResult, error) {
-	assets, err := trackers.ResolveDescriptionAssets(ctx, req.Tracker, req.Meta, req.Repo, req.Logger)
+	assets, err := trackers.ResolveDescriptionAssetsWithPrepared(ctx, req.Tracker, req.Meta, req.Repo, req.Logger, req.Assets)
 	if err != nil {
 		assets = trackers.DescriptionAssets{}
 	}

--- a/internal/trackers/impl/hds/description_assets_test.go
+++ b/internal/trackers/impl/hds/description_assets_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package hds
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackers"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestBuildDescriptionUsesPreparedDiscMenuAssets(t *testing.T) {
+	t.Parallel()
+
+	assets := trackers.DescriptionAssets{
+		Description: "Body token",
+		MenuImages: []api.ScreenshotImage{{
+			RawURL: "https://images.example.invalid/menu.png",
+			ImgURL: "https://images.example.invalid/menu-thumb.png",
+			WebURL: "https://images.example.invalid/menu-view",
+		}},
+		Screenshots: []api.ScreenshotImage{{
+			RawURL: "https://images.example.invalid/normal.png",
+			ImgURL: "https://images.example.invalid/normal-thumb.png",
+			WebURL: "https://images.example.invalid/normal-view",
+		}},
+	}
+	result, err := (definition{}).BuildDescription(context.Background(), trackers.DescriptionRequest{
+		Tracker: "HDS",
+		AppConfig: config.Config{Description: config.DescriptionSettingsConfig{
+			DiscMenuHeader:   "Disc menu token",
+			ScreenshotHeader: "Screenshots token",
+		}},
+		Assets: &assets,
+	})
+	if err != nil {
+		t.Fatalf("build description: %v", err)
+	}
+	assertDescriptionTokensInOrder(t, result.Description, "Body token", "Disc menu token", "menu-thumb.png", "Screenshots token", "normal-thumb.png")
+
+	final := trackers.DescriptionAssets{Description: " Authoritative final token ", Final: true, MenuImages: assets.MenuImages}
+	result, err = (definition{}).BuildDescription(context.Background(), trackers.DescriptionRequest{Tracker: "HDS", Assets: &final})
+	if err != nil {
+		t.Fatalf("build final description: %v", err)
+	}
+	if result.Description != "Authoritative final token" {
+		t.Fatalf("final description = %q", result.Description)
+	}
+}
+
+func assertDescriptionTokensInOrder(t *testing.T, description string, tokens ...string) {
+	t.Helper()
+	previous := -1
+	for _, token := range tokens {
+		position := strings.Index(description, token)
+		if position <= previous {
+			t.Fatalf("description tokens out of order at %q: %q", token, description)
+		}
+		previous = position
+	}
+}

--- a/internal/trackers/impl/hds/upload.go
+++ b/internal/trackers/impl/hds/upload.go
@@ -150,7 +150,7 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest) (upload
 	if err != nil {
 		return uploadState{}, nil, err
 	}
-	assets, err := trackers.ResolveDescriptionAssets(ctx, req.Tracker, req.Meta, req.Repo, req.Logger)
+	assets, err := trackers.ResolveDescriptionAssetsWithPrepared(ctx, req.Tracker, req.Meta, req.Repo, req.Logger, req.Assets)
 	if err != nil {
 		trackers.LogDescriptionAssetResolutionFailure(req.Logger, req.Tracker, err)
 		assets = trackers.DescriptionAssets{}
@@ -236,6 +236,9 @@ func resolveCategoryID(meta api.PreparedMetadata) int {
 }
 
 func buildDescription(req trackers.UploadRequest, assets trackers.DescriptionAssets) string {
+	if assets.Final {
+		return strings.TrimSpace(assets.Description)
+	}
 	meta := req.Meta
 	parts := make([]string, 0, 12)
 

--- a/internal/trackers/impl/hdt/definition.go
+++ b/internal/trackers/impl/hdt/definition.go
@@ -29,7 +29,7 @@ func (definition) BuildUploadDryRun(ctx context.Context, req trackers.UploadRequ
 }
 
 func (definition) BuildDescription(ctx context.Context, req trackers.DescriptionRequest) (trackers.DescriptionResult, error) {
-	assets, err := trackers.ResolveDescriptionAssets(ctx, req.Tracker, req.Meta, req.Repo, req.Logger)
+	assets, err := trackers.ResolveDescriptionAssetsWithPrepared(ctx, req.Tracker, req.Meta, req.Repo, req.Logger, req.Assets)
 	if err != nil {
 		assets = trackers.DescriptionAssets{}
 	}

--- a/internal/trackers/impl/hdt/description_assets_test.go
+++ b/internal/trackers/impl/hdt/description_assets_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package hdt
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackers"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestBuildDescriptionUsesPreparedDiscMenuAssets(t *testing.T) {
+	t.Parallel()
+
+	assets := trackers.DescriptionAssets{
+		Description: "Body token",
+		MenuImages: []api.ScreenshotImage{{
+			RawURL: "https://images.example.invalid/menu.png",
+			ImgURL: "https://images.example.invalid/menu-thumb.png",
+		}},
+		Screenshots: []api.ScreenshotImage{{
+			RawURL: "https://images.example.invalid/normal.png",
+			ImgURL: "https://images.example.invalid/normal-thumb.png",
+		}},
+	}
+	result, err := (definition{}).BuildDescription(context.Background(), trackers.DescriptionRequest{
+		Tracker: "HDT",
+		AppConfig: config.Config{Description: config.DescriptionSettingsConfig{
+			DiscMenuHeader:   "Disc menu token",
+			ScreenshotHeader: "Screenshots token",
+		}},
+		Assets: &assets,
+	})
+	if err != nil {
+		t.Fatalf("build description: %v", err)
+	}
+	assertDescriptionTokensInOrder(t, result.Description, "Body token", "Disc menu token", "menu.png", "Screenshots token", "normal.png")
+
+	final := trackers.DescriptionAssets{Description: " Authoritative final token ", Final: true, MenuImages: assets.MenuImages}
+	result, err = (definition{}).BuildDescription(context.Background(), trackers.DescriptionRequest{Tracker: "HDT", Assets: &final})
+	if err != nil {
+		t.Fatalf("build final description: %v", err)
+	}
+	if result.Description != "Authoritative final token" {
+		t.Fatalf("final description = %q", result.Description)
+	}
+}
+
+func assertDescriptionTokensInOrder(t *testing.T, description string, tokens ...string) {
+	t.Helper()
+	previous := -1
+	for _, token := range tokens {
+		position := strings.Index(description, token)
+		if position <= previous {
+			t.Fatalf("description tokens out of order at %q: %q", token, description)
+		}
+		previous = position
+	}
+}

--- a/internal/trackers/impl/hdt/upload.go
+++ b/internal/trackers/impl/hdt/upload.go
@@ -358,11 +358,11 @@ func buildDescription(req trackers.UploadRequest, assets trackers.DescriptionAss
 	parts = append(parts, fmt.Sprintf("[right][url=%s][size=1]%s[/size][/url][/right]", link, text))
 
 	// finalize description
-	finalDescription := bbcode.FinalizeTrackerDescription("HDS", strings.TrimSpace(strings.Join(parts, "\n\n")))
+	finalDescription := bbcode.FinalizeTrackerDescription("HDT", strings.TrimSpace(strings.Join(parts, "\n\n")))
 
 	// save debug description
 	if meta.Options.Debug {
-		descriptionunit3d.SaveDescriptionDebug(meta, "HDS", req.AppConfig.MainSettings.DBPath, finalDescription, req.Logger)
+		descriptionunit3d.SaveDescriptionDebug(meta, "HDT", req.AppConfig.MainSettings.DBPath, finalDescription, req.Logger)
 	}
 
 	return finalDescription

--- a/internal/trackers/impl/hdt/upload.go
+++ b/internal/trackers/impl/hdt/upload.go
@@ -154,7 +154,7 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest, dryRun 
 	if err != nil {
 		return uploadState{}, nil, fmt.Errorf("trackers: %w", err)
 	}
-	assets, err := trackers.ResolveDescriptionAssets(ctx, req.Tracker, req.Meta, req.Repo, req.Logger)
+	assets, err := trackers.ResolveDescriptionAssetsWithPrepared(ctx, req.Tracker, req.Meta, req.Repo, req.Logger, req.Assets)
 	if err != nil {
 		trackers.LogDescriptionAssetResolutionFailure(req.Logger, req.Tracker, err)
 		assets = trackers.DescriptionAssets{}
@@ -288,6 +288,9 @@ func resolveCategoryID(meta api.PreparedMetadata) int {
 }
 
 func buildDescription(req trackers.UploadRequest, assets trackers.DescriptionAssets) string {
+	if assets.Final {
+		return strings.TrimSpace(assets.Description)
+	}
 	meta := req.Meta
 	parts := make([]string, 0, 15)
 

--- a/internal/trackers/impl/is/definition.go
+++ b/internal/trackers/impl/is/definition.go
@@ -29,7 +29,7 @@ func (definition) BuildUploadDryRun(ctx context.Context, req trackers.UploadRequ
 }
 
 func (definition) BuildDescription(ctx context.Context, req trackers.DescriptionRequest) (trackers.DescriptionResult, error) {
-	assets, err := trackers.ResolveDescriptionAssets(ctx, req.Tracker, req.Meta, req.Repo, req.Logger)
+	assets, err := trackers.ResolveDescriptionAssetsWithPrepared(ctx, req.Tracker, req.Meta, req.Repo, req.Logger, req.Assets)
 	if err != nil {
 		assets = trackers.DescriptionAssets{}
 	}

--- a/internal/trackers/impl/is/description_assets_test.go
+++ b/internal/trackers/impl/is/description_assets_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package is
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackers"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestBuildDescriptionUsesPreparedDiscMenuAssets(t *testing.T) {
+	t.Parallel()
+
+	assets := trackers.DescriptionAssets{
+		Description: "Body token",
+		MenuImages:  []api.ScreenshotImage{{RawURL: "https://images.example.invalid/menu.png"}},
+		Screenshots: []api.ScreenshotImage{{RawURL: "https://images.example.invalid/normal.png"}},
+	}
+	result, err := (definition{}).BuildDescription(context.Background(), trackers.DescriptionRequest{
+		Tracker: "IS",
+		AppConfig: config.Config{Description: config.DescriptionSettingsConfig{
+			DiscMenuHeader: "Disc menu token",
+		}},
+		Assets: &assets,
+	})
+	if err != nil {
+		t.Fatalf("build description: %v", err)
+	}
+	assertDescriptionTokensInOrder(t, result.Description, "Body token", "Disc menu token", "menu.png", "Screenshots:", "normal.png")
+
+	final := trackers.DescriptionAssets{Description: " Authoritative final token ", Final: true, MenuImages: assets.MenuImages}
+	result, err = (definition{}).BuildDescription(context.Background(), trackers.DescriptionRequest{Tracker: "IS", Assets: &final})
+	if err != nil {
+		t.Fatalf("build final description: %v", err)
+	}
+	if result.Description != "Authoritative final token" {
+		t.Fatalf("final description = %q", result.Description)
+	}
+}
+
+func assertDescriptionTokensInOrder(t *testing.T, description string, tokens ...string) {
+	t.Helper()
+	previous := -1
+	for _, token := range tokens {
+		position := strings.Index(description, token)
+		if position <= previous {
+			t.Fatalf("description tokens out of order at %q: %q", token, description)
+		}
+		previous = position
+	}
+}

--- a/internal/trackers/impl/is/upload.go
+++ b/internal/trackers/impl/is/upload.go
@@ -168,7 +168,7 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest) (upload
 	if err != nil {
 		return uploadState{}, nil, err
 	}
-	assets, err := trackers.ResolveDescriptionAssets(ctx, req.Tracker, req.Meta, req.Repo, req.Logger)
+	assets, err := trackers.ResolveDescriptionAssetsWithPrepared(ctx, req.Tracker, req.Meta, req.Repo, req.Logger, req.Assets)
 	if err != nil {
 		trackers.LogDescriptionAssetResolutionFailure(req.Logger, req.Tracker, err)
 		assets = trackers.DescriptionAssets{}
@@ -202,6 +202,9 @@ func loadCookies(ctx context.Context, dbPath string) ([]*http.Cookie, error) {
 }
 
 func buildDescription(req trackers.UploadRequest, assets trackers.DescriptionAssets) string {
+	if assets.Final {
+		return strings.TrimSpace(assets.Description)
+	}
 	meta := req.Meta
 	parts := make([]string, 0, 8)
 	if strings.TrimSpace(meta.EpisodeOverview) != "" {

--- a/internal/trackers/impl/tl/definition.go
+++ b/internal/trackers/impl/tl/definition.go
@@ -24,7 +24,7 @@ func (definition) BuildUploadDryRun(ctx context.Context, req trackers.UploadRequ
 }
 
 func (definition) BuildDescription(ctx context.Context, req trackers.DescriptionRequest) (trackers.DescriptionResult, error) {
-	assets, err := trackers.ResolveDescriptionAssets(ctx, req.Tracker, req.Meta, req.Repo, req.Logger)
+	assets, err := trackers.ResolveDescriptionAssetsWithPrepared(ctx, req.Tracker, req.Meta, req.Repo, req.Logger, req.Assets)
 	if err != nil {
 		assets = trackers.DescriptionAssets{}
 	}

--- a/internal/trackers/impl/tl/description_assets_test.go
+++ b/internal/trackers/impl/tl/description_assets_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package tl
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackers"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestBuildDescriptionUsesPreparedDiscMenuAssets(t *testing.T) {
+	t.Parallel()
+
+	assets := trackers.DescriptionAssets{
+		Description: "Body token",
+		MenuImages:  []api.ScreenshotImage{{RawURL: "https://images.example.invalid/menu.png"}},
+		Screenshots: []api.ScreenshotImage{{RawURL: "https://images.example.invalid/normal.png"}},
+	}
+	result, err := (definition{}).BuildDescription(context.Background(), trackers.DescriptionRequest{
+		Tracker: "TL",
+		AppConfig: config.Config{Description: config.DescriptionSettingsConfig{
+			DiscMenuHeader:   "Disc menu token",
+			ScreenshotHeader: "Screenshots token",
+		}},
+		Assets: &assets,
+	})
+	if err != nil {
+		t.Fatalf("build description: %v", err)
+	}
+	assertDescriptionTokensInOrder(t, result.Description, "Body token", "Disc menu token", "menu.png", "Screenshots token", "normal.png")
+
+	final := trackers.DescriptionAssets{Description: " Authoritative final token ", Final: true, MenuImages: assets.MenuImages}
+	result, err = (definition{}).BuildDescription(context.Background(), trackers.DescriptionRequest{Tracker: "TL", Assets: &final})
+	if err != nil {
+		t.Fatalf("build final description: %v", err)
+	}
+	if result.Description != "Authoritative final token" {
+		t.Fatalf("final description = %q", result.Description)
+	}
+}
+
+func assertDescriptionTokensInOrder(t *testing.T, description string, tokens ...string) {
+	t.Helper()
+	previous := -1
+	for _, token := range tokens {
+		position := strings.Index(description, token)
+		if position <= previous {
+			t.Fatalf("description tokens out of order at %q: %q", token, description)
+		}
+		previous = position
+	}
+}

--- a/internal/trackers/impl/tl/upload.go
+++ b/internal/trackers/impl/tl/upload.go
@@ -123,7 +123,7 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest) (upload
 	if err != nil {
 		return uploadState{}, nil, fmt.Errorf("trackers: %w", err)
 	}
-	assets, err := trackers.ResolveDescriptionAssets(ctx, req.Tracker, req.Meta, req.Repo, req.Logger)
+	assets, err := trackers.ResolveDescriptionAssetsWithPrepared(ctx, req.Tracker, req.Meta, req.Repo, req.Logger, req.Assets)
 	if err != nil {
 		trackers.LogDescriptionAssetResolutionFailure(req.Logger, req.Tracker, err)
 		assets = trackers.DescriptionAssets{}
@@ -228,6 +228,9 @@ func cookieClient(ctx context.Context, dbPath string) (*http.Client, error) {
 }
 
 func buildDescription(req trackers.UploadRequest, assets trackers.DescriptionAssets) string {
+	if assets.Final {
+		return strings.TrimSpace(assets.Description)
+	}
 	meta := req.Meta
 	parts := make([]string, 0, 8)
 

--- a/internal/trackers/screenshot_slots.go
+++ b/internal/trackers/screenshot_slots.go
@@ -23,7 +23,7 @@ const (
 	screenshotSlotSourceDescription = "description"
 	screenshotSlotSourceSelection   = "final_selection"
 	screenshotSlotSourceTracker     = "tracker_metadata"
-	screenshotPurposeMenu           = string(api.ScreenshotPurposeMenu)
+	screenshotPurposeMenu           = api.ScreenshotSelectionSourceMenu
 
 	screenshotSectionWrapped    = "wrapped"
 	screenshotSectionComparison = "comparison"

--- a/internal/trackers/service_test.go
+++ b/internal/trackers/service_test.go
@@ -494,7 +494,7 @@ func (testHDBPreparationDefinition) BuildDescription(ctx context.Context, req De
 	if req.Assets != nil {
 		assets = *req.Assets
 	}
-	description, err := descriptionhdb.BuildDescription(ctx, req.Meta, req.AppConfig, assets.Description, assets.Screenshots)
+	description, err := descriptionhdb.BuildDescription(ctx, req.Meta, req.AppConfig, assets.Description, assets.MenuImages, assets.Screenshots)
 	if err != nil {
 		return DescriptionResult{}, fmt.Errorf("trackers: %w", err)
 	}

--- a/internal/webserver/app_routes.go
+++ b/internal/webserver/app_routes.go
@@ -613,6 +613,99 @@ func (s *Server) registerAppRoutes(mux *http.ServeMux) {
 		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 	}))
 
+	mux.HandleFunc("/api/app/StartDVDMenuCapture", s.requireSession(func(w http.ResponseWriter, r *http.Request, current session) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+		var req struct {
+			Path          string
+			Overrides     api.ExternalIDOverrides
+			NameOverrides api.ReleaseNameOverrides
+		}
+		if err := decodeJSON(r, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		value, err := s.backend.StartDVDMenuCapture(r.Context(), current.ID, req.Path, req.Overrides, req.NameOverrides)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, value)
+	}))
+
+	mux.HandleFunc("/api/app/GetDVDMenuCaptureSnapshot", s.requireSession(func(w http.ResponseWriter, r *http.Request, current session) {
+		var req struct{ JobID string }
+		if err := decodeJSON(r, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		value, err := s.backend.GetDVDMenuCaptureSnapshot(current.ID, req.JobID)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, value)
+	}))
+
+	mux.HandleFunc("/api/app/CancelDVDMenuCapture", s.requireSession(func(w http.ResponseWriter, r *http.Request, current session) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+		var req struct{ JobID string }
+		if err := decodeJSON(r, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		if err := s.backend.CancelDVDMenuCapture(current.ID, req.JobID); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	}))
+
+	mux.HandleFunc("/api/app/ListDVDMenuScreenshots", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
+		var req struct {
+			Path          string
+			Overrides     api.ExternalIDOverrides
+			NameOverrides api.ReleaseNameOverrides
+		}
+		if err := decodeJSON(r, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		value, err := s.backend.ListDVDMenuScreenshots(req.Path, req.Overrides, req.NameOverrides)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, value)
+	}))
+
+	mux.HandleFunc("/api/app/DeleteDVDMenuScreenshot", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+			return
+		}
+		var req struct {
+			Path          string
+			Overrides     api.ExternalIDOverrides
+			NameOverrides api.ReleaseNameOverrides
+			ImagePath     string
+		}
+		if err := decodeJSON(r, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		if err := s.backend.DeleteDVDMenuScreenshot(req.Path, req.Overrides, req.NameOverrides, req.ImagePath); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	}))
+
 	mux.HandleFunc("/api/app/ReadScreenshotImage", s.requireSession(func(w http.ResponseWriter, r *http.Request, _ session) {
 		var req struct{ Path string }
 		if err := decodeJSON(r, &req); err != nil {

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -61,6 +61,10 @@ type Backend struct {
 	uploads  map[string]*trackerUploadJob
 	uploadWG sync.WaitGroup
 
+	dvdMenuMu sync.Mutex
+	dvdMenus  map[string]*dvdMenuCaptureJob
+	dvdMenuWG sync.WaitGroup
+
 	sharedCookieMigrator func(context.Context, string, api.Logger) error
 }
 
@@ -138,6 +142,7 @@ func NewBackendWithContext(ctx context.Context, cfg config.Config, hub *eventHub
 		streams:     make(map[string]*backendLogStream),
 		dupes:       make(map[string]*dupeCheckJob),
 		uploads:     make(map[string]*trackerUploadJob),
+		dvdMenus:    make(map[string]*dvdMenuCaptureJob),
 	}, nil
 }
 
@@ -146,6 +151,7 @@ func (b *Backend) Close() error {
 	b.stopAllLogStreams()
 	b.stopAllDupeJobs()
 	b.stopAllUploadJobs()
+	b.stopAllDVDMenuJobs()
 	rt := b.runtimeSnapshot()
 	if rt.core != nil {
 		_ = rt.core.Close()
@@ -741,8 +747,12 @@ func (b *Backend) GetConfig() (string, error) {
 	return wrapWebResult(config.ExportToJSON(cfg))
 }
 
+// GetApplicationInfo returns build/runtime metadata plus a bounded, path-free
+// DVD menu capability probe for embedded-web diagnostics.
 func (b *Backend) GetApplicationInfo() (api.ApplicationInfo, error) {
-	return api.CurrentApplicationInfo(), nil
+	rt := b.runtimeSnapshot()
+	provider, _ := rt.core.(api.DVDMenuCapabilityProvider)
+	return guishared.CurrentApplicationInfo(context.Background(), provider), nil
 }
 
 // ExportConfig returns the exportable config, using plaintext secrets only

--- a/internal/webserver/dvd_menu_jobs.go
+++ b/internal/webserver/dvd_menu_jobs.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/guishared"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -241,7 +242,7 @@ func (b *Backend) runDVDMenuCaptureJob(ctx context.Context, job *dvdMenuCaptureJ
 			job.status = "failed"
 			job.phase = "failed"
 			job.message = "DVD menu capture failed."
-			job.errorMessage = err.Error()
+			job.errorMessage = redaction.RedactValue(err.Error(), nil)
 		}
 	} else {
 		job.status = "completed"

--- a/internal/webserver/dvd_menu_jobs.go
+++ b/internal/webserver/dvd_menu_jobs.go
@@ -1,0 +1,419 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package webserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/guishared"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+const (
+	errDVDMenuCaptureRequiresMetadataCache = "DVD menu capture requires metadata preview"
+	maxCompletedDVDMenuJobs                = 200
+	dvdMenuSnapshotThrottle                = 150 * time.Millisecond
+)
+
+// dvdMenuCaptureJob owns one isolated core/logger snapshot and synchronized
+// session-visible progress state.
+type dvdMenuCaptureJob struct {
+	mu             sync.Mutex
+	cleanupOnce    sync.Once
+	sessionID      string
+	id             string
+	sourcePath     string
+	uploadOptions  api.UploadOptions
+	core           api.Core
+	logger         interface{ Close() error }
+	overrides      api.ExternalIDOverrides
+	nameOverrides  api.ReleaseNameOverrides
+	status         string
+	phase          string
+	message        string
+	discovered     int
+	visitedStates  int
+	visitedButtons int
+	captured       int
+	warnings       int
+	result         api.DVDMenuCaptureResult
+	errorMessage   string
+	startedAt      time.Time
+	finishedAt     time.Time
+	lastEmit       time.Time
+	cancel         context.CancelFunc
+}
+
+// StartDVDMenuCapture starts a session-owned background DVD menu capture job
+// using cached prepared metadata. The returned job continues after the request
+// context ends and emits dvdmenu:job:<jobID> only to the owning session.
+func (b *Backend) StartDVDMenuCapture(ctx context.Context, sessionID string, path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) (string, error) {
+	rt, err := b.requireRuntime()
+	if err != nil {
+		return "", err
+	}
+	if ctx == nil {
+		return "", errors.New("request context is required")
+	}
+	trimmedPath := strings.TrimSpace(path)
+	if trimmedPath == "" {
+		return "", errors.New("path is required")
+	}
+	req := newWebDVDMenuRequest(trimmedPath, overrides, nameOverrides, rt.baseUploadOptions())
+
+	var preparedMeta api.PreparedMetadata
+	preparedMetaFound := false
+	if exporter, ok := rt.core.(guishared.PreparedMetaExporter); ok {
+		preparedMeta, preparedMetaFound, err = exporter.ExportGUICachedPreparedMeta(ctx, req)
+		if err != nil {
+			return "", fmt.Errorf("DVD menu capture metadata preview cache: %w", err)
+		}
+		if !preparedMetaFound {
+			return "", errors.New(errDVDMenuCaptureRequiresMetadataCache)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("DVD menu capture metadata preview cache: %w", err)
+	}
+	//nolint:contextcheck // Per-run core construction has no context-aware API; request context is checked before and after setup.
+	runCore, runLogger, err := b.buildRunCoreFromSnapshot(rt, runOptions{})
+	if err != nil {
+		return "", err
+	}
+	if err := ctx.Err(); err != nil {
+		_ = runCore.Close()
+		_ = runLogger.Close()
+		return "", fmt.Errorf("DVD menu capture metadata preview cache: %w", err)
+	}
+	if preparedMetaFound {
+		importer, ok := runCore.(guishared.PreparedMetaImporter)
+		if !ok {
+			_ = runCore.Close()
+			_ = runLogger.Close()
+			return "", errors.New("DVD menu capture metadata preview cache: run core cannot import prepared metadata")
+		}
+		if err := importer.ImportPreparedMetadataForGUI(ctx, req, preparedMeta); err != nil {
+			_ = runCore.Close()
+			_ = runLogger.Close()
+			return "", fmt.Errorf("DVD menu capture metadata preview cache: %w", err)
+		}
+	}
+
+	job := &dvdMenuCaptureJob{
+		sessionID:     strings.TrimSpace(sessionID),
+		id:            randomJobID(),
+		sourcePath:    trimmedPath,
+		uploadOptions: req.Options,
+		core:          runCore,
+		logger:        runLogger,
+		overrides:     overrides,
+		nameOverrides: nameOverrides,
+		status:        "queued",
+		phase:         "queued",
+		message:       "DVD menu capture queued.",
+		startedAt:     time.Now().UTC(),
+	}
+	jobCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	job.cancel = cancel
+
+	b.dvdMenuMu.Lock()
+	if b.dvdMenus == nil {
+		b.dvdMenus = make(map[string]*dvdMenuCaptureJob)
+	}
+	b.dvdMenus[job.id] = job
+	b.pruneCompletedDVDMenuJobsLocked(maxCompletedDVDMenuJobs)
+	b.dvdMenuWG.Add(1)
+	b.dvdMenuMu.Unlock()
+	b.emitDVDMenuCaptureSnapshot(job, true)
+	go func() {
+		defer cancel()
+		b.runDVDMenuCaptureJob(jobCtx, job)
+	}()
+	return job.id, nil
+}
+
+// GetDVDMenuCaptureSnapshot returns a capture job only to its owning session.
+// Unknown, expired, and foreign-session job IDs return the same not-found error.
+func (b *Backend) GetDVDMenuCaptureSnapshot(sessionID string, jobID string) (api.DVDMenuCaptureSnapshot, error) {
+	job := b.getDVDMenuCaptureJobForSession(strings.TrimSpace(sessionID), strings.TrimSpace(jobID))
+	if job == nil {
+		return api.DVDMenuCaptureSnapshot{}, errors.New("DVD menu capture job not found")
+	}
+	return buildWebDVDMenuCaptureSnapshot(job), nil
+}
+
+// CancelDVDMenuCapture requests cancellation only for an owned capture job.
+// Completion is asynchronous and is reflected in later snapshots.
+func (b *Backend) CancelDVDMenuCapture(sessionID string, jobID string) error {
+	job := b.getDVDMenuCaptureJobForSession(strings.TrimSpace(sessionID), strings.TrimSpace(jobID))
+	if job == nil {
+		return errors.New("DVD menu capture job not found")
+	}
+	job.mu.Lock()
+	cancel := job.cancel
+	job.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	return nil
+}
+
+// ListDVDMenuScreenshots returns persisted manual and automatic menu images for
+// one host filesystem source path. The call requires prepared GUI metadata.
+func (b *Backend) ListDVDMenuScreenshots(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides) ([]api.ScreenshotImage, error) {
+	rt, err := b.requireRuntime()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	defer cancel()
+	req := newWebDVDMenuRequest(path, overrides, nameOverrides, rt.baseUploadOptions())
+	return wrapWebResult(rt.core.ListDVDMenuScreenshots(ctx, req))
+}
+
+// DeleteDVDMenuScreenshot removes one persisted image from the prepared
+// release's managed directory and local records. Remote-host assets remain.
+func (b *Backend) DeleteDVDMenuScreenshot(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, imagePath string) error {
+	rt, err := b.requireRuntime()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), previewTimeout)
+	defer cancel()
+	req := newWebDVDMenuRequest(path, overrides, nameOverrides, rt.baseUploadOptions())
+	return wrapWebError(rt.core.DeleteDVDMenuScreenshot(ctx, req, imagePath))
+}
+
+func newWebDVDMenuRequest(path string, overrides api.ExternalIDOverrides, nameOverrides api.ReleaseNameOverrides, options api.UploadOptions) api.Request {
+	return api.Request{
+		Paths:                []string{strings.TrimSpace(path)},
+		Mode:                 api.ModeGUI,
+		Options:              options,
+		ExternalIDOverrides:  overrides,
+		ReleaseNameOverrides: nameOverrides,
+	}
+}
+
+// runDVDMenuCaptureJob owns the queued-to-terminal lifecycle, releases its
+// per-run resources, and schedules completed-job retention cleanup.
+func (b *Backend) runDVDMenuCaptureJob(ctx context.Context, job *dvdMenuCaptureJob) {
+	defer b.dvdMenuWG.Done()
+	defer job.closeResources()
+	if job == nil || job.core == nil {
+		return
+	}
+	job.mu.Lock()
+	job.status = "running"
+	job.phase = "preflight"
+	job.message = "Checking DVD menu capture support."
+	job.mu.Unlock()
+	b.emitDVDMenuCaptureSnapshot(job, true)
+
+	progressCtx := api.WithDVDMenuProgressReporter(ctx, func(update api.DVDMenuProgressUpdate) {
+		b.applyDVDMenuCaptureProgress(job, update)
+	})
+	req := newWebDVDMenuRequest(job.sourcePath, job.overrides, job.nameOverrides, job.uploadOptions)
+	result, err := job.core.CaptureDVDMenus(progressCtx, req)
+
+	job.mu.Lock()
+	job.result = result
+	job.finishedAt = time.Now().UTC()
+	job.cancel = nil
+	job.discovered = result.DiscoveredMenus
+	job.visitedStates = result.VisitedStates
+	job.visitedButtons = result.VisitedButtons
+	job.captured = len(result.Images)
+	job.warnings = len(result.Warnings)
+	if err != nil {
+		if ctx.Err() != nil {
+			job.status = "canceled"
+			job.phase = "canceled"
+			job.message = "DVD menu capture canceled."
+			job.errorMessage = "DVD menu capture canceled"
+		} else {
+			job.status = "failed"
+			job.phase = "failed"
+			job.message = "DVD menu capture failed."
+			job.errorMessage = err.Error()
+		}
+	} else {
+		job.status = "completed"
+		job.phase = "complete"
+		job.message = "DVD menu capture finished."
+		job.errorMessage = ""
+	}
+	job.mu.Unlock()
+	b.emitDVDMenuCaptureSnapshot(job, true)
+	b.scheduleDVDMenuJobCleanup(job)
+}
+
+func (b *Backend) applyDVDMenuCaptureProgress(job *dvdMenuCaptureJob, update api.DVDMenuProgressUpdate) {
+	job.mu.Lock()
+	if strings.TrimSpace(update.Phase) != "" {
+		job.phase = strings.TrimSpace(update.Phase)
+	}
+	if strings.TrimSpace(update.Message) != "" {
+		job.message = strings.TrimSpace(update.Message)
+	}
+	job.discovered = update.DiscoveredMenus
+	job.visitedStates = update.VisitedStates
+	job.visitedButtons = update.VisitedButtons
+	job.captured = update.CapturedCount
+	job.warnings = update.WarningCount
+	job.mu.Unlock()
+	b.emitDVDMenuCaptureSnapshot(job, false)
+}
+
+// emitDVDMenuCaptureSnapshot publishes a throttled session event; force
+// bypasses throttling for queued and terminal transitions.
+func (b *Backend) emitDVDMenuCaptureSnapshot(job *dvdMenuCaptureJob, force bool) {
+	if b == nil || b.hub == nil || job == nil {
+		return
+	}
+	job.mu.Lock()
+	if !force && time.Since(job.lastEmit) < dvdMenuSnapshotThrottle {
+		job.mu.Unlock()
+		return
+	}
+	job.lastEmit = time.Now()
+	job.mu.Unlock()
+	b.hub.Emit(job.sessionID, "dvdmenu:job:"+job.id, buildWebDVDMenuCaptureSnapshot(job))
+}
+
+func buildWebDVDMenuCaptureSnapshot(job *dvdMenuCaptureJob) api.DVDMenuCaptureSnapshot {
+	job.mu.Lock()
+	defer job.mu.Unlock()
+	return api.DVDMenuCaptureSnapshot{
+		JobID:           job.id,
+		SourcePath:      job.sourcePath,
+		Status:          job.status,
+		Phase:           job.phase,
+		Message:         job.message,
+		DiscoveredMenus: job.discovered,
+		VisitedStates:   job.visitedStates,
+		VisitedButtons:  job.visitedButtons,
+		CapturedCount:   job.captured,
+		WarningCount:    job.warnings,
+		Result:          job.result,
+		Error:           job.errorMessage,
+		StartedAt:       formatTime(job.startedAt),
+		FinishedAt:      formatTime(job.finishedAt),
+	}
+}
+
+func (b *Backend) getDVDMenuCaptureJob(jobID string) *dvdMenuCaptureJob {
+	if strings.TrimSpace(jobID) == "" {
+		return nil
+	}
+	b.dvdMenuMu.Lock()
+	defer b.dvdMenuMu.Unlock()
+	return b.dvdMenus[jobID]
+}
+
+func (b *Backend) getDVDMenuCaptureJobForSession(sessionID string, jobID string) *dvdMenuCaptureJob {
+	job := b.getDVDMenuCaptureJob(jobID)
+	if job == nil {
+		return nil
+	}
+	job.mu.Lock()
+	defer job.mu.Unlock()
+	if strings.TrimSpace(job.sessionID) != sessionID {
+		return nil
+	}
+	return job
+}
+
+// closeResources closes the per-run core and logger at most once.
+func (job *dvdMenuCaptureJob) closeResources() {
+	if job == nil {
+		return
+	}
+	job.cleanupOnce.Do(func() {
+		job.mu.Lock()
+		coreSvc := job.core
+		logger := job.logger
+		job.core = nil
+		job.logger = nil
+		job.mu.Unlock()
+		if coreSvc != nil {
+			_ = coreSvc.Close()
+		}
+		if logger != nil {
+			_ = logger.Close()
+		}
+	})
+}
+
+func (b *Backend) scheduleDVDMenuJobCleanup(job *dvdMenuCaptureJob) {
+	b.dvdMenuMu.Lock()
+	b.pruneCompletedDVDMenuJobsLocked(maxCompletedDVDMenuJobs)
+	b.dvdMenuMu.Unlock()
+	time.AfterFunc(completedJobRetention, func() {
+		b.dvdMenuMu.Lock()
+		defer b.dvdMenuMu.Unlock()
+		if current := b.dvdMenus[job.id]; current == job && isDVDMenuJobTerminal(job) {
+			delete(b.dvdMenus, job.id)
+		}
+	})
+}
+
+func (b *Backend) pruneCompletedDVDMenuJobsLocked(maxCompleted int) {
+	if maxCompleted <= 0 {
+		return
+	}
+	completed := make([]*dvdMenuCaptureJob, 0, len(b.dvdMenus))
+	for _, job := range b.dvdMenus {
+		if isDVDMenuJobTerminal(job) {
+			completed = append(completed, job)
+		}
+	}
+	if len(completed) <= maxCompleted {
+		return
+	}
+	sort.Slice(completed, func(i, j int) bool {
+		return completed[i].finishedAt.Before(completed[j].finishedAt)
+	})
+	for _, job := range completed[:len(completed)-maxCompleted] {
+		delete(b.dvdMenus, job.id)
+	}
+}
+
+func isDVDMenuJobTerminal(job *dvdMenuCaptureJob) bool {
+	if job == nil {
+		return false
+	}
+	job.mu.Lock()
+	defer job.mu.Unlock()
+	return job.status == "completed" || job.status == "failed" || job.status == "canceled"
+}
+
+func (b *Backend) stopAllDVDMenuJobs() {
+	if b == nil {
+		return
+	}
+	b.dvdMenuMu.Lock()
+	jobs := make([]*dvdMenuCaptureJob, 0, len(b.dvdMenus))
+	for _, job := range b.dvdMenus {
+		jobs = append(jobs, job)
+	}
+	b.dvdMenuMu.Unlock()
+	for _, job := range jobs {
+		job.mu.Lock()
+		cancel := job.cancel
+		job.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
+	}
+	b.dvdMenuWG.Wait()
+	for _, job := range jobs {
+		job.closeResources()
+	}
+}

--- a/internal/webserver/dvd_menu_jobs_test.go
+++ b/internal/webserver/dvd_menu_jobs_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package webserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestRunDVDMenuCaptureJobPublishesProgressAndResult(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &preparedMetaTestCore{
+		dvdMenuCapture: func(ctx context.Context, _ api.Request) (api.DVDMenuCaptureResult, error) {
+			api.ReportDVDMenuProgress(ctx, api.DVDMenuProgressUpdate{
+				Phase:           "capturing",
+				DiscoveredMenus: 2,
+				VisitedStates:   4,
+				VisitedButtons:  3,
+				CapturedCount:   1,
+			})
+			return api.DVDMenuCaptureResult{
+				SourcePath:      "Example.Release.2026.1080p-GRP",
+				DiscoveredMenus: 2,
+				VisitedStates:   4,
+				VisitedButtons:  3,
+				Complete:        true,
+				Images: []api.DVDMenuCaptureImage{{ScreenshotImage: api.ScreenshotImage{
+					Path:    "menu-1.png",
+					Purpose: api.ScreenshotPurposeMenu,
+				}}},
+			}, nil
+		},
+	}
+	job := &dvdMenuCaptureJob{
+		sessionID: "session-a",
+		id:        "dvd-job-1",
+		core:      coreSvc,
+		status:    "queued",
+		startedAt: time.Now().UTC(),
+	}
+	backend := &Backend{dvdMenus: map[string]*dvdMenuCaptureJob{job.id: job}}
+	backend.dvdMenuWG.Add(1)
+
+	backend.runDVDMenuCaptureJob(context.Background(), job)
+	snapshot := buildWebDVDMenuCaptureSnapshot(job)
+	if snapshot.Status != "completed" || snapshot.CapturedCount != 1 || !snapshot.Result.Complete {
+		t.Fatalf("unexpected terminal snapshot: %#v", snapshot)
+	}
+	if coreSvc.dvdMenuCalls != 1 {
+		t.Fatalf("expected one capture call, got %d", coreSvc.dvdMenuCalls)
+	}
+}
+
+func TestDVDMenuCaptureJobAccessRequiresOwningSession(t *testing.T) {
+	t.Parallel()
+
+	job := &dvdMenuCaptureJob{
+		sessionID: "session-a",
+		id:        "dvd-job-1",
+		status:    "running",
+		startedAt: time.Now().UTC(),
+	}
+	backend := &Backend{dvdMenus: map[string]*dvdMenuCaptureJob{job.id: job}}
+
+	if _, err := backend.GetDVDMenuCaptureSnapshot("session-b", job.id); err == nil {
+		t.Fatal("expected foreign session snapshot read to fail")
+	}
+	if err := backend.CancelDVDMenuCapture("session-b", job.id); err == nil {
+		t.Fatal("expected foreign session cancellation to fail")
+	}
+	if _, err := backend.GetDVDMenuCaptureSnapshot("session-a", job.id); err != nil {
+		t.Fatalf("expected owning session snapshot read: %v", err)
+	}
+}

--- a/internal/webserver/dvd_menu_jobs_test.go
+++ b/internal/webserver/dvd_menu_jobs_test.go
@@ -5,6 +5,8 @@ package webserver
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,6 +58,34 @@ func TestRunDVDMenuCaptureJobPublishesProgressAndResult(t *testing.T) {
 	}
 	if coreSvc.closeCalls != 1 {
 		t.Fatalf("expected one core close, got %d", coreSvc.closeCalls)
+	}
+}
+
+func TestRunDVDMenuCaptureJobRedactsFailureMessage(t *testing.T) {
+	t.Parallel()
+
+	coreSvc := &preparedMetaTestCore{
+		dvdMenuCapture: func(context.Context, api.Request) (api.DVDMenuCaptureResult, error) {
+			return api.DVDMenuCaptureResult{}, errors.New("provider rejected api_key=secret-value")
+		},
+	}
+	job := &dvdMenuCaptureJob{
+		sessionID: "session-a",
+		id:        "dvd-job-1",
+		core:      coreSvc,
+		status:    "queued",
+		startedAt: time.Now().UTC(),
+	}
+	backend := &Backend{dvdMenus: map[string]*dvdMenuCaptureJob{job.id: job}}
+	backend.dvdMenuWG.Add(1)
+
+	backend.runDVDMenuCaptureJob(context.Background(), job)
+	snapshot := buildWebDVDMenuCaptureSnapshot(job)
+	if snapshot.Status != "failed" {
+		t.Fatal("expected failed snapshot")
+	}
+	if strings.Contains(snapshot.Error, "secret-value") || !strings.Contains(snapshot.Error, "[REDACTED]") {
+		t.Fatal("expected redacted DVD menu capture error")
 	}
 }
 

--- a/internal/webserver/dvd_menu_jobs_test.go
+++ b/internal/webserver/dvd_menu_jobs_test.go
@@ -54,6 +54,9 @@ func TestRunDVDMenuCaptureJobPublishesProgressAndResult(t *testing.T) {
 	if coreSvc.dvdMenuCalls != 1 {
 		t.Fatalf("expected one capture call, got %d", coreSvc.dvdMenuCalls)
 	}
+	if coreSvc.closeCalls != 1 {
+		t.Fatalf("expected one core close, got %d", coreSvc.closeCalls)
+	}
 }
 
 func TestDVDMenuCaptureJobAccessRequiresOwningSession(t *testing.T) {
@@ -67,11 +70,17 @@ func TestDVDMenuCaptureJobAccessRequiresOwningSession(t *testing.T) {
 	}
 	backend := &Backend{dvdMenus: map[string]*dvdMenuCaptureJob{job.id: job}}
 
-	if _, err := backend.GetDVDMenuCaptureSnapshot("session-b", job.id); err == nil {
-		t.Fatal("expected foreign session snapshot read to fail")
+	if _, err := backend.GetDVDMenuCaptureSnapshot("session-b", job.id); err == nil || err.Error() != "DVD menu capture job not found" {
+		t.Fatal("expected foreign session snapshot read to use the not-found privacy response")
 	}
-	if err := backend.CancelDVDMenuCapture("session-b", job.id); err == nil {
-		t.Fatal("expected foreign session cancellation to fail")
+	if err := backend.CancelDVDMenuCapture("session-b", job.id); err == nil || err.Error() != "DVD menu capture job not found" {
+		t.Fatal("expected foreign session cancellation to use the not-found privacy response")
+	}
+	if _, err := backend.GetDVDMenuCaptureSnapshot("session-b", "missing-job"); err == nil || err.Error() != "DVD menu capture job not found" {
+		t.Fatal("expected unknown snapshot read to use the same not-found privacy response")
+	}
+	if err := backend.CancelDVDMenuCapture("session-b", "missing-job"); err == nil || err.Error() != "DVD menu capture job not found" {
+		t.Fatal("expected unknown cancellation to use the same not-found privacy response")
 	}
 	if _, err := backend.GetDVDMenuCaptureSnapshot("session-a", job.id); err != nil {
 		t.Fatalf("expected owning session snapshot read: %v", err)

--- a/internal/webserver/jobs_test.go
+++ b/internal/webserver/jobs_test.go
@@ -34,6 +34,8 @@ type preparedMetaTestCore struct {
 	fetchReq          api.Request
 	dupeSummary       api.DupeCheckSummary
 	dupeCalls         int
+	dvdMenuCapture    func(context.Context, api.Request) (api.DVDMenuCaptureResult, error)
+	dvdMenuCalls      int
 	uploads           []uploadPreparedResponse
 	uploadCalls       int
 }
@@ -111,6 +113,22 @@ func (c *preparedMetaTestCore) SaveFinalScreenshotSelections(context.Context, ap
 }
 
 func (c *preparedMetaTestCore) ImportMenuImages(context.Context, api.Request, []string) error {
+	return nil
+}
+
+func (c *preparedMetaTestCore) CaptureDVDMenus(ctx context.Context, req api.Request) (api.DVDMenuCaptureResult, error) {
+	c.dvdMenuCalls++
+	if c.dvdMenuCapture != nil {
+		return c.dvdMenuCapture(ctx, req)
+	}
+	return api.DVDMenuCaptureResult{}, nil
+}
+
+func (c *preparedMetaTestCore) ListDVDMenuScreenshots(context.Context, api.Request) ([]api.ScreenshotImage, error) {
+	return nil, nil
+}
+
+func (c *preparedMetaTestCore) DeleteDVDMenuScreenshot(context.Context, api.Request, string) error {
 	return nil
 }
 

--- a/internal/webserver/jobs_test.go
+++ b/internal/webserver/jobs_test.go
@@ -36,6 +36,7 @@ type preparedMetaTestCore struct {
 	dupeCalls         int
 	dvdMenuCapture    func(context.Context, api.Request) (api.DVDMenuCaptureResult, error)
 	dvdMenuCalls      int
+	closeCalls        int
 	uploads           []uploadPreparedResponse
 	uploadCalls       int
 }
@@ -189,6 +190,7 @@ func (c *preparedMetaTestCore) SaveDescriptionOverride(context.Context, api.Requ
 }
 
 func (c *preparedMetaTestCore) Close() error {
+	c.closeCalls++
 	return nil
 }
 

--- a/pkg/api/application_info.go
+++ b/pkg/api/application_info.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+// ApplicationInfo describes the running build and optional runtime capability
+// probes returned by Wails and embedded web entrypoints.
 type ApplicationInfo struct {
 	Version         string `json:"version"`
 	BuildIdentifier string `json:"buildIdentifier"`
@@ -20,6 +22,12 @@ type ApplicationInfo struct {
 	GOARCH          string `json:"goarch"`
 	Uptime          string `json:"uptime"`
 	UptimeSeconds   int64  `json:"uptimeSeconds"`
+	// DVDMenuEngine contains path-free engine and FFmpeg probe metadata.
+	DVDMenuEngine DVDMenuEngineInfo `json:"dvdMenuEngine"`
+	// DVDMenuCapabilityStatus is available, incompatible, or unavailable.
+	DVDMenuCapabilityStatus string `json:"dvdMenuCapabilityStatus"`
+	// DVDMenuCapabilityMessage is the user-facing reason for the capability status.
+	DVDMenuCapabilityMessage string `json:"dvdMenuCapabilityMessage"`
 }
 
 var (
@@ -29,6 +37,8 @@ var (
 	applicationStartedAt = time.Now()
 )
 
+// SetApplicationBuild stores trimmed build metadata returned by
+// [CurrentApplicationInfo].
 func SetApplicationBuild(version string, buildIdentifier string) {
 	applicationInfoMu.Lock()
 	defer applicationInfoMu.Unlock()
@@ -37,6 +47,8 @@ func SetApplicationBuild(version string, buildIdentifier string) {
 	applicationBuildID = strings.TrimSpace(buildIdentifier)
 }
 
+// CurrentApplicationInfo returns process build, platform, and uptime metadata.
+// Optional capability fields remain zero until an entrypoint probes them.
 func CurrentApplicationInfo() ApplicationInfo {
 	uptime := max(time.Since(applicationStartedAt), 0)
 

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -86,6 +86,8 @@ type UploadOptions struct {
 	OnlyID          bool
 	KeepFolder      bool
 	KeepImages      bool
+	// CaptureDVDMenus requests automatic menu capture for DVD inputs before review or upload.
+	CaptureDVDMenus bool
 	InteractionMode InteractionMode
 }
 
@@ -139,6 +141,12 @@ type Core interface {
 	DeleteScreenshot(ctx context.Context, req Request, imagePath string) error
 	DeleteTrackerImageURL(ctx context.Context, req Request, url string) error
 	SaveFinalScreenshotSelections(ctx context.Context, req Request, images []ScreenshotImage) error
+	// CaptureDVDMenus captures and persists bounded automatic menu images for one prepared DVD.
+	CaptureDVDMenus(ctx context.Context, req Request) (DVDMenuCaptureResult, error)
+	// ListDVDMenuScreenshots lists persisted manual and automatic menu images for one prepared source.
+	ListDVDMenuScreenshots(ctx context.Context, req Request) ([]ScreenshotImage, error)
+	// DeleteDVDMenuScreenshot removes one managed menu image and its local references.
+	DeleteDVDMenuScreenshot(ctx context.Context, req Request, imagePath string) error
 	ListUploadCandidates(ctx context.Context, req Request) ([]ScreenshotImage, error)
 	ListUploadedImages(ctx context.Context, req Request) ([]UploadedImageLink, error)
 	UploadImages(ctx context.Context, req Request, host string, images []ScreenshotImage) (UploadImagesResult, error)

--- a/pkg/api/dvd_menu_progress.go
+++ b/pkg/api/dvd_menu_progress.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package api
+
+import "context"
+
+// DVDMenuProgressUpdate reports bounded capture progress without source paths
+// or disc-identifying material.
+type DVDMenuProgressUpdate struct {
+	// Phase is a stable capture stage such as preflight, discovering, capturing, or persisting.
+	Phase string `json:"phase"`
+	// Message is a user-facing summary of the current phase.
+	Message string `json:"message"`
+	// DiscoveredMenus is the current structural inventory count.
+	DiscoveredMenus int `json:"discoveredMenus"`
+	// VisitedStates is the current count of evaluated VM states.
+	VisitedStates int `json:"visitedStates"`
+	// VisitedButtons is the current count of evaluated button commands.
+	VisitedButtons int `json:"visitedButtons"`
+	// CapturedCount is the number of rendered menu images so far.
+	CapturedCount int `json:"capturedCount"`
+	// WarningCount is the number of distinct coverage warnings so far.
+	WarningCount int `json:"warningCount"`
+}
+
+// DVDMenuCaptureSnapshot reports frontend-visible state for one capture job.
+type DVDMenuCaptureSnapshot struct {
+	// JobID is the opaque identifier used for polling and cancellation.
+	JobID string `json:"jobID"`
+	// SourcePath is the host filesystem path associated with the prepared metadata.
+	SourcePath string `json:"sourcePath"`
+	// Status is queued, running, completed, failed, or canceled.
+	Status string `json:"status"`
+	// Phase is the current capture stage within Status.
+	Phase string `json:"phase"`
+	// Message is a user-facing progress or terminal summary.
+	Message string `json:"message"`
+	// DiscoveredMenus is the latest structural inventory count.
+	DiscoveredMenus int `json:"discoveredMenus"`
+	// VisitedStates is the latest evaluated VM-state count.
+	VisitedStates int `json:"visitedStates"`
+	// VisitedButtons is the latest evaluated button-command count.
+	VisitedButtons int `json:"visitedButtons"`
+	// CapturedCount is the latest rendered or persisted image count.
+	CapturedCount int `json:"capturedCount"`
+	// WarningCount is the latest distinct coverage-warning count.
+	WarningCount int `json:"warningCount"`
+	// Result is populated with the final or partial engine result when available.
+	Result DVDMenuCaptureResult `json:"result"`
+	// Error contains terminal failure text and is empty for successful jobs.
+	Error string `json:"error"`
+	// StartedAt is an RFC3339 UTC timestamp.
+	StartedAt string `json:"startedAt"`
+	// FinishedAt is an RFC3339 UTC timestamp, or empty while the job is active.
+	FinishedAt string `json:"finishedAt"`
+}
+
+// DVDMenuProgressReporter receives capture progress updates.
+type DVDMenuProgressReporter func(update DVDMenuProgressUpdate)
+
+type dvdMenuProgressReporterKey struct{}
+
+// WithDVDMenuProgressReporter returns a child context that reports capture
+// progress to reporter. A nil context or reporter is returned unchanged.
+func WithDVDMenuProgressReporter(ctx context.Context, reporter DVDMenuProgressReporter) context.Context {
+	if ctx == nil || reporter == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, dvdMenuProgressReporterKey{}, reporter)
+}
+
+// ReportDVDMenuProgress synchronously sends update to the reporter stored in
+// ctx, if any. A nil context is ignored.
+func ReportDVDMenuProgress(ctx context.Context, update DVDMenuProgressUpdate) {
+	if ctx == nil {
+		return
+	}
+	reporter, _ := ctx.Value(dvdMenuProgressReporterKey{}).(DVDMenuProgressReporter)
+	if reporter != nil {
+		reporter(update)
+	}
+}

--- a/pkg/api/dvd_menus.go
+++ b/pkg/api/dvd_menus.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package api
+
+import "context"
+
+// DVDMenuDiscovery describes how the navigation engine found a menu screen.
+type DVDMenuDiscovery string
+
+// DVD menu discovery sources serialized across CLI, Wails, and embedded web.
+const (
+	// DVDMenuDiscoveryReachable marks a screen reached by deterministic VM navigation.
+	DVDMenuDiscoveryReachable DVDMenuDiscovery = "reachable"
+	// DVDMenuDiscoveryStructural marks an interactive screen found only in the IFO inventory.
+	DVDMenuDiscoveryStructural DVDMenuDiscovery = "structural"
+)
+
+// DVDMenuCaptureResult reports persisted captures plus bounded traversal state.
+type DVDMenuCaptureResult struct {
+	// SourcePath is the host filesystem path of the prepared DVD source.
+	SourcePath string
+	// Images contains captures persisted for SourcePath in display order.
+	Images []DVDMenuCaptureImage
+	// SelectedLanguage is the menu language requested from the DVD engine.
+	SelectedLanguage string
+	// Region is the DVD region selection used for capture; zero means no override.
+	Region int
+	// DiscoveredMenus is the number of structurally inventoried menu programs.
+	DiscoveredMenus int
+	// VisitedStates is the number of distinct VM states evaluated during traversal.
+	VisitedStates int
+	// VisitedButtons is the number of authored button commands evaluated.
+	VisitedButtons int
+	// MaxItems is the configured upper bound on persisted automatic captures.
+	MaxItems int
+	// Complete reports that every selected screen was captured without coverage warnings.
+	Complete bool
+	// Partial reports that warnings prevented complete navigation or rendering coverage.
+	Partial bool
+	// Truncated reports that MaxItems prevented one or more eligible captures.
+	Truncated bool
+	// Warnings contains deduplicated, stable, path-free coverage diagnostics.
+	Warnings []DVDMenuCaptureWarning
+	// Engine describes the pure-Go engine and FFmpeg capability used for capture.
+	Engine DVDMenuEngineInfo
+}
+
+// DVDMenuCaptureImage is one stored menu screenshot and its discovery source.
+type DVDMenuCaptureImage struct {
+	// ScreenshotImage contains the persisted local image metadata.
+	ScreenshotImage
+	// Discovery records whether navigation or structural inventory found the screen.
+	Discovery DVDMenuDiscovery
+}
+
+// DVDMenuCaptureWarning is a stable, redacted partial-capture diagnostic.
+type DVDMenuCaptureWarning struct {
+	// Code is a stable machine-readable warning identifier.
+	Code string
+	// Message is a redacted user-facing description of the incomplete coverage.
+	Message string
+}
+
+// DVDMenuEngineInfo reports pure-Go engine and external FFmpeg capability.
+type DVDMenuEngineInfo struct {
+	// EngineVersion identifies the bundled pure-Go DVD navigation engine.
+	EngineVersion string
+	// SchemaVersion identifies the capture metadata contract version.
+	SchemaVersion int
+	// SupportedFeatures lists the engine stages available in this build.
+	SupportedFeatures []string
+	// FFmpegVersion is the bounded first line of FFmpeg version output.
+	FFmpegVersion string
+	// FFmpegDVDVideo reports whether the required dvdvideo demuxer options are available.
+	FFmpegDVDVideo bool
+	// MissingFFmpegOptions lists required dvdvideo options absent from the probe.
+	MissingFFmpegOptions []string
+}
+
+// DVDMenuCapabilityProvider is an optional Core diagnostic contract. Keeping
+// it separate from Core avoids forcing unrelated test/runtime adapters to
+// implement a capability probe.
+type DVDMenuCapabilityProvider interface {
+	// DVDMenuCapability probes the current FFmpeg executable without exposing its path.
+	DVDMenuCapability(ctx context.Context) (DVDMenuEngineInfo, error)
+}

--- a/pkg/api/repository.go
+++ b/pkg/api/repository.go
@@ -200,6 +200,28 @@ type Screenshot struct {
 	CapturedAt  time.Time `ts_type:"string"`
 }
 
+// DiscMenuDeleteResult describes local references removed by one atomic menu
+// deletion. UploadedLinks indicates that the remote host may retain an orphan.
+type DiscMenuDeleteResult struct {
+	// Selection is the deleted manual or automatic menu selection.
+	Selection ScreenshotFinalSelection
+	// UploadedLinks counts local upload records removed with the selection.
+	UploadedLinks int
+}
+
+// ScreenshotLifecycleRepository owns category-aware screenshot mutations that
+// must stay atomic without expanding the general metadata repository contract.
+type ScreenshotLifecycleRepository interface {
+	// ReplaceNormalFinalSelections replaces non-menu selections while preserving disc menus.
+	ReplaceNormalFinalSelections(ctx context.Context, path string, selections []ScreenshotFinalSelection) error
+	// AppendManualMenuScreenshots atomically appends manual menu records and selections.
+	AppendManualMenuScreenshots(ctx context.Context, path string, screenshots []Screenshot, selections []ScreenshotFinalSelection) error
+	// ReplaceDVDMenuScreenshots atomically replaces automatic captures and returns their old local paths.
+	ReplaceDVDMenuScreenshots(ctx context.Context, path string, screenshots []Screenshot, selections []ScreenshotFinalSelection) ([]string, error)
+	// DeleteDiscMenuScreenshot atomically removes one manual or automatic menu selection and local records.
+	DeleteDiscMenuScreenshot(ctx context.Context, path string, imagePath string) (DiscMenuDeleteResult, error)
+}
+
 type DVDMediaInfo struct {
 	SourcePath      string
 	IFOPath         string

--- a/pkg/api/repository.go
+++ b/pkg/api/repository.go
@@ -201,10 +201,19 @@ type Screenshot struct {
 }
 
 // DiscMenuDeleteResult describes local references removed by one atomic menu
-// deletion. UploadedLinks indicates that the remote host may retain an orphan.
+// deletion and retains the records needed for transactional compensation.
 type DiscMenuDeleteResult struct {
 	// Selection is the deleted manual or automatic menu selection.
 	Selection ScreenshotFinalSelection
+	// Screenshot is the deleted local screenshot record when one existed.
+	Screenshot *Screenshot
+	// UploadedImages are deleted local upload records. Remote assets are unchanged.
+	UploadedImages []UploadedImageLink
+	// ScreenshotSlots are deleted slot records whose selected image was removed.
+	ScreenshotSlots []ScreenshotSlot
+	// ScreenshotSlotVariants are variants deleted with a slot or because they
+	// referenced the removed image.
+	ScreenshotSlotVariants []ScreenshotSlotVariant
 	// UploadedLinks counts local upload records removed with the selection.
 	UploadedLinks int
 }
@@ -218,8 +227,12 @@ type ScreenshotLifecycleRepository interface {
 	AppendManualMenuScreenshots(ctx context.Context, path string, screenshots []Screenshot, selections []ScreenshotFinalSelection) error
 	// ReplaceDVDMenuScreenshots atomically replaces automatic captures and returns their old local paths.
 	ReplaceDVDMenuScreenshots(ctx context.Context, path string, screenshots []Screenshot, selections []ScreenshotFinalSelection) ([]string, error)
-	// DeleteDiscMenuScreenshot atomically removes one manual or automatic menu selection and local records.
+	// DeleteDiscMenuScreenshot atomically removes one manual or automatic menu
+	// selection and returns the local records needed to compensate the deletion.
 	DeleteDiscMenuScreenshot(ctx context.Context, path string, imagePath string) (DiscMenuDeleteResult, error)
+	// RestoreDiscMenuScreenshot atomically restores a result returned by
+	// DeleteDiscMenuScreenshot for the same source path.
+	RestoreDiscMenuScreenshot(ctx context.Context, path string, deleted DiscMenuDeleteResult) error
 }
 
 type DVDMediaInfo struct {

--- a/pkg/api/screenshots.go
+++ b/pkg/api/screenshots.go
@@ -3,15 +3,41 @@
 
 package api
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
+// ScreenshotPurpose classifies an image within preview, final-selection, and
+// disc-menu workflows.
 type ScreenshotPurpose string
 
+// Screenshot purpose and selection-source values shared across persistence and
+// frontend workflows.
 const (
+	// ScreenshotPurposePreview identifies transient frame previews.
 	ScreenshotPurposePreview ScreenshotPurpose = "preview"
-	ScreenshotPurposeFinal   ScreenshotPurpose = "final"
-	ScreenshotPurposeMenu    ScreenshotPurpose = "menu"
+	// ScreenshotPurposeFinal identifies normal final screenshot selections.
+	ScreenshotPurposeFinal ScreenshotPurpose = "final"
+	// ScreenshotPurposeMenu identifies manual or automatic disc-menu images.
+	ScreenshotPurposeMenu ScreenshotPurpose = "menu"
+
+	// ScreenshotSelectionSourceMenu identifies manually imported disc-menu selections.
+	ScreenshotSelectionSourceMenu = "menu"
+	// ScreenshotSelectionSourceDVDMenu identifies automatically captured DVD-menu selections.
+	ScreenshotSelectionSourceDVDMenu = "dvd_menu"
 )
+
+// IsDiscMenuSelectionSource reports whether a final-selection source belongs
+// to either manually imported or automatically captured disc menus.
+func IsDiscMenuSelectionSource(source string) bool {
+	switch strings.TrimSpace(source) {
+	case ScreenshotSelectionSourceMenu, ScreenshotSelectionSourceDVDMenu:
+		return true
+	default:
+		return false
+	}
+}
 
 type ScreenshotSelection struct {
 	Index            int
@@ -61,9 +87,11 @@ type ScreenshotImage struct {
 	Index            int
 	TimestampSeconds float64
 	Path             string
-	Width            int
-	Height           int
-	SizeBytes        int64
+	// Purpose distinguishes preview, normal final, and disc-menu images.
+	Purpose   ScreenshotPurpose
+	Width     int
+	Height    int
+	SizeBytes int64
 	// Optional upload information (populated when image has been uploaded)
 	Host       string    `json:"Host,omitempty"`
 	ImgURL     string    `json:"ImgURL,omitempty"`

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -19,7 +19,9 @@ type ServiceSet struct {
 	Filesystem  FilesystemService
 	Dupes       DupeService
 	Screenshots ScreenshotService
-	Images      ImageHostingService
+	// DVDMenus handles automatic capture and persisted disc-menu lifecycle operations.
+	DVDMenus DVDMenuService
+	Images   ImageHostingService
 }
 
 type MetadataService interface {
@@ -64,6 +66,18 @@ type ScreenshotService interface {
 	PreviewFrame(ctx context.Context, meta PreparedMetadata, timestampSeconds float64) (ScreenshotPreview, error)
 	Delete(ctx context.Context, meta PreparedMetadata, imagePath string) error
 	SaveFinalSelections(ctx context.Context, meta PreparedMetadata, images []ScreenshotImage) error
+}
+
+// DVDMenuService captures and manages persisted menu images for prepared DVD metadata.
+type DVDMenuService interface {
+	// Capture replaces automatic captures up to maxItems while preserving manual menus.
+	Capture(ctx context.Context, meta PreparedMetadata, maxItems int) (DVDMenuCaptureResult, error)
+	// List returns persisted manual and automatic menu images in selection order.
+	List(ctx context.Context, meta PreparedMetadata) ([]ScreenshotImage, error)
+	// Delete removes one managed menu image and its local repository references.
+	Delete(ctx context.Context, meta PreparedMetadata, imagePath string) error
+	// Capability reports path-free engine and FFmpeg dvdvideo support.
+	Capability(ctx context.Context) (DVDMenuEngineInfo, error)
 }
 
 type ImageHostingService interface {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in automatic DVD menu screenshot capture (`--get-dvd-menus`) with a **Maximum DVD menu images** setting.
  * New DVD menu capture workflow in CLI/GUI/web with background job snapshots and management of captured menu images.
  * GUI and settings now display DVD menu engine and FFmpeg capability details.

* **Bug Fixes**
  * Screenshot capture/preview now rejects empty or fully-black frames (with retries/fallbacks) for more reliable results.
  * DVD menu capture/preview skips empty/invalid VOBs and avoids menu-only selections.

* **Tests**
  * Added/expanded coverage for black/empty rejection and DVD menu preview, capture, and queue/job behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->