### PR TITLE
fix(screenshots): keep deleted captures regenerable

### DIFF
--- a/internal/core/workflow_media.go
+++ b/internal/core/workflow_media.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
-	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/releaseworkflow"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -265,9 +264,6 @@ func (a workflowMediaPrivateArtifacts) Commit(ctx context.Context) error {
 				return errors.New("workflow DVD menu deletion service is unavailable")
 			}
 			err = a.dvdMenuService.Delete(ctx, a.dvdMenuSubject, deletion.path)
-			if errors.Is(err, internalerrors.ErrNotFound) {
-				err = nil
-			}
 		case api.MediaArtifactHostedImage:
 			if a.hostedRepository == nil {
 				return errors.New("workflow hosted-image repository is unavailable")

--- a/internal/core/workflow_media.go
+++ b/internal/core/workflow_media.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/releaseworkflow"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -264,6 +265,9 @@ func (a workflowMediaPrivateArtifacts) Commit(ctx context.Context) error {
 				return errors.New("workflow DVD menu deletion service is unavailable")
 			}
 			err = a.dvdMenuService.Delete(ctx, a.dvdMenuSubject, deletion.path)
+			if errors.Is(err, internalerrors.ErrNotFound) {
+				err = nil
+			}
 		case api.MediaArtifactHostedImage:
 			if a.hostedRepository == nil {
 				return errors.New("workflow hosted-image repository is unavailable")

--- a/internal/core/workflow_media_test.go
+++ b/internal/core/workflow_media_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -96,11 +97,12 @@ func (*workflowScreenshotFake) SaveFinalSelections(context.Context, api.Screensh
 }
 
 type workflowDVDMenuFake struct {
-	captures int
-	deleted  []string
-	maxItems []int
-	result   *api.DVDMenuCaptureResult
-	err      error
+	captures  int
+	deleted   []string
+	maxItems  []int
+	result    *api.DVDMenuCaptureResult
+	err       error
+	deleteErr error
 }
 
 func (f *workflowDVDMenuFake) Capture(
@@ -134,6 +136,9 @@ func (*workflowDVDMenuFake) List(context.Context, api.DVDMenuSubject) ([]api.Scr
 }
 
 func (f *workflowDVDMenuFake) Delete(_ context.Context, _ api.DVDMenuSubject, path string) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
 	f.deleted = append(f.deleted, path)
 	return nil
 }
@@ -719,5 +724,43 @@ func TestWorkflowMediaPrivateResourceDeletesThroughManagedServices(t *testing.T)
 	}
 	if len(screenshots.deleted) != 1 || screenshots.deleted[0] != "C:\\private\\screen.png" || len(dvdMenus.deleted) != 0 {
 		t.Fatalf("service deletions screenshots=%v menus=%v", screenshots.deleted, dvdMenus.deleted)
+	}
+}
+
+// TestWorkflowMediaCommitPropagatesMenuDeletionFailure keeps menu-deletion
+// idempotency inside the menu service. The workflow cannot tell an already-absent
+// image from one whose cleanup failed and left local state behind, so it treats
+// every error as unfinished work and keeps the deletion pending for a retry.
+func TestWorkflowMediaCommitPropagatesMenuDeletionFailure(t *testing.T) {
+	t.Parallel()
+
+	menuPath := "C:\\private\\menu.png"
+	dvdMenus := &workflowDVDMenuFake{
+		deleteErr: fmt.Errorf("DVD menus: delete records: %w", internalerrors.ErrNotFound),
+	}
+	resource := workflowMediaPrivateArtifacts{
+		DVDMenus: []api.DVDMenuCaptureImage{{
+			ScreenshotImage: api.ScreenshotImage{Path: menuPath},
+			Discovery:       api.DVDMenuDiscoveryReachable,
+		}},
+		dvdMenuService: dvdMenus,
+	}
+	snapshot := api.MediaArtifactSet{Artifacts: []api.MediaArtifact{{
+		ID:   "menu-1",
+		Kind: api.MediaArtifactDVDMenu,
+	}}}
+	retained, err := resource.DeleteArtifacts(context.Background(), snapshot, []api.PublicResourceID{"menu-1"})
+	if err != nil {
+		t.Fatalf("delete menu artifact: %v", err)
+	}
+	updated, ok := retained.(workflowMediaPrivateArtifacts)
+	if !ok {
+		t.Fatalf("retained media = %#v", retained)
+	}
+	if err := updated.Commit(context.Background()); !errors.Is(err, internalerrors.ErrNotFound) {
+		t.Fatalf("commit error = %v, want the menu service failure", err)
+	}
+	if pending := updated.pendingDeletes(); len(pending) != 1 || pending[0].path != menuPath {
+		t.Fatalf("failed menu deletion did not stay pending: %#v", pending)
 	}
 }

--- a/internal/releaseworkflow/contracts.go
+++ b/internal/releaseworkflow/contracts.go
@@ -58,9 +58,11 @@ type RetainedMediaResource interface {
 	DeleteArtifacts(context.Context, api.MediaArtifactSet, []api.PublicResourceID) (RetainedMediaResource, error)
 }
 
-// RetainedMediaCommitter finalizes staged external media mutations after the
-// workflow revision has committed. Commit must be idempotent so retries can
-// converge after a partial filesystem or repository failure.
+// RetainedMediaCommitter finalizes staged external media mutations. Local
+// artifact deletion commits before the workflow revision is saved so a failed
+// commit keeps the artifact durable and retryable; hosted-image removal
+// commits after the revision has committed. Commit must be idempotent so
+// retries can converge after a partial filesystem or repository failure.
 type RetainedMediaCommitter interface {
 	Commit(context.Context) error
 }

--- a/internal/releaseworkflow/module.go
+++ b/internal/releaseworkflow/module.go
@@ -383,8 +383,8 @@ func commandFinalizesMedia(command mutation) bool {
 // commandCommitsMediaBeforeSave selects commands whose staged local deletions
 // commit before the snapshot save: a failed commit then fails the command while
 // durable state still owns the artifact, so any retry is a fresh, valid delete.
-// Hosted-image removal stays post-save because its repository delete rejects
-// already-removed rows and cannot re-run after a failed save.
+// Hosted-image removal stays post-save because its cleanup belongs to the
+// already-committed hosted-image revision.
 func commandCommitsMediaBeforeSave(command mutation) bool {
 	switch command.(type) {
 	case DeleteMediaArtifactsCommand:

--- a/internal/releaseworkflow/module.go
+++ b/internal/releaseworkflow/module.go
@@ -338,6 +338,12 @@ func (m *Module) execute(ctx context.Context, ownerID string, command mutation) 
 		m.cleanupUncommittedResult(ownerID, state.Workflow.ID, result)
 		return CommandResult{}, fmt.Errorf("release workflow command canceled before commit: %w", err)
 	}
+	if commandCommitsMediaBeforeSave(command) {
+		if err := m.finalizeRetainedMedia(ctx, ownerID, state.Workflow.ID, result.Media, true); err != nil {
+			m.cleanupUncommittedResult(ownerID, state.Workflow.ID, result)
+			return CommandResult{}, err
+		}
+	}
 	if err := m.repository.Save(ctx, ownerID, expectedRevision, state); err != nil {
 		m.cleanupUncommittedResult(ownerID, state.Workflow.ID, result)
 		return CommandResult{}, fmt.Errorf("release workflow save: %w", err)
@@ -345,7 +351,7 @@ func (m *Module) execute(ctx context.Context, ownerID string, command mutation) 
 	if result.Media != nil {
 		m.cleanupSupersededMediaResources(ownerID, state.Workflow.ID, priorWorkflow, state.Workflow)
 	}
-	if commandFinalizesMedia(command) {
+	if commandFinalizesMedia(command) && !commandCommitsMediaBeforeSave(command) {
 		if err := m.finalizeRetainedMedia(ctx, ownerID, state.Workflow.ID, result.Media, true); err != nil {
 			return CommandResult{}, err
 		}
@@ -368,6 +374,20 @@ func (m *Module) cleanupUncommittedResult(ownerID string, workflowID api.Workflo
 func commandFinalizesMedia(command mutation) bool {
 	switch command.(type) {
 	case DeleteMediaArtifactsCommand, RemoveHostedImagesCommand:
+		return true
+	default:
+		return false
+	}
+}
+
+// commandCommitsMediaBeforeSave selects commands whose staged local deletions
+// commit before the snapshot save: a failed commit then fails the command while
+// durable state still owns the artifact, so any retry is a fresh, valid delete.
+// Hosted-image removal stays post-save because its repository delete rejects
+// already-removed rows and cannot re-run after a failed save.
+func commandCommitsMediaBeforeSave(command mutation) bool {
+	switch command.(type) {
+	case DeleteMediaArtifactsCommand:
 		return true
 	default:
 		return false

--- a/internal/releaseworkflow/module_test.go
+++ b/internal/releaseworkflow/module_test.go
@@ -223,6 +223,7 @@ type retainedMediaResourceFake struct {
 type retainedMediaResourceStats struct {
 	staged    int
 	deletions int
+	commitErr error
 }
 
 func (*retainedMediaResourceFake) OpenArtifact(
@@ -246,6 +247,9 @@ func (f *retainedMediaResourceFake) DeleteArtifacts(
 }
 
 func (f *retainedMediaResourceFake) Commit(context.Context) error {
+	if f.stats.commitErr != nil {
+		return f.stats.commitErr
+	}
 	if f.pending {
 		f.stats.deletions++
 		f.pending = false
@@ -2811,24 +2815,224 @@ func TestModuleMediaMutationUsesOpaqueIDsAndInvalidatesDownstream(t *testing.T) 
 		ArtifactIDs:      []api.PublicResourceID{"artifact-1"},
 		IdempotencyKey:   "delete-artifact",
 	}
+	requireArtifactRetained := func(t *testing.T) {
+		t.Helper()
+		state, err := module.repository.Load(context.Background(), testOwnerID, mutated.Workflow.ID)
+		if err != nil {
+			t.Fatalf("load durable workflow state: %v", err)
+		}
+		if state.Workflow.Revision != mutated.Workflow.Revision || state.Workflow.Media == nil {
+			t.Fatalf("durable workflow advanced past failed delete: %#v", state.Workflow)
+		}
+		media, ok := state.Media[state.Workflow.Media.ID]
+		if !ok || len(media.Artifacts) != 1 || media.Artifacts[0].ID != "artifact-1" {
+			t.Fatalf("durable media lost the artifact after failed delete: %#v", media.Artifacts)
+		}
+	}
+	privateMedia.stats.commitErr = errors.New("synthetic media commit failure")
+	if _, err := module.Execute(context.Background(), testOwnerID, deletion); err == nil ||
+		!strings.Contains(err.Error(), "synthetic media commit failure") {
+		t.Fatalf("failed media finalization error = %v", err)
+	}
+	requireArtifactRetained(t)
+	privateMedia.stats.commitErr = nil
 	module.repository = &failOnceSaveRepository{Repository: module.repository}
 	if _, err := module.Execute(context.Background(), testOwnerID, deletion); err == nil ||
 		!strings.Contains(err.Error(), "synthetic repository save failure") {
-		t.Fatalf("failed media commit error = %v", err)
+		t.Fatalf("failed media save error = %v", err)
 	}
-	if privateMedia.stats.deletions != 0 {
-		t.Fatalf("filesystem deletion ran before repository commit: %d", privateMedia.stats.deletions)
+	if privateMedia.stats.deletions != 1 {
+		t.Fatalf("staged deletion did not commit before the snapshot save: %d", privateMedia.stats.deletions)
 	}
-	deleted := executeCommand(t, module, deletion)
-	if deleted.Media == nil || len(deleted.Media.Artifacts) != 0 || privateMedia.stats.deletions != 1 {
+	requireArtifactRetained(t)
+	retry := deletion
+	retry.IdempotencyKey = "delete-artifact-retry"
+	deleted := executeCommand(t, module, retry)
+	if deleted.Media == nil || len(deleted.Media.Artifacts) != 0 || privateMedia.stats.deletions != 2 {
 		t.Fatalf("deleted media = %#v deletions=%d", deleted.Media, privateMedia.stats.deletions)
 	}
-	if privateMedia.stats.staged != 2 {
-		t.Fatalf("staged deletion attempts = %d, want 2", privateMedia.stats.staged)
+	if privateMedia.stats.staged != 3 {
+		t.Fatalf("staged deletion attempts = %d, want 3", privateMedia.stats.staged)
 	}
-	replayed := executeCommand(t, module, deletion)
-	if replayed.Media == nil || replayed.Media.ID != deleted.Media.ID || privateMedia.stats.deletions != 1 {
+	replayed := executeCommand(t, module, retry)
+	if replayed.Media == nil || replayed.Media.ID != deleted.Media.ID || privateMedia.stats.deletions != 2 {
 		t.Fatalf("idempotent delete = %#v deletions=%d", replayed.Media, privateMedia.stats.deletions)
+	}
+}
+
+// readyDupeBuilder returns a dupe assessment builder that clears every selected
+// tracker, so tests can advance past duplicate checking to media commands.
+func readyDupeBuilder(t *testing.T) dupeAssessmentBuilderFunc {
+	t.Helper()
+	return func(
+		_ context.Context,
+		_ api.DuplicateSubject,
+		projections api.TrackerReleaseProjectionSet,
+		_ api.TrackerPreflightAssessment,
+		now time.Time,
+		_ bool,
+	) (api.DupeAssessment, any, error) {
+		results := make([]api.TrackerDupeAssessment, 0, len(projections.Projections))
+		for _, projection := range projections.Projections {
+			fingerprint, err := api.CanonicalWorkflowFingerprint(projection)
+			if err != nil {
+				return api.DupeAssessment{}, nil, fmt.Errorf("fingerprint synthetic dupe projection: %w", err)
+			}
+			results = append(results, api.TrackerDupeAssessment{
+				TrackerID:             projection.TrackerID,
+				UploadReleaseName:     projection.UploadReleaseName,
+				ProjectionFingerprint: fingerprint,
+				CriteriaFingerprint:   projection.CriteriaFingerprint,
+				Criteria:              projection.DuplicateCriteria,
+				Decision:              api.DupeDecisionNoMatch,
+				Status:                api.StageStatusCompleted,
+				CheckedAt:             now,
+				FreshUntil:            now.Add(time.Hour),
+			})
+		}
+		return api.DupeAssessment{
+			InputFingerprint: testFingerprint(t, "ready-dupes"),
+			Results:          results,
+			ExpiresAt:        now.Add(time.Hour),
+		}, struct{ Evidence string }{Evidence: "synthetic"}, nil
+	}
+}
+
+// TestReorderMediaArtifactsChangesOrderNotCaptureIndex pins the split that lets
+// callers reorder final media without disturbing capture slots: Order owns
+// display position, Index owns the capture slot, and Kind separates screenshots
+// from menu images.
+func TestReorderMediaArtifactsChangesOrderNotCaptureIndex(t *testing.T) {
+	t.Parallel()
+
+	privateMedia := &retainedMediaResourceFake{stats: &retainedMediaResourceStats{}}
+	mediaBuilder := mediaArtifactBuilderFunc(func(
+		_ context.Context,
+		_ api.ReleaseRef,
+		projections api.TrackerReleaseProjectionSet,
+		_ api.MediaCaptureInstructions,
+		_ time.Time,
+	) (api.MediaArtifactSet, any, error) {
+		requirements, err := mediaRequirementsFingerprint(projections.Projections)
+		if err != nil {
+			return api.MediaArtifactSet{}, nil, err
+		}
+		return api.MediaArtifactSet{
+			CaptureFingerprint:      testFingerprint(t, "reordered-media"),
+			RequirementsFingerprint: requirements,
+			Artifacts: []api.MediaArtifact{
+				{
+					ID:       "screen-a",
+					Kind:     api.MediaArtifactScreenshot,
+					Purpose:  api.ScreenshotPurposeFinal,
+					Index:    0,
+					Order:    0,
+					Selected: true,
+				},
+				{
+					ID:       "screen-b",
+					Kind:     api.MediaArtifactScreenshot,
+					Purpose:  api.ScreenshotPurposeFinal,
+					Index:    1,
+					Order:    1,
+					Selected: true,
+				},
+				{
+					ID:       "menu-a",
+					Kind:     api.MediaArtifactDVDMenu,
+					Purpose:  api.ScreenshotPurposeMenu,
+					Index:    0,
+					Order:    2,
+					Selected: true,
+				},
+			},
+			Status: api.StageStatusCompleted,
+		}, privateMedia, nil
+	})
+	module, _ := newTestModule(
+		t,
+		testPreparer(),
+		WithTrackerPreflightBuilder(readyPreflightBuilder(t)),
+		WithDupeAssessmentBuilder(readyDupeBuilder(t)),
+		WithMediaArtifactBuilder(mediaBuilder),
+		WithDescriptionBuilder(&descriptionBuilderFake{testing: t}),
+		WithUploadPlanBuilder(&uploadPlanBuilderFake{testing: t}),
+	)
+	result := executeCommand(t, module, CreateWorkflowCommand{WorkflowID: "workflow-media-reorder"})
+	result = executeCommand(t, module, PrepareReleaseCommand{
+		WorkflowID:       result.Workflow.ID,
+		ExpectedRevision: result.Workflow.Revision,
+		Input:            api.PrepareInput{SourcePath: "C:\\releases\\Example.Release.2026.1080p-GRP"},
+	})
+	result = executeTestPublication(t, module, trackerContextPublication{
+		WorkflowID:       result.Workflow.ID,
+		ExpectedRevision: result.Workflow.Revision,
+		Catalog:          testCatalog(t),
+		Runtime:          testRuntime(t),
+		Selection:        api.TrackerSelection{TrackerIDs: []api.TrackerID{"ALPHA", "BETA"}},
+	})
+	projectionSet := testProjectionSet(t)
+	for index := range projectionSet.Projections {
+		projectionSet.Projections[index].Artifacts.ScreenshotCount = 2
+		projectionSet.Projections[index].Artifacts.DVDMenuCount = 1
+	}
+	result = executeTestPublication(t, module, projectionSetPublication{
+		WorkflowID:       result.Workflow.ID,
+		ExpectedRevision: result.Workflow.Revision,
+		Snapshot:         projectionSet,
+	})
+	result = executeCommand(t, module, PreflightTrackersCommand{
+		WorkflowID:       result.Workflow.ID,
+		ExpectedRevision: result.Workflow.Revision,
+	})
+	result = executeCommand(t, module, CheckDuplicatesCommand{
+		WorkflowID:       result.Workflow.ID,
+		ExpectedRevision: result.Workflow.Revision,
+	})
+	result = executeCommand(t, module, CaptureMediaCommand{
+		WorkflowID:       result.Workflow.ID,
+		ExpectedRevision: result.Workflow.Revision,
+		Instructions:     api.MediaCaptureInstructions{ScreenshotCount: 2, Purpose: api.ScreenshotPurposeFinal},
+	})
+
+	reordered := executeCommand(t, module, ReorderMediaArtifactsCommand{
+		WorkflowID:       result.Workflow.ID,
+		ExpectedRevision: result.Workflow.Revision,
+		Media:            *result.Workflow.Media,
+		ArtifactIDs:      []api.PublicResourceID{"menu-a", "screen-b", "screen-a"},
+		IdempotencyKey:   "reorder-media",
+	})
+	if reordered.Media == nil || len(reordered.Media.Artifacts) != 3 {
+		t.Fatalf("reordered media = %#v", reordered.Media)
+	}
+	wantOrder := map[api.PublicResourceID]int{
+		"menu-a":   0,
+		"screen-b": 1,
+		"screen-a": 2,
+	}
+	wantIndex := map[api.PublicResourceID]int{
+		"screen-a": 0,
+		"screen-b": 1,
+		"menu-a":   0,
+	}
+	wantKind := map[api.PublicResourceID]api.MediaArtifactKind{
+		"screen-a": api.MediaArtifactScreenshot,
+		"screen-b": api.MediaArtifactScreenshot,
+		"menu-a":   api.MediaArtifactDVDMenu,
+	}
+	for _, artifact := range reordered.Media.Artifacts {
+		if artifact.Order != wantOrder[artifact.ID] {
+			t.Fatalf("artifact %q order = %d, want %d", artifact.ID, artifact.Order, wantOrder[artifact.ID])
+		}
+		if artifact.Index != wantIndex[artifact.ID] {
+			t.Fatalf("reorder moved the capture slot: artifact %q index = %d, want %d", artifact.ID, artifact.Index, wantIndex[artifact.ID])
+		}
+		if artifact.Kind != wantKind[artifact.ID] {
+			t.Fatalf("artifact %q kind = %q, want %q", artifact.ID, artifact.Kind, wantKind[artifact.ID])
+		}
+	}
+	if privateMedia.stats.staged != 0 || privateMedia.stats.deletions != 0 {
+		t.Fatalf("reorder touched private media: %#v", privateMedia.stats)
 	}
 }
 

--- a/internal/services/db/screenshot_lifecycle_test.go
+++ b/internal/services/db/screenshot_lifecycle_test.go
@@ -292,6 +292,47 @@ func TestAppendManualMenuScreenshotsRollsBackCrossSourceImageConflict(t *testing
 	}
 }
 
+func TestDeleteUploadedImageConvergesAfterRecordIsGone(t *testing.T) {
+	t.Parallel()
+
+	repo, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	ctx := context.Background()
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "Example.Release.2026.1080p-GRP.mkv")
+	imagePath := filepath.Join(root, "capture.png")
+	if err := repo.SaveUploadedImages(ctx, sourcePath, "example-host", []api.UploadedImageLink{{
+		SourcePath: sourcePath,
+		ImagePath:  imagePath,
+		Host:       "example-host",
+		UsageScope: "global",
+		RawURL:     "https://example.invalid/capture.png",
+		UploadedAt: time.Now().UTC(),
+	}}); err != nil {
+		t.Fatalf("save uploaded image: %v", err)
+	}
+
+	for range 2 {
+		if err := repo.DeleteUploadedImage(ctx, sourcePath, imagePath, "example-host"); err != nil {
+			t.Fatalf("delete uploaded image: %v", err)
+		}
+	}
+	stored, err := repo.ListUploadedImagesByPath(ctx, sourcePath)
+	if err != nil {
+		t.Fatalf("list uploaded images: %v", err)
+	}
+	if len(stored) != 0 {
+		t.Fatal("uploaded image record survived delete")
+	}
+}
+
 func assertFinalSelectionPaths(t *testing.T, repo *SQLiteRepository, sourcePath string, expected []string) {
 	t.Helper()
 	selections, err := repo.ListFinalSelections(context.Background(), sourcePath)

--- a/internal/services/db/sqlite.go
+++ b/internal/services/db/sqlite.go
@@ -3288,7 +3288,8 @@ func (r *SQLiteRepository) ListUploadedImagesByPath(ctx context.Context, path st
 }
 
 // DeleteUploadedImage deletes every usage-scope record matching path,
-// imagePath, and host. It returns an error when no record matched.
+// imagePath, and host. Repeated deletion succeeds once no matching record
+// remains so retained workflow cleanup can safely replay after restart.
 func (r *SQLiteRepository) DeleteUploadedImage(ctx context.Context, path string, imagePath string, host string) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
@@ -3305,19 +3306,12 @@ func (r *SQLiteRepository) DeleteUploadedImage(ctx context.Context, path string,
 	if trimmedHost == "" {
 		return internalerrors.ErrInvalidInput
 	}
-	result, err := r.execWrite(ctx, "delete uploaded image", `
+	_, err := r.execWrite(ctx, "delete uploaded image", `
 		DELETE FROM uploaded_images
 		WHERE source_path = ? AND host = ? AND image_path = ?
 	`, trimmedPath, trimmedHost, trimmedImagePath)
 	if err != nil {
 		return fmt.Errorf("db delete uploaded image: %w", err)
-	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("db delete uploaded image: rows affected: %w", err)
-	}
-	if rows == 0 {
-		return fmt.Errorf("db delete uploaded image: no image found at path %q for host %q", trimmedImagePath, trimmedHost)
 	}
 	return nil
 }

--- a/internal/services/dvdmenus/service.go
+++ b/internal/services/dvdmenus/service.go
@@ -364,7 +364,9 @@ func (s *Service) List(ctx context.Context, meta api.DVDMenuSubject) ([]api.Scre
 // directory and atomically deletes its local DB references. Remote image-host
 // assets are not deleted. If final removal of the staged file fails, Delete
 // attempts to restore the original file and its local records before returning;
-// compensation failures are joined with the removal error.
+// compensation failures are joined with the removal error. A repeated delete
+// whose file and records are both already gone succeeds so retries converge;
+// every other outcome that left local state behind is reported as an error.
 func (s *Service) Delete(ctx context.Context, meta api.DVDMenuSubject, imagePath string) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("DVD menus: delete canceled: %w", err)
@@ -405,6 +407,12 @@ func (s *Service) Delete(ctx context.Context, meta api.DVDMenuSubject, imagePath
 			if restoreErr := os.Rename(pendingPath, trimmedPath); restoreErr != nil {
 				return fmt.Errorf("DVD menus: delete records and restore local image: %w", errors.Join(err, restoreErr))
 			}
+		} else if errors.Is(err, internalerrors.ErrNotFound) {
+			// Neither the file nor its records exist, so a repeated delete has
+			// nothing left to remove and reports the end state it asked for. Any
+			// other not-found error still has local state to answer for.
+			s.logger.Debugf("DVD menus: image already absent source=%s", meta.SourcePath)
+			return nil
 		}
 		return fmt.Errorf("DVD menus: delete records: %w", err)
 	}

--- a/internal/services/dvdmenus/service_test.go
+++ b/internal/services/dvdmenus/service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/autobrr/upbrr/internal/dvdvideo/engine"
 	"github.com/autobrr/upbrr/internal/dvdvideo/graph"
 	"github.com/autobrr/upbrr/internal/dvdvideo/render"
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	paths "github.com/autobrr/upbrr/internal/pathing/layout"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
@@ -464,6 +465,81 @@ func TestDeleteRestoresFileAndRecordsWhenFinalRemoveFails(t *testing.T) {
 	}
 }
 
+// TestDeleteConvergesOnlyWhenFileAndRecordAreBothGone pins where menu deletion
+// decides idempotency. A repeat with nothing left to remove succeeds, while a
+// missing record whose file is still present stays an error so the caller keeps
+// owning the artifact instead of dropping it over a surviving file.
+func TestDeleteConvergesOnlyWhenFileAndRecordAreBothGone(t *testing.T) {
+	t.Parallel()
+
+	tmpRoot := t.TempDir()
+	discRoot := t.TempDir()
+	meta := api.DVDMenuSubject{SourcePath: discRoot, DiscType: "DVD"}
+	managedDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, api.ReleaseInfo{})
+	if err != nil {
+		t.Fatal("create managed directory failed")
+	}
+	imagePath := filepath.Join(managedDir, "Example.Release.2026-dvd-menu-01.png")
+	service := NewService(api.NopLogger{}, tmpRoot, openTestRepository(t))
+
+	if err := service.Delete(context.Background(), meta, imagePath); err != nil {
+		t.Fatalf("repeated delete of an absent menu image: %v", err)
+	}
+	if _, err := os.Stat(imagePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("absent menu image reappeared: %v", err)
+	}
+
+	writePNG(t, imagePath, color.NRGBA{
+		R: 20,
+		G: 40,
+		B: 60,
+		A: 255,
+	})
+	if err := service.Delete(context.Background(), meta, imagePath); !errors.Is(err, internalerrors.ErrNotFound) {
+		t.Fatalf("delete error = %v, want not found", err)
+	}
+	if _, err := os.Stat(imagePath); err != nil {
+		t.Fatalf("menu image without a record was not restored: %v", err)
+	}
+	pending, err := filepath.Glob(imagePath + ".delete-*")
+	if err != nil || len(pending) != 0 {
+		t.Fatalf("failed delete left a staged image behind: %v %#v", err, pending)
+	}
+}
+
+// TestDeleteFailsWhenMissingRecordAlsoFailsRestore keeps a joined not-found and
+// restore failure an error. Local state did not converge there, so reporting
+// success would drop the artifact while its staged file survives.
+func TestDeleteFailsWhenMissingRecordAlsoFailsRestore(t *testing.T) {
+	t.Parallel()
+
+	tmpRoot := t.TempDir()
+	discRoot := t.TempDir()
+	meta := api.DVDMenuSubject{SourcePath: discRoot, DiscType: "DVD"}
+	managedDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, api.ReleaseInfo{})
+	if err != nil {
+		t.Fatal("create managed directory failed")
+	}
+	imagePath := filepath.Join(managedDir, "Example.Release.2026-dvd-menu-01.png")
+	writePNG(t, imagePath, color.NRGBA{
+		R: 20,
+		G: 40,
+		B: 60,
+		A: 255,
+	})
+	repo := &restoreBlockingRepository{SQLiteRepository: openTestRepository(t)}
+	service := NewService(api.NopLogger{}, tmpRoot, repo)
+
+	err = service.Delete(context.Background(), meta, imagePath)
+	if !errors.Is(err, internalerrors.ErrNotFound) || !strings.Contains(err.Error(), "restore local image") {
+		t.Fatalf("delete error = %v, want joined not-found and restore failure", err)
+	}
+	staged, err := filepath.Glob(imagePath + ".delete-*")
+	if err != nil || len(staged) != 1 {
+		t.Fatalf("staged image after failed restore = %v %#v", err, staged)
+	}
+}
+
 func TestCapabilityCacheInvalidatesWhenExecutableIdentityChanges(t *testing.T) {
 	t.Parallel()
 
@@ -509,6 +585,23 @@ func TestMissingFFmpegOptionsReturnsEveryReportedOption(t *testing.T) {
 
 type failingCaptureRepository struct {
 	*db.SQLiteRepository
+}
+
+// restoreBlockingRepository occupies the original image path before reporting a
+// missing menu record, so the service's compensating restore cannot succeed.
+type restoreBlockingRepository struct {
+	*db.SQLiteRepository
+}
+
+func (*restoreBlockingRepository) DeleteDiscMenuScreenshot(
+	_ context.Context,
+	_ string,
+	imagePath string,
+) (api.DiscMenuDeleteResult, error) {
+	if err := os.MkdirAll(imagePath, 0o700); err != nil {
+		return api.DiscMenuDeleteResult{}, fmt.Errorf("occupy the original image path: %w", err)
+	}
+	return api.DiscMenuDeleteResult{}, internalerrors.ErrNotFound
 }
 
 func (r *failingCaptureRepository) ReplaceDVDMenuScreenshots(context.Context, string, []api.Screenshot, []api.ScreenshotFinalSelection) ([]string, error) {

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -6,6 +6,7 @@ package screenshots
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	_ "image/png" // register PNG decoder for screenshot metadata loading
@@ -32,6 +33,10 @@ import (
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
+
+// sqliteBusyAttempts bounds how often a repository call is retried while SQLite
+// reports the database busy or locked.
+const sqliteBusyAttempts = 3
 
 // Service plans, captures, previews, persists, and removes release screenshots
 // beneath a managed temporary root.
@@ -643,12 +648,14 @@ func (s *Service) PreviewFrame(ctx context.Context, meta api.ScreenshotSubject, 
 	return preview, nil
 }
 
-// Delete removes an allowed image beneath the release's managed temp directory.
-// Repository screenshot, upload, final-selection, and tracker-image references
-// are then cleaned up best-effort; those cleanup failures are logged and do not
-// restore the local file or fail the call. Cleanup covers every stored spelling
-// that names the removed file, so an accepted filesystem alias cannot delete the
-// file while leaving its records behind.
+// Delete removes an allowed image beneath the release's managed temp directory,
+// then cleans up its repository screenshot, upload, final-selection, and
+// tracker-image references. Cleanup covers every stored spelling that names the
+// removed file, so an accepted filesystem alias cannot delete the file while
+// leaving its records behind. Cleanup failures do not restore the local file,
+// but they are reported: a caller must be able to tell a complete delete from
+// one that left records behind, and calling Delete again converges because an
+// already-missing file is not an error.
 func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imagePath string) error {
 	select {
 	case <-ctx.Done():
@@ -688,7 +695,11 @@ func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imageP
 		return internalerrors.ErrInvalidInput
 	}
 
-	deleteTargets := s.storedDeleteTargets(ctx, meta.SourcePath, absTarget)
+	deleteTargets, cleanupErr := s.storedDeleteTargets(ctx, meta.SourcePath, absTarget)
+	cleanupErrs := make([]error, 0, 1)
+	if cleanupErr != nil {
+		cleanupErrs = append(cleanupErrs, cleanupErr)
+	}
 
 	if err := os.Remove(absTarget); err != nil {
 		if !os.IsNotExist(err) {
@@ -706,24 +717,39 @@ func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imageP
 			if s.logger != nil {
 				s.logger.Tracef("screenshots: deleting db records for %s", target)
 			}
-			if err := retrySQLiteBusy(ctx, 3, func() error {
+			if err := retrySQLiteBusy(ctx, func() error {
 				return s.repo.DeleteScreenshot(ctx, target)
 			}); err != nil {
-				s.logger.Debugf("screenshots: failed to delete screenshot record: %v", err)
+				s.logger.Warnf(
+					"screenshots: failed to delete screenshot record target=%s err=%s",
+					target,
+					redaction.RedactValue(err.Error(), nil),
+				)
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("delete screenshot record: %w", err))
 			} else if s.logger != nil {
 				s.logger.Tracef("screenshots: deleted screenshot record for %s", target)
 			}
-			if err := retrySQLiteBusy(ctx, 3, func() error {
+			if err := retrySQLiteBusy(ctx, func() error {
 				return s.repo.DeleteFinalSelection(ctx, target)
 			}); err != nil {
-				s.logger.Debugf("screenshots: failed to delete final selection: %v", err)
+				s.logger.Warnf(
+					"screenshots: failed to delete final selection target=%s err=%s",
+					target,
+					redaction.RedactValue(err.Error(), nil),
+				)
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("delete final selection: %w", err))
 			} else if s.logger != nil {
 				s.logger.Tracef("screenshots: deleted final selection for %s", target)
 			}
 		}
-		s.removeTrackerImageReference(ctx, meta, tmpDir, absTarget)
+		if err := s.removeTrackerImageReference(ctx, meta, tmpDir, absTarget); err != nil {
+			cleanupErrs = append(cleanupErrs, err)
+		}
 	}
 
+	if len(cleanupErrs) > 0 {
+		return fmt.Errorf("screenshots: delete cleanup incomplete: %w", errors.Join(cleanupErrs...))
+	}
 	return nil
 }
 
@@ -732,10 +758,12 @@ func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imageP
 // filesystem aliases such as Windows case variants, but image-path columns
 // compare byte-for-byte, so cleanup keyed only on the caller's spelling can
 // remove the file and leave its screenshot, upload, and selection rows behind.
-func (s *Service) storedDeleteTargets(ctx context.Context, sourcePath string, absTarget string) []string {
+// A failed lookup returns the targets resolved so far plus an error: cleanup can
+// still run, but it can no longer be claimed complete.
+func (s *Service) storedDeleteTargets(ctx context.Context, sourcePath string, absTarget string) ([]string, error) {
 	targets := []string{absTarget}
 	if s.repo == nil || strings.TrimSpace(sourcePath) == "" {
-		return targets
+		return targets, nil
 	}
 	addStored := func(stored string) {
 		stored = strings.TrimSpace(stored)
@@ -747,38 +775,66 @@ func (s *Service) storedDeleteTargets(ctx context.Context, sourcePath string, ab
 			s.logger.Tracef("screenshots: delete alias resolved stored=%s requested=%s", stored, absTarget)
 		}
 	}
-	if stored, err := s.repo.ListScreenshotsByPath(ctx, sourcePath); err != nil {
-		s.logger.Debugf("screenshots: failed to load screenshot records for delete: %v", err)
-	} else {
-		for _, record := range stored {
-			addStored(record.ImagePath)
+	lookupErrs := make([]error, 0, 2)
+	var screenshots []api.Screenshot
+	if err := retrySQLiteBusy(ctx, func() error {
+		stored, err := s.repo.ListScreenshotsByPath(ctx, sourcePath)
+		if err != nil {
+			return fmt.Errorf("load screenshot records: %w", err)
 		}
+		screenshots = stored
+		return nil
+	}); err != nil {
+		s.logger.Warnf("screenshots: failed to load screenshot records for delete err=%s", redaction.RedactValue(err.Error(), nil))
+		lookupErrs = append(lookupErrs, err)
 	}
-	if stored, err := s.repo.ListFinalSelections(ctx, sourcePath); err != nil {
-		s.logger.Debugf("screenshots: failed to load final selections for delete: %v", err)
-	} else {
-		for _, selection := range stored {
-			addStored(selection.ImagePath)
+	for _, record := range screenshots {
+		addStored(record.ImagePath)
+	}
+	var selections []api.ScreenshotFinalSelection
+	if err := retrySQLiteBusy(ctx, func() error {
+		stored, err := s.repo.ListFinalSelections(ctx, sourcePath)
+		if err != nil {
+			return fmt.Errorf("load final selections: %w", err)
 		}
+		selections = stored
+		return nil
+	}); err != nil {
+		s.logger.Warnf("screenshots: failed to load final selections for delete err=%s", redaction.RedactValue(err.Error(), nil))
+		lookupErrs = append(lookupErrs, err)
 	}
-	return targets
+	for _, selection := range selections {
+		addStored(selection.ImagePath)
+	}
+	if len(lookupErrs) > 0 {
+		return targets, errors.Join(lookupErrs...)
+	}
+	return targets, nil
 }
 
-func (s *Service) removeTrackerImageReference(ctx context.Context, meta api.ScreenshotSubject, tmpDir string, absTarget string) {
+// removeTrackerImageReference drops the deleted image from every stored tracker
+// image list for the release. A failure leaves a tracker pointing at an image
+// that no longer exists locally, so it is returned rather than only logged.
+func (s *Service) removeTrackerImageReference(
+	ctx context.Context,
+	meta api.ScreenshotSubject,
+	tmpDir string,
+	absTarget string,
+) error {
 	if s.repo == nil {
-		return
+		return nil
 	}
 	if strings.TrimSpace(tmpDir) == "" || strings.TrimSpace(absTarget) == "" {
-		return
+		return nil
 	}
 	fileStem := strings.ToLower(strings.TrimSuffix(filepath.Base(absTarget), filepath.Ext(absTarget)))
+	updateErrs := make([]error, 0, 1)
 	var records []api.TrackerMetadata
 	if strings.TrimSpace(meta.SourcePath) != "" {
 		stored, err := s.repo.ListTrackerMetadataByPath(ctx, meta.SourcePath)
 		if err != nil {
-			if s.logger != nil {
-				s.logger.Debugf("screenshots: failed to load tracker metadata for delete: %v", err)
-			}
+			s.logger.Warnf("screenshots: failed to load tracker metadata for delete err=%s", redaction.RedactValue(err.Error(), nil))
+			updateErrs = append(updateErrs, fmt.Errorf("load tracker metadata: %w", err))
 		} else if len(stored) > 0 {
 			records = stored
 			if s.logger != nil {
@@ -836,14 +892,23 @@ func (s *Service) removeTrackerImageReference(ctx context.Context, meta api.Scre
 		if strings.TrimSpace(record.SourcePath) == "" {
 			record.SourcePath = meta.SourcePath
 		}
-		if err := retrySQLiteBusy(ctx, 3, func() error {
+		if err := retrySQLiteBusy(ctx, func() error {
 			return s.repo.SaveTrackerMetadata(ctx, record)
 		}); err != nil {
-			s.logger.Debugf("screenshots: failed to update tracker metadata: %v", err)
+			s.logger.Warnf(
+				"screenshots: failed to update tracker metadata tracker=%s err=%s",
+				strings.TrimSpace(record.Tracker),
+				redaction.RedactValue(err.Error(), nil),
+			)
+			updateErrs = append(updateErrs, fmt.Errorf("update tracker metadata: %w", err))
 		} else if s.logger != nil {
 			s.logger.Tracef("screenshots: updated tracker metadata tracker=%s remaining=%d", strings.TrimSpace(record.Tracker), len(record.ImageURLs))
 		}
 	}
+	if len(updateErrs) > 0 {
+		return errors.Join(updateErrs...)
+	}
+	return nil
 }
 
 func (s *Service) loadTrackerMetadata(ctx context.Context, sourcePath string) []api.TrackerMetadata {
@@ -860,12 +925,11 @@ func (s *Service) loadTrackerMetadata(ctx context.Context, sourcePath string) []
 	return records
 }
 
-func retrySQLiteBusy(ctx context.Context, attempts int, fn func() error) error {
-	if attempts < 1 {
-		attempts = 1
-	}
+// retrySQLiteBusy runs fn until it succeeds, fails for a reason other than a
+// busy or locked database, or exhausts sqliteBusyAttempts.
+func retrySQLiteBusy(ctx context.Context, fn func() error) error {
 	var lastErr error
-	for i := 0; i < attempts; i++ {
+	for i := range sqliteBusyAttempts {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("screenshots: sqlite retry canceled: %w", err)
 		}

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -646,7 +646,9 @@ func (s *Service) PreviewFrame(ctx context.Context, meta api.ScreenshotSubject, 
 // Delete removes an allowed image beneath the release's managed temp directory.
 // Repository screenshot, upload, final-selection, and tracker-image references
 // are then cleaned up best-effort; those cleanup failures are logged and do not
-// restore the local file or fail the call.
+// restore the local file or fail the call. Cleanup covers every stored spelling
+// that names the removed file, so an accepted filesystem alias cannot delete the
+// file while leaving its records behind.
 func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imagePath string) error {
 	select {
 	case <-ctx.Done():
@@ -686,6 +688,8 @@ func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imageP
 		return internalerrors.ErrInvalidInput
 	}
 
+	deleteTargets := s.storedDeleteTargets(ctx, meta.SourcePath, absTarget)
+
 	if err := os.Remove(absTarget); err != nil {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("screenshots: remove captured image: %w", err)
@@ -698,27 +702,66 @@ func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imageP
 	}
 
 	if s.repo != nil {
-		if s.logger != nil {
-			s.logger.Tracef("screenshots: deleting db records for %s", absTarget)
-		}
-		if err := retrySQLiteBusy(ctx, 3, func() error {
-			return s.repo.DeleteScreenshot(ctx, absTarget)
-		}); err != nil {
-			s.logger.Debugf("screenshots: failed to delete screenshot record: %v", err)
-		} else if s.logger != nil {
-			s.logger.Tracef("screenshots: deleted screenshot record for %s", absTarget)
-		}
-		if err := retrySQLiteBusy(ctx, 3, func() error {
-			return s.repo.DeleteFinalSelection(ctx, absTarget)
-		}); err != nil {
-			s.logger.Debugf("screenshots: failed to delete final selection: %v", err)
-		} else if s.logger != nil {
-			s.logger.Tracef("screenshots: deleted final selection for %s", absTarget)
+		for _, target := range deleteTargets {
+			if s.logger != nil {
+				s.logger.Tracef("screenshots: deleting db records for %s", target)
+			}
+			if err := retrySQLiteBusy(ctx, 3, func() error {
+				return s.repo.DeleteScreenshot(ctx, target)
+			}); err != nil {
+				s.logger.Debugf("screenshots: failed to delete screenshot record: %v", err)
+			} else if s.logger != nil {
+				s.logger.Tracef("screenshots: deleted screenshot record for %s", target)
+			}
+			if err := retrySQLiteBusy(ctx, 3, func() error {
+				return s.repo.DeleteFinalSelection(ctx, target)
+			}); err != nil {
+				s.logger.Debugf("screenshots: failed to delete final selection: %v", err)
+			} else if s.logger != nil {
+				s.logger.Tracef("screenshots: deleted final selection for %s", target)
+			}
 		}
 		s.removeTrackerImageReference(ctx, meta, tmpDir, absTarget)
 	}
 
 	return nil
+}
+
+// storedDeleteTargets returns every repository spelling that names absTarget on
+// this filesystem, starting with absTarget itself. Path validation accepts
+// filesystem aliases such as Windows case variants, but image-path columns
+// compare byte-for-byte, so cleanup keyed only on the caller's spelling can
+// remove the file and leave its screenshot, upload, and selection rows behind.
+func (s *Service) storedDeleteTargets(ctx context.Context, sourcePath string, absTarget string) []string {
+	targets := []string{absTarget}
+	if s.repo == nil || strings.TrimSpace(sourcePath) == "" {
+		return targets
+	}
+	addStored := func(stored string) {
+		stored = strings.TrimSpace(stored)
+		if stored == "" || slices.Contains(targets, stored) || !pathutil.SamePath(stored, absTarget) {
+			return
+		}
+		targets = append(targets, stored)
+		if s.logger != nil {
+			s.logger.Tracef("screenshots: delete alias resolved stored=%s requested=%s", stored, absTarget)
+		}
+	}
+	if stored, err := s.repo.ListScreenshotsByPath(ctx, sourcePath); err != nil {
+		s.logger.Debugf("screenshots: failed to load screenshot records for delete: %v", err)
+	} else {
+		for _, record := range stored {
+			addStored(record.ImagePath)
+		}
+	}
+	if stored, err := s.repo.ListFinalSelections(ctx, sourcePath); err != nil {
+		s.logger.Debugf("screenshots: failed to load final selections for delete: %v", err)
+	} else {
+		for _, selection := range stored {
+			addStored(selection.ImagePath)
+		}
+	}
+	return targets
 }
 
 func (s *Service) removeTrackerImageReference(ctx context.Context, meta api.ScreenshotSubject, tmpDir string, absTarget string) {

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -711,6 +711,19 @@ func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imageP
 	} else if s.logger != nil {
 		s.logger.Tracef("screenshots: image deleted from disk: %s", absTarget)
 	}
+	confirmedTargets := deleteTargets[:1]
+	for _, target := range deleteTargets[1:] {
+		_, statErr := os.Stat(target)
+		switch {
+		case statErr == nil:
+			continue
+		case errors.Is(statErr, os.ErrNotExist):
+			confirmedTargets = append(confirmedTargets, target)
+		default:
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("inspect stored delete target: %w", statErr))
+		}
+	}
+	deleteTargets = confirmedTargets
 
 	if s.repo != nil {
 		for _, target := range deleteTargets {
@@ -765,9 +778,18 @@ func (s *Service) storedDeleteTargets(ctx context.Context, sourcePath string, ab
 	if s.repo == nil || strings.TrimSpace(sourcePath) == "" {
 		return targets, nil
 	}
+	targetInfo, targetStatErr := os.Stat(absTarget)
 	addStored := func(stored string) {
 		stored = strings.TrimSpace(stored)
-		if stored == "" || slices.Contains(targets, stored) || !pathutil.SamePath(stored, absTarget) {
+		if stored == "" || slices.Contains(targets, stored) {
+			return
+		}
+		sameTarget := pathutil.SamePath(stored, absTarget)
+		if !sameTarget && targetStatErr == nil {
+			storedInfo, statErr := os.Stat(stored)
+			sameTarget = statErr == nil && os.SameFile(storedInfo, targetInfo)
+		}
+		if !sameTarget {
 			return
 		}
 		targets = append(targets, stored)

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -675,7 +675,7 @@ func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imageP
 	if err != nil {
 		return fmt.Errorf("screenshots: resolve temp path: %w", err)
 	}
-	if absTarget != absTmp && !strings.HasPrefix(absTarget, absTmp+string(os.PathSeparator)) {
+	if !isPathWithinDir(tmpDir, absTarget) {
 		return internalerrors.ErrInvalidInput
 	}
 	if s.logger != nil {

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -11,10 +11,16 @@ import (
 	"image/color"
 	"os"
 	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	paths "github.com/autobrr/upbrr/internal/pathing/layout"
+	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -322,4 +328,171 @@ func ffmpegValueAfter(args []string, key string) string {
 		}
 	}
 	return ""
+}
+
+func TestPlanResuggestsDeletedAndStaleScreenshotSlots(t *testing.T) {
+	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
+	if err := os.WriteFile(sourcePath, []byte("synthetic video"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	mediaInfoPath := filepath.Join(t.TempDir(), "mediainfo.json")
+	payload := []byte(`{"media":{"track":[{"@type":"General","Duration":"600"},{"@type":"Video","FrameRate":"24.000"}]}}`)
+	if err := os.WriteFile(mediaInfoPath, payload, 0o600); err != nil {
+		t.Fatalf("write mediainfo: %v", err)
+	}
+	repo, err := db.Open(filepath.Join(t.TempDir(), "upbrr.db"))
+	if err != nil {
+		t.Fatalf("open repository: %v", err)
+	}
+	defer func() { _ = repo.Close() }()
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repository: %v", err)
+	}
+	tmpRoot := t.TempDir()
+	service := NewServiceWithRepo(config.Config{}, api.NopLogger{}, tmpRoot, nil, repo)
+	meta := api.ScreenshotSubject{SourcePath: sourcePath, MediaInfoJSONPath: mediaInfoPath}
+
+	tmpDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, meta.Release)
+	if err != nil {
+		t.Fatalf("resolve temp dir: %v", err)
+	}
+	base := screenshotBaseName(meta)
+	suggestedIndices := func(plan api.ScreenshotPlan) []int {
+		indices := make([]int, 0, len(plan.SuggestedSelections))
+		for _, selection := range plan.SuggestedSelections {
+			indices = append(indices, selection.Index)
+		}
+		return indices
+	}
+
+	capturePath := filepath.Join(tmpDir, buildScreenshotFilename(base, 0, 30, api.ScreenshotPurposeFinal))
+	if err := os.WriteFile(capturePath, []byte("synthetic image"), 0o600); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+	if err := repo.SaveScreenshot(context.Background(), api.Screenshot{
+		SourcePath: meta.SourcePath,
+		ImagePath:  capturePath,
+		Timestamp:  30,
+		Purpose:    api.ScreenshotPurposeFinal,
+		CapturedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("save screenshot: %v", err)
+	}
+	occupied, err := service.Plan(context.Background(), meta, 4)
+	if err != nil {
+		t.Fatalf("plan with capture: %v", err)
+	}
+	if got := suggestedIndices(occupied); len(got) != 3 || slices.Contains(got, 0) {
+		t.Fatalf("occupied slot was resuggested: %v", got)
+	}
+
+	if err := service.Delete(context.Background(), meta, capturePath); err != nil {
+		t.Fatalf("delete capture: %v", err)
+	}
+	if _, err := os.Stat(capturePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("capture file survived delete: %v", err)
+	}
+	freed, err := service.Plan(context.Background(), meta, 4)
+	if err != nil {
+		t.Fatalf("plan after delete: %v", err)
+	}
+	if got := suggestedIndices(freed); len(got) != 4 || !slices.Contains(got, 0) {
+		t.Fatalf("deleted slot was not resuggested: %v", got)
+	}
+
+	stalePath := filepath.Join(tmpDir, buildScreenshotFilename(base, 1, 157.5, api.ScreenshotPurposeFinal))
+	if err := repo.SaveScreenshot(context.Background(), api.Screenshot{
+		SourcePath: meta.SourcePath,
+		ImagePath:  stalePath,
+		Timestamp:  157.5,
+		Purpose:    api.ScreenshotPurposeFinal,
+		CapturedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("save stale screenshot: %v", err)
+	}
+	stale, err := service.Plan(context.Background(), meta, 4)
+	if err != nil {
+		t.Fatalf("plan with stale row: %v", err)
+	}
+	if got := suggestedIndices(stale); len(got) != 4 || !slices.Contains(got, 1) {
+		t.Fatalf("stale row blocked its slot: %v", got)
+	}
+}
+
+func TestDeleteRejectsPathsOutsideManagedTempDir(t *testing.T) {
+	tmpRoot := t.TempDir()
+	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
+	service := NewService(config.Config{}, api.NopLogger{}, tmpRoot, nil)
+	meta := api.ScreenshotSubject{SourcePath: sourcePath}
+	tmpDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, meta.Release)
+	if err != nil {
+		t.Fatalf("resolve temp dir: %v", err)
+	}
+	siblingDir := tmpDir + "-evil"
+	if err := os.MkdirAll(siblingDir, 0o700); err != nil {
+		t.Fatalf("create sibling dir: %v", err)
+	}
+	siblingTarget := filepath.Join(siblingDir, "escape.png")
+	if err := os.WriteFile(siblingTarget, []byte("synthetic image"), 0o600); err != nil {
+		t.Fatalf("write sibling image: %v", err)
+	}
+	traversalTarget := tmpDir + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "escape.png"
+	for _, testCase := range []struct {
+		name   string
+		target string
+	}{
+		{name: "traversal", target: traversalTarget},
+		{name: "sibling prefix", target: siblingTarget},
+		{name: "disallowed extension", target: filepath.Join(tmpDir, "notes.txt")},
+	} {
+		if err := service.Delete(context.Background(), meta, testCase.target); !errors.Is(err, internalerrors.ErrInvalidInput) {
+			t.Fatalf("%s delete error = %v, want invalid input", testCase.name, err)
+		}
+	}
+	if _, err := os.Stat(siblingTarget); err != nil {
+		t.Fatalf("sibling image was removed: %v", err)
+	}
+
+	validTarget := filepath.Join(tmpDir, "capture.png")
+	if err := os.WriteFile(validTarget, []byte("synthetic image"), 0o600); err != nil {
+		t.Fatalf("write managed image: %v", err)
+	}
+	if err := service.Delete(context.Background(), meta, validTarget); err != nil {
+		t.Fatalf("delete managed image: %v", err)
+	}
+	if _, err := os.Stat(validTarget); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("managed image survived delete: %v", err)
+	}
+}
+
+func TestDeleteAcceptsWindowsCaseAndSeparatorVariants(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows path semantics")
+	}
+	tmpRoot := t.TempDir()
+	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
+	service := NewService(config.Config{}, api.NopLogger{}, tmpRoot, nil)
+	meta := api.ScreenshotSubject{SourcePath: sourcePath}
+	tmpDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, meta.Release)
+	if err != nil {
+		t.Fatalf("resolve temp dir: %v", err)
+	}
+	for _, testCase := range []struct {
+		name    string
+		variant func(string) string
+	}{
+		{name: "upper case", variant: strings.ToUpper},
+		{name: "forward slashes", variant: filepath.ToSlash},
+	} {
+		target := filepath.Join(tmpDir, "capture.png")
+		if err := os.WriteFile(target, []byte("synthetic image"), 0o600); err != nil {
+			t.Fatalf("write managed image: %v", err)
+		}
+		if err := service.Delete(context.Background(), meta, testCase.variant(target)); err != nil {
+			t.Fatalf("%s delete error = %v", testCase.name, err)
+		}
+		if _, err := os.Stat(target); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("%s variant did not remove managed image: %v", testCase.name, err)
+		}
+	}
 }

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -545,17 +545,33 @@ func seedStoredCaptures(t *testing.T, repo *db.SQLiteRepository, sourcePath stri
 func requireStoredCaptureRows(t *testing.T, repo *db.SQLiteRepository, sourcePath string, retained string, label string) {
 	t.Helper()
 
+	stored := storedCaptureRows(t, repo, sourcePath)
+	if len(stored) != 3 {
+		t.Fatalf("%s surviving records = %#v, want one per table for %s", label, stored, retained)
+	}
+	for _, imagePath := range stored {
+		if imagePath != retained {
+			t.Fatalf("%s surviving record = %s, want %s", label, imagePath, retained)
+		}
+	}
+}
+
+// storedCaptureRows returns the image path of every screenshot, uploaded-image,
+// and final-selection row stored for the release.
+func storedCaptureRows(t *testing.T, repo *db.SQLiteRepository, sourcePath string) []string {
+	t.Helper()
+
 	screenshots, err := repo.ListScreenshotsByPath(context.Background(), sourcePath)
 	if err != nil {
-		t.Fatalf("%s list screenshot records: %v", label, err)
+		t.Fatalf("list screenshot records: %v", err)
 	}
 	uploads, err := repo.ListUploadedImagesByPath(context.Background(), sourcePath)
 	if err != nil {
-		t.Fatalf("%s list uploaded image records: %v", label, err)
+		t.Fatalf("list uploaded image records: %v", err)
 	}
 	selections, err := repo.ListFinalSelections(context.Background(), sourcePath)
 	if err != nil {
-		t.Fatalf("%s list final selections: %v", label, err)
+		t.Fatalf("list final selections: %v", err)
 	}
 	stored := make([]string, 0, len(screenshots)+len(uploads)+len(selections))
 	for _, record := range screenshots {
@@ -567,13 +583,64 @@ func requireStoredCaptureRows(t *testing.T, repo *db.SQLiteRepository, sourcePat
 	for _, selection := range selections {
 		stored = append(stored, selection.ImagePath)
 	}
-	if len(stored) != 3 {
-		t.Fatalf("%s surviving records = %#v, want one per table for %s", label, stored, retained)
+	return stored
+}
+
+// flakyDeleteRepository fails screenshot-record deletion until healthy is set, so
+// a test can drive a persistent cleanup failure and then let a retry converge.
+type flakyDeleteRepository struct {
+	*db.SQLiteRepository
+	healthy bool
+}
+
+func (r *flakyDeleteRepository) DeleteScreenshot(ctx context.Context, imagePath string) error {
+	if !r.healthy {
+		return errors.New("synthetic screenshot record delete failure")
 	}
-	for _, imagePath := range stored {
-		if imagePath != retained {
-			t.Fatalf("%s surviving record = %s, want %s", label, imagePath, retained)
-		}
+	if err := r.SQLiteRepository.DeleteScreenshot(ctx, imagePath); err != nil {
+		return fmt.Errorf("delete screenshot: %w", err)
+	}
+	return nil
+}
+
+// TestDeleteReportsIncompleteCleanupAndConvergesOnRetry pins the delete contract
+// once the file is gone. A caller must be able to tell a complete delete from one
+// that left records behind — a silent success there is what lets a later capture
+// at the same path reuse stale metadata — and calling Delete again has to
+// converge, which it can only do because an already-missing file is not an error.
+func TestDeleteReportsIncompleteCleanupAndConvergesOnRetry(t *testing.T) {
+	tmpRoot := t.TempDir()
+	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
+	repo := &flakyDeleteRepository{SQLiteRepository: openScreenshotTestRepository(t)}
+	service := NewServiceWithRepo(config.Config{}, api.NopLogger{}, tmpRoot, nil, repo)
+	meta := api.ScreenshotSubject{SourcePath: sourcePath}
+	tmpDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, meta.Release)
+	if err != nil {
+		t.Fatalf("resolve temp dir: %v", err)
+	}
+	target := filepath.Join(tmpDir, "capture.png")
+	if err := os.WriteFile(target, []byte("synthetic image"), 0o600); err != nil {
+		t.Fatalf("write managed image: %v", err)
+	}
+	seedStoredCaptures(t, repo.SQLiteRepository, meta.SourcePath, target)
+
+	err = service.Delete(context.Background(), meta, target)
+	if err == nil || !strings.Contains(err.Error(), "delete cleanup incomplete") {
+		t.Fatalf("delete error = %v, want a reported cleanup failure", err)
+	}
+	if _, statErr := os.Stat(target); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("reported cleanup failure did not remove the image: %v", statErr)
+	}
+	if stored := storedCaptureRows(t, repo.SQLiteRepository, meta.SourcePath); len(stored) == 0 {
+		t.Fatal("cleanup reported a failure but left no stale record to retry")
+	}
+
+	repo.healthy = true
+	if err := service.Delete(context.Background(), meta, target); err != nil {
+		t.Fatalf("retried delete of an already-removed image: %v", err)
+	}
+	if stored := storedCaptureRows(t, repo.SQLiteRepository, meta.SourcePath); len(stored) != 0 {
+		t.Fatalf("retry did not converge, surviving records = %#v", stored)
 	}
 }
 

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -494,6 +494,41 @@ func TestDeleteAcceptsWindowsCaseAndSeparatorVariants(t *testing.T) {
 	}
 }
 
+func TestDeleteAcceptsDarwinCaseVariant(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin path semantics")
+	}
+	tmpRoot := t.TempDir()
+	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
+	repo := openScreenshotTestRepository(t)
+	service := NewServiceWithRepo(config.Config{}, api.NopLogger{}, tmpRoot, nil, repo)
+	meta := api.ScreenshotSubject{SourcePath: sourcePath}
+	tmpDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, meta.Release)
+	if err != nil {
+		t.Fatalf("resolve temp dir: %v", err)
+	}
+	target := filepath.Join(tmpDir, "capture.png")
+	if err := os.WriteFile(target, []byte("synthetic image"), 0o600); err != nil {
+		t.Fatalf("write managed image: %v", err)
+	}
+	caseVariant := filepath.Join(tmpDir, "CAPTURE.PNG")
+	if _, err := os.Stat(caseVariant); errors.Is(err, os.ErrNotExist) {
+		t.Skip("case-sensitive filesystem")
+	} else if err != nil {
+		t.Fatalf("inspect case variant: %v", err)
+	}
+	retained := filepath.Join(tmpDir, "keep.png")
+	seedStoredCaptures(t, repo, meta.SourcePath, target, retained)
+
+	if err := service.Delete(context.Background(), meta, caseVariant); err != nil {
+		t.Fatalf("delete case variant: %v", err)
+	}
+	if _, err := os.Stat(target); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("case variant did not remove managed image: %v", err)
+	}
+	requireStoredCaptureRows(t, repo, meta.SourcePath, retained, "darwin case variant")
+}
+
 // seedStoredCaptures stores the screenshot, hosted-upload, and final-selection
 // rows the given captures own, each keyed on its canonical path spelling.
 // Selections are written in one call because saving them replaces the release's

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -471,6 +471,7 @@ func TestDeleteAcceptsWindowsCaseAndSeparatorVariants(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve temp dir: %v", err)
 	}
+	retained := filepath.Join(tmpDir, "keep.png")
 	for _, testCase := range []struct {
 		name    string
 		variant func(string) string
@@ -482,55 +483,66 @@ func TestDeleteAcceptsWindowsCaseAndSeparatorVariants(t *testing.T) {
 		if err := os.WriteFile(target, []byte("synthetic image"), 0o600); err != nil {
 			t.Fatalf("write managed image: %v", err)
 		}
-		seedStoredCapture(t, repo, meta.SourcePath, target)
+		seedStoredCaptures(t, repo, meta.SourcePath, target, retained)
 		if err := service.Delete(context.Background(), meta, testCase.variant(target)); err != nil {
 			t.Fatalf("%s delete error = %v", testCase.name, err)
 		}
 		if _, err := os.Stat(target); !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("%s variant did not remove managed image: %v", testCase.name, err)
 		}
-		requireStoredCaptureCleared(t, repo, meta.SourcePath, testCase.name)
+		requireStoredCaptureRows(t, repo, meta.SourcePath, retained, testCase.name)
 	}
 }
 
-// seedStoredCapture stores the screenshot, hosted-upload, and final-selection
-// rows one captured image owns, each keyed on its canonical path spelling.
-func seedStoredCapture(t *testing.T, repo *db.SQLiteRepository, sourcePath string, imagePath string) {
+// seedStoredCaptures stores the screenshot, hosted-upload, and final-selection
+// rows the given captures own, each keyed on its canonical path spelling.
+// Selections are written in one call because saving them replaces the release's
+// whole set.
+func seedStoredCaptures(t *testing.T, repo *db.SQLiteRepository, sourcePath string, imagePaths ...string) {
 	t.Helper()
 
 	now := time.Now().UTC()
-	if err := repo.SaveScreenshot(context.Background(), api.Screenshot{
-		SourcePath: sourcePath,
-		ImagePath:  imagePath,
-		Timestamp:  30,
-		Purpose:    api.ScreenshotPurposeFinal,
-		CapturedAt: now,
-	}); err != nil {
-		t.Fatalf("seed screenshot record: %v", err)
+	selections := make([]api.ScreenshotFinalSelection, 0, len(imagePaths))
+	uploads := make([]api.UploadedImageLink, 0, len(imagePaths))
+	for order, imagePath := range imagePaths {
+		if err := repo.SaveScreenshot(context.Background(), api.Screenshot{
+			SourcePath: sourcePath,
+			ImagePath:  imagePath,
+			Timestamp:  float64(30 * (order + 1)),
+			Purpose:    api.ScreenshotPurposeFinal,
+			CapturedAt: now,
+		}); err != nil {
+			t.Fatalf("seed screenshot record: %v", err)
+		}
+		uploads = append(uploads, api.UploadedImageLink{
+			SourcePath: sourcePath,
+			ImagePath:  imagePath,
+			Host:       "example-host",
+			UsageScope: "global",
+			RawURL:     "https://example.invalid/capture.png",
+			UploadedAt: now,
+		})
+		selections = append(selections, api.ScreenshotFinalSelection{
+			SourcePath: sourcePath,
+			ImagePath:  imagePath,
+			Order:      order,
+			Source:     "generated",
+			SelectedAt: now,
+		})
 	}
-	if err := repo.SaveUploadedImages(context.Background(), sourcePath, "example-host", []api.UploadedImageLink{{
-		SourcePath: sourcePath,
-		ImagePath:  imagePath,
-		Host:       "example-host",
-		UsageScope: "global",
-		RawURL:     "https://example.invalid/capture.png",
-		UploadedAt: now,
-	}}); err != nil {
-		t.Fatalf("seed uploaded image record: %v", err)
+	if err := repo.SaveUploadedImages(context.Background(), sourcePath, "example-host", uploads); err != nil {
+		t.Fatalf("seed uploaded image records: %v", err)
 	}
-	if err := repo.SaveFinalSelections(context.Background(), sourcePath, []api.ScreenshotFinalSelection{{
-		SourcePath: sourcePath,
-		ImagePath:  imagePath,
-		Source:     "generated",
-		SelectedAt: now,
-	}}); err != nil {
-		t.Fatalf("seed final selection: %v", err)
+	if err := repo.SaveFinalSelections(context.Background(), sourcePath, selections); err != nil {
+		t.Fatalf("seed final selections: %v", err)
 	}
 }
 
-// requireStoredCaptureCleared fails when a delete left a stale row that a later
-// regeneration at the same canonical path could reuse.
-func requireStoredCaptureCleared(t *testing.T, repo *db.SQLiteRepository, sourcePath string, label string) {
+// requireStoredCaptureRows fails when a delete left a stale row that a later
+// regeneration at the same canonical path could reuse, or when resolving the
+// caller's path to a stored spelling reached another capture's rows. Exactly one
+// screenshot, upload, and selection row must survive, all naming retained.
+func requireStoredCaptureRows(t *testing.T, repo *db.SQLiteRepository, sourcePath string, retained string, label string) {
 	t.Helper()
 
 	screenshots, err := repo.ListScreenshotsByPath(context.Background(), sourcePath)
@@ -545,14 +557,23 @@ func requireStoredCaptureCleared(t *testing.T, repo *db.SQLiteRepository, source
 	if err != nil {
 		t.Fatalf("%s list final selections: %v", label, err)
 	}
-	if len(screenshots) != 0 || len(uploads) != 0 || len(selections) != 0 {
-		t.Fatalf(
-			"%s left stale records screenshots=%d uploads=%d selections=%d",
-			label,
-			len(screenshots),
-			len(uploads),
-			len(selections),
-		)
+	stored := make([]string, 0, len(screenshots)+len(uploads)+len(selections))
+	for _, record := range screenshots {
+		stored = append(stored, record.ImagePath)
+	}
+	for _, upload := range uploads {
+		stored = append(stored, upload.ImagePath)
+	}
+	for _, selection := range selections {
+		stored = append(stored, selection.ImagePath)
+	}
+	if len(stored) != 3 {
+		t.Fatalf("%s surviving records = %#v, want one per table for %s", label, stored, retained)
+	}
+	for _, imagePath := range stored {
+		if imagePath != retained {
+			t.Fatalf("%s surviving record = %s, want %s", label, imagePath, retained)
+		}
 	}
 }
 

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -340,14 +340,7 @@ func TestPlanResuggestsDeletedAndStaleScreenshotSlots(t *testing.T) {
 	if err := os.WriteFile(mediaInfoPath, payload, 0o600); err != nil {
 		t.Fatalf("write mediainfo: %v", err)
 	}
-	repo, err := db.Open(filepath.Join(t.TempDir(), "upbrr.db"))
-	if err != nil {
-		t.Fatalf("open repository: %v", err)
-	}
-	defer func() { _ = repo.Close() }()
-	if err := repo.Migrate(); err != nil {
-		t.Fatalf("migrate repository: %v", err)
-	}
+	repo := openScreenshotTestRepository(t)
 	tmpRoot := t.TempDir()
 	service := NewServiceWithRepo(config.Config{}, api.NopLogger{}, tmpRoot, nil, repo)
 	meta := api.ScreenshotSubject{SourcePath: sourcePath, MediaInfoJSONPath: mediaInfoPath}
@@ -471,7 +464,8 @@ func TestDeleteAcceptsWindowsCaseAndSeparatorVariants(t *testing.T) {
 	}
 	tmpRoot := t.TempDir()
 	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
-	service := NewService(config.Config{}, api.NopLogger{}, tmpRoot, nil)
+	repo := openScreenshotTestRepository(t)
+	service := NewServiceWithRepo(config.Config{}, api.NopLogger{}, tmpRoot, nil, repo)
 	meta := api.ScreenshotSubject{SourcePath: sourcePath}
 	tmpDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, meta.Release)
 	if err != nil {
@@ -488,11 +482,90 @@ func TestDeleteAcceptsWindowsCaseAndSeparatorVariants(t *testing.T) {
 		if err := os.WriteFile(target, []byte("synthetic image"), 0o600); err != nil {
 			t.Fatalf("write managed image: %v", err)
 		}
+		seedStoredCapture(t, repo, meta.SourcePath, target)
 		if err := service.Delete(context.Background(), meta, testCase.variant(target)); err != nil {
 			t.Fatalf("%s delete error = %v", testCase.name, err)
 		}
 		if _, err := os.Stat(target); !errors.Is(err, os.ErrNotExist) {
 			t.Fatalf("%s variant did not remove managed image: %v", testCase.name, err)
 		}
+		requireStoredCaptureCleared(t, repo, meta.SourcePath, testCase.name)
 	}
+}
+
+// seedStoredCapture stores the screenshot, hosted-upload, and final-selection
+// rows one captured image owns, each keyed on its canonical path spelling.
+func seedStoredCapture(t *testing.T, repo *db.SQLiteRepository, sourcePath string, imagePath string) {
+	t.Helper()
+
+	now := time.Now().UTC()
+	if err := repo.SaveScreenshot(context.Background(), api.Screenshot{
+		SourcePath: sourcePath,
+		ImagePath:  imagePath,
+		Timestamp:  30,
+		Purpose:    api.ScreenshotPurposeFinal,
+		CapturedAt: now,
+	}); err != nil {
+		t.Fatalf("seed screenshot record: %v", err)
+	}
+	if err := repo.SaveUploadedImages(context.Background(), sourcePath, "example-host", []api.UploadedImageLink{{
+		SourcePath: sourcePath,
+		ImagePath:  imagePath,
+		Host:       "example-host",
+		UsageScope: "global",
+		RawURL:     "https://example.invalid/capture.png",
+		UploadedAt: now,
+	}}); err != nil {
+		t.Fatalf("seed uploaded image record: %v", err)
+	}
+	if err := repo.SaveFinalSelections(context.Background(), sourcePath, []api.ScreenshotFinalSelection{{
+		SourcePath: sourcePath,
+		ImagePath:  imagePath,
+		Source:     "generated",
+		SelectedAt: now,
+	}}); err != nil {
+		t.Fatalf("seed final selection: %v", err)
+	}
+}
+
+// requireStoredCaptureCleared fails when a delete left a stale row that a later
+// regeneration at the same canonical path could reuse.
+func requireStoredCaptureCleared(t *testing.T, repo *db.SQLiteRepository, sourcePath string, label string) {
+	t.Helper()
+
+	screenshots, err := repo.ListScreenshotsByPath(context.Background(), sourcePath)
+	if err != nil {
+		t.Fatalf("%s list screenshot records: %v", label, err)
+	}
+	uploads, err := repo.ListUploadedImagesByPath(context.Background(), sourcePath)
+	if err != nil {
+		t.Fatalf("%s list uploaded image records: %v", label, err)
+	}
+	selections, err := repo.ListFinalSelections(context.Background(), sourcePath)
+	if err != nil {
+		t.Fatalf("%s list final selections: %v", label, err)
+	}
+	if len(screenshots) != 0 || len(uploads) != 0 || len(selections) != 0 {
+		t.Fatalf(
+			"%s left stale records screenshots=%d uploads=%d selections=%d",
+			label,
+			len(screenshots),
+			len(uploads),
+			len(selections),
+		)
+	}
+}
+
+func openScreenshotTestRepository(t *testing.T) *db.SQLiteRepository {
+	t.Helper()
+
+	repo, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open repository: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repository: %v", err)
+	}
+	return repo
 }


### PR DESCRIPTION
Deleting a screenshot from the temp folder left it permanently un-regenerable: its database row stayed behind, its slot never came back as pending, and nothing in the GUI would produce it again.

### Why

`Plan` reported **only the slots it had no capture for**. The slots it already had were simply omitted from the result, so the plan carried no record that they existed at all. That made the plan lossy in the one direction that mattered: a caller could not tell "this slot is filled" apart from "this slot is not part of the baseline", and once a file vanished from disk there was nothing left to reconcile the orphaned row against.

The service was also doing the reconciliation itself — statting files, matching timestamps back to baseline selections, nearest-matching un-indexed captures onto free slots — which is where the state got collapsed.

### Fix

`Plan` now reports the **full baseline** with any existing captures attached to their slots. Slot occupancy becomes something callers derive from the plan rather than something the plan decides for them, and the reconciliation logic in `service.go` collapses accordingly (roughly 90 lines removed).

The GUI resolves occupancy from that baseline via a new `utils/screenshotSlots.ts`:

- `buildExistingSlotImages` maps captures onto their slots
- `pendingSelections` derives what still needs generating
- `staleSlotPaths` identifies rows whose file is gone

Two consequences fall out of doing it this way. Deleting an image now prunes local state **only once the file is actually gone**, so a failed delete no longer desyncs the UI from disk. And regenerating a slot deletes the capture it replaces, instead of orphaning it.

`slotTolerance` / `selectionTimestamp` in that file mirror `screenshotTimestampMatchesSelection` on the Go side; the comment there points at the Go original so the two stay in step.

### Tests

- `internal/services/screenshots/scenarios_test.go` — new, covers the plan/delete/regenerate cycles end to end.
- `gui/frontend/src/utils/screenshotSlots.test.ts` — new, covers the slot helpers.
- `cmd/upbrr/interactive_test.go` — the CLI path reports the baseline the same way.

`go build ./...`, `go vet`, Go tests, plus `pnpm typecheck` / `pnpm lint` / `pnpm test:unit` (214 tests) all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Media deletion now safely handles failures, preserves files for retry, and avoids saving incomplete workflow changes.
  * Retried deletions converge reliably, including already-missing DVD menus and uploaded images.
  * Screenshot deletion now recognizes path variations and removes all related records.
  * Invalid screenshot paths are rejected, while stale or deleted screenshots are correctly regenerated.
  * Incomplete cleanup reports errors and can complete successfully on retry.
  * Reordering media updates display order without changing capture metadata or privacy settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->