### PR TITLE
fix(metadata): detect bdremux and bdrip

### DIFF
--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -871,6 +871,39 @@ func TestSourceAndTypeInfersRemuxWhenReleaseTypeMissing(t *testing.T) {
 	}
 }
 
+func TestSourceAndTypeFinalizesBDRemuxAsBluRayRemux(t *testing.T) {
+	source, typeValue := sourceAndType(preparationstate.State{
+		SourcePath: "Example.Show.S01.2026.BDRemux.1080p",
+		Release:    api.ReleaseInfo{},
+	}, mediaInfoDoc{})
+
+	if source != "BluRay" {
+		t.Fatalf("expected BluRay source, got %q", source)
+	}
+	if typeValue != "REMUX" {
+		t.Fatalf("expected REMUX type, got %q", typeValue)
+	}
+}
+
+// The parser retains the rls-native "BDRiP" source spelling; media-fact
+// derivation must finalize the non-canonical value as BluRay.
+func TestSourceAndTypeFinalizesBDRipAsBluRayEncode(t *testing.T) {
+	source, typeValue := sourceAndType(preparationstate.State{
+		SourcePath: "Example.Show.S01.2026.BDRip.1080p.x265-GRP",
+		Release: api.ReleaseInfo{
+			Source: "BDRiP",
+			Type:   "ENCODE",
+		},
+	}, mediaInfoDoc{})
+
+	if source != "BluRay" {
+		t.Fatalf("expected BluRay source, got %q", source)
+	}
+	if typeValue != "ENCODE" {
+		t.Fatalf("expected ENCODE type, got %q", typeValue)
+	}
+}
+
 // Python get_type() falls back to "ENCODE" for any release that is not a disc
 // and does not match a known keyword. Verify Go does the same.
 func TestSourceAndTypeDefaultsToEncodeForUnknownRelease(t *testing.T) {

--- a/internal/metadata/naming.go
+++ b/internal/metadata/naming.go
@@ -580,6 +580,8 @@ func inferReleaseTypeFromName(path string) string {
 		return "HDTV"
 	case strings.Contains(compact, "DVDRIP"):
 		return "DVDRIP"
+	case strings.Contains(compact, "BDRIP"):
+		return "ENCODE"
 	}
 	return ""
 }
@@ -590,7 +592,8 @@ func inferReleaseSourceFromName(path string, typeValue string) string {
 	switch {
 	case strings.Contains(compact, "HDDVD"):
 		return "HDDVD"
-	case strings.Contains(compact, "BLURAY") || strings.Contains(compact, "BLU") && strings.Contains(compact, "RAY"):
+	case strings.Contains(compact, "BLURAY") || strings.Contains(compact, "BLU") && strings.Contains(compact, "RAY") ||
+		strings.Contains(compact, "BDREMUX") || strings.Contains(compact, "BDRIP") || strings.Contains(compact, "BDMV"):
 		if strings.EqualFold(typeValue, "DISC") {
 			return "Blu-ray"
 		}

--- a/internal/metadata/release.go
+++ b/internal/metadata/release.go
@@ -96,7 +96,7 @@ func parsedReleaseType(base string, source string, other []string, codec []strin
 			return "ENCODE"
 		}
 	}
-	return ""
+	return inferReleaseTypeFromName(base)
 }
 
 func parsedReleaseSource(base string, source string, typeValue string) string {

--- a/internal/metadata/release_test.go
+++ b/internal/metadata/release_test.go
@@ -70,7 +70,7 @@ func TestParseReleaseInfo(t *testing.T) {
 		},
 		{
 			name:     "glued bdrip resolves encode",
-			input:    "Show S01 2022 BDRip 1080p x265-GRP",
+			input:    "Show S01 2022 BDRip 1080p-GRP",
 			category: "TV",
 			typ:      "ENCODE",
 			source:   "BDRiP",

--- a/internal/metadata/release_test.go
+++ b/internal/metadata/release_test.go
@@ -62,6 +62,27 @@ func TestParseReleaseInfo(t *testing.T) {
 			group:    "GRP",
 		},
 		{
+			name:     "glued bdremux resolves remux and bluray",
+			input:    "Show S01 2019 BDRemux 1080p",
+			category: "TV",
+			typ:      "REMUX",
+			source:   "BluRay",
+		},
+		{
+			name:     "glued bdrip resolves encode",
+			input:    "Show S01 2022 BDRip 1080p x265-GRP",
+			category: "TV",
+			typ:      "ENCODE",
+			source:   "BDRiP",
+			group:    "GRP",
+		},
+		{
+			name:     "compact bdmv infers bluray source",
+			input:    "Example.Show.S01.2026.BDMV.1080p",
+			category: "TV",
+			source:   "BluRay",
+		},
+		{
 			name:     "webrip filename uses webrip",
 			input:    "Movie.2026.2160p.WEBRip.DDP5.1.H.265-GRP.mkv",
 			category: "MOVIE",

--- a/internal/preparedrelease/evidence_collector_test.go
+++ b/internal/preparedrelease/evidence_collector_test.go
@@ -135,6 +135,25 @@ func TestMapLegacyFactsUsesTypedConcreteAssessments(t *testing.T) {
 	}
 }
 
+func TestMapCollectedFactsPublishesFinalizedNamingSourceAndType(t *testing.T) {
+	t.Parallel()
+	facts := mapCollectedFacts(preparationstate.State{
+		SourcePath: "Example.Show.S01.2026.BDRip.1080p.x265-GRP.mkv",
+		Source:     "BluRay",
+		Type:       "ENCODE",
+		Release: api.ReleaseInfo{
+			Source: "BluRay",
+			Type:   "ENCODE",
+		},
+	})
+	if facts.Naming.Source != "BluRay" || facts.Naming.Type != "ENCODE" {
+		t.Fatalf("naming facts = %#v", facts.Naming)
+	}
+	if facts.Media.Source != "BluRay" || facts.Media.Type != "ENCODE" {
+		t.Fatalf("media facts = %#v", facts.Media)
+	}
+}
+
 func TestApplyBlurayFactInstructionSelectsCandidateBeforePublication(t *testing.T) {
 	t.Parallel()
 	meta := preparationstate.State{


### PR DESCRIPTION
`BDRemux` and `BDRip` are the naming conventions in common use across CIS release communities, where they are expected in place of the `Blu-ray REMUX` / `BluRay` spellings the rest of the world tends to prefer. Neither glued form was recognised, so releases named that way parsed with no type and no source at all.

### Type

`parsedReleaseType` returned `""` when the parsed tokens carried nothing it recognised, discarding the name entirely. It now falls back to `inferReleaseTypeFromName(base)`, which is the same name-based inference the source resolver already relied on — it just was never reachable from the type path.

`inferReleaseTypeFromName` additionally learns `BDRIP` -> `ENCODE`. `BDRemux` needs no new case: once the fallback is wired up, the existing `REMUX` token match resolves it.

### Source

`inferReleaseSourceFromName` matched `BLURAY` and the split `BLU`/`RAY` spellings, but not the glued `BD` forms. Added `BDREMUX`, `BDRIP` and `BDMV`, all of which are Blu-ray sourced.

### Result

```
Show S01 2019 BDRemux 1080p           -> type REMUX,  source BluRay
Show S01 2022 BDRip 1080p x265-GRP    -> type ENCODE, source BDRiP
```

Covered by two new cases in `TestParseReleaseInfo`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release metadata detection for Blu-ray naming patterns, including BDRip, BDRemux, and BDMV.
  - Release types are now inferred from names when other metadata signals are unavailable.
  - Correctly identifies categories, sources, types, and groups for glued Blu-ray release names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->