### PR TITLE
fix(webui): redact secrets after settings save

### DIFF
--- a/webui/src/hooks/useSettingsState.test.ts
+++ b/webui/src/hooks/useSettingsState.test.ts
@@ -167,6 +167,7 @@ function TrackerSettingsHarness() {
     "div",
     null,
     state.renderTrackerSection(false),
+    createElement("button", { type: "button", onClick: state.handleSaveSettings }, "Save settings"),
     createElement(PayloadCapture, { value: state.buildSavePayload() }),
   );
 }
@@ -796,8 +797,9 @@ describe("Tracker client selectors", () => {
     expect(screen.getByText("1/1")).toBeInTheDocument();
   });
 
-  it("masks encrypted tracker credentials and preserves them for saves", async () => {
+  it("masks tracker credentials after saving while preserving them in the payload", async () => {
     const encryptedAPIKey = "upbrr-enc:v1:encrypted-btn-api-key";
+    let savedReplacement = false;
     installAppOperationMocks({
       GetConfig: async () =>
         JSON.stringify({
@@ -828,6 +830,12 @@ describe("Tracker client selectors", () => {
           ),
         ),
       GetImageHostPolicyMetadata: async () => ({}),
+      SaveConfig: async (payload: string) => {
+        const saved = JSON.parse(payload) as {
+          Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
+        };
+        savedReplacement = saved.Trackers?.Trackers?.BTN?.APIKey === "replacement-api-key";
+      },
     });
 
     render(createElement(TrackerSettingsHarness));
@@ -857,7 +865,12 @@ describe("Tracker client selectors", () => {
     payload = readPayload<{
       Trackers?: { Trackers?: Record<string, Record<string, unknown>> };
     }>();
-    expect(payload.Trackers?.Trackers?.BTN?.APIKey).toBe("replacement-api-key");
+    expect(payload.Trackers?.Trackers?.BTN?.APIKey === "replacement-api-key").toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+    await waitFor(() => expect(screen.getByLabelText("API key")).toHaveValue("[REDACTED]"));
+    expect(savedReplacement).toBe(true);
   });
 
   it("renders BTN announce URL from tracker schema when stored config lacks the key", async () => {

--- a/webui/src/hooks/useSettingsState.test.ts
+++ b/webui/src/hooks/useSettingsState.test.ts
@@ -871,6 +871,11 @@ describe("Tracker client selectors", () => {
 
     await waitFor(() => expect(screen.getByLabelText("API key")).toHaveValue("[REDACTED]"));
     expect(savedReplacement).toBe(true);
+
+    savedReplacement = false;
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+    await waitFor(() => expect(savedReplacement).toBe(true));
   });
 
   it("renders BTN announce URL from tracker schema when stored config lacks the key", async () => {

--- a/webui/src/hooks/useSettingsState.tsx
+++ b/webui/src/hooks/useSettingsState.tsx
@@ -920,6 +920,9 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
     try {
       await saveConfig(payload);
       if (settingsMutationVersion.current === mutationVersion) {
+        const masked = maskSensitiveConfig(JSON.parse(payload) as ConfigMap);
+        setConfigData(masked.masked);
+        setSensitiveValues(masked.originals);
         markSettingsSaved("Settings saved and applied.");
       } else {
         setSettingsSaved("Earlier changes saved. Newer edits remain unsaved.");


### PR DESCRIPTION
## Summary

- Mask saved secret fields immediately in WebUI state.
- Preserve saved secret values for later settings submissions.
- Add regression coverage for post-save redaction.

## Root cause

Initial config loading applied the existing secret masker, but successful saves left edited plaintext in React state until reload or restart.

## Validation

- `make test-frontend`
- `make logpolicy`
- `git diff --check`
- pre-commit frontend format and lint hooks
- pre-push frontend typecheck hook

Fixes #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive settings are now remasked after saving.
  * Saved configuration values refresh correctly, ensuring the latest credentials are displayed securely.

* **Tests**
  * Added coverage confirming replacement credentials are submitted and API keys are remasked after repeated saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->