### PR TITLE
fix(build): stop PowerShell builds on command failures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ pnpm --dir webui run build
 For embedded web visual checks, test the embedded build rather than the Vite-only server. Rebuild the frontend, sync it into embedded assets, rebuild the CLI, then run the auth-disabled embedded server on the main port:
 
 ```powershell
-powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/build.ps1
+pwsh -NoProfile -File ./scripts/build.ps1
 .\dist\upbrr.exe serve --dev-no-auth
 ```
 
@@ -282,6 +282,7 @@ Prefer generic group tags such as `GRP` when the group is incidental; real group
 ### Logging levels
 
 Keep log levels purposeful.
+
 - `INFO` should provide concise, relevant progress or outcome details for end users during uploads and other top-level workflows.
 - `DEBUG` should include richer decision-making context useful for developer troubleshooting.
 - `TRACE` should capture near-complete operational flow for high-fidelity execution reporting.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 ifeq ($(OS),Windows_NT)
 EXE := .exe
-FULL_BUILD := powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/build.ps1
+FULL_BUILD := pwsh -NoProfile -File ./scripts/build.ps1
 MKDIR_DIST := powershell -NoProfile -Command "New-Item -ItemType Directory -Force -Path dist | Out-Null"
 RM_DIST := powershell -NoProfile -Command "Remove-Item -Recurse -Force dist, webui/dist -ErrorAction SilentlyContinue"
 BLANK := echo.

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -5,7 +5,13 @@ Set-Location $root
 Write-Host "Building WebUI..."
 Push-Location "webui"
 pnpm install --frozen-lockfile
+if ($LASTEXITCODE -ne 0) {
+  throw "pnpm install failed with exit code $LASTEXITCODE"
+}
 pnpm run build
+if ($LASTEXITCODE -ne 0) {
+  throw "pnpm build failed with exit code $LASTEXITCODE"
+}
 Pop-Location
 
 Write-Host "Syncing embedded WebUI assets..."
@@ -18,5 +24,8 @@ if (-not (Test-Path $distPath)) {
 }
 $cliOut = Join-Path $distPath "upbrr.exe"
 go build -o $cliOut ./cmd/upbrr
+if ($LASTEXITCODE -ne 0) {
+  throw "go build failed with exit code $LASTEXITCODE"
+}
 
 Write-Host "Done. Binary: dist/upbrr.exe"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows build reliability by using PowerShell Core consistently.
  - Build failures during dependency installation, frontend compilation, or Go compilation now report clear errors and exit codes.

- **Documentation**
  - Updated contributor guidance for the visual-check command.
  - Improved formatting in the logging levels section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->