### PR TITLE
feat: tracker auth concurrency

### DIFF
--- a/cmd/upbrr/cli_tracker_auth_e2e.go
+++ b/cmd/upbrr/cli_tracker_auth_e2e.go
@@ -35,9 +35,13 @@ func (e2eCLITrackerAuthService) Capabilities(context.Context) ([]api.TrackerAuth
 	return nil, nil
 }
 
-// Validate returns configured state without contacting the tracker.
-func (e2eCLITrackerAuthService) Validate(_ context.Context, trackerID string) (api.TrackerAuthStatus, error) {
-	return api.TrackerAuthStatus{TrackerID: strings.ToUpper(strings.TrimSpace(trackerID)), State: trackerauth.StateConfigured}, nil
+// ValidateMany returns configured state without contacting trackers.
+func (e2eCLITrackerAuthService) ValidateMany(_ context.Context, trackerIDs []string) ([]api.TrackerAuthStatus, error) {
+	statuses := make([]api.TrackerAuthStatus, 0, len(trackerIDs))
+	for _, trackerID := range trackerIDs {
+		statuses = append(statuses, api.TrackerAuthStatus{TrackerID: strings.ToUpper(strings.TrimSpace(trackerID)), State: trackerauth.StateConfigured})
+	}
+	return statuses, nil
 }
 
 // Submit2FA completes the fake challenge without external IO.

--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -27,10 +27,11 @@ import (
 const dryRunPayloadPreviewLimit = 240
 
 // cliTrackerAuthService is the CLI-facing subset of tracker auth operations
-// needed to verify and refresh tracker auth before dupe checking.
+// needed to verify and refresh tracker auth before dupe checking. ValidateMany
+// must return one status per tracker in input order.
 type cliTrackerAuthService interface {
 	Capabilities(ctx context.Context) ([]api.TrackerAuthCapability, error)
-	Validate(ctx context.Context, trackerID string) (api.TrackerAuthStatus, error)
+	ValidateMany(ctx context.Context, trackerIDs []string) ([]api.TrackerAuthStatus, error)
 	Submit2FA(ctx context.Context, challengeID string, code string) (api.TrackerAuthStatus, error)
 }
 
@@ -392,13 +393,19 @@ func ensureCLITrackerAuthBeforeDupeCheckWithServiceAndLogger(ctx context.Context
 	logger.Debugf("cli auth: pre-dupe auth check start trackers=%d", len(authCheckTrackers))
 	for _, name := range authCheckTrackers {
 		capability := capabilityByTracker[name]
-
 		logger.Debugf("cli auth: validating tracker=%s auth_kind=%s", name, cliAuthLogField(capability.AuthKind))
-		status, err := authSvc.Validate(ctx, name)
-		if err != nil {
-			logger.Warnf("cli auth: validation failed tracker=%s error=%s", name, cliAuthLogError(err))
-			return nil, fmt.Errorf("upbrr: tracker auth %s: %w", name, err)
-		}
+	}
+	statuses, err := authSvc.ValidateMany(ctx, authCheckTrackers)
+	if err != nil {
+		logger.Warnf("cli auth: concurrent validation failed error=%s", cliAuthLogError(err))
+		return nil, fmt.Errorf("upbrr: tracker auth validation: %w", err)
+	}
+	if len(statuses) != len(authCheckTrackers) {
+		return nil, fmt.Errorf("upbrr: tracker auth validation returned %d statuses for %d trackers", len(statuses), len(authCheckTrackers))
+	}
+	for i, name := range authCheckTrackers {
+		capability := capabilityByTracker[name]
+		status := statuses[i]
 		logCLITrackerAuthStatus(logger, "validation result", status)
 		status, keep, err := handleCLITrackerAuthStatusWithLogger(ctx, reader, authSvc, capability, status, req, logger)
 		if err != nil {
@@ -432,14 +439,7 @@ func ensureCLITrackerAuthBeforeDupeCheckWithServiceAndLogger(ctx context.Context
 // work, matching the frontend tracker-auth settings filter instead of static
 // API-key/passkey config.
 func cliTrackerAuthApplies(capability api.TrackerAuthCapability) bool {
-	authKind := strings.ToLower(strings.TrimSpace(capability.AuthKind))
-	return capability.SupportsCookieFile ||
-		capability.SupportsLogin ||
-		capability.SupportsAutoLogin ||
-		capability.SupportsTOTP ||
-		capability.SupportsManual2FA ||
-		strings.Contains(authKind, "refresh") ||
-		strings.Contains(authKind, "2fa")
+	return trackerauth.IsManagedCapability(capability)
 }
 
 // handleCLITrackerAuthStatusWithLogger converts one auth status into a CLI
@@ -569,15 +569,7 @@ func cliAuthLogField(value string) string {
 // cliTrackerAuthReady reports whether a tracker-auth status is usable without
 // further user input before CLI dupe checking.
 func cliTrackerAuthReady(status api.TrackerAuthStatus) bool {
-	if status.Needs2FA {
-		return false
-	}
-	switch strings.TrimSpace(status.State) {
-	case trackerauth.StateConfigured, trackerauth.StateHasCookies:
-		return true
-	default:
-		return false
-	}
+	return trackerauth.IsReadyStatus(status)
 }
 
 // cliTrackerAuthStatusMessage renders the tracker auth status display contract:

--- a/cmd/upbrr/interactive_test.go
+++ b/cmd/upbrr/interactive_test.go
@@ -1969,13 +1969,18 @@ func (s *cliTrackerAuthForTest) Capabilities(context.Context) ([]api.TrackerAuth
 	return append([]api.TrackerAuthCapability(nil), s.capabilities...), nil
 }
 
-func (s *cliTrackerAuthForTest) Validate(_ context.Context, trackerID string) (api.TrackerAuthStatus, error) {
-	name := strings.ToUpper(strings.TrimSpace(trackerID))
-	s.validated = append(s.validated, name)
-	if status, ok := s.validateStatus[name]; ok {
-		return status, nil
+func (s *cliTrackerAuthForTest) ValidateMany(_ context.Context, trackerIDs []string) ([]api.TrackerAuthStatus, error) {
+	statuses := make([]api.TrackerAuthStatus, 0, len(trackerIDs))
+	for _, trackerID := range trackerIDs {
+		name := strings.ToUpper(strings.TrimSpace(trackerID))
+		s.validated = append(s.validated, name)
+		if status, ok := s.validateStatus[name]; ok {
+			statuses = append(statuses, status)
+			continue
+		}
+		statuses = append(statuses, api.TrackerAuthStatus{TrackerID: name, State: trackerauth.StateConfigured})
 	}
-	return api.TrackerAuthStatus{TrackerID: name, State: trackerauth.StateConfigured}, nil
+	return statuses, nil
 }
 
 func (s *cliTrackerAuthForTest) Submit2FA(_ context.Context, challengeID string, code string) (api.TrackerAuthStatus, error) {

--- a/cmd/upbrr/interactive_test.go
+++ b/cmd/upbrr/interactive_test.go
@@ -1101,6 +1101,49 @@ func TestEnsureCLITrackerAuthBeforeDupeCheckFailsUnattendedAuthRequired(t *testi
 	}
 }
 
+func TestEnsureCLITrackerAuthBeforeDupeCheckExplainsExpiredSessionAction(t *testing.T) {
+	t.Parallel()
+
+	authSvc := &cliTrackerAuthForTest{
+		capabilities: []api.TrackerAuthCapability{{
+			TrackerID:          "HDB",
+			SupportsCookieFile: true,
+			RequiresPasskey:    true,
+		}},
+		validateStatus: map[string]api.TrackerAuthStatus{
+			"HDB": {
+				TrackerID: "HDB",
+				State:     trackerauth.StateLoginRequired,
+				Message:   "stored session expired or invalid; log in again or import fresh cookies",
+			},
+		},
+	}
+
+	_, err := ensureCLITrackerAuthBeforeDupeCheckWithService(
+		context.Background(),
+		bufio.NewReader(strings.NewReader("")),
+		authSvc,
+		api.Request{Options: api.UploadOptions{InteractionMode: api.InteractionModeUnattended}},
+		[]string{"HDB"},
+	)
+	if err == nil {
+		t.Fatal("expected unattended expired-session error")
+	}
+	got := err.Error()
+	for _, expected := range []string{
+		"unattended",
+		"no-prompt",
+		"HDB",
+		"required action",
+		"log in again",
+		"import fresh cookies",
+	} {
+		if !strings.Contains(got, expected) {
+			t.Fatalf("expected expired-session error to include %q, got %q", expected, got)
+		}
+	}
+}
+
 func TestEnsureCLITrackerAuthBeforeDupeCheckFailsUnattendedBTN2FA(t *testing.T) {
 	t.Parallel()
 

--- a/gui/frontend/src/pages/dupe_check/index.test.tsx
+++ b/gui/frontend/src/pages/dupe_check/index.test.tsx
@@ -195,6 +195,27 @@ describe("DupeCheckPage", () => {
     expect(screen.queryByText("Rule failed")).toBeNull();
   });
 
+  it("labels tracker-auth preflight skips as auth required", () => {
+    renderPage({
+      SourcePath: "C:\\Media\\Example.Movie.mkv",
+      Results: [
+        {
+          ...completedResult("PTP"),
+          Status: "skipped",
+          Skipped: true,
+          SkipReason: "tracker auth not ready: manual 2FA required",
+          SkipCode: "tracker_auth_not_ready",
+        },
+        completedResult("ANT"),
+      ],
+      Notes: [],
+    });
+
+    expect(screen.getByText("Auth required")).toBeInTheDocument();
+    expect(screen.getByText("tracker auth not ready: manual 2FA required")).toBeInTheDocument();
+    expect(screen.queryByText("Skipped")).toBeNull();
+  });
+
   it("uses structured SkipRules for rule-failure skipped results", () => {
     renderPage({
       SourcePath: "C:\\Media\\Example.Movie.mkv",

--- a/gui/frontend/src/pages/dupe_check/index.tsx
+++ b/gui/frontend/src/pages/dupe_check/index.tsx
@@ -280,8 +280,9 @@ export default function DupeCheckPage(props: Readonly<Props>) {
               const ruleSkipReason =
                 ruleSkipReasons[normalizedTracker] ||
                 (isRuleSkippedResult(result) ? skipReason || "rule check failed" : "");
+              const authRequired = result.SkipCode === "tracker_auth_not_ready";
               const skippedReason =
-                result.Skipped && !ruleSkipReason
+                result.Skipped && !ruleSkipReason && !authRequired
                   ? skippedDupeReasons[normalizedTracker] || skipReason
                   : "";
               const visibleNotes =
@@ -298,7 +299,7 @@ export default function DupeCheckPage(props: Readonly<Props>) {
               const displayDupeCount =
                 (dupeTrackerFlags[result.Tracker] ?? hasDupes) ? dupeCount : 0;
               const displayTrackers =
-                hasPathedNote || ruleSkipReason || skippedReason
+                hasPathedNote || ruleSkipReason || authRequired || skippedReason
                   ? trackerNamesForResult(result)
                   : [];
               const iconTrackers = displayTrackers.length > 0 ? displayTrackers : [result.Tracker];
@@ -339,6 +340,7 @@ export default function DupeCheckPage(props: Readonly<Props>) {
                   <div className="min-w-0">
                     {hasPathedNote ||
                     ruleSkipReason ||
+                    authRequired ||
                     skippedReason ||
                     hasFailure ||
                     visibleNotes.length ? (
@@ -349,6 +351,13 @@ export default function DupeCheckPage(props: Readonly<Props>) {
                           <>
                             <Badge tone="danger">Rule failed</Badge>
                             <span className="text-[var(--muted)]">{ruleSkipReason}</span>
+                          </>
+                        ) : null}
+
+                        {authRequired ? (
+                          <>
+                            <Badge tone="danger">Auth required</Badge>
+                            <span className="text-[var(--muted)]">{skipReason}</span>
                           </>
                         ) : null}
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -41,6 +41,7 @@ import (
 	"github.com/autobrr/upbrr/internal/services/imagehosting"
 	"github.com/autobrr/upbrr/internal/services/screenshots"
 	"github.com/autobrr/upbrr/internal/torrent"
+	"github.com/autobrr/upbrr/internal/trackerauth"
 	"github.com/autobrr/upbrr/internal/trackers"
 	trackerimpl "github.com/autobrr/upbrr/internal/trackers/impl"
 	"github.com/autobrr/upbrr/pkg/api"
@@ -186,6 +187,9 @@ func newCore(ctx context.Context, deps api.CoreDependencies) (*Core, error) {
 	}
 	if services.Dupes == nil {
 		services.Dupes = dupechecking.NewService(cfg, logger)
+	}
+	if services.TrackerAuth == nil {
+		services.TrackerAuth = trackerauth.NewServiceWithLogger(cfg, logger)
 	}
 	logger.Infof("core: initialized services")
 
@@ -560,7 +564,7 @@ func (c *Core) CheckDupes(ctx context.Context, req api.Request) (summary api.Dup
 				removeTrackers = mergeTrackerRemovals(removeTrackers, matchedTrackers)
 			}
 			resolvedTrackers := trackers.ResolveTrackers(c.cfg, req.Trackers, removeTrackers, c.logger)
-			summary, err := c.services.Dupes.Check(ctx, checkMeta, resolvedTrackers)
+			summary, err := c.checkGUIDupesWithAuth(ctx, req.Mode, checkMeta, resolvedTrackers)
 			if err != nil {
 				return api.DupeCheckSummary{}, fmt.Errorf("core: %w", err)
 			}
@@ -693,7 +697,7 @@ func (c *Core) CheckDupes(ctx context.Context, req api.Request) (summary api.Dup
 		removeTrackers = mergeTrackerRemovals(removeTrackers, matchedTrackers)
 	}
 	resolvedTrackers := trackers.ResolveTrackers(c.cfg, req.Trackers, removeTrackers, c.logger)
-	summary, err = c.services.Dupes.Check(ctx, checkMeta, resolvedTrackers)
+	summary, err = c.checkGUIDupesWithAuth(ctx, req.Mode, checkMeta, resolvedTrackers)
 	if err != nil {
 		return api.DupeCheckSummary{}, fmt.Errorf("core: %w", err)
 	}

--- a/internal/core/e2e_enabled.go
+++ b/internal/core/e2e_enabled.go
@@ -22,6 +22,7 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/internal/trackerauth"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -260,7 +261,7 @@ func (e2eTrackerAuthService) Capabilities(context.Context) ([]api.TrackerAuthCap
 func (e2eTrackerAuthService) ValidateMany(_ context.Context, trackerIDs []string) ([]api.TrackerAuthStatus, error) {
 	statuses := make([]api.TrackerAuthStatus, 0, len(trackerIDs))
 	for _, trackerID := range trackerIDs {
-		statuses = append(statuses, api.TrackerAuthStatus{TrackerID: strings.ToUpper(strings.TrimSpace(trackerID)), State: "configured"})
+		statuses = append(statuses, api.TrackerAuthStatus{TrackerID: strings.ToUpper(strings.TrimSpace(trackerID)), State: trackerauth.StateConfigured})
 	}
 	return statuses, nil
 }

--- a/internal/core/e2e_enabled.go
+++ b/internal/core/e2e_enabled.go
@@ -65,6 +65,9 @@ func maybeApplyE2EServices(_ context.Context, services *api.ServiceSet, cfg conf
 	if services.Dupes == nil {
 		services.Dupes = e2eDupeService{}
 	}
+	if services.TrackerAuth == nil {
+		services.TrackerAuth = e2eTrackerAuthService{}
+	}
 	return nil
 }
 
@@ -243,6 +246,23 @@ func (e2eDupeService) Check(_ context.Context, meta api.PreparedMetadata, tracke
 		results = append(results, api.DupeCheckResult{Tracker: strings.ToUpper(strings.TrimSpace(tracker)), Status: "completed"})
 	}
 	return api.DupeCheckSummary{SourcePath: meta.SourcePath, Results: results}, nil
+}
+
+// e2eTrackerAuthService keeps fake-services runs isolated from tracker auth IO.
+type e2eTrackerAuthService struct{}
+
+// Capabilities disables managed-auth preflight in fake-services runs.
+func (e2eTrackerAuthService) Capabilities(context.Context) ([]api.TrackerAuthCapability, error) {
+	return nil, nil
+}
+
+// ValidateMany returns configured statuses without contacting trackers.
+func (e2eTrackerAuthService) ValidateMany(_ context.Context, trackerIDs []string) ([]api.TrackerAuthStatus, error) {
+	statuses := make([]api.TrackerAuthStatus, 0, len(trackerIDs))
+	for _, trackerID := range trackerIDs {
+		statuses = append(statuses, api.TrackerAuthStatus{TrackerID: strings.ToUpper(strings.TrimSpace(trackerID)), State: "configured"})
+	}
+	return statuses, nil
 }
 
 type e2eTrackerService struct {

--- a/internal/core/tracker_auth.go
+++ b/internal/core/tracker_auth.go
@@ -163,25 +163,28 @@ func orderedReadyTrackers(trackerIDs []string, readySet map[string]struct{}) []s
 	return ready
 }
 
+const guiTrackerAuthRetryAction = "configure tracker auth and retry"
+
 // guiTrackerAuthSkipReason builds a redacted user-facing reason, preferring the
-// stable status message before error detail, 2FA state, and raw state.
+// stable status message before error detail, 2FA state, and raw state. Every
+// blocker includes the remediation action, even when diagnostics are present.
 func guiTrackerAuthSkipReason(status api.TrackerAuthStatus) string {
 	message := strings.TrimSpace(redaction.RedactValue(status.Message, nil))
 	detail := strings.TrimSpace(redaction.RedactValue(status.LastError, nil))
+	reason := "tracker auth not ready"
 	if message != "" && detail != "" && !strings.EqualFold(message, detail) {
-		return "tracker auth not ready: " + message + ": " + detail
+		reason += ": " + message + ": " + detail
+	} else if message != "" {
+		reason += ": " + message
+	} else if detail != "" {
+		reason += ": " + detail
+	} else if status.Needs2FA {
+		reason += ": manual 2FA required"
+	} else if state := strings.TrimSpace(redaction.RedactValue(status.State, nil)); state != "" {
+		reason += ": " + state
 	}
-	if message != "" {
-		return "tracker auth not ready: " + message
+	if strings.Contains(strings.ToLower(reason), guiTrackerAuthRetryAction) {
+		return reason
 	}
-	if detail != "" {
-		return "tracker auth not ready: " + detail
-	}
-	if status.Needs2FA {
-		return "tracker auth not ready: manual 2FA required; configure tracker auth and retry"
-	}
-	if state := strings.TrimSpace(redaction.RedactValue(status.State, nil)); state != "" {
-		return "tracker auth not ready: " + state
-	}
-	return "tracker auth not ready; configure tracker auth and retry"
+	return reason + "; " + guiTrackerAuthRetryAction
 }

--- a/internal/core/tracker_auth.go
+++ b/internal/core/tracker_auth.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/redaction"
+	"github.com/autobrr/upbrr/internal/trackerauth"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+// dupeSkipCodeTrackerAuthNotReady identifies auth-preflight skips for clients.
+const dupeSkipCodeTrackerAuthNotReady = "tracker_auth_not_ready"
+
+// checkGUIDupesWithAuth validates managed tracker auth before GUI and
+// embedded-web duplicate searches. Trackers needing user action are returned as
+// skipped results while ready and unmanaged trackers continue normally.
+func (c *Core) checkGUIDupesWithAuth(ctx context.Context, mode api.Mode, meta api.PreparedMetadata, trackerIDs []string) (api.DupeCheckSummary, error) {
+	if mode != api.ModeGUI {
+		summary, err := c.services.Dupes.Check(ctx, meta, trackerIDs)
+		if err != nil {
+			return api.DupeCheckSummary{}, fmt.Errorf("dupe service: %w", err)
+		}
+		return summary, nil
+	}
+
+	ready, blocked, err := c.preflightGUITrackerAuth(ctx, meta, trackerIDs)
+	if err != nil {
+		return api.DupeCheckSummary{}, err
+	}
+
+	summary := api.DupeCheckSummary{SourcePath: meta.SourcePath}
+	if len(ready) > 0 || len(blocked) == 0 {
+		summary, err = c.services.Dupes.Check(ctx, meta, ready)
+		if err != nil {
+			return api.DupeCheckSummary{}, fmt.Errorf("dupe service: %w", err)
+		}
+	}
+	summary.Results = append(summary.Results, blocked...)
+	sort.Slice(summary.Results, func(i, j int) bool {
+		return summary.Results[i].Tracker < summary.Results[j].Tracker
+	})
+	return summary, nil
+}
+
+// preflightGUITrackerAuth partitions trackers into auth-ready IDs and blocked
+// dupe results. Unmanaged trackers and trackers already destined for a rule
+// failure remain ready so the dupe service can produce their normal results.
+func (c *Core) preflightGUITrackerAuth(ctx context.Context, meta api.PreparedMetadata, trackerIDs []string) ([]string, []api.DupeCheckResult, error) {
+	if c.services.TrackerAuth == nil {
+		return nil, nil, errors.New("core: tracker auth service not configured")
+	}
+
+	capabilities, err := c.services.TrackerAuth.Capabilities(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("core: tracker auth capabilities: %w", err)
+	}
+	capabilityByTracker := make(map[string]api.TrackerAuthCapability, len(capabilities))
+	for _, capability := range capabilities {
+		name := strings.ToUpper(strings.TrimSpace(capability.TrackerID))
+		if name != "" {
+			capabilityByTracker[name] = capability
+		}
+	}
+
+	readySet := make(map[string]struct{}, len(trackerIDs))
+	managed := make([]string, 0, len(trackerIDs))
+	for _, trackerID := range trackerIDs {
+		name := strings.ToUpper(strings.TrimSpace(trackerID))
+		if name == "" {
+			continue
+		}
+		capability, ok := capabilityByTracker[name]
+		if !ok || !trackerauth.IsManagedCapability(capability) {
+			readySet[name] = struct{}{}
+			continue
+		}
+		if !meta.IgnoreTrackerRuleFailures && len(ruleFailuresForTracker(meta.TrackerRuleFailures, name)) > 0 {
+			readySet[name] = struct{}{}
+			continue
+		}
+		managed = append(managed, name)
+	}
+	if len(managed) == 0 {
+		return orderedReadyTrackers(trackerIDs, readySet), nil, nil
+	}
+
+	c.logger.Infof("core: tracker auth preflight start trackers=%d", len(managed))
+	for _, trackerID := range managed {
+		api.EmitDupeProgress(ctx, api.DupeProgressUpdate{
+			SourcePath: meta.SourcePath,
+			Tracker:    trackerID,
+			Status:     "running",
+			Message:    "checking tracker auth",
+			Total:      len(trackerIDs),
+		})
+	}
+	statuses, err := c.services.TrackerAuth.ValidateMany(ctx, managed)
+	if err != nil {
+		return nil, nil, fmt.Errorf("core: tracker auth validation: %w", err)
+	}
+	if len(statuses) != len(managed) {
+		return nil, nil, fmt.Errorf("core: tracker auth validation returned %d statuses for %d trackers", len(statuses), len(managed))
+	}
+
+	blocked := make([]api.DupeCheckResult, 0, len(managed))
+	for i, trackerID := range managed {
+		status := statuses[i]
+		if trackerauth.IsReadyStatus(status) {
+			readySet[trackerID] = struct{}{}
+			api.EmitDupeProgress(ctx, api.DupeProgressUpdate{
+				SourcePath: meta.SourcePath,
+				Tracker:    trackerID,
+				Status:     "queued",
+				Message:    "tracker auth ready; queued",
+				Total:      len(trackerIDs),
+			})
+			continue
+		}
+
+		reason := guiTrackerAuthSkipReason(status)
+		result := api.DupeCheckResult{
+			Tracker:    trackerID,
+			Skipped:    true,
+			SkipReason: reason,
+			SkipCode:   dupeSkipCodeTrackerAuthNotReady,
+			Status:     "skipped",
+			CheckedAt:  time.Now().UTC(),
+		}
+		blocked = append(blocked, result)
+		c.logger.Warnf("core: tracker auth preflight blocked tracker=%s state=%s reason=%s", trackerID, redaction.RedactValue(status.State, nil), reason)
+		api.EmitDupeProgress(ctx, api.DupeProgressUpdate{
+			SourcePath: meta.SourcePath,
+			Tracker:    trackerID,
+			Status:     "skipped",
+			Message:    reason,
+			Total:      len(trackerIDs),
+			Result:     result,
+		})
+	}
+	ready := orderedReadyTrackers(trackerIDs, readySet)
+	c.logger.Infof("core: tracker auth preflight complete ready=%d skipped=%d", len(ready), len(blocked))
+	return ready, blocked, nil
+}
+
+// orderedReadyTrackers filters and normalizes tracker IDs without changing
+// their input order.
+func orderedReadyTrackers(trackerIDs []string, readySet map[string]struct{}) []string {
+	ready := make([]string, 0, len(readySet))
+	for _, trackerID := range trackerIDs {
+		name := strings.ToUpper(strings.TrimSpace(trackerID))
+		if _, ok := readySet[name]; ok {
+			ready = append(ready, name)
+		}
+	}
+	return ready
+}
+
+// guiTrackerAuthSkipReason builds a redacted user-facing reason, preferring the
+// stable status message before error detail, 2FA state, and raw state.
+func guiTrackerAuthSkipReason(status api.TrackerAuthStatus) string {
+	message := strings.TrimSpace(redaction.RedactValue(status.Message, nil))
+	detail := strings.TrimSpace(redaction.RedactValue(status.LastError, nil))
+	if message != "" && detail != "" && !strings.EqualFold(message, detail) {
+		return "tracker auth not ready: " + message + ": " + detail
+	}
+	if message != "" {
+		return "tracker auth not ready: " + message
+	}
+	if detail != "" {
+		return "tracker auth not ready: " + detail
+	}
+	if status.Needs2FA {
+		return "tracker auth not ready: manual 2FA required; configure tracker auth and retry"
+	}
+	if state := strings.TrimSpace(redaction.RedactValue(status.State, nil)); state != "" {
+		return "tracker auth not ready: " + state
+	}
+	return "tracker auth not ready; configure tracker auth and retry"
+}

--- a/internal/core/tracker_auth_test.go
+++ b/internal/core/tracker_auth_test.go
@@ -80,7 +80,7 @@ func TestCheckGUIDupesWithAuthSkipsBlockedTrackerAndContinuesReadyTrackers(t *te
 		t.Fatalf("expected ready and auth-blocked results, got %#v", summary.Results)
 	}
 	blocked := summary.Results[1]
-	expectedReason := "tracker auth not ready: manual 2FA required"
+	expectedReason := "tracker auth not ready: manual 2FA required; configure tracker auth and retry"
 	if blocked.Tracker != "PTP" || !blocked.Skipped || blocked.SkipCode != dupeSkipCodeTrackerAuthNotReady ||
 		blocked.SkipReason != expectedReason || blocked.Status != "skipped" || blocked.CheckedAt.IsZero() {
 		t.Fatalf("expected PTP auth-required skip, got %#v", blocked)
@@ -93,6 +93,39 @@ func TestCheckGUIDupesWithAuthSkipsBlockedTrackerAndContinuesReadyTrackers(t *te
 	}
 	if !reflect.DeepEqual(progress[1].Result, blocked) {
 		t.Fatalf("expected skipped auth progress result to match summary result, got %#v", progress[1].Result)
+	}
+}
+
+func TestGUITrackerAuthSkipReasonIncludesRetryAction(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		status api.TrackerAuthStatus
+		want   string
+	}{
+		"diagnostic gets action": {
+			status: api.TrackerAuthStatus{
+				Message:   "stored session expired or invalid",
+				LastError: "remote session validation failed",
+			},
+			want: "tracker auth not ready: stored session expired or invalid: remote session validation failed; configure tracker auth and retry",
+		},
+		"existing action is not duplicated": {
+			status: api.TrackerAuthStatus{
+				Message: "stored session expired; configure tracker auth and retry",
+			},
+			want: "tracker auth not ready: stored session expired; configure tracker auth and retry",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := guiTrackerAuthSkipReason(tt.status); got != tt.want {
+				t.Fatalf("guiTrackerAuthSkipReason() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/core/tracker_auth_test.go
+++ b/internal/core/tracker_auth_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package core
+
+import (
+	"context"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/trackerauth"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+type trackerAuthPreflightTestService struct {
+	capabilities []api.TrackerAuthCapability
+	statuses     []api.TrackerAuthStatus
+	validated    []string
+}
+
+func (s *trackerAuthPreflightTestService) Capabilities(context.Context) ([]api.TrackerAuthCapability, error) {
+	return append([]api.TrackerAuthCapability(nil), s.capabilities...), nil
+}
+
+func (s *trackerAuthPreflightTestService) ValidateMany(_ context.Context, trackerIDs []string) ([]api.TrackerAuthStatus, error) {
+	s.validated = append([]string(nil), trackerIDs...)
+	return append([]api.TrackerAuthStatus(nil), s.statuses...), nil
+}
+
+type trackerAuthPreflightDupeService struct {
+	trackers []string
+}
+
+func (s *trackerAuthPreflightDupeService) Check(_ context.Context, meta api.PreparedMetadata, trackerIDs []string) (api.DupeCheckSummary, error) {
+	s.trackers = append([]string(nil), trackerIDs...)
+	results := make([]api.DupeCheckResult, 0, len(trackerIDs))
+	for _, trackerID := range trackerIDs {
+		results = append(results, api.DupeCheckResult{Tracker: trackerID, Status: "completed"})
+	}
+	return api.DupeCheckSummary{SourcePath: meta.SourcePath, Results: results}, nil
+}
+
+func TestCheckGUIDupesWithAuthSkipsBlockedTrackerAndContinuesReadyTrackers(t *testing.T) {
+	t.Parallel()
+
+	auth := &trackerAuthPreflightTestService{
+		capabilities: []api.TrackerAuthCapability{{TrackerID: "PTP", SupportsLogin: true, SupportsManual2FA: true}},
+		statuses: []api.TrackerAuthStatus{{
+			TrackerID: "PTP",
+			State:     trackerauth.StateLoginRequired,
+			Needs2FA:  true,
+			Message:   "manual 2FA required",
+		}},
+	}
+	dupes := &trackerAuthPreflightDupeService{}
+	coreSvc := &Core{
+		logger: api.NopLogger{},
+		services: api.ServiceSet{
+			Dupes:       dupes,
+			TrackerAuth: auth,
+		},
+	}
+	var progress []api.DupeProgressUpdate
+	ctx := api.WithDupeProgressReporter(context.Background(), func(update api.DupeProgressUpdate) {
+		progress = append(progress, update)
+	})
+
+	summary, err := coreSvc.checkGUIDupesWithAuth(ctx, api.ModeGUI, api.PreparedMetadata{SourcePath: "source.mkv"}, []string{"PTP", "AITHER"})
+	if err != nil {
+		t.Fatalf("check GUI dupes with auth: %v", err)
+	}
+	if !slices.Equal(auth.validated, []string{"PTP"}) {
+		t.Fatalf("expected managed auth validation for PTP, got %v", auth.validated)
+	}
+	if !slices.Equal(dupes.trackers, []string{"AITHER"}) {
+		t.Fatalf("expected only auth-ready trackers to reach dupe checking, got %v", dupes.trackers)
+	}
+	if len(summary.Results) != 2 {
+		t.Fatalf("expected ready and auth-blocked results, got %#v", summary.Results)
+	}
+	blocked := summary.Results[1]
+	expectedReason := "tracker auth not ready: manual 2FA required"
+	if blocked.Tracker != "PTP" || !blocked.Skipped || blocked.SkipCode != dupeSkipCodeTrackerAuthNotReady ||
+		blocked.SkipReason != expectedReason || blocked.Status != "skipped" || blocked.CheckedAt.IsZero() {
+		t.Fatalf("expected PTP auth-required skip, got %#v", blocked)
+	}
+	if len(progress) != 2 || progress[0].Status != "running" || progress[1].Status != "skipped" {
+		t.Fatalf("expected running then skipped auth progress, got %#v", progress)
+	}
+	if progress[1].Message != expectedReason {
+		t.Fatalf("expected skipped auth progress message %q, got %q", expectedReason, progress[1].Message)
+	}
+	if !reflect.DeepEqual(progress[1].Result, blocked) {
+		t.Fatalf("expected skipped auth progress result to match summary result, got %#v", progress[1].Result)
+	}
+}
+
+func TestCheckGUIDupesWithAuthPreservesReadyTrackerOrder(t *testing.T) {
+	t.Parallel()
+
+	auth := &trackerAuthPreflightTestService{
+		capabilities: []api.TrackerAuthCapability{{TrackerID: "PTP", SupportsLogin: true}},
+		statuses:     []api.TrackerAuthStatus{{TrackerID: "PTP", State: trackerauth.StateConfigured}},
+	}
+	dupes := &trackerAuthPreflightDupeService{}
+	coreSvc := &Core{logger: api.NopLogger{}, services: api.ServiceSet{Dupes: dupes, TrackerAuth: auth}}
+
+	_, err := coreSvc.checkGUIDupesWithAuth(context.Background(), api.ModeGUI, api.PreparedMetadata{SourcePath: "source.mkv"}, []string{"PTP", "AITHER"})
+	if err != nil {
+		t.Fatalf("check GUI dupes with auth: %v", err)
+	}
+	if !slices.Equal(dupes.trackers, []string{"PTP", "AITHER"}) {
+		t.Fatalf("expected input tracker order after auth preflight, got %v", dupes.trackers)
+	}
+}
+
+func TestCheckGUIDupesWithAuthAvoidsAuthForRuleFailedTracker(t *testing.T) {
+	t.Parallel()
+
+	auth := &trackerAuthPreflightTestService{
+		capabilities: []api.TrackerAuthCapability{{TrackerID: "PTP", SupportsLogin: true}},
+	}
+	dupes := &trackerAuthPreflightDupeService{}
+	coreSvc := &Core{logger: api.NopLogger{}, services: api.ServiceSet{Dupes: dupes, TrackerAuth: auth}}
+	meta := api.PreparedMetadata{
+		SourcePath: "source.mkv",
+		TrackerRuleFailures: map[string][]api.RuleFailure{
+			"PTP": {{Rule: "example_rule", Reason: "example rule failed"}},
+		},
+	}
+
+	_, err := coreSvc.checkGUIDupesWithAuth(context.Background(), api.ModeGUI, meta, []string{"PTP"})
+	if err != nil {
+		t.Fatalf("check GUI dupes with auth: %v", err)
+	}
+	if len(auth.validated) != 0 {
+		t.Fatalf("expected terminal rule failure to skip auth validation, got %v", auth.validated)
+	}
+	if !slices.Equal(dupes.trackers, []string{"PTP"}) {
+		t.Fatalf("expected dupe service to retain rule-failed tracker for its skip result, got %v", dupes.trackers)
+	}
+}
+
+func TestCheckGUIDupesWithAuthLeavesCLIAuthOwnershipUnchanged(t *testing.T) {
+	t.Parallel()
+
+	auth := &trackerAuthPreflightTestService{
+		capabilities: []api.TrackerAuthCapability{{TrackerID: "PTP", SupportsLogin: true}},
+	}
+	dupes := &trackerAuthPreflightDupeService{}
+	coreSvc := &Core{logger: api.NopLogger{}, services: api.ServiceSet{Dupes: dupes, TrackerAuth: auth}}
+
+	_, err := coreSvc.checkGUIDupesWithAuth(context.Background(), api.ModeCLI, api.PreparedMetadata{SourcePath: "source.mkv"}, []string{"PTP"})
+	if err != nil {
+		t.Fatalf("check CLI dupes: %v", err)
+	}
+	if len(auth.validated) != 0 {
+		t.Fatalf("expected CLI preflight to remain entrypoint-owned, got %v", auth.validated)
+	}
+}

--- a/internal/guiapp/dupe_jobs.go
+++ b/internal/guiapp/dupe_jobs.go
@@ -353,7 +353,7 @@ func (a *App) applyDupeProgress(ctx context.Context, job *dupeCheckJob, update a
 			job.completedCount++
 		}
 	}
-	if update.Total > 0 {
+	if update.Total > job.totalCount {
 		job.totalCount = update.Total
 	}
 	job.states[tracker] = state

--- a/internal/guiapp/dupe_jobs.go
+++ b/internal/guiapp/dupe_jobs.go
@@ -328,7 +328,9 @@ func (a *App) applyDupeProgress(ctx context.Context, job *dupeCheckJob, update a
 	if state.Tracker == "" {
 		state.Tracker = tracker
 		job.trackers = append(job.trackers, tracker)
-		job.totalCount++
+		if update.Total <= 0 {
+			job.totalCount++
+		}
 	}
 	previousStatus := state.Status
 	state.Status = strings.TrimSpace(update.Status)

--- a/internal/guiapp/run_options_test.go
+++ b/internal/guiapp/run_options_test.go
@@ -635,6 +635,38 @@ func TestRunDupeCheckJobSplitsGroupedPathedResultsIntoTrackerStates(t *testing.T
 	}
 }
 
+func TestApplyDupeProgressCountsNewTrackersWithoutInflatingExplicitTotal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		startTotal  int
+		updateTotal int
+		wantTotal   int
+	}{
+		{name: "explicit total", startTotal: 2, updateTotal: 2, wantTotal: 2},
+		{name: "total omitted", startTotal: 1, wantTotal: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			job := newDupeCheckJobTestJob(`C:\Media\Example.Release.2026.1080p-GRP.mkv`, []string{"AITHER"})
+			job.totalCount = tt.startTotal
+
+			(&App{}).applyDupeProgress(context.Background(), job, api.DupeProgressUpdate{
+				Tracker: "BLU",
+				Status:  "running",
+				Total:   tt.updateTotal,
+			})
+
+			if job.totalCount != tt.wantTotal {
+				t.Fatalf("expected total count %d, got %d", tt.wantTotal, job.totalCount)
+			}
+		})
+	}
+}
+
 func TestRunDupeCheckJobUsesJobCoreSnapshot(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackerauth/adapters.go
+++ b/internal/trackerauth/adapters.go
@@ -31,7 +31,7 @@ func defaultAdapters() map[string]Adapter {
 	for _, spec := range builtInSpecs() {
 		switch spec.id {
 		case "AR":
-			adapters[spec.id] = trackerAdapter{capability: validationOnlyCapability(spec), resolve: resolveARStoredSessionForTrackerAuth}
+			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: resolveARSessionForTrackerAuth}
 		case "BTN":
 			adapters[spec.id] = trackerAdapter{capability: capabilityFromSpec(spec), resolve: btn.ResolveSessionForTrackerAuthLogin}
 		case "FF":
@@ -51,17 +51,6 @@ func defaultAdapters() map[string]Adapter {
 		}
 	}
 	return adapters
-}
-
-// validationOnlyCapability keeps cookie import visible while hiding credential
-// login actions for adapters that can only test existing auth material.
-func validationOnlyCapability(spec trackerSpec) api.TrackerAuthCapability {
-	capability := capabilityFromSpec(spec)
-	capability.SupportsLogin = false
-	capability.SupportsAutoLogin = false
-	capability.SupportsTOTP = false
-	capability.SupportsManual2FA = false
-	return capability
 }
 
 func (s *Service) adapterFor(trackerID string) (Adapter, bool) {

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -49,6 +49,8 @@ const (
 
 	// maxConcurrentValidations bounds simultaneous tracker and auth DB work.
 	maxConcurrentValidations = 4
+
+	expiredSessionActionMessage = "stored session expired or invalid; log in again or import fresh cookies"
 )
 
 // Service reports and manages persisted tracker auth material for configured trackers.
@@ -57,6 +59,7 @@ type Service struct {
 	adapters           map[string]Adapter
 	challenges         *ChallengeManager
 	logger             api.Logger
+	now                func() time.Time
 	afterDeleteCleanup func()
 }
 
@@ -92,6 +95,7 @@ func NewServiceWithLogger(cfg config.Config, logger api.Logger) *Service {
 		adapters:   defaultAdapters(),
 		challenges: sharedChallengeManager,
 		logger:     logger,
+		now:        time.Now,
 	}
 }
 
@@ -235,7 +239,8 @@ func (s *Service) ImportCookies(ctx context.Context, trackerID string, fileName 
 // tracker has an adapter. Confirmed-invalid stored sessions are deleted and
 // reported as login-required status without returning an error. BTN session
 // success remains login-required until the API token needed for torrent
-// resolution is configured.
+// resolution is configured. Returned cookie counts and RFC3339 timestamps are
+// rebuilt after login or deletion side effects complete.
 func (s *Service) Validate(ctx context.Context, trackerID string) (status api.TrackerAuthStatus, err error) {
 	defer func() {
 		if err != nil {
@@ -261,6 +266,7 @@ func (s *Service) Validate(ctx context.Context, trackerID string) (status api.Tr
 			AutoLogin: true,
 		})
 		if ensureErr != nil {
+			status = s.statusForSpec(ctx, spec)
 			applyEnsureErrorToStatus(&status, ensureErr)
 			if session.ChallengeID != "" {
 				status.ChallengeID = session.ChallengeID
@@ -537,7 +543,7 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) api.Track
 		TrackerID:        spec.id,
 		DisplayName:      spec.id,
 		State:            StateNotConfigured,
-		LastCheckedAt:    time.Now().UTC().Format(time.RFC3339),
+		LastCheckedAt:    s.currentTime().UTC().Format(time.RFC3339),
 		EncryptedStorage: encryptedStorage,
 	}
 
@@ -594,6 +600,15 @@ func (s *Service) statusForSpec(ctx context.Context, spec trackerSpec) api.Track
 		status.Message = btnMissingAPIKeyMessage()
 	}
 	return status
+}
+
+// currentTime returns the service clock, falling back to the wall clock for
+// zero-value or test-constructed services without an injected clock.
+func (s *Service) currentTime() time.Time {
+	if s != nil && s.now != nil {
+		return s.now()
+	}
+	return time.Now()
 }
 
 // btnAPIKeyConfigured reports whether BTN has an API token in tracker config or
@@ -1195,8 +1210,9 @@ func mustTrackerConfig(cfg config.Config, trackerID string) config.TrackerConfig
 	return trackerCfg
 }
 
-// applyEnsureErrorToStatus maps typed ensure errors onto API status without
-// exposing an unactionable 2FA state when no challenge id exists.
+// applyEnsureErrorToStatus maps typed ensure errors onto API status. Confirmed
+// invalid sessions clear the reported cookie count and include recovery action;
+// 2FA is actionable only when a reusable challenge id exists.
 func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
 	status.LastError = redact(err.Error())
 	status.Message = "remote auth test failed"
@@ -1212,7 +1228,7 @@ func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
 		status.State = StateLoginRequired
 		if validation, ok := asValidationError(err); ok && validation.ConfirmedInvalid {
 			status.CookieCount = 0
-			status.Message = "stored session expired or invalid"
+			status.Message = expiredSessionActionMessage
 		} else {
 			status.Message = "login credentials or imported cookies required"
 		}
@@ -1246,7 +1262,7 @@ func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
 	if errors.As(err, &validation) && validation.ConfirmedInvalid {
 		status.State = StateLoginRequired
 		status.CookieCount = 0
-		status.Message = "stored session expired or invalid"
+		status.Message = expiredSessionActionMessage
 	}
 }
 

--- a/internal/trackerauth/service.go
+++ b/internal/trackerauth/service.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/autobrr/upbrr/internal/authmaterial"
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/cookies"
@@ -44,6 +46,9 @@ const (
 	StateLoginRequired = "login_required"
 	// StateEncryptedStorageUnavailable means cookie import cannot be used until web auth material exists.
 	StateEncryptedStorageUnavailable = "encrypted_storage_unavailable"
+
+	// maxConcurrentValidations bounds simultaneous tracker and auth DB work.
+	maxConcurrentValidations = 4
 )
 
 // Service reports and manages persisted tracker auth material for configured trackers.
@@ -274,6 +279,58 @@ func (s *Service) Validate(ctx context.Context, trackerID string) (status api.Tr
 	}
 	status.Message = "remote auth validation is not supported for this tracker"
 	return status, nil
+}
+
+// ValidateMany validates every tracker concurrently and returns statuses in
+// input order. It waits for the full batch with bounded concurrency; if any
+// validation fails, it returns the first input-ordered error and no statuses.
+func (s *Service) ValidateMany(ctx context.Context, trackerIDs []string) ([]api.TrackerAuthStatus, error) {
+	statuses := make([]api.TrackerAuthStatus, len(trackerIDs))
+	errs := make([]error, len(trackerIDs))
+
+	var group errgroup.Group
+	group.SetLimit(maxConcurrentValidations)
+	for i, trackerID := range trackerIDs {
+		group.Go(func() error {
+			statuses[i], errs[i] = s.Validate(ctx, trackerID)
+			return nil
+		})
+	}
+	_ = group.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			return nil, fmt.Errorf("tracker auth: validate %s: %w", trackerLogID(trackerIDs[i]), err)
+		}
+	}
+	return statuses, nil
+}
+
+// IsManagedCapability reports whether a capability requires session, login,
+// refresh, or 2FA handling rather than only static API-key/passkey config.
+func IsManagedCapability(capability api.TrackerAuthCapability) bool {
+	authKind := strings.ToLower(strings.TrimSpace(capability.AuthKind))
+	return capability.SupportsCookieFile ||
+		capability.SupportsLogin ||
+		capability.SupportsAutoLogin ||
+		capability.SupportsTOTP ||
+		capability.SupportsManual2FA ||
+		strings.Contains(authKind, "refresh") ||
+		strings.Contains(authKind, "2fa")
+}
+
+// IsReadyStatus reports whether a status represents usable auth without further
+// user input. A pending 2FA challenge is never ready, regardless of state.
+func IsReadyStatus(status api.TrackerAuthStatus) bool {
+	if status.Needs2FA {
+		return false
+	}
+	switch strings.TrimSpace(status.State) {
+	case StateConfigured, StateHasCookies:
+		return true
+	default:
+		return false
+	}
 }
 
 // Login runs credential-based tracker auth when supported and returns status for

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -528,7 +528,7 @@ func TestValidateARStoredCookies(t *testing.T) {
 		t.Fatalf("SaveTrackerCookieMap: %v", err)
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/torrents.php" {
+		if r.URL.Path != arIndexPath {
 			http.NotFound(w, r)
 			return
 		}
@@ -536,7 +536,7 @@ func TestValidateARStoredCookies(t *testing.T) {
 			t.Error("expected AR session cookie")
 			return
 		}
-		_, _ = w.Write([]byte(`<a href="/torrents.php?action=download&id=1&auth=session-key">Download</a>`))
+		_, _ = w.Write([]byte(`<a href="https://alpharatio.cc/logout.php?auth=session-key">Logout</a>`))
 	}))
 	t.Cleanup(server.Close)
 
@@ -575,6 +575,7 @@ func TestValidateARAutoLoginReplacesMissingOrExpiredCookies(t *testing.T) {
 			}
 
 			var loginCalls atomic.Int32
+			var indexCalls atomic.Int32
 			var invalidLoginForm atomic.Bool
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
@@ -584,14 +585,15 @@ func TestValidateARAutoLoginReplacesMissingOrExpiredCookies(t *testing.T) {
 						invalidLoginForm.Store(true)
 					}
 					http.SetCookie(w, &http.Cookie{Name: "session", Value: "refreshed", Path: "/"})
-					w.WriteHeader(http.StatusOK)
-				case arBrowsePath:
+					http.Redirect(w, r, arIndexPath, http.StatusFound)
+				case arIndexPath:
+					indexCalls.Add(1)
 					cookie, cookieErr := r.Cookie("session")
 					if cookieErr != nil || cookie.Value != "refreshed" {
 						_, _ = w.Write([]byte(`login.php?act=recover`))
 						return
 					}
-					_, _ = w.Write([]byte(`<a href="/torrents.php?action=download&amp;id=123&amp;auth=session-key">Download</a>`))
+					_, _ = w.Write([]byte(`<a href="https://alpharatio.cc/logout.php?auth=session-key">Logout</a>`))
 				default:
 					http.NotFound(w, r)
 				}
@@ -612,6 +614,13 @@ func TestValidateARAutoLoginReplacesMissingOrExpiredCookies(t *testing.T) {
 			}
 			if loginCalls.Load() != 1 || invalidLoginForm.Load() {
 				t.Fatal("expected one AR login with configured credentials")
+			}
+			wantIndexCalls := int32(2)
+			if tt.seedExpired {
+				wantIndexCalls++
+			}
+			if indexCalls.Load() != wantIndexCalls {
+				t.Fatalf("expected AR login redirect plus session validation, got %d index requests", indexCalls.Load())
 			}
 			values, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "AR")
 			if err != nil {
@@ -883,23 +892,74 @@ func TestValidateFLLoginPersistsCookies(t *testing.T) {
 	}
 }
 
+func TestValidateFLLoginDoesNotPersistUnverifiedCookies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case flLoginPagePath:
+			_, _ = w.Write([]byte(`<input name="validator" value="token">`))
+		case flLoginPath:
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "unverified", Path: "/"})
+			http.Redirect(w, r, flIndexPath, http.StatusFound)
+		case flIndexPath:
+			_, _ = w.Write([]byte(`<input name="username">`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	status, err := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"FL": {URL: server.URL, Username: "user", Password: "pass"},
+		}},
+	}).Validate(ctx, "FL")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.State != StateLoginRequired || status.CookieCount != 0 {
+		t.Fatalf("expected unverified FL login to remain login required, got %#v", status)
+	}
+	if _, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "FL"); err == nil {
+		t.Fatal("unverified FL login cookies were persisted")
+	}
+}
+
 func TestValidateTHRChecksCredentialLogin(t *testing.T) {
 	t.Parallel()
 
+	handlerErr := make(chan error, 4)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/takelogin.php" {
+		switch r.URL.Path {
+		case "/login.php":
+			http.SetCookie(w, &http.Cookie{Name: "bootstrap", Value: "ready", Path: "/"})
+			_, _ = w.Write([]byte(`<input type="hidden" name="token" value="login-token">`))
+		case "/takelogin.php":
+			if err := r.ParseForm(); err != nil {
+				handlerErr <- fmt.Errorf("parse THR login form: %w", err)
+				return
+			}
+			if r.FormValue("username") != "user" || r.FormValue("password") != "pass" || r.FormValue("ssl") != "yes" || r.FormValue("token") != "login-token" {
+				handlerErr <- errors.New("unexpected THR login form")
+			}
+			if cookie, err := r.Cookie("bootstrap"); err != nil || cookie.Value != "ready" {
+				handlerErr <- errors.New("THR login bootstrap cookie missing")
+			}
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "authenticated", Path: "/"})
+			http.Redirect(w, r, "/index.php", http.StatusFound)
+		case "/index.php":
+			if cookie, err := r.Cookie("session"); err != nil || cookie.Value != "authenticated" {
+				handlerErr <- errors.New("THR redirect session cookie missing")
+				return
+			}
+			_, _ = w.Write([]byte(`<a href="logout.php">Logout</a>`))
+		default:
 			http.NotFound(w, r)
-			return
 		}
-		if err := r.ParseForm(); err != nil {
-			t.Errorf("ParseForm: %v", err)
-			return
-		}
-		if r.FormValue("username") != "user" || r.FormValue("password") != "pass" || r.FormValue("ssl") != "yes" {
-			t.Error("unexpected THR login form")
-			return
-		}
-		_, _ = w.Write([]byte(`<a href="logout.php">Logout</a>`))
 	}))
 	t.Cleanup(server.Close)
 
@@ -915,6 +975,10 @@ func TestValidateTHRChecksCredentialLogin(t *testing.T) {
 	}
 	if status.State != StateConfigured {
 		t.Fatalf("expected THR configured after login check, got %#v", status)
+	}
+	close(handlerErr)
+	for err := range handlerErr {
+		t.Error(err)
 	}
 }
 

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -3032,7 +3032,12 @@ func TestValidateManyRunsTrackerChecksConcurrentlyAndPreservesOrder(t *testing.T
 		releaseValidation(trackerID)
 	}
 
-	got := <-resultCh
+	var got result
+	select {
+	case got = <-resultCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ValidateMany did not return after all validations were released")
+	}
 	if got.err != nil {
 		t.Fatalf("ValidateMany: %v", got.err)
 	}

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -402,18 +402,33 @@ func TestValidateBTNInvalidCookiesDeletesOnlyConfirmedInvalid(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	status, err := NewService(config.Config{
+	service := NewService(config.Config{
 		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
 		Metadata:     config.MetadataConfig{BTNAPI: "legacy-token"},
 		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
 			"BTN": {URL: server.URL},
 		}},
-	}).Validate(ctx, "BTN")
+	})
+	preEffectTime := time.Date(2026, time.July, 11, 1, 2, 3, 0, time.UTC)
+	postEffectTime := preEffectTime.Add(time.Minute)
+	nowCalls := 0
+	service.now = func() time.Time {
+		nowCalls++
+		if nowCalls == 1 {
+			return preEffectTime
+		}
+		return postEffectTime
+	}
+
+	status, err := service.Validate(ctx, "BTN")
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
 	if status.State != StateLoginRequired || status.CookieCount != 0 {
 		t.Fatalf("expected confirmed-invalid BTN cookies to be deleted, got %#v", status)
+	}
+	if status.LastCheckedAt != postEffectTime.Format(time.RFC3339) {
+		t.Fatalf("expected post-deletion LastCheckedAt %q, got %q", postEffectTime.Format(time.RFC3339), status.LastCheckedAt)
 	}
 	if _, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "BTN"); err == nil {
 		t.Fatal("expected BTN cookies to be deleted")
@@ -700,7 +715,7 @@ func TestValidateHDBInvalidCookiesDeletesSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
-	if status.State != StateLoginRequired || status.CookieCount != 0 || status.Message != "stored session expired or invalid" {
+	if status.State != StateLoginRequired || status.CookieCount != 0 || status.Message != "stored session expired or invalid; log in again or import fresh cookies" {
 		t.Fatalf("expected HDB login-required expired-session status, got %#v", status)
 	}
 	if _, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "HDB"); err == nil {
@@ -2274,7 +2289,7 @@ func TestApplyEnsureErrorToStatusKeepsStateMessageParity(t *testing.T) {
 		"confirmed invalid": {
 			err:         &ValidationError{TrackerID: "PTP", ConfirmedInvalid: true, Err: errors.New("expired")},
 			wantState:   StateLoginRequired,
-			wantMessage: "stored session expired or invalid",
+			wantMessage: "stored session expired or invalid; log in again or import fresh cookies",
 		},
 		"2FA with challenge": {
 			err:         &Needs2FAError{TrackerID: "PTP", ChallengeID: "challenge-1"},

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -2953,15 +2953,24 @@ func TestValidateManyRunsTrackerChecksConcurrentlyAndPreservesOrder(t *testing.T
 	t.Parallel()
 
 	dbPath := newTrackerAuthTestDB(t)
-	entered := make(chan string, 2)
-	release := make(chan struct{})
-	released := false
+	trackerIDs := [maxConcurrentValidations + 1]string{"PTP", "MTV", "RTF", "AR", "HDB"}
+	entered := make(chan string, len(trackerIDs))
+	releases := make(map[string]chan struct{}, len(trackerIDs))
+	released := make(map[string]bool, len(trackerIDs))
+	releaseValidation := func(trackerID string) {
+		if !released[trackerID] {
+			close(releases[trackerID])
+			released[trackerID] = true
+		}
+	}
 	defer func() {
-		if !released {
-			close(release)
+		for _, trackerID := range trackerIDs {
+			releaseValidation(trackerID)
 		}
 	}()
 	newBlockingAdapter := func(trackerID string) *fakeAdapter {
+		release := make(chan struct{})
+		releases[trackerID] = release
 		return &fakeAdapter{
 			capability: api.TrackerAuthCapability{TrackerID: trackerID, SupportsLogin: true},
 			validate: func() (Session, error) {
@@ -2971,15 +2980,17 @@ func TestValidateManyRunsTrackerChecksConcurrentlyAndPreservesOrder(t *testing.T
 			},
 		}
 	}
+	trackerConfigs := make(map[string]config.TrackerConfig, len(trackerIDs))
+	for _, trackerID := range trackerIDs {
+		trackerConfigs[trackerID] = config.TrackerConfig{}
+	}
 	service := NewService(config.Config{
 		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
-		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
-			"MTV": {},
-			"PTP": {},
-		}},
+		Trackers:     config.TrackersConfig{Trackers: trackerConfigs},
 	})
-	service.adapters["MTV"] = newBlockingAdapter("MTV")
-	service.adapters["PTP"] = newBlockingAdapter("PTP")
+	for _, trackerID := range trackerIDs {
+		service.adapters[trackerID] = newBlockingAdapter(trackerID)
+	}
 
 	type result struct {
 		statuses []api.TrackerAuthStatus
@@ -2987,31 +2998,54 @@ func TestValidateManyRunsTrackerChecksConcurrentlyAndPreservesOrder(t *testing.T
 	}
 	resultCh := make(chan result, 1)
 	go func() {
-		statuses, err := service.ValidateMany(context.Background(), []string{"PTP", "MTV"})
+		statuses, err := service.ValidateMany(context.Background(), trackerIDs[:])
 		resultCh <- result{statuses: statuses, err: err}
 	}()
 
-	seen := make(map[string]bool, 2)
-	for range 2 {
+	seen := make(map[string]bool, len(trackerIDs))
+	firstEntered := ""
+	for range maxConcurrentValidations {
 		select {
 		case trackerID := <-entered:
 			seen[trackerID] = true
+			if firstEntered == "" {
+				firstEntered = trackerID
+			}
 		case <-time.After(2 * time.Second):
-			t.Fatal("tracker validations did not overlap")
+			t.Fatal("concurrent tracker validations did not reach the limit")
 		}
 	}
-	close(release)
-	released = true
+	select {
+	case trackerID := <-entered:
+		t.Fatalf("expected only %d concurrent validations, but %s also entered", maxConcurrentValidations, trackerID)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	releaseValidation(firstEntered)
+	select {
+	case trackerID := <-entered:
+		seen[trackerID] = true
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued tracker validation did not enter after a slot was released")
+	}
+	for _, trackerID := range trackerIDs {
+		releaseValidation(trackerID)
+	}
 
 	got := <-resultCh
 	if got.err != nil {
 		t.Fatalf("ValidateMany: %v", got.err)
 	}
-	if !seen["PTP"] || !seen["MTV"] {
-		t.Fatalf("expected both tracker validations to start, got %#v", seen)
+	if len(seen) != len(trackerIDs) {
+		t.Fatalf("expected all tracker validations to start, got %#v", seen)
 	}
-	if len(got.statuses) != 2 || got.statuses[0].TrackerID != "PTP" || got.statuses[1].TrackerID != "MTV" {
+	if len(got.statuses) != len(trackerIDs) {
 		t.Fatalf("expected input-ordered statuses, got %#v", got.statuses)
+	}
+	for i, trackerID := range trackerIDs {
+		if got.statuses[i].TrackerID != trackerID || got.statuses[i].State != StateConfigured {
+			t.Fatalf("expected successful input-ordered status for %s, got %#v", trackerID, got.statuses[i])
+		}
 	}
 }
 

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -554,6 +554,117 @@ func TestValidateARStoredCookies(t *testing.T) {
 	}
 }
 
+func TestValidateARAutoLoginReplacesMissingOrExpiredCookies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		seedExpired bool
+	}{
+		{name: "missing cookies"},
+		{name: "expired cookies", seedExpired: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			dbPath := newTrackerAuthTestDB(t)
+			if tt.seedExpired {
+				if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "AR", map[string]string{"session": "expired"}); err != nil {
+					t.Fatalf("SaveTrackerCookieMap: %v", err)
+				}
+			}
+
+			var loginCalls atomic.Int32
+			var invalidLoginForm atomic.Bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case arLoginPath:
+					loginCalls.Add(1)
+					if r.FormValue("username") != "user" || r.FormValue("password") != "password" || r.FormValue("keeplogged") != "1" {
+						invalidLoginForm.Store(true)
+					}
+					http.SetCookie(w, &http.Cookie{Name: "session", Value: "refreshed", Path: "/"})
+					w.WriteHeader(http.StatusOK)
+				case arBrowsePath:
+					cookie, cookieErr := r.Cookie("session")
+					if cookieErr != nil || cookie.Value != "refreshed" {
+						_, _ = w.Write([]byte(`login.php?act=recover`))
+						return
+					}
+					_, _ = w.Write([]byte(`<a href="/torrents.php?action=download&amp;id=123&amp;auth=session-key">Download</a>`))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			status, err := NewService(config.Config{
+				MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+				Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+					"AR": {URL: server.URL, Username: "user", Password: "password"},
+				}},
+			}).Validate(ctx, "AR")
+			if err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			if status.State != StateConfigured || status.Message != "remote auth check succeeded" {
+				t.Fatalf("expected successful AR auto-login, got %#v", status)
+			}
+			if loginCalls.Load() != 1 || invalidLoginForm.Load() {
+				t.Fatal("expected one AR login with configured credentials")
+			}
+			values, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "AR")
+			if err != nil {
+				t.Fatalf("LoadTrackerCookieMap: %v", err)
+			}
+			if values["session"] != "refreshed" {
+				t.Fatal("expected refreshed AR session cookie")
+			}
+		})
+	}
+}
+
+func TestValidateARTransientFailurePreservesCookiesWithoutLogin(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := newTrackerAuthTestDB(t)
+	if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "AR", map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	var loginCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == arLoginPath {
+			loginCalls.Add(1)
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	status, err := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"AR": {URL: server.URL, Username: "user", Password: "password"},
+		}},
+	}).Validate(ctx, "AR")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if status.Message != "remote auth test failed" {
+		t.Fatalf("expected transient AR validation status, got %#v", status)
+	}
+	if loginCalls.Load() != 0 {
+		t.Fatal("transient AR failure must not trigger credential login")
+	}
+	values, err := cookies.LoadTrackerCookieMap(ctx, dbPath, "AR")
+	if err != nil {
+		t.Fatalf("LoadTrackerCookieMap: %v", err)
+	}
+	if values["session"] != "existing" {
+		t.Fatal("transient AR failure must preserve stored cookies")
+	}
+}
+
 func TestValidateHDBInvalidCookiesDeletesSession(t *testing.T) {
 	t.Parallel()
 
@@ -2367,8 +2478,8 @@ func TestCapabilitiesAdvertiseOnlySupportedManual2FA(t *testing.T) {
 				t.Fatalf("%s must not advertise 2FA actions: %#v", cap.TrackerID, cap)
 			}
 		case "AR":
-			if cap.SupportsLogin || cap.SupportsAutoLogin || cap.SupportsManual2FA {
-				t.Fatalf("%s auth check is validation-only in tracker-auth UI: %#v", cap.TrackerID, cap)
+			if !cap.SupportsLogin || !cap.SupportsAutoLogin || cap.SupportsManual2FA {
+				t.Fatalf("%s must advertise credential auto-login without manual 2FA: %#v", cap.TrackerID, cap)
 			}
 			if !cap.SupportsCookieFile {
 				t.Fatalf("%s must keep cookie import capability: %#v", cap.TrackerID, cap)

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/autobrr/upbrr/internal/authmaterial"
 	"github.com/autobrr/upbrr/internal/config"
@@ -2945,6 +2946,72 @@ func TestValidateTransientAdapterFailurePreservesCookieCount(t *testing.T) {
 	}
 	if values["session"] != "abc" {
 		t.Fatal("expected transient adapter failure to preserve cookies")
+	}
+}
+
+func TestValidateManyRunsTrackerChecksConcurrentlyAndPreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newTrackerAuthTestDB(t)
+	entered := make(chan string, 2)
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+	newBlockingAdapter := func(trackerID string) *fakeAdapter {
+		return &fakeAdapter{
+			capability: api.TrackerAuthCapability{TrackerID: trackerID, SupportsLogin: true},
+			validate: func() (Session, error) {
+				entered <- trackerID
+				<-release
+				return Session{TrackerID: trackerID, State: SessionStateReady}, nil
+			},
+		}
+	}
+	service := NewService(config.Config{
+		MainSettings: config.MainSettingsConfig{DBPath: dbPath},
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"MTV": {},
+			"PTP": {},
+		}},
+	})
+	service.adapters["MTV"] = newBlockingAdapter("MTV")
+	service.adapters["PTP"] = newBlockingAdapter("PTP")
+
+	type result struct {
+		statuses []api.TrackerAuthStatus
+		err      error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		statuses, err := service.ValidateMany(context.Background(), []string{"PTP", "MTV"})
+		resultCh <- result{statuses: statuses, err: err}
+	}()
+
+	seen := make(map[string]bool, 2)
+	for range 2 {
+		select {
+		case trackerID := <-entered:
+			seen[trackerID] = true
+		case <-time.After(2 * time.Second):
+			t.Fatal("tracker validations did not overlap")
+		}
+	}
+	close(release)
+	released = true
+
+	got := <-resultCh
+	if got.err != nil {
+		t.Fatalf("ValidateMany: %v", got.err)
+	}
+	if !seen["PTP"] || !seen["MTV"] {
+		t.Fatalf("expected both tracker validations to start, got %#v", seen)
+	}
+	if len(got.statuses) != 2 || got.statuses[0].TrackerID != "PTP" || got.statuses[1].TrackerID != "MTV" {
+		t.Fatalf("expected input-ordered statuses, got %#v", got.statuses)
 	}
 }
 

--- a/internal/trackerauth/site_validators.go
+++ b/internal/trackerauth/site_validators.go
@@ -27,6 +27,7 @@ const (
 	arDefaultBaseURL  = "https://alpharatio.cc"
 	authPreviewBytes  = 64 * 1024
 	arBrowsePath      = "/torrents.php"
+	arLoginPath       = "/login.php"
 	ffDefaultBaseURL  = "https://www.funfile.org"
 	ffLoginPath       = "/takelogin.php"
 	ffUploadPath      = "/upload.php"
@@ -43,16 +44,36 @@ const (
 // flValidatorPattern extracts the anti-CSRF validator required by FL login.
 var flValidatorPattern = regexp.MustCompile(`name="validator"\s+value="([^"]+)"`)
 
-// resolveARStoredSessionForTrackerAuth verifies imported AR cookies against
-// the browse page. Missing cookies require user auth material, login redirects
-// or logged-out page markers invalidate stored cookies, and transport or
-// unexpected HTTP failures preserve stored cookies as transient failures.
-func resolveARStoredSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string, _ api.TrackerAuthLoginRequest) error {
+// resolveARSessionForTrackerAuth verifies imported AR cookies against the
+// browse page and refreshes missing or confirmed-invalid sessions with
+// configured credentials. Transport and unexpected HTTP failures preserve
+// stored cookies and do not trigger credential login.
+func resolveARSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string, _ api.TrackerAuthLoginRequest) error {
+	baseURL := resolveAuthBaseURL(cfg, arDefaultBaseURL)
 	values, err := cookies.LoadTrackerHTTPCookies(ctx, dbPath, "AR", "alpharatio.cc")
-	if err != nil || len(values) == 0 {
+	switch {
+	case err == nil && len(values) > 0:
+		validationErr := validateARStoredCookies(ctx, baseURL, values)
+		if validationErr == nil {
+			return nil
+		}
+		if !shouldRefreshStoredCookiesWithCredentials(validationErr) {
+			return validationErr
+		}
+		if !hasLoginCredentials(cfg) {
+			return validationErr
+		}
+	case err != nil && !errors.Is(err, cookies.ErrTrackerCookiesNotFound):
+		return &AuthRequiredError{TrackerID: "AR", Reason: "cookies unavailable", Err: cookieLoadError("AR", err)}
+	case !hasLoginCredentials(cfg):
 		return &AuthRequiredError{TrackerID: "AR", Reason: "cookies missing", Err: cookieLoadError("AR", err)}
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, joinAuthURL(resolveAuthBaseURL(cfg, arDefaultBaseURL), arBrowsePath), nil)
+
+	return loginARForTrackerAuth(ctx, cfg, dbPath, baseURL)
+}
+
+func validateARStoredCookies(ctx context.Context, baseURL string, values []*http.Cookie) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, joinAuthURL(baseURL, arBrowsePath), nil)
 	if err != nil {
 		return fmt.Errorf("trackers: AR session validation request build: %w", err)
 	}
@@ -76,6 +97,56 @@ func resolveARStoredSessionForTrackerAuth(ctx context.Context, cfg config.Tracke
 	}
 	if !arLooksLoggedIn(string(body)) {
 		return &ValidationError{TrackerID: "AR", ConfirmedInvalid: true, Reason: "stored session expired", Err: errors.New("trackers: AR browse marker not found")}
+	}
+	return nil
+}
+
+// loginARForTrackerAuth creates a clean AR session, proves it against the
+// browse page, and persists only the validated replacement cookies.
+func loginARForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string, baseURL string) error {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return fmt.Errorf("trackers: AR create login cookie jar: %w", err)
+	}
+	client := noRedirectHTTPClient()
+	client.Jar = jar
+	data := url.Values{}
+	data.Set("username", strings.TrimSpace(cfg.Username))
+	data.Set("password", strings.TrimSpace(cfg.Password))
+	data.Set("keeplogged", "1")
+	data.Set("login", "Login")
+	loginReq, err := http.NewRequestWithContext(ctx, http.MethodPost, joinAuthURL(baseURL, arLoginPath), strings.NewReader(data.Encode()))
+	if err != nil {
+		return fmt.Errorf("trackers: AR login request build: %w", err)
+	}
+	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	loginReq.Header.Set("User-Agent", "upbrr")
+	loginResp, err := client.Do(loginReq)
+	if err != nil {
+		return &ValidationError{TrackerID: "AR", Transient: true, Reason: "remote login unavailable", Err: fmt.Errorf("trackers: AR login request: %w", err)}
+	}
+	defer loginResp.Body.Close()
+	body, readErr := readTrackerAuthResponseBody(loginResp, loginResp.StatusCode >= 200 && loginResp.StatusCode < 400)
+	if readErr != nil {
+		return &ValidationError{TrackerID: "AR", Transient: true, Reason: "remote login unavailable", Err: readErr}
+	}
+	if loginResp.StatusCode < 200 || loginResp.StatusCode >= 400 || arLooksLoggedOut(string(body)) {
+		return &ValidationError{TrackerID: "AR", ConfirmedInvalid: true, Reason: "login failed", Err: fmt.Errorf("trackers: AR login failed status=%d", loginResp.StatusCode)}
+	}
+
+	base, err := url.Parse(strings.TrimRight(baseURL, "/") + "/")
+	if err != nil {
+		return fmt.Errorf("trackers: AR parse base URL: %w", err)
+	}
+	loginCookies := jar.Cookies(base)
+	if len(usableHTTPCookies(loginCookies)) == 0 {
+		return &ValidationError{TrackerID: "AR", ConfirmedInvalid: true, Reason: "login failed", Err: errors.New("trackers: AR login returned no usable cookies")}
+	}
+	if validationErr := validateARStoredCookies(ctx, baseURL, loginCookies); validationErr != nil {
+		return validationErr
+	}
+	if err := persistHTTPCookies(ctx, dbPath, "AR", loginCookies); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/trackerauth/site_validators.go
+++ b/internal/trackerauth/site_validators.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/html"
+
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
@@ -71,6 +73,9 @@ func resolveARStoredSessionForTrackerAuth(ctx context.Context, cfg config.Tracke
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return &ValidationError{TrackerID: "AR", Transient: true, Reason: "remote validation failed", Err: fmt.Errorf("trackers: AR session validation failed status=%d", resp.StatusCode)}
+	}
+	if !arLooksLoggedIn(string(body)) {
+		return &ValidationError{TrackerID: "AR", ConfirmedInvalid: true, Reason: "stored session expired", Err: errors.New("trackers: AR browse marker not found")}
 	}
 	return nil
 }
@@ -448,6 +453,37 @@ func isLoginRedirect(resp *http.Response) bool {
 func arLooksLoggedOut(body string) bool {
 	lower := strings.ToLower(body)
 	return strings.Contains(lower, "forgot your password") || strings.Contains(lower, "login.php?act=recover")
+}
+
+// arLooksLoggedIn recognizes an authenticated AR browse-page download link.
+func arLooksLoggedIn(body string) bool {
+	tokenizer := html.NewTokenizer(strings.NewReader(body))
+	for {
+		switch tokenizer.Next() {
+		case html.ErrorToken:
+			return false
+		case html.StartTagToken, html.SelfClosingTagToken:
+			token := tokenizer.Token()
+			if !strings.EqualFold(token.Data, "a") {
+				continue
+			}
+			for _, attr := range token.Attr {
+				if !strings.EqualFold(attr.Key, "href") {
+					continue
+				}
+				candidate, err := url.Parse(attr.Val)
+				if err != nil || !strings.EqualFold(strings.TrimPrefix(candidate.Path, "/"), "torrents.php") {
+					continue
+				}
+				query := candidate.Query()
+				if strings.EqualFold(query.Get("action"), "download") && strings.TrimSpace(query.Get("auth")) != "" {
+					return true
+				}
+			}
+		case html.TextToken, html.EndTagToken, html.CommentToken, html.DoctypeToken:
+			continue
+		}
+	}
 }
 
 // hdbLooksLoggedOut recognizes HDB login form markers in validation responses.

--- a/internal/trackerauth/site_validators.go
+++ b/internal/trackerauth/site_validators.go
@@ -27,6 +27,7 @@ import (
 const (
 	arDefaultBaseURL  = "https://alpharatio.cc"
 	authPreviewBytes  = 64 * 1024
+	authResponseBytes = 1 * 1024 * 1024
 	arIndexPath       = "/index.php"
 	arLoginPath       = "/login.php"
 	ffDefaultBaseURL  = "https://www.funfile.org"
@@ -400,13 +401,17 @@ func resolveTHRSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConf
 	return nil
 }
 
-// readTrackerAuthResponseBody reads full success-candidate auth pages for
-// marker parsing while keeping failed-status diagnostics bounded.
+// readTrackerAuthResponseBody reads success-candidate auth pages through a
+// 1 MiB plus sentinel and rejects oversized bodies before marker parsing.
+// Failed-status diagnostics are capped at 64 KiB.
 func readTrackerAuthResponseBody(resp *http.Response, successCandidate bool) ([]byte, error) {
 	if successCandidate {
-		body, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(io.LimitReader(resp.Body, authResponseBytes+1))
 		if err != nil {
 			return nil, fmt.Errorf("trackers: read auth response body: %w", err)
+		}
+		if len(body) > authResponseBytes {
+			return nil, fmt.Errorf("trackers: auth response body exceeds %d bytes", authResponseBytes)
 		}
 		return body, nil
 	}
@@ -508,7 +513,8 @@ func arLooksLoggedOut(body string) bool {
 	return strings.Contains(lower, "forgot your password") || strings.Contains(lower, "login.php?act=recover")
 }
 
-// arLooksLoggedIn recognizes AR's authenticated logout link on any HTML page.
+// arLooksLoggedIn requires a logout.php anchor with a non-empty auth query.
+// Relative links are accepted; absolute links must use HTTPS on alpharatio.cc.
 func arLooksLoggedIn(body string) bool {
 	tokenizer := html.NewTokenizer(strings.NewReader(body))
 	for {
@@ -528,8 +534,13 @@ func arLooksLoggedIn(body string) bool {
 				if err != nil || !strings.EqualFold(strings.TrimPrefix(candidate.Path, "/"), "logout.php") {
 					continue
 				}
-				if candidate.IsAbs() && (!strings.EqualFold(candidate.Scheme, "https") ||
-					!strings.EqualFold(candidate.Hostname(), "alpharatio.cc")) {
+				if candidate.Scheme != "" && !strings.EqualFold(candidate.Scheme, "https") {
+					continue
+				}
+				if candidate.Host != "" && !strings.EqualFold(candidate.Hostname(), "alpharatio.cc") {
+					continue
+				}
+				if strings.TrimSpace(candidate.Query().Get("auth")) == "" {
 					continue
 				}
 				return true

--- a/internal/trackerauth/site_validators.go
+++ b/internal/trackerauth/site_validators.go
@@ -20,13 +20,14 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
+	"github.com/autobrr/upbrr/internal/trackers/impl/thr"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
 const (
 	arDefaultBaseURL  = "https://alpharatio.cc"
 	authPreviewBytes  = 64 * 1024
-	arBrowsePath      = "/torrents.php"
+	arIndexPath       = "/index.php"
 	arLoginPath       = "/login.php"
 	ffDefaultBaseURL  = "https://www.funfile.org"
 	ffLoginPath       = "/takelogin.php"
@@ -37,15 +38,13 @@ const (
 	flLoginPath       = "/takelogin.php"
 	hdbDefaultBaseURL = "https://hdbits.org"
 	hdbUploadPath     = "/upload/upload"
-	thrDefaultBaseURL = "https://www.torrenthr.org"
-	thrLoginPath      = "/takelogin.php"
 )
 
 // flValidatorPattern extracts the anti-CSRF validator required by FL login.
 var flValidatorPattern = regexp.MustCompile(`name="validator"\s+value="([^"]+)"`)
 
 // resolveARSessionForTrackerAuth verifies imported AR cookies against the
-// browse page and refreshes missing or confirmed-invalid sessions with
+// post-login index page and refreshes missing or confirmed-invalid sessions with
 // configured credentials. Transport and unexpected HTTP failures preserve
 // stored cookies and do not trigger credential login.
 func resolveARSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string, _ api.TrackerAuthLoginRequest) error {
@@ -73,7 +72,7 @@ func resolveARSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfi
 }
 
 func validateARStoredCookies(ctx context.Context, baseURL string, values []*http.Cookie) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, joinAuthURL(baseURL, arBrowsePath), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, joinAuthURL(baseURL, arIndexPath), nil)
 	if err != nil {
 		return fmt.Errorf("trackers: AR session validation request build: %w", err)
 	}
@@ -96,20 +95,19 @@ func validateARStoredCookies(ctx context.Context, baseURL string, values []*http
 		return &ValidationError{TrackerID: "AR", Transient: true, Reason: "remote validation failed", Err: fmt.Errorf("trackers: AR session validation failed status=%d", resp.StatusCode)}
 	}
 	if !arLooksLoggedIn(string(body)) {
-		return &ValidationError{TrackerID: "AR", ConfirmedInvalid: true, Reason: "stored session expired", Err: errors.New("trackers: AR browse marker not found")}
+		return &ValidationError{TrackerID: "AR", ConfirmedInvalid: true, Reason: "stored session expired", Err: errors.New("trackers: AR logout marker not found")}
 	}
 	return nil
 }
 
 // loginARForTrackerAuth creates a clean AR session, proves it against the
-// browse page, and persists only the validated replacement cookies.
+// post-login index page, and persists only the validated replacement cookies.
 func loginARForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath string, baseURL string) error {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		return fmt.Errorf("trackers: AR create login cookie jar: %w", err)
 	}
-	client := noRedirectHTTPClient()
-	client.Jar = jar
+	client := &http.Client{Timeout: 30 * time.Second, Jar: jar}
 	data := url.Values{}
 	data.Set("username", strings.TrimSpace(cfg.Username))
 	data.Set("password", strings.TrimSpace(cfg.Password))
@@ -336,7 +334,11 @@ func loginFLForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, dbPath
 	if err != nil {
 		return fmt.Errorf("trackers: FL parse base URL: %w", err)
 	}
-	if err := persistHTTPCookies(ctx, dbPath, "FL", jar.Cookies(base)); err != nil {
+	loginCookies := jar.Cookies(base)
+	if err := validateFLStoredCookies(ctx, baseURL, loginCookies); err != nil {
+		return fmt.Errorf("trackers: FL validate login cookies: %w", err)
+	}
+	if err := persistHTTPCookies(ctx, dbPath, "FL", loginCookies); err != nil {
 		return fmt.Errorf("trackers: FL persist login cookies: %w", err)
 	}
 	return nil
@@ -382,38 +384,18 @@ func resolveHDBStoredSessionForTrackerAuth(ctx context.Context, cfg config.Track
 	return nil
 }
 
-// resolveTHRSessionForTrackerAuth validates THR credentials by performing a
-// login check. THR uploads log in per request and do not use stored cookies.
+// resolveTHRSessionForTrackerAuth validates THR credentials using the same
+// browser-style session bootstrap as uploads. THR logs in per request and does
+// not persist cookies in tracker-auth storage.
 func resolveTHRSessionForTrackerAuth(ctx context.Context, cfg config.TrackerConfig, _ string, _ api.TrackerAuthLoginRequest) error {
 	if !hasLoginCredentials(cfg) {
 		return &AuthRequiredError{TrackerID: "THR", Reason: "username/password missing", Err: errors.New("trackers: THR missing username/password")}
 	}
-	baseURL := resolveAuthBaseURL(cfg, thrDefaultBaseURL)
-	data := url.Values{}
-	data.Set("username", strings.TrimSpace(cfg.Username))
-	data.Set("password", strings.TrimSpace(cfg.Password))
-	data.Set("ssl", "yes")
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, joinAuthURL(baseURL, thrLoginPath), strings.NewReader(data.Encode()))
-	if err != nil {
-		return fmt.Errorf("trackers: THR login request build: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("User-Agent", "upbrr")
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("trackers: THR login request: %w", err)
-	}
-	defer resp.Body.Close()
-	body, readErr := readTrackerAuthResponseBody(resp, resp.StatusCode >= 200 && resp.StatusCode < 400)
-	if readErr != nil {
-		return &ValidationError{TrackerID: "THR", Transient: true, Reason: "remote validation unavailable", Err: readErr}
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return &ValidationError{TrackerID: "THR", ConfirmedInvalid: true, Reason: "login failed", Err: fmt.Errorf("trackers: THR login failed status=%d", resp.StatusCode)}
-	}
-	if !thrLooksLoggedIn(string(body), resp) {
-		return &ValidationError{TrackerID: "THR", ConfirmedInvalid: true, Reason: "login failed", Err: errors.New("trackers: THR login marker not found")}
+	if _, err := thr.LoginSession(ctx, cfg); err != nil {
+		if errors.Is(err, thr.ErrLoginFailed) {
+			return &ValidationError{TrackerID: "THR", ConfirmedInvalid: true, Reason: "login failed", Err: err}
+		}
+		return fmt.Errorf("trackers: THR login session: %w", err)
 	}
 	return nil
 }
@@ -526,7 +508,7 @@ func arLooksLoggedOut(body string) bool {
 	return strings.Contains(lower, "forgot your password") || strings.Contains(lower, "login.php?act=recover")
 }
 
-// arLooksLoggedIn recognizes an authenticated AR browse-page download link.
+// arLooksLoggedIn recognizes AR's authenticated logout link on any HTML page.
 func arLooksLoggedIn(body string) bool {
 	tokenizer := html.NewTokenizer(strings.NewReader(body))
 	for {
@@ -543,13 +525,14 @@ func arLooksLoggedIn(body string) bool {
 					continue
 				}
 				candidate, err := url.Parse(attr.Val)
-				if err != nil || !strings.EqualFold(strings.TrimPrefix(candidate.Path, "/"), "torrents.php") {
+				if err != nil || !strings.EqualFold(strings.TrimPrefix(candidate.Path, "/"), "logout.php") {
 					continue
 				}
-				query := candidate.Query()
-				if strings.EqualFold(query.Get("action"), "download") && strings.TrimSpace(query.Get("auth")) != "" {
-					return true
+				if candidate.IsAbs() && (!strings.EqualFold(candidate.Scheme, "https") ||
+					!strings.EqualFold(candidate.Hostname(), "alpharatio.cc")) {
+					continue
 				}
+				return true
 			}
 		case html.TextToken, html.EndTagToken, html.CommentToken, html.DoctypeToken:
 			continue
@@ -597,18 +580,4 @@ func flLooksLoggedIn(body string) bool {
 func flLooksLoggedOut(body string) bool {
 	lower := strings.ToLower(body)
 	return strings.Contains(lower, "login.php") || strings.Contains(lower, "name=\"username\"") || strings.Contains(lower, "name=\"password\"")
-}
-
-// thrLooksLoggedIn recognizes THR credential-login success by response body or
-// final URL because THR uploads use per-request login instead of stored cookies.
-func thrLooksLoggedIn(body string, resp *http.Response) bool {
-	lower := strings.ToLower(body)
-	if strings.Contains(lower, "logout.php") {
-		return true
-	}
-	if resp != nil && resp.Request != nil && resp.Request.URL != nil {
-		path := strings.ToLower(resp.Request.URL.Path)
-		return strings.Contains(path, "index.php")
-	}
-	return false
 }

--- a/internal/trackerauth/site_validators_test.go
+++ b/internal/trackerauth/site_validators_test.go
@@ -47,16 +47,23 @@ func TestResolveARStoredSessionRequiresAuthenticatedLogoutMarker(t *testing.T) {
 			body: `<a href="/logout.php?auth=session-key">Logout</a>`,
 		},
 		{
-			name: "logout link without auth key",
-			body: `<a href="https://alpharatio.cc/logout.php?auth=">Logout</a>`,
+			name:        "logout link without auth key",
+			body:        `<a href="https://alpharatio.cc/logout.php?auth=">Logout</a>`,
+			wantInvalid: true,
 		},
 		{
-			name: "logout link without query",
-			body: `<a href="https://alpharatio.cc/logout.php">Logout</a>`,
+			name:        "logout link without query",
+			body:        `<a href="https://alpharatio.cc/logout.php">Logout</a>`,
+			wantInvalid: true,
 		},
 		{
 			name:        "foreign logout link",
 			body:        `<a href="https://example.invalid/logout.php?auth=session-key">Logout</a>`,
+			wantInvalid: true,
+		},
+		{
+			name:        "protocol-relative foreign logout link",
+			body:        `<a href="//example.invalid/logout.php?auth=session-key">Logout</a>`,
 			wantInvalid: true,
 		},
 		{
@@ -101,6 +108,50 @@ func TestResolveARStoredSessionRequiresAuthenticatedLogoutMarker(t *testing.T) {
 			}
 			if !validationErr.ConfirmedInvalid || validationErr.Transient {
 				t.Fatalf("expected missing AR logout marker to invalidate session, got %+v", validationErr)
+			}
+		})
+	}
+}
+
+func TestValidateARStoredCookiesBoundsSuccessfulResponseBody(t *testing.T) {
+	t.Parallel()
+
+	const marker = `<a href="/logout.php?auth=session-key">Logout</a>`
+	tests := []struct {
+		name          string
+		bodySize      int
+		wantTransient bool
+	}{
+		{name: "at limit", bodySize: authResponseBytes},
+		{name: "over limit", bodySize: authResponseBytes + 1, wantTransient: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := marker + strings.Repeat("a", tt.bodySize-len(marker))
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(body))
+			}))
+			t.Cleanup(server.Close)
+
+			err := validateARStoredCookies(context.Background(), server.URL, []*http.Cookie{{Name: "session", Value: "ok"}})
+			if !tt.wantTransient {
+				if err != nil {
+					t.Fatalf("expected response at size limit to validate: %v", err)
+				}
+				return
+			}
+			validationErr, ok := asValidationError(err)
+			if !ok {
+				t.Fatalf("expected oversized response validation error, got %v", err)
+			}
+			if !validationErr.Transient || validationErr.ConfirmedInvalid {
+				t.Fatalf("expected oversized response to fail transiently, got %+v", validationErr)
+			}
+			if !strings.Contains(validationErr.Error(), "exceeds") {
+				t.Fatalf("expected oversized response error, got %v", validationErr)
 			}
 		})
 	}

--- a/internal/trackerauth/site_validators_test.go
+++ b/internal/trackerauth/site_validators_test.go
@@ -30,7 +30,7 @@ func TestValidateFFStoredCookiesReadsFullSuccessBody(t *testing.T) {
 	}
 }
 
-func TestResolveARStoredSessionRequiresAuthenticatedBrowseMarker(t *testing.T) {
+func TestResolveARStoredSessionRequiresAuthenticatedLogoutMarker(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -39,8 +39,25 @@ func TestResolveARStoredSessionRequiresAuthenticatedBrowseMarker(t *testing.T) {
 		wantInvalid bool
 	}{
 		{
-			name: "authenticated download link",
-			body: `<a href="/torrents.php?action=download&amp;id=123&amp;auth=session-key">Download</a>`,
+			name: "authenticated logout link",
+			body: `<a href="https://alpharatio.cc/logout.php?auth=session-key">Logout</a>`,
+		},
+		{
+			name: "relative logout link",
+			body: `<a href="/logout.php?auth=session-key">Logout</a>`,
+		},
+		{
+			name: "logout link without auth key",
+			body: `<a href="https://alpharatio.cc/logout.php?auth=">Logout</a>`,
+		},
+		{
+			name: "logout link without query",
+			body: `<a href="https://alpharatio.cc/logout.php">Logout</a>`,
+		},
+		{
+			name:        "foreign logout link",
+			body:        `<a href="https://example.invalid/logout.php?auth=session-key">Logout</a>`,
+			wantInvalid: true,
 		},
 		{
 			name:        "arbitrary help page",
@@ -62,7 +79,7 @@ func TestResolveARStoredSessionRequiresAuthenticatedBrowseMarker(t *testing.T) {
 				t.Fatalf("SaveTrackerCookieMap: %v", err)
 			}
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != arBrowsePath {
+				if r.URL.Path != arIndexPath {
 					http.NotFound(w, r)
 					return
 				}
@@ -74,7 +91,7 @@ func TestResolveARStoredSessionRequiresAuthenticatedBrowseMarker(t *testing.T) {
 			err := resolveARSessionForTrackerAuth(ctx, config.TrackerConfig{URL: server.URL}, dbPath, api.TrackerAuthLoginRequest{})
 			if !tt.wantInvalid {
 				if err != nil {
-					t.Fatalf("expected authenticated AR browse page to validate: %v", err)
+					t.Fatalf("expected authenticated AR index page to validate: %v", err)
 				}
 				return
 			}
@@ -83,7 +100,7 @@ func TestResolveARStoredSessionRequiresAuthenticatedBrowseMarker(t *testing.T) {
 				t.Fatalf("expected validation error, got %v", err)
 			}
 			if !validationErr.ConfirmedInvalid || validationErr.Transient {
-				t.Fatalf("expected missing AR browse marker to invalidate session, got %+v", validationErr)
+				t.Fatalf("expected missing AR logout marker to invalidate session, got %+v", validationErr)
 			}
 		})
 	}

--- a/internal/trackerauth/site_validators_test.go
+++ b/internal/trackerauth/site_validators_test.go
@@ -71,7 +71,7 @@ func TestResolveARStoredSessionRequiresAuthenticatedBrowseMarker(t *testing.T) {
 			}))
 			t.Cleanup(server.Close)
 
-			err := resolveARStoredSessionForTrackerAuth(ctx, config.TrackerConfig{URL: server.URL}, dbPath, api.TrackerAuthLoginRequest{})
+			err := resolveARSessionForTrackerAuth(ctx, config.TrackerConfig{URL: server.URL}, dbPath, api.TrackerAuthLoginRequest{})
 			if !tt.wantInvalid {
 				if err != nil {
 					t.Fatalf("expected authenticated AR browse page to validate: %v", err)

--- a/internal/trackerauth/site_validators_test.go
+++ b/internal/trackerauth/site_validators_test.go
@@ -30,6 +30,65 @@ func TestValidateFFStoredCookiesReadsFullSuccessBody(t *testing.T) {
 	}
 }
 
+func TestResolveARStoredSessionRequiresAuthenticatedBrowseMarker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		body        string
+		wantInvalid bool
+	}{
+		{
+			name: "authenticated download link",
+			body: `<a href="/torrents.php?action=download&amp;id=123&amp;auth=session-key">Download</a>`,
+		},
+		{
+			name:        "arbitrary help page",
+			body:        `<html><h1>Browse help</h1></html>`,
+			wantInvalid: true,
+		},
+		{
+			name:        "unrecognized login page",
+			body:        `<form action="/login.php"><input name="username"><input name="password"></form>`,
+			wantInvalid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			dbPath := newTrackerAuthTestDB(t)
+			if err := cookies.SaveTrackerCookieMap(ctx, dbPath, "AR", map[string]string{"session": "abc"}); err != nil {
+				t.Fatalf("SaveTrackerCookieMap: %v", err)
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != arBrowsePath {
+					http.NotFound(w, r)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
+
+			err := resolveARStoredSessionForTrackerAuth(ctx, config.TrackerConfig{URL: server.URL}, dbPath, api.TrackerAuthLoginRequest{})
+			if !tt.wantInvalid {
+				if err != nil {
+					t.Fatalf("expected authenticated AR browse page to validate: %v", err)
+				}
+				return
+			}
+			validationErr, ok := asValidationError(err)
+			if !ok {
+				t.Fatalf("expected validation error, got %v", err)
+			}
+			if !validationErr.ConfirmedInvalid || validationErr.Transient {
+				t.Fatalf("expected missing AR browse marker to invalidate session, got %+v", validationErr)
+			}
+		})
+	}
+}
+
 func TestValidateFFStoredCookiesTreatsBodyReadErrorAsTransient(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/impl/thr/upload.go
+++ b/internal/trackers/impl/thr/upload.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/html"
+
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	"github.com/autobrr/upbrr/internal/services/bbcode"
@@ -27,11 +29,17 @@ import (
 )
 
 const (
-	baseURL    = "https://www.torrenthr.org"
-	loginURL   = baseURL + "/takelogin.php"
-	uploadURL  = baseURL + "/takeupload.php"
-	sourceFlag = "[https://www.torrenthr.org] TorrentHR.org"
+	baseURL              = "https://www.torrenthr.org"
+	loginPagePath        = "/login.php"
+	takeLoginPath        = "/takelogin.php"
+	uploadURL            = baseURL + "/takeupload.php"
+	sourceFlag           = "[https://www.torrenthr.org] TorrentHR.org"
+	loginResponseMaxSize = 1024 * 1024
 )
+
+// ErrLoginFailed marks a completed THR login exchange that did not produce
+// authenticated index-page evidence.
+var ErrLoginFailed = errors.New("trackers: THR login failed")
 
 var (
 	subtitleMap = map[string]string{"croatian": "1", "english": "2", "bosnian": "3", "serbian": "4", "slovenian": "5"}
@@ -158,34 +166,125 @@ func prepareUploadState(ctx context.Context, req trackers.UploadRequest) (upload
 }
 
 func login(ctx context.Context, cfg config.TrackerConfig) (*http.Client, error) {
+	return LoginSession(ctx, cfg)
+}
+
+// LoginSession performs THR's browser-style login flow. It first loads the
+// login page into a cookie jar, carries all non-empty hidden form fields into
+// the credential POST, follows the redirect to the authenticated page, and
+// returns the live client only after index/logout evidence is present.
+func LoginSession(ctx context.Context, cfg config.TrackerConfig) (*http.Client, error) {
 	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
 		return nil, errors.New("trackers: THR missing username/password")
+	}
+	resolvedBaseURL := strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
+	if resolvedBaseURL == "" {
+		resolvedBaseURL = baseURL
 	}
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		return nil, fmt.Errorf("trackers: THR create login cookie jar: %w", err)
 	}
 	client := &http.Client{Timeout: 30 * time.Second, Jar: jar}
-	form := url.Values{
-		"username": {strings.TrimSpace(cfg.Username)},
-		"password": {strings.TrimSpace(cfg.Password)},
-		"ssl":      {"yes"},
+	loginPageURL := resolvedBaseURL + loginPagePath
+	pageReq, err := http.NewRequestWithContext(ctx, http.MethodGet, loginPageURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("trackers: THR build login page request: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, loginURL, strings.NewReader(form.Encode()))
+	pageReq.Header.Set("User-Agent", "upbrr")
+	pageResp, err := client.Do(pageReq)
+	if err != nil {
+		return nil, fmt.Errorf("trackers: THR login page request: %w", err)
+	}
+	pageBody, readErr := readLoginResponse(pageResp)
+	pageResp.Body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("trackers: THR read login page: %w", readErr)
+	}
+	if pageResp.StatusCode < 200 || pageResp.StatusCode >= 300 {
+		return nil, fmt.Errorf("trackers: THR login page failed status=%d", pageResp.StatusCode)
+	}
+
+	form := hiddenLoginFields(pageBody)
+	form.Set("username", strings.TrimSpace(cfg.Username))
+	form.Set("password", strings.TrimSpace(cfg.Password))
+	form.Set("ssl", "yes")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resolvedBaseURL+takeLoginPath, strings.NewReader(form.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("trackers: THR build login request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("User-Agent", "upbrr")
+	req.Header.Set("Referer", loginPageURL)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("trackers: THR login request: %w", err)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusFound {
-		return nil, fmt.Errorf("THR login failed with status %d", resp.StatusCode)
+	body, readErr := readLoginResponse(resp)
+	resp.Body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("trackers: THR read login response: %w", readErr)
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("%w: status=%d", ErrLoginFailed, resp.StatusCode)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("trackers: THR login response status=%d", resp.StatusCode)
+	}
+	finalPath := ""
+	if resp.Request != nil && resp.Request.URL != nil {
+		finalPath = strings.ToLower(resp.Request.URL.Path)
+	}
+	if !strings.Contains(finalPath, "index.php") && !strings.Contains(strings.ToLower(string(body)), "logout.php") {
+		return nil, fmt.Errorf("%w: authenticated marker not found", ErrLoginFailed)
 	}
 	return client, nil
+}
+
+func readLoginResponse(resp *http.Response) ([]byte, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, errors.New("empty response")
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, loginResponseMaxSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+	if len(body) > loginResponseMaxSize {
+		return nil, fmt.Errorf("response exceeds %d bytes", loginResponseMaxSize)
+	}
+	return body, nil
+}
+
+func hiddenLoginFields(body []byte) url.Values {
+	fields := url.Values{}
+	tokenizer := html.NewTokenizer(bytes.NewReader(body))
+	for {
+		switch tokenizer.Next() {
+		case html.ErrorToken:
+			return fields
+		case html.StartTagToken, html.SelfClosingTagToken:
+			token := tokenizer.Token()
+			if !strings.EqualFold(token.Data, "input") {
+				continue
+			}
+			name, value, inputType := "", "", ""
+			for _, attr := range token.Attr {
+				switch {
+				case strings.EqualFold(attr.Key, "name"):
+					name = strings.TrimSpace(attr.Val)
+				case strings.EqualFold(attr.Key, "value"):
+					value = attr.Val
+				case strings.EqualFold(attr.Key, "type"):
+					inputType = strings.TrimSpace(attr.Val)
+				}
+			}
+			if strings.EqualFold(inputType, "hidden") && name != "" && value != "" {
+				fields.Set(name, value)
+			}
+		case html.TextToken, html.EndTagToken, html.CommentToken, html.DoctypeToken:
+			continue
+		}
+	}
 }
 
 func buildDescription(meta api.PreparedMetadata, assets trackers.DescriptionAssets) string {

--- a/internal/trackers/impl/thr/upload.go
+++ b/internal/trackers/impl/thr/upload.go
@@ -172,7 +172,8 @@ func login(ctx context.Context, cfg config.TrackerConfig) (*http.Client, error) 
 // LoginSession performs THR's browser-style login flow. It first loads the
 // login page into a cookie jar, carries all non-empty hidden form fields into
 // the credential POST, follows the redirect to the authenticated page, and
-// returns the live client only after index/logout evidence is present.
+// returns the live client only after the final index page contains a structured
+// logout link on the same scheme and hostname.
 func LoginSession(ctx context.Context, cfg config.TrackerConfig) (*http.Client, error) {
 	if strings.TrimSpace(cfg.Username) == "" || strings.TrimSpace(cfg.Password) == "" {
 		return nil, errors.New("trackers: THR missing username/password")
@@ -231,14 +232,53 @@ func LoginSession(ctx context.Context, cfg config.TrackerConfig) (*http.Client, 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("trackers: THR login response status=%d", resp.StatusCode)
 	}
-	finalPath := ""
+	var finalURL *url.URL
 	if resp.Request != nil && resp.Request.URL != nil {
-		finalPath = strings.ToLower(resp.Request.URL.Path)
+		finalURL = resp.Request.URL
 	}
-	if !strings.Contains(finalPath, "index.php") && !strings.Contains(strings.ToLower(string(body)), "logout.php") {
+	if !isAuthenticatedLoginPage(finalURL, body) {
 		return nil, fmt.Errorf("%w: authenticated marker not found", ErrLoginFailed)
 	}
 	return client, nil
+}
+
+// isAuthenticatedLoginPage requires THR's post-login index path and a parsed
+// logout anchor on the same scheme and hostname. Path fragments or incidental
+// response text cannot independently prove authentication.
+func isAuthenticatedLoginPage(finalURL *url.URL, body []byte) bool {
+	if finalURL == nil || !strings.EqualFold(strings.Trim(finalURL.Path, "/"), "index.php") {
+		return false
+	}
+	tokenizer := html.NewTokenizer(bytes.NewReader(body))
+	for {
+		switch tokenizer.Next() {
+		case html.ErrorToken:
+			return false
+		case html.StartTagToken, html.SelfClosingTagToken:
+			token := tokenizer.Token()
+			if !strings.EqualFold(token.Data, "a") {
+				continue
+			}
+			for _, attr := range token.Attr {
+				if !strings.EqualFold(attr.Key, "href") {
+					continue
+				}
+				candidate, err := url.Parse(strings.TrimSpace(attr.Val))
+				if err != nil || !strings.EqualFold(strings.TrimPrefix(candidate.Path, "/"), "logout.php") {
+					continue
+				}
+				if candidate.Scheme != "" && !strings.EqualFold(candidate.Scheme, finalURL.Scheme) {
+					continue
+				}
+				if candidate.Host != "" && !strings.EqualFold(candidate.Hostname(), finalURL.Hostname()) {
+					continue
+				}
+				return true
+			}
+		case html.TextToken, html.EndTagToken, html.CommentToken, html.DoctypeToken:
+			continue
+		}
+	}
 }
 
 func readLoginResponse(resp *http.Response) ([]byte, error) {

--- a/internal/trackers/impl/thr/upload_test.go
+++ b/internal/trackers/impl/thr/upload_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package thr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+)
+
+func TestLoginSessionBootstrapsHiddenFieldsAndFollowsRedirect(t *testing.T) {
+	t.Parallel()
+
+	handlerErr := make(chan error, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case loginPagePath:
+			http.SetCookie(w, &http.Cookie{Name: "bootstrap", Value: "ready", Path: "/"})
+			_, _ = w.Write([]byte(`<form><input type="hidden" name="token" value="login-token"><input type="hidden" name="blank" value=""></form>`))
+		case takeLoginPath:
+			if err := r.ParseForm(); err != nil {
+				handlerErr <- fmt.Errorf("parse login form: %w", err)
+				return
+			}
+			if r.FormValue("username") != "user" || r.FormValue("password") != "pass" || r.FormValue("ssl") != "yes" || r.FormValue("token") != "login-token" {
+				handlerErr <- errors.New("login form did not preserve credentials and hidden fields")
+			}
+			if r.Form.Has("blank") {
+				handlerErr <- errors.New("empty hidden field should not be submitted")
+			}
+			if cookie, err := r.Cookie("bootstrap"); err != nil || cookie.Value != "ready" {
+				handlerErr <- errors.New("login bootstrap cookie missing")
+			}
+			if r.Referer() != "http://"+r.Host+loginPagePath {
+				handlerErr <- fmt.Errorf("unexpected login referer %q", r.Referer())
+			}
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "authenticated", Path: "/"})
+			http.Redirect(w, r, "/index.php", http.StatusFound)
+		case "/index.php":
+			if cookie, err := r.Cookie("session"); err != nil || cookie.Value != "authenticated" {
+				_, _ = w.Write([]byte(`<form action="/login.php"></form>`))
+				return
+			}
+			_, _ = w.Write([]byte(`<a href="logout.php">Logout</a>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := LoginSession(context.Background(), config.TrackerConfig{URL: server.URL, Username: "user", Password: "pass"})
+	if err != nil {
+		t.Fatalf("LoginSession: %v", err)
+	}
+	if client == nil || client.Jar == nil {
+		t.Fatal("expected authenticated client with cookie jar")
+	}
+	close(handlerErr)
+	for err := range handlerErr {
+		t.Error(err)
+	}
+}
+
+func TestLoginSessionRejectsRedirectWithoutAuthenticatedMarker(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case loginPagePath:
+			_, _ = w.Write([]byte(`<input type="hidden" name="token" value="login-token">`))
+		case takeLoginPath:
+			http.Redirect(w, r, "/home.php", http.StatusFound)
+		case "/home.php":
+			_, _ = w.Write([]byte(`<form action="/login.php"><input name="username"></form>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := LoginSession(context.Background(), config.TrackerConfig{URL: server.URL, Username: "user", Password: "pass"})
+	if !errors.Is(err, ErrLoginFailed) {
+		t.Fatalf("expected ErrLoginFailed, got %v", err)
+	}
+}

--- a/internal/trackers/impl/thr/upload_test.go
+++ b/internal/trackers/impl/thr/upload_test.go
@@ -84,8 +84,64 @@ func TestLoginSessionRejectsRedirectWithoutAuthenticatedMarker(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	_, err := LoginSession(context.Background(), config.TrackerConfig{URL: server.URL, Username: "user", Password: "pass"})
+	client, err := LoginSession(context.Background(), config.TrackerConfig{URL: server.URL, Username: "user", Password: "pass"})
 	if !errors.Is(err, ErrLoginFailed) {
 		t.Fatalf("expected ErrLoginFailed, got %v", err)
+	}
+	if client != nil {
+		t.Fatal("expected rejected login to return no client")
+	}
+}
+
+func TestLoginSessionRejectsWeakAuthenticatedMarkers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		finalPath string
+		body      string
+	}{
+		{
+			name:      "public index path without logout anchor",
+			finalPath: "/index.php",
+			body:      `<form action="/login.php"><input name="username"></form>`,
+		},
+		{
+			name:      "incidental logout text off index",
+			finalPath: "/help.php",
+			body:      `<p>Read the logout.php troubleshooting guide.</p>`,
+		},
+		{
+			name:      "logout anchor off index",
+			finalPath: "/home.php",
+			body:      `<a href="/logout.php">Logout</a>`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case loginPagePath:
+					_, _ = w.Write([]byte(`<input type="hidden" name="token" value="login-token">`))
+				case takeLoginPath:
+					http.Redirect(w, r, tt.finalPath, http.StatusFound)
+				case tt.finalPath:
+					_, _ = w.Write([]byte(tt.body))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			client, err := LoginSession(context.Background(), config.TrackerConfig{URL: server.URL, Username: "user", Password: "pass"})
+			if !errors.Is(err, ErrLoginFailed) {
+				t.Fatalf("expected ErrLoginFailed, got %v", err)
+			}
+			if client != nil {
+				t.Fatal("expected weak marker login to return no client")
+			}
+		})
 	}
 }

--- a/internal/webserver/jobs.go
+++ b/internal/webserver/jobs.go
@@ -452,6 +452,9 @@ func (b *Backend) runDupeCheckJob(ctx context.Context, job *dupeCheckJob) {
 	b.scheduleDupeJobCleanup(job)
 }
 
+// applyDupeProgress merges one tracker update and emits the resulting job
+// snapshot. Trackers discovered after job creation increase the total once only
+// when the producer omitted an explicit total.
 func (b *Backend) applyDupeProgress(job *dupeCheckJob, update api.DupeProgressUpdate) {
 	tracker := strings.ToUpper(strings.TrimSpace(update.Tracker))
 	if tracker == "" {
@@ -459,8 +462,14 @@ func (b *Backend) applyDupeProgress(job *dupeCheckJob, update api.DupeProgressUp
 	}
 	job.mu.Lock()
 	state := job.states[tracker]
+	if state.Tracker == "" {
+		state.Tracker = tracker
+		job.trackers = append(job.trackers, tracker)
+		if update.Total <= 0 {
+			job.totalCount++
+		}
+	}
 	previousStatus := state.Status
-	state.Tracker = tracker
 	if strings.TrimSpace(update.Status) != "" {
 		state.Status = strings.TrimSpace(update.Status)
 	}

--- a/internal/webserver/jobs.go
+++ b/internal/webserver/jobs.go
@@ -478,7 +478,7 @@ func (b *Backend) applyDupeProgress(job *dupeCheckJob, update api.DupeProgressUp
 		job.completedCount++
 		state.FinishedAt = time.Now().UTC().Format(time.RFC3339)
 	}
-	if update.Total > 0 {
+	if update.Total > job.totalCount {
 		job.totalCount = update.Total
 	}
 	job.states[tracker] = state

--- a/internal/webserver/jobs_test.go
+++ b/internal/webserver/jobs_test.go
@@ -614,6 +614,45 @@ func TestRunDupeCheckJobSplitsGroupedPathedResultsIntoTrackerStates(t *testing.T
 	}
 }
 
+func TestApplyDupeProgressCountsNewTrackersWithoutInflatingExplicitTotal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		startTotal  int
+		updateTotal int
+		wantTotal   int
+	}{
+		{name: "explicit total", startTotal: 2, updateTotal: 2, wantTotal: 2},
+		{name: "total omitted", startTotal: 1, wantTotal: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			job := newDupeCheckJobTestJob("session-a", `C:\Media\Example.Release.2026.1080p-GRP.mkv`, []string{"AITHER"})
+			job.totalCount = tt.startTotal
+			backend := &Backend{hub: newEventHub()}
+
+			backend.applyDupeProgress(job, api.DupeProgressUpdate{
+				Tracker: "BLU",
+				Status:  "running",
+				Total:   tt.updateTotal,
+			})
+
+			if job.totalCount != tt.wantTotal {
+				t.Fatalf("expected total count %d, got %d", tt.wantTotal, job.totalCount)
+			}
+			if len(job.trackers) != 2 || job.trackers[1] != "BLU" {
+				t.Fatalf("expected new tracker to be appended once, got %#v", job.trackers)
+			}
+			if got := job.states["BLU"].Status; got != "running" {
+				t.Fatalf("expected BLU running state, got %q", got)
+			}
+		})
+	}
+}
+
 func TestRunDupeCheckJobUsesJobCoreSnapshot(t *testing.T) {
 	t.Parallel()
 

--- a/internal/webserver/jobs_test.go
+++ b/internal/webserver/jobs_test.go
@@ -625,6 +625,8 @@ func TestApplyDupeProgressCountsNewTrackersWithoutInflatingExplicitTotal(t *test
 	}{
 		{name: "explicit total", startTotal: 2, updateTotal: 2, wantTotal: 2},
 		{name: "total omitted", startTotal: 1, wantTotal: 2},
+		{name: "explicit total lower than current", startTotal: 3, updateTotal: 2, wantTotal: 3},
+		{name: "explicit total higher than current", startTotal: 2, updateTotal: 3, wantTotal: 3},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -12,12 +12,14 @@ import (
 )
 
 type ServiceSet struct {
-	Metadata    MetadataService
-	Trackers    TrackerService
-	Torrents    TorrentService
-	Clients     ClientService
-	Filesystem  FilesystemService
-	Dupes       DupeService
+	Metadata   MetadataService
+	Trackers   TrackerService
+	Torrents   TorrentService
+	Clients    ClientService
+	Filesystem FilesystemService
+	Dupes      DupeService
+	// TrackerAuth validates managed tracker sessions before duplicate checks.
+	TrackerAuth TrackerAuthService
 	Screenshots ScreenshotService
 	// DVDMenus handles automatic capture and persisted disc-menu lifecycle operations.
 	DVDMenus DVDMenuService
@@ -58,6 +60,17 @@ type FilesystemService interface {
 
 type DupeService interface {
 	Check(ctx context.Context, meta PreparedMetadata, trackers []string) (DupeCheckSummary, error)
+}
+
+// TrackerAuthService exposes the batch auth operations needed before GUI and
+// embedded-web duplicate checking.
+type TrackerAuthService interface {
+	// Capabilities returns the configured trackers whose auth workflows the
+	// service can classify.
+	Capabilities(ctx context.Context) ([]TrackerAuthCapability, error)
+	// ValidateMany returns one status per tracker in input order. An error means
+	// the batch has no usable status result.
+	ValidateMany(ctx context.Context, trackerIDs []string) ([]TrackerAuthStatus, error)
 }
 
 type ScreenshotService interface {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GUI duplicate checks now run tracker-auth preflight; auth-blocked trackers show an **“Auth required”** badge with the specific remediation text.
  - Tracker-auth validation now uses batch checks (`ValidateMany`) with concurrent processing while preserving tracker order (applies across GUI/CLI flows and E2E fakes).
- **Bug Fixes**
  - AR auth sessions now require an authenticated logout marker; oversized/invalid auth responses are rejected.
  - Dupe-check progress `totalCount` updates are corrected (including monotonic behavior and newly seen trackers).
- **Tests**
  - Added/updated UI, GUI/CLI preflight, batch validation, dupe-progress counting, and auth/login flow coverage (including THR session bootstrapping).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->