### PR TITLE
fix(metadata): pass parent context to ResolveAnime to avoid canceled ctx

### DIFF
--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -3094,3 +3094,21 @@ func TestResolveExternalIDsLocalizedFetchUsesVariantCachePaths(t *testing.T) {
 		t.Fatalf("expected TV content_ratings append, got %q", tmdbClient.localizedInputs[0].AppendToResponse)
 	}
 }
+
+type testLogger struct {
+	t *testing.T
+}
+
+func (l testLogger) Debugf(format string, args ...any) { l.t.Logf("[DEBUG] "+format, args...) }
+func (l testLogger) Infof(format string, args ...any)  { l.t.Logf("[INFO] "+format, args...) }
+func (l testLogger) Warnf(format string, args ...any)  { l.t.Logf("[WARN] "+format, args...) }
+func (l testLogger) Errorf(format string, args ...any) { l.t.Logf("[ERROR] "+format, args...) }
+func (l testLogger) Tracef(format string, args ...any) { l.t.Logf("[TRACE] "+format, args...) }
+
+func ptrString(s string) *string {
+	return &s
+}
+
+func ptrInt(i int) *int {
+	return &i
+}

--- a/internal/metadata/tmdb/anilist.go
+++ b/internal/metadata/tmdb/anilist.go
@@ -98,7 +98,9 @@ func (c *Client) ResolveAnime(ctx context.Context, tmdbName string, input Metada
 	result.Romaji = metautil.FirstNonEmpty(best.Title.Romaji, best.Title.English)
 	result.English = metautil.FirstNonEmpty(best.Title.English, best.Title.Romaji)
 	result.MALID = best.IDMal
-	result.SeasonYear = best.SeasonYear
+	if best.SeasonYear != 0 {
+		result.SeasonYear = strconv.Itoa(best.SeasonYear)
+	}
 	result.Episodes = best.Episodes
 	result.Demographic = resolveDemographic(best.Tags, result.Demographic)
 	if input.MALManual != 0 {
@@ -358,7 +360,7 @@ type anilistMedia struct {
 	ID         int          `json:"id"`
 	IDMal      int          `json:"idMal"`
 	Title      anilistTitle `json:"title"`
-	SeasonYear string       `json:"seasonYear"`
+	SeasonYear int          `json:"seasonYear"`
 	Episodes   int          `json:"episodes"`
 	Tags       []anilistTag `json:"tags"`
 }

--- a/internal/metadata/tmdb/anilist_test.go
+++ b/internal/metadata/tmdb/anilist_test.go
@@ -23,7 +23,7 @@ func TestAniListSearchRetriesTimeouts(t *testing.T) {
 				if attempts < 3 {
 					return nil, timeoutError{err: errors.New("timeout")}
 				}
-				body := `{"data":{"Page":{"media":[{"id":1,"idMal":20,"title":{"romaji":"Test","english":"Test"},"seasonYear":"2024","episodes":12,"tags":[{"name":"Shounen"}]}]}}}`
+				body := `{"data":{"Page":{"media":[{"id":1,"idMal":20,"title":{"romaji":"Test","english":"Test"},"seasonYear":2024,"episodes":12,"tags":[{"name":"Shounen"}]}]}}}`
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(body)),

--- a/internal/metadata/tmdb/metadata.go
+++ b/internal/metadata/tmdb/metadata.go
@@ -34,7 +34,6 @@ func (c *Client) FetchMetadata(ctx context.Context, input MetadataInput) (Metada
 	if category == "" {
 		category = "MOVIE"
 	}
-
 	var media mediaResponse
 	path := fmt.Sprintf("/movie/%d", input.TMDBID)
 	if category == "TV" {
@@ -241,7 +240,7 @@ func (c *Client) FetchMetadata(ctx context.Context, input MetadataInput) (Metada
 		result.Anime = isAnime(media.OriginalLanguage, media.Genres)
 	}
 	if result.Anime {
-		animeResult, err := c.ResolveAnime(ctx, title, input)
+		animeResult, err := c.ResolveAnime(requestCtx, title, input)
 		if err == nil {
 			result.MALID = animeResult.MALID
 			result.RetrievedAKA = animeResult.Romaji


### PR DESCRIPTION
After the parallel TMDB metadata fan-out (external_ids, translations, videos, keywords, credits), errgroup cancels the derived gctx. ResolveAnime was accidentally receiving this already-canceled context, causing every AniList search to abort immediately and the MAL ID to never be resolved.

Fix: pass the saved requestCtx (captured before errgroup shadowed ctx) so AniList searches run on a live context.

Also fix anilistMedia.SeasonYear JSON field type: the AniList API returns an integer, so parse it as int and convert to string only when non-zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anime metadata handling when season year information is unavailable.
  * Corrected season year processing from AniList responses.
  * Improved context handling during anime metadata enrichment.
* **Tests**
  * Updated AniList test data to reflect numeric season year responses.
  * Added utilities to improve metadata test logging and input setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->