### PR TITLE
feat(docker): bump alpine base to 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         CGO_ENABLED=0 GOOS="$TARGETOS" GOARCH="$TARGETARCH" GOARM="$goarm" \
             go build -trimpath -ldflags="-s -w -X main.version=${VERSION} -X main.buildIdentifier=${BUILD_ID}" -o /out/upbrr ./cmd/upbrr
 
-FROM alpine:3.23
+FROM alpine:3.24
 
 # fontconfig + a font are required by ffmpeg's drawtext filter (screenshot frame
 # overlays); without them capture fails with "Cannot find a valid font for the


### PR DESCRIPTION
The ffmpeg `libdvdnav` and `libdvdread` are enabled on 3.24 

Ref https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/101542

This should close #277 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s runtime environment to Alpine Linux 3.24.
  * Existing startup behavior, health checks, and runtime configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->