### PR TITLE
fix(tmdb): repair anilist anime resolution

### DIFF
--- a/internal/metadata/tmdb/anilist.go
+++ b/internal/metadata/tmdb/anilist.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
+	"github.com/autobrr/upbrr/internal/redaction"
 )
 
 const anilistURL = "https://graphql.anilist.co"
@@ -51,6 +52,9 @@ func (c *Client) ResolveAnime(ctx context.Context, tmdbName string, input Metada
 		}
 		items, err := c.anilistSearch(ctx, term, result.MALID)
 		if err != nil {
+			if c.logger != nil {
+				c.logger.Warnf("tmdb: anilist search failed mal=%d err=%s", result.MALID, redaction.RedactValue(err.Error(), nil))
+			}
 			continue
 		}
 		if len(items) > 0 {
@@ -192,7 +196,7 @@ func (c *Client) anilistSearch(ctx context.Context, term string, malID int) ([]a
 func (c *Client) doAniListSearch(ctx context.Context, body []byte) (anilistResponse, error) {
 	var response anilistResponse
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anilistURL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.anilistURL, bytes.NewReader(body))
 	if err != nil {
 		return response, fmt.Errorf("anilist: build search request: %w", err)
 	}
@@ -218,7 +222,7 @@ func (c *Client) doAniListSearch(ctx context.Context, body []byte) (anilistRespo
 func (c *Client) doAniListMetadata(ctx context.Context, body []byte) (anilistMetadataResponse, error) {
 	var response anilistMetadataResponse
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anilistURL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.anilistURL, bytes.NewReader(body))
 	if err != nil {
 		return response, fmt.Errorf("anilist: build metadata request: %w", err)
 	}
@@ -359,7 +363,7 @@ type anilistMedia struct {
 	ID         int          `json:"id"`
 	IDMal      int          `json:"idMal"`
 	Title      anilistTitle `json:"title"`
-	SeasonYear string       `json:"seasonYear"`
+	SeasonYear int          `json:"seasonYear"`
 	Episodes   int          `json:"episodes"`
 	Tags       []anilistTag `json:"tags"`
 }

--- a/internal/metadata/tmdb/anilist.go
+++ b/internal/metadata/tmdb/anilist.go
@@ -184,7 +184,7 @@ func (c *Client) anilistSearch(ctx context.Context, term string, malID int) ([]a
 		}
 		lastErr = err
 		if c.logger != nil {
-			c.logger.Warnf("tmdb: anilist request timed out for %q, retrying (%d/%d)", strings.TrimSpace(term), attempt+2, anilistRetryCount)
+			c.logger.Warnf("tmdb: anilist request timed out mal=%d retry=%d/%d", malID, attempt+2, anilistRetryCount)
 		}
 	}
 	if lastErr != nil {

--- a/internal/metadata/tmdb/anilist_test.go
+++ b/internal/metadata/tmdb/anilist_test.go
@@ -14,16 +14,19 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+const testAnilistURL = "https://anilist.invalid/graphql"
+
 func TestAniListSearchRetriesTimeouts(t *testing.T) {
 	attempts := 0
 	client := &Client{
+		anilistURL: testAnilistURL,
 		http: &http.Client{
 			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 				attempts++
 				if attempts < 3 {
 					return nil, timeoutError{err: errors.New("timeout")}
 				}
-				body := `{"data":{"Page":{"media":[{"id":1,"idMal":20,"title":{"romaji":"Test","english":"Test"},"seasonYear":"2024","episodes":12,"tags":[{"name":"Shounen"}]}]}}}`
+				body := `{"data":{"Page":{"media":[{"id":1,"idMal":20,"title":{"romaji":"Test","english":"Test"},"seasonYear":2024,"episodes":12,"tags":[{"name":"Shounen"}]}]}}}`
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(body)),
@@ -49,6 +52,7 @@ func TestAniListSearchRetriesTimeouts(t *testing.T) {
 func TestAniListSearchDoesNotRetryNonTimeoutErrors(t *testing.T) {
 	attempts := 0
 	client := &Client{
+		anilistURL: testAnilistURL,
 		http: &http.Client{
 			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 				attempts++
@@ -70,6 +74,7 @@ func TestAniListSearchDoesNotRetryNonTimeoutErrors(t *testing.T) {
 func TestFetchAniListMetadataReturnsGraphQLErrors(t *testing.T) {
 	attempts := 0
 	client := &Client{
+		anilistURL: testAnilistURL,
 		http: &http.Client{
 			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 				attempts++
@@ -98,6 +103,7 @@ func TestFetchAniListMetadataReturnsGraphQLErrors(t *testing.T) {
 func TestFetchAniListMetadataRejectsOversizedResponse(t *testing.T) {
 	attempts := 0
 	client := &Client{
+		anilistURL: testAnilistURL,
 		http: &http.Client{
 			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 				attempts++
@@ -126,6 +132,7 @@ func TestFetchAniListMetadataRejectsOversizedResponse(t *testing.T) {
 func TestFetchAniListMetadataRetriesTimeoutsToMappedResult(t *testing.T) {
 	attempts := 0
 	client := &Client{
+		anilistURL: testAnilistURL,
 		http: &http.Client{
 			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 				attempts++
@@ -152,6 +159,79 @@ func TestFetchAniListMetadataRetriesTimeoutsToMappedResult(t *testing.T) {
 	}
 	if result.MALID != 20 || result.AniListID != 1 || result.TitleRomaji != "Example Anime" || result.Status != "FINISHED" {
 		t.Fatalf("expected mapped AniList metadata after retry, got %#v", result)
+	}
+}
+
+func TestAniListRequestsUseInjectedEndpoint(t *testing.T) {
+	var requested []string
+	client := &Client{
+		anilistURL: testAnilistURL,
+		http: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				requested = append(requested, req.URL.String())
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"data":{}}`)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+		logger: api.NopLogger{},
+	}
+
+	if _, err := client.anilistSearch(context.Background(), "Example Anime", 0); err != nil {
+		t.Fatalf("anilist search: %v", err)
+	}
+	if _, err := client.FetchAniListMetadata(context.Background(), 20); err != nil {
+		t.Fatalf("anilist metadata: %v", err)
+	}
+	if len(requested) != 2 {
+		t.Fatalf("expected one search and one metadata request, got %d", len(requested))
+	}
+	for _, endpoint := range requested {
+		if endpoint != testAnilistURL {
+			t.Fatalf("expected injected endpoint %q, got %q", testAnilistURL, endpoint)
+		}
+	}
+}
+
+func TestResolveAnimeWarnsSanitizedOnSearchFailure(t *testing.T) {
+	logger := &captureTMDBLogger{}
+	client := &Client{
+		anilistURL: testAnilistURL,
+		http: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader("upstream failure")),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+		logger: logger,
+	}
+
+	result, err := client.ResolveAnime(context.Background(), "Example Anime", MetadataInput{
+		Filename: "Example.Anime.2026.S01.1080p.WEB-DL-GRP",
+	})
+	if err != nil {
+		t.Fatalf("expected best-effort resolve to succeed, got %v", err)
+	}
+	if result.MALID != 0 {
+		t.Fatalf("expected no MAL id without candidates, got %d", result.MALID)
+	}
+
+	warnings := logger.warnings()
+	if len(warnings) != 2 {
+		t.Fatalf("expected one warning per failed search term, got %#v", warnings)
+	}
+	for _, warning := range warnings {
+		if !strings.HasPrefix(warning, "tmdb: anilist search failed mal=0 err=") {
+			t.Fatalf("expected key/value warning, got %q", warning)
+		}
+		if strings.Contains(warning, "Example") || strings.Contains(warning, "GRP") {
+			t.Fatalf("expected warning to omit the search term, got %q", warning)
+		}
 	}
 }
 

--- a/internal/metadata/tmdb/anilist_test.go
+++ b/internal/metadata/tmdb/anilist_test.go
@@ -18,6 +18,7 @@ const testAnilistURL = "https://anilist.invalid/graphql"
 
 func TestAniListSearchRetriesTimeouts(t *testing.T) {
 	attempts := 0
+	logger := &captureTMDBLogger{}
 	client := &Client{
 		anilistURL: testAnilistURL,
 		http: &http.Client{
@@ -34,10 +35,10 @@ func TestAniListSearchRetriesTimeouts(t *testing.T) {
 				}, nil
 			}),
 		},
-		logger: api.NopLogger{},
+		logger: logger,
 	}
 
-	items, err := client.anilistSearch(context.Background(), "Test", 0)
+	items, err := client.anilistSearch(context.Background(), "Example.Anime.2026.1080p.WEB-DL-GRP", 0)
 	if err != nil {
 		t.Fatalf("expected success after retry, got error: %v", err)
 	}
@@ -46,6 +47,18 @@ func TestAniListSearchRetriesTimeouts(t *testing.T) {
 	}
 	if len(items) != 1 || items[0].IDMal != 20 {
 		t.Fatalf("expected one AniList result with MAL id 20, got %+v", items)
+	}
+	warnings := logger.warnings()
+	if len(warnings) != 2 {
+		t.Fatalf("expected two timeout warnings, got %#v", warnings)
+	}
+	for _, warning := range warnings {
+		if !strings.HasPrefix(warning, "tmdb: anilist request timed out mal=0 retry=") {
+			t.Fatalf("expected stable timeout warning fields, got %q", warning)
+		}
+		if strings.Contains(warning, "Example") || strings.Contains(warning, "GRP") {
+			t.Fatalf("expected timeout warning to omit the search term, got %q", warning)
+		}
 	}
 }
 

--- a/internal/metadata/tmdb/client.go
+++ b/internal/metadata/tmdb/client.go
@@ -28,10 +28,11 @@ var errNotFound = errors.New("tmdb: not found")
 
 // Client queries TMDB and shares its HTTP transport with AniList enrichment.
 type Client struct {
-	apiKey  string
-	baseURL string
-	http    *http.Client
-	logger  api.Logger
+	apiKey     string
+	baseURL    string
+	anilistURL string
+	http       *http.Client
+	logger     api.Logger
 }
 
 // NewClient trims apiKey and substitutes a 15-second HTTP client and no-op
@@ -44,10 +45,11 @@ func NewClient(httpClient *http.Client, logger api.Logger, apiKey string) *Clien
 		logger = api.NopLogger{}
 	}
 	return &Client{
-		apiKey:  strings.TrimSpace(apiKey),
-		baseURL: defaultBaseURL,
-		http:    httpClient,
-		logger:  logger,
+		apiKey:     strings.TrimSpace(apiKey),
+		baseURL:    defaultBaseURL,
+		anilistURL: anilistURL,
+		http:       httpClient,
+		logger:     logger,
 	}
 }
 

--- a/internal/metadata/tmdb/metadata.go
+++ b/internal/metadata/tmdb/metadata.go
@@ -25,8 +25,10 @@ const imageBaseURL = "https://image.tmdb.org/t/p/original"
 var yearPattern = regexp.MustCompile(`(18|19|20)\d{2}`)
 
 // FetchMetadata loads the primary TMDB record plus best-effort external IDs,
-// translations, media assets, credits, and keywords. A primary-record failure
-// returns no result; optional TMDB lookup failures are logged and omitted.
+// translations, media assets, credits, and keywords, then applies best-effort
+// AniList identity/title enrichment when the record resolves as anime. A
+// primary-record failure returns no result; optional TMDB and AniList lookup
+// failures are logged and omitted.
 func (c *Client) FetchMetadata(ctx context.Context, input MetadataInput) (MetadataResult, error) {
 	if input.TMDBID == 0 {
 		return MetadataResult{}, errNotFound
@@ -242,7 +244,9 @@ func (c *Client) FetchMetadata(ctx context.Context, input MetadataInput) (Metada
 		result.Anime = isAnime(media.OriginalLanguage, media.Genres)
 	}
 	if result.Anime {
-		animeResult, err := c.ResolveAnime(ctx, title, input)
+		// requestCtx, not ctx: the errgroup context above is canceled once Wait
+		// returns, which would fail every AniList request.
+		animeResult, err := c.ResolveAnime(requestCtx, title, input)
 		if err == nil {
 			result.MALID = animeResult.MALID
 			result.RetrievedAKA = animeResult.Romaji

--- a/internal/metadata/tmdb/metadata_test.go
+++ b/internal/metadata/tmdb/metadata_test.go
@@ -438,3 +438,53 @@ func (l *captureTMDBLogger) warnings() []string {
 	defer l.mu.Unlock()
 	return append([]string{}, l.warns...)
 }
+
+func TestFetchMetadataResolvesAnimeAKA(t *testing.T) {
+	var anilistRequested atomic.Bool
+
+	anilist := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		anilistRequested.Store(true)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"Page":{"media":[{"id":1,"idMal":67890,"title":{"romaji":"Rei No Sakuhin","english":"Example Anime Series","native":"サンプル作品"},"seasonYear":2026,"episodes":12}]}}}`))
+	}))
+	defer anilist.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/tv/12345":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"name":"Example Anime Series","original_name":"サンプル作品","first_air_date":"2026-07-11","original_language":"ja","genres":[{"id":16,"name":"Animation"}]}`))
+		case "/tv/12345/credits":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"crew":[],"cast":[]}`))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), nil, "api-key")
+	client.baseURL = server.URL
+	client.anilistURL = anilist.URL
+
+	result, err := client.FetchMetadata(context.Background(), MetadataInput{
+		TMDBID:   12345,
+		Category: "TV",
+	})
+	if err != nil {
+		t.Fatalf("fetch metadata: %v", err)
+	}
+	if !anilistRequested.Load() {
+		t.Fatalf("expected anilist to be queried for an anime title")
+	}
+	if !result.Anime {
+		t.Fatalf("expected anime detection for a japanese animation title")
+	}
+	if result.MALID != 67890 {
+		t.Fatalf("expected mal id 67890, got %d", result.MALID)
+	}
+	if result.RetrievedAKA != "AKA Rei No Sakuhin" {
+		t.Fatalf("expected romaji AKA, got %q", result.RetrievedAKA)
+	}
+}

--- a/internal/metadata/tmdb/types.go
+++ b/internal/metadata/tmdb/types.go
@@ -284,7 +284,7 @@ type AnimeResult struct {
 	Romaji      string
 	MALID       int
 	English     string
-	SeasonYear  string
+	SeasonYear  int
 	Episodes    int
 	Demographic string
 }


### PR DESCRIPTION
AniList enrichment has been fully broken: no anime upload has ever received a romaji AKA or a MAL ID from a title lookup. Two independent bugs each break it on their own.

### The context is dead before AniList is ever called

`FetchMetadata` does:

```go
requestCtx := ctx
group, ctx := errgroup.WithContext(ctx)   // shadows ctx
...
_ = group.Wait()                          // <- cancels the shadowed ctx
```

`errgroup` cancels its derived context once `Wait` returns, and every closure returns `nil`, so cancellation lands exactly at `Wait`. `ResolveAnime` then ran on that cancelled context and every AniList request died with `context canceled` before it left the process.

`requestCtx` already existed for precisely this reason and was already used by the German-title fallback a few lines above; `ResolveAnime` simply missed it. Switched to `requestCtx`.

### `seasonYear` is an Int, not a String

`anilistQuery` selects `seasonYear`, which AniList types as `Int`. `anilistMedia.SeasonYear` was declared `string`, so decoding a matched result failed with:

```
json: cannot unmarshal number into Go struct field ...seasonYear of type string
```

`doAniListSearch` treats that as a hard failure and the error is not retryable, so the search bailed. Verified against the live API — `https://graphql.anilist.co` returns `"seasonYear": 1998` unquoted. Changed `anilistMedia.SeasonYear` and `AnimeResult.SeasonYear` to `int`.

This also explains why no test caught it: the fixture in `anilist_test.go` had `"seasonYear":"2024"` **quoted**, encoding the bug into the test data. Corrected to a number.

### Also

- AniList search failures were swallowed silently; they now log a warning naming the term.
- `Client.anilistURL` replaces the package-level const at the two call sites, so the endpoint can be pointed at a test server. `NewClient` still defaults it to the real URL.

### Tests

`TestFetchMetadataResolvesAnimeAKA` drives the real `FetchMetadata` path (nested errgroup and all) against an httptest AniList server and asserts both that AniList was actually queried and that the romaji AKA came back. It fails on `main` for either bug alone.

Follow-up work (AniList rate limiting and the missing-media contract) is tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anime metadata enrichment, including alternate titles and MyAnimeList IDs.
  * Fixed season year handling so numeric values are displayed and processed consistently.
  * Improved reliability of AniList requests and metadata retrieval after concurrent lookups.
  * Added warning visibility when anime searches fail, helping diagnose incomplete results.

* **Tests**
  * Added coverage for anime metadata resolution and alternate-title retrieval.
  * Updated retry tests for numeric season-year responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->