### PR TITLE
chore: logpolicy updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,16 +259,19 @@ Prefer generic group tags such as `GRP` when the group is incidental; real group
 
 ### Logging levels
 
-Keep log levels purposeful. `INFO` should provide concise, relevant progress or outcome details for end users during uploads and other top-level workflows. `DEBUG` should include richer decision-making context useful for developer troubleshooting. `TRACE` should capture near-complete operational flow for high-fidelity execution reporting.
+Keep log levels purposeful.
+- `INFO` should provide concise, relevant progress or outcome details for end users during uploads and other top-level workflows.
+- `DEBUG` should include richer decision-making context useful for developer troubleshooting.
+- `TRACE` should capture near-complete operational flow for high-fidelity execution reporting.
 
 ### Sensitive information
 
-Logging should be completely safe for blanket copy/pasting, without exposing any user sensitive credentials. Err on the side of caution.
-Tests should apply redaction for any potentially sensitive information, to prevent LLM consumption of personal information/credentials.
-Pay particular attention in API/HTTP/cookie type handling, ensuring redaction of headers and response bodies.
-Gaps fixes in `internal/redaction/redaction.go` or `internal/logpolicy/checker.go` are especially appreciated.
-Config values should be encrypted where appropriate, and only ever displayed in a redacted state.
-If an endpoint supports GET/query style and POST/bearer style handling, use the endpoint that puts sensitive credentials into a secure packet, rather than as a plain URL parameter.
+- Logging should be completely safe for blanket copy/pasting, without exposing any user sensitive credentials. Err on the side of caution.
+- Test assertion output is treated as CI-visible log material. Do not print raw cookies, auth headers, API keys, passkeys, passwords, CSRF tokens, OTP secrets, tracker announce URLs, or unredacted request/response bodies in tests, application logs, CLI output, or checker failure text.
+- Pay particular attention in API/HTTP/cookie type handling, ensuring redaction of headers and response bodies.
+- Gaps fixes in `internal/redaction/redaction.go` or `internal/logpolicy/checker.go`, are especially appreciated pull requests.
+- Config values should be encrypted where appropriate, and only ever displayed in a redacted state.
+- If an endpoint supports GET/query style and POST/bearer style handling, use the endpoint that puts sensitive credentials into a secure packet, rather than as a plain URL parameter.
 
 ### Path portability
 
@@ -285,12 +288,6 @@ upbrr targets Windows, Linux, and macOS. Do not assume POSIX path behavior in Go
 - Use `path.Base`, `path.Ext`, and related `path` APIs for URL/API paths. Use `filepath.Base`, `filepath.Ext`, and related `filepath` APIs for local paths. Legit stdlib `path` imports need import-local `//nolint:depguard // <slash-data reason>`.
 
 `make pathpolicy` runs the repo-local AST checker for hardcoded OS-rooted literals in `filepath` calls, string-built local paths, wrong `path`/`filepath` package use, slash-data filesystem calls, slash assertions without `filepath.ToSlash`, and ad-hoc local path guard helpers outside `internal/pathutil`. Rare intentional checker exceptions need `//pathpolicy:allow <reason>` on the same or previous line. `make lint`, pre-commit, and pre-push run it automatically.
-
-### Sensitive output
-
-Test assertion output is treated as CI-visible log material. Do not print raw cookies, auth headers, API keys, passkeys, passwords, CSRF tokens, OTP secrets, tracker announce URLs, or unredacted request/response bodies in tests, application logs, CLI output, or checker failure text.
-
-Prefer stable state assertions without raw values, such as `expected session cookie` or `got count=%d`. When diagnostic output needs value shape, use `redaction.RedactValue` or `commonhttp.RedactErrorDetail` before formatting it.
 
 ## AI agent instructions
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -29,6 +29,7 @@ import (
 	"github.com/autobrr/upbrr/internal/dupechecking"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/filesystem"
+	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/metadata"
 	"github.com/autobrr/upbrr/internal/paths"
 	"github.com/autobrr/upbrr/internal/redaction"
@@ -1578,7 +1579,7 @@ func (c *Core) uploadImagesToTargets(ctx context.Context, meta api.PreparedMetad
 				Host:       result.target.Host,
 				UsageScope: result.target.UsageScope,
 				Trackers:   slices.Clone(result.target.Trackers),
-				Message:    uploadFailureMessage(result.err),
+				Message:    logging.SanitizeMessage(uploadFailureMessage(result.err)),
 			}
 			failures = append(failures, failure)
 			failureMessages = append(failureMessages, fmt.Sprintf("%s: %v", result.target.Host, result.err))
@@ -2198,7 +2199,73 @@ func (c *Core) FetchTrackerDryRunPreview(ctx context.Context, req api.Request) (
 
 	c.storeDupeCache(meta.SourcePath, overrideSignature(meta.ExternalIDOverrides, meta.ReleaseNameOverrides, meta.MetadataOverrides, meta.TrackerConfigOverrides, meta.TrackerSiteOverrides, meta.ClientOverrides, meta.TorrentOverrides, meta.ImageHostOverrides, meta.ScreenshotOverrides), meta)
 
-	return api.TrackerDryRunPreview{SourcePath: meta.SourcePath, Trackers: entries}, nil
+	return api.TrackerDryRunPreview{SourcePath: meta.SourcePath, Trackers: sanitizeTrackerDryRunEntries(entries)}, nil
+}
+
+func sanitizeTrackerDryRunEntries(entries []api.TrackerDryRunEntry) []api.TrackerDryRunEntry {
+	sanitized := make([]api.TrackerDryRunEntry, len(entries))
+	for index, entry := range entries {
+		entry.Message = logging.SanitizeMessage(entry.Message)
+		entry.BannedReason = logging.SanitizeMessage(entry.BannedReason)
+		entry.BannedCheckError = logging.SanitizeMessage(entry.BannedCheckError)
+		entry.Endpoint = logging.SanitizeMessage(entry.Endpoint)
+		entry.Payload = redactDryRunPayload(entry.Payload)
+		entry.Files = sanitizeTrackerDryRunFiles(entry.Files)
+		entry.DebugSections = sanitizeTrackerDryRunDebugSections(entry.DebugSections)
+		entry.ImageHost = sanitizeDryRunImageHostFeedback(entry.ImageHost)
+		sanitized[index] = entry
+	}
+	return sanitized
+}
+
+func redactDryRunPayload(payload map[string]string) map[string]string {
+	if payload == nil {
+		return nil
+	}
+	redacted := make(map[string]string, len(payload))
+	for key, value := range payload {
+		wrapped := map[string]any{key: value}
+		result, ok := redaction.RedactPrivateInfo(wrapped, nil).(map[string]any)
+		if !ok {
+			redacted[key] = "[REDACTED]"
+			continue
+		}
+		redactedValue, ok := result[key].(string)
+		if !ok {
+			redacted[key] = "[REDACTED]"
+			continue
+		}
+		redacted[key] = logging.SanitizeMessage(redactedValue)
+	}
+	return redacted
+}
+
+func sanitizeTrackerDryRunFiles(files []api.TrackerDryRunFile) []api.TrackerDryRunFile {
+	sanitized := slices.Clone(files)
+	for index := range sanitized {
+		sanitized[index].Path = logging.SanitizeMessage(sanitized[index].Path)
+	}
+	return sanitized
+}
+
+func sanitizeTrackerDryRunDebugSections(sections []api.TrackerDryRunDebugSection) []api.TrackerDryRunDebugSection {
+	sanitized := make([]api.TrackerDryRunDebugSection, len(sections))
+	for index, section := range sections {
+		section.Endpoint = logging.SanitizeMessage(section.Endpoint)
+		section.Payload = redactDryRunPayload(section.Payload)
+		section.Files = sanitizeTrackerDryRunFiles(section.Files)
+		sanitized[index] = section
+	}
+	return sanitized
+}
+
+func sanitizeDryRunImageHostFeedback(feedback api.ImageHostFeedback) api.ImageHostFeedback {
+	feedback.Message = logging.SanitizeMessage(feedback.Message)
+	feedback.Warnings = slices.Clone(feedback.Warnings)
+	for index := range feedback.Warnings {
+		feedback.Warnings[index].Message = logging.SanitizeMessage(feedback.Warnings[index].Message)
+	}
+	return feedback
 }
 
 // injectTrackerDryRunTorrents injects only ready dry-run tracker torrents into

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -3511,6 +3511,53 @@ func TestFetchTrackerDryRunPreviewUsesCachedMetadata(t *testing.T) {
 	}
 }
 
+func TestSanitizeTrackerDryRunEntriesRedactsBridgePayload(t *testing.T) {
+	t.Parallel()
+
+	entries := []api.TrackerDryRunEntry{{
+		Message:  `request failed: Get "https://tracker.example/upload?api_key=policy-secret"`,
+		Endpoint: "https://policy-user:policy-password@tracker.example/upload?api_key=policy-secret",
+		Payload: map[string]string{
+			"api_key":     "policy-secret",
+			"description": "kept",
+		},
+		Files: []api.TrackerDryRunFile{{Field: "torrent", Path: `C:\path\to\Example.Release.2026.1080p-GRP.torrent`, Present: true}},
+		DebugSections: []api.TrackerDryRunDebugSection{{
+			Endpoint: "https://tracker.example/debug?passkey=policy-passkey",
+			Payload:  map[string]string{"auth_key": "policy-auth", "name": "kept"},
+			Files:    []api.TrackerDryRunFile{{Field: "nfo", Path: `/media/releases/Example.Release.2026.1080p-GRP.nfo`, Present: true}},
+		}},
+		ImageHost: api.ImageHostFeedback{Warnings: []api.ImageHostWarning{{
+			Host:    "example",
+			Message: "failed for /media/releases/Example.Release.2026.1080p-GRP.png?token=policy-token",
+		}}},
+	}}
+
+	sanitized := sanitizeTrackerDryRunEntries(entries)
+	if len(sanitized) != 1 {
+		t.Fatal("expected one sanitized dry-run entry")
+	}
+	encoded := sanitized[0].Message + sanitized[0].Endpoint + strings.Join([]string{
+		sanitized[0].Payload["api_key"],
+		sanitized[0].Files[0].Path,
+		sanitized[0].DebugSections[0].Endpoint,
+		sanitized[0].DebugSections[0].Payload["auth_key"],
+		sanitized[0].DebugSections[0].Files[0].Path,
+		sanitized[0].ImageHost.Warnings[0].Message,
+	}, " ")
+	for _, marker := range []string{"policy-secret", "policy-user", "policy-password", "policy-passkey", "policy-auth", "policy-token", `C:\path\to`, "/media/releases/"} {
+		if strings.Contains(encoded, marker) {
+			t.Fatal("expected bridge dry-run payload to omit secrets and local paths")
+		}
+	}
+	if sanitized[0].Payload["description"] != "kept" || sanitized[0].DebugSections[0].Payload["name"] != "kept" {
+		t.Fatal("expected non-sensitive dry-run payload fields preserved")
+	}
+	if entries[0].Payload["api_key"] != "policy-secret" || entries[0].Files[0].Path == sanitized[0].Files[0].Path {
+		t.Fatal("expected sanitizer to clone nested dry-run data")
+	}
+}
+
 func TestRunUploadPreparedDebugDryRunIgnoresCheckBlocksForArtifacts(t *testing.T) {
 	t.Parallel()
 

--- a/internal/dupechecking/service.go
+++ b/internal/dupechecking/service.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/internal/trackerdata"
 	trackerspkg "github.com/autobrr/upbrr/internal/trackers"
@@ -265,10 +266,14 @@ func (s *Service) checkTracker(ctx context.Context, meta api.PreparedMetadata, t
 
 	raw, notes, err := handler.Search(ctx, meta, tracker)
 	if err != nil {
+		message := strings.TrimSpace(logging.SanitizeMessage(err.Error()))
+		if message == "" {
+			message = "dupe search failed"
+		}
 		result.Status = "failed"
-		result.Error = err.Error()
-		result.Notes = append(result.Notes, fmt.Sprintf("dupe search failed: %v", err))
-		s.logger.Warnf("dupechecking: %s search failed for %s: %v", tracker, meta.SourcePath, err)
+		result.Error = message
+		result.Notes = append(result.Notes, "dupe search failed: "+message)
+		s.logger.Warnf("dupechecking: %s search failed for %s: %s", tracker, meta.SourcePath, message)
 		return result
 	}
 	skipCode, notes := splitSkipCodeNotes(notes)

--- a/internal/dupechecking/service_test.go
+++ b/internal/dupechecking/service_test.go
@@ -86,6 +86,65 @@ func TestCheckNoTrackers(t *testing.T) {
 	}
 }
 
+func TestCheckRedactsSearchErrorsFromResultProgressAndLogs(t *testing.T) {
+	t.Parallel()
+
+	logger := &recordingLogger{}
+	svc := NewService(config.Config{}, logger)
+	svc.handlers = map[string]searchHandler{
+		"DP": testSearchHandler{err: errors.New(`unit3d: request: Get "https://tracker.example/api/torrents/filter?api_token=secret-api-token&name=Example.Release.2026.1080p-GRP": context deadline exceeded`)},
+	}
+
+	var updatesMu sync.Mutex
+	updates := make([]api.DupeProgressUpdate, 0, 3)
+	ctx := api.WithDupeProgressReporter(context.Background(), func(update api.DupeProgressUpdate) {
+		updatesMu.Lock()
+		updates = append(updates, update)
+		updatesMu.Unlock()
+	})
+
+	summary, err := svc.Check(ctx, api.PreparedMetadata{SourcePath: `D:\media\Example's.Release.2026-GRP`}, []string{"DP"})
+	if err != nil {
+		t.Fatalf("check dupes: %v", err)
+	}
+	if len(summary.Results) != 1 {
+		t.Fatalf("expected one result, got %d", len(summary.Results))
+	}
+	result := summary.Results[0]
+	if strings.Contains(result.Error, "secret-api-token") || strings.Contains(strings.Join(result.Notes, " "), "secret-api-token") {
+		t.Fatal("expected dupe result error details to redact request secret")
+	}
+	if !strings.Contains(result.Error, "api_token=[REDACTED]") {
+		t.Fatal("expected dupe result to preserve redacted request context")
+	}
+
+	updatesMu.Lock()
+	capturedUpdates := slices.Clone(updates)
+	updatesMu.Unlock()
+	foundFailed := false
+	for _, update := range capturedUpdates {
+		if strings.Contains(update.Message, "secret-api-token") || strings.Contains(update.Result.Error, "secret-api-token") {
+			t.Fatal("expected dupe progress to redact request secret")
+		}
+		if update.Status == "failed" {
+			foundFailed = true
+			if !strings.Contains(update.Message, "api_token=[REDACTED]") {
+				t.Fatal("expected failed progress to preserve redacted request context")
+			}
+		}
+	}
+	if !foundFailed {
+		t.Fatal("expected failed dupe progress update")
+	}
+
+	logger.mu.Lock()
+	warns := slices.Clone(logger.warns)
+	logger.mu.Unlock()
+	if strings.Contains(strings.Join(warns, " "), "secret-api-token") {
+		t.Fatal("expected dupe warning to redact request secret before logger boundary")
+	}
+}
+
 func TestCheckSkipsRuleFailures(t *testing.T) {
 	t.Parallel()
 	svc := NewService(config.Config{}, api.NopLogger{})

--- a/internal/guiapp/dupe_jobs.go
+++ b/internal/guiapp/dupe_jobs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 
 	"github.com/autobrr/upbrr/internal/guishared"
+	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -261,7 +262,7 @@ func (a *App) runDupeCheckJob(ctx context.Context, eventCtx context.Context, job
 			}
 		} else {
 			job.status = "failed"
-			job.errorMessage = err.Error()
+			job.errorMessage = logging.SanitizeMessage(err.Error())
 		}
 		job.mu.Unlock()
 		a.emitDupeCheckSnapshot(eventCtx, job)

--- a/internal/guiapp/run_options_test.go
+++ b/internal/guiapp/run_options_test.go
@@ -875,6 +875,30 @@ func TestRunTrackerUploadJobContainsCleanupPanic(t *testing.T) {
 	}
 }
 
+func TestRunTrackerUploadJobSanitizesCleanupError(t *testing.T) {
+	app := &App{}
+	coreSvc := &closeCounterCore{uploads: []uploadPreparedResponse{
+		{
+			result: api.Result{UploadedCount: 1},
+		},
+	}}
+	coreSvc.closeErr = errors.New(`request failed for C:\path\to\Example.Release.2026.1080p-GRP: Get "https://tracker.invalid/api/torrents?api_token=secret-value"`)
+	job := newTrackerUploadJobTestJob(coreSvc, []string{"BLU"})
+
+	app.runTrackerUploadJob(context.Background(), context.Background(), job)
+
+	snapshot := buildTrackerUploadSnapshot(job)
+	if snapshot.Status != "failed" {
+		t.Fatalf("expected failed status after cleanup error, got %q", snapshot.Status)
+	}
+	if strings.Contains(snapshot.Error, "secret-value") {
+		t.Fatal("expected cleanup error to redact secrets")
+	}
+	if strings.Contains(snapshot.Error, "Example.Release.2026.1080p-GRP") {
+		t.Fatal("expected cleanup error to redact local path details")
+	}
+}
+
 func newTrackerUploadJobTestJob(coreSvc api.Core, trackers []string) *trackerUploadJob {
 	job := &trackerUploadJob{
 		id:         "job",

--- a/internal/guiapp/upload_jobs.go
+++ b/internal/guiapp/upload_jobs.go
@@ -408,7 +408,7 @@ func (a *App) runTrackerUploadJob(ctx context.Context, eventCtx context.Context,
 	job.cancel = nil
 	job.mu.Unlock()
 	if err := job.closeResources(); err != nil {
-		a.failTrackerUploadJob(eventCtx, job, err.Error())
+		a.failTrackerUploadJob(eventCtx, job, logging.SanitizeMessage(err.Error()))
 		return
 	}
 	a.emitTrackerUploadSnapshot(eventCtx, job)

--- a/internal/guiapp/upload_jobs.go
+++ b/internal/guiapp/upload_jobs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 
 	"github.com/autobrr/upbrr/internal/guishared"
+	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -360,13 +361,14 @@ func (a *App) runTrackerUploadJob(ctx context.Context, eventCtx context.Context,
 				break
 			}
 			job.mu.Lock()
+			message := logging.SanitizeMessage(err.Error())
 			state = job.states[tracker]
 			state.Status = "failed"
-			state.Message = err.Error()
+			state.Message = message
 			state.FinishedAt = time.Now().UTC().Format(time.RFC3339)
 			job.states[tracker] = state
 			job.failedTrackers = append(job.failedTrackers, tracker)
-			job.errorMessage = err.Error()
+			job.errorMessage = message
 			job.mu.Unlock()
 			a.emitTrackerUploadSnapshot(eventCtx, job)
 			continue
@@ -538,10 +540,11 @@ func (a *App) failTrackerUploadJob(eventCtx context.Context, job *trackerUploadJ
 
 	if err := job.closeResources(); err != nil {
 		job.mu.Lock()
+		message := logging.SanitizeMessage(err.Error())
 		if job.errorMessage == "" {
-			job.errorMessage = err.Error()
-		} else if !strings.Contains(job.errorMessage, err.Error()) {
-			job.errorMessage += "; " + err.Error()
+			job.errorMessage = message
+		} else if !strings.Contains(job.errorMessage, message) {
+			job.errorMessage += "; " + message
 		}
 		for _, tracker := range job.trackers {
 			state := job.states[tracker]

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -240,11 +241,12 @@ func (l *Logger) logf(level Level, label string, format string, args ...any) {
 	l.record(label, formatted)
 }
 
-// SanitizeMessage replaces local filesystem paths in user-shareable log or
-// terminal output with stable labels. Paths under known app DB tmp/cache/log
-// directories keep only their .upbrr-relative suffix; other local paths become
-// [local path].
+// SanitizeMessage redacts secrets and replaces local filesystem paths in
+// user-shareable log or terminal output with stable labels. Paths under known
+// app DB tmp/cache/log directories keep only their .upbrr-relative suffix;
+// other local paths become [local path].
 func SanitizeMessage(message string) string {
+	message = redaction.RedactValue(message, nil)
 	if strings.TrimSpace(message) == "" {
 		return message
 	}
@@ -344,8 +346,12 @@ func isURLEndDelimiter(ch byte) bool {
 func localPathEnd(value string, start int) int {
 	for index := start; index < len(value); index++ {
 		switch value[index] {
-		case '\r', '\n', '\t', '"', '\'', '`', ',', ';', ')', ']', '}':
+		case '\r', '\n', '\t', '"', '`', ',', ';', ')', ']', '}':
 			return index
+		case ':':
+			if index > start+2 && index+1 < len(value) && value[index+1] == ' ' {
+				return index
+			}
 		case ' ':
 			if nextLooksLikeLogField(value, index+1) {
 				return index

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -62,6 +62,56 @@ func TestLoggerSanitizesLocalPaths(t *testing.T) {
 	}
 }
 
+func TestLoggerSanitizesRequestSecretsAndApostrophePaths(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	logger, err := NewWithLevel(config.LoggingConfig{Level: "debug"}, "", "")
+	if err != nil {
+		t.Fatalf("new logger: %v", err)
+	}
+	logger.SetConsoleOutput(&stdout, &stderr)
+
+	logger.Warnf(
+		"dupechecking: DP search failed for %s: %s",
+		`D:\media\Example's.Release.2026-GRP`,
+		`unit3d: request: Get "https://tracker.example/api/torrents/filter?api_token=secret-api-token&name=Example.Release.2026.1080p-GRP": context deadline exceeded`,
+	)
+
+	console := stderr.String()
+	for _, leaked := range []string{"secret-api-token", `D:\media`, "Example's.Release.2026-GRP"} {
+		if strings.Contains(console, leaked) {
+			t.Fatal("expected console log to redact request secret and complete local path")
+		}
+	}
+	for _, expected := range []string{"for [local path]: unit3d: request", "api_token=[REDACTED]", "context deadline exceeded"} {
+		if !strings.Contains(console, expected) {
+			t.Fatal("expected console log to preserve sanitized request context")
+		}
+	}
+
+	recent := logger.Recent(1)
+	if len(recent) != 1 {
+		t.Fatalf("expected one buffered log entry, got %d", len(recent))
+	}
+	if strings.Contains(recent[0].Message, "secret-api-token") || strings.Contains(recent[0].Message, "Example's.Release.2026-GRP") {
+		t.Fatal("expected frontend log entry to redact request secret and complete local path")
+	}
+}
+
+func TestSanitizeMessageHandlesApostrophesInUnixLocalPaths(t *testing.T) {
+	t.Parallel()
+
+	got := SanitizeMessage("source=/media/releases/Example's.Release.2026-GRP: state=failed")
+	if strings.Contains(got, "/media/releases") || strings.Contains(got, "Example's.Release.2026-GRP") {
+		t.Fatal("expected complete Unix local path with apostrophe to be redacted")
+	}
+	if !strings.Contains(got, "source=[local path]: state=failed") {
+		t.Fatal("expected diagnostic context after Unix local path to remain")
+	}
+}
+
 func TestSanitizeLogMessageHandlesUnixLocalPaths(t *testing.T) {
 	t.Parallel()
 
@@ -104,5 +154,17 @@ func TestSanitizeLogMessagePreservesURLs(t *testing.T) {
 	}
 	if !strings.Contains(got, "image=https://img.example.com/media/poster.jpg source=[local path]") {
 		t.Fatalf("expected URL preserved and local path redacted, got %q", got)
+	}
+}
+
+func TestSanitizeMessageRedactsURLUserinfo(t *testing.T) {
+	t.Parallel()
+
+	got := SanitizeMessage("client=https://policy-user:policy-password@host.example/path")
+	if strings.Contains(got, "policy-user") || strings.Contains(got, "policy-password") {
+		t.Fatal("expected URL userinfo credentials redacted")
+	}
+	if !strings.Contains(got, "https://[REDACTED]@host.example/path") {
+		t.Fatal("expected URL host and path preserved")
 	}
 }

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -1158,6 +1158,7 @@ func exprContainsNameSignal(expr ast.Expr, signals ...string) bool {
 }
 
 func isSanitizedBindingBefore(body *ast.BlockStmt, expr ast.Expr, before token.Pos) bool {
+	expr = unwrapSingleArgTypeConversion(expr)
 	ident, ok := expr.(*ast.Ident)
 	if !ok {
 		return false
@@ -1185,6 +1186,28 @@ func isSanitizedBindingBefore(body *ast.BlockStmt, expr ast.Expr, before token.P
 		return true
 	})
 	return sanitized
+}
+
+// unwrapSingleArgTypeConversion removes conversions whose function expression
+// is syntactically a type. Named conversions remain wrapped because AST-only
+// analysis cannot distinguish them from ordinary single-argument calls.
+func unwrapSingleArgTypeConversion(expr ast.Expr) ast.Expr {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 || !isSyntacticTypeExpr(call.Fun) {
+		return expr
+	}
+	return call.Args[0]
+}
+
+func isSyntacticTypeExpr(expr ast.Expr) bool {
+	switch typed := expr.(type) {
+	case *ast.ArrayType, *ast.MapType, *ast.StructType, *ast.InterfaceType, *ast.ChanType, *ast.FuncType:
+		return true
+	case *ast.ParenExpr:
+		return isSyntacticTypeExpr(typed.X)
+	default:
+		return false
+	}
 }
 
 // checkFrontendVisibleRawErrors guards Wails/web job state and pkg/api result
@@ -1227,6 +1250,15 @@ func checkFrontendVisibleRawErrors(fset *token.FileSet, relPath string, file *as
 				}
 				appendLogpolicyViolation(fset, relPath, allows, &violations, field.Value.Pos(), "frontend-visible API error/message fields must redact raw errors before serialization")
 			}
+		case *ast.CallExpr:
+			if !bridgeFile || callName(typed) != "failTrackerUploadJob" || len(typed.Args) < 3 {
+				return true
+			}
+			message := typed.Args[2]
+			if isShareableMessageSanitizedExpr(message) || !isRawErrorLikeExpr(message) {
+				return true
+			}
+			appendLogpolicyViolation(fset, relPath, allows, &violations, message.Pos(), "frontend-visible upload job failure messages must redact raw errors before state update and event emission")
 		}
 		return true
 	})

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -334,9 +334,27 @@ func checkProjectLoggerPathSanitization(fset *token.FileSet, root string) ([]Vio
 	violations := checkProjectLoggerURLPathPreservation(
 		fset,
 		relPath,
-		functionPosition(file, "SanitizeMessage", file.Package),
+		sanitizeMessagePosition(file, file.Package),
 		logging.SanitizeMessage,
 	)
+	violations = append(violations, checkProjectLoggerSecretRedaction(
+		fset,
+		relPath,
+		sanitizeMessagePosition(file, file.Package),
+		logging.SanitizeMessage,
+	)...)
+	violations = append(violations, checkProjectLoggerURLUserinfoRedaction(
+		fset,
+		relPath,
+		sanitizeMessagePosition(file, file.Package),
+		logging.SanitizeMessage,
+	)...)
+	violations = append(violations, checkProjectLoggerApostrophePathRedaction(
+		fset,
+		relPath,
+		sanitizeMessagePosition(file, file.Package),
+		logging.SanitizeMessage,
+	)...)
 
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
@@ -372,13 +390,46 @@ func checkProjectLoggerURLPathPreservation(fset *token.FileSet, relPath string, 
 	return nil
 }
 
-// functionPosition anchors behavioral sanitizer violations at the named
-// declaration when it exists, falling back to the package position for malformed
-// or partial fixtures.
-func functionPosition(file *ast.File, name string, fallback token.Pos) token.Pos {
+// checkProjectLoggerSecretRedaction guards the logger boundary shared by
+// console, file, buffered, and frontend-streamed output.
+func checkProjectLoggerSecretRedaction(fset *token.FileSet, relPath string, pos token.Pos, sanitize func(string) string) []Violation {
+	sanitized := sanitize(`unit3d: request: Get "https://tracker.example/api/torrents/filter?api_token=policy-secret&name=Example.Release.2026.1080p-GRP": timeout`)
+	if strings.Contains(sanitized, "policy-secret") || !strings.Contains(sanitized, "api_token=[REDACTED]") {
+		return []Violation{violationAt(fset, relPath, pos, "project logger sanitizer must redact secret-bearing request URLs")}
+	}
+	return nil
+}
+
+// checkProjectLoggerURLUserinfoRedaction guards credentials embedded in URL
+// authority components, which query/key-value redaction does not cover.
+func checkProjectLoggerURLUserinfoRedaction(fset *token.FileSet, relPath string, pos token.Pos, sanitize func(string) string) []Violation {
+	sanitized := sanitize(`clients: connecting to qbit https://policy-user:policy-password@host.example`)
+	if strings.Contains(sanitized, "policy-user") || strings.Contains(sanitized, "policy-password") ||
+		!strings.Contains(sanitized, "https://[REDACTED]@host.example") {
+		return []Violation{violationAt(fset, relPath, pos, "project logger sanitizer must redact URL userinfo credentials")}
+	}
+	return nil
+}
+
+// checkProjectLoggerApostrophePathRedaction guards complete path labeling for
+// valid release names that contain apostrophes.
+func checkProjectLoggerApostrophePathRedaction(fset *token.FileSet, relPath string, pos token.Pos, sanitize func(string) string) []Violation {
+	sanitized := sanitize(`source=C:\media\Example's.Release.2026-GRP: state=failed`)
+	if strings.Contains(sanitized, `C:\media`) ||
+		strings.Contains(sanitized, "Example's.Release.2026-GRP") ||
+		!strings.Contains(sanitized, "source=[local path]: state=failed") {
+		return []Violation{violationAt(fset, relPath, pos, "project logger sanitizer must redact complete local paths containing apostrophes")}
+	}
+	return nil
+}
+
+// sanitizeMessagePosition anchors behavioral sanitizer violations at the
+// declaration when it exists, falling back to the package position for
+// malformed or partial fixtures.
+func sanitizeMessagePosition(file *ast.File, fallback token.Pos) token.Pos {
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
-		if ok && fn.Name != nil && fn.Name.Name == name {
+		if ok && fn.Name != nil && fn.Name.Name == "SanitizeMessage" {
 			return fn.Name.Pos()
 		}
 	}
@@ -861,6 +912,9 @@ func checkFile(fset *token.FileSet, root string, path string) ([]Violation, erro
 	})
 	violations = append(violations, checkWorkflowLoggingCoverage(fset, relPath, file, allows)...)
 	violations = append(violations, checkUnboundedResponseBodyUses(fset, relPath, file, aliases)...)
+	violations = append(violations, checkDiagnosticArtifactWrites(fset, relPath, file, aliases, allows)...)
+	violations = append(violations, checkFrontendVisibleRawErrors(fset, relPath, file, aliases, allows)...)
+	violations = append(violations, checkDryRunPreviewSerialization(fset, relPath, file, allows)...)
 
 	sensitiveViolations := checkSensitiveOutputParsed(fset, relPath, file, aliases, allows, false)
 	violations = append(violations, sensitiveViolations...)
@@ -1026,6 +1080,241 @@ func checkSensitiveOutputParsed(fset *token.FileSet, relPath string, file *ast.F
 	}
 
 	return violations
+}
+
+// checkDiagnosticArtifactWrites requires response-derived failure artifacts to
+// pass through an approved redaction helper before reaching os.WriteFile.
+func checkDiagnosticArtifactWrites(fset *token.FileSet, relPath string, file *ast.File, aliases map[string]string, allows map[int]*logpolicyAllow) []Violation {
+	violations := make([]Violation, 0)
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Body == nil {
+			continue
+		}
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok || !isOSWriteFileCall(call, aliases) || len(call.Args) < 2 {
+				return true
+			}
+			if !isDiagnosticArtifactWrite(fn.Name.Name, call.Args[0], call.Args[1]) {
+				return true
+			}
+			if isSafeSensitiveOutputExpr(call.Args[1]) || isSanitizedBindingBefore(fn.Body, call.Args[1], call.Pos()) {
+				return true
+			}
+			appendLogpolicyViolation(fset, relPath, allows, &violations, call.Args[1].Pos(), "diagnostic response artifacts must redact body/payload data before writing")
+			return true
+		})
+	}
+	return violations
+}
+
+func isOSWriteFileCall(call *ast.CallExpr, aliases map[string]string) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "WriteFile" {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && aliases[pkg.Name] == "os"
+}
+
+func isDiagnosticArtifactWrite(functionName string, pathExpr ast.Expr, dataExpr ast.Expr) bool {
+	functionName = canonicalSensitiveKeyName(functionName)
+	if strings.Contains(functionName, "failureartifact") || strings.Contains(functionName, "diagnosticartifact") {
+		return true
+	}
+	return exprContainsNameSignal(pathExpr, "failure", "artifact") &&
+		exprContainsNameSignal(dataExpr, "body", "payload", "response", "preview")
+}
+
+func exprContainsNameSignal(expr ast.Expr, signals ...string) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if found || node == nil {
+			return false
+		}
+		value := ""
+		switch typed := node.(type) {
+		case *ast.Ident:
+			value = typed.Name
+		case *ast.SelectorExpr:
+			value = typed.Sel.Name
+		case *ast.BasicLit:
+			if typed.Kind == token.STRING {
+				value, _ = strconv.Unquote(typed.Value)
+			}
+		}
+		lower := strings.ToLower(value)
+		for _, signal := range signals {
+			if strings.Contains(lower, signal) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func isSanitizedBindingBefore(body *ast.BlockStmt, expr ast.Expr, before token.Pos) bool {
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	sanitized := false
+	ast.Inspect(body, func(node ast.Node) bool {
+		if node == nil || node.Pos() >= before {
+			return false
+		}
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for index, lhs := range assign.Lhs {
+			name, ok := lhs.(*ast.Ident)
+			if !ok || name.Name != ident.Name {
+				continue
+			}
+			rhsIndex := index
+			if len(assign.Rhs) == 1 {
+				rhsIndex = 0
+			}
+			sanitized = rhsIndex < len(assign.Rhs) && containsSafeOutputCall(assign.Rhs[rhsIndex])
+		}
+		return true
+	})
+	return sanitized
+}
+
+// checkFrontendVisibleRawErrors guards Wails/web job state and pkg/api result
+// objects, whose string fields are rendered or serialized for users.
+func checkFrontendVisibleRawErrors(fset *token.FileSet, relPath string, file *ast.File, aliases map[string]string, allows map[int]*logpolicyAllow) []Violation {
+	violations := make([]Violation, 0)
+	bridgeFile := strings.HasPrefix(relPath, "internal/guiapp/") || strings.HasPrefix(relPath, "internal/webserver/")
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.AssignStmt:
+			if !bridgeFile {
+				return true
+			}
+			for index, lhs := range typed.Lhs {
+				selector, ok := lhs.(*ast.SelectorExpr)
+				if !ok || !isFrontendDiagnosticField(selector.Sel.Name) {
+					continue
+				}
+				rhsIndex := index
+				if len(typed.Rhs) == 1 {
+					rhsIndex = 0
+				}
+				if rhsIndex >= len(typed.Rhs) || isShareableMessageSanitizedExpr(typed.Rhs[rhsIndex]) || !isRawErrorLikeExpr(typed.Rhs[rhsIndex]) {
+					continue
+				}
+				appendLogpolicyViolation(fset, relPath, allows, &violations, typed.Rhs[rhsIndex].Pos(), "frontend-visible error/message fields must redact raw errors before assignment")
+			}
+		case *ast.CompositeLit:
+			if !isAPICompositeType(typed.Type, aliases) {
+				return true
+			}
+			for _, element := range typed.Elts {
+				field, ok := element.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				key, ok := field.Key.(*ast.Ident)
+				if !ok || !isFrontendDiagnosticField(key.Name) || isShareableMessageSanitizedExpr(field.Value) || !isRawErrorLikeExpr(field.Value) {
+					continue
+				}
+				appendLogpolicyViolation(fset, relPath, allows, &violations, field.Value.Pos(), "frontend-visible API error/message fields must redact raw errors before serialization")
+			}
+		}
+		return true
+	})
+	return violations
+}
+
+func isFrontendDiagnosticField(name string) bool {
+	switch canonicalSensitiveKeyName(name) {
+	case "error", "errormessage", "lasterror", "message", "warning":
+		return true
+	default:
+		return false
+	}
+}
+
+func isShareableMessageSanitizedExpr(expr ast.Expr) bool {
+	sanitized := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		name := strings.ToLower(callName(call))
+		if name == "sanitizemessage" || (strings.Contains(name, "sanit") && (strings.Contains(name, "message") || strings.Contains(name, "error"))) {
+			sanitized = true
+			return false
+		}
+		return true
+	})
+	return sanitized
+}
+
+func isAPICompositeType(expr ast.Expr, aliases map[string]string) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && aliases[pkg.Name] == "github.com/autobrr/upbrr/pkg/api"
+}
+
+// checkDryRunPreviewSerialization requires backend redaction before tracker
+// endpoint/payload data is placed in a bridge/API preview response.
+func checkDryRunPreviewSerialization(fset *token.FileSet, relPath string, file *ast.File, allows map[int]*logpolicyAllow) []Violation {
+	violations := make([]Violation, 0)
+	ast.Inspect(file, func(node ast.Node) bool {
+		literal, ok := node.(*ast.CompositeLit)
+		if !ok || compositeTypeName(literal.Type) != "TrackerDryRunPreview" {
+			return true
+		}
+		for _, element := range literal.Elts {
+			field, ok := element.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := field.Key.(*ast.Ident)
+			if !ok || key.Name != "Trackers" || isEmptyCompositeLiteral(field.Value) || isSanitizedDryRunEntriesExpr(field.Value) {
+				continue
+			}
+			appendLogpolicyViolation(fset, relPath, allows, &violations, field.Value.Pos(), "TrackerDryRunPreview entries must be sanitized before bridge/API serialization")
+		}
+		return true
+	})
+	return violations
+}
+
+func compositeTypeName(expr ast.Expr) string {
+	switch typed := expr.(type) {
+	case *ast.Ident:
+		return typed.Name
+	case *ast.SelectorExpr:
+		return typed.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func isEmptyCompositeLiteral(expr ast.Expr) bool {
+	literal, ok := expr.(*ast.CompositeLit)
+	return ok && len(literal.Elts) == 0
+}
+
+func isSanitizedDryRunEntriesExpr(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	name := strings.ToLower(callName(call))
+	return strings.Contains(name, "dryrun") && (strings.Contains(name, "redact") || strings.Contains(name, "sanit"))
 }
 
 // checkResponseJSONParseErrorOutput flags parse errors from raw JSON envelope
@@ -2499,7 +2788,7 @@ func isSafeOutputCall(call *ast.CallExpr) bool {
 		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(fun.Sel.Name)), "redact") {
 			return true
 		}
-		return fun.Sel.Name == "RedactErrorDetail" || fun.Sel.Name == "ExtractHTTPErrorDetail"
+		return fun.Sel.Name == "RedactErrorDetail" || fun.Sel.Name == "ExtractHTTPErrorDetail" || fun.Sel.Name == "SanitizeMessage"
 	default:
 		return false
 	}

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -393,7 +393,7 @@ func checkProjectLoggerURLPathPreservation(fset *token.FileSet, relPath string, 
 // checkProjectLoggerSecretRedaction guards the logger boundary shared by
 // console, file, buffered, and frontend-streamed output.
 func checkProjectLoggerSecretRedaction(fset *token.FileSet, relPath string, pos token.Pos, sanitize func(string) string) []Violation {
-	sanitized := sanitize(`unit3d: request: Get "https://tracker.example/api/torrents/filter?api_token=policy-secret&name=Example.Release.2026.1080p-GRP": timeout`)
+	sanitized := sanitize(`tracker: request: Get "https://tracker.example/api/torrents/filter?api_token=policy-secret&name=Example.Release.2026.1080p-GRP": timeout`)
 	if strings.Contains(sanitized, "policy-secret") || !strings.Contains(sanitized, "api_token=[REDACTED]") {
 		return []Violation{violationAt(fset, relPath, pos, "project logger sanitizer must redact secret-bearing request URLs")}
 	}
@@ -915,6 +915,7 @@ func checkFile(fset *token.FileSet, root string, path string) ([]Violation, erro
 	violations = append(violations, checkDiagnosticArtifactWrites(fset, relPath, file, aliases, allows)...)
 	violations = append(violations, checkFrontendVisibleRawErrors(fset, relPath, file, aliases, allows)...)
 	violations = append(violations, checkDryRunPreviewSerialization(fset, relPath, file, allows)...)
+	violations = append(violations, checkUnit3DQueryCredentialAuth(fset, relPath, file, allows)...)
 
 	sensitiveViolations := checkSensitiveOutputParsed(fset, relPath, file, aliases, allows, false)
 	violations = append(violations, sensitiveViolations...)
@@ -3439,6 +3440,35 @@ func isSafeDryRunOutputExpr(expr ast.Expr) bool {
 	default:
 		return false
 	}
+}
+
+// checkUnit3DQueryCredentialAuth prevents API credentials from returning to
+// request URLs after Unit3D authentication has moved to Bearer headers.
+func checkUnit3DQueryCredentialAuth(fset *token.FileSet, relPath string, file *ast.File, allows map[int]*logpolicyAllow) []Violation {
+	if relPath != "internal/trackerdata/unit3d.go" && !strings.HasPrefix(relPath, "internal/trackers/impl/unit3d/") {
+		return nil
+	}
+	violations := make([]Violation, 0)
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || len(call.Args) < 2 {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || (selector.Sel.Name != "Set" && selector.Sel.Name != "Add") {
+			return true
+		}
+		key, ok := stringLiteral(call.Args[0])
+		if !ok {
+			return true
+		}
+		switch canonicalSensitiveKeyName(key) {
+		case "apikey", "apitoken", "authkey", "passkey", "token":
+			appendLogpolicyViolation(fset, relPath, allows, &violations, call.Args[0].Pos(), "Unit3D API credentials must use Authorization: Bearer instead of URL query parameters")
+		}
+		return true
+	})
+	return violations
 }
 
 func violationAt(fset *token.FileSet, file string, pos token.Pos, message string) Violation {

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -1270,6 +1270,57 @@ func TestProjectLoggerURLPathPreservationFlagsSanitizerRegression(t *testing.T) 
 	}
 }
 
+func TestProjectLoggerSecretRedactionFlagsSanitizerRegression(t *testing.T) {
+	t.Parallel()
+
+	violations := checkProjectLoggerSecretRedaction(
+		token.NewFileSet(),
+		"internal/logging/logger.go",
+		token.NoPos,
+		func(value string) string { return value },
+	)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "request URLs") {
+		t.Fatalf("expected request URL secret violation, got %q", violations[0].Message)
+	}
+}
+
+func TestProjectLoggerApostrophePathRedactionFlagsSanitizerRegression(t *testing.T) {
+	t.Parallel()
+
+	violations := checkProjectLoggerApostrophePathRedaction(
+		token.NewFileSet(),
+		"internal/logging/logger.go",
+		token.NoPos,
+		func(value string) string { return value },
+	)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "apostrophes") {
+		t.Fatalf("expected apostrophe path violation, got %q", violations[0].Message)
+	}
+}
+
+func TestProjectLoggerURLUserinfoRedactionFlagsSanitizerRegression(t *testing.T) {
+	t.Parallel()
+
+	violations := checkProjectLoggerURLUserinfoRedaction(
+		token.NewFileSet(),
+		"internal/logging/logger.go",
+		token.NoPos,
+		func(value string) string { return value },
+	)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "URL userinfo") {
+		t.Fatalf("expected URL userinfo violation, got %q", violations[0].Message)
+	}
+}
+
 func TestCheckRepositoryFlagsRawTerminalErrorOutput(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "internal"), 0o755); err != nil {
@@ -3083,6 +3134,114 @@ func check(log logger, tracker string) {
 	if !strings.Contains(violations[0].Message, "user-visible outcome") {
 		t.Fatalf("expected trace outcome violation, got %q", violations[0].Message)
 	}
+}
+
+func TestDiagnosticArtifactWritesRequireRedaction(t *testing.T) {
+	t.Parallel()
+
+	content := `package sample
+
+import (
+	"os"
+
+	"github.com/autobrr/upbrr/internal/redaction"
+)
+
+func writeFailureArtifact(path string, payload []byte) error {
+	return os.WriteFile(path, payload, 0o600)
+}
+
+func writeSafeFailureArtifact(path string, payload []byte) error {
+	payload = []byte(redaction.RedactValue(string(payload), nil))
+	return os.WriteFile(path, payload, 0o600)
+}
+`
+	fset, file := parsePolicyFixture(t, content)
+	violations := checkDiagnosticArtifactWrites(fset, "internal/sample/sample.go", file, importAliases(file), nil)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "artifacts must redact") {
+		t.Fatalf("expected artifact redaction violation, got %q", violations[0].Message)
+	}
+}
+
+func TestFrontendVisibleRawErrorsRequireRedaction(t *testing.T) {
+	t.Parallel()
+
+	content := `package guiapp
+
+import (
+	"github.com/autobrr/upbrr/internal/logging"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+type trackerState struct { Message string }
+type uploadJob struct { errorMessage string }
+
+func update(state *trackerState, job *uploadJob, err error, captureErr error) api.ScreenshotError {
+	state.Message = err.Error()
+	job.errorMessage = err.Error()
+	return api.ScreenshotError{Message: captureErr.Error()}
+}
+
+func updateSafe(state *trackerState, err error) {
+	state.Message = logging.SanitizeMessage(err.Error())
+}
+`
+	fset, file := parsePolicyFixture(t, content)
+	violations := checkFrontendVisibleRawErrors(fset, "internal/guiapp/sample.go", file, importAliases(file), nil)
+	if len(violations) != 3 {
+		t.Fatalf("expected 3 violations, got %d: %#v", len(violations), violations)
+	}
+	for _, violation := range violations {
+		if !strings.Contains(violation.Message, "frontend-visible") {
+			t.Fatalf("expected frontend-visible violation, got %q", violation.Message)
+		}
+	}
+}
+
+func TestDryRunPreviewSerializationRequiresSanitization(t *testing.T) {
+	t.Parallel()
+
+	content := `package core
+
+import "github.com/autobrr/upbrr/pkg/api"
+
+func unsafe(entries []api.TrackerDryRunEntry) api.TrackerDryRunPreview {
+	return api.TrackerDryRunPreview{Trackers: entries}
+}
+
+func safe(entries []api.TrackerDryRunEntry) api.TrackerDryRunPreview {
+	return api.TrackerDryRunPreview{Trackers: sanitizeTrackerDryRunEntries(entries)}
+}
+
+func empty() api.TrackerDryRunPreview {
+	return api.TrackerDryRunPreview{Trackers: []api.TrackerDryRunEntry{}}
+}
+
+func sanitizeTrackerDryRunEntries(entries []api.TrackerDryRunEntry) []api.TrackerDryRunEntry {
+	return entries
+}
+`
+	fset, file := parsePolicyFixture(t, content)
+	violations := checkDryRunPreviewSerialization(fset, "internal/core/sample.go", file, nil)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "must be sanitized") {
+		t.Fatalf("expected dry-run serialization violation, got %q", violations[0].Message)
+	}
+}
+
+func parsePolicyFixture(t *testing.T, content string) (*token.FileSet, *ast.File) {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "sample.go", content, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse policy fixture: %v", err)
+	}
+	return fset, file
 }
 
 func writeInternalProductionFixture(t *testing.T, root string, content string) {

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -3234,6 +3234,36 @@ func sanitizeTrackerDryRunEntries(entries []api.TrackerDryRunEntry) []api.Tracke
 	}
 }
 
+func TestUnit3DQueryCredentialAuthRequiresBearerHeader(t *testing.T) {
+	t.Parallel()
+
+	content := `package trackerdata
+
+import (
+	"net/http"
+	"net/url"
+)
+
+func unsafe(req *http.Request, apiKey string) {
+	params := url.Values{}
+	params.Set("api_token", apiKey)
+	req.URL.RawQuery = params.Encode()
+}
+
+func safe(req *http.Request, apiKey string) {
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+}
+`
+	fset, file := parsePolicyFixture(t, content)
+	violations := checkUnit3DQueryCredentialAuth(fset, "internal/trackerdata/unit3d.go", file, nil)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "Authorization: Bearer") {
+		t.Fatalf("expected Unit3D Bearer auth violation, got %q", violations[0].Message)
+	}
+}
+
 func parsePolicyFixture(t *testing.T, content string) (*token.FileSet, *ast.File) {
 	t.Helper()
 	fset := token.NewFileSet()

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -3166,6 +3166,43 @@ func writeSafeFailureArtifact(path string, payload []byte) error {
 	}
 }
 
+func TestDiagnosticArtifactWritesRecognizeConvertedSanitizedBindings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		writeExpr      string
+		wantViolations int
+	}{
+		{name: "slice conversion", writeExpr: "[]byte(payload)", wantViolations: 0},
+		{name: "ordinary call", writeExpr: "cloneBytes(payload)", wantViolations: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := `package sample
+
+import (
+	"os"
+
+	"github.com/autobrr/upbrr/internal/redaction"
+)
+
+func cloneBytes(payload []byte) []byte { return payload }
+
+func writeFailureArtifact(path string, payload []byte) error {
+	payload = []byte(redaction.RedactValue(string(payload), nil))
+	return os.WriteFile(path, ` + tt.writeExpr + `, 0o600)
+}
+`
+			fset, file := parsePolicyFixture(t, content)
+			violations := checkDiagnosticArtifactWrites(fset, "internal/sample/sample.go", file, importAliases(file), nil)
+			if len(violations) != tt.wantViolations {
+				t.Fatalf("expected %d violations, got %d: %#v", tt.wantViolations, len(violations), violations)
+			}
+		})
+	}
+}
+
 func TestFrontendVisibleRawErrorsRequireRedaction(t *testing.T) {
 	t.Parallel()
 
@@ -3198,6 +3235,35 @@ func updateSafe(state *trackerState, err error) {
 		if !strings.Contains(violation.Message, "frontend-visible") {
 			t.Fatalf("expected frontend-visible violation, got %q", violation.Message)
 		}
+	}
+}
+
+func TestFrontendVisibleUploadJobFailureMessagesRequireRedaction(t *testing.T) {
+	t.Parallel()
+
+	content := `package guiapp
+
+import "github.com/autobrr/upbrr/internal/logging"
+
+func unsafe(app *App, eventCtx any, job *trackerUploadJob, err error) {
+	app.failTrackerUploadJob(eventCtx, job, err.Error())
+}
+
+func safe(app *App, eventCtx any, job *trackerUploadJob, err error) {
+	app.failTrackerUploadJob(eventCtx, job, logging.SanitizeMessage(err.Error()))
+}
+
+func stable(app *App, eventCtx any, job *trackerUploadJob) {
+	app.failTrackerUploadJob(eventCtx, job, "upload failed")
+}
+`
+	fset, file := parsePolicyFixture(t, content)
+	violations := checkFrontendVisibleRawErrors(fset, "internal/guiapp/sample.go", file, importAliases(file), nil)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %#v", len(violations), violations)
+	}
+	if !strings.Contains(violations[0].Message, "upload job failure") {
+		t.Fatalf("expected upload job failure violation, got %q", violations[0].Message)
 	}
 }
 

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -36,6 +36,7 @@ var (
 	announcePathTokenRe = regexp.MustCompile(`(?i)(/announce(?:\.php)?/)([A-Za-z0-9]{10,})($|[/?#])`)
 	apiPathTokenRe      = regexp.MustCompile(`(?i)(/api/torrents/)([A-Za-z0-9]{10,})($|[/?#"])`)
 	proxyPathRe         = regexp.MustCompile(`(?i)(/proxy/)([^/\s?#"]+)`) // /proxy/<secret>
+	urlUserinfoRe       = regexp.MustCompile(`(?i)(\b[a-z][a-z0-9+.-]*://|//)([^/@\s]+)@`)
 	queryParamRe        = regexp.MustCompile(`(?i)([?&](anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|auth|auth[_-]?key|csrf|info[_-]?hash|key|passkey|password|rss[_-]?key|secret|token|torrent[_-]?pass|uid|user|user[_-]?id|userid)=)[^&]+`)
 	keyValueQuotedRe    = regexp.MustCompile(`(?i)\b(anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|authorization|auth|auth[_-]?key|cookie|csrf|passkey|password|rss[_-]?key|secret|token|torrent[_-]?pass)\b(\s*[:=]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')`)
 	keyValuePlainRe     = regexp.MustCompile(`(?i)\b(anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|authorization|auth|auth[_-]?key|cookie|csrf|passkey|password|rss[_-]?key|secret|token|torrent[_-]?pass)\b(\s*[:=]\s*)(bearer\s+)?([^"'\s,;)\]}]+)`)
@@ -131,6 +132,7 @@ func RedactValue(value string, sensitiveKeys map[string]struct{}) string {
 	value = announcePathTokenRe.ReplaceAllString(value, `${1}[REDACTED]${3}`)
 	value = apiPathTokenRe.ReplaceAllString(value, `${1}[REDACTED]${3}`)
 	value = proxyPathRe.ReplaceAllString(value, `${1}[REDACTED]`)
+	value = urlUserinfoRe.ReplaceAllString(value, `${1}[REDACTED]@`)
 	value = queryParamRe.ReplaceAllString(value, `${1}[REDACTED]`)
 	value = keyValueQuotedRe.ReplaceAllStringFunc(value, redactQuotedKeyValue)
 	value = keyValuePlainRe.ReplaceAllStringFunc(value, redactPlainKeyValue)

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -122,6 +122,24 @@ func TestRedactValueDoesNotReredactRedactedQueryValues(t *testing.T) {
 	}
 }
 
+func TestRedactValueURLUserinfo(t *testing.T) {
+	t.Parallel()
+
+	input := `primary=https://policy-user:policy-password@host.example secondary=//other-user:other-password@proxy.example/path`
+	output := RedactValue(input, nil)
+
+	for _, secret := range []string{"policy-user", "policy-password", "other-user", "other-password"} {
+		if contains(output, secret) {
+			t.Fatal("expected URL userinfo redacted")
+		}
+	}
+	for _, marker := range []string{"https://[REDACTED]@host.example", "//[REDACTED]@proxy.example/path"} {
+		if !contains(output, marker) {
+			t.Fatal("expected URL authority preserved around redacted userinfo")
+		}
+	}
+}
+
 func TestRedactValueQuotedKeyValuePairsWithEscapedQuotes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/autobrr/upbrr/internal/config"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/paths"
 	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/internal/redaction"
@@ -343,7 +344,7 @@ func (s *Service) Capture(ctx context.Context, meta api.PreparedMetadata, select
 			usedLib, captureErr := captureFrame(ctx, s.runner, cmd, capture)
 			if captureErr != nil {
 				mu.Lock()
-				errors = append(errors, api.ScreenshotError{Index: selection.Index, Message: captureErr.Error()})
+				errors = append(errors, api.ScreenshotError{Index: selection.Index, Message: logging.SanitizeMessage(captureErr.Error())})
 				mu.Unlock()
 				continue
 			}

--- a/internal/trackerdata/unit3d.go
+++ b/internal/trackerdata/unit3d.go
@@ -302,7 +302,7 @@ func (c *Client) lookupUnit3D(ctx context.Context, tracker string, id string, fi
 	if len(params) > 0 {
 		req.URL.RawQuery = params.Encode()
 	}
-	setUnit3DAPIHeaders(req, apiKey)
+	SetUnit3DAPIHeaders(req, apiKey)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -437,7 +437,7 @@ func (c *Client) searchUnit3DEndpoint(ctx context.Context, tracker string, endpo
 	if len(params) > 0 {
 		req.URL.RawQuery = params.Encode()
 	}
-	setUnit3DAPIHeaders(req, apiKey)
+	SetUnit3DAPIHeaders(req, apiKey)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -466,9 +466,9 @@ func (c *Client) searchUnit3DEndpoint(ctx context.Context, tracker string, endpo
 	return buildUnit3DSearchEntries(payload.Data, isDisc), "", nil
 }
 
-// setUnit3DAPIHeaders applies the authentication and response format expected
+// SetUnit3DAPIHeaders applies the authentication and response format expected
 // by every Unit3D API request.
-func setUnit3DAPIHeaders(req *http.Request, apiKey string) {
+func SetUnit3DAPIHeaders(req *http.Request, apiKey string) {
 	if req == nil {
 		return
 	}

--- a/internal/trackerdata/unit3d.go
+++ b/internal/trackerdata/unit3d.go
@@ -280,10 +280,8 @@ func (c *Client) lookupUnit3D(ctx context.Context, tracker string, id string, fi
 
 	apiKey := strings.TrimSpace(TrackerAPIKey(c.cfg, tracker))
 	params := url.Values{}
-	if apiKey != "" {
-		params.Set("api_token", apiKey)
-	} else {
-		c.logger.Debugf("unit3d: %s missing api token; request may be unauthenticated", tracker)
+	if apiKey == "" {
+		c.logger.Debugf("unit3d: %s missing API key; request will be unauthenticated", tracker)
 	}
 
 	var endpoint string
@@ -304,6 +302,7 @@ func (c *Client) lookupUnit3D(ctx context.Context, tracker string, id string, fi
 	if len(params) > 0 {
 		req.URL.RawQuery = params.Encode()
 	}
+	setUnit3DAPIHeaders(req, apiKey)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -398,11 +397,8 @@ func (c *Client) SearchTorrents(ctx context.Context, tracker string, params url.
 	}
 
 	apiKey := strings.TrimSpace(TrackerAPIKey(c.cfg, tracker))
-	if apiKey != "" {
-		params = cloneValues(params)
-		params.Set("api_token", apiKey)
-	} else if c.logger != nil {
-		c.logger.Debugf("unit3d: %s missing api token; request may be unauthenticated", tracker)
+	if apiKey == "" && c.logger != nil {
+		c.logger.Debugf("unit3d: %s missing API key; request will be unauthenticated", tracker)
 	}
 
 	endpoints := []unit3dSearchEndpoint{{
@@ -420,7 +416,7 @@ func (c *Client) SearchTorrents(ctx context.Context, tracker string, params url.
 
 	var entries []api.DupeEntry
 	for _, endpoint := range endpoints {
-		endpointEntries, warning, err := c.searchUnit3DEndpoint(ctx, tracker, endpoint, params, isDisc)
+		endpointEntries, warning, err := c.searchUnit3DEndpoint(ctx, tracker, endpoint, params, apiKey, isDisc)
 		if err != nil {
 			return nil, "", err
 		}
@@ -433,7 +429,7 @@ func (c *Client) SearchTorrents(ctx context.Context, tracker string, params url.
 	return entries, "", nil
 }
 
-func (c *Client) searchUnit3DEndpoint(ctx context.Context, tracker string, endpoint unit3dSearchEndpoint, params url.Values, isDisc bool) ([]api.DupeEntry, string, error) {
+func (c *Client) searchUnit3DEndpoint(ctx context.Context, tracker string, endpoint unit3dSearchEndpoint, params url.Values, apiKey string, isDisc bool) ([]api.DupeEntry, string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.url, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("unit3d: request: %w", err)
@@ -441,6 +437,7 @@ func (c *Client) searchUnit3DEndpoint(ctx context.Context, tracker string, endpo
 	if len(params) > 0 {
 		req.URL.RawQuery = params.Encode()
 	}
+	setUnit3DAPIHeaders(req, apiKey)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -467,6 +464,18 @@ func (c *Client) searchUnit3DEndpoint(ctx context.Context, tracker string, endpo
 		return nil, "", fmt.Errorf("unit3d: decode: %w", err)
 	}
 	return buildUnit3DSearchEntries(payload.Data, isDisc), "", nil
+}
+
+// setUnit3DAPIHeaders applies the authentication and response format expected
+// by every Unit3D API request.
+func setUnit3DAPIHeaders(req *http.Request, apiKey string) {
+	if req == nil {
+		return
+	}
+	req.Header.Set("Accept", "application/json")
+	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
 }
 
 func buildUnit3DSearchEntries(items []unit3dSearchItem, isDisc bool) []api.DupeEntry {
@@ -814,16 +823,6 @@ func baseFromAnnounce(announce string) string {
 	parsed.RawQuery = ""
 	parsed.Fragment = ""
 	return parsed.String()
-}
-
-func cloneValues(values url.Values) url.Values {
-	clone := url.Values{}
-	for key, list := range values {
-		for _, value := range list {
-			clone.Add(key, value)
-		}
-	}
-	return clone
 }
 
 func parseNumberToInt64(value json.Number) (int64, error) {

--- a/internal/trackerdata/unit3d_test.go
+++ b/internal/trackerdata/unit3d_test.go
@@ -29,6 +29,23 @@ func TestIsUnit3DTracker(t *testing.T) {
 	}
 }
 
+func TestSetUnit3DAPIHeadersUsesBearerAuthorization(t *testing.T) {
+	t.Parallel()
+
+	SetUnit3DAPIHeaders(nil, "ignored")
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "https://tracker.example/api/torrents/upload", nil)
+	SetUnit3DAPIHeaders(req, " secret ")
+	if req.Header.Get("Authorization") != "Bearer secret" {
+		t.Fatal("expected Unit3D Bearer authorization")
+	}
+	if req.Header.Get("Accept") != "application/json" {
+		t.Fatal("expected Unit3D JSON accept header")
+	}
+	if req.URL.Query().Has("api_token") {
+		t.Fatal("Unit3D API token must not be placed in the query")
+	}
+}
+
 func TestUnit3DMappings(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackerdata/unit3d_test.go
+++ b/internal/trackerdata/unit3d_test.go
@@ -137,8 +137,12 @@ func TestSearchTorrentsCBRIncludesPendingAndFiltersTMDB(t *testing.T) {
 	var paths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		paths = append(paths, r.URL.Path)
-		if got := r.URL.Query().Get("api_token"); got != "secret" {
-			t.Error("api token mismatch")
+		if r.Header.Get("Authorization") != "Bearer secret" {
+			t.Error("bearer authorization mismatch")
+			return
+		}
+		if r.URL.Query().Has("api_token") {
+			t.Error("API token must not be placed in the query")
 			return
 		}
 
@@ -191,6 +195,42 @@ func TestSearchTorrentsCBRIncludesPendingAndFiltersTMDB(t *testing.T) {
 	}
 	if entries[1].ID != "202" || entries[1].SizeBytes != 456 || entries[1].Files[0] != "pending.mkv" {
 		t.Fatalf("unexpected pending fields: %#v", entries[1])
+	}
+}
+
+func TestTorrentInfoUsesBearerAuthorization(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer secret" {
+			t.Error("bearer authorization mismatch")
+			return
+		}
+		if r.URL.Query().Has("api_token") {
+			t.Error("API token must not be placed in the query")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"attributes":{"tmdb_id":123,"category":"MOVIE"}}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	base, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal("parse test server URL")
+	}
+	client := NewClient(config.Config{
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"AITHER": {APIKey: "secret"},
+		}},
+	}, api.NopLogger{}, &http.Client{Transport: rewriteHostTransport{base: base, rt: server.Client().Transport}})
+
+	result, err := client.TorrentInfo(context.Background(), "AITHER", "123", "", true, false)
+	if err != nil {
+		t.Fatalf("torrent info: %v", err)
+	}
+	if result.TMDBID != 123 || result.Category != "MOVIE" {
+		t.Fatalf("unexpected Unit3D lookup result: %#v", result)
 	}
 }
 

--- a/internal/trackers/image_host_resolution.go
+++ b/internal/trackers/image_host_resolution.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/paths"
 	dbsvc "github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/services/imagehost"
@@ -233,7 +234,7 @@ func ensureDescriptionImageHostWithData(
 			}
 			feedback.Warnings = append(feedback.Warnings, api.ImageHostWarning{
 				Host:    host,
-				Message: err.Error(),
+				Message: logging.SanitizeMessage(err.Error()),
 			})
 			if logger != nil {
 				logger.Warnf("trackers: image host upload failed tracker=%s host=%s: %v", tracker, host, err)
@@ -251,7 +252,7 @@ func ensureDescriptionImageHostWithData(
 			lastErr = err
 			feedback.Warnings = append(feedback.Warnings, api.ImageHostWarning{
 				Host:    host,
-				Message: err.Error(),
+				Message: logging.SanitizeMessage(err.Error()),
 			})
 			if logger != nil {
 				logger.Warnf("trackers: image host upload produced unusable screenshots tracker=%s host=%s: %v", tracker, host, err)

--- a/internal/trackers/impl/ar/upload.go
+++ b/internal/trackers/impl/ar/upload.go
@@ -28,6 +28,7 @@ import (
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	"github.com/autobrr/upbrr/internal/paths"
 	"github.com/autobrr/upbrr/internal/pathutil"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackerauth"
 	"github.com/autobrr/upbrr/internal/trackers"
@@ -89,7 +90,10 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyBytes, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode == http.StatusOK, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: AR read upload response: %w", err)
+	}
 	groupID, torrentID := parseUploadIDs(finalURL, string(bodyBytes))
 	if resp.StatusCode == http.StatusOK && groupID != "" {
 		torrentURL := buildTorrentURL(groupID, torrentID)
@@ -120,12 +124,13 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	failurePath := ""
 	if pathValue, pathErr := resolveFailurePath(req.Meta, req.AppConfig.MainSettings.DBPath); pathErr == nil {
 		failurePath = pathValue
-		_ = os.WriteFile(failurePath, bodyBytes, 0o600)
+		redactedBody := []byte(redaction.RedactValue(string(responsePreview), nil))
+		_ = os.WriteFile(failurePath, redactedBody, 0o600)
 	}
 	if failurePath != "" {
-		return api.UploadSummary{}, fmt.Errorf("%w failure=%s", commonhttp.UploadHTTPErrorWithURL("AR", resp.StatusCode, finalURL, bodyBytes), failurePath)
+		return api.UploadSummary{}, fmt.Errorf("%w failure=%s", commonhttp.UploadHTTPErrorWithURL("AR", resp.StatusCode, finalURL, responsePreview), failurePath)
 	}
-	return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("AR", resp.StatusCode, finalURL, bodyBytes)
+	return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("AR", resp.StatusCode, finalURL, responsePreview)
 }
 
 func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.TrackerDryRunEntry, error) {

--- a/internal/trackers/impl/asc/upload.go
+++ b/internal/trackers/impl/asc/upload.go
@@ -21,6 +21,7 @@ import (
 	"github.com/autobrr/upbrr/internal/httpclient"
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	"github.com/autobrr/upbrr/internal/paths"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
@@ -74,7 +75,10 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	bodyBytes, _ := io.ReadAll(resp.Body)
+	bodyBytes, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode == http.StatusOK, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: ASC read upload response: %w", err)
+	}
 	torrentID := parseUploadID(finalURL, string(bodyBytes))
 	if resp.StatusCode == http.StatusOK && torrentID != "" {
 		torrentURL := baseURL + "/torrents-details.php?id=" + url.QueryEscape(torrentID)
@@ -105,12 +109,13 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	failurePath := ""
 	if pathValue, pathErr := resolveFailurePath(req.Meta, req.AppConfig.MainSettings.DBPath); pathErr == nil {
 		failurePath = pathValue
-		_ = os.WriteFile(failurePath, bodyBytes, 0o600)
+		redactedBody := []byte(redaction.RedactValue(string(responsePreview), nil))
+		_ = os.WriteFile(failurePath, redactedBody, 0o600)
 	}
 	if failurePath != "" {
-		return api.UploadSummary{}, fmt.Errorf("%w failure=%s", commonhttp.UploadHTTPErrorWithURL("ASC", resp.StatusCode, finalURL, bodyBytes), failurePath)
+		return api.UploadSummary{}, fmt.Errorf("%w failure=%s", commonhttp.UploadHTTPErrorWithURL("ASC", resp.StatusCode, finalURL, responsePreview), failurePath)
 	}
-	return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("ASC", resp.StatusCode, finalURL, bodyBytes)
+	return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("ASC", resp.StatusCode, finalURL, responsePreview)
 }
 
 func buildUploadDryRun(ctx context.Context, req trackers.UploadRequest) (api.TrackerDryRunEntry, error) {

--- a/internal/trackers/impl/bhd/upload.go
+++ b/internal/trackers/impl/bhd/upload.go
@@ -25,6 +25,7 @@ import (
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	"github.com/autobrr/upbrr/internal/paths"
 	"github.com/autobrr/upbrr/internal/pathutil"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
@@ -360,6 +361,7 @@ func writeFailureArtifact(req trackers.UploadRequest, payload []byte, name strin
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", fmt.Errorf("trackers: BHD create failure artifact dir: %w", err)
 	}
+	payload = []byte(redaction.RedactValue(string(payload), nil))
 	if err := os.WriteFile(path, payload, 0o600); err != nil {
 		return "", fmt.Errorf("trackers: BHD write failure artifact: %w", err)
 	}

--- a/internal/trackers/impl/bhdtv/upload.go
+++ b/internal/trackers/impl/bhdtv/upload.go
@@ -21,6 +21,7 @@ import (
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	"github.com/autobrr/upbrr/internal/paths"
 	"github.com/autobrr/upbrr/internal/pathutil"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
@@ -447,6 +448,7 @@ func writeFailureArtifact(req trackers.UploadRequest, payload []byte, name strin
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", fmt.Errorf("trackers: BHDTV create failure artifact dir: %w", err)
 	}
+	payload = []byte(redaction.RedactValue(string(payload), nil))
 	if err := os.WriteFile(path, payload, 0o600); err != nil {
 		return "", fmt.Errorf("trackers: BHDTV write failure artifact: %w", err)
 	}

--- a/internal/trackers/impl/ptp/upload.go
+++ b/internal/trackers/impl/ptp/upload.go
@@ -34,6 +34,7 @@ import (
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	"github.com/autobrr/upbrr/internal/paths"
 	"github.com/autobrr/upbrr/internal/pathutil"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/internal/services/bbcode"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/services/imagehost"
@@ -112,7 +113,10 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	bodyBytes, _ := io.ReadAll(resp.Body)
+	_, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode == http.StatusOK, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: PTP read upload response: %w", err)
+	}
 	if matches := ptpSuccessPattern.FindStringSubmatch(finalURL); len(matches) == 3 {
 		groupID := strings.TrimSpace(matches[1])
 		torrentID := strings.TrimSpace(matches[2])
@@ -139,11 +143,12 @@ func upload(ctx context.Context, req trackers.UploadRequest) (api.UploadSummary,
 	failurePath := ""
 	if pathValue, pathErr := resolveFailurePath(req.Meta, req.AppConfig.MainSettings.DBPath); pathErr == nil {
 		failurePath = pathValue
-		_ = os.WriteFile(failurePath, bodyBytes, 0o600)
+		redactedBody := []byte(redaction.RedactValue(string(responsePreview), nil))
+		_ = os.WriteFile(failurePath, redactedBody, 0o600)
 	}
-	errText := commonhttp.RedactErrorDetail(extractAlertError(string(bodyBytes)))
+	errText := commonhttp.RedactErrorDetail(extractAlertError(string(responsePreview)))
 	if errText == "" {
-		errText = commonhttp.ExtractHTTPErrorDetail(bodyBytes)
+		errText = commonhttp.ExtractHTTPErrorDetail(responsePreview)
 	}
 	if errText == "" {
 		errText = "upload failed"

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -159,7 +159,7 @@ func uploadUnit3D(ctx context.Context, req trackers.UploadRequest) (api.UploadSu
 		logger.Errorf("trackers: %s failed to create HTTP request: %v", trackerName, err)
 		return api.UploadSummary{}, fmt.Errorf("trackers: %s build upload request: %w", trackerName, err)
 	}
-	setUnit3DAPIHeaders(httpReq, apiKey)
+	trackerdata.SetUnit3DAPIHeaders(httpReq, apiKey)
 	httpReq.Header.Set("Content-Type", contentType)
 	httpReq.Header.Set("User-Agent", "upbrr")
 
@@ -739,16 +739,6 @@ func resolveKeywordsForTracker(tracker string, meta api.PreparedMetadata) string
 		return resolveACMKeywords(meta)
 	}
 	return resolveKeywords(meta)
-}
-
-func setUnit3DAPIHeaders(req *http.Request, apiKey string) {
-	if req == nil {
-		return
-	}
-	req.Header.Set("Accept", "application/json")
-	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+apiKey)
-	}
 }
 
 func resolveTVDBID(meta api.PreparedMetadata) int {

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -159,14 +159,7 @@ func uploadUnit3D(ctx context.Context, req trackers.UploadRequest) (api.UploadSu
 		logger.Errorf("trackers: %s failed to create HTTP request: %v", trackerName, err)
 		return api.UploadSummary{}, fmt.Errorf("trackers: %s build upload request: %w", trackerName, err)
 	}
-	if usesUnit3DBearerAuth(trackerName) {
-		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-	} else {
-		query := httpReq.URL.Query()
-		query.Set("api_token", apiKey)
-		httpReq.URL.RawQuery = query.Encode()
-	}
-	httpReq.Header.Set("Accept", "application/json")
+	setUnit3DAPIHeaders(httpReq, apiKey)
 	httpReq.Header.Set("Content-Type", contentType)
 	httpReq.Header.Set("User-Agent", "upbrr")
 
@@ -748,8 +741,14 @@ func resolveKeywordsForTracker(tracker string, meta api.PreparedMetadata) string
 	return resolveKeywords(meta)
 }
 
-func usesUnit3DBearerAuth(tracker string) bool {
-	return !strings.EqualFold(strings.TrimSpace(tracker), "ACM")
+func setUnit3DAPIHeaders(req *http.Request, apiKey string) {
+	if req == nil {
+		return
+	}
+	req.Header.Set("Accept", "application/json")
+	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
 }
 
 func resolveTVDBID(meta api.PreparedMetadata) int {

--- a/internal/trackers/impl/unit3d/upload_test.go
+++ b/internal/trackers/impl/unit3d/upload_test.go
@@ -534,6 +534,22 @@ func TestUploadUnit3DBlocksMissingCanonicalTVSeasonEpisode(t *testing.T) {
 	}
 }
 
+func TestSetUnit3DAPIHeadersUsesBearerAuthorization(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "https://tracker.example/api/torrents/upload", nil)
+	setUnit3DAPIHeaders(req, " secret ")
+	if req.Header.Get("Authorization") != "Bearer secret" {
+		t.Fatal("expected Unit3D Bearer authorization")
+	}
+	if req.Header.Get("Accept") != "application/json" {
+		t.Fatal("expected Unit3D JSON accept header")
+	}
+	if req.URL.Query().Has("api_token") {
+		t.Fatal("Unit3D API token must not be placed in the query")
+	}
+}
+
 func TestBuildUnit3DDataFailsOnUnknownType(t *testing.T) {
 	req := trackers.UploadRequest{
 		Tracker: "AITHER",

--- a/internal/trackers/impl/unit3d/upload_test.go
+++ b/internal/trackers/impl/unit3d/upload_test.go
@@ -534,22 +534,6 @@ func TestUploadUnit3DBlocksMissingCanonicalTVSeasonEpisode(t *testing.T) {
 	}
 }
 
-func TestSetUnit3DAPIHeadersUsesBearerAuthorization(t *testing.T) {
-	t.Parallel()
-
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "https://tracker.example/api/torrents/upload", nil)
-	setUnit3DAPIHeaders(req, " secret ")
-	if req.Header.Get("Authorization") != "Bearer secret" {
-		t.Fatal("expected Unit3D Bearer authorization")
-	}
-	if req.Header.Get("Accept") != "application/json" {
-		t.Fatal("expected Unit3D JSON accept header")
-	}
-	if req.URL.Query().Has("api_token") {
-		t.Fatal("Unit3D API token must not be placed in the query")
-	}
-}
-
 func TestBuildUnit3DDataFailsOnUnknownType(t *testing.T) {
 	req := trackers.UploadRequest{
 		Tracker: "AITHER",

--- a/internal/webserver/jobs.go
+++ b/internal/webserver/jobs.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/guishared"
+	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -394,7 +395,7 @@ func (b *Backend) runDupeCheckJob(ctx context.Context, job *dupeCheckJob) {
 		job.finishedAt = time.Now().UTC()
 		job.cancel = nil
 		job.status = "failed"
-		job.errorMessage = err.Error()
+		job.errorMessage = logging.SanitizeMessage(err.Error())
 		job.mu.Unlock()
 		b.emitDupeCheckSnapshot(job)
 		b.scheduleDupeJobCleanup(job)
@@ -411,7 +412,7 @@ func (b *Backend) runDupeCheckJob(ctx context.Context, job *dupeCheckJob) {
 			job.errorMessage = "dupe check canceled"
 		} else {
 			job.status = "failed"
-			job.errorMessage = err.Error()
+			job.errorMessage = logging.SanitizeMessage(err.Error())
 		}
 		job.mu.Unlock()
 		b.emitDupeCheckSnapshot(job)
@@ -723,13 +724,14 @@ func (b *Backend) runTrackerUploadJob(ctx context.Context, job *trackerUploadJob
 				break
 			}
 			job.mu.Lock()
+			message := logging.SanitizeMessage(err.Error())
 			state = job.states[tracker]
 			state.Status = "failed"
-			state.Message = err.Error()
+			state.Message = message
 			state.FinishedAt = time.Now().UTC().Format(time.RFC3339)
 			job.states[tracker] = state
 			job.failedTrackers = append(job.failedTrackers, tracker)
-			job.errorMessage = err.Error()
+			job.errorMessage = message
 			job.mu.Unlock()
 			b.emitTrackerUploadSnapshot(job)
 			continue


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Sensitive credentials are now redacted from logs, error messages, previews, diagnostic files, and upload failure artifacts.
  * Local file paths and credentials embedded in URLs are concealed in user-visible diagnostics.
  * Unit3D authentication now uses secure Bearer headers instead of URL query parameters.

* **Documentation**
  * Updated contributor guidance with clearer logging levels and stricter sensitive-information handling rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->