### PR TITLE
feat: remove tmdb absolute gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,7 @@ Have these ready:
       The CLI can find ffmpeg when your shell PATH includes Homebrew. If you start the GUI from Finder, macOS may not pass your shell PATH to the app, so the GUI may not see Homebrew's ffmpeg. Start the GUI from Terminal, or make ffmpeg available in the environment used to launch the app.
     - Automatic DVD menu screenshots need an FFmpeg build whose `dvdvideo` demuxer exposes `menu`, `menu_lu`, `menu_vts`, `pgc`, and `pg`. A version number alone does not prove this capability. upbrr checks the selected FFmpeg at runtime; see [FFmpeg's dvdvideo documentation](https://ffmpeg.org/ffmpeg-formats.html#dvdvideo).
 
-A TMDB API key is optional, but required for specific trackers.
-When configured, upbrr uses it for additional metadata enrichment;
-tracker-required metadata IDs can be supplied by the tracker,
-media files, scene data, Arr integrations, or manual overrides.
+- A TMDB API key is optional, but required for most trackers in upbrr.
 
 By default, upbrr stores its database at:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ You should already know how your trackers expect uploads to be named and categor
 
 Have these ready:
 
-- TMDB API key
 - tracker API keys, cookies, or credentials required by the trackers you use
 - image host credentials
 - torrent client details or watch-folder paths
@@ -41,6 +40,11 @@ Have these ready:
 
       The CLI can find ffmpeg when your shell PATH includes Homebrew. If you start the GUI from Finder, macOS may not pass your shell PATH to the app, so the GUI may not see Homebrew's ffmpeg. Start the GUI from Terminal, or make ffmpeg available in the environment used to launch the app.
     - Automatic DVD menu screenshots need an FFmpeg build whose `dvdvideo` demuxer exposes `menu`, `menu_lu`, `menu_vts`, `pgc`, and `pg`. A version number alone does not prove this capability. upbrr checks the selected FFmpeg at runtime; see [FFmpeg's dvdvideo documentation](https://ffmpeg.org/ffmpeg-formats.html#dvdvideo).
+
+A TMDB API key is optional, but required for specific trackers.
+When configured, upbrr uses it for additional metadata enrichment;
+tracker-required metadata IDs can be supplied by the tracker,
+media files, scene data, Arr integrations, or manual overrides.
 
 By default, upbrr stores its database at:
 

--- a/cmd/upbrr/interactive.go
+++ b/cmd/upbrr/interactive.go
@@ -382,7 +382,7 @@ func ensureCLITrackerAuthBeforeDupeCheckWithServiceAndLogger(ctx context.Context
 			readyByTracker[name] = struct{}{}
 			continue
 		}
-		if !cliTrackerRuleFailuresIgnored(req, name) && len(trackerRuleFailuresForPreview(preview, name)) > 0 {
+		if !cliTrackerRuleFailuresIgnored(req, name) && api.HasBlockingRuleFailures(trackerRuleFailuresForPreview(preview, name)) {
 			logger.Debugf("cli auth: tracker=%s skipped before auth due to rule failure", name)
 			continue
 		}
@@ -1091,12 +1091,7 @@ func runSiteCheckCLIPath(ctx context.Context, coreSvc api.Core, opts cliOptions,
 		if tracker.Banned && !tracker.DryRun.Banned {
 			fmt.Printf("Banned group: %s\n", tracker.BannedReason)
 		}
-		if len(tracker.RuleFailures) > 0 {
-			fmt.Println("Rule failures:")
-			for _, failure := range tracker.RuleFailures {
-				fmt.Printf("- %s: %s\n", failure.Rule, failure.Reason)
-			}
-		}
+		printRuleFailures(tracker.RuleFailures)
 		if !req.SkipDupeCheck && tracker.DupeCheck.HasDupes {
 			printDupeResult(tracker.DupeCheck)
 		}
@@ -1113,7 +1108,7 @@ func promptTrackerQuestionnaires(reader *bufio.Reader, review api.UploadReview, 
 	answers := make(map[string]map[string]string)
 	changed := false
 	for _, tracker := range review.Trackers {
-		if tracker.Banned || len(tracker.RuleFailures) > 0 || tracker.Questionnaire == nil || len(tracker.Questionnaire.Fields) == 0 {
+		if tracker.Banned || api.HasBlockingRuleFailures(tracker.RuleFailures) || tracker.Questionnaire == nil || len(tracker.Questionnaire.Fields) == 0 {
 			continue
 		}
 		trackerKey := strings.ToUpper(strings.TrimSpace(tracker.Tracker))
@@ -1574,16 +1569,29 @@ func printDryRunUploadReview(review api.UploadReview, req api.Request) {
 		if tracker.Banned && !tracker.DryRun.Banned {
 			fmt.Printf("Banned group: %s\n", tracker.BannedReason)
 		}
-		if len(tracker.RuleFailures) > 0 {
-			fmt.Println("Rule failures:")
-			for _, failure := range tracker.RuleFailures {
-				fmt.Printf("- %s: %s\n", failure.Rule, failure.Reason)
-			}
-		}
+		printRuleFailures(tracker.RuleFailures)
 		if !req.SkipDupeCheck && tracker.DupeCheck.HasDupes {
 			printDupeResult(tracker.DupeCheck)
 		}
 		printDryRunSummary(tracker.DryRun)
+	}
+}
+
+// printRuleFailures groups blocking results and advisory warnings for CLI output.
+func printRuleFailures(failures []api.RuleFailure) {
+	blocking := api.BlockingRuleFailures(failures)
+	if len(blocking) > 0 {
+		fmt.Println("Rule failures:")
+		for _, failure := range blocking {
+			fmt.Printf("- %s: %s\n", failure.Rule, failure.Reason)
+		}
+	}
+	warnings := api.WarningRuleFailures(failures)
+	if len(warnings) > 0 {
+		fmt.Println("Rule warnings:")
+		for _, warning := range warnings {
+			fmt.Printf("- %s: %s\n", warning.Rule, warning.Reason)
+		}
 	}
 }
 

--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -1040,8 +1040,8 @@ func loadCLIConfig(configPath string, configProvided bool) (config.Config, strin
 }
 
 // loadServeConfig loads config for the web server without requiring a fully
-// valid config (e.g. tmdb_api). The web UI handles initial setup, so the
-// server must be able to start even on a fresh install with no config yet. A
+// valid config. The web UI handles initial setup, so the server must be able
+// to start even on a fresh install with no config yet. A
 // provided --config may seed or merge database config, but invalid env-applied
 // input is not persisted over stored settings.
 func loadServeConfig(configPath string, configProvided bool) (config.Config, string, error) {

--- a/gui/frontend/src/app.tsx
+++ b/gui/frontend/src/app.tsx
@@ -85,6 +85,7 @@ import {
   type SourcePathMode,
   sourcePathHistoryStorageKey,
 } from "./utils/inputHistory";
+import { hasFetchedExternalPreviewData } from "./utils/externalPreview";
 import { handleExternalLinkClick } from "./utils/externalLinks";
 import { normalizeJobStatus } from "./utils/jobStatus";
 import { isMetadataProgressPathMatch } from "./utils/metadataProgress";
@@ -2082,7 +2083,14 @@ export default function App() {
     }
     setReleaseEdits(buildReleaseEditState(result.ReleaseNameOverrides || {}));
     setReleaseTouched(buildReleaseTouchedState(result.ReleaseNameOverrides || {}));
-    const orderedIDs = filterAndOrderExternalIDs(result.ExternalIDInfo || []);
+    const fetchedProviders = new Set(
+      (result.ExternalPreview || [])
+        .filter(hasFetchedExternalPreviewData)
+        .map((item) => item.Provider),
+    );
+    const orderedIDs = filterAndOrderExternalIDs(result.ExternalIDInfo || []).filter((item) =>
+      fetchedProviders.has(item.Provider),
+    );
     if (orderedIDs.length > 0) {
       setSelectedProvider(orderedIDs[0].Provider);
     } else {

--- a/gui/frontend/src/pages/history/index.tsx
+++ b/gui/frontend/src/pages/history/index.tsx
@@ -326,7 +326,18 @@ export default function HistoryPage({ onReleaseDeleted }: Props) {
                 <article className="rounded-lg border border-white/10 bg-[var(--panel-light)] p-2.5 [&_p]:mb-1 [&_p]:mt-0">
                   <h3>Counts</h3>
                   <p>Tracker metadata: {overview.TrackerMetadata?.length || 0}</p>
-                  <p>Rule failures: {overview.TrackerRuleFailures?.length || 0}</p>
+                  <p>
+                    Rule failures:{" "}
+                    {overview.TrackerRuleFailures?.filter(
+                      (failure) => String(failure.Severity || "blocking") !== "warning",
+                    ).length || 0}
+                  </p>
+                  <p>
+                    Rule warnings:{" "}
+                    {overview.TrackerRuleFailures?.filter(
+                      (failure) => String(failure.Severity || "blocking") === "warning",
+                    ).length || 0}
+                  </p>
                   <p>Screenshots: {overview.Screenshots?.length || 0}</p>
                   <p>Final selections: {overview.FinalSelections?.length || 0}</p>
                   <p>Uploaded images: {overview.UploadedImages?.length || 0}</p>
@@ -371,18 +382,19 @@ export default function HistoryPage({ onReleaseDeleted }: Props) {
                 </article>
 
                 <article className="col-span-full rounded-lg border border-white/10 bg-[var(--panel-light)] p-2.5">
-                  <h3>Tracker Rule Failures</h3>
+                  <h3>Tracker Rule Results</h3>
                   {overview.TrackerRuleFailures?.length ? (
                     <ul className="m-0 grid gap-1 pl-4">
                       {overview.TrackerRuleFailures.map((failure, index) => (
                         <li key={`${failure.Tracker}-${failure.Rule}-${index}`}>
-                          <strong>{failure.Tracker || "UNKNOWN"}</strong>: {failure.Rule}{" "}
+                          <strong>{failure.Tracker || "UNKNOWN"}</strong> [
+                          {failure.Severity || "blocking"}]: {failure.Rule}{" "}
                           {failure.Reason ? `— ${failure.Reason}` : ""}
                         </li>
                       ))}
                     </ul>
                   ) : (
-                    <p className="muted">No tracker rule failures stored.</p>
+                    <p className="muted">No tracker rule results stored.</p>
                   )}
                 </article>
 

--- a/gui/frontend/src/pages/input/index.test.tsx
+++ b/gui/frontend/src/pages/input/index.test.tsx
@@ -135,7 +135,7 @@ describe("InputPage external ID preview", () => {
     cleanup();
   });
 
-  it("renders an explicit unavailable preview for selected MAL IDs", () => {
+  it("hides metadata providers when an ID resolved without fetched provider data", () => {
     render(
       <InputPage
         path="C:\\media\\Example.mkv"
@@ -157,8 +157,14 @@ describe("InputPage external ID preview", () => {
         error=""
         preview={{
           ...preview,
-          ExternalIDInfo: [{ Provider: "mal", ID: 5114, Source: "tmdb" }],
-          ExternalPreview: [],
+          ExternalIDInfo: [{ Provider: "tmdb", ID: 123, Source: "tracker" }],
+          ExternalPreview: [
+            {
+              Provider: "tmdb",
+              ID: 123,
+              Source: "tracker",
+            } as MetadataPreview["ExternalPreview"][number],
+          ],
         }}
         trackerUploadItems={[]}
         releasePageTrackerSelection={{}}
@@ -173,7 +179,7 @@ describe("InputPage external ID preview", () => {
         releaseOverrideState={{ overrides: {}, dirty: false, invalid: false }}
         showExternalIDInputUI={false}
         refreshDisabled={false}
-        selectedProvider="mal"
+        selectedProvider="tmdb"
         setSelectedProvider={vi.fn()}
         setLightboxImage={vi.fn()}
         setLightboxAlt={vi.fn()}
@@ -187,10 +193,9 @@ describe("InputPage external ID preview", () => {
       />,
     );
 
-    expect(screen.getByText("MAL metadata preview unavailable.")).toBeInTheDocument();
-    expect(screen.getByText("MAL URL")).toBeInTheDocument();
-    expect(screen.getByText("https://myanimelist.net/anime/5114")).toBeInTheDocument();
-    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /TMDB/i })).not.toBeInTheDocument();
+    expect(screen.getByText("No external metadata details found.")).toBeInTheDocument();
+    expect(screen.queryByText("123")).not.toBeInTheDocument();
   });
 
   it("renders rich AniList metadata for selected MAL IDs", () => {

--- a/gui/frontend/src/pages/input/index.tsx
+++ b/gui/frontend/src/pages/input/index.tsx
@@ -31,6 +31,7 @@ import type {
   TrackerUploadItem,
 } from "../../types";
 import type { SourcePathHistoryEntry } from "../../utils/inputHistory";
+import { hasFetchedExternalPreviewData } from "../../utils/externalPreview";
 
 const compactInputClass =
   "h-8 rounded-md border border-white/10 bg-slate-950/45 px-2.5 text-sm text-[var(--text)] outline-none transition placeholder:text-[var(--muted)] focus:border-[var(--accent-2)] focus:ring-2 focus:ring-[rgba(53,194,193,0.18)]";
@@ -631,15 +632,6 @@ const buildPreviewDetails = (
   return [baseID].filter((item) => item.value || (item.blocks && item.blocks.length > 0));
 };
 
-/** Builds the explicit MAL fallback shown when the backend has no rich ExternalPreview payload. */
-const buildMALPreviewDetails = (info: ExternalIDInfo): DetailItem[] =>
-  [
-    { label: "MAL ID", value: formatID("mal", info.ID), mono: true },
-    { label: "MAL URL", value: `${malAnimeBaseURL}${info.ID}`, mono: true },
-    { label: "Source", value: info.Source },
-    { label: "Preview", value: "Unavailable" },
-  ].filter((item) => item.value);
-
 const renderDetailValue = (item: DetailItem) => {
   if (item.blocks && item.blocks.length > 0) {
     return (
@@ -885,10 +877,16 @@ export default function InputPage(props: Props) {
     return "";
   }, [path]);
 
-  const orderedExternalIDs = useMemo(
-    () => filterAndOrderExternalIDs(preview.ExternalIDInfo || []),
-    [preview.ExternalIDInfo],
-  );
+  const orderedExternalIDs = useMemo(() => {
+    const fetchedProviders = new Set(
+      (preview.ExternalPreview || [])
+        .filter(hasFetchedExternalPreviewData)
+        .map((item) => item.Provider),
+    );
+    return filterAndOrderExternalIDs(preview.ExternalIDInfo || []).filter((item) =>
+      fetchedProviders.has(item.Provider),
+    );
+  }, [preview.ExternalIDInfo, preview.ExternalPreview]);
 
   const tmdbCandidates = useMemo(
     () => preview.ExternalIDCandidates?.TMDB || [],
@@ -964,14 +962,11 @@ export default function InputPage(props: Props) {
   const selectedPreview = useMemo(() => {
     if (!selectedProvider) return null;
     return (
-      (preview.ExternalPreview || []).find((item) => item.Provider === selectedProvider) || null
+      (preview.ExternalPreview || []).find(
+        (item) => item.Provider === selectedProvider && hasFetchedExternalPreviewData(item),
+      ) || null
     );
   }, [preview.ExternalPreview, selectedProvider]);
-
-  const selectedMALInfo = useMemo(() => {
-    if (selectedProvider !== "mal") return null;
-    return orderedExternalIDs.find((item) => item.Provider === "mal") || null;
-  }, [orderedExternalIDs, selectedProvider]);
 
   const [tvdbDisplayMode, setTVDBDisplayMode] = useState<TVDBDisplayMode>("original");
 
@@ -1014,9 +1009,7 @@ export default function InputPage(props: Props) {
 
   const previewDetails = selectedPreview
     ? buildPreviewDetails(selectedPreview, tvdbDisplayMode)
-    : selectedMALInfo
-      ? buildMALPreviewDetails(selectedMALInfo)
-      : [];
+    : [];
 
   // Keep this aligned with the backend FetchMetadataPreview phase emissions so
   // progress updates advance without skipping backend work, including fallback retries.
@@ -1896,14 +1889,6 @@ export default function InputPage(props: Props) {
                   {selectedPreview.BackdropURL ? (
                     <img src={selectedPreview.BackdropURL} alt="Backdrop" loading="lazy" />
                   ) : null}
-                </div>
-              </div>
-            ) : selectedMALInfo ? (
-              <div className="preview-content">
-                <div className="preview-text">
-                  <p className="title">MAL</p>
-                  <p className="overview">MAL metadata preview unavailable.</p>
-                  <PreviewDetailsList items={previewDetails} />
                 </div>
               </div>
             ) : (

--- a/gui/frontend/src/pages/tracker_upload/index.test.tsx
+++ b/gui/frontend/src/pages/tracker_upload/index.test.tsx
@@ -126,6 +126,29 @@ describe("TrackerUploadPage", () => {
     expect(screen.queryByText(/Upload:/)).toBeNull();
   });
 
+  it("shows rule warnings without blocking tracker eligibility", () => {
+    render(
+      <TrackerUploadPage
+        {...baseProps}
+        preview={{
+          ...preview,
+          TrackerRuleFailures: {
+            AITHER: [
+              {
+                Rule: "require_metadata_id",
+                Reason: "missing recommended IMDb ID",
+                Severity: "warning",
+              },
+            ],
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Rule warning: missing recommended IMDb ID")).toBeTruthy();
+    expect(screen.queryByText("Blocked trackers (1)")).toBeNull();
+  });
+
   it("renders cached tracker icons without fetching from the page", () => {
     const getTrackerIcon = vi.fn().mockResolvedValue("");
     vi.stubGlobal("go", { guiapp: { App: { GetTrackerIcon: getTrackerIcon } } });

--- a/gui/frontend/src/pages/tracker_upload/index.tsx
+++ b/gui/frontend/src/pages/tracker_upload/index.tsx
@@ -223,6 +223,19 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
     [trackerUploadItems, releasePageTrackerSelection],
   );
 
+  const ruleWarningsByTracker = useMemo(() => {
+    const warnings: Record<string, string[]> = {};
+    Object.entries(preview.TrackerRuleFailures || {}).forEach(([tracker, failures]) => {
+      const key = tracker.toLowerCase().trim();
+      const reasons = (failures || [])
+        .filter((failure) => String(failure.Severity || "").toLowerCase() === "warning")
+        .map((failure) => failure.Reason?.trim() || failure.Rule?.trim())
+        .filter((reason): reason is string => Boolean(reason));
+      if (key && reasons.length > 0) warnings[key] = reasons;
+    });
+    return warnings;
+  }, [preview.TrackerRuleFailures]);
+
   const trackerBlockState = useMemo(() => {
     const next: Record<string, { blocked: boolean; reasons: string[]; hardBlocked: boolean }> = {};
     visibleTrackers.forEach((tracker) => {
@@ -598,6 +611,7 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
             const dryRun = selected ? dryRunMap[normalizedTrackerName] : undefined;
             const imageHost = dryRun?.ImageHost;
             const imageHostWarnings = imageHost?.Warnings || [];
+            const ruleWarnings = ruleWarningsByTracker[normalizedTrackerName] || [];
             const iconSrc = trackerIconFor(trackerIconSrcByName, tracker.name);
             const imageHostStatus = String(imageHost?.Status || "").toLowerCase();
             const questionnaire = dryRun?.Questionnaire;
@@ -702,6 +716,14 @@ export default function TrackerUploadPage(props: Readonly<Props>) {
                     </p>
                   );
                 })}
+                {ruleWarnings.map((warning, index) => (
+                  <p
+                    className="m-0 rounded-md border border-amber-400/40 bg-amber-400/10 px-2 py-1 text-xs text-amber-100 [overflow-wrap:anywhere]"
+                    key={`${tracker.name}-rule-warning-${index}`}
+                  >
+                    Rule warning: {warning}
+                  </p>
+                ))}
 
                 {releaseNameChanged ? (
                   <div className="grid gap-1 rounded-md border border-amber-300/55 bg-amber-300/12 px-2.5 py-2">

--- a/gui/frontend/src/types.ts
+++ b/gui/frontend/src/types.ts
@@ -597,6 +597,8 @@ export type TrackerPreview = {
 export type RuleFailure = {
   Rule: string;
   Reason: string;
+  /** Empty and unrecognized values are treated as blocking by backend APIs. */
+  Severity?: "blocking" | "warning" | string;
 };
 
 export type DupeEntry = {
@@ -958,6 +960,8 @@ export type HistoryEntry = {
   LatestUploadStatus: string;
   LatestUploadAt: string;
   RuleFailureCount: number;
+  /** Number of explicitly advisory rule results; absent on older API responses. */
+  RuleWarningCount?: number;
 };
 
 export type HistoryUploadRecord = {
@@ -989,6 +993,8 @@ export type HistoryRuleFailure = {
   Tracker: string;
   Rule: string;
   Reason: string;
+  /** Empty and unrecognized values represent blocking legacy results. */
+  Severity?: "blocking" | "warning" | string;
   CreatedAt: string;
 };
 

--- a/gui/frontend/src/utils/externalPreview.ts
+++ b/gui/frontend/src/utils/externalPreview.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import type { ExternalPreview } from "../types";
+
+/**
+ * Reports whether a preview contains its provider-specific fetched metadata payload.
+ * Resolved IDs and shallow preview entries without that payload return false.
+ */
+export const hasFetchedExternalPreviewData = (preview: ExternalPreview) => {
+  switch (preview.Provider) {
+    case "imdb":
+      return preview.IMDB != null;
+    case "tmdb":
+      return preview.TMDB != null;
+    case "tvdb":
+      return preview.TVDB != null;
+    case "tvmaze":
+      return preview.TVmaze != null;
+    case "mal":
+      return preview.AniList != null;
+    default:
+      return false;
+  }
+};

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,16 +48,20 @@ const (
 	MaxDVDMenuItems = 32
 )
 
+// MainSettingsConfig defines application-wide runtime and presentation settings.
+// TMDB enrichment is disabled when TMDBAPI is empty; other metadata providers
+// and externally supplied metadata IDs remain available.
 type MainSettingsConfig struct {
-	UpdateNotification  bool   `yaml:"update_notification"`
-	VerboseNotification bool   `yaml:"verbose_notification"`
-	TMDBAPI             string `yaml:"tmdb_api"`
-	TrackerPassChecks   int    `yaml:"tracker_pass_checks"`
-	InputHistoryLimit   int    `yaml:"input_history_limit"`
-	DBPath              string `yaml:"db_path"`
-	UseFavicons         bool   `yaml:"use_favicons"`
-	FaviconOnly         bool   `yaml:"favicon_only"`
-	SceneDetection      bool   `yaml:"scene_detection"`
+	UpdateNotification  bool `yaml:"update_notification"`
+	VerboseNotification bool `yaml:"verbose_notification"`
+	// TMDBAPI is the optional API key used for TMDB lookups and enrichment.
+	TMDBAPI           string `yaml:"tmdb_api"`
+	TrackerPassChecks int    `yaml:"tracker_pass_checks"`
+	InputHistoryLimit int    `yaml:"input_history_limit"`
+	DBPath            string `yaml:"db_path"`
+	UseFavicons       bool   `yaml:"use_favicons"`
+	FaviconOnly       bool   `yaml:"favicon_only"`
+	SceneDetection    bool   `yaml:"scene_detection"`
 }
 
 type mainSettingsConfigAlias MainSettingsConfig
@@ -872,11 +876,9 @@ func torrentClientConfigYAMLMap(c TorrentClientConfig) map[string]any {
 }
 
 // Validate checks the loaded configuration values needed before runtime
-// services can safely start or save settings.
+// services can safely start or save settings. An empty TMDBAPI is valid and
+// leaves TMDB enrichment disabled.
 func (c Config) Validate() error {
-	if c.MainSettings.TMDBAPI == "" {
-		return errors.New("config: main_settings.tmdb_api is required")
-	}
 	if c.MainSettings.InputHistoryLimit < 0 {
 		return errors.New("config: main_settings.input_history_limit must be zero or greater")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -469,9 +469,9 @@ func TestLoadExampleConfig(t *testing.T) {
 	path := filepath.Join("defaults", "example.yaml")
 	_, err := Load(path)
 	if err == nil {
-		t.Fatalf("expected example config validation error, got nil")
+		t.Fatal("expected example config validation error")
 	}
-	if err.Error() != "config: main_settings.tmdb_api is required" {
+	if err.Error() != "config: torrent_clients.qbittorrent.url or qbit_url is required" {
 		t.Fatalf("unexpected example config error: %v", err)
 	}
 }

--- a/internal/config/loader_penetration_test.go
+++ b/internal/config/loader_penetration_test.go
@@ -55,25 +55,24 @@ func TestLoadParseError(t *testing.T) {
 func TestLoadValidateError(t *testing.T) {
 	t.Parallel()
 
-	path := writeTemp(t, "main_settings:\n  tmdb_api: \"\"\n")
+	path := writeTemp(t, "main_settings:\n  input_history_limit: -1\n")
 	_, err := Load(path)
 	if err == nil {
 		t.Fatalf("expected validate error")
 	}
-	if !strings.Contains(err.Error(), "tmdb_api") {
-		t.Fatalf("validate error should mention tmdb_api, got: %v", err)
+	if !strings.Contains(err.Error(), "input_history_limit") {
+		t.Fatalf("validate error should mention input_history_limit, got: %v", err)
 	}
 }
 
-// Env overrides must be applied before Validate so an env-supplied TMDB_API
-// rescues a file with an empty tmdb_api.
-func TestLoadEnvOverrideRescuesValidation(t *testing.T) {
+// Env overrides must still populate the optional TMDB API key.
+func TestLoadEnvOverridePopulatesOptionalTMDBAPI(t *testing.T) {
 	t.Setenv("UA_DEFAULT_TMDB_API", "rescued")
 
 	path := writeTemp(t, "main_settings:\n  tmdb_api: \"\"\nscreenshot_handling:\n  screens: 2\n")
 	cfg, err := Load(path)
 	if err != nil {
-		t.Fatalf("expected rescue, got: %v", err)
+		t.Fatalf("load: %v", err)
 	}
 	if cfg.MainSettings.TMDBAPI != "rescued" {
 		t.Fatalf("TMDBAPI: got %q", cfg.MainSettings.TMDBAPI)
@@ -124,14 +123,13 @@ func TestLoadInvalidEnvBoolFallsBackToYAML(t *testing.T) {
 	}
 }
 
-// Loading the embedded example.yaml is the CLI's smoke test for template
-// integrity. It currently fails validate (no TMDB key). We pin that behavior
-// here so anyone who removes the validation must update this test too.
-func TestLoadExampleYAMLFailsValidate(t *testing.T) {
+// Loading the embedded example.yaml reaches required runtime settings after
+// accepting its empty optional TMDB key.
+func TestLoadExampleYAMLAllowsMissingTMDBAPI(t *testing.T) {
 	t.Parallel()
 
 	_, err := Load(filepath.Join("defaults", "example.yaml"))
-	if err == nil {
-		t.Fatalf("embedded example must still fail validate (template has no TMDB key)")
+	if err == nil || !strings.Contains(err.Error(), "torrent_clients.qbittorrent") {
+		t.Fatalf("expected validation to advance past optional TMDB key, got %v", err)
 	}
 }

--- a/internal/config/validate_penetration_test.go
+++ b/internal/config/validate_penetration_test.go
@@ -25,13 +25,12 @@ func withBase(mut func(*Config)) Config {
 	return cfg
 }
 
-func TestValidateMissingTMDBAPI(t *testing.T) {
+func TestValidateAllowsMissingTMDBAPI(t *testing.T) {
 	t.Parallel()
 
 	cfg := withBase(func(c *Config) { c.MainSettings.TMDBAPI = "" })
-	err := cfg.Validate()
-	if err == nil || !strings.Contains(err.Error(), "tmdb_api") {
-		t.Fatalf("want tmdb_api error, got %v", err)
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("missing optional tmdb_api: %v", err)
 	}
 }
 

--- a/internal/configstore/dbloader_penetration_test.go
+++ b/internal/configstore/dbloader_penetration_test.go
@@ -345,7 +345,7 @@ func TestBootstrapWithValidatorRejectsInvalidProvidedYAMLBeforePersist(t *testin
 	}
 }
 
-func TestBootstrapWithValidatorRejectsEnvOnlyProvidedYAMLBeforePersist(t *testing.T) {
+func TestBootstrapWithValidatorAcceptsMissingOptionalTMDBAPI(t *testing.T) {
 	ctx := context.Background()
 	tmp := t.TempDir()
 	dbPath := filepath.Join(tmp, "env-rescue.db")
@@ -357,17 +357,24 @@ func TestBootstrapWithValidatorRejectsEnvOnlyProvidedYAMLBeforePersist(t *testin
 	}
 
 	t.Setenv("UA_DEFAULT_TMDB_API", "from-env")
-	_, _, err := configstore.BootstrapWithValidator(ctx, yamlPath, true, true, func(cfg *config.Config) error {
+	runtime, resolvedDB, err := configstore.BootstrapWithValidator(ctx, yamlPath, true, true, func(cfg *config.Config) error {
 		return cfg.Validate()
 	})
-	if err == nil {
-		t.Fatal("expected env-only valid config to fail before persistence")
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
 	}
-	if !strings.Contains(err.Error(), "tmdb_api") {
-		t.Fatalf("expected raw config validation error, got %v", err)
+	if resolvedDB != dbPath {
+		t.Fatalf("DB path: got %q want %q", resolvedDB, dbPath)
 	}
-	if _, statErr := os.Stat(dbPath); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("env-rescued provided config should not create database file, stat err=%v", statErr)
+	if runtime.MainSettings.TMDBAPI != "from-env" {
+		t.Fatalf("runtime TMDBAPI: got %q want env override", runtime.MainSettings.TMDBAPI)
+	}
+	stored, loadErr := configstore.LoadFromDBPath(ctx, dbPath)
+	if loadErr != nil {
+		t.Fatalf("load stored: %v", loadErr)
+	}
+	if stored.MainSettings.TMDBAPI != "from-env" {
+		t.Fatalf("stored TMDBAPI: got %q want env override", stored.MainSettings.TMDBAPI)
 	}
 }
 
@@ -613,7 +620,7 @@ func TestBootstrapProvidedYAMLMergeSkipsNilDynamicTorrentClientEntry(t *testing.
 	}
 }
 
-func TestBootstrapProvidedYAMLInvalidMergeDoesNotOverwriteStoredConfig(t *testing.T) {
+func TestBootstrapProvidedYAMLEmptyTMDBAPIOverwritesStoredConfig(t *testing.T) {
 	ctx := context.Background()
 	tmp := t.TempDir()
 	dbPath := filepath.Join(tmp, "invalid-merge.db")
@@ -643,20 +650,20 @@ func TestBootstrapProvidedYAMLInvalidMergeDoesNotOverwriteStoredConfig(t *testin
 	if resolvedDB != dbPath {
 		t.Fatalf("DB path: got %q want %q", resolvedDB, dbPath)
 	}
-	if runtime.MainSettings.TMDBAPI != "stored-key" || runtime.ScreenshotHandling.Screens != 7 {
-		t.Fatalf("runtime should fall back to stored config, got tmdb=%q screens=%d", runtime.MainSettings.TMDBAPI, runtime.ScreenshotHandling.Screens)
+	if runtime.MainSettings.TMDBAPI != "" || runtime.ScreenshotHandling.Screens != 4 {
+		t.Fatalf("runtime should use provided config, got tmdb=%q screens=%d", runtime.MainSettings.TMDBAPI, runtime.ScreenshotHandling.Screens)
 	}
 
 	reloaded, err := configstore.LoadFromDBPath(ctx, dbPath)
 	if err != nil {
 		t.Fatalf("load stored: %v", err)
 	}
-	if reloaded.MainSettings.TMDBAPI != "stored-key" || reloaded.ScreenshotHandling.Screens != 7 {
-		t.Fatalf("stored config overwritten: tmdb=%q screens=%d", reloaded.MainSettings.TMDBAPI, reloaded.ScreenshotHandling.Screens)
+	if reloaded.MainSettings.TMDBAPI != "" || reloaded.ScreenshotHandling.Screens != 4 {
+		t.Fatalf("provided config not persisted: tmdb=%q screens=%d", reloaded.MainSettings.TMDBAPI, reloaded.ScreenshotHandling.Screens)
 	}
 }
 
-func TestBootstrapProvidedYAMLInvalidFreshSetupDoesNotCreateDB(t *testing.T) {
+func TestBootstrapProvidedYAMLEmptyTMDBAPICreatesDB(t *testing.T) {
 	ctx := context.Background()
 	tmp := t.TempDir()
 	dbPath := filepath.Join(tmp, "fresh-invalid.db")
@@ -677,8 +684,12 @@ func TestBootstrapProvidedYAMLInvalidFreshSetupDoesNotCreateDB(t *testing.T) {
 	if runtime.MainSettings.TMDBAPI != "" {
 		t.Fatalf("runtime TMDBAPI: got %q want empty setup value", runtime.MainSettings.TMDBAPI)
 	}
-	if _, statErr := os.Stat(dbPath); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("invalid fresh setup should not create database before validation succeeds, stat err=%v", statErr)
+	stored, loadErr := configstore.LoadFromDBPath(ctx, dbPath)
+	if loadErr != nil {
+		t.Fatalf("load stored: %v", loadErr)
+	}
+	if stored.MainSettings.TMDBAPI != "" || stored.ScreenshotHandling.Screens != 4 {
+		t.Fatalf("stored config: tmdb=%q screens=%d", stored.MainSettings.TMDBAPI, stored.ScreenshotHandling.Screens)
 	}
 }
 

--- a/internal/configstore/dbloader_penetration_test.go
+++ b/internal/configstore/dbloader_penetration_test.go
@@ -369,12 +369,19 @@ func TestBootstrapWithValidatorAcceptsMissingOptionalTMDBAPI(t *testing.T) {
 	if runtime.MainSettings.TMDBAPI != "from-env" {
 		t.Fatalf("runtime TMDBAPI: got %q want env override", runtime.MainSettings.TMDBAPI)
 	}
+
+	// Reload without the runtime overlay so this assertion proves the YAML
+	// candidate, including its empty optional TMDB key, was persisted.
+	t.Setenv("UA_DEFAULT_TMDB_API", "")
 	stored, loadErr := configstore.LoadFromDBPath(ctx, dbPath)
 	if loadErr != nil {
 		t.Fatalf("load stored: %v", loadErr)
 	}
-	if stored.MainSettings.TMDBAPI != "from-env" {
-		t.Fatalf("stored TMDBAPI: got %q want env override", stored.MainSettings.TMDBAPI)
+	if stored.MainSettings.TMDBAPI != "" {
+		t.Fatalf("stored TMDBAPI: got %q want empty persisted value", stored.MainSettings.TMDBAPI)
+	}
+	if stored.ScreenshotHandling.Screens != 2 {
+		t.Fatalf("stored screens: got %d want persisted YAML value 2", stored.ScreenshotHandling.Screens)
 	}
 }
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -1400,7 +1400,7 @@ func (c *Core) filterImageUploadTrackers(trackerNames []string, meta api.Prepare
 		blockedReasons := blockedReasonsForTracker(meta.BlockedTrackers, name)
 		ruleFailures := ruleFailuresForTracker(meta.TrackerRuleFailures, name)
 		existingMatch := matchedTrackerForUpload(meta.MatchedTrackers, name)
-		if len(blockedReasons) > 0 || (!meta.IgnoreTrackerRuleFailures && len(ruleFailures) > 0) || existingMatch {
+		if len(blockedReasons) > 0 || (!meta.IgnoreTrackerRuleFailures && api.HasBlockingRuleFailures(ruleFailures)) || existingMatch {
 			if c.logger != nil {
 				c.logger.Debugf("core: excluding blocked image upload tracker tracker=%s blocked_reasons=%v rule_failures=%d existing_match=%t", name, blockedReasons, len(ruleFailures), existingMatch)
 			}
@@ -4142,7 +4142,13 @@ func (c *Core) GetHistoryOverview(ctx context.Context, sourcePath string) (api.H
 		overview.LatestUploadStatus = uploadHistory[0].Status
 		overview.LatestUploadAt = uploadHistory[0].CreatedAt
 	}
-	overview.StatusLabel = historyStatusLabel(overview.LatestUploadStatus, len(ruleFailures))
+	blockingRuleFailures := 0
+	for _, failure := range ruleFailures {
+		if api.NormalizeRuleFailureSeverity(failure.Severity) == api.RuleFailureSeverityBlocking {
+			blockingRuleFailures++
+		}
+	}
+	overview.StatusLabel = historyStatusLabel(overview.LatestUploadStatus, blockingRuleFailures)
 
 	return overview, nil
 }

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -4724,120 +4724,111 @@ func buildExternalIDInfo(ids api.ExternalIDs) []api.ExternalIDInfo {
 	return result
 }
 
+// buildExternalPreviews returns previews only for resolved IDs with matching fetched provider data.
 func buildExternalPreviews(ids api.ExternalIDs, metadata api.ExternalMetadata) []api.ExternalPreview {
 	result := make([]api.ExternalPreview, 0, 4)
-	if ids.IMDBID != 0 {
+	if ids.IMDBID != 0 && metadata.IMDB != nil {
 		preview := api.ExternalPreview{Provider: "imdb", ID: ids.IMDBID, Source: ids.SourceIMDB}
-		if metadata.IMDB != nil {
-			preview.Title = metadata.IMDB.Title
-			preview.Year = metadata.IMDB.Year
-			preview.Overview = metadata.IMDB.Plot
-			preview.PosterURL = metadata.IMDB.Cover
-			preview.IMDBType = metadata.IMDB.Type
-			preview.Rating = metadata.IMDB.Rating
-			preview.RatingCount = metadata.IMDB.RatingCount
-			preview.RuntimeMinutes = metadata.IMDB.RuntimeMinutes
-			preview.Genres = metadata.IMDB.Genres
-			preview.Country = metadata.IMDB.Country
-			preview.IMDB = metadata.IMDB
-		}
+		preview.Title = metadata.IMDB.Title
+		preview.Year = metadata.IMDB.Year
+		preview.Overview = metadata.IMDB.Plot
+		preview.PosterURL = metadata.IMDB.Cover
+		preview.IMDBType = metadata.IMDB.Type
+		preview.Rating = metadata.IMDB.Rating
+		preview.RatingCount = metadata.IMDB.RatingCount
+		preview.RuntimeMinutes = metadata.IMDB.RuntimeMinutes
+		preview.Genres = metadata.IMDB.Genres
+		preview.Country = metadata.IMDB.Country
+		preview.IMDB = metadata.IMDB
 		result = append(result, preview)
 	}
-	if ids.TMDBID != 0 {
+	if ids.TMDBID != 0 && metadata.TMDB != nil {
 		preview := api.ExternalPreview{Provider: "tmdb", ID: ids.TMDBID, Source: ids.SourceTMDB}
-		if metadata.TMDB != nil {
-			preview.Title = metadata.TMDB.Title
-			preview.Year = metadata.TMDB.Year
-			preview.Overview = metadata.TMDB.Overview
-			preview.PosterURL = metadata.TMDB.Poster
-			preview.BackdropURL = metadata.TMDB.Backdrop
-			preview.Category = metadata.TMDB.Category
-			preview.OriginalTitle = metadata.TMDB.OriginalTitle
-			preview.ReleaseDate = metadata.TMDB.ReleaseDate
-			preview.FirstAirDate = metadata.TMDB.FirstAirDate
-			preview.LastAirDate = metadata.TMDB.LastAirDate
-			preview.OriginalLanguage = metadata.TMDB.OriginalLanguage
-			preview.TMDBType = metadata.TMDB.TMDBType
-			preview.Runtime = metadata.TMDB.Runtime
-			preview.Genres = metadata.TMDB.Genres
-			preview.Keywords = metadata.TMDB.Keywords
-			preview.YouTube = metadata.TMDB.YouTube
-			preview.IMDBID = metadata.TMDB.IMDBID
-			preview.TVDBID = metadata.TMDB.TVDBID
-			preview.TMDB = metadata.TMDB
-		}
+		preview.Title = metadata.TMDB.Title
+		preview.Year = metadata.TMDB.Year
+		preview.Overview = metadata.TMDB.Overview
+		preview.PosterURL = metadata.TMDB.Poster
+		preview.BackdropURL = metadata.TMDB.Backdrop
+		preview.Category = metadata.TMDB.Category
+		preview.OriginalTitle = metadata.TMDB.OriginalTitle
+		preview.ReleaseDate = metadata.TMDB.ReleaseDate
+		preview.FirstAirDate = metadata.TMDB.FirstAirDate
+		preview.LastAirDate = metadata.TMDB.LastAirDate
+		preview.OriginalLanguage = metadata.TMDB.OriginalLanguage
+		preview.TMDBType = metadata.TMDB.TMDBType
+		preview.Runtime = metadata.TMDB.Runtime
+		preview.Genres = metadata.TMDB.Genres
+		preview.Keywords = metadata.TMDB.Keywords
+		preview.YouTube = metadata.TMDB.YouTube
+		preview.IMDBID = metadata.TMDB.IMDBID
+		preview.TVDBID = metadata.TMDB.TVDBID
+		preview.TMDB = metadata.TMDB
 		result = append(result, preview)
 	}
-	if ids.TVDBID != 0 {
+	if ids.TVDBID != 0 && metadata.TVDB != nil {
 		preview := api.ExternalPreview{Provider: "tvdb", ID: ids.TVDBID, Source: ids.SourceTVDB}
-		if metadata.TVDB != nil {
-			preview.Title = metadata.TVDB.Name
-			preview.Year = metadata.TVDB.Year
-			preview.Overview = metadata.TVDB.Overview
-			preview.PosterURL = metadata.TVDB.Poster
-			preview.FirstAirDate = metadata.TVDB.FirstAired
-			preview.TMDBType = metadata.TVDB.Type
-			preview.Country = metadata.TVDB.OriginalCountry
-			preview.OriginalLanguage = metadata.TVDB.OriginalLanguage
-			preview.Genres = metadata.TVDB.Genres
-			preview.TVDBID = metadata.TVDB.TVDBID
-			preview.TVDB = metadata.TVDB
-		}
+		preview.Title = metadata.TVDB.Name
+		preview.Year = metadata.TVDB.Year
+		preview.Overview = metadata.TVDB.Overview
+		preview.PosterURL = metadata.TVDB.Poster
+		preview.FirstAirDate = metadata.TVDB.FirstAired
+		preview.TMDBType = metadata.TVDB.Type
+		preview.Country = metadata.TVDB.OriginalCountry
+		preview.OriginalLanguage = metadata.TVDB.OriginalLanguage
+		preview.Genres = metadata.TVDB.Genres
+		preview.TVDBID = metadata.TVDB.TVDBID
+		preview.TVDB = metadata.TVDB
 		result = append(result, preview)
 	}
-	if ids.TVmazeID != 0 {
+	if ids.TVmazeID != 0 && metadata.TVmaze != nil {
 		preview := api.ExternalPreview{Provider: "tvmaze", ID: ids.TVmazeID, Source: ids.SourceTVmaze}
-		if metadata.TVmaze != nil {
-			preview.Title = metadata.TVmaze.Name
-			preview.Year = yearFromDate(metadata.TVmaze.Premiered)
-			preview.Overview = metadata.TVmaze.Summary
-			preview.PosterURL = metadata.TVmaze.Poster
-			preview.BackdropURL = metadata.TVmaze.Backdrop
-			preview.TMDBType = metadata.TVmaze.Type
-			preview.OriginalLanguage = metadata.TVmaze.Language
-			preview.Runtime = metadata.TVmaze.Runtime
-			preview.Genres = metadata.TVmaze.Genres
-			preview.Rating = metadata.TVmaze.Rating
-			preview.RatingCount = metadata.TVmaze.Weight
-			preview.Country = metadata.TVmaze.Country
-			preview.Premiered = metadata.TVmaze.Premiered
-			preview.IMDBID = metadata.TVmaze.IMDBID
-			preview.TVDBID = metadata.TVmaze.TVDBID
-			preview.TVmaze = metadata.TVmaze
-		}
+		preview.Title = metadata.TVmaze.Name
+		preview.Year = yearFromDate(metadata.TVmaze.Premiered)
+		preview.Overview = metadata.TVmaze.Summary
+		preview.PosterURL = metadata.TVmaze.Poster
+		preview.BackdropURL = metadata.TVmaze.Backdrop
+		preview.TMDBType = metadata.TVmaze.Type
+		preview.OriginalLanguage = metadata.TVmaze.Language
+		preview.Runtime = metadata.TVmaze.Runtime
+		preview.Genres = metadata.TVmaze.Genres
+		preview.Rating = metadata.TVmaze.Rating
+		preview.RatingCount = metadata.TVmaze.Weight
+		preview.Country = metadata.TVmaze.Country
+		preview.Premiered = metadata.TVmaze.Premiered
+		preview.IMDBID = metadata.TVmaze.IMDBID
+		preview.TVDBID = metadata.TVmaze.TVDBID
+		preview.TVmaze = metadata.TVmaze
 		result = append(result, preview)
 	}
-	if ids.MALID != 0 {
+	if ids.MALID != 0 && metadata.AniList != nil {
 		preview := api.ExternalPreview{Provider: "mal", ID: ids.MALID, Source: ids.SourceMAL}
-		if metadata.AniList != nil {
-			title := firstNonEmpty(
-				metadata.AniList.TitleEnglish,
-				metadata.AniList.TitleUserPreferred,
-				metadata.AniList.TitleRomaji,
-				metadata.AniList.TitleNative,
-			)
-			preview.Title = title
-			preview.Year = metadata.AniList.SeasonYear
-			preview.Overview = metadata.AniList.Description
-			preview.PosterURL = firstNonEmpty(
-				metadata.AniList.CoverExtraLarge,
-				metadata.AniList.CoverLarge,
-				metadata.AniList.CoverMedium,
-			)
-			preview.BackdropURL = metadata.AniList.BannerImage
-			preview.Category = metadata.AniList.Format
-			preview.OriginalTitle = metadata.AniList.TitleRomaji
-			preview.ReleaseDate = metadata.AniList.StartDate
-			preview.FirstAirDate = metadata.AniList.StartDate
-			preview.LastAirDate = metadata.AniList.EndDate
-			preview.OriginalLanguage = anilistPreviewOriginalLanguage(metadata.AniList)
-			preview.TMDBType = metadata.AniList.Format
-			preview.Runtime = metadata.AniList.Duration
-			preview.Genres = strings.Join(metadata.AniList.Genres, ", ")
-			preview.Rating = float64(metadata.AniList.AverageScore) / 10
-			preview.RatingCount = metadata.AniList.Popularity
-			preview.AniList = metadata.AniList
-		}
+		title := firstNonEmpty(
+			metadata.AniList.TitleEnglish,
+			metadata.AniList.TitleUserPreferred,
+			metadata.AniList.TitleRomaji,
+			metadata.AniList.TitleNative,
+		)
+		preview.Title = title
+		preview.Year = metadata.AniList.SeasonYear
+		preview.Overview = metadata.AniList.Description
+		preview.PosterURL = firstNonEmpty(
+			metadata.AniList.CoverExtraLarge,
+			metadata.AniList.CoverLarge,
+			metadata.AniList.CoverMedium,
+		)
+		preview.BackdropURL = metadata.AniList.BannerImage
+		preview.Category = metadata.AniList.Format
+		preview.OriginalTitle = metadata.AniList.TitleRomaji
+		preview.ReleaseDate = metadata.AniList.StartDate
+		preview.FirstAirDate = metadata.AniList.StartDate
+		preview.LastAirDate = metadata.AniList.EndDate
+		preview.OriginalLanguage = anilistPreviewOriginalLanguage(metadata.AniList)
+		preview.TMDBType = metadata.AniList.Format
+		preview.Runtime = metadata.AniList.Duration
+		preview.Genres = strings.Join(metadata.AniList.Genres, ", ")
+		preview.Rating = float64(metadata.AniList.AverageScore) / 10
+		preview.RatingCount = metadata.AniList.Popularity
+		preview.AniList = metadata.AniList
 		result = append(result, preview)
 	}
 	return result

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -4038,7 +4038,7 @@ func (c *Core) ListHistory(ctx context.Context) ([]api.HistoryEntry, error) {
 	result := make([]api.HistoryEntry, 0, len(entries))
 	for _, entry := range entries {
 		entryCopy := entry
-		entryCopy.LatestUploadStatus = historyStatusLabel(entry.LatestUploadStatus, entry.RuleFailureCount)
+		entryCopy.LatestUploadStatus = api.HistoryStatusLabel(entry.LatestUploadStatus, entry.RuleFailureCount)
 		result = append(result, entryCopy)
 	}
 
@@ -4146,13 +4146,8 @@ func (c *Core) GetHistoryOverview(ctx context.Context, sourcePath string) (api.H
 		overview.LatestUploadStatus = uploadHistory[0].Status
 		overview.LatestUploadAt = uploadHistory[0].CreatedAt
 	}
-	blockingRuleFailures := 0
-	for _, failure := range ruleFailures {
-		if api.NormalizeRuleFailureSeverity(failure.Severity) == api.RuleFailureSeverityBlocking {
-			blockingRuleFailures++
-		}
-	}
-	overview.StatusLabel = historyStatusLabel(overview.LatestUploadStatus, blockingRuleFailures)
+	blockingRuleFailures := api.CountBlockingRuleFailures(ruleFailures)
+	overview.StatusLabel = api.HistoryStatusLabel(overview.LatestUploadStatus, blockingRuleFailures)
 
 	return overview, nil
 }
@@ -4273,35 +4268,6 @@ func (c *Core) SaveDescriptionOverride(ctx context.Context, req api.Request, raw
 		RawDescriptionHTML: description.Render(trimmed),
 		HasOverride:        true,
 	}, nil
-}
-
-func historyStatusLabel(rawStatus string, ruleFailureCount int) string {
-	status := strings.TrimSpace(strings.ToLower(rawStatus))
-	switch status {
-	case "pending":
-		return "Pending"
-	case "pending-internal":
-		return "Pending Internal"
-	case "uploaded", "success", "completed":
-		return "Uploaded"
-	case "failed", "error":
-		return "Failed"
-	}
-	if status != "" {
-		normalized := strings.ReplaceAll(status, "-", " ")
-		words := strings.Fields(normalized)
-		for idx, word := range words {
-			if word == "" {
-				continue
-			}
-			words[idx] = strings.ToUpper(word[:1]) + word[1:]
-		}
-		return strings.Join(words, " ")
-	}
-	if ruleFailureCount > 0 {
-		return "Rule Issues"
-	}
-	return "Stored"
 }
 
 func (c *Core) applyDefaultOptions(options api.UploadOptions) (api.UploadOptions, error) {

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -288,6 +288,106 @@ func TestGetHistoryOverviewIncludesGroupedDescriptionOverrides(t *testing.T) {
 	}
 }
 
+func TestHistoryStatusLabelsUseBlockingRuleFailuresAcrossListAndOverview(t *testing.T) {
+	t.Parallel()
+
+	repoPath := filepath.Join(t.TempDir(), "history-status.db")
+	repo, err := db.OpenWithLogger(repoPath, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := repo.Close(); closeErr != nil {
+			t.Fatalf("close repo: %v", closeErr)
+		}
+	})
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repo: %v", err)
+	}
+
+	tests := []struct {
+		name             string
+		failures         []db.TrackerRuleFailure
+		wantStatus       string
+		wantFailureCount int
+		wantWarningCount int
+	}{
+		{
+			name: "warning only",
+			failures: []db.TrackerRuleFailure{
+				{Rule: "recommended_metadata", Severity: api.RuleFailureSeverityWarning},
+			},
+			wantStatus:       "Stored",
+			wantWarningCount: 1,
+		},
+		{
+			name: "blocking only",
+			failures: []db.TrackerRuleFailure{
+				{Rule: "required_metadata"},
+			},
+			wantStatus:       "Rule Issues",
+			wantFailureCount: 1,
+		},
+		{
+			name: "mixed",
+			failures: []db.TrackerRuleFailure{
+				{Rule: "required_metadata"},
+				{Rule: "recommended_metadata", Severity: api.RuleFailureSeverityWarning},
+			},
+			wantStatus:       "Rule Issues",
+			wantFailureCount: 1,
+			wantWarningCount: 1,
+		},
+	}
+
+	ctx := context.Background()
+	paths := make(map[string]string, len(tests))
+	for idx, tt := range tests {
+		sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026."+strconv.Itoa(idx)+".mkv")
+		paths[tt.name] = sourcePath
+		if err := repo.Save(ctx, db.FileMetadata{
+			Path:       sourcePath,
+			Title:      "Example Release 2026",
+			SourceSize: 1,
+			UpdatedAt:  time.Now().UTC().Add(time.Duration(idx) * time.Second),
+		}); err != nil {
+			t.Fatalf("%s: save metadata: %v", tt.name, err)
+		}
+		if err := repo.SaveTrackerRuleFailures(ctx, sourcePath, "EXAMPLE", tt.failures); err != nil {
+			t.Fatalf("%s: save rule results: %v", tt.name, err)
+		}
+	}
+
+	core := &Core{repo: repo, logger: api.NopLogger{}}
+	entries, err := core.ListHistory(ctx)
+	if err != nil {
+		t.Fatalf("list history: %v", err)
+	}
+	entriesByPath := make(map[string]api.HistoryEntry, len(entries))
+	for _, entry := range entries {
+		entriesByPath[entry.SourcePath] = entry
+	}
+
+	for _, tt := range tests {
+		sourcePath := paths[tt.name]
+		entry, ok := entriesByPath[sourcePath]
+		if !ok {
+			t.Fatalf("%s: history entry missing", tt.name)
+		}
+		if entry.LatestUploadStatus != tt.wantStatus || entry.RuleFailureCount != tt.wantFailureCount || entry.RuleWarningCount != tt.wantWarningCount {
+			t.Fatalf("%s: unexpected list history state: %#v", tt.name, entry)
+		}
+
+		overview, err := core.GetHistoryOverview(ctx, sourcePath)
+		if err != nil {
+			t.Fatalf("%s: get history overview: %v", tt.name, err)
+		}
+		if overview.StatusLabel != tt.wantStatus {
+			t.Fatalf("%s: list status %q differs from overview status %q", tt.name, entry.LatestUploadStatus, overview.StatusLabel)
+		}
+	}
+}
+
 func TestRunUploadMultiplePaths(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/preview_test.go
+++ b/internal/core/preview_test.go
@@ -78,6 +78,25 @@ func TestBuildMetadataPreviewMapsExternalData(t *testing.T) {
 	}
 }
 
+func TestBuildMetadataPreviewOmitsResolvedIDsWithoutProviderData(t *testing.T) {
+	meta := api.PreparedMetadata{
+		SourcePath: "/media/example.mkv",
+		ExternalIDs: api.ExternalIDs{
+			TMDBID:     123,
+			SourceTMDB: "tracker",
+		},
+	}
+
+	preview := buildMetadataPreview(meta, config.Config{})
+
+	if len(preview.ExternalIDInfo) != 1 {
+		t.Fatalf("expected resolved external ID to remain visible for editing, got %d", len(preview.ExternalIDInfo))
+	}
+	if len(preview.ExternalPreview) != 0 {
+		t.Fatalf("expected no provider previews without fetched metadata, got %d", len(preview.ExternalPreview))
+	}
+}
+
 func TestBuildMetadataPreviewMapsTVmazeRichData(t *testing.T) {
 	meta := api.PreparedMetadata{
 		SourcePath:  "/media/example-tv.mkv",

--- a/internal/core/preview_test.go
+++ b/internal/core/preview_test.go
@@ -4,6 +4,7 @@
 package core
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -79,8 +80,9 @@ func TestBuildMetadataPreviewMapsExternalData(t *testing.T) {
 }
 
 func TestBuildMetadataPreviewOmitsResolvedIDsWithoutProviderData(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "example.mkv")
 	meta := api.PreparedMetadata{
-		SourcePath: "/media/example.mkv",
+		SourcePath: sourcePath,
 		ExternalIDs: api.ExternalIDs{
 			TMDBID:     123,
 			SourceTMDB: "tracker",
@@ -91,6 +93,10 @@ func TestBuildMetadataPreviewOmitsResolvedIDsWithoutProviderData(t *testing.T) {
 
 	if len(preview.ExternalIDInfo) != 1 {
 		t.Fatalf("expected resolved external ID to remain visible for editing, got %d", len(preview.ExternalIDInfo))
+	}
+	info := preview.ExternalIDInfo[0]
+	if info.Provider != "tmdb" || info.ID != 123 || info.Source != "tracker" {
+		t.Fatalf("expected preserved TMDB external ID info, got %#v", info)
 	}
 	if len(preview.ExternalPreview) != 0 {
 		t.Fatalf("expected no provider previews without fetched metadata, got %d", len(preview.ExternalPreview))

--- a/internal/core/upload_review.go
+++ b/internal/core/upload_review.go
@@ -565,6 +565,10 @@ func filterTrackerRuleFailures(failures map[string][]api.RuleFailure, allowTrack
 	filtered := make(map[string][]api.RuleFailure, len(failures))
 	for tracker, trackerFailures := range failures {
 		if _, ok := allowed[strings.ToUpper(strings.TrimSpace(tracker))]; ok {
+			warnings := api.WarningRuleFailures(trackerFailures)
+			if len(warnings) > 0 {
+				filtered[tracker] = warnings
+			}
 			continue
 		}
 		filtered[tracker] = cloneRuleFailures(trackerFailures)

--- a/internal/dupechecking/common.go
+++ b/internal/dupechecking/common.go
@@ -26,6 +26,7 @@ func skipReason(meta api.PreparedMetadata, tracker string) (string, []string) {
 		return "", nil
 	}
 	failures := meta.TrackerRuleFailures[tracker]
+	failures = api.BlockingRuleFailures(failures)
 	if len(failures) == 0 {
 		return "", nil
 	}

--- a/internal/dupechecking/common_test.go
+++ b/internal/dupechecking/common_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package dupechecking
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestSkipReasonIgnoresWarnings(t *testing.T) {
+	t.Parallel()
+	meta := api.PreparedMetadata{TrackerRuleFailures: map[string][]api.RuleFailure{
+		"PTP": {{Rule: "require_metadata_id", Reason: "IMDb recommended", Severity: api.RuleFailureSeverityWarning}},
+	}}
+	reason, rules := skipReason(meta, "PTP")
+	if reason != "" || len(rules) != 0 {
+		t.Fatalf("expected warning not to skip dupe checking, got reason=%q rules=%v", reason, rules)
+	}
+}

--- a/internal/guiapp/history.go
+++ b/internal/guiapp/history.go
@@ -139,7 +139,13 @@ func (a *App) getHistoryOverviewFromRepo(ctx context.Context, sourcePath string)
 		overview.LatestUploadStatus = uploadHistory[0].Status
 		overview.LatestUploadAt = uploadHistory[0].CreatedAt
 	}
-	overview.StatusLabel = historyStatusLabel(overview.LatestUploadStatus, len(ruleFailures))
+	blockingRuleFailures := 0
+	for _, failure := range ruleFailures {
+		if api.NormalizeRuleFailureSeverity(failure.Severity) == api.RuleFailureSeverityBlocking {
+			blockingRuleFailures++
+		}
+	}
+	overview.StatusLabel = historyStatusLabel(overview.LatestUploadStatus, blockingRuleFailures)
 
 	return overview, nil
 }

--- a/internal/guiapp/history.go
+++ b/internal/guiapp/history.go
@@ -29,7 +29,7 @@ func (a *App) listHistoryFromRepo(ctx context.Context) ([]api.HistoryEntry, erro
 	result := make([]api.HistoryEntry, 0, len(entries))
 	for _, entry := range entries {
 		entryCopy := entry
-		entryCopy.LatestUploadStatus = historyStatusLabel(entry.LatestUploadStatus, entry.RuleFailureCount)
+		entryCopy.LatestUploadStatus = api.HistoryStatusLabel(entry.LatestUploadStatus, entry.RuleFailureCount)
 		result = append(result, entryCopy)
 	}
 
@@ -139,44 +139,10 @@ func (a *App) getHistoryOverviewFromRepo(ctx context.Context, sourcePath string)
 		overview.LatestUploadStatus = uploadHistory[0].Status
 		overview.LatestUploadAt = uploadHistory[0].CreatedAt
 	}
-	blockingRuleFailures := 0
-	for _, failure := range ruleFailures {
-		if api.NormalizeRuleFailureSeverity(failure.Severity) == api.RuleFailureSeverityBlocking {
-			blockingRuleFailures++
-		}
-	}
-	overview.StatusLabel = historyStatusLabel(overview.LatestUploadStatus, blockingRuleFailures)
+	blockingRuleFailures := api.CountBlockingRuleFailures(ruleFailures)
+	overview.StatusLabel = api.HistoryStatusLabel(overview.LatestUploadStatus, blockingRuleFailures)
 
 	return overview, nil
-}
-
-func historyStatusLabel(rawStatus string, ruleFailureCount int) string {
-	status := strings.TrimSpace(strings.ToLower(rawStatus))
-	switch status {
-	case "pending":
-		return "Pending"
-	case "pending-internal":
-		return "Pending Internal"
-	case "uploaded", "success", "completed":
-		return "Uploaded"
-	case "failed", "error":
-		return "Failed"
-	}
-	if status != "" {
-		normalized := strings.ReplaceAll(status, "-", " ")
-		words := strings.Fields(normalized)
-		for idx, word := range words {
-			if word == "" {
-				continue
-			}
-			words[idx] = strings.ToUpper(word[:1]) + word[1:]
-		}
-		return strings.Join(words, " ")
-	}
-	if ruleFailureCount > 0 {
-		return "Rule Issues"
-	}
-	return "Stored"
 }
 
 func preferredHistoryDescriptionOverride(overrides []api.DescriptionOverride) api.DescriptionOverride {

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -53,11 +53,15 @@ type TMDBClient interface {
 	FindByExternalID(ctx context.Context, input tmdb.FindInput) (tmdb.FindResult, error)
 	SearchID(ctx context.Context, input tmdb.SearchInput) (tmdb.SearchOutcome, error)
 	FetchMetadata(ctx context.Context, input tmdb.MetadataInput) (tmdb.MetadataResult, error)
-	FetchAniListMetadata(ctx context.Context, malID int) (tmdb.AniListMetadataResult, error)
 	GetEpisodeDetails(ctx context.Context, tmdbID, season, episode int) (tmdb.EpisodeDetails, error)
 	GetSeasonDetails(ctx context.Context, tmdbID, season int) (tmdb.SeasonDetails, error)
 	DailyToSeasonEpisode(ctx context.Context, tmdbID int, date time.Time) (int, int, error)
 	GetLocalizedData(ctx context.Context, input tmdb.LocalizedDataInput) (map[string]any, error)
+}
+
+// AniListClient is the keyless AniList metadata surface used by external-ID resolution.
+type AniListClient interface {
+	FetchAniListMetadata(ctx context.Context, malID int) (tmdb.AniListMetadataResult, error)
 }
 
 // IMDBClient is the IMDb metadata surface used by external-ID resolution.
@@ -216,7 +220,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 	}
 	metadataChanged := invalidateMismatchedProviderMetadata(&metadata, ids)
 
-	tmdbClient, imdbClient, tvdbClient, tvmazeClient := s.ensureExternalClients()
+	tmdbClient, anilistClient, imdbClient, tvdbClient, tvmazeClient := s.ensureExternalClients()
 
 	filename, secondary := resolveSearchTitles(meta)
 	year := resolveSearchYear(meta)
@@ -423,7 +427,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 		if shouldFetchTMDBMetadata() {
 			return true
 		}
-		if tmdbClient != nil && shouldFetchAniListMetadata(ids.MALID, metadata.AniList) && !anilistFetchAttempted {
+		if anilistClient != nil && shouldFetchAniListMetadata(ids.MALID, metadata.AniList) && !anilistFetchAttempted {
 			return true
 		}
 		if shouldFetchIMDBMetadata() || shouldFetchTVDBMetadata() || shouldFetchTVmazeMetadata() {
@@ -443,7 +447,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 		if fetchTMDB && s.cfg.Description.AddLogo {
 			tmdbLogoFetchAttempted = true
 		}
-		fetchAniList := tmdbClient != nil && shouldFetchAniListMetadata(ids.MALID, metadata.AniList) && !anilistFetchAttempted
+		fetchAniList := anilistClient != nil && shouldFetchAniListMetadata(ids.MALID, metadata.AniList) && !anilistFetchAttempted
 		if fetchAniList {
 			anilistFetchAttempted = true
 		}
@@ -504,7 +508,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 
 		if fetchAniList {
 			group.Go(func() error {
-				result, err := tmdbClient.FetchAniListMetadata(gctx, ids.MALID)
+				result, err := anilistClient.FetchAniListMetadata(gctx, ids.MALID)
 				if err != nil {
 					mu.Lock()
 					if anilistErr == nil {
@@ -1144,14 +1148,21 @@ func mapIMDBCandidates(items []imdb.Candidate) []api.ExternalIDCandidate {
 
 // ensureExternalClients initializes missing provider clients. It returns a nil
 // TMDB client when no client was injected and no TMDB API key is configured;
-// the remaining provider clients are always initialized.
-func (s *Service) ensureExternalClients() (TMDBClient, IMDBClient, TVDBClient, TVmazeClient) {
+// the keyless AniList and remaining provider clients are always initialized.
+func (s *Service) ensureExternalClients() (TMDBClient, AniListClient, IMDBClient, TVDBClient, TVmazeClient) {
 	if s.tmdb == nil {
 		apiKey := strings.TrimSpace(s.cfg.MainSettings.TMDBAPI)
 		if apiKey != "" {
 			s.tmdb = tmdb.NewClient(nil, s.logger, apiKey)
 		} else if s.logger != nil {
 			s.logger.Debugf("metadata: tmdb client disabled reason=api_key_missing")
+		}
+	}
+	if s.anilist == nil {
+		if anilistClient, ok := s.tmdb.(AniListClient); ok {
+			s.anilist = anilistClient
+		} else {
+			s.anilist = tmdb.NewClient(nil, s.logger, "")
 		}
 	}
 	if s.imdb == nil {
@@ -1169,7 +1180,7 @@ func (s *Service) ensureExternalClients() (TMDBClient, IMDBClient, TVDBClient, T
 	if s.tvmaze == nil {
 		s.tvmaze = tvmaze.NewClient(nil, s.logger)
 	}
-	return s.tmdb, s.imdb, s.tvdb, s.tvmaze
+	return s.tmdb, s.anilist, s.imdb, s.tvdb, s.tvmaze
 }
 
 func isIMDbTVMovie(ids api.ExternalIDs, metadata api.ExternalMetadata) bool {

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -68,6 +69,11 @@ type AniListClient interface {
 type IMDBClient interface {
 	Search(ctx context.Context, input imdb.SearchInput) (imdb.SearchResult, error)
 	GetInfo(ctx context.Context, imdbID string, manualLanguage string, debug bool) (imdb.Info, error)
+}
+
+// imdbEpisodeClient resolves an episode-level IMDb title to its parent series.
+type imdbEpisodeClient interface {
+	GetEpisodeInfo(ctx context.Context, imdbID string, debug bool) (imdb.EpisodeLookup, error)
 }
 
 // TVDBClient is the TVDB metadata surface used by external-ID resolution.
@@ -725,6 +731,25 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 
 	if shouldRunFetchPass() {
 		runFetchPass(false)
+	}
+	// Tracker and media metadata can supply an episode IMDb ID where downstream
+	// providers require the parent series ID. Clear the episode snapshot so the
+	// second fetch pass refreshes series metadata after a successful adjustment.
+	if episodeClient, ok := imdbClient.(imdbEpisodeClient); ok && shouldUseTVDBForCategory(meta, ids) && metadata.IMDB != nil && strings.EqualFold(strings.TrimSpace(metadata.IMDB.Type), "tvEpisode") {
+		lookup, err := episodeClient.GetEpisodeInfo(ctx, formatIMDbID(ids.IMDBID), meta.Options.Debug)
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Debugf("metadata: imdb episode parent lookup failed")
+			}
+		} else if parentID := metautil.ParseIMDbNumeric(lookup.Series.SeriesID); parentID != 0 && parentID != ids.IMDBID {
+			ids.IMDBID = parentID
+			ids.SourceIMDB = "imdb_episode_parent"
+			metadata.IMDB = nil
+			metadataChanged = true
+			if s.logger != nil {
+				s.logger.Debugf("metadata: imdb episode id adjusted to parent series id=%d", parentID)
+			}
+		}
 	}
 	if shouldRunFetchPass() {
 		runFetchPass(true)
@@ -2021,7 +2046,9 @@ func mapTVmazeMetadata(result tvmaze.SearchResult) *api.TVmazeMetadata {
 // Parsed release season/episode values may seed provider lookups, but only
 // canonical metadata or provider-confirmed mappings are persisted back to
 // SeasonInt and EpisodeInt. A nil TMDB client skips TMDB-specific mapping and
-// detail lookups without disabling TVDB or TVmaze enrichment.
+// detail lookups without disabling TVDB or TVmaze enrichment. TVDB episode
+// matches take precedence; otherwise IMDb can map an exact, dated, or
+// seasonless absolute episode before TVmaze and TMDB detail lookups run.
 func (s *Service) applyTVEpisodeMetadata(
 	ctx context.Context,
 	meta api.PreparedMetadata,
@@ -2129,6 +2156,8 @@ func (s *Service) applyTVEpisodeMetadata(
 	tvmazeEpisodeOverview := ""
 	tmdbEpisodeTitle := ""
 	tmdbEpisodeOverview := ""
+	imdbEpisodeTitle := ""
+	tvdbEpisodeMatched := false
 
 	if ids.TVDBID != 0 {
 		querySeason := metautil.FirstInt(season, fallbackSeason)
@@ -2176,6 +2205,7 @@ func (s *Service) applyTVEpisodeMetadata(
 			}
 			if !meta.TVPack {
 				if match, ok := tvdb.GetSpecificEpisodeData(episodes, query); ok {
+					tvdbEpisodeMatched = true
 					meta.TVDBAiredDate = strings.TrimSpace(match.Aired)
 					preferredTVDBEpisodeTitle := strings.TrimSpace(match.EpisodeName)
 					englishTVDBEpisodeTitle := ""
@@ -2238,6 +2268,21 @@ func (s *Service) applyTVEpisodeMetadata(
 			}
 		} else if s.logger != nil {
 			s.logger.Debugf("metadata: tvdb episode lookup failed: %v", err)
+		}
+	}
+
+	if !meta.TVPack && !tvdbEpisodeMatched && external != nil && external.IMDB != nil {
+		if match, ok := findIMDBEpisode(external.IMDB.Episodes, season, episode, dailyDate); ok {
+			imdbEpisodeTitle = strings.TrimSpace(match.Title)
+			if match.Season > 0 {
+				season = match.Season
+			}
+			if matchedEpisode := parseIMDBEpisodeNumber(match.EpisodeText); matchedEpisode > 0 {
+				episode = matchedEpisode
+			}
+			if episodeYear == 0 {
+				episodeYear = metautil.FirstInt(match.ReleaseYear, match.ReleaseDate.Year)
+			}
 		}
 	}
 
@@ -2316,7 +2361,7 @@ func (s *Service) applyTVEpisodeMetadata(
 	meta.SeasonStr = seasonep.FormatSeason(season)
 	meta.EpisodeStr = seasonep.FormatEpisode(episode)
 	meta.EpisodeYear = metautil.FirstInt(episodeYear, meta.EpisodeYear)
-	meta.EpisodeTitle = sanitizeEpisodeTitle(metautil.FirstNonEmptyTrimmed(episodeTitle, tvdbEpisodeTitle, tvmazeEpisodeTitle, tmdbEpisodeTitle))
+	meta.EpisodeTitle = sanitizeEpisodeTitle(metautil.FirstNonEmptyTrimmed(episodeTitle, tvdbEpisodeTitle, tvmazeEpisodeTitle, tmdbEpisodeTitle, imdbEpisodeTitle))
 	meta.EpisodeOverview = metautil.FirstNonEmptyTrimmed(episodeOverview, tvdbEpisodeOverview, tvmazeEpisodeOverview, tmdbEpisodeOverview)
 
 	if s.logger != nil && (initialSeason != season || initialEpisode != episode || initialSeasonStr != meta.SeasonStr || initialEpisodeStr != meta.EpisodeStr) {
@@ -2336,6 +2381,59 @@ func (s *Service) applyTVEpisodeMetadata(
 	}
 
 	return meta
+}
+
+// findIMDBEpisode matches by air date, then canonical season/episode. When the
+// season is unknown, episode is treated as a one-based absolute position among
+// numbered, non-special episodes ordered by season and episode number.
+func findIMDBEpisode(episodes []api.IMDBEpisode, season, episode int, airedDate string) (api.IMDBEpisode, bool) {
+	if len(episodes) == 0 {
+		return api.IMDBEpisode{}, false
+	}
+	if aired, err := time.Parse("2006-01-02", strings.TrimSpace(airedDate)); err == nil {
+		for _, candidate := range episodes {
+			if candidate.ReleaseDate.Year == aired.Year() && candidate.ReleaseDate.Month == int(aired.Month()) && candidate.ReleaseDate.Day == aired.Day() {
+				return candidate, true
+			}
+		}
+	}
+	if season > 0 && episode > 0 {
+		for _, candidate := range episodes {
+			if candidate.Season == season && parseIMDBEpisodeNumber(candidate.EpisodeText) == episode {
+				return candidate, true
+			}
+		}
+	}
+	if season != 0 || episode <= 0 {
+		return api.IMDBEpisode{}, false
+	}
+
+	ordered := make([]api.IMDBEpisode, 0, len(episodes))
+	for _, candidate := range episodes {
+		if candidate.Season > 0 && parseIMDBEpisodeNumber(candidate.EpisodeText) > 0 {
+			ordered = append(ordered, candidate)
+		}
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].Season != ordered[j].Season {
+			return ordered[i].Season < ordered[j].Season
+		}
+		return parseIMDBEpisodeNumber(ordered[i].EpisodeText) < parseIMDBEpisodeNumber(ordered[j].EpisodeText)
+	})
+	if episode > len(ordered) {
+		return api.IMDBEpisode{}, false
+	}
+	return ordered[episode-1], true
+}
+
+// parseIMDBEpisodeNumber returns a positive numeric IMDb episode label, or zero
+// when the label is empty, non-numeric, or non-positive.
+func parseIMDBEpisodeNumber(value string) int {
+	number, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || number <= 0 {
+		return 0
+	}
+	return number
 }
 
 func wantsSeasonEpisodeNaming(overrides api.ReleaseNameOverrides) bool {

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -85,8 +85,11 @@ type TVmazeClient interface {
 
 // ResolveExternalIDs resolves and persists cross-provider IDs and metadata for
 // a prepared item, honoring fresh stored data, overrides, scene IDs, and tracker
-// matches before falling back to provider searches. Selected BJS, BT, and ASC
-// targets trigger pt-BR TMDB localized metadata when a TMDB ID is known.
+// matches before falling back to provider searches. Without a configured or
+// injected TMDB client, it preserves independently resolved TMDB IDs while
+// skipping TMDB searches and enrichment; other providers continue normally.
+// Selected BJS, BT, and ASC targets trigger pt-BR TMDB localized metadata when
+// both a TMDB ID and client are available.
 func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetadata) (api.PreparedMetadata, error) {
 	select {
 	case <-ctx.Done():
@@ -212,10 +215,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 		)
 	}
 
-	tmdbClient, imdbClient, tvdbClient, tvmazeClient, err := s.ensureExternalClients()
-	if err != nil {
-		return api.PreparedMetadata{}, err
-	}
+	tmdbClient, imdbClient, tvdbClient, tvmazeClient := s.ensureExternalClients()
 
 	filename, secondary := resolveSearchTitles(meta)
 	year := resolveSearchYear(meta)
@@ -224,7 +224,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 		manualLanguage = strings.TrimSpace(*meta.MetadataOverrides.OriginalLanguage)
 	}
 	unattendedSearch := isUnattendedMetadataSearch(meta)
-	if !overrideTMDB && ids.TMDBID == 0 && ids.IMDBID != 0 {
+	if tmdbClient != nil && !overrideTMDB && ids.TMDBID == 0 && ids.IMDBID != 0 {
 		if s.logger != nil {
 			s.logger.Debugf("metadata: external ids lookup tmdb from imdb=%d", ids.IMDBID)
 		}
@@ -258,19 +258,21 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 		}
 	}
 
-	needsTMDBSearch := !overrideTMDB && ids.TMDBID == 0
+	needsTMDBSearch := tmdbClient != nil && !overrideTMDB && ids.TMDBID == 0
 	needsIMDBSearch := !overrideIMDB && ids.IMDBID == 0
 
 	if needsTMDBSearch || needsIMDBSearch {
 		searchYears := buildSearchYears(year)
 		if s.logger != nil {
 			s.logger.Debugf(
-				"metadata: external ids search tmdb+imdb filename=%q year=%d stages=%v unattended=%t category=%q",
+				"metadata: external ids search filename=%q year=%d stages=%v unattended=%t category=%q tmdb=%t imdb=%t",
 				filename,
 				year,
 				searchYears,
 				unattendedSearch,
 				tmdbCategoryPref,
+				needsTMDBSearch,
+				needsIMDBSearch,
 			)
 		}
 
@@ -279,7 +281,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 				break
 			}
 
-			stageNeedsTMDB := !overrideTMDB && ids.TMDBID == 0
+			stageNeedsTMDB := tmdbClient != nil && !overrideTMDB && ids.TMDBID == 0
 			stageNeedsIMDB := !overrideIMDB && ids.IMDBID == 0
 			if !stageNeedsTMDB && !stageNeedsIMDB {
 				break
@@ -399,7 +401,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 	tmdbLogoFetchAttempted := false
 	anilistFetchAttempted := false
 	shouldFetchTMDBMetadata := func() bool {
-		if ids.TMDBID == 0 {
+		if tmdbClient == nil || ids.TMDBID == 0 {
 			return false
 		}
 		if metadata.TMDB == nil {
@@ -412,7 +414,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 		if shouldFetchTMDBMetadata() {
 			return true
 		}
-		if shouldFetchAniListMetadata(ids.MALID, metadata.AniList) && !anilistFetchAttempted {
+		if tmdbClient != nil && shouldFetchAniListMetadata(ids.MALID, metadata.AniList) && !anilistFetchAttempted {
 			return true
 		}
 		if ids.IMDBID != 0 && metadata.IMDB == nil {
@@ -432,7 +434,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 		if fetchTMDB && s.cfg.Description.AddLogo {
 			tmdbLogoFetchAttempted = true
 		}
-		fetchAniList := shouldFetchAniListMetadata(ids.MALID, metadata.AniList) && !anilistFetchAttempted
+		fetchAniList := tmdbClient != nil && shouldFetchAniListMetadata(ids.MALID, metadata.AniList) && !anilistFetchAttempted
 		if fetchAniList {
 			anilistFetchAttempted = true
 		}
@@ -726,7 +728,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 
 	needsPTBR := trackers.AnyNeedsPTBRLocalizedMetadata(meta.Trackers) || trackers.AnyNeedsPTBRLocalizedMetadata(meta.MatchedTrackers)
 
-	if needsPTBR && ids.TMDBID != 0 {
+	if tmdbClient != nil && needsPTBR && ids.TMDBID != 0 {
 		var mainData, seasonData, episodeData map[string]any
 		var localizedErr error
 		isTV := strings.EqualFold(ids.Category, "TV")
@@ -1096,13 +1098,17 @@ func mapIMDBCandidates(items []imdb.Candidate) []api.ExternalIDCandidate {
 	return mapped
 }
 
-func (s *Service) ensureExternalClients() (TMDBClient, IMDBClient, TVDBClient, TVmazeClient, error) {
+// ensureExternalClients initializes missing provider clients. It returns a nil
+// TMDB client when no client was injected and no TMDB API key is configured;
+// the remaining provider clients are always initialized.
+func (s *Service) ensureExternalClients() (TMDBClient, IMDBClient, TVDBClient, TVmazeClient) {
 	if s.tmdb == nil {
 		apiKey := strings.TrimSpace(s.cfg.MainSettings.TMDBAPI)
-		if apiKey == "" {
-			return nil, nil, nil, nil, errors.New("metadata: tmdb api key missing")
+		if apiKey != "" {
+			s.tmdb = tmdb.NewClient(nil, s.logger, apiKey)
+		} else if s.logger != nil {
+			s.logger.Debugf("metadata: tmdb client disabled reason=api_key_missing")
 		}
-		s.tmdb = tmdb.NewClient(nil, s.logger, apiKey)
 	}
 	if s.imdb == nil {
 		s.imdb = imdb.NewClient(nil, s.logger)
@@ -1119,7 +1125,7 @@ func (s *Service) ensureExternalClients() (TMDBClient, IMDBClient, TVDBClient, T
 	if s.tvmaze == nil {
 		s.tvmaze = tvmaze.NewClient(nil, s.logger)
 	}
-	return s.tmdb, s.imdb, s.tvdb, s.tvmaze, nil
+	return s.tmdb, s.imdb, s.tvdb, s.tvmaze
 }
 
 func isIMDbTVMovie(ids api.ExternalIDs, metadata api.ExternalMetadata) bool {
@@ -1959,7 +1965,8 @@ func mapTVmazeMetadata(result tvmaze.SearchResult) *api.TVmazeMetadata {
 // applyTVEpisodeMetadata enriches TV episode fields from provider data.
 // Parsed release season/episode values may seed provider lookups, but only
 // canonical metadata or provider-confirmed mappings are persisted back to
-// SeasonInt and EpisodeInt.
+// SeasonInt and EpisodeInt. A nil TMDB client skips TMDB-specific mapping and
+// detail lookups without disabling TVDB or TVmaze enrichment.
 func (s *Service) applyTVEpisodeMetadata(
 	ctx context.Context,
 	meta api.PreparedMetadata,
@@ -2002,7 +2009,7 @@ func (s *Service) applyTVEpisodeMetadata(
 	hasManualSeasonEpisode := hasManualSeasonEpisodeOverrides(meta.ReleaseNameOverrides)
 	tmdbDateMatch := false
 
-	if dailyDate != "" && ids.TMDBID != 0 && ((season == 0 || episode == 0) || (wantsSeasonEpisode && !hasManualSeasonEpisode)) {
+	if tmdbClient != nil && dailyDate != "" && ids.TMDBID != 0 && ((season == 0 || episode == 0) || (wantsSeasonEpisode && !hasManualSeasonEpisode)) {
 		if parsedDate, err := time.Parse("2006-01-02", dailyDate); err == nil {
 			if mappedSeason, mappedEpisode, mapErr := tmdbClient.DailyToSeasonEpisode(ctx, ids.TMDBID, parsedDate); mapErr == nil {
 				if mappedSeason > 0 && mappedEpisode > 0 {
@@ -2210,7 +2217,7 @@ func (s *Service) applyTVEpisodeMetadata(
 		}
 	}
 
-	if ids.TMDBID != 0 {
+	if tmdbClient != nil && ids.TMDBID != 0 {
 		lookupSeason := metautil.FirstInt(season, fallbackSeason)
 		lookupEpisode := metautil.FirstInt(episode, fallbackEpisode)
 		if !meta.TVPack && lookupSeason > 0 && lookupEpisode > 0 {
@@ -2269,7 +2276,7 @@ func (s *Service) applyTVEpisodeMetadata(
 		)
 	}
 
-	if wantsSeasonEpisode && !hasManualSeasonEpisode && !tmdbDateMatch && strings.TrimSpace(meta.DailyEpisodeDate) != "" && ids.TMDBID != 0 && s.logger != nil {
+	if tmdbClient != nil && wantsSeasonEpisode && !hasManualSeasonEpisode && !tmdbDateMatch && strings.TrimSpace(meta.DailyEpisodeDate) != "" && ids.TMDBID != 0 && s.logger != nil {
 		s.logger.Warnf("metadata: season/episode naming requested but TMDB season/episode lookup failed for daily_date=%q tmdb_id=%d", strings.TrimSpace(meta.DailyEpisodeDate), ids.TMDBID)
 	}
 

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -214,6 +214,7 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 			ids.SourceTVDB,
 		)
 	}
+	metadataChanged := invalidateMismatchedProviderMetadata(&metadata, ids)
 
 	tmdbClient, imdbClient, tvdbClient, tvmazeClient := s.ensureExternalClients()
 
@@ -391,7 +392,6 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 	var tvdbErr error
 	var tvmazeErr error
 	var anilistErr error
-	metadataChanged := false
 	tvdbName := ""
 
 	isTVForTVmaze := func() bool {
@@ -404,10 +404,19 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 		if tmdbClient == nil || ids.TMDBID == 0 {
 			return false
 		}
-		if metadata.TMDB == nil {
+		if !usableTMDBMetadata(metadata.TMDB, ids.TMDBID) {
 			return true
 		}
 		return s.cfg.Description.AddLogo && strings.TrimSpace(metadata.TMDB.Logo) == "" && !tmdbLogoFetchAttempted
+	}
+	shouldFetchIMDBMetadata := func() bool {
+		return imdbClient != nil && ids.IMDBID != 0 && !usableIMDBMetadata(metadata.IMDB, ids.IMDBID)
+	}
+	shouldFetchTVDBMetadata := func() bool {
+		return tvdbClient != nil && shouldUseTVDBForCategory(meta, ids) && ids.TVDBID != 0 && !usableTVDBMetadata(metadata.TVDB, ids.TVDBID)
+	}
+	shouldFetchTVmazeMetadata := func() bool {
+		return tvmazeClient != nil && isTVForTVmaze() && ids.TVmazeID != 0 && !usableTVmazeMetadata(metadata.TVmaze, ids.TVmazeID)
 	}
 
 	shouldRunFetchPass := func() bool {
@@ -417,13 +426,13 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 		if tmdbClient != nil && shouldFetchAniListMetadata(ids.MALID, metadata.AniList) && !anilistFetchAttempted {
 			return true
 		}
-		if ids.IMDBID != 0 && metadata.IMDB == nil {
+		if shouldFetchIMDBMetadata() || shouldFetchTVDBMetadata() || shouldFetchTVmazeMetadata() {
 			return true
 		}
 		if shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && ids.TVDBID == 0 && (ids.IMDBID != 0 || ids.TMDBID != 0) {
 			return true
 		}
-		if metadata.TVmaze == nil && isTVForTVmaze() && (ids.TVmazeID != 0 || (!overrideTVmaze && ids.TVmazeID == 0 && (ids.IMDBID != 0 || ids.TVDBID != 0))) {
+		if isTVForTVmaze() && (shouldFetchTVmazeMetadata() || (!overrideTVmaze && ids.TVmazeID == 0 && (ids.IMDBID != 0 || ids.TVDBID != 0))) {
 			return true
 		}
 		return false
@@ -438,9 +447,9 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 		if fetchAniList {
 			anilistFetchAttempted = true
 		}
-		fetchIMDB := ids.IMDBID != 0 && metadata.IMDB == nil
+		fetchIMDB := shouldFetchIMDBMetadata()
 		lookupTVDB := shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && ids.TVDBID == 0 && (ids.IMDBID != 0 || ids.TMDBID != 0)
-		lookupTVmaze := metadata.TVmaze == nil && isTVForTVmaze() && (ids.TVmazeID != 0 || (!overrideTVmaze && ids.TVmazeID == 0 && (ids.IMDBID != 0 || ids.TVDBID != 0)))
+		lookupTVmaze := isTVForTVmaze() && (shouldFetchTVmazeMetadata() || (!overrideTVmaze && ids.TVmazeID == 0 && (ids.IMDBID != 0 || ids.TVDBID != 0)))
 
 		if s.logger != nil {
 			s.logger.Debugf(
@@ -694,12 +703,6 @@ func (s *Service) ResolveExternalIDs(ctx context.Context, meta api.PreparedMetad
 			metadata.TVmaze = mapTVmazeMetadata(*tvmazeResult)
 		}
 
-		if shouldUseTVDBForCategory(meta, ids) && metadata.TVDB == nil && ids.TVDBID != 0 {
-			metadata.TVDB = &api.TVDBMetadata{TVDBID: ids.TVDBID, Name: tvdbName}
-		}
-		if metadata.TVmaze == nil && ids.TVmazeID != 0 {
-			metadata.TVmaze = &api.TVmazeMetadata{TVmazeID: ids.TVmazeID, IMDBID: ids.IMDBID, TVDBID: ids.TVDBID}
-		}
 		if manualLanguage != "" {
 			if metadata.TMDB != nil {
 				metadata.TMDB.OriginalLanguage = manualLanguage
@@ -863,6 +866,47 @@ func sourceScopedMetadataMatches(storedSourcePath string, currentSourcePath stri
 		return true
 	}
 	return strings.EqualFold(trimmedStored, strings.TrimSpace(currentSourcePath))
+}
+
+func invalidateMismatchedProviderMetadata(metadata *api.ExternalMetadata, ids api.ExternalIDs) bool {
+	if metadata == nil {
+		return false
+	}
+	changed := false
+	if metadata.TMDB != nil && (ids.TMDBID == 0 || metadata.TMDB.TMDBID != ids.TMDBID) {
+		metadata.TMDB = nil
+		changed = true
+	}
+	if metadata.IMDB != nil && (ids.IMDBID == 0 || metadata.IMDB.IMDBID != ids.IMDBID) {
+		metadata.IMDB = nil
+		changed = true
+	}
+	if metadata.TVDB != nil && (ids.TVDBID == 0 || metadata.TVDB.TVDBID != ids.TVDBID) {
+		metadata.TVDB = nil
+		changed = true
+	}
+	if metadata.TVmaze != nil && (ids.TVmazeID == 0 || metadata.TVmaze.TVmazeID != ids.TVmazeID) {
+		metadata.TVmaze = nil
+		changed = true
+	}
+	return changed
+}
+
+func usableTMDBMetadata(metadata *api.TMDBMetadata, tmdbID int) bool {
+	return metadata != nil && tmdbID > 0 && metadata.TMDBID == tmdbID && strings.TrimSpace(metadata.Title) != ""
+}
+
+func usableIMDBMetadata(metadata *api.IMDBMetadata, imdbID int) bool {
+	return metadata != nil && imdbID > 0 && metadata.IMDBID == imdbID && strings.TrimSpace(metadata.Title) != ""
+}
+
+func usableTVDBMetadata(metadata *api.TVDBMetadata, tvdbID int) bool {
+	return metadata != nil && tvdbID > 0 && metadata.TVDBID == tvdbID &&
+		(strings.TrimSpace(metadata.NameEnglish) != "" || strings.TrimSpace(metadata.Name) != "")
+}
+
+func usableTVmazeMetadata(metadata *api.TVmazeMetadata, tvmazeID int) bool {
+	return metadata != nil && tvmazeID > 0 && metadata.TVmazeID == tvmazeID && strings.TrimSpace(metadata.Name) != ""
 }
 
 // shouldFetchAniListMetadata returns true when the current canonical MAL ID has

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -473,6 +473,68 @@ func TestResolveExternalIDsWithoutTMDBAPIKey(t *testing.T) {
 	}
 }
 
+func TestEnsureExternalClientsInitializesKeylessAniListWithoutTMDBAPIKey(t *testing.T) {
+	svc := NewService(&fakeRepo{})
+
+	tmdbClient, anilistClient, _, _, _ := svc.ensureExternalClients()
+	if tmdbClient != nil {
+		t.Fatal("expected TMDB client to remain unavailable without API key")
+	}
+	if anilistClient == nil {
+		t.Fatal("expected keyless AniList client without TMDB API key")
+	}
+}
+
+func TestResolveExternalIDsRefreshesAniListWithoutTMDBAPIKey(t *testing.T) {
+	sourcePath := "Example.Anime.S01E01.2026.1080p-GRP.mkv"
+	repo := &fakeRepo{
+		meta: api.ExternalMetadata{
+			SourcePath: sourcePath,
+			AniList: &api.AniListMetadata{
+				AniListID:   100,
+				MALID:       200,
+				TitleRomaji: "Stale Anime",
+			},
+		},
+	}
+	anilistClient := &stubTMDB{
+		anilistMetadata: tmdb.AniListMetadataResult{
+			AniListID:   300,
+			MALID:       400,
+			TitleRomaji: "Current Anime",
+		},
+	}
+	svc := NewService(repo,
+		WithAniListClient(anilistClient),
+		WithIMDBClient(&stubIMDB{}),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(&stubTVmaze{}),
+	)
+
+	result, err := svc.ResolveExternalIDs(context.Background(), api.PreparedMetadata{
+		SourcePath: sourcePath,
+		MALID:      400,
+	})
+	if err != nil {
+		t.Fatalf("resolve without TMDB API key: %v", err)
+	}
+	if svc.tmdb != nil {
+		t.Fatal("expected TMDB client to remain unavailable without API key")
+	}
+	if anilistClient.anilistCalls != 1 || len(anilistClient.anilistInputs) != 1 || anilistClient.anilistInputs[0] != 400 {
+		t.Fatalf("expected one keyless AniList fetch for MAL 400, got calls=%d inputs=%v", anilistClient.anilistCalls, anilistClient.anilistInputs)
+	}
+	if result.ExternalMetadata.TMDB != nil {
+		t.Fatalf("expected TMDB enrichment to remain unavailable, got %#v", result.ExternalMetadata.TMDB)
+	}
+	if result.ExternalMetadata.AniList == nil || result.ExternalMetadata.AniList.MALID != 400 || result.ExternalMetadata.AniList.TitleRomaji != "Current Anime" {
+		t.Fatalf("expected refreshed AniList metadata, got %#v", result.ExternalMetadata.AniList)
+	}
+	if repo.meta.AniList == nil || repo.meta.AniList.MALID != 400 {
+		t.Fatalf("expected refreshed AniList metadata persisted, got %#v", repo.meta.AniList)
+	}
+}
+
 func TestResolveExternalIDsDoesNotCreateTVmazePlaceholder(t *testing.T) {
 	repo := &fakeRepo{}
 	tvmazeClient := &stubTVmaze{}

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -301,6 +301,9 @@ type stubIMDB struct {
 	searchResult       imdb.SearchResult
 	searchFn           func(imdb.SearchInput) (imdb.SearchResult, error)
 	info               imdb.Info
+	infoFn             func(string) imdb.Info
+	episodeLookup      imdb.EpisodeLookup
+	episodeLookupCalls int
 	searchCalls        int
 	infoCalls          int
 	searchInputs       []imdb.SearchInput
@@ -316,10 +319,18 @@ func (s *stubIMDB) Search(_ context.Context, input imdb.SearchInput) (imdb.Searc
 	return s.searchResult, nil
 }
 
-func (s *stubIMDB) GetInfo(_ context.Context, _ string, manualLanguage string, _ bool) (imdb.Info, error) {
+func (s *stubIMDB) GetInfo(_ context.Context, imdbID string, manualLanguage string, _ bool) (imdb.Info, error) {
 	s.infoCalls++
 	s.lastManualLanguage = manualLanguage
+	if s.infoFn != nil {
+		return s.infoFn(imdbID), nil
+	}
 	return s.info, nil
+}
+
+func (s *stubIMDB) GetEpisodeInfo(_ context.Context, _ string, _ bool) (imdb.EpisodeLookup, error) {
+	s.episodeLookupCalls++
+	return s.episodeLookup, nil
 }
 
 type stubTVDB struct {
@@ -390,6 +401,8 @@ type stubTVmaze struct {
 	episodeData *tvmaze.EpisodeData
 	calls       int
 	inputs      []tvmaze.SearchInput
+	lastSeason  int
+	lastEpisode int
 }
 
 func (s *stubTVmaze) Search(_ context.Context, input tvmaze.SearchInput) (tvmaze.SearchResult, error) {
@@ -398,7 +411,9 @@ func (s *stubTVmaze) Search(_ context.Context, input tvmaze.SearchInput) (tvmaze
 	return s.result, nil
 }
 
-func (s *stubTVmaze) GetEpisodeByNumber(_ context.Context, _, _, _ int, _ tvmaze.EpisodeLookupContext) (*tvmaze.EpisodeData, error) {
+func (s *stubTVmaze) GetEpisodeByNumber(_ context.Context, _, season, episode int, _ tvmaze.EpisodeLookupContext) (*tvmaze.EpisodeData, error) {
+	s.lastSeason = season
+	s.lastEpisode = episode
 	return s.episodeData, nil
 }
 
@@ -470,6 +485,51 @@ func TestResolveExternalIDsWithoutTMDBAPIKey(t *testing.T) {
 	}
 	if result.ExternalMetadata.TMDB != nil {
 		t.Fatalf("expected TMDB enrichment to remain unavailable, got %#v", result.ExternalMetadata.TMDB)
+	}
+}
+
+func TestResolveExternalIDsAdjustsEpisodeIMDbIDToParentSeries(t *testing.T) {
+	repo := &fakeRepo{}
+	imdbClient := &stubIMDB{
+		infoFn: func(imdbID string) imdb.Info {
+			if imdbID == "tt7654321" {
+				return imdb.Info{IMDbID: imdbID, Title: "Example Episode", Type: "tvEpisode"}
+			}
+			return imdb.Info{IMDbID: imdbID, Title: "Example Series", Type: "tvSeries"}
+		},
+		episodeLookup: imdb.EpisodeLookup{Series: imdb.SeriesInfo{SeriesID: "tt1234567", SeriesTitle: "Example Series"}},
+	}
+	tvmazeClient := &stubTVmaze{result: tvmaze.SearchResult{
+		SelectedID: 55,
+		IMDBID:     1234567,
+		Candidates: []tvmaze.Candidate{{ID: 55, Name: "Example Series", Externals: tvmaze.Externals{IMDB: "tt1234567"}}},
+	}}
+	imdbOverride := 7654321
+	svc := NewService(repo,
+		WithIMDBClient(imdbClient),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(tvmazeClient),
+	)
+
+	result, err := svc.ResolveExternalIDs(context.Background(), api.PreparedMetadata{
+		SourcePath:        "Example.Series.-.02.1080p-GRP.mkv",
+		MediaInfoCategory: "TV",
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			IMDBID: &imdbOverride,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve episode IMDb ID: %v", err)
+	}
+
+	if result.ExternalIDs.IMDBID != 1234567 || result.ExternalIDs.SourceIMDB != "imdb_episode_parent" {
+		t.Fatalf("expected parent-series IMDb ID, got %#v", result.ExternalIDs)
+	}
+	if result.ExternalMetadata.IMDB == nil || result.ExternalMetadata.IMDB.Title != "Example Series" || result.ExternalMetadata.IMDB.Type != "tvSeries" {
+		t.Fatalf("expected parent-series IMDb metadata, got %#v", result.ExternalMetadata.IMDB)
+	}
+	if imdbClient.episodeLookupCalls != 1 || imdbClient.infoCalls != 2 {
+		t.Fatalf("expected one parent lookup and parent metadata refetch, got lookups=%d info=%d", imdbClient.episodeLookupCalls, imdbClient.infoCalls)
 	}
 }
 
@@ -2153,6 +2213,63 @@ func TestApplyTVEpisodeMetadataTVDBMapsSeasonlessAbsoluteWithoutTMDB(t *testing.
 	}
 	if tvdbClient.lastEpisodeQuery.Season != 0 || tvdbClient.lastEpisodeQuery.Episode != 12 || tvdbClient.lastEpisodeQuery.Absolute != 0 {
 		t.Fatalf("expected seasonless TVDB query independent of TMDB anime metadata, got %#v", tvdbClient.lastEpisodeQuery)
+	}
+}
+
+func TestApplyTVEpisodeMetadataIMDbMapsSeasonlessAbsoluteThenUsesTVmaze(t *testing.T) {
+	svc := NewService(&fakeRepo{})
+	tvmazeClient := &stubTVmaze{episodeData: &tvmaze.EpisodeData{
+		EpisodeName:   "TVmaze Episode Three",
+		Overview:      "TVmaze overview.",
+		SeasonNumber:  2,
+		EpisodeNumber: 1,
+		AirDate:       "2026-04-24",
+	}}
+	meta := api.PreparedMetadata{
+		SourcePath: "Example.Series.-.03.1080p-GRP.mkv",
+		EpisodeInt: 3,
+	}
+	ids := &api.ExternalIDs{IMDBID: 1234567, TVmazeID: 55, Category: "TV"}
+	external := &api.ExternalMetadata{IMDB: &api.IMDBMetadata{
+		IMDBID: 1234567,
+		Title:  "Example Series",
+		Type:   "tvSeries",
+		Episodes: []api.IMDBEpisode{
+			{ID: "tt1000001", Title: "Episode One", Season: 1, EpisodeText: "1"},
+			{ID: "tt1000002", Title: "Episode Two", Season: 1, EpisodeText: "2"},
+			{ID: "tt1000003", Title: "IMDb Episode Three", Season: 2, EpisodeText: "1", ReleaseYear: 2026},
+		},
+	}}
+
+	updated := svc.applyTVEpisodeMetadata(context.Background(), meta, ids, external, nil, &stubTVDB{}, tvmazeClient)
+
+	if updated.SeasonInt != 2 || updated.EpisodeInt != 1 || updated.SeasonStr != "S02" || updated.EpisodeStr != "E01" {
+		t.Fatalf("expected IMDb absolute mapping to S02E01, got season=%d episode=%d strings=%q/%q", updated.SeasonInt, updated.EpisodeInt, updated.SeasonStr, updated.EpisodeStr)
+	}
+	if tvmazeClient.lastSeason != 2 || tvmazeClient.lastEpisode != 1 {
+		t.Fatalf("expected mapped S02E01 TVmaze lookup, got S%02dE%02d", tvmazeClient.lastSeason, tvmazeClient.lastEpisode)
+	}
+	if updated.EpisodeTitle != "TVmaze Episode Three" || updated.EpisodeOverview != "TVmaze overview." || updated.EpisodeYear != 2026 {
+		t.Fatalf("expected TVmaze details with IMDb year fallback, got title=%q overview=%q year=%d", updated.EpisodeTitle, updated.EpisodeOverview, updated.EpisodeYear)
+	}
+}
+
+func TestApplyTVEpisodeMetadataIMDbTitleFallbackWithoutTVmaze(t *testing.T) {
+	svc := NewService(&fakeRepo{})
+	meta := api.PreparedMetadata{SourcePath: "Example.Series.S01E02.1080p-GRP.mkv", SeasonInt: 1, EpisodeInt: 2}
+	ids := &api.ExternalIDs{IMDBID: 1234567, Category: "TV"}
+	external := &api.ExternalMetadata{IMDB: &api.IMDBMetadata{
+		IMDBID: 1234567,
+		Title:  "Example Series",
+		Episodes: []api.IMDBEpisode{{
+			ID: "tt1000002", Title: "The Example Path", Season: 1, EpisodeText: "2", ReleaseYear: 2026,
+		}},
+	}}
+
+	updated := svc.applyTVEpisodeMetadata(context.Background(), meta, ids, external, nil, &stubTVDB{}, &stubTVmaze{})
+
+	if updated.EpisodeTitle != "The Example Path" || updated.EpisodeYear != 2026 {
+		t.Fatalf("expected IMDb episode fallback, got title=%q year=%d", updated.EpisodeTitle, updated.EpisodeYear)
 	}
 }
 

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -2122,6 +2122,40 @@ func TestApplyTVEpisodeMetadataTVDBEpisodeTranslationApplied(t *testing.T) {
 	}
 }
 
+func TestApplyTVEpisodeMetadataTVDBMapsSeasonlessAbsoluteWithoutTMDB(t *testing.T) {
+	svc := NewService(&fakeRepo{})
+	tvdbClient := &stubTVDB{
+		episodes: tvdb.EpisodesData{Episodes: []tvdb.Episode{{
+			ID:             112,
+			SeasonNumber:   1,
+			Number:         12,
+			AbsoluteNumber: 12,
+			Name:           "第12話",
+		}}},
+		episodeTranslate: tvdb.EpisodeTranslation{Name: "Take the Example Path"},
+	}
+	meta := api.PreparedMetadata{
+		SourcePath: "Example.Release.-.12.1080p-GRP.mkv",
+		EpisodeInt: 12,
+	}
+	ids := &api.ExternalIDs{TVDBID: 200, Category: "TV"}
+	external := &api.ExternalMetadata{
+		TVDB: &api.TVDBMetadata{TVDBID: 200, OriginalLanguage: "jpn"},
+	}
+
+	updated := svc.applyTVEpisodeMetadata(context.Background(), meta, ids, external, nil, tvdbClient, &stubTVmaze{})
+
+	if updated.SeasonInt != 1 || updated.EpisodeInt != 12 || updated.SeasonStr != "S01" || updated.EpisodeStr != "E12" {
+		t.Fatalf("expected TVDB absolute mapping to S01E12, got season=%d episode=%d strings=%q/%q", updated.SeasonInt, updated.EpisodeInt, updated.SeasonStr, updated.EpisodeStr)
+	}
+	if updated.EpisodeTitle != "Take the Example Path" {
+		t.Fatalf("expected translated TVDB episode title, got %q", updated.EpisodeTitle)
+	}
+	if tvdbClient.lastEpisodeQuery.Season != 0 || tvdbClient.lastEpisodeQuery.Episode != 12 || tvdbClient.lastEpisodeQuery.Absolute != 0 {
+		t.Fatalf("expected seasonless TVDB query independent of TMDB anime metadata, got %#v", tvdbClient.lastEpisodeQuery)
+	}
+}
+
 func TestApplyTVEpisodeMetadataStoresTVDBSeasonEpisodesForPack(t *testing.T) {
 	svc := NewService(&fakeRepo{})
 	tmdbClient := &stubTMDB{}

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -473,6 +473,34 @@ func TestResolveExternalIDsWithoutTMDBAPIKey(t *testing.T) {
 	}
 }
 
+func TestResolveExternalIDsDoesNotCreateTVmazePlaceholder(t *testing.T) {
+	repo := &fakeRepo{}
+	tvmazeClient := &stubTVmaze{}
+	svc := NewService(repo,
+		WithIMDBClient(&stubIMDB{}),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(tvmazeClient),
+	)
+
+	result, err := svc.ResolveExternalIDs(context.Background(), api.PreparedMetadata{
+		SourcePath:        "Example.Release.2026.S01.1080p.WEB-DL-GRP",
+		MediaInfoCategory: "TV",
+		SceneTVmazeID:     55,
+	})
+	if err != nil {
+		t.Fatalf("resolve unresolved TVmaze ID: %v", err)
+	}
+	if result.ExternalIDs.TVmazeID != 55 {
+		t.Fatalf("expected canonical TVmaze ID to remain, got %#v", result.ExternalIDs)
+	}
+	if result.ExternalMetadata.TVmaze != nil {
+		t.Fatalf("expected no placeholder TVmaze snapshot, got %#v", result.ExternalMetadata.TVmaze)
+	}
+	if tvmazeClient.calls == 0 {
+		t.Fatal("expected TVmaze fetch attempt")
+	}
+}
+
 func TestMapTMDBMetadataClonesLocalizedTitles(t *testing.T) {
 	t.Parallel()
 
@@ -1477,6 +1505,51 @@ func TestResolveExternalIDsOverride(t *testing.T) {
 	}
 	if result.ExternalIDs.SourceTMDB != "override" || result.ExternalIDs.SourceIMDB != "override" {
 		t.Fatalf("unexpected override sources: %#v", result.ExternalIDs)
+	}
+}
+
+func TestResolveExternalIDsRefetchesProviderSnapshotsAfterIDOverride(t *testing.T) {
+	repo := &fakeRepo{}
+	tmdbClient := &stubTMDB{metadata: tmdb.MetadataResult{Title: "Current TMDB", TMDBType: "Movie"}}
+	imdbClient := &stubIMDB{info: imdb.Info{IMDbID: "tt0000111", Title: "Current IMDb"}}
+
+	svc := NewService(repo,
+		WithTMDBClient(tmdbClient),
+		WithIMDBClient(imdbClient),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(&stubTVmaze{}),
+	)
+
+	result, err := svc.ResolveExternalIDs(context.Background(), api.PreparedMetadata{
+		SourcePath:      "Example.Release.2026.1080p-GRP.mkv",
+		StoredDataFresh: true,
+		ExternalIDs: api.ExternalIDs{
+			SourcePath: "Example.Release.2026.1080p-GRP.mkv",
+			Category:   "movie",
+			TMDBID:     1,
+			IMDBID:     2,
+		},
+		ExternalMetadata: api.ExternalMetadata{
+			SourcePath: "Example.Release.2026.1080p-GRP.mkv",
+			TMDB:       &api.TMDBMetadata{TMDBID: 1, Title: "Stale TMDB"},
+			IMDB:       &api.IMDBMetadata{IMDBID: 2, Title: "Stale IMDb"},
+		},
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			TMDBID: new(999),
+			IMDBID: new(111),
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve changed provider IDs: %v", err)
+	}
+	if result.ExternalMetadata.TMDB == nil || result.ExternalMetadata.TMDB.TMDBID != 999 || result.ExternalMetadata.TMDB.Title != "Current TMDB" {
+		t.Fatalf("expected refetched TMDB snapshot, got %#v", result.ExternalMetadata.TMDB)
+	}
+	if result.ExternalMetadata.IMDB == nil || result.ExternalMetadata.IMDB.IMDBID != 111 || result.ExternalMetadata.IMDB.Title != "Current IMDb" {
+		t.Fatalf("expected refetched IMDb snapshot, got %#v", result.ExternalMetadata.IMDB)
+	}
+	if tmdbClient.metaCalls != 1 || imdbClient.infoCalls != 1 {
+		t.Fatalf("expected one provider refetch each, got tmdb=%d imdb=%d", tmdbClient.metaCalls, imdbClient.infoCalls)
 	}
 }
 

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -449,6 +449,30 @@ func TestResolveExternalIDsPrecedence(t *testing.T) {
 	}
 }
 
+func TestResolveExternalIDsWithoutTMDBAPIKey(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := NewService(repo,
+		WithIMDBClient(&stubIMDB{}),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(&stubTVmaze{}),
+	)
+
+	result, err := svc.ResolveExternalIDs(context.Background(), api.PreparedMetadata{
+		SourcePath:        "Example.Release.2026.1080p-GRP.mkv",
+		MediaInfoCategory: "MOVIE",
+		TrackerData:       []api.TrackerMetadata{{TMDBID: 123456}},
+	})
+	if err != nil {
+		t.Fatalf("resolve without TMDB API key: %v", err)
+	}
+	if result.ExternalIDs.TMDBID != 123456 || result.ExternalIDs.SourceTMDB != "tracker" {
+		t.Fatalf("expected tracker TMDB ID without enrichment, got %#v", result.ExternalIDs)
+	}
+	if result.ExternalMetadata.TMDB != nil {
+		t.Fatalf("expected TMDB enrichment to remain unavailable, got %#v", result.ExternalMetadata.TMDB)
+	}
+}
+
 func TestMapTMDBMetadataClonesLocalizedTitles(t *testing.T) {
 	t.Parallel()
 

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -1095,6 +1095,7 @@ func TestRefreshPreparedMetadataClearsResolvedRuleFailures(t *testing.T) {
 		Trackers:   []string{"ANT"},
 		ExternalIDs: api.ExternalIDs{
 			Category: "MOVIE",
+			TMDBID:   1,
 		},
 		TrackerRuleFailures: map[string][]api.RuleFailure{
 			"ANT": {

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -1097,6 +1097,9 @@ func TestRefreshPreparedMetadataClearsResolvedRuleFailures(t *testing.T) {
 			Category: "MOVIE",
 			TMDBID:   1,
 		},
+		ExternalMetadata: api.ExternalMetadata{
+			TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Release"},
+		},
 		TrackerRuleFailures: map[string][]api.RuleFailure{
 			"ANT": {
 				{Rule: "require_movie_only", Reason: "category tv is not movie"},

--- a/internal/metadata/naming.go
+++ b/internal/metadata/naming.go
@@ -323,18 +323,23 @@ func releaseNameRequestFromMeta(meta api.PreparedMetadata, logger api.Logger) ap
 	}
 }
 
+// resolveReleaseNameTitle selects naming fields from current matching provider
+// metadata while preserving parsed values when no eligible snapshot exists.
 func resolveReleaseNameTitle(category string, meta api.PreparedMetadata) (string, string, int) {
 	title := strings.TrimSpace(meta.Release.Title)
 	altTitle := strings.TrimSpace(meta.Release.Alt)
 	year := meta.Release.Year
 	isTV := strings.EqualFold(strings.TrimSpace(category), "TV")
 
-	if isTV && meta.ExternalMetadata.TVDB != nil {
+	if isTV && matchingTVDBMetadataForNaming(meta) {
 		tvdb := meta.ExternalMetadata.TVDB
-		if strings.TrimSpace(tvdb.NameEnglish) != "" {
-			title = strings.TrimSpace(tvdb.NameEnglish)
-		} else if strings.TrimSpace(tvdb.Name) != "" {
-			title = strings.TrimSpace(tvdb.Name)
+		englishTitle := strings.TrimSpace(tvdb.NameEnglish)
+		nativeTitle := strings.TrimSpace(tvdb.Name)
+		if englishTitle != "" {
+			title = englishTitle
+			altTitle = fillProviderAlternateTitle(altTitle, title, nativeTitle)
+		} else {
+			title = nativeTitle
 		}
 		if tvdb.Year > 0 && tvdb.YearFromAlias {
 			year = tvdb.Year
@@ -345,35 +350,73 @@ func resolveReleaseNameTitle(category string, meta api.PreparedMetadata) (string
 	}
 
 	switch {
-	case meta.ExternalMetadata.TMDB != nil:
+	case matchingTMDBMetadataForNaming(meta):
 		tmdb := meta.ExternalMetadata.TMDB
-		if strings.TrimSpace(tmdb.Title) != "" {
-			title = strings.TrimSpace(tmdb.Title)
-		}
-		if altTitle == "" && strings.TrimSpace(tmdb.OriginalTitle) != "" && !strings.EqualFold(tmdb.Title, tmdb.OriginalTitle) {
-			altTitle = "AKA " + strings.TrimSpace(tmdb.OriginalTitle)
-		}
+		title = strings.TrimSpace(tmdb.Title)
+		altTitle = fillProviderAlternateTitle(altTitle, title, tmdb.OriginalTitle)
 		if year == 0 && tmdb.Year > 0 {
 			year = tmdb.Year
 		}
-	case meta.ExternalMetadata.IMDB != nil:
+	case matchingIMDBMetadataForNaming(meta):
 		imdb := meta.ExternalMetadata.IMDB
-		if strings.TrimSpace(imdb.Title) != "" {
-			title = strings.TrimSpace(imdb.Title)
-		}
+		title = strings.TrimSpace(imdb.Title)
+		altTitle = fillProviderAlternateTitle(altTitle, title, imdb.AKA)
 		if year == 0 && imdb.Year > 0 {
 			year = imdb.Year
 		}
-	case meta.ExternalMetadata.TVDB != nil:
-		if strings.TrimSpace(meta.ExternalMetadata.TVDB.Name) != "" {
-			title = strings.TrimSpace(meta.ExternalMetadata.TVDB.Name)
-		}
-	case meta.ExternalMetadata.TVmaze != nil:
-		if strings.TrimSpace(meta.ExternalMetadata.TVmaze.Name) != "" {
-			title = strings.TrimSpace(meta.ExternalMetadata.TVmaze.Name)
-		}
 	}
 	return title, altTitle, year
+}
+
+// matchingTMDBMetadataForNaming reports whether TMDB can supply the naming title.
+func matchingTMDBMetadataForNaming(meta api.PreparedMetadata) bool {
+	value := meta.ExternalMetadata.TMDB
+	return namingProviderMetadataCurrent(meta) && value != nil && meta.ExternalIDs.TMDBID > 0 &&
+		value.TMDBID == meta.ExternalIDs.TMDBID && strings.TrimSpace(value.Title) != ""
+}
+
+// matchingIMDBMetadataForNaming reports whether IMDb can supply the naming title.
+func matchingIMDBMetadataForNaming(meta api.PreparedMetadata) bool {
+	value := meta.ExternalMetadata.IMDB
+	return namingProviderMetadataCurrent(meta) && value != nil && meta.ExternalIDs.IMDBID > 0 &&
+		value.IMDBID == meta.ExternalIDs.IMDBID && strings.TrimSpace(value.Title) != ""
+}
+
+// matchingTVDBMetadataForNaming reports whether TVDB can supply the TV naming title.
+func matchingTVDBMetadataForNaming(meta api.PreparedMetadata) bool {
+	value := meta.ExternalMetadata.TVDB
+	return namingProviderMetadataCurrent(meta) && value != nil && meta.ExternalIDs.TVDBID > 0 &&
+		value.TVDBID == meta.ExternalIDs.TVDBID &&
+		(strings.TrimSpace(value.NameEnglish) != "" || strings.TrimSpace(value.Name) != "")
+}
+
+// namingProviderMetadataCurrent reports whether both provider IDs and snapshots
+// are unscoped or belong to the prepared source.
+func namingProviderMetadataCurrent(meta api.PreparedMetadata) bool {
+	return namingSourceMatches(meta.ExternalIDs.SourcePath, meta.SourcePath) &&
+		namingSourceMatches(meta.ExternalMetadata.SourcePath, meta.SourcePath)
+}
+
+// namingSourceMatches accepts legacy unscoped data and case-insensitive source matches.
+func namingSourceMatches(scopedPath, currentPath string) bool {
+	trimmed := strings.TrimSpace(scopedPath)
+	return trimmed == "" || strings.EqualFold(trimmed, strings.TrimSpace(currentPath))
+}
+
+// fillProviderAlternateTitle preserves a parsed alternate and otherwise returns
+// one normalized AKA title when the provider candidate differs from the primary.
+func fillProviderAlternateTitle(current, primary, candidate string) string {
+	if strings.TrimSpace(current) != "" {
+		return strings.TrimSpace(current)
+	}
+	alternate := strings.TrimSpace(candidate)
+	if len(alternate) > len("AKA ") && strings.EqualFold(alternate[:len("AKA ")], "AKA ") {
+		alternate = strings.TrimSpace(alternate[len("AKA "):])
+	}
+	if alternate == "" || strings.EqualFold(strings.TrimSpace(primary), alternate) {
+		return ""
+	}
+	return "AKA " + alternate
 }
 
 func trimTrailingParentheticalYear(title string, year int) string {

--- a/internal/metadata/naming_test.go
+++ b/internal/metadata/naming_test.go
@@ -175,9 +175,9 @@ func TestReleaseNameRequestFromMetaDefaultsToDailyForTVEpisode(t *testing.T) {
 
 func TestReleaseNameRequestFromMetaOmitsSeriesTitleEpisodeTitle(t *testing.T) {
 	meta := api.PreparedMetadata{
-		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		ExternalIDs: api.ExternalIDs{Category: "TV", TVDBID: 2},
 		ExternalMetadata: api.ExternalMetadata{
-			TVDB: &api.TVDBMetadata{NameEnglish: "Re: ZERO, Starting Life in Another World"},
+			TVDB: &api.TVDBMetadata{TVDBID: 2, NameEnglish: "Re: ZERO, Starting Life in Another World"},
 		},
 		Type:         "ENCODE",
 		SeasonStr:    "S04",
@@ -198,7 +198,7 @@ func TestReleaseNameRequestFromMetaOmitsSeriesTitleEpisodeTitle(t *testing.T) {
 
 func TestReleaseNameRequestFromMetaTVPackOmitsSeasonTitle(t *testing.T) {
 	meta := api.PreparedMetadata{
-		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		ExternalIDs: api.ExternalIDs{Category: "TV", TMDBID: 1, TVDBID: 2},
 		Release: api.ReleaseInfo{
 			Title:      "Example Spy Show",
 			Resolution: "2160p",
@@ -350,11 +350,11 @@ func TestBuildReleaseNameTVSeriesAliasFallsBackEncode(t *testing.T) {
 
 func TestResolveReleaseNameTitleTVDBEnglishWinsForTV(t *testing.T) {
 	meta := api.PreparedMetadata{
-		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		ExternalIDs: api.ExternalIDs{Category: "TV", TMDBID: 1, TVDBID: 2},
 		Release:     api.ReleaseInfo{Title: "Release Name", Year: 2001},
 		ExternalMetadata: api.ExternalMetadata{
-			TMDB: &api.TMDBMetadata{Title: "TMDB Name", OriginalTitle: "TMDB Original", Year: 2010},
-			TVDB: &api.TVDBMetadata{Name: "TVDB Native", NameEnglish: "TVDB English", Year: 2012, YearFromAlias: true},
+			TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "TMDB Name", OriginalTitle: "TMDB Original", Year: 2010},
+			TVDB: &api.TVDBMetadata{TVDBID: 2, Name: "TVDB Native", NameEnglish: "TVDB English", Year: 2012, YearFromAlias: true},
 		},
 	}
 
@@ -365,18 +365,18 @@ func TestResolveReleaseNameTitleTVDBEnglishWinsForTV(t *testing.T) {
 	if year != 2012 {
 		t.Fatalf("expected tvdb year, got %d", year)
 	}
-	if altTitle != "" {
-		t.Fatalf("expected no tmdb aka when tvdb precedence is active, got %q", altTitle)
+	if altTitle != "AKA TVDB Native" {
+		t.Fatalf("expected native TVDB alternate title, got %q", altTitle)
 	}
 }
 
 func TestResolveReleaseNameTitleTVDBFallsBackToOriginalWhenEnglishMissing(t *testing.T) {
 	meta := api.PreparedMetadata{
-		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		ExternalIDs: api.ExternalIDs{Category: "TV", TMDBID: 1, TVDBID: 2},
 		Release:     api.ReleaseInfo{Title: "Release Name", Year: 2001},
 		ExternalMetadata: api.ExternalMetadata{
-			TMDB: &api.TMDBMetadata{Title: "TMDB Name", OriginalTitle: "TMDB Original", Year: 2010},
-			TVDB: &api.TVDBMetadata{Name: "TVDB Native", Year: 2012},
+			TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "TMDB Name", OriginalTitle: "TMDB Original", Year: 2010},
+			TVDB: &api.TVDBMetadata{TVDBID: 2, Name: "TVDB Native", Year: 2012},
 		},
 	}
 
@@ -392,18 +392,158 @@ func TestResolveReleaseNameTitleTVDBFallsBackToOriginalWhenEnglishMissing(t *tes
 	}
 }
 
+func TestReleaseNameRequestFromMetaMovieUsesIMDbWithoutTMDB(t *testing.T) {
+	meta := api.PreparedMetadata{
+		SourcePath:  `D:\Movies\Parsed.Title.2026.1080p.BluRay.x264-GRP.mkv`,
+		ExternalIDs: api.ExternalIDs{Category: "MOVIE", IMDBID: 1234567},
+		Type:        "ENCODE",
+		Source:      "BluRay",
+		Audio:       "AAC 2.0",
+		VideoEncode: "x264",
+		Tag:         "-GRP",
+		Release:     api.ReleaseInfo{Title: "Parsed Title", Resolution: "1080p"},
+		ExternalMetadata: api.ExternalMetadata{
+			IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "IMDb Title", AKA: "Original Title", Year: 2026},
+		},
+	}
+
+	req := releaseNameRequestFromMeta(meta, api.NopLogger{})
+	if req.Title != "IMDb Title" || req.AltTitle != "AKA Original Title" || req.Year != 2026 {
+		t.Fatalf("unexpected IMDb naming fields: title=%q alt=%q year=%d", req.Title, req.AltTitle, req.Year)
+	}
+	result := BuildReleaseName(req, api.NopLogger{})
+	if !containsAll(result.NameNoTag, []string{"IMDb Title", "AKA Original Title", "2026"}) {
+		t.Fatalf("expected rebuilt IMDb-only name, got %q", result.NameNoTag)
+	}
+}
+
+func TestResolveReleaseNameTitleProviderAlternateRules(t *testing.T) {
+	tests := []struct {
+		name       string
+		releaseAlt string
+		imdbAKA    string
+		wantAlt    string
+	}{
+		{name: "same as title", imdbAKA: "IMDb Title"},
+		{name: "normalizes prefix", imdbAKA: "AKA Original Title", wantAlt: "AKA Original Title"},
+		{name: "preserves parsed alternate", releaseAlt: "AKA Parsed Alternate", imdbAKA: "Original Title", wantAlt: "AKA Parsed Alternate"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			meta := api.PreparedMetadata{
+				ExternalIDs: api.ExternalIDs{Category: "MOVIE", IMDBID: 1234567},
+				Release:     api.ReleaseInfo{Title: "Parsed Title", Alt: tc.releaseAlt},
+				ExternalMetadata: api.ExternalMetadata{
+					IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "IMDb Title", AKA: tc.imdbAKA},
+				},
+			}
+			_, got, _ := resolveReleaseNameTitle("MOVIE", meta)
+			if got != tc.wantAlt {
+				t.Fatalf("alternate=%q, want %q", got, tc.wantAlt)
+			}
+		})
+	}
+}
+
+func TestResolveReleaseNameTitlePrefersTMDBForMovie(t *testing.T) {
+	meta := api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "MOVIE", TMDBID: 1, IMDBID: 1234567},
+		Release:     api.ReleaseInfo{Title: "Parsed Title"},
+		ExternalMetadata: api.ExternalMetadata{
+			TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "TMDB Title", OriginalTitle: "TMDB Original", Year: 2025},
+			IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "IMDb Title", AKA: "IMDb Original", Year: 2026},
+		},
+	}
+	title, alt, year := resolveReleaseNameTitle("MOVIE", meta)
+	if title != "TMDB Title" || alt != "AKA TMDB Original" || year != 2025 {
+		t.Fatalf("unexpected TMDB-preferred fields: title=%q alt=%q year=%d", title, alt, year)
+	}
+}
+
+func TestResolveReleaseNameTitleTVFallsBackFromUnusableTVDBToIMDb(t *testing.T) {
+	meta := api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "TV", IMDBID: 1234567, TVDBID: 2},
+		Release:     api.ReleaseInfo{Title: "Parsed Series"},
+		ExternalMetadata: api.ExternalMetadata{
+			IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "IMDb Series", AKA: "Original Series", Year: 2026},
+			TVDB: &api.TVDBMetadata{TVDBID: 3, NameEnglish: "Wrong Series"},
+		},
+	}
+	title, alt, year := resolveReleaseNameTitle("TV", meta)
+	if title != "IMDb Series" || alt != "AKA Original Series" || year != 2026 {
+		t.Fatalf("unexpected IMDb fallback fields: title=%q alt=%q year=%d", title, alt, year)
+	}
+}
+
+func TestReleaseNameRequestFromMetaTVUsesIMDbWithoutTVDBOrTMDB(t *testing.T) {
+	meta := api.PreparedMetadata{
+		SourcePath:  `D:\Shows\Parsed.Series.S01E01.1080p.WEB-DL.x264-GRP.mkv`,
+		ExternalIDs: api.ExternalIDs{Category: "TV", IMDBID: 1234567},
+		Type:        "WEBDL",
+		Source:      "Web",
+		Audio:       "AAC 2.0",
+		VideoEncode: "x264",
+		SeasonStr:   "S01",
+		EpisodeStr:  "E01",
+		Tag:         "-GRP",
+		Release:     api.ReleaseInfo{Title: "Parsed Series", Resolution: "1080p"},
+		ExternalMetadata: api.ExternalMetadata{
+			IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "IMDb Series", AKA: "Original Series", Year: 2026},
+		},
+	}
+	req := releaseNameRequestFromMeta(meta, api.NopLogger{})
+	if req.SearchYear != "2026" {
+		t.Fatalf("expected IMDb TV search year, got %q", req.SearchYear)
+	}
+	result := BuildReleaseName(req, api.NopLogger{})
+	if !containsAll(result.NameNoTag, []string{"IMDb Series", "AKA Original Series", "2026", "S01E01"}) {
+		t.Fatalf("expected rebuilt IMDb-only TV name, got %q", result.NameNoTag)
+	}
+}
+
+func TestResolveReleaseNameTitleIgnoresTVmazeOnlyMetadata(t *testing.T) {
+	meta := api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "TV", TVmazeID: 3},
+		Release:     api.ReleaseInfo{Title: "Parsed Series", Year: 2025},
+		ExternalMetadata: api.ExternalMetadata{
+			TVmaze: &api.TVmazeMetadata{TVmazeID: 3, Name: "TVmaze Series", Premiered: "2026-01-01"},
+		},
+	}
+	title, alt, year := resolveReleaseNameTitle("TV", meta)
+	if title != "Parsed Series" || alt != "" || year != 2025 {
+		t.Fatalf("TVmaze changed shared naming: title=%q alt=%q year=%d", title, alt, year)
+	}
+}
+
+func TestResolveReleaseNameTitleIgnoresStaleProviderMetadata(t *testing.T) {
+	meta := api.PreparedMetadata{
+		SourcePath:  "current-source",
+		ExternalIDs: api.ExternalIDs{SourcePath: "current-source", Category: "MOVIE", IMDBID: 1234567},
+		Release:     api.ReleaseInfo{Title: "Parsed Title", Year: 2025},
+		ExternalMetadata: api.ExternalMetadata{
+			SourcePath: "stale-source",
+			IMDB:       &api.IMDBMetadata{IMDBID: 1234567, Title: "Stale IMDb Title", AKA: "Stale Original", Year: 2026},
+		},
+	}
+	title, alt, year := resolveReleaseNameTitle("MOVIE", meta)
+	if title != "Parsed Title" || alt != "" || year != 2025 {
+		t.Fatalf("stale metadata changed naming: title=%q alt=%q year=%d", title, alt, year)
+	}
+}
+
 func TestReleaseNameRequestFromMetaTVSearchYearComesFromTVDB(t *testing.T) {
 	meta := api.PreparedMetadata{
 		SourcePath:  `D:\Shows\Example.Show.S01E01.1080p.BluRay.x264`,
-		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		ExternalIDs: api.ExternalIDs{Category: "TV", TMDBID: 1, TVDBID: 2},
 		Type:        "ENCODE",
 		Source:      "BluRay",
 		Audio:       "AAC 2.0",
 		VideoEncode: "x264",
 		Release:     api.ReleaseInfo{Title: "Example Show", Resolution: "1080p"},
 		ExternalMetadata: api.ExternalMetadata{
-			TMDB: &api.TMDBMetadata{Title: "TMDB Name", Year: 2010},
-			TVDB: &api.TVDBMetadata{Name: "TVDB Name", Year: 2024, YearFromAlias: true},
+			TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "TMDB Name", Year: 2010},
+			TVDB: &api.TVDBMetadata{TVDBID: 2, Name: "TVDB Name", Year: 2024, YearFromAlias: true},
 		},
 	}
 
@@ -421,7 +561,7 @@ func TestReleaseNameRequestFromMetaTVStripsBracketedTVDBYear(t *testing.T) {
 	sourceName := "Example.Show.2024.S01.720p.NF.WEB-DL.DDP5.1.x264-GRP"
 	meta := api.PreparedMetadata{
 		SourcePath:  sourceName,
-		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		ExternalIDs: api.ExternalIDs{Category: "TV", TVDBID: 2},
 		Type:        "WEBDL",
 		Source:      "Web",
 		Audio:       "DD+ 5.1 Atmos",
@@ -435,7 +575,7 @@ func TestReleaseNameRequestFromMetaTVStripsBracketedTVDBYear(t *testing.T) {
 			Resolution: "720p",
 		},
 		ExternalMetadata: api.ExternalMetadata{
-			TVDB: &api.TVDBMetadata{NameEnglish: "Example Show (2024)", Year: 2024, YearFromAlias: true},
+			TVDB: &api.TVDBMetadata{TVDBID: 2, NameEnglish: "Example Show (2024)", Year: 2024, YearFromAlias: true},
 		},
 		Tag: "-GRP",
 	}
@@ -457,14 +597,14 @@ func TestReleaseNameRequestFromMetaTVStripsBracketedTVDBYear(t *testing.T) {
 func TestReleaseNameRequestFromMetaTVOmitsSearchYearWhenTVDBYearNotAliasDerived(t *testing.T) {
 	meta := api.PreparedMetadata{
 		SourcePath:  `D:\Shows\Example.Show.S01E01.1080p.BluRay.x264`,
-		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		ExternalIDs: api.ExternalIDs{Category: "TV", TVDBID: 2},
 		Type:        "ENCODE",
 		Source:      "BluRay",
 		Audio:       "AAC 2.0",
 		VideoEncode: "x264",
 		Release:     api.ReleaseInfo{Title: "Example Show", Resolution: "1080p"},
 		ExternalMetadata: api.ExternalMetadata{
-			TVDB: &api.TVDBMetadata{Name: "TVDB Name", Year: 2024},
+			TVDB: &api.TVDBMetadata{TVDBID: 2, Name: "TVDB Name", Year: 2024},
 		},
 	}
 
@@ -477,12 +617,12 @@ func TestReleaseNameRequestFromMetaTVOmitsSearchYearWhenTVDBYearNotAliasDerived(
 func TestReleaseNameRequestFromMetaLogsTVDBYearSource(t *testing.T) {
 	meta := api.PreparedMetadata{
 		SourcePath:  `D:\Shows\Example.Show.S01E01.1080p.BluRay.x264`,
-		ExternalIDs: api.ExternalIDs{Category: "TV"},
+		ExternalIDs: api.ExternalIDs{Category: "TV", TVDBID: 2},
 		Type:        "ENCODE",
 		Source:      "BluRay",
 		Release:     api.ReleaseInfo{Title: "Example Show", Resolution: "1080p"},
 		ExternalMetadata: api.ExternalMetadata{
-			TVDB: &api.TVDBMetadata{Name: "TVDB Name", Year: 2024, YearSource: "first_aired"},
+			TVDB: &api.TVDBMetadata{TVDBID: 2, Name: "TVDB Name", Year: 2024, YearSource: "first_aired"},
 		},
 	}
 	logger := &captureLogger{}
@@ -545,7 +685,7 @@ func TestBuildReleaseNameTVStripsDuplicateParentheticalSearchYear(t *testing.T) 
 func TestReleaseNameRequestFromMetaMovieKeepsParsedYearWhenTVDBMetadataPresent(t *testing.T) {
 	meta := api.PreparedMetadata{
 		SourcePath:  `D:\Movies\Example.Movie.2026.720p.BluRay.x264-GRP.mkv`,
-		ExternalIDs: api.ExternalIDs{Category: "MOVIE"},
+		ExternalIDs: api.ExternalIDs{Category: "MOVIE", TMDBID: 1},
 		Type:        "ENCODE",
 		Source:      "BluRay",
 		Audio:       "DD 5.1",
@@ -556,7 +696,7 @@ func TestReleaseNameRequestFromMetaMovieKeepsParsedYearWhenTVDBMetadataPresent(t
 			Resolution: "720p",
 		},
 		ExternalMetadata: api.ExternalMetadata{
-			TMDB: &api.TMDBMetadata{Title: "Example Movie", Year: 2026},
+			TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Movie", Year: 2026},
 			TVDB: &api.TVDBMetadata{},
 		},
 	}

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -42,6 +42,7 @@ type Service struct {
 	nfoDir   string
 	cfg      config.Config
 	tmdb     TMDBClient
+	anilist  AniListClient
 	imdb     IMDBClient
 	tvdb     TVDBClient
 	tvmaze   TVmazeClient
@@ -132,6 +133,15 @@ func WithConfig(cfg config.Config) Option {
 func WithTMDBClient(client TMDBClient) Option {
 	return func(s *Service) {
 		s.tmdb = client
+		if anilistClient, ok := client.(AniListClient); ok && s.anilist == nil {
+			s.anilist = anilistClient
+		}
+	}
+}
+
+func WithAniListClient(client AniListClient) Option {
+	return func(s *Service) {
+		s.anilist = client
 	}
 }
 

--- a/internal/metadata/tracker_rules.go
+++ b/internal/metadata/tracker_rules.go
@@ -46,7 +46,11 @@ func (s *Service) applyTrackerRules(ctx context.Context, meta api.PreparedMetada
 			ruleFailures[name] = append([]api.RuleFailure{}, failures...)
 			if s.logger != nil {
 				for _, failure := range failures {
-					s.logger.Debugf("metadata: tracker rule failed tracker=%s rule=%s reason=%s", name, failure.Rule, failure.Reason)
+					if api.IsBlockingRuleFailure(failure) {
+						s.logger.Debugf("metadata: tracker rule result tracker=%s decision=blocked rule=%s reason=%s", name, failure.Rule, failure.Reason)
+					} else {
+						s.logger.Debugf("metadata: tracker rule result tracker=%s decision=warning rule=%s reason=%s", name, failure.Rule, failure.Reason)
+					}
 				}
 			}
 		} else {
@@ -100,6 +104,7 @@ func (s *Service) persistRuleFailures(ctx context.Context, sourcePath string, tr
 			Tracker:    strings.ToUpper(trimmedTracker),
 			Rule:       strings.TrimSpace(failure.Rule),
 			Reason:     strings.TrimSpace(failure.Reason),
+			Severity:   api.NormalizeRuleFailureSeverity(failure.Severity),
 			CreatedAt:  time.Now().UTC(),
 		})
 	}

--- a/internal/metadata/tvdb/client.go
+++ b/internal/metadata/tvdb/client.go
@@ -1443,6 +1443,9 @@ func episodeIsPresent(episodes []Episode, query EpisodeQuery) bool {
 		if query.Season != 0 && query.Episode != 0 && ep.SeasonNumber == query.Season && ep.Number == query.Episode {
 			return true
 		}
+		if query.Episode != 0 && ep.AbsoluteNumber == query.Episode {
+			return true
+		}
 	}
 	return false
 }
@@ -1459,19 +1462,18 @@ func findEpisodeMatch(episodes []Episode, query EpisodeQuery) (EpisodeMatch, boo
 			}
 		}
 	}
-	if query.Season == 0 {
-		return EpisodeMatch{}, false
-	}
-	if query.Episode == 0 {
+	if query.Season != 0 && query.Episode == 0 {
 		for _, ep := range episodes {
 			if ep.SeasonNumber == query.Season {
 				return toMatch(ep), true
 			}
 		}
 	}
-	for _, ep := range episodes {
-		if ep.SeasonNumber == query.Season && ep.Number == query.Episode {
-			return toMatch(ep), true
+	if query.Season != 0 {
+		for _, ep := range episodes {
+			if ep.SeasonNumber == query.Season && ep.Number == query.Episode {
+				return toMatch(ep), true
+			}
 		}
 	}
 	if query.Absolute != 0 {

--- a/internal/metadata/tvdb/client_test.go
+++ b/internal/metadata/tvdb/client_test.go
@@ -125,6 +125,15 @@ func TestFindEpisodeMatch(t *testing.T) {
 	if !ok || match.EpisodeID != 11 {
 		t.Fatalf("expected absolute number match")
 	}
+
+	match, ok = findEpisodeMatch(episodes, EpisodeQuery{Episode: 2})
+	if !ok || match.EpisodeID != 11 || match.SeasonNumber != 1 || match.EpisodeNumber != 2 {
+		t.Fatalf("expected seasonless episode to map by absolute number, got %#v", match)
+	}
+
+	if !episodeIsPresent(episodes, EpisodeQuery{Episode: 2}) {
+		t.Fatal("expected cached absolute episode to satisfy seasonless query")
+	}
 }
 
 func TestEpisodesResponseUnmarshal(t *testing.T) {

--- a/internal/services/db/migrations.go
+++ b/internal/services/db/migrations.go
@@ -71,6 +71,48 @@ var migrationRegistry = []migrationStep{
 	{id: "2026_06_add_tracker_auth_state", dependsOn: []string{"2026_05_add_bluray_external_metadata"}, apply: migrateAddTrackerAuthState},
 	{id: "2026_07_add_external_ids_mal", dependsOn: []string{"2026_06_add_tracker_auth_state"}, apply: migrateAddExternalIDsMAL},
 	{id: "2026_07_add_anilist_external_metadata", dependsOn: []string{"2026_07_add_external_ids_mal"}, apply: migrateAddAniListExternalMetadata},
+	{id: "2026_07_add_tracker_rule_failure_severity", dependsOn: []string{"2026_07_add_anilist_external_metadata"}, apply: migrateAddTrackerRuleFailureSeverity},
+}
+
+// migrateAddTrackerRuleFailureSeverity creates the rule-results table when
+// absent or adds a fail-closed severity column to the legacy table.
+func migrateAddTrackerRuleFailureSeverity(ctx context.Context, exec migrationExecutor) error {
+	exists, err := tableExists(ctx, exec, "tracker_rule_failures")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		statements := []string{
+			`CREATE TABLE tracker_rule_failures (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				source_path TEXT NOT NULL,
+				tracker TEXT NOT NULL,
+				rule TEXT NOT NULL,
+				reason TEXT NOT NULL DEFAULT "",
+				severity TEXT NOT NULL DEFAULT "blocking",
+				created_at TEXT NOT NULL
+			)`,
+			`CREATE INDEX IF NOT EXISTS idx_tracker_rule_failures_source_path ON tracker_rule_failures (source_path)`,
+			`CREATE INDEX IF NOT EXISTS idx_tracker_rule_failures_tracker ON tracker_rule_failures (tracker)`,
+		}
+		for _, statement := range statements {
+			if _, err := exec.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("db: add tracker rule failure severity: %w", err)
+			}
+		}
+		return nil
+	}
+
+	hasSeverity, err := tableColumnExists(ctx, exec, "tracker_rule_failures", "severity")
+	if err != nil {
+		return err
+	}
+	if !hasSeverity {
+		if _, err := exec.ExecContext(ctx, `ALTER TABLE tracker_rule_failures ADD COLUMN severity TEXT NOT NULL DEFAULT "blocking"`); err != nil {
+			return fmt.Errorf("db: add tracker rule failure severity: %w", err)
+		}
+	}
+	return nil
 }
 
 var legacyVersionToMigrationIDs = map[int][]string{
@@ -1029,6 +1071,7 @@ func createBaselineSchema(ctx context.Context, exec migrationExecutor) error {
 			tracker TEXT NOT NULL,
 			rule TEXT NOT NULL,
 			reason TEXT NOT NULL DEFAULT "",
+			severity TEXT NOT NULL DEFAULT "blocking",
 			created_at TEXT NOT NULL
 		)
 		`,

--- a/internal/services/db/migrations_test.go
+++ b/internal/services/db/migrations_test.go
@@ -10,9 +10,65 @@ import (
 	"testing"
 
 	_ "modernc.org/sqlite"
+
+	"github.com/autobrr/upbrr/pkg/api"
 )
 
 const expectedSchemaVersion = 8
+
+func TestMigrateAddTrackerRuleFailureSeverityHandlesAbsentAndLegacyTables(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		seed string
+	}{
+		{name: "absent"},
+		{name: "legacy", seed: `CREATE TABLE tracker_rule_failures (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			source_path TEXT NOT NULL,
+			tracker TEXT NOT NULL,
+			rule TEXT NOT NULL,
+			reason TEXT NOT NULL DEFAULT "",
+			created_at TEXT NOT NULL
+		)`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			db, err := sql.Open("sqlite", ":memory:")
+			if err != nil {
+				t.Fatalf("open: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			if tc.seed != "" {
+				if _, err := db.ExecContext(context.Background(), tc.seed); err != nil {
+					t.Fatalf("seed: %v", err)
+				}
+				if _, err := db.ExecContext(context.Background(), `INSERT INTO tracker_rule_failures (source_path, tracker, rule, created_at) VALUES ("source", "PTP", "legacy", "now")`); err != nil {
+					t.Fatalf("seed legacy row: %v", err)
+				}
+			}
+			if err := migrateAddTrackerRuleFailureSeverity(context.Background(), db); err != nil {
+				t.Fatalf("migrate: %v", err)
+			}
+			if err := migrateAddTrackerRuleFailureSeverity(context.Background(), db); err != nil {
+				t.Fatalf("idempotent migrate: %v", err)
+			}
+			exists, err := tableColumnExists(context.Background(), db, "tracker_rule_failures", "severity")
+			if err != nil || !exists {
+				t.Fatalf("severity column exists=%t err=%v", exists, err)
+			}
+			if tc.seed != "" {
+				var severity string
+				if err := db.QueryRowContext(context.Background(), `SELECT severity FROM tracker_rule_failures WHERE rule = "legacy"`).Scan(&severity); err != nil {
+					t.Fatalf("read legacy severity: %v", err)
+				}
+				if severity != string(api.RuleFailureSeverityBlocking) {
+					t.Fatalf("legacy severity=%q", severity)
+				}
+			}
+		})
+	}
+}
 
 func TestMigrateCreatesTrackerCookiesSchema(t *testing.T) {
 	t.Parallel()

--- a/internal/services/db/sqlite.go
+++ b/internal/services/db/sqlite.go
@@ -1421,7 +1421,12 @@ func (r *SQLiteRepository) ListHistoryEntries(ctx context.Context) ([]HistoryEnt
 			(
 				SELECT COUNT(1)
 				FROM tracker_rule_failures trf
-				WHERE trf.source_path = fm.path
+				WHERE trf.source_path = fm.path AND trf.severity <> "warning"
+			),
+			(
+				SELECT COUNT(1)
+				FROM tracker_rule_failures trf
+				WHERE trf.source_path = fm.path AND trf.severity = "warning"
 			)
 		FROM file_metadata fm
 		LEFT JOIN upload_records ur ON ur.id = (
@@ -1477,6 +1482,7 @@ func (r *SQLiteRepository) ListHistoryEntries(ctx context.Context) ([]HistoryEnt
 			&entry.LatestUploadStatus,
 			&uploadCreatedAt,
 			&entry.RuleFailureCount,
+			&entry.RuleWarningCount,
 		); err != nil {
 			return nil, fmt.Errorf("db list history entries: %w", err)
 		}
@@ -1663,8 +1669,8 @@ func (r *SQLiteRepository) SaveTrackerRuleFailures(ctx context.Context, sourcePa
 
 		if len(failures) > 0 {
 			stmt, err := tx.PrepareContext(ctx, `
-				INSERT INTO tracker_rule_failures (source_path, tracker, rule, reason, created_at)
-				VALUES (?, ?, ?, ?, ?)
+				INSERT INTO tracker_rule_failures (source_path, tracker, rule, reason, severity, created_at)
+				VALUES (?, ?, ?, ?, ?, ?)
 			`)
 			if err != nil {
 				return fmt.Errorf("db save tracker rule failures: prepare: %w", err)
@@ -1685,6 +1691,7 @@ func (r *SQLiteRepository) SaveTrackerRuleFailures(ctx context.Context, sourcePa
 					strings.ToUpper(trimmedTracker),
 					rule,
 					strings.TrimSpace(failure.Reason),
+					api.NormalizeRuleFailureSeverity(failure.Severity),
 					createdAt.Format(time.RFC3339Nano),
 				); err != nil {
 					return fmt.Errorf("db save tracker rule failures: insert: %w", err)
@@ -1708,7 +1715,7 @@ func (r *SQLiteRepository) ListTrackerRuleFailuresByPath(ctx context.Context, pa
 	}
 
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT source_path, tracker, rule, reason, created_at
+		SELECT source_path, tracker, rule, reason, severity, created_at
 		FROM tracker_rule_failures
 		WHERE source_path = ?
 		ORDER BY id ASC
@@ -1722,7 +1729,7 @@ func (r *SQLiteRepository) ListTrackerRuleFailuresByPath(ctx context.Context, pa
 	for rows.Next() {
 		var record TrackerRuleFailure
 		var createdAt string
-		if err := rows.Scan(&record.SourcePath, &record.Tracker, &record.Rule, &record.Reason, &createdAt); err != nil {
+		if err := rows.Scan(&record.SourcePath, &record.Tracker, &record.Rule, &record.Reason, &record.Severity, &createdAt); err != nil {
 			return nil, fmt.Errorf("db list tracker rule failures: %w", err)
 		}
 		if createdAt != "" {

--- a/internal/services/db/sqlite_test.go
+++ b/internal/services/db/sqlite_test.go
@@ -549,7 +549,7 @@ func TestSQLiteRepositoryHistoryCountsRuleSeverities(t *testing.T) {
 		t.Fatalf("migrate: %v", err)
 	}
 	ctx := context.Background()
-	const sourcePath = "/media/example-release.mkv"
+	sourcePath := filepath.Join(t.TempDir(), "example-release.mkv")
 	if err := repo.Save(ctx, FileMetadata{Path: sourcePath, Title: "Example Release", SourceSize: 1, UpdatedAt: time.Now().UTC()}); err != nil {
 		t.Fatalf("save metadata: %v", err)
 	}

--- a/internal/services/db/sqlite_test.go
+++ b/internal/services/db/sqlite_test.go
@@ -538,6 +538,36 @@ func TestSQLiteRepositoryListHistoryEntriesSkipsInfoHashOnlyPlaceholders(t *test
 	}
 }
 
+func TestSQLiteRepositoryHistoryCountsRuleSeverities(t *testing.T) {
+	t.Parallel()
+	repo, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	ctx := context.Background()
+	const sourcePath = "/media/example-release.mkv"
+	if err := repo.Save(ctx, FileMetadata{Path: sourcePath, Title: "Example Release", SourceSize: 1, UpdatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	if err := repo.SaveTrackerRuleFailures(ctx, sourcePath, "PTP", []TrackerRuleFailure{
+		{Rule: "blocking"},
+		{Rule: "warning", Severity: api.RuleFailureSeverityWarning},
+	}); err != nil {
+		t.Fatalf("save rule results: %v", err)
+	}
+	entries, err := repo.ListHistoryEntries(ctx)
+	if err != nil {
+		t.Fatalf("list history: %v", err)
+	}
+	if len(entries) != 1 || entries[0].RuleFailureCount != 1 || entries[0].RuleWarningCount != 1 {
+		t.Fatalf("unexpected history counts: %#v", entries)
+	}
+}
+
 func TestSQLiteRepositoryConcurrentDistinctPathWritesOnDisk(t *testing.T) {
 	t.Parallel()
 
@@ -957,12 +987,21 @@ func TestTrackerRuleFailuresCRUD(t *testing.T) {
 	path := "/tmp/source"
 	tracker := "AITHER"
 
-	failures := []TrackerRuleFailure{{
-		SourcePath: path,
-		Tracker:    tracker,
-		Rule:       "require_unique_id",
-		Reason:     "missing MediaInfo Unique ID",
-	}}
+	failures := []TrackerRuleFailure{
+		{
+			SourcePath: path,
+			Tracker:    tracker,
+			Rule:       "require_unique_id",
+			Reason:     "missing MediaInfo Unique ID",
+		},
+		{
+			SourcePath: path,
+			Tracker:    tracker,
+			Rule:       "recommended_id",
+			Reason:     "missing recommended ID",
+			Severity:   api.RuleFailureSeverityWarning,
+		},
+	}
 	if err := repo.SaveTrackerRuleFailures(ctx, path, tracker, failures); err != nil {
 		t.Fatalf("save tracker rule failures: %v", err)
 	}
@@ -971,11 +1010,14 @@ func TestTrackerRuleFailuresCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list tracker rule failures: %v", err)
 	}
-	if len(stored) != 1 {
-		t.Fatalf("expected 1 tracker rule failure, got %d", len(stored))
+	if len(stored) != 2 {
+		t.Fatalf("expected 2 tracker rule results, got %d", len(stored))
 	}
-	if stored[0].Rule != "require_unique_id" || stored[0].Tracker != tracker {
+	if stored[0].Rule != "require_unique_id" || stored[0].Tracker != tracker || stored[0].Severity != api.RuleFailureSeverityBlocking {
 		t.Fatalf("unexpected rule failure: %#v", stored[0])
+	}
+	if stored[1].Severity != api.RuleFailureSeverityWarning {
+		t.Fatalf("unexpected rule warning: %#v", stored[1])
 	}
 
 	if err := repo.SaveTrackerRuleFailures(ctx, path, tracker, nil); err != nil {

--- a/internal/trackerauth/service_test.go
+++ b/internal/trackerauth/service_test.go
@@ -3225,7 +3225,7 @@ func TestValidateManyRunsTrackerChecksConcurrentlyAndPreservesOrder(t *testing.T
 	var got result
 	select {
 	case got = <-resultCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("ValidateMany did not return after all validations were released")
 	}
 	if got.err != nil {

--- a/internal/trackers/impl/azfamily/common.go
+++ b/internal/trackers/impl/azfamily/common.go
@@ -88,6 +88,14 @@ func tmdbForLookup(meta api.PreparedMetadata) string {
 	return ""
 }
 
+// tvdbForLookup returns a TVDB search value only for identified TV content.
+func tvdbForLookup(meta api.PreparedMetadata) string {
+	if isTV(meta) && meta.ExternalIDs.TVDBID > 0 {
+		return strconv.Itoa(meta.ExternalIDs.TVDBID)
+	}
+	return ""
+}
+
 func lookupTitle(meta api.PreparedMetadata) string {
 	if title := strings.TrimSpace(meta.Release.Title); title != "" {
 		return title

--- a/internal/trackers/impl/azfamily/session.go
+++ b/internal/trackers/impl/azfamily/session.go
@@ -104,27 +104,43 @@ func lookupMediaCode(ctx context.Context, site siteDefinition, state sessionStat
 
 	imdbID := imdbForLookup(meta)
 	tmdbID := tmdbForLookup(meta)
+	tvdbID := tvdbForLookup(meta)
 	all := make([]map[string]any, 0)
-	if imdbID != "" {
-		list, err := search(imdbID)
-		if err != nil {
-			return mediaLookupResult{}, fmt.Errorf("trackers: %s media search by imdb failed: %w", site.Name, err)
+	for _, lookup := range []struct {
+		provider string
+		value    string
+	}{
+		{provider: "imdb", value: imdbID},
+		{provider: "tmdb", value: tmdbID},
+		{provider: "tvdb", value: tvdbID},
+	} {
+		if lookup.value == "" {
+			continue
 		}
-		all = append(all, list...)
-	}
-	if len(all) == 0 {
-		list, err := search(lookupTitle(meta))
+		list, err := search(lookup.value)
 		if err != nil {
-			return mediaLookupResult{}, fmt.Errorf("trackers: %s media search by title failed: %w", site.Name, err)
+			return mediaLookupResult{}, fmt.Errorf("trackers: %s media search by %s failed: %w", site.Name, lookup.provider, err)
 		}
 		all = append(all, list...)
 	}
 	for _, item := range all {
-		if imdbID != "" && strings.EqualFold(stringValue(item["imdb"]), imdbID) {
+		if mediaItemMatchesIDs(item, imdbID, tmdbID, tvdbID) {
 			return mediaLookupResult{MediaCode: stringValue(item["id"])}, nil
 		}
-		if tmdbID != "" && strings.EqualFold(stringValue(item["tmdb"]), tmdbID) {
+	}
+
+	titleResults, err := search(lookupTitle(meta))
+	if err != nil {
+		return mediaLookupResult{}, fmt.Errorf("trackers: %s media search by title failed: %w", site.Name, err)
+	}
+	for _, item := range titleResults {
+		if mediaItemMatchesIDs(item, imdbID, tmdbID, tvdbID) {
 			return mediaLookupResult{MediaCode: stringValue(item["id"])}, nil
+		}
+	}
+	if len(titleResults) > 0 {
+		if id := stringValue(titleResults[0]["id"]); id != "" {
+			return mediaLookupResult{MediaCode: id}, nil
 		}
 	}
 	if len(all) > 0 {
@@ -133,6 +149,13 @@ func lookupMediaCode(ctx context.Context, site siteDefinition, state sessionStat
 		}
 	}
 	return mediaLookupResult{Missing: true}, nil
+}
+
+// mediaItemMatchesIDs reports whether an item matches any supplied provider ID.
+func mediaItemMatchesIDs(item map[string]any, imdbID, tmdbID, tvdbID string) bool {
+	return (imdbID != "" && strings.EqualFold(stringValue(item["imdb"]), imdbID)) ||
+		(tmdbID != "" && strings.EqualFold(stringValue(item["tmdb"]), tmdbID)) ||
+		(tvdbID != "" && strings.EqualFold(stringValue(item["tvdb"]), tvdbID))
 }
 
 func searchRequests(ctx context.Context, site siteDefinition, state sessionState, meta api.PreparedMetadata) ([]string, error) {

--- a/internal/trackers/impl/azfamily/session.go
+++ b/internal/trackers/impl/azfamily/session.go
@@ -105,7 +105,6 @@ func lookupMediaCode(ctx context.Context, site siteDefinition, state sessionStat
 	imdbID := imdbForLookup(meta)
 	tmdbID := tmdbForLookup(meta)
 	tvdbID := tvdbForLookup(meta)
-	all := make([]map[string]any, 0)
 	for _, lookup := range []struct {
 		provider string
 		value    string
@@ -121,11 +120,12 @@ func lookupMediaCode(ctx context.Context, site siteDefinition, state sessionStat
 		if err != nil {
 			return mediaLookupResult{}, fmt.Errorf("trackers: %s media search by %s failed: %w", site.Name, lookup.provider, err)
 		}
-		all = append(all, list...)
-	}
-	for _, item := range all {
-		if mediaItemMatchesIDs(item, imdbID, tmdbID, tvdbID) {
-			return mediaLookupResult{MediaCode: stringValue(item["id"])}, nil
+		for _, item := range list {
+			if mediaItemMatchesIDs(item, imdbID, tmdbID, tvdbID) {
+				if id := stringValue(item["id"]); id != "" {
+					return mediaLookupResult{MediaCode: id}, nil
+				}
+			}
 		}
 	}
 
@@ -135,17 +135,9 @@ func lookupMediaCode(ctx context.Context, site siteDefinition, state sessionStat
 	}
 	for _, item := range titleResults {
 		if mediaItemMatchesIDs(item, imdbID, tmdbID, tvdbID) {
-			return mediaLookupResult{MediaCode: stringValue(item["id"])}, nil
-		}
-	}
-	if len(titleResults) > 0 {
-		if id := stringValue(titleResults[0]["id"]); id != "" {
-			return mediaLookupResult{MediaCode: id}, nil
-		}
-	}
-	if len(all) > 0 {
-		if id := stringValue(all[0]["id"]); id != "" {
-			return mediaLookupResult{MediaCode: id}, nil
+			if id := stringValue(item["id"]); id != "" {
+				return mediaLookupResult{MediaCode: id}, nil
+			}
 		}
 	}
 	return mediaLookupResult{Missing: true}, nil

--- a/internal/trackers/impl/azfamily/session_test.go
+++ b/internal/trackers/impl/azfamily/session_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package azfamily
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestLookupMediaCodeSupportsTVDBOnlyTV(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ajax/movies/2" || r.URL.Query().Get("term") != "456789" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"data":[{"id":"77","tvdb":"456789"}]}`)
+	}))
+	t.Cleanup(server.Close)
+
+	result, err := lookupMediaCode(context.Background(), siteDefinition{Name: "AZ", BaseURL: server.URL}, sessionState{client: server.Client()}, api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "TV", TVDBID: 456789},
+	})
+	if err != nil {
+		t.Fatalf("lookup TVDB media: %v", err)
+	}
+	if result.MediaCode != "77" || result.Missing {
+		t.Fatalf("unexpected lookup result: %#v", result)
+	}
+}

--- a/internal/trackers/impl/azfamily/session_test.go
+++ b/internal/trackers/impl/azfamily/session_test.go
@@ -8,10 +8,33 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/autobrr/upbrr/pkg/api"
 )
+
+type mediaSearchResponse struct {
+	status int
+	body   string
+}
+
+func newMediaSearchServer(t *testing.T, responses map[string]mediaSearchResponse) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response, ok := responses[r.URL.Query().Get("term")]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		if response.status != 0 {
+			w.WriteHeader(response.status)
+		}
+		_, _ = fmt.Fprint(w, response.body)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
 
 func TestLookupMediaCodeSupportsTVDBOnlyTV(t *testing.T) {
 	t.Parallel()
@@ -32,5 +55,147 @@ func TestLookupMediaCodeSupportsTVDBOnlyTV(t *testing.T) {
 	}
 	if result.MediaCode != "77" || result.Missing {
 		t.Fatalf("unexpected lookup result: %#v", result)
+	}
+}
+
+func TestLookupMediaCodeReturnsExactMatchBeforeLaterProviderFailure(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		meta      api.PreparedMetadata
+		responses map[string]mediaSearchResponse
+		wantCode  string
+	}{
+		{
+			name: "imdb before tmdb failure",
+			meta: api.PreparedMetadata{ExternalIDs: api.ExternalIDs{
+				Category: "MOVIE",
+				IMDBID:   123,
+				TMDBID:   456,
+			}},
+			responses: map[string]mediaSearchResponse{
+				"tt0000123": {body: `{"data":[{"id":"11","imdb":"tt0000123"}]}`},
+				"456":       {status: http.StatusBadGateway},
+			},
+			wantCode: "11",
+		},
+		{
+			name: "tmdb before tvdb failure",
+			meta: api.PreparedMetadata{ExternalIDs: api.ExternalIDs{
+				Category: "TV",
+				IMDBID:   123,
+				TMDBID:   456,
+				TVDBID:   789,
+			}},
+			responses: map[string]mediaSearchResponse{
+				"tt0000123": {body: `{"data":[]}`},
+				"456":       {body: `{"data":[{"id":"22","tmdb":"456"}]}`},
+				"789":       {status: http.StatusBadGateway},
+			},
+			wantCode: "22",
+		},
+		{
+			name: "tvdb after earlier misses",
+			meta: api.PreparedMetadata{ExternalIDs: api.ExternalIDs{
+				Category: "TV",
+				IMDBID:   123,
+				TMDBID:   456,
+				TVDBID:   789,
+			}},
+			responses: map[string]mediaSearchResponse{
+				"tt0000123": {body: `{"data":[]}`},
+				"456":       {body: `{"data":[]}`},
+				"789":       {body: `{"data":[{"id":"33","tvdb":"789"}]}`},
+			},
+			wantCode: "33",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := newMediaSearchServer(t, tt.responses)
+			result, err := lookupMediaCode(
+				context.Background(),
+				siteDefinition{Name: "AZ", BaseURL: server.URL},
+				sessionState{client: server.Client()},
+				tt.meta,
+			)
+			if err != nil {
+				t.Fatal("expected earlier exact provider match to succeed")
+			}
+			if result.MediaCode != tt.wantCode || result.Missing {
+				t.Fatalf("expected media code %q, got %#v", tt.wantCode, result)
+			}
+		})
+	}
+}
+
+func TestLookupMediaCodeReturnsProviderErrorWithoutEarlierExactMatch(t *testing.T) {
+	t.Parallel()
+	server := newMediaSearchServer(t, map[string]mediaSearchResponse{
+		"tt0000123": {body: `{"data":[{"id":"11","imdb":"tt9999999"}]}`},
+		"456":       {status: http.StatusBadGateway},
+	})
+
+	_, err := lookupMediaCode(
+		context.Background(),
+		siteDefinition{Name: "AZ", BaseURL: server.URL},
+		sessionState{client: server.Client()},
+		api.PreparedMetadata{ExternalIDs: api.ExternalIDs{Category: "MOVIE", IMDBID: 123, TMDBID: 456}},
+	)
+	if err == nil || !strings.Contains(err.Error(), "media search by tmdb failed") {
+		t.Fatal("expected later provider failure when no earlier exact match exists")
+	}
+}
+
+func TestLookupMediaCodeSelectsExactIDFromTitleResults(t *testing.T) {
+	t.Parallel()
+	server := newMediaSearchServer(t, map[string]mediaSearchResponse{
+		"456":                  {body: `{"data":[]}`},
+		"Example Release 2026": {body: `{"data":[{"id":"11","tmdb":"999"},{"id":"22","tmdb":"456"}]}`},
+	})
+
+	result, err := lookupMediaCode(
+		context.Background(),
+		siteDefinition{Name: "AZ", BaseURL: server.URL},
+		sessionState{client: server.Client()},
+		api.PreparedMetadata{
+			ExternalIDs: api.ExternalIDs{Category: "MOVIE", TMDBID: 456},
+			Release:     api.ReleaseInfo{Title: "Example Release 2026", Year: 2026},
+		},
+	)
+	if err != nil {
+		t.Fatal("expected exact ID in title results to succeed")
+	}
+	if result.MediaCode != "22" || result.Missing {
+		t.Fatalf("expected exact title-result media code, got %#v", result)
+	}
+}
+
+func TestLookupMediaCodeRejectsUnmatchedTitleResults(t *testing.T) {
+	t.Parallel()
+	server := newMediaSearchServer(t, map[string]mediaSearchResponse{
+		"456": {body: `{"data":[]}`},
+		"Example Release 2026": {body: `{"data":[
+			{"id":"11","title":"Example Release 2026","year":2026,"tmdb":"999"},
+			{"id":"22","title":"Example Release 2026","year":2026,"tmdb":"998"}
+		]}`},
+	})
+
+	result, err := lookupMediaCode(
+		context.Background(),
+		siteDefinition{Name: "AZ", BaseURL: server.URL},
+		sessionState{client: server.Client()},
+		api.PreparedMetadata{
+			ExternalIDs: api.ExternalIDs{Category: "MOVIE", TMDBID: 456},
+			Release:     api.ReleaseInfo{Title: "Example Release 2026", Year: 2026},
+		},
+	)
+	if err != nil {
+		t.Fatal("expected unmatched title results to return a missing result")
+	}
+	if !result.Missing || result.MediaCode != "" {
+		t.Fatalf("expected unmatched title results to remain missing, got %#v", result)
 	}
 }

--- a/internal/trackers/impl/ptp/definition_test.go
+++ b/internal/trackers/impl/ptp/definition_test.go
@@ -206,7 +206,7 @@ func TestDefinitionBuildUploadDryRunForNewGroupIncludesQuestionnaire(t *testing.
 			ReleaseName: "Movie.2026.1080p.BluRay.x264",
 			Source:      "BluRay",
 			VideoCodec:  "AVC",
-			ExternalIDs: api.ExternalIDs{Category: "MOVIE", IMDBID: 1234567},
+			ExternalIDs: api.ExternalIDs{Category: "MOVIE"},
 			ExternalMetadata: api.ExternalMetadata{
 				TMDB: &api.TMDBMetadata{
 					Title:    "Movie",
@@ -232,6 +232,9 @@ func TestDefinitionBuildUploadDryRunForNewGroupIncludesQuestionnaire(t *testing.
 	}
 	if entry.Questionnaire.Fields[0].Key != "title" {
 		t.Fatalf("expected first questionnaire field to be title, got %q", entry.Questionnaire.Fields[0].Key)
+	}
+	if got := entry.Payload["imdb"]; got != "0" {
+		t.Fatalf("expected missing IMDb dry-run payload value 0, got %q", got)
 	}
 }
 

--- a/internal/trackers/metadata_requirements.go
+++ b/internal/trackers/metadata_requirements.go
@@ -15,14 +15,22 @@ import (
 type MetadataField string
 
 const (
-	// MetadataFieldTMDBID represents a positive TMDB identifier.
-	MetadataFieldTMDBID MetadataField = "tmdb_id"
-	// MetadataFieldIMDBID represents a positive IMDb identifier.
-	MetadataFieldIMDBID MetadataField = "imdb_id"
-	// MetadataFieldTVDBID represents a positive TVDB identifier.
-	MetadataFieldTVDBID MetadataField = "tvdb_id"
-	// MetadataFieldTVmazeID represents a positive TVmaze identifier.
-	MetadataFieldTVmazeID MetadataField = "tvmaze_id"
+	// MetadataFieldTMDBIDOnly represents a positive TMDB identifier without requiring fetched metadata.
+	MetadataFieldTMDBIDOnly MetadataField = "tmdb_id_only"
+	// MetadataFieldIMDBIDOnly represents a positive IMDb identifier without requiring fetched metadata.
+	MetadataFieldIMDBIDOnly MetadataField = "imdb_id_only"
+	// MetadataFieldTVDBIDOnly represents a positive TVDB identifier without requiring fetched metadata.
+	MetadataFieldTVDBIDOnly MetadataField = "tvdb_id_only"
+	// MetadataFieldTVmazeIDOnly represents a positive TVmaze identifier without requiring fetched metadata.
+	MetadataFieldTVmazeIDOnly MetadataField = "tvmaze_id_only"
+	// MetadataFieldTMDB represents fetched TMDB data matching the canonical ID.
+	MetadataFieldTMDB MetadataField = "tmdb"
+	// MetadataFieldIMDB represents fetched IMDb data matching the canonical ID.
+	MetadataFieldIMDB MetadataField = "imdb"
+	// MetadataFieldTVDB represents fetched TVDB data matching the canonical ID.
+	MetadataFieldTVDB MetadataField = "tvdb"
+	// MetadataFieldTVmaze represents fetched TVmaze data matching the canonical ID.
+	MetadataFieldTVmaze MetadataField = "tvmaze"
 	// MetadataFieldTVDBTitle represents a non-empty title from matching TVDB metadata.
 	MetadataFieldTVDBTitle MetadataField = "tvdb_title"
 )
@@ -58,35 +66,35 @@ type TrackerMetadataPolicy struct {
 }
 
 var trackerMetadataPolicies = map[string]TrackerMetadataPolicy{
-	"PTP": {Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldIMDBID}, Severity: api.RuleFailureSeverityWarning}}},
+	"PTP": {Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldIMDBIDOnly}, Severity: api.RuleFailureSeverityWarning}}},
 	"HDB": {RequireKnownCategory: true, Requirements: []MetadataRequirement{
-		{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldIMDBID}},
-		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldIMDBID, MetadataFieldTVDBID}},
+		{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldIMDBIDOnly}},
+		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldIMDBIDOnly, MetadataFieldTVDBIDOnly}},
 	}},
-	"NBL": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTVmazeID}}}},
-	"ANT": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDBID}}}},
-	"BHD": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDBID}}}},
+	"NBL": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTVmaze}}}},
+	"ANT": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDB}}}},
+	"BHD": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDBIDOnly}}}},
 	"MTV": {RequireKnownCategory: true, Requirements: []MetadataRequirement{
-		{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldTMDBID, MetadataFieldIMDBID}},
+		{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldTMDB, MetadataFieldIMDB}},
 		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTVDBTitle}},
 	}},
-	"BTN": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldIMDBID, MetadataFieldTVDBID}}}},
+	"BTN": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldIMDB, MetadataFieldTVDB}}}},
 	"AR": {RequireKnownCategory: true, Requirements: []MetadataRequirement{
-		{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDBID, MetadataFieldIMDBID}},
-		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTMDBID, MetadataFieldIMDBID, MetadataFieldTVDBID, MetadataFieldTVmazeID}},
+		{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDB, MetadataFieldIMDB}},
+		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTMDB, MetadataFieldIMDB, MetadataFieldTVDB, MetadataFieldTVmaze}},
 	}},
 	"AZ":  multiIDMetadataPolicy(),
 	"CZ":  multiIDMetadataPolicy(),
 	"PHD": multiIDMetadataPolicy(),
-	"CZT": {Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldIMDBID}}}},
+	"CZT": {Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldIMDBIDOnly}}}},
 }
 
 // multiIDMetadataPolicy returns the shared movie and TV policy for trackers
 // that accept several provider identifiers.
 func multiIDMetadataPolicy() TrackerMetadataPolicy {
 	return TrackerMetadataPolicy{RequireKnownCategory: true, Requirements: []MetadataRequirement{
-		{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDBID, MetadataFieldIMDBID}},
-		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTMDBID, MetadataFieldIMDBID, MetadataFieldTVDBID}},
+		{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDBIDOnly, MetadataFieldIMDBIDOnly}},
+		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTMDBIDOnly, MetadataFieldIMDBIDOnly, MetadataFieldTVDBIDOnly}},
 	}}
 }
 
@@ -97,7 +105,7 @@ func MetadataPolicyFor(tracker string) (TrackerMetadataPolicy, bool) {
 	name := strings.ToUpper(strings.TrimSpace(tracker))
 	policy, ok := trackerMetadataPolicies[name]
 	if !ok && IsUnit3DTracker(name) {
-		policy = TrackerMetadataPolicy{Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldTMDBID}}}}
+		policy = TrackerMetadataPolicy{Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldTMDB}}}}
 		ok = true
 	}
 	if !ok {
@@ -165,24 +173,56 @@ func metadataRequirementPresent(fields []MetadataField, meta api.PreparedMetadat
 func metadataFieldPresent(field MetadataField, meta api.PreparedMetadata) bool {
 	idsCurrent := sourceMatches(meta.ExternalIDs.SourcePath, meta.SourcePath)
 	switch field {
-	case MetadataFieldTMDBID:
+	case MetadataFieldTMDBIDOnly:
 		return idsCurrent && meta.ExternalIDs.TMDBID > 0
-	case MetadataFieldIMDBID:
+	case MetadataFieldIMDBIDOnly:
 		return idsCurrent && meta.ExternalIDs.IMDBID > 0
-	case MetadataFieldTVDBID:
+	case MetadataFieldTVDBIDOnly:
 		return idsCurrent && meta.ExternalIDs.TVDBID > 0
-	case MetadataFieldTVmazeID:
+	case MetadataFieldTVmazeIDOnly:
 		return idsCurrent && meta.ExternalIDs.TVmazeID > 0
+	case MetadataFieldTMDB:
+		return matchingTMDBMetadata(meta)
+	case MetadataFieldIMDB:
+		return matchingIMDBMetadata(meta)
+	case MetadataFieldTVDB:
+		return matchingTVDBMetadata(meta)
+	case MetadataFieldTVmaze:
+		return matchingTVmazeMetadata(meta)
 	case MetadataFieldTVDBTitle:
-		if !idsCurrent || meta.ExternalIDs.TVDBID <= 0 || !sourceMatches(meta.ExternalMetadata.SourcePath, meta.SourcePath) || meta.ExternalMetadata.TVDB == nil {
-			return false
-		}
-		if meta.ExternalMetadata.TVDB.TVDBID <= 0 || meta.ExternalMetadata.TVDB.TVDBID != meta.ExternalIDs.TVDBID {
-			return false
-		}
-		return strings.TrimSpace(meta.ExternalMetadata.TVDB.NameEnglish) != "" || strings.TrimSpace(meta.ExternalMetadata.TVDB.Name) != ""
+		return matchingTVDBMetadata(meta)
 	}
 	return false
+}
+
+func matchingTMDBMetadata(meta api.PreparedMetadata) bool {
+	value := meta.ExternalMetadata.TMDB
+	return providerMetadataCurrent(meta) && value != nil && meta.ExternalIDs.TMDBID > 0 &&
+		value.TMDBID == meta.ExternalIDs.TMDBID && strings.TrimSpace(value.Title) != ""
+}
+
+func matchingIMDBMetadata(meta api.PreparedMetadata) bool {
+	value := meta.ExternalMetadata.IMDB
+	return providerMetadataCurrent(meta) && value != nil && meta.ExternalIDs.IMDBID > 0 &&
+		value.IMDBID == meta.ExternalIDs.IMDBID && strings.TrimSpace(value.Title) != ""
+}
+
+func matchingTVDBMetadata(meta api.PreparedMetadata) bool {
+	value := meta.ExternalMetadata.TVDB
+	return providerMetadataCurrent(meta) && value != nil && meta.ExternalIDs.TVDBID > 0 &&
+		value.TVDBID == meta.ExternalIDs.TVDBID &&
+		(strings.TrimSpace(value.NameEnglish) != "" || strings.TrimSpace(value.Name) != "")
+}
+
+func matchingTVmazeMetadata(meta api.PreparedMetadata) bool {
+	value := meta.ExternalMetadata.TVmaze
+	return providerMetadataCurrent(meta) && value != nil && meta.ExternalIDs.TVmazeID > 0 &&
+		value.TVmazeID == meta.ExternalIDs.TVmazeID && strings.TrimSpace(value.Name) != ""
+}
+
+func providerMetadataCurrent(meta api.PreparedMetadata) bool {
+	return sourceMatches(meta.ExternalIDs.SourcePath, meta.SourcePath) &&
+		sourceMatches(meta.ExternalMetadata.SourcePath, meta.SourcePath)
 }
 
 // sourceMatches reports whether data is unscoped or belongs to the current
@@ -197,14 +237,22 @@ func metadataFieldList(fields []MetadataField) string {
 	labels := make([]string, 0, len(fields))
 	for _, field := range fields {
 		switch field {
-		case MetadataFieldTMDBID:
+		case MetadataFieldTMDBIDOnly:
 			labels = append(labels, "TMDB ID")
-		case MetadataFieldIMDBID:
+		case MetadataFieldIMDBIDOnly:
 			labels = append(labels, "IMDb ID")
-		case MetadataFieldTVDBID:
+		case MetadataFieldTVDBIDOnly:
 			labels = append(labels, "TVDB ID")
-		case MetadataFieldTVmazeID:
+		case MetadataFieldTVmazeIDOnly:
 			labels = append(labels, "TVmaze ID")
+		case MetadataFieldTMDB:
+			labels = append(labels, "fetched TMDB metadata")
+		case MetadataFieldIMDB:
+			labels = append(labels, "fetched IMDb metadata")
+		case MetadataFieldTVDB:
+			labels = append(labels, "fetched TVDB metadata")
+		case MetadataFieldTVmaze:
+			labels = append(labels, "fetched TVmaze metadata")
 		case MetadataFieldTVDBTitle:
 			labels = append(labels, "TVDB series title")
 		}

--- a/internal/trackers/metadata_requirements.go
+++ b/internal/trackers/metadata_requirements.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackers
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+// MetadataField identifies metadata that a tracker policy can require.
+type MetadataField string
+
+const (
+	// MetadataFieldTMDBID represents a positive TMDB identifier.
+	MetadataFieldTMDBID MetadataField = "tmdb_id"
+	// MetadataFieldIMDBID represents a positive IMDb identifier.
+	MetadataFieldIMDBID MetadataField = "imdb_id"
+	// MetadataFieldTVDBID represents a positive TVDB identifier.
+	MetadataFieldTVDBID MetadataField = "tvdb_id"
+	// MetadataFieldTVmazeID represents a positive TVmaze identifier.
+	MetadataFieldTVmazeID MetadataField = "tvmaze_id"
+	// MetadataFieldTVDBTitle represents a non-empty title from matching TVDB metadata.
+	MetadataFieldTVDBTitle MetadataField = "tvdb_title"
+)
+
+// MetadataScope limits a metadata requirement to a content category.
+type MetadataScope string
+
+const (
+	// MetadataScopeAny applies regardless of content category.
+	MetadataScopeAny MetadataScope = "any"
+	// MetadataScopeMovie applies only to movie content.
+	MetadataScopeMovie MetadataScope = "movie"
+	// MetadataScopeTV applies only to TV content.
+	MetadataScopeTV MetadataScope = "tv"
+)
+
+// MetadataRequirement defines one group of alternative metadata fields.
+type MetadataRequirement struct {
+	// Scope selects the content category to which the requirement applies.
+	Scope MetadataScope
+	// AnyOf is satisfied when at least one listed field is present and current.
+	AnyOf []MetadataField
+	// Severity defaults to blocking when empty or unrecognized.
+	Severity api.RuleFailureSeverity
+}
+
+// TrackerMetadataPolicy defines declarative metadata requirements for a tracker.
+type TrackerMetadataPolicy struct {
+	// RequireKnownCategory blocks evaluation when content is neither movie nor TV.
+	RequireKnownCategory bool
+	// Requirements are evaluated in order after category resolution.
+	Requirements []MetadataRequirement
+}
+
+var trackerMetadataPolicies = map[string]TrackerMetadataPolicy{
+	"PTP": {Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldIMDBID}, Severity: api.RuleFailureSeverityWarning}}},
+	"HDB": {RequireKnownCategory: true, Requirements: []MetadataRequirement{
+		{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldIMDBID}},
+		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldIMDBID, MetadataFieldTVDBID}},
+	}},
+	"NBL": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTVmazeID}}}},
+	"ANT": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDBID}}}},
+	"BHD": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDBID}}}},
+	"MTV": {RequireKnownCategory: true, Requirements: []MetadataRequirement{
+		{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldTMDBID, MetadataFieldIMDBID}},
+		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTVDBTitle}},
+	}},
+	"BTN": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldIMDBID, MetadataFieldTVDBID}}}},
+	"AR": {RequireKnownCategory: true, Requirements: []MetadataRequirement{
+		{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDBID, MetadataFieldIMDBID}},
+		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTMDBID, MetadataFieldIMDBID, MetadataFieldTVDBID, MetadataFieldTVmazeID}},
+	}},
+	"AZ":  multiIDMetadataPolicy(),
+	"CZ":  multiIDMetadataPolicy(),
+	"PHD": multiIDMetadataPolicy(),
+	"CZT": {Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldIMDBID}}}},
+}
+
+// multiIDMetadataPolicy returns the shared movie and TV policy for trackers
+// that accept several provider identifiers.
+func multiIDMetadataPolicy() TrackerMetadataPolicy {
+	return TrackerMetadataPolicy{RequireKnownCategory: true, Requirements: []MetadataRequirement{
+		{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDBID, MetadataFieldIMDBID}},
+		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTMDBID, MetadataFieldIMDBID, MetadataFieldTVDBID}},
+	}}
+}
+
+// MetadataPolicyFor returns an independent copy of a tracker's metadata policy.
+// Tracker names are case-insensitive and whitespace-trimmed. Known Unit3D
+// trackers without an explicit policy require a current TMDB ID.
+func MetadataPolicyFor(tracker string) (TrackerMetadataPolicy, bool) {
+	name := strings.ToUpper(strings.TrimSpace(tracker))
+	policy, ok := trackerMetadataPolicies[name]
+	if !ok && IsUnit3DTracker(name) {
+		policy = TrackerMetadataPolicy{Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldTMDBID}}}}
+		ok = true
+	}
+	if !ok {
+		return TrackerMetadataPolicy{}, false
+	}
+	policy.Requirements = slices.Clone(policy.Requirements)
+	for i := range policy.Requirements {
+		policy.Requirements[i].AnyOf = slices.Clone(policy.Requirements[i].AnyOf)
+	}
+	return policy, true
+}
+
+// evaluateMetadataRequirements returns policy results and whether the tracker
+// has a metadata policy. An evaluated policy may produce a non-nil empty slice.
+func evaluateMetadataRequirements(tracker string, meta api.PreparedMetadata) ([]api.RuleFailure, bool) {
+	policy, ok := MetadataPolicyFor(tracker)
+	if !ok {
+		return nil, false
+	}
+
+	category := MetadataScope(strings.ToLower(strings.TrimSpace(resolveCategory(meta))))
+	if policy.RequireKnownCategory && category != MetadataScopeMovie && category != MetadataScopeTV {
+		return []api.RuleFailure{{
+			Rule:     "require_metadata_category",
+			Reason:   "missing category required to select tracker metadata requirements",
+			Severity: api.RuleFailureSeverityBlocking,
+		}}, true
+	}
+
+	failures := make([]api.RuleFailure, 0)
+	for _, requirement := range policy.Requirements {
+		if requirement.Scope != MetadataScopeAny && requirement.Scope != category {
+			continue
+		}
+		if metadataRequirementPresent(requirement.AnyOf, meta) {
+			continue
+		}
+		severity := api.NormalizeRuleFailureSeverity(requirement.Severity)
+		rule := "require_metadata_id"
+		reason := "missing required " + metadataFieldList(requirement.AnyOf)
+		if slices.Contains(requirement.AnyOf, MetadataFieldTVDBTitle) {
+			rule = "require_tvdb_title"
+			reason = "missing required TVDB series title for MTV TV upload"
+		} else if severity == api.RuleFailureSeverityWarning {
+			reason = "missing recommended IMDb ID; PTP upload remains allowed"
+		}
+		failures = append(failures, api.RuleFailure{Rule: rule, Reason: reason, Severity: severity})
+	}
+	return failures, true
+}
+
+// metadataRequirementPresent reports whether any alternative field satisfies
+// a requirement.
+func metadataRequirementPresent(fields []MetadataField, meta api.PreparedMetadata) bool {
+	for _, field := range fields {
+		if metadataFieldPresent(field, meta) {
+			return true
+		}
+	}
+	return false
+}
+
+// metadataFieldPresent accepts only IDs and provider data scoped to the current
+// source; an empty scope remains compatible with legacy unscoped metadata.
+func metadataFieldPresent(field MetadataField, meta api.PreparedMetadata) bool {
+	idsCurrent := sourceMatches(meta.ExternalIDs.SourcePath, meta.SourcePath)
+	switch field {
+	case MetadataFieldTMDBID:
+		return idsCurrent && meta.ExternalIDs.TMDBID > 0
+	case MetadataFieldIMDBID:
+		return idsCurrent && meta.ExternalIDs.IMDBID > 0
+	case MetadataFieldTVDBID:
+		return idsCurrent && meta.ExternalIDs.TVDBID > 0
+	case MetadataFieldTVmazeID:
+		return idsCurrent && meta.ExternalIDs.TVmazeID > 0
+	case MetadataFieldTVDBTitle:
+		if !idsCurrent || meta.ExternalIDs.TVDBID <= 0 || !sourceMatches(meta.ExternalMetadata.SourcePath, meta.SourcePath) || meta.ExternalMetadata.TVDB == nil {
+			return false
+		}
+		if meta.ExternalMetadata.TVDB.TVDBID <= 0 || meta.ExternalMetadata.TVDB.TVDBID != meta.ExternalIDs.TVDBID {
+			return false
+		}
+		return strings.TrimSpace(meta.ExternalMetadata.TVDB.NameEnglish) != "" || strings.TrimSpace(meta.ExternalMetadata.TVDB.Name) != ""
+	}
+	return false
+}
+
+// sourceMatches reports whether data is unscoped or belongs to the current
+// source. Path comparison is case-insensitive to match persisted source keys.
+func sourceMatches(scopedPath, currentPath string) bool {
+	trimmed := strings.TrimSpace(scopedPath)
+	return trimmed == "" || strings.EqualFold(trimmed, strings.TrimSpace(currentPath))
+}
+
+// metadataFieldList formats alternative field names for a rule-result reason.
+func metadataFieldList(fields []MetadataField) string {
+	labels := make([]string, 0, len(fields))
+	for _, field := range fields {
+		switch field {
+		case MetadataFieldTMDBID:
+			labels = append(labels, "TMDB ID")
+		case MetadataFieldIMDBID:
+			labels = append(labels, "IMDb ID")
+		case MetadataFieldTVDBID:
+			labels = append(labels, "TVDB ID")
+		case MetadataFieldTVmazeID:
+			labels = append(labels, "TVmaze ID")
+		case MetadataFieldTVDBTitle:
+			labels = append(labels, "TVDB series title")
+		}
+	}
+	if len(labels) == 0 {
+		return "metadata"
+	}
+	if len(labels) == 1 {
+		return labels[0]
+	}
+	return fmt.Sprintf("%s or %s", strings.Join(labels[:len(labels)-1], ", "), labels[len(labels)-1])
+}

--- a/internal/trackers/metadata_requirements.go
+++ b/internal/trackers/metadata_requirements.go
@@ -33,6 +33,8 @@ const (
 	MetadataFieldTVmaze MetadataField = "tvmaze"
 	// MetadataFieldTVDBTitle represents a non-empty title from matching TVDB metadata.
 	MetadataFieldTVDBTitle MetadataField = "tvdb_title"
+	// MetadataFieldPoster represents poster artwork from matching provider metadata.
+	MetadataFieldPoster MetadataField = "poster"
 )
 
 // MetadataScope limits a metadata requirement to a content category.
@@ -65,6 +67,8 @@ type TrackerMetadataPolicy struct {
 	Requirements []MetadataRequirement
 }
 
+// trackerMetadataPolicies maps normalized tracker names to their required
+// provider evidence; requirements within one entry are cumulative.
 var trackerMetadataPolicies = map[string]TrackerMetadataPolicy{
 	"PTP": {Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldIMDBIDOnly}, Severity: api.RuleFailureSeverityWarning}}},
 	"HDB": {RequireKnownCategory: true, Requirements: []MetadataRequirement{
@@ -73,7 +77,7 @@ var trackerMetadataPolicies = map[string]TrackerMetadataPolicy{
 	}},
 	"NBL": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTVmaze}}}},
 	"ANT": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDB}}}},
-	"BHD": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDBIDOnly}}}},
+	"BHD": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldIMDB}}}},
 	"MTV": {RequireKnownCategory: true, Requirements: []MetadataRequirement{
 		{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldTMDB, MetadataFieldIMDB}},
 		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTVDBTitle}},
@@ -81,8 +85,14 @@ var trackerMetadataPolicies = map[string]TrackerMetadataPolicy{
 	"BTN": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldIMDB, MetadataFieldTVDB}}}},
 	"AR": {RequireKnownCategory: true, Requirements: []MetadataRequirement{
 		{Scope: MetadataScopeMovie, AnyOf: []MetadataField{MetadataFieldTMDB, MetadataFieldIMDB}},
-		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTMDB, MetadataFieldIMDB, MetadataFieldTVDB, MetadataFieldTVmaze}},
+		{Scope: MetadataScopeTV, AnyOf: []MetadataField{MetadataFieldTMDB, MetadataFieldIMDB, MetadataFieldTVDB}},
+		{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldPoster}},
 	}},
+	"SPD": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldTMDB, MetadataFieldIMDB}}}},
+	"THR": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldTMDB, MetadataFieldIMDB}}}},
+	"TVC": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldTMDB, MetadataFieldIMDB}}}},
+	"TL":  {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldTMDB, MetadataFieldIMDB}}}},
+	"BJS": {RequireKnownCategory: true, Requirements: []MetadataRequirement{{Scope: MetadataScopeAny, AnyOf: []MetadataField{MetadataFieldTMDB}}}},
 	"AZ":  multiIDMetadataPolicy(),
 	"CZ":  multiIDMetadataPolicy(),
 	"PHD": multiIDMetadataPolicy(),
@@ -146,10 +156,14 @@ func evaluateMetadataRequirements(tracker string, meta api.PreparedMetadata) ([]
 		severity := api.NormalizeRuleFailureSeverity(requirement.Severity)
 		rule := "require_metadata_id"
 		reason := "missing required " + metadataFieldList(requirement.AnyOf)
-		if slices.Contains(requirement.AnyOf, MetadataFieldTVDBTitle) {
+		switch {
+		case slices.Contains(requirement.AnyOf, MetadataFieldTVDBTitle):
 			rule = "require_tvdb_title"
 			reason = "missing required TVDB series title for MTV TV upload"
-		} else if severity == api.RuleFailureSeverityWarning {
+		case slices.Contains(requirement.AnyOf, MetadataFieldPoster):
+			rule = "require_metadata_poster"
+			reason = "missing required metadata poster"
+		case severity == api.RuleFailureSeverityWarning:
 			reason = "missing recommended IMDb ID; PTP upload remains allowed"
 		}
 		failures = append(failures, api.RuleFailure{Rule: rule, Reason: reason, Severity: severity})
@@ -191,6 +205,8 @@ func metadataFieldPresent(field MetadataField, meta api.PreparedMetadata) bool {
 		return matchingTVmazeMetadata(meta)
 	case MetadataFieldTVDBTitle:
 		return matchingTVDBMetadata(meta)
+	case MetadataFieldPoster:
+		return matchingMetadataPoster(meta)
 	}
 	return false
 }
@@ -218,6 +234,29 @@ func matchingTVmazeMetadata(meta api.PreparedMetadata) bool {
 	value := meta.ExternalMetadata.TVmaze
 	return providerMetadataCurrent(meta) && value != nil && meta.ExternalIDs.TVmazeID > 0 &&
 		value.TVmazeID == meta.ExternalIDs.TVmazeID && strings.TrimSpace(value.Name) != ""
+}
+
+// matchingMetadataPoster reports whether any current matching provider snapshot
+// supplies poster artwork, independently of the provider used for identity.
+func matchingMetadataPoster(meta api.PreparedMetadata) bool {
+	if !providerMetadataCurrent(meta) {
+		return false
+	}
+	if value := meta.ExternalMetadata.TMDB; value != nil && meta.ExternalIDs.TMDBID > 0 &&
+		value.TMDBID == meta.ExternalIDs.TMDBID && strings.TrimSpace(value.Poster) != "" {
+		return true
+	}
+	if value := meta.ExternalMetadata.IMDB; value != nil && meta.ExternalIDs.IMDBID > 0 &&
+		value.IMDBID == meta.ExternalIDs.IMDBID && strings.TrimSpace(value.Cover) != "" {
+		return true
+	}
+	if value := meta.ExternalMetadata.TVDB; value != nil && meta.ExternalIDs.TVDBID > 0 &&
+		value.TVDBID == meta.ExternalIDs.TVDBID && strings.TrimSpace(value.Poster) != "" {
+		return true
+	}
+	value := meta.ExternalMetadata.TVmaze
+	return value != nil && meta.ExternalIDs.TVmazeID > 0 && value.TVmazeID == meta.ExternalIDs.TVmazeID &&
+		(strings.TrimSpace(value.Poster) != "" || strings.TrimSpace(value.PosterMedium) != "")
 }
 
 func providerMetadataCurrent(meta api.PreparedMetadata) bool {
@@ -255,6 +294,8 @@ func metadataFieldList(fields []MetadataField) string {
 			labels = append(labels, "fetched TVmaze metadata")
 		case MetadataFieldTVDBTitle:
 			labels = append(labels, "TVDB series title")
+		case MetadataFieldPoster:
+			labels = append(labels, "metadata poster")
 		}
 	}
 	if len(labels) == 0 {

--- a/internal/trackers/metadata_requirements_test.go
+++ b/internal/trackers/metadata_requirements_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package trackers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestMetadataRequirementMatrix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		tracker  string
+		category string
+		ids      api.ExternalIDs
+		tvdb     *api.TVDBMetadata
+		warning  bool
+		fail     bool
+	}{
+		{name: "unit3d tmdb", tracker: "AITHER", ids: api.ExternalIDs{TMDBID: 1}},
+		{name: "unit3d missing", tracker: "AITHER", fail: true},
+		{name: "ptp imdb", tracker: "PTP", ids: api.ExternalIDs{IMDBID: 1234567}},
+		{name: "ptp warning", tracker: "PTP", warning: true},
+		{name: "hdb movie imdb", tracker: "HDB", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}},
+		{name: "hdb movie tvdb rejected", tracker: "HDB", category: "movie", ids: api.ExternalIDs{TVDBID: 2}, fail: true},
+		{name: "hdb tv imdb", tracker: "HDB", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}},
+		{name: "hdb tv tvdb", tracker: "HDB", category: "tv", ids: api.ExternalIDs{TVDBID: 2}},
+		{name: "hdb tv missing", tracker: "HDB", category: "tv", fail: true},
+		{name: "nbl tvmaze", tracker: "NBL", category: "tv", ids: api.ExternalIDs{TVmazeID: 3}},
+		{name: "nbl wrong provider", tracker: "NBL", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}, fail: true},
+		{name: "ant tmdb", tracker: "ANT", category: "movie", ids: api.ExternalIDs{TMDBID: 1}},
+		{name: "ant imdb rejected", tracker: "ANT", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, fail: true},
+		{name: "bhd tmdb", tracker: "BHD", category: "movie", ids: api.ExternalIDs{TMDBID: 1}},
+		{name: "mtv movie imdb", tracker: "MTV", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}},
+		{name: "mtv movie tmdb", tracker: "MTV", category: "movie", ids: api.ExternalIDs{TMDBID: 1}},
+		{name: "mtv tv complete", tracker: "MTV", category: "tv", ids: api.ExternalIDs{TMDBID: 1, TVDBID: 2}, tvdb: &api.TVDBMetadata{TVDBID: 2, NameEnglish: "Example Series"}},
+		{name: "mtv tv blank title", tracker: "MTV", category: "tv", ids: api.ExternalIDs{TMDBID: 1, TVDBID: 2}, tvdb: &api.TVDBMetadata{TVDBID: 2}, fail: true},
+		{name: "mtv tv mismatched title metadata", tracker: "MTV", category: "tv", ids: api.ExternalIDs{TMDBID: 1, TVDBID: 2}, tvdb: &api.TVDBMetadata{TVDBID: 3, Name: "Example Series"}, fail: true},
+		{name: "mtv tv tvdb identity rejected", tracker: "MTV", category: "tv", ids: api.ExternalIDs{TVDBID: 2}, tvdb: &api.TVDBMetadata{TVDBID: 2, Name: "Example Series"}, fail: true},
+		{name: "btn imdb", tracker: "BTN", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}},
+		{name: "btn tvdb", tracker: "BTN", category: "tv", ids: api.ExternalIDs{TVDBID: 2}},
+		{name: "btn tmdb rejected", tracker: "BTN", category: "tv", ids: api.ExternalIDs{TMDBID: 1}, fail: true},
+		{name: "ar movie imdb", tracker: "AR", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}},
+		{name: "ar movie tmdb", tracker: "AR", category: "movie", ids: api.ExternalIDs{TMDBID: 1}},
+		{name: "ar movie tvdb rejected", tracker: "AR", category: "movie", ids: api.ExternalIDs{TVDBID: 2}, fail: true},
+		{name: "ar tv imdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}},
+		{name: "ar tv tmdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{TMDBID: 1}},
+		{name: "ar tv tvdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{TVDBID: 2}},
+		{name: "ar tv tvmaze", tracker: "AR", category: "tv", ids: api.ExternalIDs{TVmazeID: 3}},
+		{name: "ar tv missing", tracker: "AR", category: "tv", fail: true},
+		{name: "z movie imdb", tracker: "AZ", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}},
+		{name: "z movie tvdb rejected", tracker: "CZ", category: "movie", ids: api.ExternalIDs{TVDBID: 2}, fail: true},
+		{name: "z tv tvdb", tracker: "PHD", category: "tv", ids: api.ExternalIDs{TVDBID: 2}},
+		{name: "czteam imdb", tracker: "CZT", ids: api.ExternalIDs{IMDBID: 1234567}},
+		{name: "czteam tmdb rejected", tracker: "CZT", ids: api.ExternalIDs{TMDBID: 1}, fail: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			meta := api.PreparedMetadata{ExternalIDs: tc.ids, ExternalMetadata: api.ExternalMetadata{TVDB: tc.tvdb}}
+			meta.ExternalIDs.Category = tc.category
+			failures, evaluated := evaluateMetadataRequirements(tc.tracker, meta)
+			if !evaluated {
+				t.Fatal("expected metadata policy evaluation")
+			}
+			if tc.warning {
+				if len(failures) != 1 || failures[0].Severity != api.RuleFailureSeverityWarning {
+					t.Fatalf("expected one warning, got %#v", failures)
+				}
+				return
+			}
+			if got := api.HasBlockingRuleFailures(failures); got != tc.fail {
+				t.Fatalf("blocking=%t, want %t; failures=%#v", got, tc.fail, failures)
+			}
+		})
+	}
+}
+
+func TestMetadataRequirementRejectsStaleSourceData(t *testing.T) {
+	t.Parallel()
+	meta := api.PreparedMetadata{
+		SourcePath:  "current",
+		ExternalIDs: api.ExternalIDs{SourcePath: "stale", Category: "movie", TMDBID: 1},
+	}
+	failures, _ := evaluateMetadataRequirements("ANT", meta)
+	if !api.HasBlockingRuleFailures(failures) {
+		t.Fatalf("expected stale ID to fail, got %#v", failures)
+	}
+}
+
+func TestMetadataPolicyForReturnsClonedRequirements(t *testing.T) {
+	t.Parallel()
+	first, ok := MetadataPolicyFor("HDB")
+	if !ok {
+		t.Fatal("expected HDB policy")
+	}
+	first.Requirements[0].AnyOf[0] = MetadataFieldTMDBID
+	second, _ := MetadataPolicyFor("HDB")
+	if second.Requirements[0].AnyOf[0] != MetadataFieldIMDBID {
+		t.Fatalf("policy was mutated: %#v", second)
+	}
+}
+
+func TestMetadataPolicyLookupNormalizationAndExactFamilyMatch(t *testing.T) {
+	t.Parallel()
+	if _, ok := MetadataPolicyFor(" aither "); !ok {
+		t.Fatal("expected normalized Unit3D policy lookup")
+	}
+	if _, ok := MetadataPolicyFor("AITHER_EXTRA"); ok {
+		t.Fatal("unexpected prefix match for unknown tracker")
+	}
+}
+
+func TestMetadataRequirementNeedsKnownCategory(t *testing.T) {
+	t.Parallel()
+	failures, evaluated := evaluateMetadataRequirements("HDB", api.PreparedMetadata{ExternalIDs: api.ExternalIDs{IMDBID: 1234567}})
+	if !evaluated || len(failures) != 1 || failures[0].Rule != "require_metadata_category" || !api.HasBlockingRuleFailures(failures) {
+		t.Fatalf("expected blocking category result, got %#v", failures)
+	}
+}
+
+func TestTVDBTitleRequirementRejectsStaleProviderMetadata(t *testing.T) {
+	t.Parallel()
+	meta := api.PreparedMetadata{
+		SourcePath:  "current",
+		ExternalIDs: api.ExternalIDs{SourcePath: "current", Category: "tv", TMDBID: 1, TVDBID: 2},
+		ExternalMetadata: api.ExternalMetadata{
+			SourcePath: "stale",
+			TVDB:       &api.TVDBMetadata{TVDBID: 2, Name: "Example Series"},
+		},
+	}
+	failures, _ := evaluateMetadataRequirements("MTV", meta)
+	if len(failures) != 1 || failures[0].Rule != "require_tvdb_title" {
+		t.Fatalf("expected stale TVDB metadata failure, got %#v", failures)
+	}
+}
+
+func TestPTPMetadataWarningDoesNotBlock(t *testing.T) {
+	t.Parallel()
+	failures := EvaluateRules(context.Background(), "PTP", api.PreparedMetadata{ExternalIDs: api.ExternalIDs{Category: "movie"}}, nil)
+	if len(failures) != 1 || failures[0].Severity != api.RuleFailureSeverityWarning || api.HasBlockingRuleFailures(failures) {
+		t.Fatalf("expected non-blocking PTP warning, got %#v", failures)
+	}
+}

--- a/internal/trackers/metadata_requirements_test.go
+++ b/internal/trackers/metadata_requirements_test.go
@@ -17,11 +17,12 @@ func TestMetadataRequirementMatrix(t *testing.T) {
 		tracker  string
 		category string
 		ids      api.ExternalIDs
-		tvdb     *api.TVDBMetadata
+		metadata api.ExternalMetadata
 		warning  bool
 		fail     bool
 	}{
-		{name: "unit3d tmdb", tracker: "AITHER", ids: api.ExternalIDs{TMDBID: 1}},
+		{name: "unit3d tmdb", tracker: "AITHER", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Release"}}},
+		{name: "unit3d id only", tracker: "AITHER", ids: api.ExternalIDs{TMDBID: 1}, fail: true},
 		{name: "unit3d missing", tracker: "AITHER", fail: true},
 		{name: "ptp imdb", tracker: "PTP", ids: api.ExternalIDs{IMDBID: 1234567}},
 		{name: "ptp warning", tracker: "PTP", warning: true},
@@ -30,27 +31,30 @@ func TestMetadataRequirementMatrix(t *testing.T) {
 		{name: "hdb tv imdb", tracker: "HDB", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}},
 		{name: "hdb tv tvdb", tracker: "HDB", category: "tv", ids: api.ExternalIDs{TVDBID: 2}},
 		{name: "hdb tv missing", tracker: "HDB", category: "tv", fail: true},
-		{name: "nbl tvmaze", tracker: "NBL", category: "tv", ids: api.ExternalIDs{TVmazeID: 3}},
+		{name: "nbl tvmaze", tracker: "NBL", category: "tv", ids: api.ExternalIDs{TVmazeID: 3}, metadata: api.ExternalMetadata{TVmaze: &api.TVmazeMetadata{TVmazeID: 3, Name: "Example Series"}}},
+		{name: "nbl id only", tracker: "NBL", category: "tv", ids: api.ExternalIDs{TVmazeID: 3}, fail: true},
 		{name: "nbl wrong provider", tracker: "NBL", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}, fail: true},
-		{name: "ant tmdb", tracker: "ANT", category: "movie", ids: api.ExternalIDs{TMDBID: 1}},
+		{name: "ant tmdb", tracker: "ANT", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Release"}}},
 		{name: "ant imdb rejected", tracker: "ANT", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, fail: true},
 		{name: "bhd tmdb", tracker: "BHD", category: "movie", ids: api.ExternalIDs{TMDBID: 1}},
-		{name: "mtv movie imdb", tracker: "MTV", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}},
-		{name: "mtv movie tmdb", tracker: "MTV", category: "movie", ids: api.ExternalIDs{TMDBID: 1}},
-		{name: "mtv tv complete", tracker: "MTV", category: "tv", ids: api.ExternalIDs{TMDBID: 1, TVDBID: 2}, tvdb: &api.TVDBMetadata{TVDBID: 2, NameEnglish: "Example Series"}},
-		{name: "mtv tv blank title", tracker: "MTV", category: "tv", ids: api.ExternalIDs{TMDBID: 1, TVDBID: 2}, tvdb: &api.TVDBMetadata{TVDBID: 2}, fail: true},
-		{name: "mtv tv mismatched title metadata", tracker: "MTV", category: "tv", ids: api.ExternalIDs{TMDBID: 1, TVDBID: 2}, tvdb: &api.TVDBMetadata{TVDBID: 3, Name: "Example Series"}, fail: true},
-		{name: "mtv tv tvdb identity rejected", tracker: "MTV", category: "tv", ids: api.ExternalIDs{TVDBID: 2}, tvdb: &api.TVDBMetadata{TVDBID: 2, Name: "Example Series"}, fail: true},
-		{name: "btn imdb", tracker: "BTN", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}},
-		{name: "btn tvdb", tracker: "BTN", category: "tv", ids: api.ExternalIDs{TVDBID: 2}},
+		{name: "mtv movie imdb", tracker: "MTV", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release"}}},
+		{name: "mtv movie tmdb", tracker: "MTV", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Release"}}},
+		{name: "mtv movie id only", tracker: "MTV", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, fail: true},
+		{name: "mtv tv complete", tracker: "MTV", category: "tv", ids: api.ExternalIDs{TMDBID: 1, TVDBID: 2}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Series"}, TVDB: &api.TVDBMetadata{TVDBID: 2, NameEnglish: "Example Series"}}},
+		{name: "mtv tv blank title", tracker: "MTV", category: "tv", ids: api.ExternalIDs{TMDBID: 1, TVDBID: 2}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Series"}, TVDB: &api.TVDBMetadata{TVDBID: 2}}, fail: true},
+		{name: "mtv tv mismatched title metadata", tracker: "MTV", category: "tv", ids: api.ExternalIDs{TMDBID: 1, TVDBID: 2}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Series"}, TVDB: &api.TVDBMetadata{TVDBID: 3, Name: "Example Series"}}, fail: true},
+		{name: "mtv tv tvdb identity rejected", tracker: "MTV", category: "tv", ids: api.ExternalIDs{TVDBID: 2}, metadata: api.ExternalMetadata{TVDB: &api.TVDBMetadata{TVDBID: 2, Name: "Example Series"}}, fail: true},
+		{name: "btn imdb", tracker: "BTN", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Series"}}},
+		{name: "btn tvdb", tracker: "BTN", category: "tv", ids: api.ExternalIDs{TVDBID: 2}, metadata: api.ExternalMetadata{TVDB: &api.TVDBMetadata{TVDBID: 2, Name: "Example Series"}}},
+		{name: "btn id only", tracker: "BTN", category: "tv", ids: api.ExternalIDs{TVDBID: 2}, fail: true},
 		{name: "btn tmdb rejected", tracker: "BTN", category: "tv", ids: api.ExternalIDs{TMDBID: 1}, fail: true},
-		{name: "ar movie imdb", tracker: "AR", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}},
-		{name: "ar movie tmdb", tracker: "AR", category: "movie", ids: api.ExternalIDs{TMDBID: 1}},
+		{name: "ar movie imdb", tracker: "AR", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release"}}},
+		{name: "ar movie tmdb", tracker: "AR", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Release"}}},
 		{name: "ar movie tvdb rejected", tracker: "AR", category: "movie", ids: api.ExternalIDs{TVDBID: 2}, fail: true},
-		{name: "ar tv imdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}},
-		{name: "ar tv tmdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{TMDBID: 1}},
-		{name: "ar tv tvdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{TVDBID: 2}},
-		{name: "ar tv tvmaze", tracker: "AR", category: "tv", ids: api.ExternalIDs{TVmazeID: 3}},
+		{name: "ar tv imdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Series"}}},
+		{name: "ar tv tmdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Series"}}},
+		{name: "ar tv tvdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{TVDBID: 2}, metadata: api.ExternalMetadata{TVDB: &api.TVDBMetadata{TVDBID: 2, Name: "Example Series"}}},
+		{name: "ar tv tvmaze", tracker: "AR", category: "tv", ids: api.ExternalIDs{TVmazeID: 3}, metadata: api.ExternalMetadata{TVmaze: &api.TVmazeMetadata{TVmazeID: 3, Name: "Example Series"}}},
 		{name: "ar tv missing", tracker: "AR", category: "tv", fail: true},
 		{name: "z movie imdb", tracker: "AZ", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}},
 		{name: "z movie tvdb rejected", tracker: "CZ", category: "movie", ids: api.ExternalIDs{TVDBID: 2}, fail: true},
@@ -61,7 +65,7 @@ func TestMetadataRequirementMatrix(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			meta := api.PreparedMetadata{ExternalIDs: tc.ids, ExternalMetadata: api.ExternalMetadata{TVDB: tc.tvdb}}
+			meta := api.PreparedMetadata{ExternalIDs: tc.ids, ExternalMetadata: tc.metadata}
 			meta.ExternalIDs.Category = tc.category
 			failures, evaluated := evaluateMetadataRequirements(tc.tracker, meta)
 			if !evaluated {
@@ -92,15 +96,29 @@ func TestMetadataRequirementRejectsStaleSourceData(t *testing.T) {
 	}
 }
 
+func TestMetadataRequirementRejectsMismatchedProviderSnapshot(t *testing.T) {
+	t.Parallel()
+	meta := api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "movie", TMDBID: 1},
+		ExternalMetadata: api.ExternalMetadata{
+			TMDB: &api.TMDBMetadata{TMDBID: 2, Title: "Example Release"},
+		},
+	}
+	failures, _ := evaluateMetadataRequirements("ANT", meta)
+	if !api.HasBlockingRuleFailures(failures) {
+		t.Fatalf("expected mismatched TMDB snapshot to fail, got %#v", failures)
+	}
+}
+
 func TestMetadataPolicyForReturnsClonedRequirements(t *testing.T) {
 	t.Parallel()
 	first, ok := MetadataPolicyFor("HDB")
 	if !ok {
 		t.Fatal("expected HDB policy")
 	}
-	first.Requirements[0].AnyOf[0] = MetadataFieldTMDBID
+	first.Requirements[0].AnyOf[0] = MetadataFieldTMDBIDOnly
 	second, _ := MetadataPolicyFor("HDB")
-	if second.Requirements[0].AnyOf[0] != MetadataFieldIMDBID {
+	if second.Requirements[0].AnyOf[0] != MetadataFieldIMDBIDOnly {
 		t.Fatalf("policy was mutated: %#v", second)
 	}
 }
@@ -134,7 +152,14 @@ func TestTVDBTitleRequirementRejectsStaleProviderMetadata(t *testing.T) {
 		},
 	}
 	failures, _ := evaluateMetadataRequirements("MTV", meta)
-	if len(failures) != 1 || failures[0].Rule != "require_tvdb_title" {
+	found := false
+	for _, failure := range failures {
+		if failure.Rule == "require_tvdb_title" {
+			found = true
+			break
+		}
+	}
+	if !found {
 		t.Fatalf("expected stale TVDB metadata failure, got %#v", failures)
 	}
 }

--- a/internal/trackers/metadata_requirements_test.go
+++ b/internal/trackers/metadata_requirements_test.go
@@ -5,6 +5,7 @@ package trackers
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/autobrr/upbrr/pkg/api"
@@ -36,7 +37,9 @@ func TestMetadataRequirementMatrix(t *testing.T) {
 		{name: "nbl wrong provider", tracker: "NBL", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}, fail: true},
 		{name: "ant tmdb", tracker: "ANT", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Release"}}},
 		{name: "ant imdb rejected", tracker: "ANT", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, fail: true},
-		{name: "bhd tmdb", tracker: "BHD", category: "movie", ids: api.ExternalIDs{TMDBID: 1}},
+		{name: "bhd imdb", tracker: "BHD", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release"}}},
+		{name: "bhd imdb id only", tracker: "BHD", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, fail: true},
+		{name: "bhd tmdb rejected", tracker: "BHD", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Release"}}, fail: true},
 		{name: "mtv movie imdb", tracker: "MTV", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release"}}},
 		{name: "mtv movie tmdb", tracker: "MTV", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Release"}}},
 		{name: "mtv movie id only", tracker: "MTV", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, fail: true},
@@ -48,14 +51,24 @@ func TestMetadataRequirementMatrix(t *testing.T) {
 		{name: "btn tvdb", tracker: "BTN", category: "tv", ids: api.ExternalIDs{TVDBID: 2}, metadata: api.ExternalMetadata{TVDB: &api.TVDBMetadata{TVDBID: 2, Name: "Example Series"}}},
 		{name: "btn id only", tracker: "BTN", category: "tv", ids: api.ExternalIDs{TVDBID: 2}, fail: true},
 		{name: "btn tmdb rejected", tracker: "BTN", category: "tv", ids: api.ExternalIDs{TMDBID: 1}, fail: true},
-		{name: "ar movie imdb", tracker: "AR", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release"}}},
-		{name: "ar movie tmdb", tracker: "AR", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Release"}}},
+		{name: "ar movie imdb", tracker: "AR", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release", Cover: "https://img.example/poster.jpg"}}},
+		{name: "ar movie tmdb", tracker: "AR", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Release", Poster: "https://img.example/poster.jpg"}}},
+		{name: "ar movie missing poster", tracker: "AR", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release"}}, fail: true},
 		{name: "ar movie tvdb rejected", tracker: "AR", category: "movie", ids: api.ExternalIDs{TVDBID: 2}, fail: true},
-		{name: "ar tv imdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Series"}}},
-		{name: "ar tv tmdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Series"}}},
-		{name: "ar tv tvdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{TVDBID: 2}, metadata: api.ExternalMetadata{TVDB: &api.TVDBMetadata{TVDBID: 2, Name: "Example Series"}}},
-		{name: "ar tv tvmaze", tracker: "AR", category: "tv", ids: api.ExternalIDs{TVmazeID: 3}, metadata: api.ExternalMetadata{TVmaze: &api.TVmazeMetadata{TVmazeID: 3, Name: "Example Series"}}},
+		{name: "ar tv imdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Series", Cover: "https://img.example/poster.jpg"}}},
+		{name: "ar tv tmdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Series", Poster: "https://img.example/poster.jpg"}}},
+		{name: "ar tv tvdb", tracker: "AR", category: "tv", ids: api.ExternalIDs{TVDBID: 2}, metadata: api.ExternalMetadata{TVDB: &api.TVDBMetadata{TVDBID: 2, Name: "Example Series", Poster: "https://img.example/poster.jpg"}}},
+		{name: "ar tv tvmaze rejected", tracker: "AR", category: "tv", ids: api.ExternalIDs{TVmazeID: 3}, metadata: api.ExternalMetadata{TVmaze: &api.TVmazeMetadata{TVmazeID: 3, Name: "Example Series", Poster: "https://img.example/poster.jpg"}}, fail: true},
 		{name: "ar tv missing", tracker: "AR", category: "tv", fail: true},
+		{name: "spd tmdb", tracker: "SPD", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Release"}}},
+		{name: "spd imdb", tracker: "SPD", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release"}}},
+		{name: "spd id only", tracker: "SPD", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, fail: true},
+		{name: "thr imdb", tracker: "THR", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release"}}},
+		{name: "tvc tmdb", tracker: "TVC", category: "tv", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Series"}}},
+		{name: "tl imdb", tracker: "TL", category: "tv", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Series"}}},
+		{name: "bjs tmdb", tracker: "BJS", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, metadata: api.ExternalMetadata{TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "Example Release"}}},
+		{name: "bjs imdb rejected", tracker: "BJS", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}, metadata: api.ExternalMetadata{IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release"}}, fail: true},
+		{name: "bjs tmdb id only", tracker: "BJS", category: "movie", ids: api.ExternalIDs{TMDBID: 1}, fail: true},
 		{name: "z movie imdb", tracker: "AZ", category: "movie", ids: api.ExternalIDs{IMDBID: 1234567}},
 		{name: "z movie tvdb rejected", tracker: "CZ", category: "movie", ids: api.ExternalIDs{TVDBID: 2}, fail: true},
 		{name: "z tv tvdb", tracker: "PHD", category: "tv", ids: api.ExternalIDs{TVDBID: 2}},
@@ -170,4 +183,90 @@ func TestPTPMetadataWarningDoesNotBlock(t *testing.T) {
 	if len(failures) != 1 || failures[0].Severity != api.RuleFailureSeverityWarning || api.HasBlockingRuleFailures(failures) {
 		t.Fatalf("expected non-blocking PTP warning, got %#v", failures)
 	}
+}
+
+func TestMetadataRequirementTMDBOrIMDbTrackersRejectIDsAlone(t *testing.T) {
+	t.Parallel()
+	for _, tracker := range []string{"SPD", "THR", "TVC", "TL"} {
+		t.Run(tracker, func(t *testing.T) {
+			t.Parallel()
+			meta := api.PreparedMetadata{ExternalIDs: api.ExternalIDs{Category: "tv", TMDBID: 1, IMDBID: 1234567}}
+			failures, evaluated := evaluateMetadataRequirements(tracker, meta)
+			if !evaluated || !api.HasBlockingRuleFailures(failures) {
+				t.Fatalf("expected IDs alone to fail for %s, got %#v", tracker, failures)
+			}
+		})
+	}
+}
+
+func TestARMetadataPosterMayComeFromDifferentProvider(t *testing.T) {
+	t.Parallel()
+	meta := api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "movie", TMDBID: 1, IMDBID: 1234567},
+		ExternalMetadata: api.ExternalMetadata{
+			TMDB: &api.TMDBMetadata{TMDBID: 1, Poster: "https://img.example/poster.jpg"},
+			IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release"},
+		},
+	}
+	failures, _ := evaluateMetadataRequirements("AR", meta)
+	if api.HasBlockingRuleFailures(failures) {
+		t.Fatalf("expected IMDb identity plus TMDB poster to pass, got %#v", failures)
+	}
+}
+
+func TestARMetadataPosterRejectsMismatchedSnapshot(t *testing.T) {
+	t.Parallel()
+	meta := api.PreparedMetadata{
+		ExternalIDs: api.ExternalIDs{Category: "tv", IMDBID: 1234567, TVmazeID: 3},
+		ExternalMetadata: api.ExternalMetadata{
+			IMDB:   &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Series"},
+			TVmaze: &api.TVmazeMetadata{TVmazeID: 4, PosterMedium: "https://img.example/poster.jpg"},
+		},
+	}
+	failures, _ := evaluateMetadataRequirements("AR", meta)
+	if len(failures) != 1 || failures[0].Rule != "require_metadata_poster" || !api.HasBlockingRuleFailures(failures) {
+		t.Fatalf("expected blocking poster failure, got %#v", failures)
+	}
+}
+
+func TestARMetadataPosterRejectsStaleSnapshots(t *testing.T) {
+	t.Parallel()
+	meta := api.PreparedMetadata{
+		SourcePath:  "current",
+		ExternalIDs: api.ExternalIDs{SourcePath: "current", Category: "movie", IMDBID: 1234567},
+		ExternalMetadata: api.ExternalMetadata{
+			SourcePath: "stale",
+			IMDB:       &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release", Cover: "https://img.example/poster.jpg"},
+		},
+	}
+	failures, _ := evaluateMetadataRequirements("AR", meta)
+	for _, failure := range failures {
+		if failure.Rule == "require_metadata_poster" && failure.Severity == api.RuleFailureSeverityBlocking {
+			return
+		}
+	}
+	t.Fatalf("expected stale poster failure, got %#v", failures)
+}
+
+func TestOnlyNBLDeclaresTVmazeIdentityRequirement(t *testing.T) {
+	t.Parallel()
+	foundNBL := false
+	for tracker, policy := range trackerMetadataPolicies {
+		for _, requirement := range policy.Requirements {
+			if !containsMetadataField(requirement.AnyOf, MetadataFieldTVmaze) {
+				continue
+			}
+			if tracker != "NBL" {
+				t.Fatalf("tracker %s unexpectedly accepts TVmaze identity", tracker)
+			}
+			foundNBL = true
+		}
+	}
+	if !foundNBL {
+		t.Fatal("expected NBL TVmaze identity requirement")
+	}
+}
+
+func containsMetadataField(fields []MetadataField, want MetadataField) bool {
+	return slices.Contains(fields, want)
 }

--- a/internal/trackers/rules.go
+++ b/internal/trackers/rules.go
@@ -51,6 +51,8 @@ func EvaluateRules(ctx context.Context, tracker string, meta api.PreparedMetadat
 			addFailure("modified_release", reason)
 		}
 	}
+	metadataFailures, metadataEvaluated := evaluateMetadataRequirements(name, meta)
+	failures = append(failures, metadataFailures...)
 
 	switch name {
 	case "AZ", "CZ", "PHD":
@@ -60,7 +62,7 @@ func EvaluateRules(ctx context.Context, tracker string, meta api.PreparedMetadat
 	// UNIT3D-known trackers without a tracker-specific RuleSet must still reach
 	// the MediaInfo-settings check below (rules is the zero value for them, which
 	// no-ops every other rule), so don't bail early when the tracker is known.
-	if !ok && name != "PTP" && !unit3dmeta.IsKnown(name) {
+	if !ok && name != "PTP" && !unit3dmeta.IsKnown(name) && !metadataEvaluated {
 		// Preserve the nil contract for trackers without their own rule set: the
 		// consumer (applyTrackerRules) treats a nil result as "not evaluated, keep
 		// pre-existing failures" but an empty slice as "evaluated, clear failures".
@@ -357,15 +359,31 @@ func countrySet(values ...string) map[string]struct{} {
 }
 
 func resolveCategory(meta api.PreparedMetadata) string {
-	if value := strings.ToLower(strings.TrimSpace(meta.ExternalIDs.Category)); value != "" {
-		return value
+	if sourceMatches(meta.ExternalIDs.SourcePath, meta.SourcePath) {
+		if value := strings.ToLower(strings.TrimSpace(meta.ExternalIDs.Category)); value != "" {
+			return value
+		}
 	}
 	if value := strings.ToLower(strings.TrimSpace(meta.MediaInfoCategory)); value != "" {
 		return value
 	}
-	if meta.ExternalMetadata.TMDB != nil {
-		if value := strings.ToLower(strings.TrimSpace(meta.ExternalMetadata.TMDB.Category)); value != "" {
-			return value
+	if sourceMatches(meta.ExternalMetadata.SourcePath, meta.SourcePath) {
+		if meta.ExternalMetadata.TMDB != nil {
+			if value := strings.ToLower(strings.TrimSpace(meta.ExternalMetadata.TMDB.Category)); value != "" {
+				return value
+			}
+		}
+		if meta.ExternalMetadata.TVDB != nil || meta.ExternalMetadata.TVmaze != nil {
+			return "tv"
+		}
+		if meta.ExternalMetadata.IMDB != nil {
+			typeValue := strings.ToLower(strings.TrimSpace(meta.ExternalMetadata.IMDB.Type))
+			switch {
+			case strings.Contains(typeValue, "tv"), strings.Contains(typeValue, "series"), strings.Contains(typeValue, "episode"):
+				return "tv"
+			case strings.Contains(typeValue, "movie"), strings.Contains(typeValue, "film"), strings.Contains(typeValue, "feature"):
+				return "movie"
+			}
 		}
 	}
 	if value := strings.ToLower(strings.TrimSpace(meta.Release.Category)); value != "" {

--- a/internal/trackers/rules.go
+++ b/internal/trackers/rules.go
@@ -374,7 +374,9 @@ func resolveCategory(meta api.PreparedMetadata) string {
 				return value
 			}
 		}
-		if meta.ExternalMetadata.TVDB != nil || meta.ExternalMetadata.TVmaze != nil {
+		if (meta.ExternalMetadata.TVDB != nil &&
+			(strings.TrimSpace(meta.ExternalMetadata.TVDB.Name) != "" || strings.TrimSpace(meta.ExternalMetadata.TVDB.NameEnglish) != "")) ||
+			(meta.ExternalMetadata.TVmaze != nil && strings.TrimSpace(meta.ExternalMetadata.TVmaze.Name) != "") {
 			return "tv"
 		}
 		if meta.ExternalMetadata.IMDB != nil {

--- a/internal/trackers/rules_test.go
+++ b/internal/trackers/rules_test.go
@@ -24,7 +24,34 @@ func evaluateNonMetadataRulesForTest(ctx context.Context, tracker string, meta a
 	meta.ExternalIDs.IMDBID = 1234567
 	meta.ExternalIDs.TVDBID = 1
 	meta.ExternalIDs.TVmazeID = 1
-	meta.ExternalMetadata.TVDB = &api.TVDBMetadata{TVDBID: 1, Name: "Example Series"}
+	if meta.ExternalMetadata.TMDB == nil {
+		meta.ExternalMetadata.TMDB = &api.TMDBMetadata{}
+	}
+	meta.ExternalMetadata.TMDB.TMDBID = 1
+	if strings.TrimSpace(meta.ExternalMetadata.TMDB.Title) == "" {
+		meta.ExternalMetadata.TMDB.Title = "Example Release"
+	}
+	if meta.ExternalMetadata.IMDB == nil {
+		meta.ExternalMetadata.IMDB = &api.IMDBMetadata{}
+	}
+	meta.ExternalMetadata.IMDB.IMDBID = 1234567
+	if strings.TrimSpace(meta.ExternalMetadata.IMDB.Title) == "" {
+		meta.ExternalMetadata.IMDB.Title = "Example Release"
+	}
+	if meta.ExternalMetadata.TVDB == nil {
+		meta.ExternalMetadata.TVDB = &api.TVDBMetadata{}
+	}
+	meta.ExternalMetadata.TVDB.TVDBID = 1
+	if strings.TrimSpace(meta.ExternalMetadata.TVDB.Name) == "" {
+		meta.ExternalMetadata.TVDB.Name = "Example Series"
+	}
+	if meta.ExternalMetadata.TVmaze == nil {
+		meta.ExternalMetadata.TVmaze = &api.TVmazeMetadata{}
+	}
+	meta.ExternalMetadata.TVmaze.TVmazeID = 1
+	if strings.TrimSpace(meta.ExternalMetadata.TVmaze.Name) == "" {
+		meta.ExternalMetadata.TVmaze.Name = "Example Series"
+	}
 	return EvaluateRules(ctx, tracker, meta, nil)
 }
 

--- a/internal/trackers/rules_test.go
+++ b/internal/trackers/rules_test.go
@@ -11,9 +11,26 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+func evaluateNonMetadataRulesForTest(ctx context.Context, tracker string, meta api.PreparedMetadata) []api.RuleFailure {
+	if strings.TrimSpace(meta.ExternalIDs.Category) == "" {
+		switch strings.ToUpper(strings.TrimSpace(tracker)) {
+		case "NBL", "BTN":
+			meta.ExternalIDs.Category = "TV"
+		default:
+			meta.ExternalIDs.Category = "MOVIE"
+		}
+	}
+	meta.ExternalIDs.TMDBID = 1
+	meta.ExternalIDs.IMDBID = 1234567
+	meta.ExternalIDs.TVDBID = 1
+	meta.ExternalIDs.TVmazeID = 1
+	meta.ExternalMetadata.TVDB = &api.TVDBMetadata{TVDBID: 1, Name: "Example Series"}
+	return EvaluateRules(ctx, tracker, meta, nil)
+}
+
 func TestEvaluateRulesRequiresUniqueID(t *testing.T) {
 	meta := api.PreparedMetadata{ValidMediaInfo: false}
-	failures := EvaluateRules(context.Background(), "AITHER", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "AITHER", meta)
 	if len(failures) == 0 {
 		t.Fatalf("expected rule failure")
 	}
@@ -39,7 +56,7 @@ func TestEvaluateRulesUnit3DEnforcesMediaInfoSettings(t *testing.T) {
 		ExternalIDs:            api.ExternalIDs{Category: "movie"},
 		ValidMediaInfoSettings: false,
 	}
-	failures := EvaluateRules(context.Background(), "RF", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "RF", meta)
 	if !hasMISettingsFailure(failures) {
 		t.Fatalf("expected require_valid_mi_setting failure for RF, got %#v", failures)
 	}
@@ -49,13 +66,13 @@ func TestEvaluateRulesUnit3DWithoutRuleSetEnforcesMediaInfoSettings(t *testing.T
 	// ACM is a known UNIT3D tracker with no tracker-specific RuleSet. The early
 	// "not found" return must not skip the MediaInfo-settings enforcement.
 	meta := api.PreparedMetadata{ValidMediaInfoSettings: false}
-	failures := EvaluateRules(context.Background(), "ACM", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "ACM", meta)
 	if !hasMISettingsFailure(failures) {
 		t.Fatalf("expected require_valid_mi_setting failure for ACM, got %#v", failures)
 	}
 
 	meta.ValidMediaInfoSettings = true
-	failures = EvaluateRules(context.Background(), "ACM", meta, nil)
+	failures = evaluateNonMetadataRulesForTest(context.Background(), "ACM", meta)
 	if len(failures) != 0 {
 		t.Fatalf("expected no failures for ACM with valid MI settings, got %#v", failures)
 	}
@@ -66,7 +83,7 @@ func TestEvaluateRulesUnit3DAllowsValidMediaInfoSettings(t *testing.T) {
 		ExternalIDs:            api.ExternalIDs{Category: "movie"},
 		ValidMediaInfoSettings: true,
 	}
-	failures := EvaluateRules(context.Background(), "RF", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "RF", meta)
 	if hasMISettingsFailure(failures) {
 		t.Fatalf("did not expect require_valid_mi_setting failure for RF, got %#v", failures)
 	}
@@ -76,7 +93,7 @@ func TestEvaluateRulesNonUnit3DOptInMediaInfoSettings(t *testing.T) {
 	// BHD is not a UNIT3D-upload tracker but opts in via its RuleSet, so the
 	// per-tracker flag must still be honored.
 	meta := api.PreparedMetadata{ValidMediaInfoSettings: false}
-	failures := EvaluateRules(context.Background(), "BHD", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "BHD", meta)
 	if !hasMISettingsFailure(failures) {
 		t.Fatalf("expected require_valid_mi_setting failure for BHD, got %#v", failures)
 	}
@@ -88,7 +105,7 @@ func TestEvaluateRulesLanguageRulePasses(t *testing.T) {
 		SubtitleLanguages:      nil,
 		ValidMediaInfoSettings: true,
 	}
-	failures := EvaluateRules(context.Background(), "TOS", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "TOS", meta)
 	if len(failures) != 0 {
 		t.Fatalf("expected no failures, got %#v", failures)
 	}
@@ -96,7 +113,7 @@ func TestEvaluateRulesLanguageRulePasses(t *testing.T) {
 
 func TestEvaluateRulesLanguageRuleMissingData(t *testing.T) {
 	meta := api.PreparedMetadata{ValidMediaInfoSettings: true}
-	failures := EvaluateRules(context.Background(), "TOS", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "TOS", meta)
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure, got %#v", failures)
 	}
@@ -116,7 +133,7 @@ func TestEvaluateRulesLanguageRuleOriginalFallback(t *testing.T) {
 			TMDB: &api.TMDBMetadata{OriginalLanguage: "ja"},
 		},
 	}
-	failures := EvaluateRules(context.Background(), "LUME", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "LUME", meta)
 	if len(failures) != 0 {
 		t.Fatalf("expected no failures, got %#v", failures)
 	}
@@ -130,7 +147,7 @@ func TestEvaluateRulesLUMERequiresMKVForNonDisc(t *testing.T) {
 		ValidMediaInfoSettings: true,
 		Release:                api.ReleaseInfo{Resolution: "720p"},
 	}
-	failures := EvaluateRules(context.Background(), "LUME", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "LUME", meta)
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure, got %#v", failures)
 	}
@@ -150,7 +167,7 @@ func TestEvaluateRulesLUMEAllowsMKVForNonDisc(t *testing.T) {
 		ValidMediaInfoSettings: true,
 		Release:                api.ReleaseInfo{Resolution: "720p"},
 	}
-	failures := EvaluateRules(context.Background(), "LUME", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "LUME", meta)
 	if len(failures) != 0 {
 		t.Fatalf("expected no failures, got %#v", failures)
 	}
@@ -163,7 +180,7 @@ func TestEvaluateRulesLUMESkipsContainerRuleForDisc(t *testing.T) {
 		ValidMediaInfoSettings: true,
 		Release:                api.ReleaseInfo{Resolution: "480p"},
 	}
-	failures := EvaluateRules(context.Background(), "LUME", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "LUME", meta)
 	if len(failures) != 0 {
 		t.Fatalf("expected disc upload to skip LUME container and resolution rules, got %#v", failures)
 	}
@@ -171,7 +188,7 @@ func TestEvaluateRulesLUMESkipsContainerRuleForDisc(t *testing.T) {
 
 func TestEvaluateRulesPTPRequiresMovieForNonPackTV(t *testing.T) {
 	meta := api.PreparedMetadata{ExternalIDs: api.ExternalIDs{Category: "tv"}}
-	failures := EvaluateRules(context.Background(), "PTP", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "PTP", meta)
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure, got %#v", failures)
 	}
@@ -182,7 +199,7 @@ func TestEvaluateRulesPTPRequiresMovieForNonPackTV(t *testing.T) {
 
 func TestEvaluateRulesPTPAllowsTVPacks(t *testing.T) {
 	meta := api.PreparedMetadata{ExternalIDs: api.ExternalIDs{Category: "tv"}, TVPack: true}
-	failures := EvaluateRules(context.Background(), "PTP", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "PTP", meta)
 	if len(failures) != 0 {
 		t.Fatalf("expected no failures, got %#v", failures)
 	}
@@ -190,7 +207,7 @@ func TestEvaluateRulesPTPAllowsTVPacks(t *testing.T) {
 
 func TestEvaluateRulesANTRequiresMovie(t *testing.T) {
 	meta := api.PreparedMetadata{ExternalIDs: api.ExternalIDs{Category: "tv"}}
-	failures := EvaluateRules(context.Background(), "ANT", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "ANT", meta)
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure, got %#v", failures)
 	}
@@ -201,7 +218,7 @@ func TestEvaluateRulesANTRequiresMovie(t *testing.T) {
 
 func TestEvaluateRulesANTAllowsMovie(t *testing.T) {
 	meta := api.PreparedMetadata{ExternalIDs: api.ExternalIDs{Category: "movie"}}
-	failures := EvaluateRules(context.Background(), "ANT", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "ANT", meta)
 	if len(failures) != 0 {
 		t.Fatalf("expected no failures, got %#v", failures)
 	}
@@ -209,7 +226,7 @@ func TestEvaluateRulesANTAllowsMovie(t *testing.T) {
 
 func TestEvaluateRulesBHDRequiresValidMISettings(t *testing.T) {
 	meta := api.PreparedMetadata{ValidMediaInfoSettings: false}
-	failures := EvaluateRules(context.Background(), "BHD", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "BHD", meta)
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure, got %#v", failures)
 	}
@@ -218,7 +235,7 @@ func TestEvaluateRulesBHDRequiresValidMISettings(t *testing.T) {
 	}
 
 	meta.ValidMediaInfoSettings = true
-	failures = EvaluateRules(context.Background(), "BHD", meta, nil)
+	failures = evaluateNonMetadataRulesForTest(context.Background(), "BHD", meta)
 	if len(failures) != 0 {
 		t.Fatalf("expected no failures, got %#v", failures)
 	}
@@ -232,7 +249,7 @@ func TestEvaluateRulesBHDRejectsInvalidContainerForUploadTypes(t *testing.T) {
 		Type:                   "REMUX",
 		Container:              "avi",
 	}
-	failures := EvaluateRules(context.Background(), "BHD", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "BHD", meta)
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure, got %#v", failures)
 	}
@@ -241,7 +258,7 @@ func TestEvaluateRulesBHDRejectsInvalidContainerForUploadTypes(t *testing.T) {
 	}
 
 	meta.Container = "mkv"
-	failures = EvaluateRules(context.Background(), "BHD", meta, nil)
+	failures = evaluateNonMetadataRulesForTest(context.Background(), "BHD", meta)
 	if len(failures) != 0 {
 		t.Fatalf("expected no failures for MKV, got %#v", failures)
 	}
@@ -281,7 +298,7 @@ func TestEvaluateRulesBLUContainerRules(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			failures := EvaluateRules(context.Background(), "BLU", tc.meta, nil)
+			failures := evaluateNonMetadataRulesForTest(context.Background(), "BLU", tc.meta)
 			if tc.wantBlock && len(failures) == 0 {
 				t.Fatalf("expected BLU container failure")
 			}
@@ -294,7 +311,7 @@ func TestEvaluateRulesBLUContainerRules(t *testing.T) {
 
 func TestEvaluateRulesNBLRequiresTV(t *testing.T) {
 	meta := api.PreparedMetadata{ExternalIDs: api.ExternalIDs{Category: "movie"}}
-	failures := EvaluateRules(context.Background(), "NBL", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "NBL", meta)
 	if len(failures) != 2 {
 		t.Fatalf("expected 2 failures, got %#v", failures)
 	}
@@ -305,7 +322,7 @@ func TestEvaluateRulesNBLRequiresTV(t *testing.T) {
 
 func TestEvaluateRulesNBLAllowsTV(t *testing.T) {
 	meta := api.PreparedMetadata{ExternalIDs: api.ExternalIDs{Category: "tv"}}
-	failures := EvaluateRules(context.Background(), "NBL", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "NBL", meta)
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure because language data is missing, got %#v", failures)
 	}
@@ -324,7 +341,7 @@ func TestEvaluateRulesNBLAllowsTVWithOriginalAudioAndEnglishSubs(t *testing.T) {
 			TMDB: &api.TMDBMetadata{OriginalLanguage: "ja"},
 		},
 	}
-	failures := EvaluateRules(context.Background(), "NBL", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "NBL", meta)
 	if len(failures) != 0 {
 		t.Fatalf("expected no failures, got %#v", failures)
 	}
@@ -335,7 +352,7 @@ func TestEvaluateRulesNBLSkipsLanguageRuleForBDMVOnly(t *testing.T) {
 		ExternalIDs: api.ExternalIDs{Category: "tv"},
 		DiscType:    "BDMV",
 	}
-	if failures := EvaluateRules(context.Background(), "NBL", bdmv, nil); len(failures) != 0 {
+	if failures := evaluateNonMetadataRulesForTest(context.Background(), "NBL", bdmv); len(failures) != 0 {
 		t.Fatalf("expected BDMV to skip NBL language rule, got %#v", failures)
 	}
 
@@ -343,7 +360,7 @@ func TestEvaluateRulesNBLSkipsLanguageRuleForBDMVOnly(t *testing.T) {
 		ExternalIDs: api.ExternalIDs{Category: "tv"},
 		DiscType:    "DVD",
 	}
-	failures := EvaluateRules(context.Background(), "NBL", dvd, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "NBL", dvd)
 	if len(failures) != 1 {
 		t.Fatalf("expected DVD to require NBL language data, got %#v", failures)
 	}
@@ -361,7 +378,7 @@ func TestEvaluateRulesDPDoesNotSpecialCaseFGTEncodes(t *testing.T) {
 		AudioLanguages:    []string{"English"},
 		SubtitleLanguages: []string{"English"},
 	}
-	failures := EvaluateRules(context.Background(), "DP", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "DP", meta)
 	for _, failure := range failures {
 		if failure.Rule == "block_group" {
 			t.Fatalf("expected FGT to be handled as a banned group, got rule failure %#v", failures)
@@ -377,7 +394,7 @@ func TestEvaluateRulesRHDRequiresGermanAudio(t *testing.T) {
 		Release:                api.ReleaseInfo{Resolution: "1080p"},
 		ValidMediaInfoSettings: true,
 	}
-	failures := EvaluateRules(context.Background(), "RHD", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "RHD", meta)
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure, got %#v", failures)
 	}
@@ -394,7 +411,7 @@ func TestEvaluateRulesRHDAllowsGermanAudio(t *testing.T) {
 		Release:                api.ReleaseInfo{Resolution: "1080p"},
 		ValidMediaInfoSettings: true,
 	}
-	failures := EvaluateRules(context.Background(), "RHD", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "RHD", meta)
 	if len(failures) != 0 {
 		t.Fatalf("expected no failures, got %#v", failures)
 	}
@@ -410,7 +427,7 @@ func TestEvaluateRulesRHDRequiresGermanAudioForDisc(t *testing.T) {
 		Release:                api.ReleaseInfo{Resolution: "1080p"},
 		ValidMediaInfoSettings: true,
 	}
-	failures := EvaluateRules(context.Background(), "RHD", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "RHD", meta)
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure, got %#v", failures)
 	}
@@ -429,7 +446,7 @@ func TestEvaluateRulesRHDAllowsGermanAudioForDisc(t *testing.T) {
 		Release:                api.ReleaseInfo{Resolution: "1080p"},
 		ValidMediaInfoSettings: true,
 	}
-	failures := EvaluateRules(context.Background(), "RHD", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "RHD", meta)
 	if len(failures) != 0 {
 		t.Fatalf("expected no failures, got %#v", failures)
 	}
@@ -444,7 +461,7 @@ func TestEvaluateRulesRHDRequiresSceneNFO(t *testing.T) {
 		Release:                api.ReleaseInfo{Resolution: "1080p"},
 		ValidMediaInfoSettings: true,
 	}
-	failures := EvaluateRules(context.Background(), "RHD", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "RHD", meta)
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure, got %#v", failures)
 	}
@@ -460,7 +477,7 @@ func TestEvaluateRulesRHDAllowsNonSceneWithoutNFO(t *testing.T) {
 		AudioLanguages: []string{"German"},
 		Release:        api.ReleaseInfo{Resolution: "1080p"},
 	}
-	failures := EvaluateRules(context.Background(), "RHD", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "RHD", meta)
 	for _, failure := range failures {
 		if failure.Rule == "require_scene_nfo" {
 			t.Fatalf("expected non-scene upload to avoid NFO blocker, got %#v", failures)
@@ -476,7 +493,7 @@ func TestEvaluateRulesTOSRequiresSceneNFO(t *testing.T) {
 		AudioLanguages:         []string{"French"},
 		ValidMediaInfoSettings: true,
 	}
-	failures := EvaluateRules(context.Background(), "TOS", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "TOS", meta)
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure, got %#v", failures)
 	}
@@ -496,7 +513,7 @@ func TestEvaluateRulesAitherRequiresLanguageForNonDisc(t *testing.T) {
 			TMDB: &api.TMDBMetadata{OriginalLanguage: "ja"},
 		},
 	}
-	failures := EvaluateRules(context.Background(), "AITHER", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "AITHER", meta)
 	if len(failures) == 0 {
 		t.Fatalf("expected language failure")
 	}
@@ -510,7 +527,7 @@ func TestEvaluateRulesA4KSkipsLanguageRuleForDisc(t *testing.T) {
 		DiscType:               "BDMV",
 		ValidMediaInfoSettings: true,
 	}
-	failures := EvaluateRules(context.Background(), "A4K", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "A4K", meta)
 	if len(failures) != 0 {
 		t.Fatalf("expected no failures for disc upload, got %#v", failures)
 	}
@@ -521,7 +538,7 @@ func TestEvaluateRulesLSTRequiresValidMIAndLanguage(t *testing.T) {
 		DiscType:               "",
 		ValidMediaInfoSettings: false,
 	}
-	failures := EvaluateRules(context.Background(), "LST", meta, nil)
+	failures := evaluateNonMetadataRulesForTest(context.Background(), "LST", meta)
 	if len(failures) < 2 {
 		t.Fatalf("expected at least 2 failures, got %#v", failures)
 	}
@@ -559,7 +576,7 @@ func TestEvaluateRulesModifiedReleaseAcrossFamilies(t *testing.T) {
 	for _, tracker := range []string{"LST", "PTP", "PHD", "HDB"} {
 		t.Run(tracker, func(t *testing.T) {
 			t.Parallel()
-			got := EvaluateRules(context.Background(), tracker, renamed, nil)
+			got := evaluateNonMetadataRulesForTest(context.Background(), tracker, renamed)
 			failure, ok := findRuleFailure(got, "modified_release")
 			if !ok {
 				t.Fatalf("expected modified_release failure for %s, got %#v", tracker, got)
@@ -567,27 +584,25 @@ func TestEvaluateRulesModifiedReleaseAcrossFamilies(t *testing.T) {
 			if !strings.Contains(failure.Reason, "renamed") {
 				t.Fatalf("expected a meaningful reason mentioning 'renamed' for %s, got %q", tracker, failure.Reason)
 			}
-			if clean := EvaluateRules(context.Background(), tracker, clean, nil); hasRuleFailure(clean, "modified_release") {
+			if clean := evaluateNonMetadataRulesForTest(context.Background(), tracker, clean); hasRuleFailure(clean, "modified_release") {
 				t.Fatalf("did not expect modified_release failure for clean release on %s, got %#v", tracker, clean)
 			}
 		})
 	}
 }
 
-// TestEvaluateRulesPreservesNilForTrackerWithoutFailures guards the contract that
-// applyTrackerRules relies on: a tracker with no rule set and no rule failure must
-// return nil (not an empty slice), so the consumer preserves pre-existing failures
-// (e.g. audio_bloat) instead of clearing them.
-func TestEvaluateRulesPreservesNilForTrackerWithoutFailures(t *testing.T) {
+// TestEvaluateRulesMetadataPolicyReturnsEvaluatedEmpty guards the contract that
+// a configured metadata policy returns a non-nil empty slice after passing, so
+// the consumer clears stale stored metadata failures.
+func TestEvaluateRulesMetadataPolicyReturnsEvaluatedEmpty(t *testing.T) {
 	t.Parallel()
 
 	clean := api.PreparedMetadata{
 		SourcePath: "/data/movies/Example.Movie.2026.2160p.MA.WEB-DL.DDP5.1.HDR.H.265-GRP",
 		Release:    api.ReleaseInfo{Group: "GRP"},
 	}
-	// MTV is non-UNIT3D, not PTP, and has no rule set of its own.
-	if got := EvaluateRules(context.Background(), "MTV", clean, nil); got != nil {
-		t.Fatalf("expected nil for a tracker without failures, got %#v", got)
+	if got := evaluateNonMetadataRulesForTest(context.Background(), "MTV", clean); got == nil || len(got) != 0 {
+		t.Fatalf("expected evaluated empty result, got %#v", got)
 	}
 }
 
@@ -598,7 +613,7 @@ func TestEvaluateRulesModifiedReleaseExemptsManual(t *testing.T) {
 		SourcePath: "/data/movies/Example Movie 2026 2160p MA WEB-DL DDP5 1 HDR H 265-GRP",
 		Release:    api.ReleaseInfo{Group: "GRP"},
 	}
-	if got := EvaluateRules(context.Background(), "MANUAL", renamed, nil); hasRuleFailure(got, "modified_release") {
+	if got := evaluateNonMetadataRulesForTest(context.Background(), "MANUAL", renamed); hasRuleFailure(got, "modified_release") {
 		t.Fatalf("expected MANUAL to be exempt from modified_release, got %#v", got)
 	}
 }

--- a/internal/trackers/rules_test.go
+++ b/internal/trackers/rules_test.go
@@ -68,6 +68,31 @@ func TestEvaluateRulesRequiresUniqueID(t *testing.T) {
 	}
 }
 
+func TestResolveCategoryIgnoresEmptyTVMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		metadata api.ExternalMetadata
+	}{
+		{name: "TVDB", metadata: api.ExternalMetadata{TVDB: &api.TVDBMetadata{}}},
+		{name: "TVmaze", metadata: api.ExternalMetadata{TVmaze: &api.TVmazeMetadata{}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			meta := api.PreparedMetadata{
+				ExternalMetadata: tt.metadata,
+				Release:          api.ReleaseInfo{Category: "movie"},
+			}
+			if got := resolveCategory(meta); got != "movie" {
+				t.Fatalf("expected movie fallback, got %q", got)
+			}
+		})
+	}
+}
+
 func hasMISettingsFailure(failures []api.RuleFailure) bool {
 	for _, failure := range failures {
 		if failure.Rule == "require_valid_mi_setting" {

--- a/internal/trackers/rules_test.go
+++ b/internal/trackers/rules_test.go
@@ -275,8 +275,10 @@ func TestEvaluateRulesBHDBlocksAdultContent(t *testing.T) {
 
 	meta := api.PreparedMetadata{
 		ValidMediaInfoSettings: true,
+		ExternalIDs:            api.ExternalIDs{Category: "movie", IMDBID: 1234567},
 		ExternalMetadata: api.ExternalMetadata{
 			TMDB: &api.TMDBMetadata{Keywords: "adult"},
+			IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release"},
 		},
 	}
 

--- a/internal/trackers/service.go
+++ b/internal/trackers/service.go
@@ -1124,9 +1124,12 @@ func filterTrackersByRuleFailures(trackers []string, failures map[string][]api.R
 	for _, tracker := range trackers {
 		name := strings.ToUpper(strings.TrimSpace(tracker))
 		trackerFailures, ok := failures[name]
-		if ok && len(trackerFailures) > 0 {
+		if ok && api.HasBlockingRuleFailures(trackerFailures) {
 			if logger != nil {
 				for _, failure := range trackerFailures {
+					if !api.IsBlockingRuleFailure(failure) {
+						continue
+					}
 					logger.Warnf("trackers: skipping %s due to rule failure %s (%s)", name, failure.Rule, failure.Reason)
 				}
 			}

--- a/internal/trackers/service_test.go
+++ b/internal/trackers/service_test.go
@@ -2363,6 +2363,7 @@ func TestFilterTrackersByRuleFailuresExcludesModifiedReleaseAcrossFamilies(t *te
 	failures := map[string][]api.RuleFailure{
 		"PTP": {{Rule: "modified_release", Reason: "source renamed from original release name"}},
 		"LST": {{Rule: "modified_release", Reason: "source renamed from original release name"}},
+		"HDB": {{Rule: "recommended_id", Reason: "recommended ID missing", Severity: api.RuleFailureSeverityWarning}},
 	}
 	trackers := []string{"PTP", "LST", "HDB"}
 
@@ -2371,7 +2372,7 @@ func TestFilterTrackersByRuleFailuresExcludesModifiedReleaseAcrossFamilies(t *te
 		t.Fatalf("expected PTP and LST skipped for modified_release, got %v", got)
 	}
 	if !slices.Contains(got, "HDB") {
-		t.Fatalf("expected HDB (no failure) retained, got %v", got)
+		t.Fatalf("expected warning-only HDB retained, got %v", got)
 	}
 
 	// The override flag must let the user force-upload past the failure.

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -1162,7 +1162,7 @@ func (b *Backend) ListHistory() ([]api.HistoryEntry, error) {
 	result := make([]api.HistoryEntry, 0, len(entries))
 	for _, entry := range entries {
 		entryCopy := entry
-		entryCopy.LatestUploadStatus = historyStatusLabel(entry.LatestUploadStatus, entry.RuleFailureCount)
+		entryCopy.LatestUploadStatus = api.HistoryStatusLabel(entry.LatestUploadStatus, entry.RuleFailureCount)
 		result = append(result, entryCopy)
 	}
 	return result, nil
@@ -1601,38 +1601,7 @@ func historyOverviewFromRepo(repo *db.SQLiteRepository, sourcePath string) (api.
 		overview.LatestUploadStatus = uploadHistory[0].Status
 		overview.LatestUploadAt = uploadHistory[0].CreatedAt
 	}
-	blockingRuleFailures := 0
-	for _, failure := range ruleFailures {
-		if api.NormalizeRuleFailureSeverity(failure.Severity) == api.RuleFailureSeverityBlocking {
-			blockingRuleFailures++
-		}
-	}
-	overview.StatusLabel = historyStatusLabel(overview.LatestUploadStatus, blockingRuleFailures)
+	blockingRuleFailures := api.CountBlockingRuleFailures(ruleFailures)
+	overview.StatusLabel = api.HistoryStatusLabel(overview.LatestUploadStatus, blockingRuleFailures)
 	return overview, nil
-}
-
-func historyStatusLabel(rawStatus string, ruleFailureCount int) string {
-	status := strings.TrimSpace(strings.ToLower(rawStatus))
-	switch status {
-	case "pending":
-		return "Pending"
-	case "pending-internal":
-		return "Pending Internal"
-	case "uploaded", "success", "completed":
-		return "Uploaded"
-	case "failed", "error":
-		return "Failed"
-	}
-	if status != "" {
-		normalized := strings.ReplaceAll(status, "-", " ")
-		words := strings.Fields(normalized)
-		for idx, word := range words {
-			words[idx] = strings.ToUpper(word[:1]) + word[1:]
-		}
-		return strings.Join(words, " ")
-	}
-	if ruleFailureCount > 0 {
-		return "Rule Issues"
-	}
-	return "Stored"
 }

--- a/internal/webserver/backend.go
+++ b/internal/webserver/backend.go
@@ -1601,7 +1601,13 @@ func historyOverviewFromRepo(repo *db.SQLiteRepository, sourcePath string) (api.
 		overview.LatestUploadStatus = uploadHistory[0].Status
 		overview.LatestUploadAt = uploadHistory[0].CreatedAt
 	}
-	overview.StatusLabel = historyStatusLabel(overview.LatestUploadStatus, len(ruleFailures))
+	blockingRuleFailures := 0
+	for _, failure := range ruleFailures {
+		if api.NormalizeRuleFailureSeverity(failure.Severity) == api.RuleFailureSeverityBlocking {
+			blockingRuleFailures++
+		}
+	}
+	overview.StatusLabel = historyStatusLabel(overview.LatestUploadStatus, blockingRuleFailures)
 	return overview, nil
 }
 

--- a/internal/webserver/backend_repo_test.go
+++ b/internal/webserver/backend_repo_test.go
@@ -680,6 +680,7 @@ func TestBackendSaveConfigAfterInvalidStartupMigratesLegacyCookies(t *testing.T)
 
 	startupCfg := backendConfigTestConfig(repoPath)
 	startupCfg.MainSettings.TMDBAPI = ""
+	startupCfg.ScreenshotHandling.Screens = 0
 	backend, err := NewBackend(startupCfg, newEventHub())
 	if err != nil {
 		t.Fatalf("new backend: %v", err)

--- a/pkg/api/history.go
+++ b/pkg/api/history.go
@@ -14,6 +14,8 @@ type HistoryEntry struct {
 	LatestUploadStatus string
 	LatestUploadAt     time.Time `ts_type:"string"`
 	RuleFailureCount   int
+	// RuleWarningCount excludes blocking, legacy, and unrecognized rule results.
+	RuleWarningCount int
 }
 
 type HistoryOverview struct {

--- a/pkg/api/history.go
+++ b/pkg/api/history.go
@@ -3,7 +3,10 @@
 
 package api
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type HistoryEntry struct {
 	SourcePath         string
@@ -40,4 +43,35 @@ type HistoryOverview struct {
 	FinalSelections      []ScreenshotFinalSelection
 	UploadedImages       []UploadedImageLink
 	UploadHistory        []UploadRecord
+}
+
+// HistoryStatusLabel returns the display label for a persisted upload status,
+// falling back to rule-issue or stored state when no status is available.
+func HistoryStatusLabel(rawStatus string, ruleFailureCount int) string {
+	status := strings.TrimSpace(strings.ToLower(rawStatus))
+	switch status {
+	case "pending":
+		return "Pending"
+	case "pending-internal":
+		return "Pending Internal"
+	case "uploaded", "success", "completed":
+		return "Uploaded"
+	case "failed", "error":
+		return "Failed"
+	}
+	if status != "" {
+		normalized := strings.ReplaceAll(status, "-", " ")
+		words := strings.Fields(normalized)
+		for idx, word := range words {
+			if word == "" {
+				continue
+			}
+			words[idx] = strings.ToUpper(word[:1]) + word[1:]
+		}
+		return strings.Join(words, " ")
+	}
+	if ruleFailureCount > 0 {
+		return "Rule Issues"
+	}
+	return "Stored"
 }

--- a/pkg/api/history_test.go
+++ b/pkg/api/history_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package api
+
+import "testing"
+
+func TestHistoryStatusLabel(t *testing.T) {
+	t.Parallel()
+
+	if got := HistoryStatusLabel("custom--status", 0); got != "Custom Status" {
+		t.Fatalf("custom status label = %q, want %q", got, "Custom Status")
+	}
+	if got := HistoryStatusLabel("", 1); got != "Rule Issues" {
+		t.Fatalf("rule failure status label = %q, want %q", got, "Rule Issues")
+	}
+}

--- a/pkg/api/preview.go
+++ b/pkg/api/preview.go
@@ -19,10 +19,12 @@ type MetadataPreview struct {
 	ReleaseNameOverrides ReleaseNameOverrides
 	ExternalIDs          ExternalIDs
 	ExternalIDCandidates ExternalIDCandidates
-	ExternalIDInfo       []ExternalIDInfo
-	ExternalPreview      []ExternalPreview
-	Bluray               *BlurayMetadata
-	TrackerData          []TrackerPreview
+	// ExternalIDInfo includes resolved IDs even when no metadata was fetched from that provider.
+	ExternalIDInfo []ExternalIDInfo
+	// ExternalPreview includes only providers whose metadata payload was fetched and populated.
+	ExternalPreview []ExternalPreview
+	Bluray          *BlurayMetadata
+	TrackerData     []TrackerPreview
 	// TrackerRuleFailures is keyed by normalized tracker code and contains
 	// upload rule failures known at preview time.
 	TrackerRuleFailures map[string][]RuleFailure
@@ -171,6 +173,8 @@ type ExternalIDInfo struct {
 	Source   string
 }
 
+// ExternalPreview contains fetched metadata for one resolved external provider ID.
+// A resolved ID without provider metadata appears in [MetadataPreview.ExternalIDInfo] only.
 type ExternalPreview struct {
 	Provider         string
 	ID               int

--- a/pkg/api/repository.go
+++ b/pkg/api/repository.go
@@ -172,7 +172,9 @@ type TrackerRuleFailure struct {
 	Tracker    string
 	Rule       string
 	Reason     string
-	CreatedAt  time.Time `ts_type:"string"`
+	// Severity defaults to blocking for records created before severity was stored.
+	Severity  RuleFailureSeverity
+	CreatedAt time.Time `ts_type:"string"`
 }
 
 type DescriptionOverride struct {

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -379,6 +379,18 @@ func HasBlockingRuleFailures(failures []RuleFailure) bool {
 	return slices.ContainsFunc(failures, IsBlockingRuleFailure)
 }
 
+// CountBlockingRuleFailures returns the number of rule results that block
+// tracker work. Legacy and unrecognized severities are counted as blocking.
+func CountBlockingRuleFailures(failures []TrackerRuleFailure) int {
+	count := 0
+	for _, failure := range failures {
+		if NormalizeRuleFailureSeverity(failure.Severity) == RuleFailureSeverityBlocking {
+			count++
+		}
+	}
+	return count
+}
+
 // filterRuleFailures copies results whose normalized blocking state matches the
 // requested state.
 func filterRuleFailures(failures []RuleFailure, blocking bool) []RuleFailure {

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 )
@@ -314,9 +315,67 @@ type ExternalIDCandidate struct {
 	Similarity    float64
 }
 
+// RuleFailureSeverity classifies whether a tracker rule result blocks work.
+// The zero value and unrecognized values are treated as blocking for backward
+// compatibility and fail-closed behavior.
+type RuleFailureSeverity string
+
+const (
+	// RuleFailureSeverityBlocking prevents the affected tracker operation.
+	RuleFailureSeverityBlocking RuleFailureSeverity = "blocking"
+	// RuleFailureSeverityWarning reports advice without preventing the operation.
+	RuleFailureSeverityWarning RuleFailureSeverity = "warning"
+)
+
+// RuleFailure describes a failed or advisory tracker rule result.
 type RuleFailure struct {
 	Rule   string
 	Reason string
+	// Severity defaults to blocking when empty or unrecognized.
+	Severity RuleFailureSeverity
+}
+
+// NormalizeRuleFailureSeverity maps the warning value to itself and all other
+// values, including legacy empty values, to blocking.
+func NormalizeRuleFailureSeverity(severity RuleFailureSeverity) RuleFailureSeverity {
+	if severity == RuleFailureSeverityWarning {
+		return RuleFailureSeverityWarning
+	}
+	return RuleFailureSeverityBlocking
+}
+
+// IsBlockingRuleFailure reports whether a rule result blocks tracker work.
+func IsBlockingRuleFailure(failure RuleFailure) bool {
+	return NormalizeRuleFailureSeverity(failure.Severity) == RuleFailureSeverityBlocking
+}
+
+// BlockingRuleFailures returns an independent slice containing only blocking
+// results. Legacy and unrecognized severities are included.
+func BlockingRuleFailures(failures []RuleFailure) []RuleFailure {
+	return filterRuleFailures(failures, true)
+}
+
+// WarningRuleFailures returns an independent slice containing only results with
+// the explicit warning severity.
+func WarningRuleFailures(failures []RuleFailure) []RuleFailure {
+	return filterRuleFailures(failures, false)
+}
+
+// HasBlockingRuleFailures reports whether any rule result blocks tracker work.
+func HasBlockingRuleFailures(failures []RuleFailure) bool {
+	return slices.ContainsFunc(failures, IsBlockingRuleFailure)
+}
+
+// filterRuleFailures copies results whose normalized blocking state matches the
+// requested state.
+func filterRuleFailures(failures []RuleFailure, blocking bool) []RuleFailure {
+	filtered := make([]RuleFailure, 0, len(failures))
+	for _, failure := range failures {
+		if IsBlockingRuleFailure(failure) == blocking {
+			filtered = append(filtered, failure)
+		}
+	}
+	return filtered
 }
 
 // ExternalIDOverrides carries caller-supplied ID intent into metadata

--- a/pkg/api/services_test.go
+++ b/pkg/api/services_test.go
@@ -31,6 +31,24 @@ func TestPreparedMetadataSeasonEpisodeHelpers(t *testing.T) {
 	}
 }
 
+func TestRuleFailureSeverityFailClosed(t *testing.T) {
+	t.Parallel()
+	failures := []RuleFailure{
+		{Rule: "legacy"},
+		{Rule: "warning", Severity: RuleFailureSeverityWarning},
+		{Rule: "unknown", Severity: "unexpected"},
+	}
+	if !HasBlockingRuleFailures(failures) {
+		t.Fatal("expected legacy and unknown severities to block")
+	}
+	if got := BlockingRuleFailures(failures); len(got) != 2 || got[0].Rule != "legacy" || got[1].Rule != "unknown" {
+		t.Fatalf("unexpected blocking subset: %#v", got)
+	}
+	if got := WarningRuleFailures(failures); len(got) != 1 || got[0].Rule != "warning" {
+		t.Fatalf("unexpected warning subset: %#v", got)
+	}
+}
+
 func TestTMDBMetadataMarshalLocalizedTitlesAsObject(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/api/services_test.go
+++ b/pkg/api/services_test.go
@@ -41,6 +41,14 @@ func TestRuleFailureSeverityFailClosed(t *testing.T) {
 	if !HasBlockingRuleFailures(failures) {
 		t.Fatal("expected legacy and unknown severities to block")
 	}
+	storedFailures := []TrackerRuleFailure{
+		{Rule: "legacy"},
+		{Rule: "warning", Severity: RuleFailureSeverityWarning},
+		{Rule: "unknown", Severity: "unexpected"},
+	}
+	if got := CountBlockingRuleFailures(storedFailures); got != 2 {
+		t.Fatalf("blocking count = %d, want 2", got)
+	}
 	if got := BlockingRuleFailures(failures); len(got) != 2 || got[0].Rule != "legacy" || got[1].Rule != "unknown" {
 		t.Fatalf("unexpected blocking subset: %#v", got)
 	}


### PR DESCRIPTION
closes https://github.com/autobrr/upbrr/issues/21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracker rule results now include severity (“blocking” vs “warning”) and surface warning messages in tracker upload and history/overview.
  * TMDB API key is optional; TMDB enrichment runs only when configured.
  * Improved external-ID/provider preview behavior when provider metadata isn’t available.

* **Bug Fixes**
  * Advisory warnings no longer prevent eligibility, uploads, or duplicate-check skipping; status labels/counts now use blocking-only logic.

* **Tests**
  * Added/updated unit and UI tests for warning vs blocking behavior and optional TMDB validation/enrichment.
  * Added migration/database tests and SQLite coverage for severity persistence and counting.

* **Documentation**
  * Updated setup/prerequisites notes to reflect optional TMDB configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->