### PR TITLE
chore(trackers): log which rename signal fired

### DIFF
--- a/internal/releasepolicy/modified.go
+++ b/internal/releasepolicy/modified.go
@@ -23,6 +23,30 @@ type ModifiedReleaseSubject struct {
 	Release            api.ReleaseInfo
 }
 
+// ModifiedReleaseSignal identifies which modified-release detection fired. The
+// values are stable diagnostic identifiers for logs and dispositions only; they
+// must never enter a user-facing failure reason.
+type ModifiedReleaseSignal string
+
+const (
+	// ModifiedReleaseSignalNone is the zero value: no detection fired.
+	ModifiedReleaseSignalNone ModifiedReleaseSignal = ""
+	// ModifiedReleaseSignalSRRDB marks the authoritative srrdb scene comparison.
+	ModifiedReleaseSignalSRRDB ModifiedReleaseSignal = "srrdb"
+	// ModifiedReleaseSignalArrToken marks the *arr id-token heuristic.
+	ModifiedReleaseSignalArrToken ModifiedReleaseSignal = "arr-token"
+	// ModifiedReleaseSignalSpaceRename marks the whitespace rename heuristic.
+	ModifiedReleaseSignalSpaceRename ModifiedReleaseSignal = "space-rename"
+)
+
+// ModifiedReleaseDetection is the result of DetectModifiedRelease. The zero
+// value represents no detection.
+type ModifiedReleaseDetection struct {
+	Modified bool
+	Reason   string
+	Signal   ModifiedReleaseSignal
+}
+
 // DetectModifiedRelease reports whether source media was renamed away from its
 // original scene/P2P release name. Trackers reject such modified releases
 // ([Modified Release] Renamed), so detecting it lets us skip the upload before it
@@ -50,12 +74,15 @@ type ModifiedReleaseSubject struct {
 //
 // Both the source path (folder) and the primary video file are checked, since the
 // tracker inspects the file (MediaInfo "Complete name") and the in-torrent names.
-func DetectModifiedRelease(meta ModifiedReleaseSubject) (bool, string) {
+//
+// The returned detection carries the signal that fired so callers can derive
+// disposition and diagnostics from a single authority.
+func DetectModifiedRelease(meta ModifiedReleaseSubject) ModifiedReleaseDetection {
 	if meta.PersonalRelease {
-		return false, ""
+		return ModifiedReleaseDetection{}
 	}
 	if strings.TrimSpace(meta.DiscType) != "" {
-		return false, ""
+		return ModifiedReleaseDetection{}
 	}
 
 	// srrdb scene detection (the imdb: fallback) authoritatively compares the
@@ -68,12 +95,16 @@ func DetectModifiedRelease(meta ModifiedReleaseSubject) (bool, string) {
 		if reason == "" {
 			reason = modifiedReleaseReason
 		}
-		return true, reason
+		return ModifiedReleaseDetection{
+			Modified: true,
+			Reason:   reason,
+			Signal:   ModifiedReleaseSignalSRRDB,
+		}
 	}
 
 	group := strings.TrimSpace(meta.Release.Group)
 	if skipsStandardRenameCheck(group) {
-		return false, ""
+		return ModifiedReleaseDetection{}
 	}
 
 	names := candidateReleaseNames(meta)
@@ -82,19 +113,27 @@ func DetectModifiedRelease(meta ModifiedReleaseSubject) (bool, string) {
 	// (which an *arr rename often strips), so check them before the group gate.
 	for _, name := range names {
 		if arrRenameToken(name) != "" {
-			return true, modifiedReleaseReason
+			return ModifiedReleaseDetection{
+				Modified: true,
+				Reason:   modifiedReleaseReason,
+				Signal:   ModifiedReleaseSignalArrToken,
+			}
 		}
 	}
 
 	if group == "" {
-		return false, ""
+		return ModifiedReleaseDetection{}
 	}
 	for _, name := range names {
 		if isRenamedReleaseName(name, group) {
-			return true, modifiedReleaseReason
+			return ModifiedReleaseDetection{
+				Modified: true,
+				Reason:   modifiedReleaseReason,
+				Signal:   ModifiedReleaseSignalSpaceRename,
+			}
 		}
 	}
-	return false, ""
+	return ModifiedReleaseDetection{}
 }
 
 // modifiedReleaseReason is deliberately generic: it discloses neither the

--- a/internal/releasepolicy/modified_test.go
+++ b/internal/releasepolicy/modified_test.go
@@ -4,6 +4,7 @@
 package releasepolicy
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/autobrr/upbrr/pkg/api"
@@ -20,9 +21,10 @@ func TestIsRenamedRelease(t *testing.T) {
 	}
 
 	cases := []struct {
-		name string
-		meta ModifiedReleaseSubject
-		want bool
+		name   string
+		meta   ModifiedReleaseSubject
+		want   bool
+		signal ModifiedReleaseSignal
 	}{
 		{
 			name: "clean dotted folder with group",
@@ -30,14 +32,16 @@ func TestIsRenamedRelease(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "renamed spaced folder with group",
-			meta: grouped("/data/movies/Example Movie 2026 2160p MA WEB-DL DDP5 1 HDR H 265-GRP"),
-			want: true,
+			name:   "renamed spaced folder with group",
+			meta:   grouped("/data/movies/Example Movie 2026 2160p MA WEB-DL DDP5 1 HDR H 265-GRP"),
+			want:   true,
+			signal: ModifiedReleaseSignalSpaceRename,
 		},
 		{
-			name: "renamed spaced single file with group",
-			meta: grouped("/data/movies/Example Movie 2026 2160p MA WEB-DL DDP5 1 HDR H 265-GRP.mkv"),
-			want: true,
+			name:   "renamed spaced single file with group",
+			meta:   grouped("/data/movies/Example Movie 2026 2160p MA WEB-DL DDP5 1 HDR H 265-GRP.mkv"),
+			want:   true,
+			signal: ModifiedReleaseSignalSpaceRename,
 		},
 		{
 			name: "spaced name without group tag is not flagged",
@@ -58,7 +62,8 @@ func TestIsRenamedRelease(t *testing.T) {
 				SourcePath: "/data/movies/Example Movie (2026) {imdb-tt1234567}",
 				Release:    api.ReleaseInfo{Group: "tt1234567"},
 			},
-			want: true,
+			want:   true,
+			signal: ModifiedReleaseSignalArrToken,
 		},
 		{
 			name: "sonarr-renamed file with tmdb token is flagged",
@@ -66,54 +71,64 @@ func TestIsRenamedRelease(t *testing.T) {
 				SourcePath: "/data/tv/Example Show (2026) {tmdb-12345}/Example Show S01E01 {tmdb-12345}.mkv",
 				VideoPath:  "/data/tv/Example Show (2026) {tmdb-12345}/Example Show S01E01 {tmdb-12345}.mkv",
 			},
-			want: true,
+			want:   true,
+			signal: ModifiedReleaseSignalArrToken,
 		},
 		{
-			name: "tvdb token is flagged",
-			meta: ModifiedReleaseSubject{SourcePath: "/data/tv/Show (2020) {tvdb-360893}"},
-			want: true,
+			name:   "tvdb token is flagged",
+			meta:   ModifiedReleaseSubject{SourcePath: "/data/tv/Show (2020) {tvdb-360893}"},
+			want:   true,
+			signal: ModifiedReleaseSignalArrToken,
 		},
 		{
-			name: "arr token match is case-insensitive",
-			meta: ModifiedReleaseSubject{SourcePath: "/data/movies/Example Movie (2026) {IMDb-tt1234567}"},
-			want: true,
+			name:   "arr token match is case-insensitive",
+			meta:   ModifiedReleaseSubject{SourcePath: "/data/movies/Example Movie (2026) {IMDb-tt1234567}"},
+			want:   true,
+			signal: ModifiedReleaseSignalArrToken,
 		},
 		{
 			name: "arr token is flagged even when the group tag was stripped",
 			// *arr renames frequently drop the trailing -GROUP, so the token check
 			// must fire without a parsed group.
-			meta: ModifiedReleaseSubject{SourcePath: "/data/movies/Example Movie (2026) {tmdb-12345}"},
-			want: true,
+			meta:   ModifiedReleaseSubject{SourcePath: "/data/movies/Example Movie (2026) {tmdb-12345}"},
+			want:   true,
+			signal: ModifiedReleaseSignalArrToken,
 		},
 		{
-			name: "tmdb bracket token is flagged",
-			meta: ModifiedReleaseSubject{SourcePath: "/data/movies/Example Movie (2026) [tmdb-12345]"},
-			want: true,
+			name:   "tmdb bracket token is flagged",
+			meta:   ModifiedReleaseSubject{SourcePath: "/data/movies/Example Movie (2026) [tmdb-12345]"},
+			want:   true,
+			signal: ModifiedReleaseSignalArrToken,
 		},
 		{
-			name: "tmdb paren token is flagged",
-			meta: ModifiedReleaseSubject{SourcePath: "/data/movies/Example Movie (2026) (tmdb-12345)"},
-			want: true,
+			name:   "tmdb paren token is flagged",
+			meta:   ModifiedReleaseSubject{SourcePath: "/data/movies/Example Movie (2026) (tmdb-12345)"},
+			want:   true,
+			signal: ModifiedReleaseSignalArrToken,
 		},
 		{
-			name: "imdb bracket token is flagged",
-			meta: ModifiedReleaseSubject{SourcePath: "/data/movies/Example Movie (2026) [imdb-tt1234567]"},
-			want: true,
+			name:   "imdb bracket token is flagged",
+			meta:   ModifiedReleaseSubject{SourcePath: "/data/movies/Example Movie (2026) [imdb-tt1234567]"},
+			want:   true,
+			signal: ModifiedReleaseSignalArrToken,
 		},
 		{
-			name: "imdb paren token is flagged",
-			meta: ModifiedReleaseSubject{SourcePath: "/data/movies/Example Movie (2026) (imdb-tt1234567)"},
-			want: true,
+			name:   "imdb paren token is flagged",
+			meta:   ModifiedReleaseSubject{SourcePath: "/data/movies/Example Movie (2026) (imdb-tt1234567)"},
+			want:   true,
+			signal: ModifiedReleaseSignalArrToken,
 		},
 		{
-			name: "tvdb bracket token is flagged",
-			meta: ModifiedReleaseSubject{SourcePath: "/data/tv/Example Show (2026) [tvdb-12345]"},
-			want: true,
+			name:   "tvdb bracket token is flagged",
+			meta:   ModifiedReleaseSubject{SourcePath: "/data/tv/Example Show (2026) [tvdb-12345]"},
+			want:   true,
+			signal: ModifiedReleaseSignalArrToken,
 		},
 		{
-			name: "tvdb paren token is flagged",
-			meta: ModifiedReleaseSubject{SourcePath: "/data/tv/Example Show (2026) (tvdb-12345)"},
-			want: true,
+			name:   "tvdb paren token is flagged",
+			meta:   ModifiedReleaseSubject{SourcePath: "/data/tv/Example Show (2026) (tvdb-12345)"},
+			want:   true,
+			signal: ModifiedReleaseSignalArrToken,
 		},
 		{
 			name: "standard rename check skipped for configured group",
@@ -205,7 +220,8 @@ func TestIsRenamedRelease(t *testing.T) {
 				VideoPath:  "/data/movies/Example.Movie.2026.2160p.MA.WEB-DL.DDP5.1.HDR.H.265-GRP/Example Movie 2026 2160p MA WEB-DL DDP5 1 HDR H 265-GRP.mkv",
 				Release:    api.ReleaseInfo{Group: "GRP"},
 			},
-			want: true,
+			want:   true,
+			signal: ModifiedReleaseSignalSpaceRename,
 		},
 		{
 			name: "falls back to video path when source path is empty",
@@ -214,7 +230,8 @@ func TestIsRenamedRelease(t *testing.T) {
 				VideoPath:  "/data/movies/Example Movie 2026 2160p MA WEB-DL DDP5 1 HDR H 265-GRP.mkv",
 				Release:    api.ReleaseInfo{Group: "GRP"},
 			},
-			want: true,
+			want:   true,
+			signal: ModifiedReleaseSignalSpaceRename,
 		},
 		{
 			name: "spaced folder retaining dotted tokens is still flagged",
@@ -222,8 +239,9 @@ func TestIsRenamedRelease(t *testing.T) {
 			// dotted tokens (DDP5.1, H.265) must not have its trailing "-GROUP" tag
 			// stripped by extension handling on the directory basename (filepath.Ext
 			// would otherwise treat ".265-GRP" as an extension).
-			meta: grouped("/data/movies/Example Movie 2026 2160p MA WEB-DL DDP5.1 HDR H.265-GRP"),
-			want: true,
+			meta:   grouped("/data/movies/Example Movie 2026 2160p MA WEB-DL DDP5.1 HDR H.265-GRP"),
+			want:   true,
+			signal: ModifiedReleaseSignalSpaceRename,
 		},
 		{
 			name: "srrdb rename signal flags a clean-looking name with no group",
@@ -234,7 +252,8 @@ func TestIsRenamedRelease(t *testing.T) {
 				SceneRenamed:       true,
 				SceneRenamedReason: "source appears renamed or modified from its original release name; verify the file hash and source provenance",
 			},
-			want: true,
+			want:   true,
+			signal: ModifiedReleaseSignalSRRDB,
 		},
 		{
 			name: "srrdb rename signal still flags configured standard-skip group",
@@ -243,7 +262,8 @@ func TestIsRenamedRelease(t *testing.T) {
 				Release:      api.ReleaseInfo{Group: "HiDt"},
 				SceneRenamed: true,
 			},
-			want: true,
+			want:   true,
+			signal: ModifiedReleaseSignalSRRDB,
 		},
 		{
 			name: "srrdb rename signal is exempt for personal release",
@@ -268,12 +288,28 @@ func TestIsRenamedRelease(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, reason := DetectModifiedRelease(tc.meta)
-			if got != tc.want {
-				t.Fatalf("isRenamedRelease = %v (%q), want %v", got, reason, tc.want)
+			got := DetectModifiedRelease(tc.meta)
+			if got.Modified != tc.want {
+				t.Fatalf("DetectModifiedRelease = %+v, want modified=%v", got, tc.want)
 			}
-			if got && reason == "" {
+			if got.Signal != tc.signal {
+				t.Fatalf("signal = %q, want %q", got.Signal, tc.signal)
+			}
+			// Clean, exempt, and skipped-group subjects must yield the zero value.
+			if !tc.want && got != (ModifiedReleaseDetection{}) {
+				t.Fatalf("expected zero-value detection, got %+v", got)
+			}
+			if got.Modified && got.Reason == "" {
 				t.Fatal("expected a non-empty reason when renamed")
+			}
+			// The signal is diagnostic-only and must never leak into the
+			// user-facing reason.
+			if got.Modified && strings.Contains(got.Reason, string(got.Signal)) {
+				t.Fatalf("signal %q leaked into user-facing reason %q", got.Signal, got.Reason)
+			}
+			// Heuristic detections must keep the generic disclosed reason.
+			if got.Modified && got.Signal != ModifiedReleaseSignalSRRDB && got.Reason != modifiedReleaseReason {
+				t.Fatalf("heuristic reason = %q, want the generic modified-release reason", got.Reason)
 			}
 		})
 	}

--- a/internal/trackers/rules.go
+++ b/internal/trackers/rules.go
@@ -100,10 +100,13 @@ func evaluateRules(ctx context.Context, registry *Registry, tracker string, meta
 	addStrict := func(rule, reason string) { addFailure(rule, reason, api.RuleDispositionStrict) }
 	addWaivable := func(rule, reason string) { addFailure(rule, reason, api.RuleDispositionWaivable) }
 
-	// Renamed/modified releases are rejected by every supported tracker. Scene
-	// renames are authoritative and remain strict; heuristic rename detections
-	// may be explicitly authorized as a non-resolution policy exception.
-	if renamed, reason := releasepolicy.DetectModifiedRelease(releasepolicy.ModifiedReleaseSubject{
+	// Renamed/modified releases are rejected by every supported tracker. The
+	// disposition derives from the detection signal so there is one authority:
+	// the authoritative srrdb comparison remains strict; heuristic rename
+	// detections may be explicitly authorized as a non-resolution policy
+	// exception. The signal is diagnostic-only and never enters the disclosed
+	// failure reason.
+	if detection := releasepolicy.DetectModifiedRelease(releasepolicy.ModifiedReleaseSubject{
 		SourcePath:         meta.SourcePath,
 		VideoPath:          meta.VideoPath,
 		DiscType:           meta.DiscType,
@@ -111,12 +114,15 @@ func evaluateRules(ctx context.Context, registry *Registry, tracker string, meta
 		SceneRenamed:       meta.SceneRenamed,
 		SceneRenamedReason: meta.SceneRenamedReason,
 		Release:            meta.Release,
-	}); renamed {
+	}); detection.Modified {
 		disposition := api.RuleDispositionWaivable
-		if meta.SceneRenamed {
+		if detection.Signal == releasepolicy.ModifiedReleaseSignalSRRDB {
 			disposition = api.RuleDispositionStrict
 		}
-		addFailure("modified_release", reason, disposition)
+		addFailure("modified_release", detection.Reason, disposition)
+		if logger != nil {
+			logger.Debugf("trackers: rule matched tracker=%s rule=modified_release signal=%s disposition=%s", name, detection.Signal, disposition)
+		}
 	}
 	metadataFailures, metadataEvaluated := evaluateMetadataRequirementsWithRegistry(registry, name, meta)
 	failures = append(failures, metadataFailures...)

--- a/internal/trackers/rules_test.go
+++ b/internal/trackers/rules_test.go
@@ -5,6 +5,7 @@ package trackers_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -214,20 +215,20 @@ func TestUnit3DPayloadCallbacksRejectKnownInvalidFacts(t *testing.T) {
 		rule    string
 	}{
 		{
-tracker: "ACM",
- subject: api.TrackerValidationSubject{Region: "North America"},
- rule: "unsupported_region",
-},
+			tracker: "ACM",
+			subject: api.TrackerValidationSubject{Region: "North America"},
+			rule:    "unsupported_region",
+		},
 		{
-tracker: "LST",
- subject: api.TrackerValidationSubject{Edition: "Unknown Edition"},
- rule: "unsupported_edition",
-},
+			tracker: "LST",
+			subject: api.TrackerValidationSubject{Edition: "Unknown Edition"},
+			rule:    "unsupported_edition",
+		},
 		{
-tracker: "SHRI",
- subject: api.TrackerValidationSubject{DiscType: "DVD"},
- rule: "region_required",
-},
+			tracker: "SHRI",
+			subject: api.TrackerValidationSubject{DiscType: "DVD"},
+			rule:    "region_required",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.tracker, func(t *testing.T) {
@@ -914,6 +915,9 @@ func TestEvaluateRulesModifiedReleaseAcrossFamilies(t *testing.T) {
 		SourcePath: "/data/movies/Example Movie 2026 2160p MA WEB-DL DDP5 1 HDR H 265-GRP",
 		Release:    api.ReleaseInfo{Group: "GRP"},
 	}
+	arrRename := api.RuleSubject{
+		SourcePath: "/data/movies/Example Movie (2026) {imdb-tt1234567}",
+	}
 	clean := api.RuleSubject{
 		SourcePath: "/data/movies/Example.Movie.2026.2160p.MA.WEB-DL.DDP5.1.HDR.H.265-GRP",
 		Release:    api.ReleaseInfo{Group: "GRP", Resolution: "2160p"},
@@ -928,16 +932,19 @@ func TestEvaluateRulesModifiedReleaseAcrossFamilies(t *testing.T) {
 	for _, tracker := range []string{"LST", "PTP", "PHD", "HDB"} {
 		t.Run(tracker, func(t *testing.T) {
 			t.Parallel()
-			got := evaluateNonMetadataRulesForTest(context.Background(), tracker, heuristicRename)
-			failure, ok := findRuleFailure(got, "modified_release")
-			if !ok {
-				t.Fatalf("expected modified_release failure for %s, got %#v", tracker, got)
-			}
-			if failure.Disposition != api.RuleDispositionWaivable {
-				t.Fatalf("heuristic modified_release disposition for %s = %q, want waivable", tracker, failure.Disposition)
-			}
-			if !strings.Contains(failure.Reason, "renamed") {
-				t.Fatalf("expected a meaningful reason mentioning 'renamed' for %s, got %q", tracker, failure.Reason)
+			// Both heuristic signals (space rename and *arr token) stay waivable.
+			for _, meta := range []api.RuleSubject{heuristicRename, arrRename} {
+				got := evaluateNonMetadataRulesForTest(context.Background(), tracker, meta)
+				failure, ok := findRuleFailure(got, "modified_release")
+				if !ok {
+					t.Fatalf("expected modified_release failure for %s, got %#v", tracker, got)
+				}
+				if failure.Disposition != api.RuleDispositionWaivable {
+					t.Fatalf("heuristic modified_release disposition for %s = %q, want waivable", tracker, failure.Disposition)
+				}
+				if !strings.Contains(failure.Reason, "renamed") {
+					t.Fatalf("expected a meaningful reason mentioning 'renamed' for %s, got %q", tracker, failure.Reason)
+				}
 			}
 
 			sceneFailures := evaluateNonMetadataRulesForTest(context.Background(), tracker, sceneRename)
@@ -953,6 +960,101 @@ func TestEvaluateRulesModifiedReleaseAcrossFamilies(t *testing.T) {
 			}
 		})
 	}
+}
+
+type ruleDebugLogger struct {
+	api.NopLogger
+	debugs []string
+}
+
+func (l *ruleDebugLogger) Debugf(format string, args ...any) {
+	l.debugs = append(l.debugs, fmt.Sprintf(format, args...))
+}
+
+// TestEvaluateRulesModifiedReleaseDebugLog verifies the diagnostic rule-match
+// log carries only stable tracker/rule/signal/disposition fields, never a
+// local source/video path, and that the disclosed reason stays generic.
+func TestEvaluateRulesModifiedReleaseDebugLog(t *testing.T) {
+	t.Parallel()
+
+	const genericReason = "source appears renamed or modified from its original release name; verify the file hash and source provenance"
+
+	cases := []struct {
+		name string
+		meta api.RuleSubject
+		want string
+	}{
+		{
+			name: "srrdb detection logs strict",
+			meta: api.RuleSubject{
+				SourcePath:   "/data/movies/Example.Movie.2026.1080p.BluRay.x264-GRP",
+				VideoPath:    "/data/movies/Example.Movie.2026.1080p.BluRay.x264-GRP/Example.Movie.2026.1080p.BluRay.x264-GRP.mkv",
+				SceneRenamed: true,
+			},
+			want: "trackers: rule matched tracker=LST rule=modified_release signal=srrdb disposition=strict",
+		},
+		{
+			name: "arr token detection logs waivable",
+			meta: api.RuleSubject{
+				SourcePath: "/data/movies/Example Movie (2026) {imdb-tt1234567}",
+				VideoPath:  "/data/movies/Example Movie (2026) {imdb-tt1234567}/Example Movie (2026) {imdb-tt1234567}.mkv",
+			},
+			want: "trackers: rule matched tracker=LST rule=modified_release signal=arr-token disposition=waivable",
+		},
+		{
+			name: "space rename detection logs waivable",
+			meta: api.RuleSubject{
+				SourcePath: "/data/movies/Example Movie 2026 2160p MA WEB-DL DDP5 1 HDR H 265-GRP",
+				Release:    api.ReleaseInfo{Group: "GRP"},
+			},
+			want: "trackers: rule matched tracker=LST rule=modified_release signal=space-rename disposition=waivable",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			logger := &ruleDebugLogger{}
+			failures, err := trackers.EvaluateRules(context.Background(), "lst", tc.meta, logger)
+			if err != nil {
+				t.Fatalf("EvaluateRules: %v", err)
+			}
+			failure, ok := findRuleFailure(failures, "modified_release")
+			if !ok {
+				t.Fatalf("expected modified_release failure, got %#v", failures)
+			}
+			if failure.Reason != genericReason {
+				t.Fatalf("disclosed reason = %q, want the generic modified-release reason", failure.Reason)
+			}
+			if len(logger.debugs) != 1 || logger.debugs[0] != tc.want {
+				t.Fatalf("debug logs = %q, want exactly [%q]", logger.debugs, tc.want)
+			}
+			for _, entry := range logger.debugs {
+				for _, path := range []string{tc.meta.SourcePath, tc.meta.VideoPath, "/data/"} {
+					if path != "" && strings.Contains(entry, path) {
+						t.Fatalf("log entry %q discloses local path %q", entry, path)
+					}
+				}
+			}
+		})
+	}
+
+	t.Run("clean release logs nothing", func(t *testing.T) {
+		t.Parallel()
+		logger := &ruleDebugLogger{}
+		failures, err := trackers.EvaluateRules(context.Background(), "LST", api.RuleSubject{
+			SourcePath: "/data/movies/Example.Movie.2026.2160p.MA.WEB-DL.DDP5.1.HDR.H.265-GRP",
+			Release:    api.ReleaseInfo{Group: "GRP"},
+		}, logger)
+		if err != nil {
+			t.Fatalf("EvaluateRules: %v", err)
+		}
+		if hasRuleFailure(failures, "modified_release") {
+			t.Fatalf("did not expect modified_release failure, got %#v", failures)
+		}
+		if len(logger.debugs) != 0 {
+			t.Fatalf("expected no rule-match log for clean release, got %q", logger.debugs)
+		}
+	})
 }
 
 // TestEvaluateRulesMetadataPolicyReturnsEvaluatedEmpty guards the contract that


### PR DESCRIPTION
`isRenamedRelease` fires on three separate heuristics — the srrdb scene comparison, an \*arr rename token, and the space-rename check — but reports a **deliberately generic** user-facing reason for all three, since the reason is disclosed and must not reveal which detection tripped.

That left no way to tell them apart when diagnosing a false positive. A user reports "modified_release fired and it shouldn't have" and there is nothing in the logs saying which of the three did it.

`isRenamedRelease` now returns the signal name (`srrdb`, `arr-token`, `space-rename`) as a third value, and `EvaluateRules` logs it at debug alongside the source path, video path and group. The disclosed reason is unchanged — the signal is logging-only, which the doc comment states explicitly so nobody wires it into user-facing output later.

Pure observability, no behaviour change. `go build ./...`, `go vet` and the trackers suite (28 packages) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modified-release detection with clearer diagnostic classifications.
  * Applied stricter handling for database-confirmed release changes while allowing other detected changes to be waived.
  * Preserved user-facing explanations and prevented local file paths from appearing in diagnostics.
  * Improved tracking logs with consistent release-change details and dispositions.

* **Tests**
  * Expanded coverage for renamed releases, including common path and naming variations.
  * Added validation for clean-release behavior and diagnostic consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->