### PR TITLE
fix(gui): fetch metadata when the dry run finds no prepared cache

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -2268,6 +2268,16 @@ func (c *Core) FetchTrackerDryRunPreview(ctx context.Context, req api.Request) (
 				}
 			}
 		}
+		if !ok {
+			// The prepared-metadata cache is in-memory, so a restarted GUI session has
+			// none until the metadata is fetched again. Fetch it here instead of
+			// refusing the dry run: the preview populates the same cache this reads.
+			c.logger.Debugf("core: tracker dry-run fetching metadata after cache miss for %s", uniquePaths[0])
+			if _, err := c.FetchMetadataPreview(ctx, singleReq); err != nil {
+				return api.TrackerDryRunPreview{}, err
+			}
+			meta, ok = c.getDupeCache(uniquePaths[0], signature)
+		}
 	} else {
 		if !ok {
 			return api.TrackerDryRunPreview{}, fmt.Errorf("core: tracker dry-run requires prepared metadata for %s", uniquePaths[0])

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -3741,6 +3741,45 @@ func TestRunUploadPreparedDebugDryRunIgnoresCheckBlocksForArtifacts(t *testing.T
 	}
 }
 
+func TestFetchTrackerDryRunPreviewFetchesMetadataOnCacheMiss(t *testing.T) {
+	t.Parallel()
+
+	meta := &stubMeta{}
+	tracker := &stubTrackers{dryRunEntries: []api.TrackerDryRunEntry{{Tracker: "AITHER", Status: "ready"}}}
+	core, err := New(api.CoreDependencies{
+		Config: config.Config{MainSettings: config.MainSettingsConfig{TMDBAPI: "x"}, ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 1}},
+		Services: api.ServiceSet{
+			Filesystem: &stubFS{},
+			Metadata:   meta,
+			Torrents:   &stubTorrent{},
+			Clients:    &stubClient{},
+			Trackers:   tracker,
+		},
+		Repository: &stubRepo{},
+	})
+	if err != nil {
+		t.Fatalf("new core: %v", err)
+	}
+
+	preview, err := core.FetchTrackerDryRunPreview(context.Background(), api.Request{
+		Paths:    []string{"/tmp/a"},
+		Mode:     api.ModeGUI,
+		Trackers: []string{"AITHER"},
+	})
+	if err != nil {
+		t.Fatalf("fetch tracker dry-run preview: %v", err)
+	}
+	if preview.SourcePath != "/tmp/a" {
+		t.Fatalf("expected source path /tmp/a, got %q", preview.SourcePath)
+	}
+	if meta.calls != 1 {
+		t.Fatalf("expected metadata to be prepared once on cache miss, got %d calls", meta.calls)
+	}
+	if tracker.dryRunCalls != 1 {
+		t.Fatalf("expected 1 dry-run build call, got %d", tracker.dryRunCalls)
+	}
+}
+
 func TestFetchTrackerDryRunPreviewNoSeedSkipsClient(t *testing.T) {
 	t.Parallel()
 
@@ -3968,7 +4007,7 @@ func TestFetchTrackerDryRunPreviewRequiresCachedMetadata(t *testing.T) {
 
 	_, err = core.FetchTrackerDryRunPreview(context.Background(), api.Request{
 		Paths: []string{"/tmp/a"},
-		Mode:  api.ModeGUI,
+		Mode:  api.ModeCLI,
 	})
 	assertRequiresPreparedMetadata(t, err, "/tmp/a")
 }


### PR DESCRIPTION
The prepared-metadata cache lives in memory, so a restarted GUI session starts with an empty one. `FetchTrackerDryRunPreview` treated a cache miss as fatal and refused the dry run outright, and the only way out was for the user to go and re-run the metadata fetch by hand before the button would work again — with nothing on screen explaining why.

The preparation preview already handles exactly this case: on a miss it fetches. The dry run now does the same, calling `FetchMetadataPreview` and re-reading the cache that call populates.

Scoped deliberately to the GUI path. The `else` branch — every caller outside the GUI — still hard-fails on a missing prepared metadata, because those callers are expected to have prepared it themselves and a silent fetch there would mask a real sequencing bug.

Covered by a new case in `internal/core/core_test.go`.