### PR TITLE
fix(torrentclient): preserve qBittorrent injection save path

### DIFF
--- a/internal/torrentclient/linking.go
+++ b/internal/torrentclient/linking.go
@@ -347,9 +347,10 @@ func sourcePathForLinking(meta api.ClientSubject) (string, error) {
 	return absLocalPath("linking source", source)
 }
 
-// sourcePathForQbitSavePath returns the prepared source path used for qbit
-// savepath mapping. It is intentionally lexical and does not stat the source,
-// because qbit injection can still be valid when source metadata is unavailable.
+// sourcePathForQbitSavePath returns the prepared content path used for
+// qBittorrent savepath mapping. Resolution is lexical because client-visible content need
+// not be available to stat locally. A torrent artifact path or URL is separate
+// from the prepared content source and cannot replace it.
 func sourcePathForQbitSavePath(meta api.ClientSubject) (string, error) {
 	if len(meta.FileList) == 1 {
 		if candidate := strings.TrimSpace(meta.FileList[0]); candidate != "" {
@@ -358,7 +359,10 @@ func sourcePathForQbitSavePath(meta api.ClientSubject) (string, error) {
 	}
 	source := strings.TrimSpace(meta.SourcePath)
 	if source == "" {
-		return "", internalerrors.ErrInvalidInput
+		return "", fmt.Errorf(
+			"prepared source path is required for qBittorrent save path; torrent artifact path or URL does not replace it: %w",
+			internalerrors.ErrInvalidInput,
+		)
 	}
 	return absLocalPath("qbit mapping source", source)
 }

--- a/internal/torrentclient/linking.go
+++ b/internal/torrentclient/linking.go
@@ -778,21 +778,16 @@ func mappedRemotePath[S ~[]string](value string, localPaths S, remotePaths S) (s
 	return bestMapped, bestSpecificity >= 0
 }
 
-// mappedQbitSavePathForSource maps the prepared source path to the qBittorrent
-// save path parent that can contain the torrent's top-level content. It returns
-// mapped=false without touching source metadata when no usable path pairs exist
-// or no configured pair matches the lexical source path.
-func mappedQbitSavePathForSource[S ~[]string](meta api.ClientSubject, localPaths S, remotePaths S) (string, bool, error) {
-	if len(pathMappingPairs(localPaths, remotePaths)) == 0 {
-		return "", false, nil
-	}
+// qbitSavePathForSource returns the prepared source parent, mapped to the
+// qBittorrent host when a configured local/remote path pair matches.
+func qbitSavePathForSource[S ~[]string](meta api.ClientSubject, localPaths S, remotePaths S) (string, bool, error) {
 	source, err := sourcePathForQbitSavePath(meta)
 	if err != nil {
 		return "", false, err
 	}
 	mappedSource, ok := mappedRemotePath(source, localPaths, remotePaths)
 	if !ok {
-		return "", false, nil
+		return qbitSavePath(filepath.Dir(source)), false, nil
 	}
 	return qbitSavePath(filepath.Dir(mappedSource)), true, nil
 }

--- a/internal/torrentclient/service.go
+++ b/internal/torrentclient/service.go
@@ -384,16 +384,14 @@ func (s *Service) injectQbit(ctx context.Context, name string, client config.Tor
 			staging.SavePath,
 		)
 	} else {
-		// Without link staging, local_path/remote_path still controls where
-		// qBittorrent should save the injected torrent on the client host.
-		savePath, mapped, err := mappedQbitSavePathForSource(meta, client.LocalPath, client.RemotePath)
+		// Without link staging, save beside the prepared source unless a
+		// local_path/remote_path pair maps that location to the client host.
+		savePath, mapped, err := qbitSavePathForSource(meta, client.LocalPath, client.RemotePath)
 		if err != nil {
-			return fmt.Errorf("clients: %s qbit path mapping: %w", name, err)
+			return fmt.Errorf("clients: %s qbit save path: %w", name, err)
 		}
-		if mapped {
-			options.SavePath = savePath
-			logger.Debugf("clients: qbit path mapping ready client=%s save_path=%s", name, savePath)
-		}
+		options.SavePath = savePath
+		logger.Debugf("clients: qbit save path ready client=%s mapped=%t save_path=%s", name, mapped, savePath)
 	}
 	if category := strings.TrimSpace(client.QbitCrossCategory); torrent.CrossSeed && category != "" {
 		options.Category = category

--- a/internal/torrentclient/service.go
+++ b/internal/torrentclient/service.go
@@ -109,9 +109,11 @@ func NewServiceWithRegistry(cfg config.Config, logger api.Logger, registry *trac
 
 // Inject dispatches a prepared torrent to selected clients in sorted name order
 // and applies per-client delay, path mapping, link staging, category, and tag
-// policy. URL-only torrents require a URL-capable client unless global/default
-// fallback can select one; explicit tracker or caller selections that resolve
-// only to watch-folder clients return [internalerrors.ErrInvalidInput].
+// policy. URL-only describes the torrent artifact delivery mode; the prepared
+// content source remains required for qBittorrent save-path resolution. URL-only
+// torrents require a URL-capable client unless global/default fallback can select
+// one; explicit tracker or caller selections that resolve only to watch-folder
+// clients return [internalerrors.ErrInvalidInput].
 //
 // qBittorrent adds set skip_checking=true for both linked and original-path
 // injection. The first client error stops dispatch; prior watch-folder copies or
@@ -388,7 +390,7 @@ func (s *Service) injectQbit(ctx context.Context, name string, client config.Tor
 		// local_path/remote_path pair maps that location to the client host.
 		savePath, mapped, err := qbitSavePathForSource(meta, client.LocalPath, client.RemotePath)
 		if err != nil {
-			return fmt.Errorf("clients: %s qbit save path: %w", name, err)
+			return fmt.Errorf("clients: %s resolve qBittorrent save path: %w", name, err)
 		}
 		options.SavePath = savePath
 		logger.Debugf("clients: qbit save path ready client=%s mapped=%t save_path=%s", name, mapped, savePath)

--- a/internal/torrentclient/service_test.go
+++ b/internal/torrentclient/service_test.go
@@ -235,6 +235,30 @@ func TestInjectQbitClient(t *testing.T) {
 	}
 }
 
+func TestInjectQbitClientRejectsMissingPreparedSourceForURLArtifact(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newQbitAddCaptureServer(t)
+	svc := NewService(config.Config{
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:     "qbit",
+				URL:      server.URL,
+				Username: "user",
+				Password: "pass",
+			},
+		},
+	}, nil)
+
+	err := svc.Inject(context.Background(), api.ClientSubject{}, api.TorrentResult{URL: "https://tracker.example/download/1"})
+	if !errors.Is(err, internalerrors.ErrInvalidInput) {
+		t.Fatalf("expected invalid input, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "torrent artifact path or URL does not replace it") {
+		t.Fatal("expected source-versus-artifact guidance")
+	}
+}
+
 func TestInjectQbitClientRejectsCookieBearingNonOKLogin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/torrentclient/service_test.go
+++ b/internal/torrentclient/service_test.go
@@ -131,6 +131,7 @@ func TestInjectQbitClient(t *testing.T) {
 	var addTags string
 	var addSkipChecking string
 	var addAutoTMM string
+	var addSavePath string
 	var fileCount int
 	errCh := make(chan error, 1)
 
@@ -155,6 +156,7 @@ func TestInjectQbitClient(t *testing.T) {
 			addTags = r.FormValue("tags")
 			addSkipChecking = r.FormValue("skip_checking")
 			addAutoTMM = r.FormValue("autoTMM")
+			addSavePath = r.FormValue("savepath")
 			if files, ok := r.MultipartForm.File["torrents"]; ok {
 				fileCount = len(files)
 			}
@@ -171,6 +173,8 @@ func TestInjectQbitClient(t *testing.T) {
 	defer server.Close()
 
 	root := t.TempDir()
+	mediaRoot := filepath.Join(root, "media")
+	sourcePath := filepath.Join(mediaRoot, "video.mkv")
 	torrentPath := filepath.Join(root, "sample.torrent")
 	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
@@ -185,11 +189,13 @@ func TestInjectQbitClient(t *testing.T) {
 				Password: "pass",
 				Category: "ua",
 				Tags:     []string{"tag1", "tag2"},
+				LocalPath:  config.StringList{""},
+				RemotePath: config.StringList{""},
 			},
 		},
 	}, nil)
 
-	if err := svc.Inject(context.Background(), api.ClientSubject{SourcePath: "video.mkv"}, api.TorrentResult{Path: torrentPath}); err != nil {
+	if err := svc.Inject(context.Background(), api.ClientSubject{SourcePath: sourcePath}, api.TorrentResult{Path: torrentPath}); err != nil {
 		t.Fatalf("inject: %v", err)
 	}
 
@@ -218,6 +224,11 @@ func TestInjectQbitClient(t *testing.T) {
 	}
 	if addAutoTMM != "false" {
 		t.Fatalf("expected autoTMM false, got %q", addAutoTMM)
+	}
+	//pathpolicy:allow qBittorrent savepath is slash-delimited API data.
+	wantSavePath := filepath.ToSlash(mediaRoot) + "/"
+	if addSavePath != wantSavePath {
+		t.Fatalf("expected source-parent savepath %q, got %q", wantSavePath, addSavePath)
 	}
 	if fileCount != 1 {
 		t.Fatalf("expected 1 torrent file, got %d", fileCount)
@@ -940,8 +951,10 @@ func TestInjectQbitClientInvalidLinkPlanFallbackSkipsHashCheck(t *testing.T) {
 
 	capture.mu.Lock()
 	defer capture.mu.Unlock()
-	if capture.savePath != "" {
-		t.Fatalf("expected original-path fallback, got savepath %q", capture.savePath)
+	//pathpolicy:allow qBittorrent savepath is slash-delimited API data.
+	wantSavePath := filepath.ToSlash(root) + "/"
+	if capture.savePath != wantSavePath {
+		t.Fatalf("expected original-path fallback savepath %q, got %q", wantSavePath, capture.savePath)
 	}
 	if capture.skipChecking != "true" {
 		t.Fatalf("expected fallback to skip hash checking, got skip_checking=%q", capture.skipChecking)
@@ -1259,8 +1272,10 @@ func TestInjectQbitClientFailedLinkPlanFallbackSkipsHashCheck(t *testing.T) {
 	if capture.addCalls != 1 {
 		t.Fatalf("expected one qbit add attempt, got %d", capture.addCalls)
 	}
-	if capture.savePath != "" {
-		t.Fatalf("expected original-path fallback, got savepath %q", capture.savePath)
+	//pathpolicy:allow qBittorrent savepath is slash-delimited API data.
+	wantSavePath := filepath.ToSlash(root) + "/"
+	if capture.savePath != wantSavePath {
+		t.Fatalf("expected original-path fallback savepath %q, got %q", wantSavePath, capture.savePath)
 	}
 	if capture.skipChecking != "true" {
 		t.Fatalf("expected failed-link fallback to skip hash checking, got skip_checking=%q", capture.skipChecking)

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -712,8 +712,9 @@ type TorrentSubject struct {
 	TorrentOverrides  TorrentOverrides
 }
 
-// ClientSubject contains only source facts and caller instructions required
-// for torrent-client search, linking, and injection.
+// ClientSubject contains prepared content source facts and caller instructions
+// for torrent-client search, linking, and injection. [TorrentResult] paths and
+// URLs identify torrent artifacts and do not replace these source facts.
 type ClientSubject struct {
 	SourcePath      string
 	FileList        []string


### PR DESCRIPTION
## Summary

- default unlinked qBittorrent injections to the prepared upbrr source parent
- keep linked staging paths and matching local-to-remote mappings authoritative
- cover blank example mappings and linking fallbacks with wire-level savepath assertions

## Root cause

When no usable local-to-remote mapping matched, upbrr omitted the qBittorrent `savepath` field. qBittorrent then selected its category or global default path instead of reusing the upbrr input location.

## Impact

Direct qBittorrent and Qui-proxied injections now use the source parent by default. Remote installations can continue translating that path with `local_path` and `remote_path`; linking modes continue using their staging paths.

## Validation

- `go test -race -v -timeout 20m ./internal/torrentclient`
- `make gofix-check-changed`
- `make pathpolicy`
- `make logpolicy`
- `make lint`
- pre-commit and pre-push hooks, including frontend typecheck

Closes #158


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved qBittorrent save-path handling when path mappings are unavailable.
  * Save paths are now consistently populated using the source media location as a fallback.
  * Corrected save-path propagation across standard, invalid-plan, and failed-plan scenarios.
  * Improved error messages when save-path resolution fails.
  * URL-only torrent artifacts now provide clearer guidance when a prepared source is missing.

* **Documentation**
  * Clarified how prepared source paths are used during torrent client operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->