### PR TITLE
fix(docker): use Node 24 for pnpm 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # consumed (see below), so they do not need global declarations.
 ARG GO_VERSION=1.26.5
 
-FROM --platform=$BUILDPLATFORM node:20-alpine AS frontend
+FROM --platform=$BUILDPLATFORM node:24-alpine AS frontend
 
 WORKDIR /src/webui
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the frontend build environment to use Node.js 24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->