### PR TITLE
fix(trackerdata): send a user-agent on unit3d api requests

### DIFF
--- a/internal/trackers/data/unit3d.go
+++ b/internal/trackers/data/unit3d.go
@@ -35,6 +35,7 @@ const (
 	imageTimeout     = 15 * time.Second
 	maxImageBytes    = 20 * 1024 * 1024
 	imageConcurrency = 5
+	unit3DUserAgent  = "upbrr"
 )
 
 var unit3DImageBlockedIPRanges = []netip.Prefix{
@@ -457,12 +458,13 @@ func (c *Client) searchUnit3DEndpoint(
 	return buildUnit3DSearchEntries(payload.Data, isDisc), "", nil
 }
 
-// SetUnit3DAPIHeaders applies the authentication and response format expected
-// by every Unit3D API request.
+// SetUnit3DAPIHeaders applies the client identification, JSON response format,
+// and optional bearer authentication expected by every Unit3D API request.
 func SetUnit3DAPIHeaders(req *http.Request, apiKey string) {
 	if req == nil {
 		return
 	}
+	req.Header.Set("User-Agent", unit3DUserAgent)
 	req.Header.Set("Accept", "application/json")
 	if apiKey = strings.TrimSpace(apiKey); apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)

--- a/internal/trackers/data/unit3d_test.go
+++ b/internal/trackers/data/unit3d_test.go
@@ -69,6 +69,9 @@ func TestSetUnit3DAPIHeadersUsesBearerAuthorization(t *testing.T) {
 	if req.Header.Get("Authorization") != "Bearer secret" {
 		t.Fatal("expected Unit3D Bearer authorization")
 	}
+	if req.Header.Get("User-Agent") != "upbrr" {
+		t.Fatal("expected Unit3D upbrr user agent")
+	}
 	if req.Header.Get("Accept") != "application/json" {
 		t.Fatal("expected Unit3D JSON accept header")
 	}
@@ -189,6 +192,10 @@ func TestSearchTorrentsCBRIncludesPendingAndFiltersTMDB(t *testing.T) {
 			t.Error("bearer authorization mismatch")
 			return
 		}
+		if r.Header.Get("User-Agent") != "upbrr" {
+			t.Error("user agent mismatch")
+			return
+		}
 		if r.URL.Query().Has("api_token") {
 			t.Error("API token must not be placed in the query")
 			return
@@ -256,6 +263,10 @@ func TestTorrentInfoUsesBearerAuthorization(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer secret" {
 			t.Error("bearer authorization mismatch")
+			return
+		}
+		if r.Header.Get("User-Agent") != "upbrr" {
+			t.Error("user agent mismatch")
 			return
 		}
 		if r.URL.Query().Has("api_token") {

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -61,7 +61,6 @@ func submitUnit3DUpload(
 	}
 	trackerdata.SetUnit3DAPIHeaders(httpReq, apiKey)
 	httpReq.Header.Set("Content-Type", contentType)
-	httpReq.Header.Set("User-Agent", "upbrr")
 
 	logger.Debugf("trackers: %s sending upload request...", trackerName)
 	client := &http.Client{Timeout: 40 * time.Second}

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -137,7 +137,6 @@ func submitUnit3DUpload(
 		return summary, nil
 	}
 	trackerdata.SetUnit3DAPIHeaders(downloadRequest, apiKey)
-	downloadRequest.Header.Set("User-Agent", "upbrr")
 	downloadClient := unit3DRegisteredTorrentClient(client, baseURL)
 	if err := trackers.DownloadRegisteredTorrent(reqCtx, downloadClient, downloadRequest, artifactPath); err != nil {
 		trackers.LogRegisteredTorrentUnavailable(logger, trackerName)


### PR DESCRIPTION
UNIT3D API requests went out with no `User-Agent` header at all.

Surfaced while testing UTP, but `SetUnit3DAPIHeaders` is the shared header path for **every** UNIT3D tracker, so the fix belongs there rather than being special-cased to one site. Every UNIT3D tracker now identifies itself.

One line in `internal/trackerdata/unit3d.go`, asserted in the existing `TestSetUnit3DAPIHeadersUsesBearerAuthorization` alongside the `Accept` and `Authorization` header checks.

`go build ./...` and the `trackerdata` + `trackers` suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unit3D tracker request identification by consistently including the `upbrr` User-Agent.
  * Preserved JSON and optional authentication headers for API requests.
  * Streamlined upload and registered-torrent download request header handling without changing functionality.
  * Improved consistency across search, torrent information, upload, and download requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->