### PR TITLE
fix(imagehosting): normalize pixhost URLs to the pixhost.to domain

### DIFF
--- a/internal/services/imagehosting/uploaders.go
+++ b/internal/services/imagehosting/uploaders.go
@@ -864,10 +864,14 @@ func (u *pixhostUploader) Upload(ctx context.Context, imagePath string) (uploadR
 	if response.ThumbnailURL == "" {
 		return uploadResult{}, errors.New("pixhost upload failed")
 	}
-	rawURL := strings.ReplaceAll(response.ThumbnailURL, "https://t", "https://img")
+	// The API responds with pixhost.cc URLs, but some trackers (e.g. BHD) only
+	// render images hosted on pixhost.to; both domains serve the same content.
+	thumbURL := strings.ReplaceAll(response.ThumbnailURL, ".pixhost.cc/", ".pixhost.to/")
+	showURL := strings.ReplaceAll(response.ShowURL, "://pixhost.cc/", "://pixhost.to/")
+	rawURL := strings.ReplaceAll(thumbURL, "https://t", "https://img")
 	rawURL = strings.ReplaceAll(rawURL, "/thumbs/", "/images/")
 
-	return uploadResult{ImgURL: response.ThumbnailURL, RawURL: rawURL, WebURL: response.ShowURL}, nil
+	return uploadResult{ImgURL: thumbURL, RawURL: rawURL, WebURL: showURL}, nil
 }
 
 type ziplineUploader struct {

--- a/internal/services/imagehosting/uploaders_test.go
+++ b/internal/services/imagehosting/uploaders_test.go
@@ -503,13 +503,13 @@ func TestPixhostUploaderPostsCurrentDomain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Upload returned error: %v", err)
 	}
-	if result.ImgURL != "https://t1.pixhost.cc/thumbs/11645/shot.png" {
+	if result.ImgURL != "https://t1.pixhost.to/thumbs/11645/shot.png" {
 		t.Fatalf("unexpected img URL: %q", result.ImgURL)
 	}
-	if result.RawURL != "https://img1.pixhost.cc/images/11645/shot.png" {
+	if result.RawURL != "https://img1.pixhost.to/images/11645/shot.png" {
 		t.Fatalf("unexpected raw URL: %q", result.RawURL)
 	}
-	if result.WebURL != "https://pixhost.cc/show/11645/shot.png" {
+	if result.WebURL != "https://pixhost.to/show/11645/shot.png" {
 		t.Fatalf("unexpected web URL: %q", result.WebURL)
 	}
 }


### PR DESCRIPTION
## What

The pixhost API (`api.pixhost.cc`) responds with `pixhost.cc` thumbnail and show URLs. Some trackers (e.g. BHD) only render images hosted on `pixhost.to`, so descriptions built from the returned URLs end up with broken thumbnails there.

Both domains serve the same content, so this rewrites the returned `th_url`/`show_url` (and the derived raw image URL) to the `.to` domain in the pixhost uploader — one spot, fixes every tracker.

## Testing

- `go test -race ./internal/services/imagehosting/` passes (fixture updated to expect `.to` URLs).
- Verified `t1.pixhost.to` / `pixhost.to` serve the same content as their `.cc` counterparts.
- Observed on a real BHD upload: `.cc` thumbs not rendered, `.to` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Pixhost image, thumbnail, and viewing links to use the current `pixhost.to` domains.
  - Improved compatibility with Pixhost-hosted uploads by ensuring generated raw image links use the updated host format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->