### PR TITLE
fix(security): update Go vulnerability tooling

### DIFF
--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GOVULNCHECK_VERSION: v1.3.0
-  OSV_SCANNER_VERSION: v2.3.8
+  GOVULNCHECK_VERSION: v1.6.0
+  OSV_SCANNER_VERSION: v2.4.0
 
 jobs:
   vuln:
@@ -36,4 +36,5 @@ jobs:
         run: go run golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} ./...
 
       - name: Run OSV dependency scan
+        if: ${{ !cancelled() }}
         run: go run github.com/google/osv-scanner/v2/cmd/osv-scanner@${OSV_SCANNER_VERSION} scan source --lockfile go.mod --lockfile gui/frontend/pnpm-lock.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # below. The predefined platform args (BUILDPLATFORM, TARGET*) are auto-available
 # to FROM, and VERSION/BUILD_ID are declared inside the build stage where they are
 # consumed (see below), so they do not need global declarations.
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 
 FROM --platform=$BUILDPLATFORM node:20-alpine AS frontend
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/autobrr/upbrr
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/anacrolix/torrent v1.61.0


### PR DESCRIPTION
## Summary

- build CLI and Docker binaries with Go 1.26.5
- update govulncheck to v1.6.0 and OSV Scanner to v2.4.0
- run the OSV scan after a govulncheck failure unless the workflow was canceled

## Root cause

The scheduled vulnerability workflow built with Go 1.26.4. Govulncheck detected reachable `crypto/tls` symbols affected by GO-2026-5856, which is fixed in Go 1.26.5. That failure also caused the independent OSV dependency scan to be skipped.

## Impact

CLI and Docker builds now embed the patched Go standard library. Scheduled scans use current scanner releases and report both Go and dependency findings in the same run.

## Validation

- `actionlint .github/workflows/vuln.yml`
- `go mod tidy -diff`
- `make backend`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...`
- `go run github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.4.0 scan source --lockfile go.mod --lockfile gui/frontend/pnpm-lock.yaml`
- `git diff --check`
- `make gofix-check-changed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to use a newer Go toolchain.
  * Updated vulnerability scanning tools to newer versions for more current security checks.
  * Improved workflow behavior so dependency scans do not continue after a cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->