### PR TITLE
fix(imagehosting): update OnlyImage uploader to v1.1 contract

### DIFF
--- a/internal/imagehosting/uploaders.go
+++ b/internal/imagehosting/uploaders.go
@@ -623,9 +623,6 @@ func (u *onlyImageUploader) Upload(ctx context.Context, imagePath string) (uploa
 	if err != nil {
 		return uploadResult{}, err
 	}
-	if status != http.StatusOK {
-		return uploadResult{}, fmt.Errorf("onlyimage upload failed with status %d", status)
-	}
 
 	var response struct {
 		StatusCode int `json:"status_code"`
@@ -651,13 +648,22 @@ func (u *onlyImageUploader) Upload(ctx context.Context, imagePath string) (uploa
 		StatusText string `json:"status_txt"`
 	}
 	if err := json.Unmarshal(body, &response); err != nil {
+		if status != http.StatusOK {
+			return uploadResult{}, fmt.Errorf("onlyimage upload failed with status %d", status)
+		}
 		return uploadResult{}, fmt.Errorf("onlyimage invalid response: %w", err)
 	}
-	if response.StatusCode != http.StatusOK || (response.Success.Code != 0 && response.Success.Code != http.StatusOK) {
-		message := safeResponseMessage(response.Error.Message)
+	message := safeResponseMessage(response.Error.Message)
+	if message == "" {
+		message = safeResponseMessage(response.StatusText)
+	}
+	if status != http.StatusOK {
 		if message == "" {
-			message = safeResponseMessage(response.StatusText)
+			return uploadResult{}, fmt.Errorf("onlyimage upload failed with status %d", status)
 		}
+		return uploadResult{}, fmt.Errorf("onlyimage upload failed: %s", message)
+	}
+	if response.StatusCode != http.StatusOK || (response.Success.Code != 0 && response.Success.Code != http.StatusOK) {
 		if message == "" {
 			message = "onlyimage upload failed"
 		}

--- a/internal/imagehosting/uploaders.go
+++ b/internal/imagehosting/uploaders.go
@@ -617,16 +617,9 @@ func (u *onlyImageUploader) Upload(ctx context.Context, imagePath string) (uploa
 	if strings.TrimSpace(u.apiKey) == "" {
 		return uploadResult{}, errors.New("image hosting: onlyimage api key missing")
 	}
-	encoded, err := readBase64(imagePath)
-	if err != nil {
-		return uploadResult{}, err
-	}
-
-	form := url.Values{}
-	form.Set("image", encoded)
 	headers := map[string]string{"X-API-Key": strings.TrimSpace(u.apiKey)}
 
-	body, status, err := postForm(ctx, u.client, "https://onlyimage.org/api/1/upload", form, headers)
+	body, status, err := postMultipart(ctx, u.client, "https://onlyimage.org/api/1/upload", nil, "source", imagePath, headers)
 	if err != nil {
 		return uploadResult{}, err
 	}
@@ -635,28 +628,60 @@ func (u *onlyImageUploader) Upload(ctx context.Context, imagePath string) (uploa
 	}
 
 	var response struct {
-		Success bool `json:"success"`
-		Data    struct {
+		StatusCode int `json:"status_code"`
+		Success    struct {
+			Code int `json:"code"`
+		} `json:"success"`
+		Image struct {
 			Image struct {
 				URL string `json:"url"`
 			} `json:"image"`
 			Medium struct {
 				URL string `json:"url"`
 			} `json:"medium"`
+			Thumb struct {
+				URL string `json:"url"`
+			} `json:"thumb"`
+			URL       string `json:"url"`
 			URLViewer string `json:"url_viewer"`
-		} `json:"data"`
+		} `json:"image"`
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+		StatusText string `json:"status_txt"`
 	}
 	if err := json.Unmarshal(body, &response); err != nil {
 		return uploadResult{}, fmt.Errorf("onlyimage invalid response: %w", err)
 	}
-	if !response.Success {
+	if response.StatusCode != http.StatusOK || (response.Success.Code != 0 && response.Success.Code != http.StatusOK) {
+		message := safeResponseMessage(response.Error.Message)
+		if message == "" {
+			message = safeResponseMessage(response.StatusText)
+		}
+		if message == "" {
+			message = "onlyimage upload failed"
+		}
+		return uploadResult{}, fmt.Errorf("onlyimage upload failed: %s", message)
+	}
+	rawURL := strings.TrimSpace(response.Image.URL)
+	if rawURL == "" {
+		rawURL = strings.TrimSpace(response.Image.Image.URL)
+	}
+	if rawURL == "" {
 		return uploadResult{}, errors.New("onlyimage upload failed")
+	}
+	imgURL := strings.TrimSpace(response.Image.Medium.URL)
+	if imgURL == "" {
+		imgURL = strings.TrimSpace(response.Image.Thumb.URL)
+	}
+	if imgURL == "" {
+		imgURL = rawURL
 	}
 
 	return uploadResult{
-		ImgURL: response.Data.Medium.URL,
-		RawURL: response.Data.Image.URL,
-		WebURL: response.Data.URLViewer,
+		ImgURL: imgURL,
+		RawURL: rawURL,
+		WebURL: response.Image.URLViewer,
 	}, nil
 }
 

--- a/internal/imagehosting/uploaders_test.go
+++ b/internal/imagehosting/uploaders_test.go
@@ -742,7 +742,7 @@ func TestOnlyImageUploaderRejectsV11Failure(t *testing.T) {
 	client := &http.Client{
 		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 			return &http.Response{
-				StatusCode: http.StatusOK,
+				StatusCode: http.StatusBadRequest,
 				Header:     make(http.Header),
 				Body: io.NopCloser(strings.NewReader(`{
 					"status_code": 400,

--- a/internal/imagehosting/uploaders_test.go
+++ b/internal/imagehosting/uploaders_test.go
@@ -660,6 +660,105 @@ func TestPixhostUploaderPostsCurrentDomain(t *testing.T) {
 	}
 }
 
+func TestOnlyImageUploaderUsesV11Contract(t *testing.T) {
+	imagePath := filepath.Join(t.TempDir(), "shot.png")
+	if err := os.WriteFile(imagePath, []byte("synthetic image"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() != "https://onlyimage.org/api/1/upload" {
+				t.Fatalf("unexpected request URL: %s", req.URL.String())
+			}
+			if req.Header.Get("X-Api-Key") != "secret" {
+				t.Fatal("expected X-API-Key")
+			}
+			mediaType, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+			if err != nil {
+				t.Fatalf("parse media type: %v", err)
+			}
+			if mediaType != "multipart/form-data" {
+				t.Fatalf("unexpected media type: %s", mediaType)
+			}
+			reader := multipartReader(t, req, params["boundary"])
+			part, err := reader.NextPart()
+			if err != nil {
+				t.Fatalf("read source part: %v", err)
+			}
+			if part.FormName() != "source" || part.FileName() != "shot.png" {
+				t.Fatal("expected source file field")
+			}
+			payload, err := io.ReadAll(part)
+			if err != nil {
+				t.Fatalf("read source payload: %v", err)
+			}
+			if string(payload) != "synthetic image" {
+				t.Fatal("unexpected source payload")
+			}
+			if _, err := reader.NextPart(); !errors.Is(err, io.EOF) {
+				t.Fatalf("expected end of multipart request: %v", err)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+					"status_code": 200,
+					"success": {"message": "file uploaded", "code": 200},
+					"image": {
+						"url": "https://onlyimage.example.invalid/images/shot.png",
+						"image": {"url": "https://onlyimage.example.invalid/images/shot.png"},
+						"medium": {"url": null},
+						"thumb": {"url": "https://onlyimage.example.invalid/images/shot.th.png"},
+						"url_viewer": "https://onlyimage.example.invalid/image/shot"
+					},
+					"status_txt": "OK"
+				}`)),
+			}, nil
+		}),
+	}
+
+	result, err := (&onlyImageUploader{apiKey: "secret", client: client}).Upload(context.Background(), imagePath)
+	if err != nil {
+		t.Fatalf("Upload returned error: %v", err)
+	}
+	if result.ImgURL != "https://onlyimage.example.invalid/images/shot.th.png" {
+		t.Fatalf("unexpected img URL: %q", result.ImgURL)
+	}
+	if result.RawURL != "https://onlyimage.example.invalid/images/shot.png" {
+		t.Fatalf("unexpected raw URL: %q", result.RawURL)
+	}
+	if result.WebURL != "https://onlyimage.example.invalid/image/shot" {
+		t.Fatalf("unexpected web URL: %q", result.WebURL)
+	}
+}
+
+func TestOnlyImageUploaderRejectsV11Failure(t *testing.T) {
+	imagePath := filepath.Join(t.TempDir(), "shot.png")
+	if err := os.WriteFile(imagePath, []byte("synthetic image"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(`{
+					"status_code": 400,
+					"error": {"message": "invalid source"},
+					"status_txt": "Bad Request"
+				}`)),
+			}, nil
+		}),
+	}
+
+	_, err := (&onlyImageUploader{apiKey: "secret", client: client}).Upload(context.Background(), imagePath)
+	if err == nil || !strings.Contains(err.Error(), "invalid source") {
+		t.Fatal("expected OnlyImage rejection")
+	}
+}
+
 func TestReelflixUploaderPostsSourceWithAPIKey(t *testing.T) {
 	tmpDir := t.TempDir()
 	imagePath := filepath.Join(tmpDir, "shot.png")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OnlyImage uploads to use the current multipart API contract, including the required API key header.
  * Improved validation of upload responses and clearer failure handling for non-OK and contract-mismatch cases.
  * Corrected mapping of returned URLs into raw, preview (thumb), and viewer links.

* **Tests**
  * Added tests covering the multipart v1.1 request format and successful URL mapping.
  * Added tests for rejecting v1.1-style failure responses and surfacing the error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->