### PR TITLE
fix: frontend input issues

### DIFF
--- a/internal/preparedrelease/display.go
+++ b/internal/preparedrelease/display.go
@@ -32,7 +32,7 @@ func projectPreparedReleaseDisplay(release api.PreparedRelease) (api.PreparedRel
 		return api.PreparedReleaseDisplay{}, fmt.Errorf("prepared release: clone display source: %w", err)
 	}
 	release = detached
-	display := api.PreparedReleaseDisplay{ReleaseName: release.Naming.ReleaseName}
+	display := api.PreparedReleaseDisplay{ReleaseName: release.Naming.ReleaseName, Providers: []api.ProviderDisplay{}}
 	identity := release.Identity
 	metadata := release.ProviderMetadata
 	if value := metadata.TMDB; value != nil {

--- a/internal/preparedrelease/display_test.go
+++ b/internal/preparedrelease/display_test.go
@@ -69,6 +69,9 @@ func TestProjectPreparedReleaseDisplaySparseAndLocalFallbacks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if display.Providers == nil {
+		t.Fatal("identity-only display providers are nil")
+	}
 	if len(display.Providers) != 0 {
 		t.Fatalf("identity-only display providers = %d, want 0", len(display.Providers))
 	}

--- a/webui/src/app.test.ts
+++ b/webui/src/app.test.ts
@@ -76,12 +76,23 @@ describe("App shell", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: "Dupe Check" })).toBeDisabled());
   });
 
-  it("opens the global host-browser dialog from input presentation", async () => {
-    const browse = vi.fn(async (_path: string) => ({
-      currentPath: "C:\\media",
-      parentPath: "C:\\",
-      mode: "folder",
-      entries: [],
+  it("opens folders separately from selecting them", async () => {
+    const browse = vi.fn(async (path: string) => ({
+      currentPath: path || "C:\\media",
+      parentPath: path ? "C:\\media" : "C:\\",
+      mode: "folder" as const,
+      entries:
+        path === "C:\\media\\Example"
+          ? []
+          : [
+              {
+                name: "Example",
+                path: "C:\\media\\Example",
+                isDir: true,
+                size: 0,
+                modifiedAt: "2026-01-01T00:00:00Z",
+              },
+            ],
     }));
     setAppRequestHandlerForTests(async (method, body) => {
       if (method === "GetConfig" || method === "GetDefaultConfig") return "{}";
@@ -92,8 +103,22 @@ describe("App shell", () => {
     render(createElement(App));
     screen.getByRole("button", { name: "Browse folder" }).click();
 
-    expect(await screen.findByRole("dialog", { name: "Select folder" })).toBeInTheDocument();
+    expect(await screen.findByRole("dialog", { name: "Host browser" })).toBeInTheDocument();
+    await waitFor(() => expect(browse).toHaveBeenCalledWith(""));
+    expect(await screen.findByText("C:\\media")).toBeInTheDocument();
+    expect(await screen.findByText("[DIR] Example")).toBeInTheDocument();
+    expect(screen.queryByText("C:\\media\\Example")).not.toBeInTheDocument();
     expect(browse).toHaveBeenCalledOnce();
+
+    screen.getByRole("button", { name: "Open Example" }).click();
+    await waitFor(() => expect(browse).toHaveBeenLastCalledWith("C:\\media\\Example"));
+    expect(screen.getByLabelText("Source path")).toHaveValue("");
+    expect(await screen.findByText("C:\\media\\Example")).toBeInTheDocument();
+
+    screen.getByRole("button", { name: "Select folder" }).click();
+    await waitFor(() =>
+      expect(screen.getByLabelText("Source path")).toHaveValue("C:\\media\\Example"),
+    );
   });
 
   it("starts with a blank source draft while retaining source history", async () => {

--- a/webui/src/app.tsx
+++ b/webui/src/app.tsx
@@ -276,7 +276,6 @@ function AppShell() {
   const selectHostPath = (path: string, isDir: boolean) => {
     if (!hostBrowserMode) return;
     if ((hostBrowserMode === "folder" && !isDir) || (hostBrowserMode === "file" && isDir)) {
-      if (isDir) void loadHostDirectory(path, hostBrowserMode);
       return;
     }
     releaseSession.input.updateSourceDraft(path);
@@ -623,13 +622,26 @@ function AppShell() {
           }}
         >
           <Dialog.Portal>
-            <Dialog.Overlay className="dialog-overlay" />
+            <Dialog.Overlay className="host-browser-overlay" />
             <Dialog.Content className="host-browser-dialog">
-              <Dialog.Title>Select {hostBrowserMode === "file" ? "file" : "folder"}</Dialog.Title>
-              <Dialog.Description className="sr-only">
-                Browse host paths allowed by WebUI policy.
-              </Dialog.Description>
-              <div className="flex flex-wrap gap-2">
+              <div className="host-browser-header">
+                <div>
+                  <Dialog.Title asChild>
+                    <h2 className="label">Host browser</h2>
+                  </Dialog.Title>
+                  <Dialog.Description asChild>
+                    <p className="mono host-browser-path">
+                      {hostBrowser?.currentPath || "Computer"}
+                    </p>
+                  </Dialog.Description>
+                </div>
+                <Dialog.Close asChild>
+                  <button className="ghost" type="button">
+                    Close
+                  </button>
+                </Dialog.Close>
+              </div>
+              <div className="host-browser-toolbar">
                 <button
                   className="ghost"
                   type="button"
@@ -641,45 +653,91 @@ function AppShell() {
                 >
                   Up
                 </button>
-                <input
-                  aria-label="Filter host paths"
-                  value={hostBrowserSearch}
-                  onChange={(event) => setHostBrowserSearch(event.target.value)}
-                  placeholder="Filter paths"
-                />
+                <button
+                  className="ghost"
+                  type="button"
+                  disabled={hostBrowserLoading}
+                  onClick={() => {
+                    if (hostBrowserMode) void loadHostDirectory("", hostBrowserMode);
+                  }}
+                >
+                  Roots
+                </button>
                 {hostBrowserMode === "folder" && hostBrowser?.currentPath ? (
                   <button
                     className="primary"
                     type="button"
+                    disabled={hostBrowserLoading}
                     onClick={() => selectHostPath(hostBrowser.currentPath, true)}
                   >
-                    Select current folder
+                    Select folder
                   </button>
                 ) : null}
+                <label className="host-browser-search" htmlFor="host-browser-search">
+                  <span>Search</span>
+                  <input
+                    id="host-browser-search"
+                    className="host-browser-search__input"
+                    value={hostBrowserSearch}
+                    onChange={(event) => setHostBrowserSearch(event.target.value)}
+                    placeholder="Filter current path"
+                    disabled={hostBrowserLoading || !hostBrowser}
+                  />
+                </label>
               </div>
               {hostBrowserError ? (
                 <p className="error" role="alert">
                   {hostBrowserError}
                 </p>
               ) : null}
-              <div className="host-browser-list">
-                {hostBrowserLoading ? (
-                  <p className="muted">Loading...</p>
-                ) : (
-                  visibleHostEntries.map((entry) => (
-                    <button
-                      className="host-browser-entry"
-                      type="button"
-                      key={entry.path}
-                      onClick={() => selectHostPath(entry.path, entry.isDir)}
-                    >
-                      <span>{entry.isDir ? "Folder" : "File"}</span>
-                      <span className="mono">{entry.path}</span>
-                    </button>
-                  ))
-                )}
-              </div>
-              <Dialog.Close className="ghost">Cancel</Dialog.Close>
+              {hostBrowserLoading ? <p className="muted">Loading host paths...</p> : null}
+              {!hostBrowserLoading && hostBrowser ? (
+                <div className="host-browser-list">
+                  {visibleHostEntries.length === 0 ? (
+                    <p className="muted host-browser-empty">No matching paths.</p>
+                  ) : (
+                    visibleHostEntries.map((entry) => (
+                      <div className="host-browser-entry" key={entry.path}>
+                        <span className="host-browser-entry__name">
+                          {entry.isDir ? "[DIR] " : ""}
+                          {entry.name}
+                        </span>
+                        <span className="host-browser-entry__meta">
+                          {entry.isDir
+                            ? "Folder"
+                            : `${Math.round(entry.size / 1024).toLocaleString()} KiB`}
+                        </span>
+                        <span className="host-browser-entry__actions">
+                          {entry.isDir ? (
+                            <button
+                              className="ghost"
+                              type="button"
+                              aria-label={`Open ${entry.name}`}
+                              onClick={() => {
+                                if (hostBrowserMode)
+                                  void loadHostDirectory(entry.path, hostBrowserMode);
+                              }}
+                            >
+                              Open
+                            </button>
+                          ) : null}
+                          {(hostBrowserMode === "folder" && entry.isDir) ||
+                          (hostBrowserMode === "file" && !entry.isDir) ? (
+                            <button
+                              className="primary"
+                              type="button"
+                              aria-label={`Select ${entry.name}`}
+                              onClick={() => selectHostPath(entry.path, entry.isDir)}
+                            >
+                              Select
+                            </button>
+                          ) : null}
+                        </span>
+                      </div>
+                    ))
+                  )}
+                </div>
+              ) : null}
             </Dialog.Content>
           </Dialog.Portal>
         </Dialog.Root>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prepared release displays now keep provider information as an empty list instead of a null value when no provider details are available.
  * This improves consistency for identity-only releases and helps avoid issues in screens or integrations that expect a list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->