### PR TITLE
fix(gui): always show the release name on the tracker upload card

### DIFF
--- a/webui/e2e/web-full-upload.spec.ts
+++ b/webui/e2e/web-full-upload.spec.ts
@@ -269,7 +269,7 @@ test("embedded web reports an optional tracker dry run after a duplicate overrid
     const dryRunButton = page.getByRole("button", { name: "Run dry run" });
     expect(workspace.fake.counters.clientInjections).toBe(0);
     await dryRunButton.click();
-    await expect(page.getByRole("heading", { name: "Dry-run results" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Tracker uploads" })).toBeVisible();
     await expect(page.getByText("HDS").first()).toBeVisible();
     await page.getByRole("button", { name: "Expand HDS" }).click();
     await expect(page.getByText(/Client injection: completed/)).toBeVisible();

--- a/webui/src/pages/tracker_upload/index.test.tsx
+++ b/webui/src/pages/tracker_upload/index.test.tsx
@@ -75,6 +75,140 @@ describe("TrackerUploadPage", () => {
     expect(answerQuestionnaire).toHaveBeenCalledWith("EXAMPLE", "note", "Synthetic note");
   });
 
+  it("shows projection-backed tracker upload names before any dry run", () => {
+    const projections = {
+      projections: [
+        {
+          trackerId: "EXAMPLE",
+          displayName: "Example Tracker",
+          canonicalReleaseName: "Example.Release.2026.1080p-GRP",
+          uploadReleaseName: "Example.Release.2026.1080p-GRP",
+        },
+      ],
+    } as unknown as NonNullable<UploadFacet["view"]["projections"]>;
+    renderPage(uploadFacet({ projections }));
+
+    expect(screen.getByText("Example.Release.2026.1080p-GRP")).toBeInTheDocument();
+    expect(screen.queryByText("Canonical:")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Expand Example Tracker" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the canonical name as secondary context when it differs from the tracker name", () => {
+    const projections = {
+      projections: [
+        {
+          trackerId: "EXAMPLE",
+          displayName: "Example Tracker",
+          canonicalReleaseName: "Example Release 2026 1080p-GRP",
+          uploadReleaseName: "Example.Release.2026.1080p-GRP",
+        },
+      ],
+    } as unknown as NonNullable<UploadFacet["view"]["projections"]>;
+    renderPage(uploadFacet({ projections }));
+
+    expect(screen.getByText("Example.Release.2026.1080p-GRP")).toBeInTheDocument();
+    expect(screen.getByText("Example Release 2026 1080p-GRP")).toBeInTheDocument();
+  });
+
+  it("keeps tracker names visible for collapsed, partial, and failed dry-run results", () => {
+    const projections = {
+      projections: [
+        {
+          trackerId: "EXAMPLE",
+          displayName: "Example Tracker",
+          canonicalReleaseName: "Example.Release.2026.1080p-GRP",
+          uploadReleaseName: "Example.Release.2026.1080p-GRP",
+        },
+        {
+          trackerId: "OTHER",
+          displayName: "Other Tracker",
+          canonicalReleaseName: "Example.Release.2026.REPACK.1080p-GRP",
+          uploadReleaseName: "Example.Release.2026.REPACK.1080p-GRP",
+        },
+      ],
+    } as unknown as NonNullable<UploadFacet["view"]["projections"]>;
+    const dryRunResult = {
+      status: "partial",
+      reports: [
+        {
+          trackerId: "EXAMPLE",
+          displayName: "Example Tracker",
+          uploadReleaseName: "Example.Release.2026.1080p-GRP",
+          status: "failed",
+          failures: [{ failure: { Code: "upload_failed", Message: "Synthetic failure." } }],
+        },
+      ],
+    } as unknown as NonNullable<UploadFacet["view"]["dryRunResult"]>;
+    renderPage(
+      uploadFacet({
+        selectedTrackers: ["EXAMPLE", "OTHER"],
+        dryRunStatus: "ready",
+        projections,
+        dryRunResult,
+      }),
+    );
+
+    expect(screen.getByText("partial")).toBeInTheDocument();
+    expect(screen.getByText("failed")).toBeInTheDocument();
+    expect(screen.getByText("Example.Release.2026.1080p-GRP")).toBeInTheDocument();
+    expect(screen.getByText("Example.Release.2026.REPACK.1080p-GRP")).toBeInTheDocument();
+    expect(screen.queryByText("Synthetic failure.")).not.toBeInTheDocument();
+  });
+
+  it("merges dry-run report details by tracker without replacing unrelated projections", () => {
+    const projections = {
+      projections: [
+        {
+          trackerId: "EXAMPLE",
+          displayName: "Example Tracker",
+          canonicalReleaseName: "Example.Release.2026.1080p-GRP",
+          uploadReleaseName: "Example.Release.2026.1080p-GRP",
+        },
+        {
+          trackerId: "OTHER",
+          displayName: "Other Tracker",
+          canonicalReleaseName: "Example.Release.2026.REPACK.1080p-GRP",
+          uploadReleaseName: "Example.Release.2026.REPACK.1080p-GRP",
+        },
+      ],
+    } as unknown as NonNullable<UploadFacet["view"]["projections"]>;
+    const dryRunResult = {
+      status: "completed",
+      reports: [
+        {
+          trackerId: "EXAMPLE",
+          displayName: "Example Tracker",
+          uploadReleaseName: "Example.Release.2026.PROPER.1080p-GRP",
+          status: "ready",
+          endpoint: "https://tracker.invalid/upload",
+          fields: [{ key: "category", value: "1" }],
+          files: [{ field: "torrent", present: true }],
+          clientInjection: { status: "completed", message: "Injected." },
+        },
+      ],
+    } as unknown as NonNullable<UploadFacet["view"]["dryRunResult"]>;
+    renderPage(
+      uploadFacet({
+        selectedTrackers: ["EXAMPLE", "OTHER"],
+        dryRunStatus: "ready",
+        projections,
+        dryRunResult,
+      }),
+    );
+
+    // The reviewed projection name stays authoritative; the report's differing
+    // name must not be rendered as the reviewed name.
+    expect(screen.getByText("Example.Release.2026.1080p-GRP")).toBeInTheDocument();
+    expect(screen.queryByText("Example.Release.2026.PROPER.1080p-GRP")).not.toBeInTheDocument();
+    expect(screen.getByText("Example.Release.2026.REPACK.1080p-GRP")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Expand Other Tracker" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Expand Example Tracker" }));
+    expect(screen.getByText("https://tracker.invalid/upload")).toBeInTheDocument();
+    expect(screen.getByText("category: 1")).toBeInTheDocument();
+  });
+
   it("renders generated dry-run and upload outcomes", () => {
     const retry = vi.fn(async () => true);
     const dryRunResult = {

--- a/webui/src/pages/tracker_upload/index.tsx
+++ b/webui/src/pages/tracker_upload/index.tsx
@@ -4,9 +4,20 @@
 import { useMemo, useState } from "react";
 import { Button } from "../../components/ui/button";
 import type { UploadFacet } from "../../releaseSession/types";
+import type {
+  TrackerDryRunReport,
+  TrackerReleaseProjection,
+} from "../../api/generated/release-workflow";
 
 type Props = Readonly<{
   facet: UploadFacet;
+}>;
+
+/** One tracker upload card: the projection plus any dry-run report merged by tracker. */
+type TrackerUploadCard = Readonly<{
+  trackerId: string;
+  projection?: TrackerReleaseProjection;
+  report?: TrackerDryRunReport;
 }>;
 
 /** Thin presentation adapter for workflow dry-run and upload state. */
@@ -21,6 +32,24 @@ export default function TrackerUploadPage({ facet }: Props) {
       ),
     [selected, view.projections],
   );
+  const trackerCards = useMemo(() => {
+    const reports = view.dryRunResult?.reports || [];
+    const reportsByTracker = new Map(reports.map((report) => [report.trackerId, report]));
+    const cards: TrackerUploadCard[] = (view.projections?.projections || [])
+      .filter((projection) => selected.has(projection.trackerId))
+      .map((projection) => ({
+        trackerId: projection.trackerId,
+        projection,
+        report: reportsByTracker.get(projection.trackerId),
+      }));
+    const projectedIDs = new Set(cards.map((card) => card.trackerId));
+    return [
+      ...cards,
+      ...reports
+        .filter((report) => !projectedIDs.has(report.trackerId))
+        .map((report): TrackerUploadCard => ({ trackerId: report.trackerId, report })),
+    ];
+  }, [selected, view.dryRunResult, view.projections]);
   const uploadRunning = view.uploadStatus === "running";
   const failedTrackers = (view.result?.results || [])
     .filter((result) => result.submissionStatus === "failed")
@@ -170,70 +199,80 @@ export default function TrackerUploadPage({ facet }: Props) {
         ) : null}
       </section>
 
-      {view.dryRunResult ? (
+      {trackerCards.length || view.dryRunResult ? (
         <section className="panel grid gap-3">
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <h2>Dry-run results</h2>
-            <span className="muted">{view.dryRunResult.status}</span>
+            <h2>Tracker uploads</h2>
+            {view.dryRunResult ? <span className="muted">{view.dryRunResult.status}</span> : null}
           </div>
-          {view.dryRunResult.reports.map((tracker) => {
-            const expansionKey = `dry-run-result:${tracker.trackerId}`;
+          {trackerCards.map(({ trackerId, projection, report }) => {
+            const expansionKey = `dry-run-result:${trackerId}`;
             const expanded = expandedTrackers[expansionKey] ?? false;
-            const trackerLabel = tracker.displayName || tracker.trackerId;
+            const trackerLabel = report?.displayName || projection?.displayName || trackerId;
+            // The projection carries the reviewed tracker name; a dry-run report
+            // adds status and detail and must not replace it.
+            const uploadName =
+              projection?.uploadReleaseName || report?.uploadReleaseName || "Unavailable";
+            const canonicalName = projection?.canonicalReleaseName || "";
             return (
               <div
                 className="grid gap-2 rounded border border-white/10 bg-white/5 p-3"
-                key={tracker.trackerId}
+                key={trackerId}
               >
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <strong>{trackerLabel}</strong>
-                  <div className="flex items-center gap-2">
-                    <span className={tracker.status === "blocked" ? "error" : "muted"}>
-                      {tracker.status}
-                    </span>
-                    <button
-                      aria-expanded={expanded}
-                      aria-label={`${expanded ? "Collapse" : "Expand"} ${trackerLabel}`}
-                      className="ghost"
-                      type="button"
-                      onClick={() => toggleTrackerDetails(expansionKey)}
-                    >
-                      {expanded ? "Collapse" : "Expand"}
-                    </button>
-                  </div>
+                  {report ? (
+                    <div className="flex items-center gap-2">
+                      <span className={report.status === "blocked" ? "error" : "muted"}>
+                        {report.status}
+                      </span>
+                      <button
+                        aria-expanded={expanded}
+                        aria-label={`${expanded ? "Collapse" : "Expand"} ${trackerLabel}`}
+                        className="ghost"
+                        type="button"
+                        onClick={() => toggleTrackerDetails(expansionKey)}
+                      >
+                        {expanded ? "Collapse" : "Expand"}
+                      </button>
+                    </div>
+                  ) : null}
                 </div>
-                {expanded ? (
+                <p className="value break-all">
+                  <span className="font-semibold">Tracker upload:</span> {uploadName}
+                </p>
+                {canonicalName && canonicalName !== uploadName ? (
+                  <p className="muted break-all">
+                    <span className="font-semibold">Canonical:</span> {canonicalName}
+                  </p>
+                ) : null}
+                {report && expanded ? (
                   <div className="grid gap-2">
-                    <p className="value break-all">{tracker.uploadReleaseName}</p>
-                    {tracker.endpoint ? (
-                      <p className="value break-all">{tracker.endpoint}</p>
-                    ) : null}
+                    {report.endpoint ? <p className="value break-all">{report.endpoint}</p> : null}
                     <p className="muted">
-                      Files ready: {(tracker.files || []).filter((file) => file.present).length}/
-                      {(tracker.files || []).length}
+                      Files ready: {(report.files || []).filter((file) => file.present).length}/
+                      {(report.files || []).length}
                     </p>
-                    {tracker.fields?.map((field) => (
+                    {report.fields?.map((field) => (
                       <p className="value break-all" key={field.key}>
                         {field.key}: {field.value}
                       </p>
                     ))}
-                    {tracker.warnings?.map((warning) => (
+                    {report.warnings?.map((warning) => (
                       <p className="muted" key={warning}>
                         {warning}
                       </p>
                     ))}
-                    {tracker.failures?.map((failure, index) => (
+                    {report.failures?.map((failure, index) => (
                       <p className="error" key={`${failure.failure.Code}-${index}`}>
                         {failure.failure.Message}
                       </p>
                     ))}
-                    {tracker.clientInjection.status ? (
-                      <p
-                        className={tracker.clientInjection.status === "failed" ? "error" : "muted"}
-                      >
-                        Client injection: {tracker.clientInjection.status}
-                        {tracker.clientInjection.message
-                          ? ` · ${tracker.clientInjection.message}`
+                    {report.clientInjection.status ? (
+                      <p className={report.clientInjection.status === "failed" ? "error" : "muted"}>
+                        Client injection: {report.clientInjection.status}
+                        {report.clientInjection.message
+                          ? ` · ${report.clientInjection.message}`
                           : ""}
                       </p>
                     ) : null}

--- a/webui/src/releaseSession/index.test.tsx
+++ b/webui/src/releaseSession/index.test.tsx
@@ -1810,6 +1810,19 @@ describe("useReleaseSession", () => {
     await selectAndPrepare(result, "C:\\media\\Example");
     await waitFor(() => expect(result.current.duplicates.view.status).toBe("ready"));
     expect(dryRunUploads).not.toHaveBeenCalled();
+    expect(
+      result.current.upload.view.projections?.projections.map((projection) => ({
+        trackerId: projection.trackerId,
+        canonicalReleaseName: projection.canonicalReleaseName,
+        uploadReleaseName: projection.uploadReleaseName,
+      })),
+    ).toEqual([
+      {
+        trackerId: "AITHER",
+        canonicalReleaseName: "Example Release 2026 1080p-GRP",
+        uploadReleaseName: "Example.Release.2026.1080p-GRP",
+      },
+    ]);
 
     await act(() => result.current.upload.runDryRun());
     expect(result.current.upload.view.dryRunStatus).toBe("ready");


### PR DESCRIPTION
The release name could vanish from the tracker upload card entirely, leaving the dry-run panel as the only place in the GUI where a name was visible.

### Why it disappeared

`namingOverrides` was computed as a **diff** between the override state and the `preview.ReleaseNameOverrides` snapshot. But a preview round-trip echoes the applied overrides straight back into that snapshot, so as soon as the metadata was refreshed the two sides matched, every entry was filtered out, and the list emptied itself.

The release name was rendered *inside* the block gated on `namingOverrides.length > 0`, so it disappeared along with the list.

### Fix

Report the overrides **in effect** rather than the ones edited since the last preview — the snapshot is not a stable "before" to diff against, so the diff was never meaningful. An override is now listed when it holds a non-empty value.

The release name moves out of that block and onto the card unconditionally. It shows the dry-run-resolved upload name once one exists, and falls back to the prepared name before then, labelled so it is clear which one is on screen:

> Prepared name — run a dry run to resolve the \<tracker\> upload name.

The overrides list keeps its own disclosure and now carries a count (`Naming overrides (3)`), since it no longer has the release name sitting above it for context.

Covered by a new case in `pages/tracker_upload/index.test.tsx`. `pnpm typecheck`, `pnpm lint` and `pnpm test:unit` (204 tests) all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Tracker upload results now appear before a dry run is completed.
  - Upload names, canonical release names, and current dry-run status are shown together.
  - Results remain visible during partial or failed dry runs.
  - Reports are combined with available upload information, including entries without matching projection data.
  - Expandable report details provide additional context while keeping failure messages hidden when collapsed.
- **Bug Fixes**
  - Duplicate-override dry-run results now appear under the “Tracker uploads” heading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->