### PR TITLE
fix: harden torrent injection

### DIFF
--- a/gui/frontend/src/hooks/useSettingsState.test.ts
+++ b/gui/frontend/src/hooks/useSettingsState.test.ts
@@ -325,6 +325,7 @@ describe("renderTorrentClientsSection", () => {
                   QbitURL: "http://localhost:8080",
                   QbitUser: "user",
                   QbitPass: "secret",
+                  AutomaticManagementPaths: ["/media"],
                 },
               },
             }),
@@ -351,6 +352,13 @@ describe("renderTorrentClientsSection", () => {
     expect(watchScope.getByLabelText("Watch folder")).toHaveValue("/watch");
     expect(watchScope.getByLabelText("Storage directory")).toHaveValue("/storage");
     expect(qbitScope.getByLabelText("qBit URL")).toHaveValue("http://localhost:8080");
+    expect(qbitScope.getByLabelText("Automatic management paths 1")).toHaveValue("/media");
+    expect(qbitScope.getByRole("button", { name: "Add Linked folder item" })).toBeInTheDocument();
+    expect(qbitScope.getByRole("button", { name: "Add Local path item" })).toBeInTheDocument();
+    expect(qbitScope.getByRole("button", { name: "Add Remote path item" })).toBeInTheDocument();
+    expect(
+      qbitScope.getByRole("button", { name: "Add Automatic management paths item" }),
+    ).toBeInTheDocument();
     expect(qbitScope.getByLabelText("qBit direct")).toBeChecked();
 
     fireEvent.change(watchScope.getByLabelText("Watch folder"), {
@@ -373,6 +381,7 @@ describe("renderTorrentClientsSection", () => {
       QbitURL: "http://localhost:8080",
       QbitUser: "user",
       QbitPass: "secret",
+      AutomaticManagementPaths: ["/media"],
     });
   });
 });

--- a/gui/frontend/src/hooks/useSettingsState.tsx
+++ b/gui/frontend/src/hooks/useSettingsState.tsx
@@ -832,6 +832,9 @@ const sectionFieldMeta: Record<string, Record<string, FieldMeta>> = {
     LinkedFolder: stringField("LinkedFolder", { label: "Linked folder" }),
     LocalPath: stringField("LocalPath", { label: "Local path" }),
     RemotePath: stringField("RemotePath", { label: "Remote path" }),
+    AutomaticManagementPaths: stringField("AutomaticManagementPaths", {
+      label: "Automatic management paths",
+    }),
     VerifyWebUICertificate: boolField("VerifyWebUICertificate", {
       label: "Verify WebUI certificate",
       advanced: true,
@@ -932,6 +935,7 @@ const qbitDefaultClient = (): ConfigMap => ({
   LinkedFolder: [],
   LocalPath: [],
   RemotePath: [],
+  AutomaticManagementPaths: [],
   VerifyWebUICertificate: true,
 });
 
@@ -1604,7 +1608,11 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
             </Button>
           </div>
         ))}
-        <Button type="button" onClick={() => updateConfigValue(path, [...value, newItemValue])}>
+        <Button
+          type="button"
+          aria-label={displayLabel ? `Add ${displayLabel} item` : "Add item"}
+          onClick={() => updateConfigValue(path, [...value, newItemValue])}
+        >
           Add item
         </Button>
       </div>
@@ -2002,6 +2010,14 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
                           arrayFor(client, "RemotePath"),
                           ["TorrentClients", name, "RemotePath"],
                           meta.RemotePath,
+                        )
+                      : null}
+                    {!watchClient
+                      ? renderField(
+                          "AutomaticManagementPaths",
+                          arrayFor(client, "AutomaticManagementPaths"),
+                          ["TorrentClients", name, "AutomaticManagementPaths"],
+                          meta.AutomaticManagementPaths,
                         )
                       : null}
                     {!watchClient && advancedOpen

--- a/internal/clients/linking.go
+++ b/internal/clients/linking.go
@@ -23,16 +23,14 @@ import (
 )
 
 // linkStagingResult records a link-staging decision and any cleanup needed if
-// the subsequent client add fails. HashCheckRequired distinguishes an unsafe
-// original-path fallback from ordinary unlinked mode. LayoutValidated and
-// FileCount describe only staging derived from a local torrent artifact.
+// the subsequent client add fails. LayoutValidated and FileCount describe only
+// staging derived from a local torrent artifact.
 type linkStagingResult struct {
-	SavePath          string
-	Linked            bool
-	HashCheckRequired bool
-	LayoutValidated   bool
-	FileCount         int
-	Cleanup           *linkStagingCleanup
+	SavePath        string
+	Linked          bool
+	LayoutValidated bool
+	FileCount       int
+	Cleanup         *linkStagingCleanup
 }
 
 type linkStagingCleanup struct {
@@ -126,7 +124,7 @@ func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, cli
 			}
 			if client.FallbackAllowed() {
 				s.logger.Warnf("clients: injected torrent layout validation failed client=%s tracker=%s mode=%s decision=original-path-fallback reason=%s", clientName, tracker, mode, redaction.RedactValue(err.Error(), nil))
-				return linkStagingResult{HashCheckRequired: true}, nil
+				return linkStagingResult{}, nil
 			}
 			return linkStagingResult{}, fmt.Errorf("clients: %s plan %s staging from injected torrent: %w", clientName, mode, err)
 		}
@@ -140,7 +138,7 @@ func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, cli
 			return linkStagingResult{}, fmt.Errorf("clients: %s cannot validate %s staging for URL-only torrent; provide a torrent file or enable allow_fallback for this client", clientName, mode)
 		}
 		s.logger.Warnf("clients: URL-only linked injection cannot inspect torrent layout client=%s tracker=%s mode=%s decision=original-path-fallback", clientName, tracker, mode)
-		return linkStagingResult{HashCheckRequired: true}, nil
+		return linkStagingResult{}, nil
 	}
 
 	mappingPairs := pathMappingPairs(client.LocalPath, client.RemotePath)
@@ -229,7 +227,7 @@ func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, cli
 	}
 	if client.FallbackAllowed() {
 		s.logger.Warnf("clients: %s %s failed for %s, falling back to original qbit path: %v", clientName, mode, source, lastErr)
-		return linkStagingResult{HashCheckRequired: true}, nil
+		return linkStagingResult{}, nil
 	}
 	return linkStagingResult{}, lastErr
 }

--- a/internal/clients/linking.go
+++ b/internal/clients/linking.go
@@ -18,13 +18,19 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/pathutil"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+// linkStagingResult records a successful link-staging decision and the cleanup
+// needed if the subsequent client add fails. LayoutValidated and FileCount
+// describe only staging derived from a locally available torrent artifact.
 type linkStagingResult struct {
-	SavePath string
-	Linked   bool
-	Cleanup  *linkStagingCleanup
+	SavePath        string
+	Linked          bool
+	LayoutValidated bool
+	FileCount       int
+	Cleanup         *linkStagingCleanup
 }
 
 type linkStagingCleanup struct {
@@ -76,7 +82,11 @@ func (c *linkStagingCleanup) Run() error {
 
 var createReflink = reflinkFile
 
-func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, client config.TorrentClientConfig, meta api.PreparedMetadata, tracker string) (linkStagingResult, error) {
+// prepareLinkStaging creates a client-visible staging tree for the final local
+// torrent artifact. It uses the torrent's metainfo layout, validates staged
+// files before returning, and maps the containing directory to the qBittorrent
+// host path. URL-only or invalid layouts fall back only when the client permits it.
+func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, client config.TorrentClientConfig, meta api.PreparedMetadata, torrent api.TorrentResult) (linkStagingResult, error) {
 	mode := client.LinkingMode()
 	if mode == "" {
 		s.logger.Tracef("clients: %s link staging disabled", clientName)
@@ -95,11 +105,39 @@ func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, cli
 		return linkStagingResult{}, fmt.Errorf("clients: %s linking target: %w", clientName, err)
 	}
 
+	tracker := strings.TrimSpace(torrent.Tracker)
 	trackerDirName, err := sanitizeTrackerLinkDirName(s.trackerLinkDirName(tracker))
 	if err != nil {
 		return linkStagingResult{}, fmt.Errorf("clients: %s invalid link staging directory for tracker %q: %w", clientName, strings.TrimSpace(tracker), err)
 	}
 
+	var torrentPlan torrentLinkPlan
+	if torrentPath := strings.TrimSpace(torrent.Path); torrentPath != "" {
+		s.logger.Debugf("clients: inspecting injected torrent layout client=%s tracker=%s mode=%s", clientName, tracker, mode)
+		plan, err := buildTorrentLinkPlan(torrentPath, meta)
+		if err != nil {
+			if client.FallbackAllowed() {
+				s.logger.Warnf("clients: injected torrent layout validation failed client=%s tracker=%s mode=%s decision=original-path-fallback reason=%s", clientName, tracker, mode, redaction.RedactValue(err.Error(), nil))
+				return linkStagingResult{}, nil
+			}
+			return linkStagingResult{}, fmt.Errorf("clients: %s plan %s staging from injected torrent: %w", clientName, mode, err)
+		}
+		torrentPlan = plan
+		s.logger.Debugf("clients: injected torrent layout ready client=%s tracker=%s root=%q files=%d padding_files=%d multi_file=%t", clientName, tracker, plan.root, len(plan.files), plan.paddingFiles, plan.torrentIsMulti)
+		for _, file := range plan.files {
+			s.logger.Tracef("clients: injected torrent file mapped client=%s tracker=%s match=%s source=%s destination=%s", clientName, tracker, file.match, file.sourcePath, file.destRel)
+		}
+	} else {
+		if !client.FallbackAllowed() {
+			return linkStagingResult{}, fmt.Errorf("clients: %s cannot validate %s staging for URL-only torrent; provide a torrent file or enable allow_fallback for this client", clientName, mode)
+		}
+		s.logger.Warnf("clients: URL-only linked injection cannot inspect torrent layout client=%s tracker=%s mode=%s decision=original-path-fallback", clientName, tracker, mode)
+		return linkStagingResult{}, nil
+	}
+
+	mappingPairs := pathMappingPairs(client.LocalPath, client.RemotePath)
+	mappingRequired := len(mappingPairs) > 0
+	mappingCandidateFound := false
 	var lastErr error
 	for _, linkTarget := range linkTargets {
 		trackerDir := filepath.Join(linkTarget, trackerDirName)
@@ -107,6 +145,22 @@ func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, cli
 			lastErr = fmt.Errorf("clients: %s link staging directory escapes target: %w", clientName, internalerrors.ErrInvalidInput)
 			continue
 		}
+
+		savePath := trackerDir
+		mappingState := "not-configured"
+		if mappingRequired {
+			mappedPath, mapped := mappedRemotePath(trackerDir, client.LocalPath, client.RemotePath)
+			if !mapped {
+				lastErr = fmt.Errorf("clients: %s linked staging path is outside configured local_path roots: %w", clientName, internalerrors.ErrInvalidInput)
+				s.logger.Debugf("clients: linked torrent path mapping skipped client=%s tracker=%s mode=%s state=no-local-root-match tracker_dir=%s", clientName, tracker, mode, trackerDir)
+				continue
+			}
+			mappingCandidateFound = true
+			mappingState = "matched"
+			savePath = mappedPath
+			s.logger.Debugf("clients: linked torrent path mapping ready client=%s tracker=%s mode=%s state=%s local=%s remote=%s", clientName, tracker, mode, mappingState, trackerDir, savePath)
+		}
+
 		trackerDirExisted, err := pathExists(trackerDir)
 		if err != nil {
 			lastErr = fmt.Errorf("clients: %s stat link staging directory: %w", clientName, err)
@@ -117,7 +171,7 @@ func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, cli
 			continue
 		}
 
-		dest := filepath.Join(trackerDir, filepath.Base(source))
+		dest := filepath.Join(trackerDir, torrentPlan.root)
 		if !pathutil.IsWithinRoot(trackerDir, dest) {
 			lastErr = fmt.Errorf("clients: %s link destination escapes target: %w", clientName, internalerrors.ErrInvalidInput)
 			continue
@@ -127,7 +181,8 @@ func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, cli
 			lastErr = fmt.Errorf("clients: %s stat link destination: %w", clientName, err)
 			continue
 		}
-		if err := createLinkTree(ctx, source, dest, mode); err != nil {
+		linkErr := createTorrentLinkPlan(ctx, trackerDir, torrentPlan, mode)
+		if linkErr != nil {
 			if !destExisted {
 				if cleanupErr := (&linkStagingCleanup{
 					TrackerDir:       trackerDir,
@@ -137,11 +192,10 @@ func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, cli
 					s.logger.Warnf("clients: %s cleanup failed after staged link error target=%s: %v", clientName, linkTarget, cleanupErr)
 				}
 			}
-			lastErr = fmt.Errorf("clients: %s %s target %s: %w", clientName, mode, linkTarget, err)
+			lastErr = fmt.Errorf("clients: %s %s target %s: %w", clientName, mode, linkTarget, linkErr)
 			continue
 		}
 
-		savePath := mapLocalPathToRemote(trackerDir, client.LocalPath, client.RemotePath)
 		var cleanup *linkStagingCleanup
 		if !destExisted {
 			cleanup = &linkStagingCleanup{
@@ -150,11 +204,21 @@ func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, cli
 				RemoveTrackerDir: !trackerDirExisted,
 			}
 		}
-		result := linkStagingResult{SavePath: qbitSavePath(savePath), Linked: true, Cleanup: cleanup}
-		s.logger.Debugf("clients: %s linked content tracker=%s mode=%s save_path=%s", clientName, strings.TrimSpace(tracker), mode, result.SavePath)
+		result := linkStagingResult{
+			SavePath:        qbitSavePath(savePath),
+			Linked:          true,
+			LayoutValidated: true,
+			FileCount:       len(torrentPlan.files),
+			Cleanup:         cleanup,
+		}
+		s.logger.Infof("clients: linked torrent staging ready client=%s tracker=%s mode=%s files=%d layout_validated=%t path_mapping=%s save_path=%s", clientName, tracker, mode, result.FileCount, result.LayoutValidated, mappingState, result.SavePath)
 		return result, nil
 	}
 
+	if mappingRequired && !mappingCandidateFound {
+		s.logger.Warnf("clients: linked torrent path mapping blocked client=%s tracker=%s mode=%s decision=abort reason=no-local-root-match", clientName, tracker, mode)
+		return linkStagingResult{}, lastErr
+	}
 	if client.FallbackAllowed() {
 		s.logger.Warnf("clients: %s %s failed for %s, falling back to original qbit path: %v", clientName, mode, source, lastErr)
 		return linkStagingResult{}, nil
@@ -609,35 +673,33 @@ func symlink(source string, dest string, _ bool) error {
 	return nil
 }
 
-// mapLocalPathToRemote maps a local filesystem path through the first matching,
-// positionally paired local_path/remote_path entry, or returns the trimmed input
-// when no usable pair matches.
-func mapLocalPathToRemote[S ~[]string](value string, localPaths S, remotePaths S) string {
-	if mapped, ok := mappedRemotePath(value, localPaths, remotePaths); ok {
-		return mapped
-	}
-	return strings.TrimSpace(value)
-}
-
 // mappedRemotePath reports whether value is under a usable configured local
-// root and, when it is, returns the paired remote root plus relative suffix.
-// Blank local or remote entries are ignored without shifting later pairs.
+// root and, when it is, returns the most-specific paired remote root plus
+// relative suffix. Blank entries are ignored without shifting later pairs.
 func mappedRemotePath[S ~[]string](value string, localPaths S, remotePaths S) (string, bool) {
 	savePath := strings.TrimSpace(value)
 	if savePath == "" {
 		return "", false
 	}
+	bestSpecificity := -1
+	bestMapped := ""
 	for _, pair := range pathMappingPairs(localPaths, remotePaths) {
 		rel, ok := relativePathUnderRoot(pair.local, savePath)
 		if !ok {
 			continue
 		}
-		if rel == "." {
-			return pair.remote, true
+		localRoot, err := filepath.Abs(filepath.Clean(pair.local))
+		if err != nil || len(localRoot) <= bestSpecificity {
+			continue
 		}
-		return filepath.Join(pair.remote, rel), true
+		bestSpecificity = len(localRoot)
+		if rel == "." {
+			bestMapped = pair.remote
+			continue
+		}
+		bestMapped = filepath.Join(pair.remote, rel)
 	}
-	return "", false
+	return bestMapped, bestSpecificity >= 0
 }
 
 // mappedQbitSavePathForSource maps the prepared source path to the qBittorrent

--- a/internal/clients/linking.go
+++ b/internal/clients/linking.go
@@ -22,15 +22,17 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-// linkStagingResult records a successful link-staging decision and the cleanup
-// needed if the subsequent client add fails. LayoutValidated and FileCount
-// describe only staging derived from a locally available torrent artifact.
+// linkStagingResult records a link-staging decision and any cleanup needed if
+// the subsequent client add fails. HashCheckRequired distinguishes an unsafe
+// original-path fallback from ordinary unlinked mode. LayoutValidated and
+// FileCount describe only staging derived from a local torrent artifact.
 type linkStagingResult struct {
-	SavePath        string
-	Linked          bool
-	LayoutValidated bool
-	FileCount       int
-	Cleanup         *linkStagingCleanup
+	SavePath          string
+	Linked            bool
+	HashCheckRequired bool
+	LayoutValidated   bool
+	FileCount         int
+	Cleanup           *linkStagingCleanup
 }
 
 type linkStagingCleanup struct {
@@ -85,7 +87,10 @@ var createReflink = reflinkFile
 // prepareLinkStaging creates a client-visible staging tree for the final local
 // torrent artifact. It uses the torrent's metainfo layout, validates staged
 // files before returning, and maps the containing directory to the qBittorrent
-// host path. URL-only or invalid layouts fall back only when the client permits it.
+// host path. URL-only or invalid layouts fall back only when the client permits
+// it; every original-path fallback requires qBittorrent to verify content.
+// Cancellation during metainfo planning returns a wrapped context error instead
+// of falling back.
 func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, client config.TorrentClientConfig, meta api.PreparedMetadata, torrent api.TorrentResult) (linkStagingResult, error) {
 	mode := client.LinkingMode()
 	if mode == "" {
@@ -114,11 +119,14 @@ func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, cli
 	var torrentPlan torrentLinkPlan
 	if torrentPath := strings.TrimSpace(torrent.Path); torrentPath != "" {
 		s.logger.Debugf("clients: inspecting injected torrent layout client=%s tracker=%s mode=%s", clientName, tracker, mode)
-		plan, err := buildTorrentLinkPlan(torrentPath, meta)
+		plan, err := buildTorrentLinkPlan(ctx, torrentPath, meta)
 		if err != nil {
+			if ctx.Err() != nil {
+				return linkStagingResult{}, fmt.Errorf("clients: %s plan %s staging from injected torrent: %w", clientName, mode, err)
+			}
 			if client.FallbackAllowed() {
 				s.logger.Warnf("clients: injected torrent layout validation failed client=%s tracker=%s mode=%s decision=original-path-fallback reason=%s", clientName, tracker, mode, redaction.RedactValue(err.Error(), nil))
-				return linkStagingResult{}, nil
+				return linkStagingResult{HashCheckRequired: true}, nil
 			}
 			return linkStagingResult{}, fmt.Errorf("clients: %s plan %s staging from injected torrent: %w", clientName, mode, err)
 		}
@@ -132,7 +140,7 @@ func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, cli
 			return linkStagingResult{}, fmt.Errorf("clients: %s cannot validate %s staging for URL-only torrent; provide a torrent file or enable allow_fallback for this client", clientName, mode)
 		}
 		s.logger.Warnf("clients: URL-only linked injection cannot inspect torrent layout client=%s tracker=%s mode=%s decision=original-path-fallback", clientName, tracker, mode)
-		return linkStagingResult{}, nil
+		return linkStagingResult{HashCheckRequired: true}, nil
 	}
 
 	mappingPairs := pathMappingPairs(client.LocalPath, client.RemotePath)
@@ -221,7 +229,7 @@ func (s *Service) prepareLinkStaging(ctx context.Context, clientName string, cli
 	}
 	if client.FallbackAllowed() {
 		s.logger.Warnf("clients: %s %s failed for %s, falling back to original qbit path: %v", clientName, mode, source, lastErr)
-		return linkStagingResult{}, nil
+		return linkStagingResult{HashCheckRequired: true}, nil
 	}
 	return linkStagingResult{}, lastErr
 }

--- a/internal/clients/linking_torrent.go
+++ b/internal/clients/linking_torrent.go
@@ -49,13 +49,24 @@ type sourceLinkCandidate struct {
 
 // buildTorrentLinkPlan parses the final torrent artifact and maps every
 // non-padding metainfo file to one unique regular source file. Destination
-// paths preserve the torrent root and internal file layout.
-func buildTorrentLinkPlan(torrentPath string, meta api.PreparedMetadata) (torrentLinkPlan, error) {
+// paths preserve the torrent root and internal file layout. It checks ctx
+// around metainfo processing and during source discovery and matching, returning
+// an error that wraps the context error when canceled.
+func buildTorrentLinkPlan(ctx context.Context, torrentPath string, meta api.PreparedMetadata) (torrentLinkPlan, error) {
+	if err := torrentLinkPlanContextError(ctx); err != nil {
+		return torrentLinkPlan{}, err
+	}
 	torrentMeta, err := metainfo.LoadFromFile(torrentPath)
+	if err := torrentLinkPlanContextError(ctx); err != nil {
+		return torrentLinkPlan{}, err
+	}
 	if err != nil {
 		return torrentLinkPlan{}, fmt.Errorf("load injected torrent metainfo: %w", err)
 	}
 	info, err := torrentMeta.UnmarshalInfo()
+	if err := torrentLinkPlanContextError(ctx); err != nil {
+		return torrentLinkPlan{}, err
+	}
 	if err != nil {
 		return torrentLinkPlan{}, fmt.Errorf("decode injected torrent info: %w", err)
 	}
@@ -63,7 +74,7 @@ func buildTorrentLinkPlan(torrentPath string, meta api.PreparedMetadata) (torren
 	if err != nil {
 		return torrentLinkPlan{}, fmt.Errorf("injected torrent root: %w", err)
 	}
-	candidates, err := sourceLinkCandidates(meta)
+	candidates, err := sourceLinkCandidates(ctx, meta)
 	if err != nil {
 		return torrentLinkPlan{}, err
 	}
@@ -73,6 +84,9 @@ func buildTorrentLinkPlan(torrentPath string, meta api.PreparedMetadata) (torren
 
 	plan := torrentLinkPlan{root: root, torrentIsMulti: info.IsDir()}
 	for _, torrentFile := range info.UpvertedFiles() {
+		if err := torrentLinkPlanContextError(ctx); err != nil {
+			return torrentLinkPlan{}, err
+		}
 		if strings.Contains(torrentFile.Attr, "p") {
 			plan.paddingFiles++
 			continue
@@ -87,7 +101,7 @@ func buildTorrentLinkPlan(torrentPath string, meta api.PreparedMetadata) (torren
 			torrentRel = filepath.Join(components...)
 			destRel = filepath.Join(append([]string{root}, components...)...)
 		}
-		candidate, match, err := matchSourceLinkCandidate(candidates, torrentRel, torrentFile.Length)
+		candidate, match, err := matchSourceLinkCandidate(ctx, candidates, torrentRel, torrentFile.Length)
 		if err != nil {
 			return torrentLinkPlan{}, fmt.Errorf("map injected torrent file %q: %w", filepath.ToSlash(torrentRel), err)
 		}
@@ -101,12 +115,20 @@ func buildTorrentLinkPlan(torrentPath string, meta api.PreparedMetadata) (torren
 	if len(plan.files) == 0 {
 		return torrentLinkPlan{}, errors.New("injected torrent has no non-padding files")
 	}
+	if err := torrentLinkPlanContextError(ctx); err != nil {
+		return torrentLinkPlan{}, err
+	}
 	return plan, nil
 }
 
 // sourceLinkCandidates enumerates regular files below the prepared source path.
-// Single-file sources produce one candidate; directory sources are walked recursively.
-func sourceLinkCandidates(meta api.PreparedMetadata) ([]sourceLinkCandidate, error) {
+// Single-file sources produce one candidate; directory sources are walked
+// recursively. It checks ctx around filesystem operations and on every walk
+// callback, returning a wrapped context error when canceled.
+func sourceLinkCandidates(ctx context.Context, meta api.PreparedMetadata) ([]sourceLinkCandidate, error) {
+	if err := torrentLinkPlanContextError(ctx); err != nil {
+		return nil, err
+	}
 	source := strings.TrimSpace(meta.SourcePath)
 	if source == "" {
 		return nil, errors.New("source path is required for torrent link staging")
@@ -115,7 +137,13 @@ func sourceLinkCandidates(meta api.PreparedMetadata) ([]sourceLinkCandidate, err
 	if err != nil {
 		return nil, err
 	}
+	if err := torrentLinkPlanContextError(ctx); err != nil {
+		return nil, err
+	}
 	sourceInfo, err := os.Stat(sourceAbs)
+	if err := torrentLinkPlanContextError(ctx); err != nil {
+		return nil, err
+	}
 	if err != nil {
 		return nil, fmt.Errorf("stat torrent link source: %w", err)
 	}
@@ -123,11 +151,17 @@ func sourceLinkCandidates(meta api.PreparedMetadata) ([]sourceLinkCandidate, err
 	candidates := make([]sourceLinkCandidate, 0, max(1, len(meta.FileList)))
 	seen := make(map[string]struct{})
 	add := func(path string, rel string) error {
+		if err := torrentLinkPlanContextError(ctx); err != nil {
+			return err
+		}
 		pathAbs, err := absLocalPath("torrent link candidate", path)
 		if err != nil {
 			return err
 		}
 		info, err := os.Stat(pathAbs)
+		if err := torrentLinkPlanContextError(ctx); err != nil {
+			return err
+		}
 		if err != nil {
 			return fmt.Errorf("stat torrent link candidate: %w", err)
 		}
@@ -159,6 +193,9 @@ func sourceLinkCandidates(meta api.PreparedMetadata) ([]sourceLinkCandidate, err
 	}
 
 	if err := filepath.WalkDir(sourceAbs, func(path string, entry fs.DirEntry, walkErr error) error {
+		if err := torrentLinkPlanContextError(ctx); err != nil {
+			return err
+		}
 		if walkErr != nil {
 			return fmt.Errorf("walk torrent link source: %w", walkErr)
 		}
@@ -173,13 +210,26 @@ func sourceLinkCandidates(meta api.PreparedMetadata) ([]sourceLinkCandidate, err
 	}); err != nil {
 		return nil, fmt.Errorf("walk torrent link candidates: %w", err)
 	}
+	if err := torrentLinkPlanContextError(ctx); err != nil {
+		return nil, err
+	}
 	return candidates, nil
 }
 
 // matchSourceLinkCandidate selects one unused file by path and size, then name
 // and size, then unique size. Ambiguous or absent matches return an error rather
-// than risk staging the wrong content.
-func matchSourceLinkCandidate(candidates []sourceLinkCandidate, torrentRel string, length int64) (*sourceLinkCandidate, string, error) {
+// than risk staging the wrong content. Path and name matching follows host case
+// semantics, and size-only matching cannot revive a rejected case-only match.
+// It stops scanning and returns a wrapped context error when ctx is canceled.
+func matchSourceLinkCandidate(ctx context.Context, candidates []sourceLinkCandidate, torrentRel string, length int64) (*sourceLinkCandidate, string, error) {
+	return matchSourceLinkCandidateWithCaseFold(ctx, candidates, torrentRel, length, runtime.GOOS == "windows")
+}
+
+// matchSourceLinkCandidateWithCaseFold applies the matcher with explicit case
+// semantics so host-independent tests can prove Windows and non-Windows rules.
+func matchSourceLinkCandidateWithCaseFold(ctx context.Context, candidates []sourceLinkCandidate, torrentRel string, length int64, foldCase bool) (*sourceLinkCandidate, string, error) {
+	torrentRel = filepath.Clean(torrentRel)
+	torrentName := filepath.Base(torrentRel)
 	checks := []struct {
 		name  string
 		match func(sourceLinkCandidate) bool
@@ -187,25 +237,31 @@ func matchSourceLinkCandidate(candidates []sourceLinkCandidate, torrentRel strin
 		{
 			name: "path_size",
 			match: func(candidate sourceLinkCandidate) bool {
-				return candidate.size == length && strings.EqualFold(filepath.Clean(candidate.rel), filepath.Clean(torrentRel))
+				return candidate.size == length && sourceLinkPathEqual(filepath.Clean(candidate.rel), torrentRel, foldCase)
 			},
 		},
 		{
 			name: "name_size",
 			match: func(candidate sourceLinkCandidate) bool {
-				return candidate.size == length && strings.EqualFold(candidate.name, filepath.Base(torrentRel))
+				return candidate.size == length && sourceLinkPathEqual(candidate.name, torrentName, foldCase)
 			},
 		},
 		{
 			name: "unique_size",
 			match: func(candidate sourceLinkCandidate) bool {
-				return candidate.size == length
+				return candidate.size == length && !sourceLinkCaseOnlyMismatch(candidate, torrentRel, torrentName, foldCase)
 			},
 		},
 	}
 	for _, check := range checks {
+		if err := torrentLinkPlanContextError(ctx); err != nil {
+			return nil, "", err
+		}
 		matched := -1
 		for index := range candidates {
+			if err := torrentLinkPlanContextError(ctx); err != nil {
+				return nil, "", err
+			}
 			if candidates[index].used || !check.match(candidates[index]) {
 				continue
 			}
@@ -224,6 +280,36 @@ func matchSourceLinkCandidate(candidates []sourceLinkCandidate, torrentRel strin
 		}
 	}
 	return nil, "", fmt.Errorf("no unique source match with length=%d", length)
+}
+
+// sourceLinkPathEqual compares a candidate path or name using the selected host
+// case semantics.
+func sourceLinkPathEqual(left string, right string, foldCase bool) bool {
+	if foldCase {
+		return strings.EqualFold(left, right)
+	}
+	return left == right
+}
+
+// sourceLinkCaseOnlyMismatch reports whether a candidate differs only by case.
+// Such candidates cannot bypass case-sensitive rejection via unique-size match.
+func sourceLinkCaseOnlyMismatch(candidate sourceLinkCandidate, torrentRel string, torrentName string, foldCase bool) bool {
+	if foldCase {
+		return false
+	}
+	candidateRel := filepath.Clean(candidate.rel)
+	relMismatch := candidateRel != torrentRel && strings.EqualFold(candidateRel, torrentRel)
+	nameMismatch := candidate.name != torrentName && strings.EqualFold(candidate.name, torrentName)
+	return relMismatch || nameMismatch
+}
+
+// torrentLinkPlanContextError returns nil while ctx is active or an error that
+// wraps ctx.Err after cancellation.
+func torrentLinkPlanContextError(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("torrent link planning canceled: %w", err)
+	}
+	return nil
 }
 
 // safeTorrentLinkPath validates metainfo components before they become a local
@@ -254,24 +340,53 @@ func safeTorrentLinkComponent(value string) (string, error) {
 }
 
 // createTorrentLinkPlan materializes a metainfo-shaped staging tree and checks
-// that every destination is a regular file with the declared length. qBittorrent
-// performs the subsequent piece hash check during injection.
+// that every destination is a regular file with the declared length. On failure
+// it removes links created by the current attempt while preserving pre-existing
+// destinations. qBittorrent performs the subsequent piece hash check.
 func createTorrentLinkPlan(ctx context.Context, trackerDir string, plan torrentLinkPlan, mode string) error {
+	created := make([]string, 0, len(plan.files))
 	for _, file := range plan.files {
 		dest := filepath.Join(trackerDir, file.destRel)
 		if !pathutil.IsWithinRoot(trackerDir, dest) {
-			return errors.New("torrent link destination escapes tracker directory")
+			return rollbackTorrentLinkPlan(trackerDir, created, errors.New("torrent link destination escapes tracker directory"))
+		}
+		destExisted, err := pathExists(dest)
+		if err != nil {
+			return rollbackTorrentLinkPlan(trackerDir, created, fmt.Errorf("stat staged torrent file: %w", err))
 		}
 		if err := createLinkTree(ctx, file.sourcePath, dest, mode); err != nil {
-			return fmt.Errorf("create metainfo-shaped %s link: %w", mode, err)
+			return rollbackTorrentLinkPlan(trackerDir, created, fmt.Errorf("create metainfo-shaped %s link: %w", mode, err))
+		}
+		if !destExisted {
+			created = append(created, dest)
 		}
 		info, err := os.Stat(dest)
 		if err != nil {
-			return fmt.Errorf("validate staged torrent file: %w", err)
+			return rollbackTorrentLinkPlan(trackerDir, created, fmt.Errorf("validate staged torrent file: %w", err))
 		}
 		if !info.Mode().IsRegular() || info.Size() != file.length {
-			return fmt.Errorf("staged torrent file size mismatch: expected=%d actual=%d", file.length, info.Size())
+			return rollbackTorrentLinkPlan(trackerDir, created, fmt.Errorf("staged torrent file size mismatch: expected=%d actual=%d", file.length, info.Size()))
 		}
 	}
 	return nil
+}
+
+// rollbackTorrentLinkPlan removes created links in reverse order and combines
+// cleanup failures with the original plan error.
+func rollbackTorrentLinkPlan(trackerDir string, created []string, planErr error) error {
+	var rollbackErrs []error
+	for i := len(created) - 1; i >= 0; i-- {
+		dest := created[i]
+		if !pathutil.IsWithinRoot(trackerDir, dest) {
+			rollbackErrs = append(rollbackErrs, errors.New("torrent link rollback destination escapes tracker directory"))
+			continue
+		}
+		if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {
+			rollbackErrs = append(rollbackErrs, fmt.Errorf("remove staged torrent link: %w", err))
+		}
+	}
+	if len(rollbackErrs) == 0 {
+		return planErr
+	}
+	return fmt.Errorf("rollback failed: %w", errors.Join(append([]error{planErr}, rollbackErrs...)...))
 }

--- a/internal/clients/linking_torrent.go
+++ b/internal/clients/linking_torrent.go
@@ -1,0 +1,277 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package clients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/anacrolix/torrent/metainfo"
+
+	"github.com/autobrr/upbrr/internal/pathutil"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+// torrentLinkPlan describes the qBittorrent-visible tree derived from the final
+// torrent artifact, excluding padding files that require no source content.
+type torrentLinkPlan struct {
+	root           string
+	files          []torrentLinkFile
+	paddingFiles   int
+	torrentIsMulti bool
+}
+
+// torrentLinkFile maps one non-padding metainfo file to its local source and
+// exact path beneath qBittorrent's configured save directory.
+type torrentLinkFile struct {
+	sourcePath string
+	destRel    string
+	length     int64
+	match      string
+}
+
+// sourceLinkCandidate tracks one regular source file while a torrent layout is
+// matched. A candidate can satisfy at most one metainfo file.
+type sourceLinkCandidate struct {
+	path string
+	rel  string
+	name string
+	size int64
+	used bool
+}
+
+// buildTorrentLinkPlan parses the final torrent artifact and maps every
+// non-padding metainfo file to one unique regular source file. Destination
+// paths preserve the torrent root and internal file layout.
+func buildTorrentLinkPlan(torrentPath string, meta api.PreparedMetadata) (torrentLinkPlan, error) {
+	torrentMeta, err := metainfo.LoadFromFile(torrentPath)
+	if err != nil {
+		return torrentLinkPlan{}, fmt.Errorf("load injected torrent metainfo: %w", err)
+	}
+	info, err := torrentMeta.UnmarshalInfo()
+	if err != nil {
+		return torrentLinkPlan{}, fmt.Errorf("decode injected torrent info: %w", err)
+	}
+	root, err := safeTorrentLinkComponent(info.BestName())
+	if err != nil {
+		return torrentLinkPlan{}, fmt.Errorf("injected torrent root: %w", err)
+	}
+	candidates, err := sourceLinkCandidates(meta)
+	if err != nil {
+		return torrentLinkPlan{}, err
+	}
+	if len(candidates) == 0 {
+		return torrentLinkPlan{}, errors.New("no regular source files available for injected torrent")
+	}
+
+	plan := torrentLinkPlan{root: root, torrentIsMulti: info.IsDir()}
+	for _, torrentFile := range info.UpvertedFiles() {
+		if strings.Contains(torrentFile.Attr, "p") {
+			plan.paddingFiles++
+			continue
+		}
+		torrentRel := root
+		destRel := root
+		if plan.torrentIsMulti {
+			components, err := safeTorrentLinkPath(torrentFile.BestPath())
+			if err != nil {
+				return torrentLinkPlan{}, fmt.Errorf("injected torrent file path: %w", err)
+			}
+			torrentRel = filepath.Join(components...)
+			destRel = filepath.Join(append([]string{root}, components...)...)
+		}
+		candidate, match, err := matchSourceLinkCandidate(candidates, torrentRel, torrentFile.Length)
+		if err != nil {
+			return torrentLinkPlan{}, fmt.Errorf("map injected torrent file %q: %w", filepath.ToSlash(torrentRel), err)
+		}
+		plan.files = append(plan.files, torrentLinkFile{
+			sourcePath: candidate.path,
+			destRel:    destRel,
+			length:     torrentFile.Length,
+			match:      match,
+		})
+	}
+	if len(plan.files) == 0 {
+		return torrentLinkPlan{}, errors.New("injected torrent has no non-padding files")
+	}
+	return plan, nil
+}
+
+// sourceLinkCandidates enumerates regular files below the prepared source path.
+// Single-file sources produce one candidate; directory sources are walked recursively.
+func sourceLinkCandidates(meta api.PreparedMetadata) ([]sourceLinkCandidate, error) {
+	source := strings.TrimSpace(meta.SourcePath)
+	if source == "" {
+		return nil, errors.New("source path is required for torrent link staging")
+	}
+	sourceAbs, err := absLocalPath("torrent link source", source)
+	if err != nil {
+		return nil, err
+	}
+	sourceInfo, err := os.Stat(sourceAbs)
+	if err != nil {
+		return nil, fmt.Errorf("stat torrent link source: %w", err)
+	}
+
+	candidates := make([]sourceLinkCandidate, 0, max(1, len(meta.FileList)))
+	seen := make(map[string]struct{})
+	add := func(path string, rel string) error {
+		pathAbs, err := absLocalPath("torrent link candidate", path)
+		if err != nil {
+			return err
+		}
+		info, err := os.Stat(pathAbs)
+		if err != nil {
+			return fmt.Errorf("stat torrent link candidate: %w", err)
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		key := pathAbs
+		if runtime.GOOS == "windows" {
+			key = strings.ToLower(key)
+		}
+		if _, ok := seen[key]; ok {
+			return nil
+		}
+		seen[key] = struct{}{}
+		candidates = append(candidates, sourceLinkCandidate{
+			path: pathAbs,
+			rel:  filepath.Clean(rel),
+			name: filepath.Base(pathAbs),
+			size: info.Size(),
+		})
+		return nil
+	}
+
+	if !sourceInfo.IsDir() {
+		if err := add(sourceAbs, filepath.Base(sourceAbs)); err != nil {
+			return nil, err
+		}
+		return candidates, nil
+	}
+
+	if err := filepath.WalkDir(sourceAbs, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("walk torrent link source: %w", walkErr)
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(sourceAbs, path)
+		if err != nil {
+			return fmt.Errorf("torrent link source relative path: %w", err)
+		}
+		return add(path, rel)
+	}); err != nil {
+		return nil, fmt.Errorf("walk torrent link candidates: %w", err)
+	}
+	return candidates, nil
+}
+
+// matchSourceLinkCandidate selects one unused file by path and size, then name
+// and size, then unique size. Ambiguous or absent matches return an error rather
+// than risk staging the wrong content.
+func matchSourceLinkCandidate(candidates []sourceLinkCandidate, torrentRel string, length int64) (*sourceLinkCandidate, string, error) {
+	checks := []struct {
+		name  string
+		match func(sourceLinkCandidate) bool
+	}{
+		{
+			name: "path_size",
+			match: func(candidate sourceLinkCandidate) bool {
+				return candidate.size == length && strings.EqualFold(filepath.Clean(candidate.rel), filepath.Clean(torrentRel))
+			},
+		},
+		{
+			name: "name_size",
+			match: func(candidate sourceLinkCandidate) bool {
+				return candidate.size == length && strings.EqualFold(candidate.name, filepath.Base(torrentRel))
+			},
+		},
+		{
+			name: "unique_size",
+			match: func(candidate sourceLinkCandidate) bool {
+				return candidate.size == length
+			},
+		},
+	}
+	for _, check := range checks {
+		matched := -1
+		for index := range candidates {
+			if candidates[index].used || !check.match(candidates[index]) {
+				continue
+			}
+			if matched != -1 {
+				matched = -2
+				break
+			}
+			matched = index
+		}
+		if matched >= 0 {
+			candidates[matched].used = true
+			return &candidates[matched], check.name, nil
+		}
+		if matched == -2 {
+			continue
+		}
+	}
+	return nil, "", fmt.Errorf("no unique source match with length=%d", length)
+}
+
+// safeTorrentLinkPath validates metainfo components before they become a local
+// filesystem path. Empty, rooted, traversal, drive, and separator-bearing
+// components are rejected.
+func safeTorrentLinkPath(parts []string) ([]string, error) {
+	if len(parts) == 0 {
+		return nil, errors.New("empty torrent file path")
+	}
+	clean := make([]string, 0, len(parts))
+	for _, part := range parts {
+		component, err := safeTorrentLinkComponent(part)
+		if err != nil {
+			return nil, err
+		}
+		clean = append(clean, component)
+	}
+	return clean, nil
+}
+
+// safeTorrentLinkComponent validates one torrent name or path component for
+// use beneath the guarded staging directory.
+func safeTorrentLinkComponent(value string) (string, error) {
+	if value == "" || value == "." || value == ".." || filepath.IsAbs(value) || filepath.VolumeName(value) != "" || strings.ContainsAny(value, `/\`) {
+		return "", fmt.Errorf("unsafe component %q", value)
+	}
+	return value, nil
+}
+
+// createTorrentLinkPlan materializes a metainfo-shaped staging tree and checks
+// that every destination is a regular file with the declared length. qBittorrent
+// performs the subsequent piece hash check during injection.
+func createTorrentLinkPlan(ctx context.Context, trackerDir string, plan torrentLinkPlan, mode string) error {
+	for _, file := range plan.files {
+		dest := filepath.Join(trackerDir, file.destRel)
+		if !pathutil.IsWithinRoot(trackerDir, dest) {
+			return errors.New("torrent link destination escapes tracker directory")
+		}
+		if err := createLinkTree(ctx, file.sourcePath, dest, mode); err != nil {
+			return fmt.Errorf("create metainfo-shaped %s link: %w", mode, err)
+		}
+		info, err := os.Stat(dest)
+		if err != nil {
+			return fmt.Errorf("validate staged torrent file: %w", err)
+		}
+		if !info.Mode().IsRegular() || info.Size() != file.length {
+			return fmt.Errorf("staged torrent file size mismatch: expected=%d actual=%d", file.length, info.Size())
+		}
+	}
+	return nil
+}

--- a/internal/clients/linking_torrent_test.go
+++ b/internal/clients/linking_torrent_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package clients
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/metainfo"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func writeQbitTestTorrentForSource(t *testing.T, torrentPath string, sourcePath string) {
+	t.Helper()
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		t.Fatalf("stat torrent source fixture: %v", err)
+	}
+	if !info.IsDir() {
+		writeQbitTestTorrent(t, torrentPath, filepath.Base(sourcePath), map[string]string{
+			filepath.Base(sourcePath): sourcePath,
+		}, false)
+		return
+	}
+	files := make(map[string]string)
+	if err := filepath.WalkDir(sourcePath, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(sourcePath, path)
+		if err != nil {
+			return fmt.Errorf("torrent source fixture relative path: %w", err)
+		}
+		files[rel] = path
+		return nil
+	}); err != nil {
+		t.Fatalf("walk torrent source fixture: %v", err)
+	}
+	writeQbitTestTorrent(t, torrentPath, filepath.Base(sourcePath), files, true)
+}
+
+func writeQbitTestTorrent(t *testing.T, torrentPath string, rootName string, files map[string]string, multi bool) {
+	t.Helper()
+	info := metainfo.Info{Name: rootName, PieceLength: 16 * 1024, Private: new(true)}
+	if multi {
+		for rel, source := range files {
+			fileInfo, err := os.Stat(source)
+			if err != nil {
+				t.Fatalf("stat torrent source fixture: %v", err)
+			}
+			info.Files = append(info.Files, metainfo.FileInfo{
+				Length: fileInfo.Size(),
+				Path:   strings.Split(filepath.ToSlash(rel), "/"),
+			})
+		}
+	} else {
+		for _, source := range files {
+			fileInfo, err := os.Stat(source)
+			if err != nil {
+				t.Fatalf("stat torrent source fixture: %v", err)
+			}
+			info.Length = fileInfo.Size()
+			break
+		}
+	}
+	infoBytes, err := bencode.Marshal(info)
+	if err != nil {
+		t.Fatalf("marshal torrent fixture info: %v", err)
+	}
+	file, err := os.OpenFile(torrentPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("create torrent fixture: %v", err)
+	}
+	if err := (&metainfo.MetaInfo{InfoBytes: infoBytes}).Write(file); err != nil {
+		_ = file.Close()
+		t.Fatalf("write torrent fixture: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close torrent fixture: %v", err)
+	}
+}
+
+func TestBuildTorrentLinkPlanUsesInjectedSingleFileName(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	source := filepath.Join(root, "Original.Name.2026.mkv")
+	if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	torrentPath := filepath.Join(root, "renamed.torrent")
+	writeQbitTestTorrent(t, torrentPath, "Tracker.Name.2026.mkv", map[string]string{"source": source}, false)
+
+	plan, err := buildTorrentLinkPlan(torrentPath, api.PreparedMetadata{SourcePath: source, FileList: []string{source}})
+	if err != nil {
+		t.Fatalf("build plan: %v", err)
+	}
+	if plan.root != "Tracker.Name.2026.mkv" || len(plan.files) != 1 || plan.files[0].destRel != "Tracker.Name.2026.mkv" {
+		t.Fatalf("unexpected single-file torrent plan")
+	}
+}
+
+func TestBuildTorrentLinkPlanUsesInjectedMultiFileLayout(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sourceRoot := filepath.Join(root, "Original.Release.2026")
+	source := filepath.Join(sourceRoot, "Original.Name.2026.mkv")
+	if err := os.MkdirAll(sourceRoot, 0o700); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	torrentPath := filepath.Join(root, "renamed-pack.torrent")
+	writeQbitTestTorrent(t, torrentPath, "Tracker.Release.2026", map[string]string{
+		filepath.Join("Feature", "Tracker.Name.2026.mkv"): source,
+	}, true)
+
+	plan, err := buildTorrentLinkPlan(torrentPath, api.PreparedMetadata{SourcePath: sourceRoot, FileList: []string{source}})
+	if err != nil {
+		t.Fatalf("build plan: %v", err)
+	}
+	wantDest := filepath.Join("Tracker.Release.2026", "Feature", "Tracker.Name.2026.mkv")
+	if len(plan.files) != 1 || plan.files[0].destRel != wantDest {
+		t.Fatalf("unexpected multi-file torrent plan")
+	}
+	trackerDir := filepath.Join(root, "links", "TRACKER")
+	if err := os.MkdirAll(trackerDir, 0o700); err != nil {
+		t.Fatalf("mkdir tracker staging: %v", err)
+	}
+	if err := createTorrentLinkPlan(context.Background(), trackerDir, plan, "hardlink"); err != nil {
+		t.Fatalf("create torrent link plan: %v", err)
+	}
+	stagedInfo, err := os.Stat(filepath.Join(trackerDir, wantDest))
+	if err != nil {
+		t.Fatalf("stat staged torrent file: %v", err)
+	}
+	sourceInfo, err := os.Stat(source)
+	if err != nil {
+		t.Fatalf("stat source: %v", err)
+	}
+	if !os.SameFile(sourceInfo, stagedInfo) {
+		t.Fatalf("expected metainfo-shaped destination to hardlink source")
+	}
+}
+
+func TestBuildTorrentLinkPlanRejectsAmbiguousSizeOnlyMatch(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	sourceRoot := filepath.Join(root, "Original.Release.2026")
+	if err := os.MkdirAll(sourceRoot, 0o700); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	first := filepath.Join(sourceRoot, "First.mkv")
+	second := filepath.Join(sourceRoot, "Second.mkv")
+	for _, path := range []string{first, second} {
+		if err := os.WriteFile(path, []byte("same-size"), 0o600); err != nil {
+			t.Fatalf("write source: %v", err)
+		}
+	}
+	torrentPath := filepath.Join(root, "ambiguous.torrent")
+	writeQbitTestTorrent(t, torrentPath, "Renamed.mkv", map[string]string{"source": first}, false)
+
+	_, err := buildTorrentLinkPlan(torrentPath, api.PreparedMetadata{SourcePath: sourceRoot})
+	if err == nil || !strings.Contains(err.Error(), "no unique source match") {
+		t.Fatalf("expected ambiguous source mapping error")
+	}
+}
+
+func TestPrepareLinkStagingRejectsURLOnlyWhenFallbackDisabled(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	source := filepath.Join(root, "Example.Release.2026.mkv")
+	if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	linkRoot := filepath.Join(root, "links")
+	client := config.TorrentClientConfig{
+		Linking:       "hardlink",
+		LinkedFolder:  config.StringList{linkRoot},
+		AllowFallback: new(false),
+	}
+	service := NewService(config.Config{}, nil)
+
+	_, err := service.prepareLinkStaging(context.Background(), "qbit", client, api.PreparedMetadata{
+		SourcePath: source,
+		FileList:   []string{source},
+	}, api.TorrentResult{URL: "https://tracker.example/torrent/1", Tracker: "EXAMPLE"})
+	if err == nil {
+		t.Fatal("expected URL-only layout validation error")
+	}
+	for _, expected := range []string{"hardlink staging", "URL-only torrent", "provide a torrent file", "enable allow_fallback"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("expected URL-only error to contain %q", expected)
+		}
+	}
+}

--- a/internal/clients/linking_torrent_test.go
+++ b/internal/clients/linking_torrent_test.go
@@ -5,6 +5,7 @@ package clients
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -101,7 +102,7 @@ func TestBuildTorrentLinkPlanUsesInjectedSingleFileName(t *testing.T) {
 	torrentPath := filepath.Join(root, "renamed.torrent")
 	writeQbitTestTorrent(t, torrentPath, "Tracker.Name.2026.mkv", map[string]string{"source": source}, false)
 
-	plan, err := buildTorrentLinkPlan(torrentPath, api.PreparedMetadata{SourcePath: source, FileList: []string{source}})
+	plan, err := buildTorrentLinkPlan(context.Background(), torrentPath, api.PreparedMetadata{SourcePath: source, FileList: []string{source}})
 	if err != nil {
 		t.Fatalf("build plan: %v", err)
 	}
@@ -126,7 +127,7 @@ func TestBuildTorrentLinkPlanUsesInjectedMultiFileLayout(t *testing.T) {
 		filepath.Join("Feature", "Tracker.Name.2026.mkv"): source,
 	}, true)
 
-	plan, err := buildTorrentLinkPlan(torrentPath, api.PreparedMetadata{SourcePath: sourceRoot, FileList: []string{source}})
+	plan, err := buildTorrentLinkPlan(context.Background(), torrentPath, api.PreparedMetadata{SourcePath: sourceRoot, FileList: []string{source}})
 	if err != nil {
 		t.Fatalf("build plan: %v", err)
 	}
@@ -154,6 +155,50 @@ func TestBuildTorrentLinkPlanUsesInjectedMultiFileLayout(t *testing.T) {
 	}
 }
 
+func TestCreateTorrentLinkPlanRollsBackCreatedLinksUnderExistingRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	trackerDir := filepath.Join(root, "links", "EXAMPLE")
+	planRoot := filepath.Join(trackerDir, "Example.Release.2026")
+	if err := os.MkdirAll(planRoot, 0o700); err != nil {
+		t.Fatalf("mkdir existing plan root: %v", err)
+	}
+	firstSource := filepath.Join(root, "first.mkv")
+	secondSource := filepath.Join(root, "second.mkv")
+	for _, source := range []string{firstSource, secondSource} {
+		if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
+			t.Fatalf("write source: %v", err)
+		}
+	}
+	staleDest := filepath.Join(planRoot, "second.mkv")
+	if err := os.WriteFile(staleDest, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale destination: %v", err)
+	}
+
+	plan := torrentLinkPlan{
+		root: "Example.Release.2026",
+		files: []torrentLinkFile{
+			{sourcePath: firstSource, destRel: filepath.Join("Example.Release.2026", "first.mkv"), length: 5},
+			{sourcePath: secondSource, destRel: filepath.Join("Example.Release.2026", "second.mkv"), length: 5},
+		},
+		torrentIsMulti: true,
+	}
+	if err := createTorrentLinkPlan(context.Background(), trackerDir, plan, "hardlink"); err == nil {
+		t.Fatal("expected stale destination to fail link plan")
+	}
+	if _, err := os.Stat(filepath.Join(planRoot, "first.mkv")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected failed attempt to remove its created link, stat err=%v", err)
+	}
+	stale, err := os.ReadFile(staleDest)
+	if err != nil {
+		t.Fatalf("read stale destination: %v", err)
+	}
+	if string(stale) != "stale" {
+		t.Fatal("expected rollback to preserve pre-existing destination")
+	}
+}
+
 func TestBuildTorrentLinkPlanRejectsAmbiguousSizeOnlyMatch(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -171,9 +216,119 @@ func TestBuildTorrentLinkPlanRejectsAmbiguousSizeOnlyMatch(t *testing.T) {
 	torrentPath := filepath.Join(root, "ambiguous.torrent")
 	writeQbitTestTorrent(t, torrentPath, "Renamed.mkv", map[string]string{"source": first}, false)
 
-	_, err := buildTorrentLinkPlan(torrentPath, api.PreparedMetadata{SourcePath: sourceRoot})
+	_, err := buildTorrentLinkPlan(context.Background(), torrentPath, api.PreparedMetadata{SourcePath: sourceRoot})
 	if err == nil || !strings.Contains(err.Error(), "no unique source match") {
 		t.Fatalf("expected ambiguous source mapping error")
+	}
+}
+
+func TestMatchSourceLinkCandidateUsesHostCaseSemantics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exact case", func(t *testing.T) {
+		candidates := []sourceLinkCandidate{{
+			path: "exact",
+			rel:  filepath.Join("Feature", "Example.Release.2026.mkv"),
+			name: "Example.Release.2026.mkv",
+			size: 5,
+		}}
+		candidate, match, err := matchSourceLinkCandidateWithCaseFold(
+			context.Background(),
+			candidates,
+			filepath.Join("Feature", "Example.Release.2026.mkv"),
+			5,
+			false,
+		)
+		if err != nil {
+			t.Fatalf("match exact-case candidate: %v", err)
+		}
+		if candidate.path != "exact" || match != "path_size" {
+			t.Fatal("expected exact-case path match")
+		}
+	})
+
+	t.Run("case-only mismatch", func(t *testing.T) {
+		candidates := []sourceLinkCandidate{{
+			path: "case-only",
+			rel:  filepath.Join("Feature", "Example.Release.2026.mkv"),
+			name: "Example.Release.2026.mkv",
+			size: 5,
+		}}
+		candidate, match, err := matchSourceLinkCandidateWithCaseFold(
+			context.Background(),
+			candidates,
+			filepath.Join("feature", "example.release.2026.mkv"),
+			5,
+			false,
+		)
+		if err == nil {
+			t.Fatal("expected case-only mismatch rejection on case-sensitive host")
+		}
+		if candidate != nil || match != "" {
+			t.Fatal("expected rejected case-only candidate without a match")
+		}
+	})
+
+	t.Run("Windows case folding", func(t *testing.T) {
+		candidates := []sourceLinkCandidate{{
+			path: "case-only",
+			rel:  filepath.Join("Feature", "Example.Release.2026.mkv"),
+			name: "Example.Release.2026.mkv",
+			size: 5,
+		}}
+		candidate, match, err := matchSourceLinkCandidateWithCaseFold(
+			context.Background(),
+			candidates,
+			filepath.Join("feature", "example.release.2026.mkv"),
+			5,
+			true,
+		)
+		if err != nil {
+			t.Fatalf("match Windows case-folded candidate: %v", err)
+		}
+		if candidate.path != "case-only" || match != "path_size" {
+			t.Fatal("expected Windows case-folded path match")
+		}
+	})
+
+	t.Run("true rename keeps unique-size fallback", func(t *testing.T) {
+		candidates := []sourceLinkCandidate{{
+			path: "renamed",
+			rel:  "Original.Name.2026.mkv",
+			name: "Original.Name.2026.mkv",
+			size: 5,
+		}}
+		candidate, match, err := matchSourceLinkCandidateWithCaseFold(context.Background(), candidates, "Tracker.Name.2026.mkv", 5, false)
+		if err != nil {
+			t.Fatalf("match renamed candidate: %v", err)
+		}
+		if candidate.path != "renamed" || match != "unique_size" {
+			t.Fatal("expected renamed unique-size match")
+		}
+	})
+}
+
+func TestPrepareLinkStagingReturnsPlannerCancellation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	source := filepath.Join(root, "Example.Release.2026.mkv")
+	if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	service := NewService(config.Config{}, nil)
+	_, err := service.prepareLinkStaging(ctx, "qbit", config.TorrentClientConfig{
+		Linking:      "hardlink",
+		LinkedFolder: config.StringList{filepath.Join(root, "links")},
+	}, api.PreparedMetadata{
+		SourcePath: source,
+		FileList:   []string{source},
+	}, api.TorrentResult{Path: filepath.Join(root, "injected.torrent"), Tracker: "EXAMPLE"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatal("expected planner cancellation")
 	}
 }
 

--- a/internal/clients/service.go
+++ b/internal/clients/service.go
@@ -11,11 +11,13 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	"github.com/autobrr/upbrr/internal/pathutil"
 	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/pkg/api"
 
@@ -276,16 +278,18 @@ func (s *Service) injectQbit(ctx context.Context, name string, client config.Tor
 	qbit := qbittorrent.NewClient(qbitInjectClientConfig(host, username, password, client))
 
 	options := qbittorrent.TorrentAddOptions{}
-	options.SkipHashCheck = true
-	s.logger.Debugf("clients: preparing qbit add options for client %s", name)
+	s.logger.Debugf("clients: preparing qbit add options client=%s tracker=%s cross_seed=%t", name, strings.TrimSpace(torrent.Tracker), torrent.CrossSeed)
 	optionsStart := time.Now()
-	staging, err := s.prepareLinkStaging(ctx, name, client, meta, torrent.Tracker)
+	staging, err := s.prepareLinkStaging(ctx, name, client, meta, torrent)
 	if err != nil {
 		return err
 	}
+	// Linked staging is checked by qBittorrent after add so a successful API
+	// response cannot mask a metainfo/content mismatch as a seeded torrent.
+	options.SkipHashCheck = !staging.Linked
 	if staging.Linked {
 		options.SavePath = staging.SavePath
-		s.logger.Debugf("clients: qbit link staging ready client=%s tracker=%s save_path=%s", name, strings.TrimSpace(torrent.Tracker), staging.SavePath)
+		s.logger.Debugf("clients: qbit link staging selected client=%s tracker=%s files=%d layout_validated=%t save_path=%s", name, strings.TrimSpace(torrent.Tracker), staging.FileCount, staging.LayoutValidated, staging.SavePath)
 	} else {
 		// Without link staging, local_path/remote_path still controls where
 		// qBittorrent should save the injected torrent on the client host.
@@ -310,7 +314,13 @@ func (s *Service) injectQbit(ctx context.Context, name string, client config.Tor
 	} else if client.UseTrackerAsTag {
 		options.Tags = strings.TrimSpace(torrent.Tracker)
 	}
-	s.logger.Debugf("clients: qbit add options ready client=%s elapsed=%s", name, time.Since(optionsStart).Round(time.Millisecond))
+	autoManagement := !staging.Linked && qbitAutomaticManagementEnabled(meta, client.AutomaticManagementPaths)
+	addOptions := options.Prepare()
+	addOptions["autoTMM"] = strconv.FormatBool(autoManagement)
+	if staging.Linked {
+		addOptions["skip_checking"] = "false"
+	}
+	s.logger.Debugf("clients: qbit add options ready client=%s auto_tmm=%t skip_hash_check=%t elapsed=%s", name, autoManagement, options.SkipHashCheck, time.Since(optionsStart).Round(time.Millisecond))
 
 	qbitCtx, cancel := context.WithTimeout(ctx, qbitInjectHTTPTimeout)
 	defer cancel()
@@ -318,6 +328,7 @@ func (s *Service) injectQbit(ctx context.Context, name string, client config.Tor
 	s.logger.Debugf("clients: connecting to qbit %s timeout=%s retries=%d", redaction.RedactValue(host, nil), qbitInjectHTTPTimeout, qbitInjectHTTPRetryAttempts)
 	if !client.UsesQuiProxy() {
 		if err := qbit.LoginCtx(qbitCtx); err != nil {
+			s.cleanupFailedLinkStaging(name, torrent.Tracker, staging)
 			return fmt.Errorf("clients: %s qbit login: %w", name, err)
 		}
 		s.logger.Debugf("clients: connected to qbit client %s", name)
@@ -327,26 +338,53 @@ func (s *Service) injectQbit(ctx context.Context, name string, client config.Tor
 
 	if torrentPath := strings.TrimSpace(torrent.Path); torrentPath != "" {
 		s.logger.Debugf("clients: adding torrent file to qbit client %s for %s", name, meta.SourcePath)
-		if _, err := qbit.AddTorrentFromFileCtx(qbitCtx, torrentPath, options.Prepare()); err != nil {
+		if _, err := qbit.AddTorrentFromFileCtx(qbitCtx, torrentPath, addOptions); err != nil {
 			s.cleanupFailedLinkStaging(name, torrent.Tracker, staging)
 			return fmt.Errorf("clients: %s qbit add torrent file: %w", name, err)
 		}
 
-		s.logger.Infof("clients: added torrent file to qbit client=%s tracker=%s source=%s", name, logTracker(torrent.Tracker), meta.SourcePath)
+		s.logger.Infof("clients: added torrent file to qbit client=%s tracker=%s linked=%t qbit_hash_check=%t source=%s", name, logTracker(torrent.Tracker), staging.Linked, !options.SkipHashCheck, meta.SourcePath)
 		return nil
 	}
 
 	if torrentURL := strings.TrimSpace(torrent.URL); torrentURL != "" {
 		s.logger.Debugf("clients: adding tracker torrent URL to qbit client %s for %s", name, meta.SourcePath)
-		if _, err := qbit.AddTorrentFromUrlCtx(qbitCtx, torrentURL, options.Prepare()); err != nil {
+		if _, err := qbit.AddTorrentFromUrlCtx(qbitCtx, torrentURL, addOptions); err != nil {
 			s.cleanupFailedLinkStaging(name, torrent.Tracker, staging)
 			return fmt.Errorf("clients: %s qbit add torrent URL: %w", name, err)
 		}
-		s.logger.Infof("clients: added tracker torrent URL to qbit client=%s tracker=%s source=%s", name, logTracker(torrent.Tracker), meta.SourcePath)
+		s.logger.Infof("clients: added tracker torrent URL to qbit client=%s tracker=%s linked=%t qbit_hash_check=%t source=%s", name, logTracker(torrent.Tracker), staging.Linked, !options.SkipHashCheck, meta.SourcePath)
 		return nil
 	}
 
 	return internalerrors.ErrInvalidInput
+}
+
+// qbitAutomaticManagementEnabled reports whether the original local save path
+// is a configured automatic-management root or one of its descendants after
+// case-insensitive host path normalization. Linked staging is excluded by the
+// caller.
+func qbitAutomaticManagementEnabled(meta api.PreparedMetadata, configuredPaths config.StringList) bool {
+	if len(configuredPaths) == 0 {
+		return false
+	}
+
+	source, err := sourcePathForQbitSavePath(meta)
+	if err != nil {
+		return false
+	}
+	localSavePath := strings.ToLower(filepath.Clean(filepath.Dir(source)))
+	for _, configuredPath := range configuredPaths {
+		configuredPath = strings.TrimSpace(configuredPath)
+		if configuredPath == "" {
+			continue
+		}
+		configuredPath = strings.ToLower(filepath.Clean(configuredPath))
+		if pathutil.IsWithinRoot(configuredPath, localSavePath) {
+			return true
+		}
+	}
+	return false
 }
 
 func logTracker(tracker string) string {
@@ -375,10 +413,10 @@ func (s *Service) cleanupFailedLinkStaging(clientName string, tracker string, st
 		return
 	}
 	if err := staging.Cleanup.Run(); err != nil {
-		s.logger.Warnf("clients: %s cleanup failed after qbit add error tracker=%s: %v", clientName, strings.TrimSpace(tracker), err)
+		s.logger.Warnf("clients: %s cleanup failed after qbit injection error tracker=%s: %v", clientName, strings.TrimSpace(tracker), err)
 		return
 	}
-	s.logger.Debugf("clients: %s cleaned staged links after qbit add error tracker=%s", clientName, strings.TrimSpace(tracker))
+	s.logger.Debugf("clients: %s cleaned staged links after qbit injection error tracker=%s", clientName, strings.TrimSpace(tracker))
 }
 
 // resolveInjectClients selects the configured torrent clients that should receive

--- a/internal/clients/service.go
+++ b/internal/clients/service.go
@@ -331,9 +331,7 @@ func (s *Service) injectQbit(ctx context.Context, name string, client config.Tor
 	if err != nil {
 		return err
 	}
-	// Linked staging is checked by qBittorrent after add so a successful API
-	// response cannot mask a metainfo/content mismatch as a seeded torrent.
-	options.SkipHashCheck = !staging.Linked && !staging.HashCheckRequired
+	options.SkipHashCheck = true
 	if staging.Linked {
 		options.SavePath = staging.SavePath
 		s.logger.Debugf("clients: qbit link staging selected client=%s tracker=%s files=%d layout_validated=%t save_path=%s", name, strings.TrimSpace(torrent.Tracker), staging.FileCount, staging.LayoutValidated, staging.SavePath)
@@ -364,11 +362,6 @@ func (s *Service) injectQbit(ctx context.Context, name string, client config.Tor
 	autoManagement := !staging.Linked && qbitAutomaticManagementEnabled(meta, client.AutomaticManagementPaths)
 	addOptions := options.Prepare()
 	addOptions["autoTMM"] = strconv.FormatBool(autoManagement)
-	// go-qbittorrent omits skip_checking when SkipHashCheck is false, so states
-	// that require verification must send the false value explicitly.
-	if staging.Linked || staging.HashCheckRequired {
-		addOptions["skip_checking"] = "false"
-	}
 	s.logger.Debugf("clients: qbit add options ready client=%s auto_tmm=%t skip_hash_check=%t elapsed=%s", name, autoManagement, options.SkipHashCheck, time.Since(optionsStart).Round(time.Millisecond))
 
 	qbitCtx, cancel := context.WithTimeout(ctx, qbitInjectHTTPTimeout)

--- a/internal/clients/service.go
+++ b/internal/clients/service.go
@@ -4,10 +4,13 @@
 package clients
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -34,7 +37,43 @@ type Service struct {
 const (
 	qbitInjectHTTPTimeout       = 30 * time.Second
 	qbitInjectHTTPRetryAttempts = 1
+	qbitLoginResponseMaxBytes   = 4 << 10
 )
+
+// qbitLoginValidatingTransport verifies direct qBittorrent login responses
+// before net/http can persist response cookies in the client's jar.
+type qbitLoginValidatingTransport struct {
+	base http.RoundTripper
+}
+
+// RoundTrip requires the exact qBittorrent success body for HTTP 200 login
+// responses. It bounds the body read and restores valid bodies for LoginCtx.
+func (t qbitLoginValidatingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, fmt.Errorf("qbit HTTP request: %w", err)
+	}
+	if !strings.HasSuffix(req.URL.Path, "/api/v2/auth/login") || resp.StatusCode != http.StatusOK {
+		return resp, nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, qbitLoginResponseMaxBytes+1))
+	if err != nil {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("read qbit login response: %w", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		return nil, fmt.Errorf("close qbit login response: %w", err)
+	}
+	if len(body) > qbitLoginResponseMaxBytes {
+		return nil, errors.New("qbit login response exceeds limit")
+	}
+	if string(body) != "Ok." {
+		return nil, errors.New("qbit login response was not successful")
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return resp, nil
+}
 
 func NewService(cfg config.Config, logger api.Logger) *Service {
 	if logger == nil {
@@ -276,6 +315,14 @@ func (s *Service) injectQbit(ctx context.Context, name string, client config.Tor
 	}
 
 	qbit := qbittorrent.NewClient(qbitInjectClientConfig(host, username, password, client))
+	qbitHTTP := qbit.GetHTTPClient()
+	baseTransport := qbitHTTP.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	// The transport sees the response before http.Client stores Set-Cookie
+	// values, so a transient body cannot create an authenticated session.
+	qbitHTTP.Transport = qbitLoginValidatingTransport{base: baseTransport}
 
 	options := qbittorrent.TorrentAddOptions{}
 	s.logger.Debugf("clients: preparing qbit add options client=%s tracker=%s cross_seed=%t", name, strings.TrimSpace(torrent.Tracker), torrent.CrossSeed)
@@ -286,7 +333,7 @@ func (s *Service) injectQbit(ctx context.Context, name string, client config.Tor
 	}
 	// Linked staging is checked by qBittorrent after add so a successful API
 	// response cannot mask a metainfo/content mismatch as a seeded torrent.
-	options.SkipHashCheck = !staging.Linked
+	options.SkipHashCheck = !staging.Linked && !staging.HashCheckRequired
 	if staging.Linked {
 		options.SavePath = staging.SavePath
 		s.logger.Debugf("clients: qbit link staging selected client=%s tracker=%s files=%d layout_validated=%t save_path=%s", name, strings.TrimSpace(torrent.Tracker), staging.FileCount, staging.LayoutValidated, staging.SavePath)
@@ -317,7 +364,9 @@ func (s *Service) injectQbit(ctx context.Context, name string, client config.Tor
 	autoManagement := !staging.Linked && qbitAutomaticManagementEnabled(meta, client.AutomaticManagementPaths)
 	addOptions := options.Prepare()
 	addOptions["autoTMM"] = strconv.FormatBool(autoManagement)
-	if staging.Linked {
+	// go-qbittorrent omits skip_checking when SkipHashCheck is false, so states
+	// that require verification must send the false value explicitly.
+	if staging.Linked || staging.HashCheckRequired {
 		addOptions["skip_checking"] = "false"
 	}
 	s.logger.Debugf("clients: qbit add options ready client=%s auto_tmm=%t skip_hash_check=%t elapsed=%s", name, autoManagement, options.SkipHashCheck, time.Since(optionsStart).Round(time.Millisecond))
@@ -362,8 +411,9 @@ func (s *Service) injectQbit(ctx context.Context, name string, client config.Tor
 
 // qbitAutomaticManagementEnabled reports whether the original local save path
 // is a configured automatic-management root or one of its descendants after
-// case-insensitive host path normalization. Linked staging is excluded by the
-// caller.
+// trimming and filepath cleaning. Containment uses host semantics: Windows
+// comparisons ignore case, while case-sensitive systems preserve it. Linked
+// staging is excluded by the caller.
 func qbitAutomaticManagementEnabled(meta api.PreparedMetadata, configuredPaths config.StringList) bool {
 	if len(configuredPaths) == 0 {
 		return false
@@ -373,13 +423,13 @@ func qbitAutomaticManagementEnabled(meta api.PreparedMetadata, configuredPaths c
 	if err != nil {
 		return false
 	}
-	localSavePath := strings.ToLower(filepath.Clean(filepath.Dir(source)))
+	localSavePath := filepath.Clean(filepath.Dir(source))
 	for _, configuredPath := range configuredPaths {
 		configuredPath = strings.TrimSpace(configuredPath)
 		if configuredPath == "" {
 			continue
 		}
-		configuredPath = strings.ToLower(filepath.Clean(configuredPath))
+		configuredPath = filepath.Clean(configuredPath)
 		if pathutil.IsWithinRoot(configuredPath, localSavePath) {
 			return true
 		}

--- a/internal/clients/service_test.go
+++ b/internal/clients/service_test.go
@@ -23,13 +23,14 @@ import (
 )
 
 type qbitAddCapture struct {
-	errCh    chan error
-	mu       sync.Mutex
-	addCalls int
-	category string
-	savePath string
-	tags     string
-	autoTMM  string
+	errCh        chan error
+	mu           sync.Mutex
+	addCalls     int
+	category     string
+	savePath     string
+	tags         string
+	autoTMM      string
+	skipChecking string
 }
 
 func newQbitAddCaptureServer(t *testing.T) (*httptest.Server, *qbitAddCapture) {
@@ -43,7 +44,13 @@ func newQbitAddCaptureServer(t *testing.T) (*httptest.Server, *qbitAddCapture) {
 			_, _ = w.Write([]byte("Ok."))
 			return
 		case "/api/v2/torrents/add":
-			if err := r.ParseMultipartForm(10 << 20); err != nil {
+			if strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data") {
+				if err := r.ParseMultipartForm(10 << 20); err != nil {
+					capture.errCh <- err
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+			} else if err := r.ParseForm(); err != nil {
 				capture.errCh <- err
 				w.WriteHeader(http.StatusBadRequest)
 				return
@@ -54,6 +61,7 @@ func newQbitAddCaptureServer(t *testing.T) (*httptest.Server, *qbitAddCapture) {
 			capture.savePath = r.FormValue("savepath")
 			capture.tags = r.FormValue("tags")
 			capture.autoTMM = r.FormValue("autoTMM")
+			capture.skipChecking = r.FormValue("skip_checking")
 			capture.mu.Unlock()
 			w.Header().Set("Content-Type", "text/plain")
 			w.WriteHeader(http.StatusOK)
@@ -216,6 +224,58 @@ func TestInjectQbitClient(t *testing.T) {
 	}
 }
 
+func TestInjectQbitClientRejectsCookieBearingNonOKLogin(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	addCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			http.SetCookie(w, &http.Cookie{Name: "SID", Value: "transient-session"})
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Try again."))
+		case "/api/v2/torrents/add":
+			mu.Lock()
+			addCalls++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ok."))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	torrentPath := filepath.Join(t.TempDir(), "sample.torrent")
+	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+	svc := NewService(config.Config{
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:     "qbit",
+				URL:      server.URL,
+				Username: "user",
+				Password: "pass",
+			},
+		},
+	}, nil)
+
+	err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: "Example.Release.2026.mkv"}, api.TorrentResult{Path: torrentPath})
+	if err == nil {
+		t.Fatal("expected cookie-bearing non-Ok login rejection")
+	}
+	if !strings.Contains(err.Error(), "qbit login") {
+		t.Fatal("expected qbit login error")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if addCalls != 0 {
+		t.Fatalf("expected no qbit add attempt, got %d", addCalls)
+	}
+}
+
 func TestQbitInjectClientConfigCapsTimeoutAndRetries(t *testing.T) {
 	t.Parallel()
 
@@ -255,6 +315,12 @@ func TestQbitAutomaticManagementEnabledUsesPathBoundaries(t *testing.T) {
 			sourcePath: filepath.Join(root+"-old", "video.mkv"),
 			configured: root,
 			want:       false,
+		},
+		{
+			name:       "case variant directory",
+			sourcePath: filepath.Join(root, "media", "video.mkv"),
+			configured: filepath.Join(root, "Media"),
+			want:       runtime.GOOS == "windows",
 		},
 	}
 
@@ -770,7 +836,7 @@ func TestInjectQbitClientCleansStagingAfterFileAddFailure(t *testing.T) {
 func TestInjectQbitClientURLLinkingFallsBackWithoutStaging(t *testing.T) {
 	t.Parallel()
 
-	server, _ := newQbitAddFailureServer(t)
+	server, capture := newQbitAddCaptureServer(t)
 	root := t.TempDir()
 	source := filepath.Join(root, "source.mkv")
 	if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
@@ -797,9 +863,13 @@ func TestInjectQbitClientURLLinkingFallsBackWithoutStaging(t *testing.T) {
 		},
 	}, nil)
 
-	err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: source, FileList: []string{source}}, api.TorrentResult{URL: "https://tracker.example/torrent/1", Tracker: "AITHER"})
-	if err == nil {
-		t.Fatal("expected qbit add failure")
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: source, FileList: []string{source}}, api.TorrentResult{URL: "https://tracker.example/torrent/1", Tracker: "AITHER"}); err != nil {
+		t.Fatalf("inject URL fallback: %v", err)
+	}
+	select {
+	case err := <-capture.errCh:
+		t.Fatalf("handler: %v", err)
+	default:
 	}
 
 	stagedPath := filepath.Join(linkRoot, "aither-links", filepath.Base(source))
@@ -808,6 +878,69 @@ func TestInjectQbitClientURLLinkingFallsBackWithoutStaging(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(linkRoot, "aither-links")); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("expected URL-only injection not to create tracker staging, stat err=%v", statErr)
+	}
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	if capture.addCalls != 1 {
+		t.Fatalf("expected one qbit add attempt, got %d", capture.addCalls)
+	}
+	if capture.skipChecking != "false" {
+		t.Fatalf("expected URL fallback hash checking, got skip_checking=%q", capture.skipChecking)
+	}
+}
+
+func TestInjectQbitClientInvalidLinkPlanFallbackChecksHash(t *testing.T) {
+	t.Parallel()
+
+	server, capture := newQbitAddCaptureServer(t)
+	root := t.TempDir()
+	source := filepath.Join(root, "Example.Release.2026.mkv")
+	if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	linkRoot := filepath.Join(root, "links")
+	if err := os.MkdirAll(linkRoot, 0o700); err != nil {
+		t.Fatalf("mkdir links: %v", err)
+	}
+	torrentPath := filepath.Join(root, "invalid.torrent")
+	if err := os.WriteFile(torrentPath, []byte("invalid metainfo"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+
+	svc := NewService(config.Config{
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:         "qbit",
+				URL:          server.URL,
+				Username:     "user",
+				Password:     "pass",
+				Linking:      "hardlink",
+				LinkedFolder: config.StringList{linkRoot},
+			},
+		},
+	}, nil)
+
+	err := svc.Inject(context.Background(), api.PreparedMetadata{
+		SourcePath: source,
+		FileList:   []string{source},
+	}, api.TorrentResult{Path: torrentPath, Tracker: "EXAMPLE"})
+	if err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	select {
+	case err := <-capture.errCh:
+		t.Fatalf("handler: %v", err)
+	default:
+	}
+
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	if capture.savePath != "" {
+		t.Fatalf("expected original-path fallback, got savepath %q", capture.savePath)
+	}
+	if capture.skipChecking != "false" {
+		t.Fatalf("expected fallback hash checking, got skip_checking=%q", capture.skipChecking)
 	}
 }
 
@@ -1070,6 +1203,63 @@ func TestInjectQbitClientRejectsStaleExistingHardlinkDest(t *testing.T) {
 	case err := <-capture.errCh:
 		t.Fatalf("handler: %v", err)
 	default:
+	}
+}
+
+func TestInjectQbitClientFailedLinkPlanFallbackChecksHash(t *testing.T) {
+	t.Parallel()
+
+	server, capture := newQbitAddCaptureServer(t)
+	root := t.TempDir()
+	source := filepath.Join(root, "source.mkv")
+	if err := os.WriteFile(source, []byte("fresh"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	linkRoot := filepath.Join(root, "links")
+	trackerDir := filepath.Join(linkRoot, "example-links")
+	if err := os.MkdirAll(trackerDir, 0o700); err != nil {
+		t.Fatalf("mkdir links: %v", err)
+	}
+	dest := filepath.Join(trackerDir, filepath.Base(source))
+	if err := os.WriteFile(dest, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("write stale dest: %v", err)
+	}
+	torrentPath := filepath.Join(root, "sample.torrent")
+	writeQbitTestTorrentForSource(t, torrentPath, source)
+	svc := NewService(config.Config{
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"EXAMPLE": {LinkDirName: "example-links"},
+		}},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:         "qbit",
+				URL:          server.URL,
+				Username:     "user",
+				Password:     "pass",
+				Linking:      "hardlink",
+				LinkedFolder: config.StringList{linkRoot},
+			},
+		},
+	}, nil)
+
+	if err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: source, FileList: []string{source}}, api.TorrentResult{Path: torrentPath, Tracker: "EXAMPLE"}); err != nil {
+		t.Fatalf("inject failed-link fallback: %v", err)
+	}
+	select {
+	case err := <-capture.errCh:
+		t.Fatalf("handler: %v", err)
+	default:
+	}
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	if capture.addCalls != 1 {
+		t.Fatalf("expected one qbit add attempt, got %d", capture.addCalls)
+	}
+	if capture.savePath != "" {
+		t.Fatalf("expected original-path fallback, got savepath %q", capture.savePath)
+	}
+	if capture.skipChecking != "false" {
+		t.Fatalf("expected failed-link fallback hash checking, got skip_checking=%q", capture.skipChecking)
 	}
 }
 

--- a/internal/clients/service_test.go
+++ b/internal/clients/service_test.go
@@ -25,9 +25,11 @@ import (
 type qbitAddCapture struct {
 	errCh    chan error
 	mu       sync.Mutex
+	addCalls int
 	category string
 	savePath string
 	tags     string
+	autoTMM  string
 }
 
 func newQbitAddCaptureServer(t *testing.T) (*httptest.Server, *qbitAddCapture) {
@@ -47,9 +49,11 @@ func newQbitAddCaptureServer(t *testing.T) (*httptest.Server, *qbitAddCapture) {
 				return
 			}
 			capture.mu.Lock()
+			capture.addCalls++
 			capture.category = r.FormValue("category")
 			capture.savePath = r.FormValue("savepath")
 			capture.tags = r.FormValue("tags")
+			capture.autoTMM = r.FormValue("autoTMM")
 			capture.mu.Unlock()
 			w.Header().Set("Content-Type", "text/plain")
 			w.WriteHeader(http.StatusOK)
@@ -118,6 +122,7 @@ func TestInjectQbitClient(t *testing.T) {
 	var addCategory string
 	var addTags string
 	var addSkipChecking string
+	var addAutoTMM string
 	var fileCount int
 	errCh := make(chan error, 1)
 
@@ -141,6 +146,7 @@ func TestInjectQbitClient(t *testing.T) {
 			addCategory = r.FormValue("category")
 			addTags = r.FormValue("tags")
 			addSkipChecking = r.FormValue("skip_checking")
+			addAutoTMM = r.FormValue("autoTMM")
 			if files, ok := r.MultipartForm.File["torrents"]; ok {
 				fileCount = len(files)
 			}
@@ -202,6 +208,9 @@ func TestInjectQbitClient(t *testing.T) {
 	if addSkipChecking != "true" {
 		t.Fatalf("expected skip_checking true, got %q", addSkipChecking)
 	}
+	if addAutoTMM != "false" {
+		t.Fatalf("expected autoTMM false, got %q", addAutoTMM)
+	}
 	if fileCount != 1 {
 		t.Fatalf("expected 1 torrent file, got %d", fileCount)
 	}
@@ -216,6 +225,48 @@ func TestQbitInjectClientConfigCapsTimeoutAndRetries(t *testing.T) {
 	}
 	if cfg.RetryAttempts != qbitInjectHTTPRetryAttempts {
 		t.Fatalf("expected retry attempts %d, got %d", qbitInjectHTTPRetryAttempts, cfg.RetryAttempts)
+	}
+}
+
+func TestQbitAutomaticManagementEnabledUsesPathBoundaries(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	tests := []struct {
+		name       string
+		sourcePath string
+		configured string
+		want       bool
+	}{
+		{
+			name:       "configured root",
+			sourcePath: filepath.Join(root, "video.mkv"),
+			configured: root,
+			want:       true,
+		},
+		{
+			name:       "configured root child",
+			sourcePath: filepath.Join(root, "child", "video.mkv"),
+			configured: root,
+			want:       true,
+		},
+		{
+			name:       "sibling prefix",
+			sourcePath: filepath.Join(root+"-old", "video.mkv"),
+			configured: root,
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			meta := api.PreparedMetadata{SourcePath: tt.sourcePath}
+			if got := qbitAutomaticManagementEnabled(meta, config.StringList{tt.configured}); got != tt.want {
+				t.Fatalf("qbitAutomaticManagementEnabled() = %t, want %t", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -243,12 +294,13 @@ func TestInjectQbitClientUsesPathMappingSavePath(t *testing.T) {
 	svc := NewService(config.Config{
 		TorrentClients: map[string]config.TorrentClientConfig{
 			"qbit": {
-				Type:       "qbit",
-				URL:        server.URL,
-				Username:   "user",
-				Password:   "pass",
-				LocalPath:  config.StringList{"", localRoot},
-				RemotePath: config.StringList{"/wrong/root", remoteRoot},
+				Type:                     "qbit",
+				URL:                      server.URL,
+				Username:                 "user",
+				Password:                 "pass",
+				LocalPath:                config.StringList{"", localRoot},
+				RemotePath:               config.StringList{"/wrong/root", remoteRoot},
+				AutomaticManagementPaths: config.StringList{localRoot},
 			},
 		},
 	}, nil)
@@ -269,6 +321,9 @@ func TestInjectQbitClientUsesPathMappingSavePath(t *testing.T) {
 	wantSavePath := "/remote/media/Movies/Fixture.Title.2024/"
 	if capture.savePath != wantSavePath {
 		t.Fatalf("expected mapped savepath %q, got %q", wantSavePath, capture.savePath)
+	}
+	if capture.autoTMM != "true" {
+		t.Fatalf("expected autoTMM true, got %q", capture.autoTMM)
 	}
 }
 
@@ -354,6 +409,47 @@ func TestMappedRemotePathPreservesBlankPathPairAlignment(t *testing.T) {
 				t.Fatalf("expected mapped path %q, got %q", want, got)
 			}
 		})
+	}
+}
+
+func TestMappedRemotePathUsesMostSpecificRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	linkedRoot := filepath.Join(root, "cross-seed")
+	source := filepath.Join(linkedRoot, "EXAMPLE", "Example.Release.2026.mkv")
+
+	got, ok := mappedRemotePath(
+		source,
+		config.StringList{root, linkedRoot},
+		config.StringList{"/remote/general", "/remote/cross-seed"},
+	)
+	if !ok {
+		t.Fatal("expected mapped path")
+	}
+	want := filepath.Join("/remote/cross-seed", "EXAMPLE", "Example.Release.2026.mkv")
+	if got != want {
+		t.Fatalf("expected most-specific mapped path %q, got %q", want, got)
+	}
+}
+
+func TestMappedRemotePathIsCaseInsensitiveOnWindows(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows path semantics")
+	}
+	root := t.TempDir()
+	source := filepath.Join(root, "CrossSeed", "EXAMPLE", "Example.Release.2026.mkv")
+	localRoot := strings.ToUpper(filepath.Join(root, "crossseed"))
+
+	got, ok := mappedRemotePath(source, config.StringList{localRoot}, config.StringList{"/remote/cross-seed"})
+	if !ok {
+		t.Fatal("expected case-insensitive mapped path")
+	}
+	want := filepath.Join("/remote/cross-seed", "EXAMPLE", "Example.Release.2026.mkv")
+	if got != want {
+		t.Fatalf("expected mapped path %q, got %q", want, got)
 	}
 }
 
@@ -530,9 +626,10 @@ func TestInjectQbitClientUsesCrossFieldsForCrossSeedTorrent(t *testing.T) {
 	}
 }
 
-func newQbitAddFailureServer(t *testing.T) *httptest.Server {
+func newQbitAddFailureServer(t *testing.T) (*httptest.Server, *qbitAddCapture) {
 	t.Helper()
 
+	capture := &qbitAddCapture{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v2/auth/login":
@@ -551,6 +648,9 @@ func newQbitAddFailureServer(t *testing.T) *httptest.Server {
 					return
 				}
 			}
+			capture.mu.Lock()
+			capture.addCalls++
+			capture.mu.Unlock()
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte("Fails."))
 			return
@@ -560,13 +660,22 @@ func newQbitAddFailureServer(t *testing.T) *httptest.Server {
 		}
 	}))
 	t.Cleanup(server.Close)
-	return server
+	return server, capture
 }
 
-func TestInjectQbitClientCleansStagingAfterFileAddFailure(t *testing.T) {
+func TestInjectQbitClientCleansStagingAfterLoginFailure(t *testing.T) {
 	t.Parallel()
 
-	server := newQbitAddFailureServer(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/auth/login" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("Fails."))
+	}))
+	t.Cleanup(server.Close)
+
 	root := t.TempDir()
 	source := filepath.Join(root, "source.mkv")
 	if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
@@ -577,13 +686,11 @@ func TestInjectQbitClientCleansStagingAfterFileAddFailure(t *testing.T) {
 		t.Fatalf("mkdir links: %v", err)
 	}
 	torrentPath := filepath.Join(root, "sample.torrent")
-	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
-		t.Fatalf("write torrent: %v", err)
-	}
+	writeQbitTestTorrentForSource(t, torrentPath, source)
 
 	svc := NewService(config.Config{
 		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
-			"AITHER": {LinkDirName: "aither-links"},
+			"EXAMPLE": {LinkDirName: "example-links"},
 		}},
 		TorrentClients: map[string]config.TorrentClientConfig{
 			"qbit": {
@@ -597,24 +704,73 @@ func TestInjectQbitClientCleansStagingAfterFileAddFailure(t *testing.T) {
 		},
 	}, nil)
 
-	err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: source, FileList: []string{source}}, api.TorrentResult{Path: torrentPath, Tracker: "AITHER"})
+	err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: source, FileList: []string{source}}, api.TorrentResult{Path: torrentPath, Tracker: "EXAMPLE"})
+	if err == nil {
+		t.Fatal("expected qbit login failure")
+	}
+
+	stagingDir := filepath.Join(linkRoot, "example-links")
+	if _, statErr := os.Stat(stagingDir); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected login failure to remove staging, stat err=%v", statErr)
+	}
+}
+
+func TestInjectQbitClientCleansStagingAfterFileAddFailure(t *testing.T) {
+	t.Parallel()
+
+	server, capture := newQbitAddFailureServer(t)
+	root := t.TempDir()
+	source := filepath.Join(root, "source.mkv")
+	if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	linkRoot := filepath.Join(root, "links")
+	if err := os.MkdirAll(linkRoot, 0o700); err != nil {
+		t.Fatalf("mkdir links: %v", err)
+	}
+	torrentPath := filepath.Join(root, "sample.torrent")
+	writeQbitTestTorrentForSource(t, torrentPath, source)
+
+	svc := NewService(config.Config{
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"EXAMPLE": {LinkDirName: "example-links"},
+		}},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:         "qbit",
+				URL:          server.URL,
+				Username:     "user",
+				Password:     "pass",
+				Linking:      "hardlink",
+				LinkedFolder: config.StringList{linkRoot},
+			},
+		},
+	}, nil)
+
+	err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: source, FileList: []string{source}}, api.TorrentResult{Path: torrentPath, Tracker: "EXAMPLE"})
 	if err == nil {
 		t.Fatal("expected qbit add failure")
 	}
+	capture.mu.Lock()
+	addCalls := capture.addCalls
+	capture.mu.Unlock()
+	if addCalls != 1 {
+		t.Fatalf("expected one qbit add attempt, got %d", addCalls)
+	}
 
-	stagedPath := filepath.Join(linkRoot, "aither-links", filepath.Base(source))
+	stagedPath := filepath.Join(linkRoot, "example-links", filepath.Base(source))
 	if _, statErr := os.Stat(stagedPath); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("expected staged file cleanup, stat err=%v", statErr)
 	}
-	if _, statErr := os.Stat(filepath.Join(linkRoot, "aither-links")); !errors.Is(statErr, os.ErrNotExist) {
+	if _, statErr := os.Stat(filepath.Join(linkRoot, "example-links")); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("expected tracker staging dir cleanup, stat err=%v", statErr)
 	}
 }
 
-func TestInjectQbitClientCleansStagingAfterURLAddFailure(t *testing.T) {
+func TestInjectQbitClientURLLinkingFallsBackWithoutStaging(t *testing.T) {
 	t.Parallel()
 
-	server := newQbitAddFailureServer(t)
+	server, _ := newQbitAddFailureServer(t)
 	root := t.TempDir()
 	source := filepath.Join(root, "source.mkv")
 	if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
@@ -648,10 +804,10 @@ func TestInjectQbitClientCleansStagingAfterURLAddFailure(t *testing.T) {
 
 	stagedPath := filepath.Join(linkRoot, "aither-links", filepath.Base(source))
 	if _, statErr := os.Stat(stagedPath); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("expected staged file cleanup, stat err=%v", statErr)
+		t.Fatalf("expected URL-only injection not to stage files, stat err=%v", statErr)
 	}
 	if _, statErr := os.Stat(filepath.Join(linkRoot, "aither-links")); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("expected tracker staging dir cleanup, stat err=%v", statErr)
+		t.Fatalf("expected URL-only injection not to create tracker staging, stat err=%v", statErr)
 	}
 }
 
@@ -661,6 +817,8 @@ func TestInjectQbitClientHardlinksSourceAndUsesLinkedSavePath(t *testing.T) {
 	var mu sync.Mutex
 	var addSavePath string
 	var addTags string
+	var addAutoTMM string
+	var addSkipChecking string
 	errCh := make(chan error, 1)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -678,6 +836,8 @@ func TestInjectQbitClientHardlinksSourceAndUsesLinkedSavePath(t *testing.T) {
 			mu.Lock()
 			addSavePath = r.FormValue("savepath")
 			addTags = r.FormValue("tags")
+			addAutoTMM = r.FormValue("autoTMM")
+			addSkipChecking = r.FormValue("skip_checking")
 			mu.Unlock()
 			w.Header().Set("Content-Type", "text/plain")
 			w.WriteHeader(http.StatusOK)
@@ -700,9 +860,8 @@ func TestInjectQbitClientHardlinksSourceAndUsesLinkedSavePath(t *testing.T) {
 		t.Fatalf("mkdir links: %v", err)
 	}
 	torrentPath := filepath.Join(root, "sample.torrent")
-	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
-		t.Fatalf("write torrent: %v", err)
-	}
+	torrentRoot := "Tracker.Name.2026.mkv"
+	writeQbitTestTorrent(t, torrentPath, torrentRoot, map[string]string{"source": source}, false)
 
 	svc := NewService(config.Config{
 		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
@@ -710,13 +869,16 @@ func TestInjectQbitClientHardlinksSourceAndUsesLinkedSavePath(t *testing.T) {
 		}},
 		TorrentClients: map[string]config.TorrentClientConfig{
 			"qbit": {
-				Type:            "qbit",
-				URL:             server.URL,
-				Username:        "user",
-				Password:        "pass",
-				Linking:         "hardlink",
-				LinkedFolder:    config.StringList{linkRoot},
-				UseTrackerAsTag: true,
+				Type:                     "qbit",
+				URL:                      server.URL,
+				Username:                 "user",
+				Password:                 "pass",
+				Linking:                  "hardlink",
+				LinkedFolder:             config.StringList{linkRoot},
+				LocalPath:                config.StringList{root},
+				RemotePath:               config.StringList{"/remote/root"},
+				AutomaticManagementPaths: config.StringList{root},
+				UseTrackerAsTag:          true,
 			},
 		},
 	}, nil)
@@ -732,7 +894,7 @@ func TestInjectQbitClientHardlinksSourceAndUsesLinkedSavePath(t *testing.T) {
 	default:
 	}
 
-	linkedSource := filepath.Join(linkRoot, "aither-links", filepath.Base(source))
+	linkedSource := filepath.Join(linkRoot, "aither-links", torrentRoot)
 	sourceInfo, err := os.Stat(source)
 	if err != nil {
 		t.Fatalf("stat source: %v", err)
@@ -747,12 +909,70 @@ func TestInjectQbitClientHardlinksSourceAndUsesLinkedSavePath(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	wantSavePath := filepath.ToSlash(filepath.Join(linkRoot, "aither-links")) + "/"
+	wantSavePath := "/remote/root/links/aither-links/"
 	if addSavePath != wantSavePath {
 		t.Fatalf("expected savepath %q, got %q", wantSavePath, addSavePath)
 	}
 	if addTags != "AITHER" {
 		t.Fatalf("expected tracker tag, got %q", addTags)
+	}
+	if addAutoTMM != "false" {
+		t.Fatalf("expected linked injection autoTMM false, got %q", addAutoTMM)
+	}
+	if addSkipChecking != "false" {
+		t.Fatalf("expected linked injection hash checking, got skip_checking=%q", addSkipChecking)
+	}
+}
+
+func TestInjectQbitClientRejectsUnmappedLinkedSavePath(t *testing.T) {
+	t.Parallel()
+
+	server, capture := newQbitAddCaptureServer(t)
+	root := t.TempDir()
+	mediaRoot := filepath.Join(root, "media")
+	if err := os.MkdirAll(mediaRoot, 0o700); err != nil {
+		t.Fatalf("mkdir media: %v", err)
+	}
+	source := filepath.Join(mediaRoot, "Example.Release.2026.mkv")
+	if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	linkRoot := filepath.Join(root, "cross-seed")
+	if err := os.MkdirAll(linkRoot, 0o700); err != nil {
+		t.Fatalf("mkdir links: %v", err)
+	}
+	torrentPath := filepath.Join(root, "sample.torrent")
+	writeQbitTestTorrentForSource(t, torrentPath, source)
+
+	svc := NewService(config.Config{
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"EXAMPLE": {LinkDirName: "example-links"},
+		}},
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:         "qbit",
+				URL:          server.URL,
+				Username:     "user",
+				Password:     "pass",
+				Linking:      "hardlink",
+				LinkedFolder: config.StringList{linkRoot},
+				LocalPath:    config.StringList{mediaRoot},
+				RemotePath:   config.StringList{"/remote/media"},
+			},
+		},
+	}, nil)
+
+	err := svc.Inject(context.Background(), api.PreparedMetadata{SourcePath: source, FileList: []string{source}}, api.TorrentResult{Path: torrentPath, Tracker: "EXAMPLE"})
+	if err == nil || !strings.Contains(err.Error(), "outside configured local_path roots") {
+		t.Fatal("expected linked staging path mapping error")
+	}
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	if capture.addCalls != 0 {
+		t.Fatal("expected mapping failure to prevent qBittorrent add")
+	}
+	if _, statErr := os.Stat(filepath.Join(linkRoot, "example-links")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatal("expected mapping failure not to create tracker staging")
 	}
 }
 
@@ -823,9 +1043,7 @@ func TestInjectQbitClientRejectsStaleExistingHardlinkDest(t *testing.T) {
 		t.Fatalf("write stale dest: %v", err)
 	}
 	torrentPath := filepath.Join(root, "sample.torrent")
-	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
-		t.Fatalf("write torrent: %v", err)
-	}
+	writeQbitTestTorrentForSource(t, torrentPath, source)
 	allowFallback := false
 	svc := NewService(config.Config{
 		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
@@ -874,9 +1092,7 @@ func TestInjectQbitClientAllowsMatchingExistingHardlinkDest(t *testing.T) {
 		t.Fatalf("precreate hardlink dest: %v", err)
 	}
 	torrentPath := filepath.Join(root, "sample.torrent")
-	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
-		t.Fatalf("write torrent: %v", err)
-	}
+	writeQbitTestTorrentForSource(t, torrentPath, source)
 
 	svc := NewService(config.Config{
 		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
@@ -932,9 +1148,7 @@ func TestInjectQbitClientTriesLaterLinkedFolderAfterFirstFails(t *testing.T) {
 		t.Fatalf("write stale first dest: %v", err)
 	}
 	torrentPath := filepath.Join(root, "sample.torrent")
-	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
-		t.Fatalf("write torrent: %v", err)
-	}
+	writeQbitTestTorrentForSource(t, torrentPath, source)
 	allowFallback := false
 
 	svc := NewService(config.Config{
@@ -1059,9 +1273,7 @@ func TestInjectQbitClientReflinksSourceAndUsesLinkedSavePath(t *testing.T) {
 		t.Fatalf("mkdir links: %v", err)
 	}
 	torrentPath := filepath.Join(root, "sample.torrent")
-	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
-		t.Fatalf("write torrent: %v", err)
-	}
+	writeQbitTestTorrentForSource(t, torrentPath, source)
 
 	originalCreateReflink := createReflink
 	var cloneCalls []string

--- a/internal/clients/service_test.go
+++ b/internal/clients/service_test.go
@@ -884,12 +884,12 @@ func TestInjectQbitClientURLLinkingFallsBackWithoutStaging(t *testing.T) {
 	if capture.addCalls != 1 {
 		t.Fatalf("expected one qbit add attempt, got %d", capture.addCalls)
 	}
-	if capture.skipChecking != "false" {
-		t.Fatalf("expected URL fallback hash checking, got skip_checking=%q", capture.skipChecking)
+	if capture.skipChecking != "true" {
+		t.Fatalf("expected URL fallback to skip hash checking, got skip_checking=%q", capture.skipChecking)
 	}
 }
 
-func TestInjectQbitClientInvalidLinkPlanFallbackChecksHash(t *testing.T) {
+func TestInjectQbitClientInvalidLinkPlanFallbackSkipsHashCheck(t *testing.T) {
 	t.Parallel()
 
 	server, capture := newQbitAddCaptureServer(t)
@@ -939,8 +939,8 @@ func TestInjectQbitClientInvalidLinkPlanFallbackChecksHash(t *testing.T) {
 	if capture.savePath != "" {
 		t.Fatalf("expected original-path fallback, got savepath %q", capture.savePath)
 	}
-	if capture.skipChecking != "false" {
-		t.Fatalf("expected fallback hash checking, got skip_checking=%q", capture.skipChecking)
+	if capture.skipChecking != "true" {
+		t.Fatalf("expected fallback to skip hash checking, got skip_checking=%q", capture.skipChecking)
 	}
 }
 
@@ -1052,8 +1052,8 @@ func TestInjectQbitClientHardlinksSourceAndUsesLinkedSavePath(t *testing.T) {
 	if addAutoTMM != "false" {
 		t.Fatalf("expected linked injection autoTMM false, got %q", addAutoTMM)
 	}
-	if addSkipChecking != "false" {
-		t.Fatalf("expected linked injection hash checking, got skip_checking=%q", addSkipChecking)
+	if addSkipChecking != "true" {
+		t.Fatalf("expected linked injection to skip hash checking, got skip_checking=%q", addSkipChecking)
 	}
 }
 
@@ -1206,7 +1206,7 @@ func TestInjectQbitClientRejectsStaleExistingHardlinkDest(t *testing.T) {
 	}
 }
 
-func TestInjectQbitClientFailedLinkPlanFallbackChecksHash(t *testing.T) {
+func TestInjectQbitClientFailedLinkPlanFallbackSkipsHashCheck(t *testing.T) {
 	t.Parallel()
 
 	server, capture := newQbitAddCaptureServer(t)
@@ -1258,8 +1258,8 @@ func TestInjectQbitClientFailedLinkPlanFallbackChecksHash(t *testing.T) {
 	if capture.savePath != "" {
 		t.Fatalf("expected original-path fallback, got savepath %q", capture.savePath)
 	}
-	if capture.skipChecking != "false" {
-		t.Fatalf("expected failed-link fallback hash checking, got skip_checking=%q", capture.skipChecking)
+	if capture.skipChecking != "true" {
+		t.Fatalf("expected failed-link fallback to skip hash checking, got skip_checking=%q", capture.skipChecking)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -746,6 +746,9 @@ type TorrentClientConfig struct {
 	LinkedFolder  StringList `yaml:"linked_folder"`
 	LocalPath     StringList `yaml:"local_path"`
 	RemotePath    StringList `yaml:"remote_path"`
+	// AutomaticManagementPaths enables qBittorrent automatic management when
+	// an unlinked injection's original local save path contains any configured value.
+	AutomaticManagementPaths StringList `yaml:"automatic_management_paths"`
 
 	QbitURL                string   `yaml:"qbit_url"`
 	QbitPort               int      `yaml:"qbit_port"`
@@ -815,6 +818,7 @@ func torrentClientConfigJSONMap(c TorrentClientConfig) map[string]any {
 	addStringList("LinkedFolder", c.LinkedFolder)
 	addStringList("LocalPath", c.LocalPath)
 	addStringList("RemotePath", c.RemotePath)
+	addStringList("AutomaticManagementPaths", c.AutomaticManagementPaths)
 	if c.VerifyWebUICertificate != nil {
 		out["VerifyWebUICertificate"] = *c.VerifyWebUICertificate
 	}
@@ -864,6 +868,7 @@ func torrentClientConfigYAMLMap(c TorrentClientConfig) map[string]any {
 	addStringList("linked_folder", c.LinkedFolder)
 	addStringList("local_path", c.LocalPath)
 	addStringList("remote_path", c.RemotePath)
+	addStringList("automatic_management_paths", c.AutomaticManagementPaths)
 	if c.VerifyWebUICertificate != nil {
 		out["verify_webui_certificate"] = *c.VerifyWebUICertificate
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1158,24 +1159,25 @@ func TestTorrentClientConfigExportUsesCanonicalTypeAndQbitSettings(t *testing.T)
 	cfg := &Config{
 		TorrentClients: map[string]TorrentClientConfig{
 			"q": {
-				Type:                   "qbit",
-				TorrentClient:          "qbit",
-				URL:                    "http://legacy",
-				WatchFolder:            "D:\\Watch",
-				Username:               "legacy-user",
-				Password:               "legacy-pass",
-				Category:               "legacy-cat",
-				Tags:                   []string{"legacy-tag"},
-				QbitURL:                "http://qbit",
-				QbitPort:               8080,
-				QbitUser:               "qbit-user",
-				QbitPass:               "qbit-pass",
-				QbitCategoryValue:      "qbit-cat",
-				QbitTag:                "qbit-tag",
-				QbitCrossCategory:      "cross-cat",
-				QbitCrossTag:           "cross-tag",
-				AllowFallback:          &allowFallback,
-				VerifyWebUICertificate: &verifyWebUI,
+				Type:                     "qbit",
+				TorrentClient:            "qbit",
+				URL:                      "http://legacy",
+				WatchFolder:              "D:\\Watch",
+				Username:                 "legacy-user",
+				Password:                 "legacy-pass",
+				Category:                 "legacy-cat",
+				Tags:                     []string{"legacy-tag"},
+				QbitURL:                  "http://qbit",
+				QbitPort:                 8080,
+				QbitUser:                 "qbit-user",
+				QbitPass:                 "qbit-pass",
+				QbitCategoryValue:        "qbit-cat",
+				QbitTag:                  "qbit-tag",
+				QbitCrossCategory:        "cross-cat",
+				QbitCrossTag:             "cross-tag",
+				AutomaticManagementPaths: StringList{"media-root", "archive-root"},
+				AllowFallback:            &allowFallback,
+				VerifyWebUICertificate:   &verifyWebUI,
 			},
 		},
 	}
@@ -1190,10 +1192,51 @@ func TestTorrentClientConfigExportUsesCanonicalTypeAndQbitSettings(t *testing.T)
 			t.Fatalf("exported torrent client should not contain legacy key %s: %s", key, exported)
 		}
 	}
-	for _, key := range []string{"Type", "QbitURL", "QbitUser", "QbitPass", "QbitCategoryValue", "QbitTag", "QbitCrossCategory", "QbitCrossTag"} {
+	for _, key := range []string{"Type", "QbitURL", "QbitUser", "QbitPass", "QbitCategoryValue", "QbitTag", "QbitCrossCategory", "QbitCrossTag", "AutomaticManagementPaths"} {
 		if !strings.Contains(exported, `"`+key+`"`) {
 			t.Fatalf("exported torrent client missing qbit key %s: %s", key, exported)
 		}
+	}
+	var exportShape struct {
+		TorrentClients map[string]struct {
+			AutomaticManagementPaths []string `json:"AutomaticManagementPaths"`
+		} `json:"TorrentClients"`
+	}
+	if err := json.Unmarshal([]byte(exported), &exportShape); err != nil {
+		t.Fatalf("decode exported config: %v", err)
+	}
+	wantPaths := []string{"media-root", "archive-root"}
+	gotPaths := exportShape.TorrentClients["q"].AutomaticManagementPaths
+	if !slices.Equal(gotPaths, wantPaths) {
+		t.Fatalf("AutomaticManagementPaths = %q, want %q", gotPaths, wantPaths)
+	}
+}
+
+func TestTorrentClientConfigAutomaticManagementPathsAcceptsStringOrList(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    string
+		expected StringList
+	}{
+		{name: "string", value: `media-root`, expected: StringList{"media-root"}},
+		{name: "list", value: "[media-root, archive-root]", expected: StringList{"media-root", "archive-root"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			payload := "torrent_clients:\n  qbit:\n    type: qbit\n    automatic_management_paths: " + tt.value
+			var cfg Config
+			if err := yaml.Unmarshal([]byte(payload), &cfg); err != nil {
+				t.Fatalf("unmarshal config: %v", err)
+			}
+			client := cfg.TorrentClients["qbit"]
+			if strings.Join(client.AutomaticManagementPaths, "|") != strings.Join(tt.expected, "|") {
+				t.Fatalf("unexpected automatic management paths")
+			}
+		})
 	}
 }
 

--- a/internal/config/defaults/example.yaml
+++ b/internal/config/defaults/example.yaml
@@ -553,4 +553,8 @@ torrent_clients:
       - ""
     remote_path:
       - ""
+    # Enable qBittorrent automatic torrent management when the original save path matches an entry.
+    # Automatic management stays disabled for hardlink, reflink, and symlink staging.
+    automatic_management_paths:
+      - ""
     verify_webui_certificate: true

--- a/internal/torrent/service.go
+++ b/internal/torrent/service.go
@@ -297,21 +297,26 @@ func torrentOverrideEnabled(value *bool) bool {
 	return value != nil && *value
 }
 
+// validateCandidateTorrent checks an existing torrent against the active
+// tracker policy and prepared source layout. Expected candidate rejection is
+// logged at debug level so discovery can continue without operator warnings.
 func validateCandidateTorrent(path string, policy *trackerTorrentPolicy, meta api.PreparedMetadata, logger api.Logger) error {
-	if policy == nil {
-		return validateTorrentContent(path, meta)
-	}
-	if err := policy.validateTorrent(path, meta); err != nil {
-		if logger != nil {
-			logger.Warnf("torrent: skipping non-compliant torrent %s: %v", path, err)
+	if policy != nil {
+		if err := policy.validateTorrent(path, meta); err != nil {
+			if logger != nil {
+				logger.Debugf("torrent: reusable candidate rejected path=%s stage=tracker_policy reason=%s", path, redaction.RedactValue(err.Error(), nil))
+			}
+			return err
 		}
-		return err
 	}
 	if err := validateTorrentContent(path, meta); err != nil {
 		if logger != nil {
-			logger.Warnf("torrent: skipping mismatched torrent %s: %v", path, err)
+			logger.Debugf("torrent: reusable candidate rejected path=%s stage=content_layout reason=%s", path, redaction.RedactValue(err.Error(), nil))
 		}
 		return err
+	}
+	if logger != nil {
+		logger.Debugf("torrent: reusable candidate validated path=%s tracker_policy=%t", path, policy != nil)
 	}
 	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added qBittorrent “Automatic management paths” setting (supports a single path or a list) and added the corresponding controls in the torrent client settings UI.
  * Improved torrent link staging for both single- and multi-file torrents.
* **Bug Fixes**
  * Refined qBittorrent injection to apply automatic management only when the destination matches configured paths, with more reliable hash-check and fallback behavior for URL-only torrents.
  * Improved validation and cleanup when staged linking fails.
* **Configuration**
  * Added/documented `automatic_management_paths` in default configuration and ensured it’s correctly exported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->