### PR TITLE
fix(history): display stored releases across sessions

### DIFF
--- a/internal/core/history.go
+++ b/internal/core/history.go
@@ -106,20 +106,16 @@ func (h *historyModule) Overview(ctx context.Context, sourcePath string) (api.Hi
 		return api.HistoryOverview{}, fmt.Errorf("core: %w", err)
 	}
 	overview := historyOverviewFromRecord(record)
-	if record.PreparedReleaseRef != nil {
-		if h.preparedFacts == nil {
-			return api.HistoryOverview{}, errors.New("core: canonical preparation is not configured")
-		}
-		prepared, resolveErr := h.preparedFacts.ResolveResult(ctx, *record.PreparedReleaseRef)
-		if resolveErr != nil {
-			return api.HistoryOverview{}, fmt.Errorf("core: resolve history prepared generation: %w", resolveErr)
-		}
-		display, displayErr := h.preparedFacts.ResolveDisplay(ctx, *record.PreparedReleaseRef)
+	if record.PreparedRelease != nil {
+		display, displayErr := preparedrelease.ProjectDisplay(*record.PreparedRelease)
 		if displayErr != nil {
 			return api.HistoryOverview{}, fmt.Errorf("core: project history prepared generation: %w", displayErr)
 		}
-		overview.Release = *record.PreparedReleaseRef
-		overview.Identity = prepared.Release.Identity
+		overview.Release = api.ReleaseRef{
+			SourcePath: record.PreparedRelease.Source.SourcePath,
+			Generation: record.PreparedRelease.Generation,
+		}
+		overview.Identity = record.PreparedRelease.Identity
 		overview.Display = display
 	}
 	overview.StatusLabel = api.HistoryStatusLabel(overview.LatestUploadStatus, api.CountBlockingRuleFailures(overview.TrackerRuleFailures))

--- a/internal/core/history_test.go
+++ b/internal/core/history_test.go
@@ -6,11 +6,21 @@ package core
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/pkg/api"
 )
+
+type historyRecordRepo struct {
+	stubRepo
+	record api.HistoryRecord
+}
+
+func (r historyRecordRepo) LoadHistoryRecord(context.Context, string) (api.HistoryRecord, error) {
+	return r.record, nil
+}
 
 func TestHistoryOperationsHonorPreCanceledContext(t *testing.T) {
 	t.Parallel()
@@ -86,5 +96,40 @@ func TestHistoryOverviewRejectsBlankPathBeforeRepositoryRead(t *testing.T) {
 	history := newHistoryModule(&stubRepo{}, "", api.NopLogger{})
 	if _, err := history.Overview(context.Background(), "  "); !errors.Is(err, internalerrors.ErrInvalidInput) {
 		t.Fatalf("expected invalid input, got %v", err)
+	}
+}
+
+func TestHistoryOverviewProjectsStoredPreparedReleaseWithoutPublishedSession(t *testing.T) {
+	t.Parallel()
+
+	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
+	prepared := api.PreparedRelease{
+		Generation: 1,
+		Source:     api.SourceManifest{SourcePath: sourcePath},
+		Naming:     api.NamingFacts{ReleaseName: "Example.Release.2026.1080p-GRP"},
+		Identity: api.ExternalIdentity{
+			SourcePath: sourcePath,
+			Generation: 1,
+			TMDBID:     1234567,
+			Category:   api.CanonicalCategoryMovie,
+		},
+	}
+	history := newHistoryModule(historyRecordRepo{record: api.HistoryRecord{
+		SourcePath:      sourcePath,
+		PreparedRelease: &prepared,
+	}}, "", api.NopLogger{})
+
+	overview, err := history.Overview(context.Background(), sourcePath)
+	if err != nil {
+		t.Fatalf("history overview: %v", err)
+	}
+	if overview.Release.SourcePath != sourcePath || overview.Release.Generation != prepared.Generation {
+		t.Fatalf("release ref = %#v", overview.Release)
+	}
+	if overview.Identity.TMDBID != prepared.Identity.TMDBID {
+		t.Fatalf("TMDB ID = %d, want %d", overview.Identity.TMDBID, prepared.Identity.TMDBID)
+	}
+	if overview.Display.ReleaseName != prepared.Naming.ReleaseName {
+		t.Fatalf("release name = %q, want %q", overview.Display.ReleaseName, prepared.Naming.ReleaseName)
 	}
 }

--- a/internal/preparedrelease/display.go
+++ b/internal/preparedrelease/display.go
@@ -20,10 +20,11 @@ func (m *Module) ResolveDisplay(ctx context.Context, ref api.ReleaseRef) (api.Pr
 	if err != nil {
 		return api.PreparedReleaseDisplay{}, err
 	}
-	return projectPreparedReleaseDisplay(owned.result.Release)
+	return ProjectDisplay(owned.result.Release)
 }
 
-func projectPreparedReleaseDisplay(release api.PreparedRelease) (api.PreparedReleaseDisplay, error) {
+// ProjectDisplay builds the canonical provider presentation from stored prepared facts.
+func ProjectDisplay(release api.PreparedRelease) (api.PreparedReleaseDisplay, error) {
 	if reason := providerIdentityMismatch(release); reason != "" {
 		return api.PreparedReleaseDisplay{}, &IncompatiblePreparationError{SourcePath: release.Source.SourcePath, Reason: reason}
 	}

--- a/internal/preparedrelease/display_test.go
+++ b/internal/preparedrelease/display_test.go
@@ -26,7 +26,7 @@ func TestProjectPreparedReleaseDisplayCanonicalFixture(t *testing.T) {
 	}
 
 	release := canonicalDisplayFixtureRelease()
-	actual, err := projectPreparedReleaseDisplay(release)
+	actual, err := ProjectDisplay(release)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestProjectPreparedReleaseDisplayCanonicalFixture(t *testing.T) {
 	if release.ProviderMetadata.TMDB.OriginCountry[0] != "AU" {
 		t.Fatal("display mutation changed prepared release")
 	}
-	repeated, err := projectPreparedReleaseDisplay(release)
+	repeated, err := ProjectDisplay(release)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestProjectPreparedReleaseDisplaySparseAndLocalFallbacks(t *testing.T) {
 		Naming:   api.NamingFacts{ReleaseName: "Example.Release.2026-GRP"},
 		Identity: api.ExternalIdentity{TMDBID: 101, Category: api.CanonicalCategoryMovie},
 	}
-	display, err := projectPreparedReleaseDisplay(identityOnly)
+	display, err := ProjectDisplay(identityOnly)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestProjectPreparedReleaseDisplaySparseAndLocalFallbacks(t *testing.T) {
 			IMDB: &api.IMDBMetadata{IMDBID: 123456},
 		},
 	}
-	display, err = projectPreparedReleaseDisplay(noSummary)
+	display, err = ProjectDisplay(noSummary)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestProjectPreparedReleaseDisplaySparseAndLocalFallbacks(t *testing.T) {
 			},
 		},
 	}
-	display, err = projectPreparedReleaseDisplay(fallback)
+	display, err = ProjectDisplay(fallback)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func TestProjectPreparedReleaseDisplayRejectsProviderIdentityMismatch(t *testing
 		t.Run(test.name, func(t *testing.T) {
 			release := canonicalDisplayFixtureRelease()
 			test.mutate(&release)
-			if _, err := projectPreparedReleaseDisplay(release); err == nil {
+			if _, err := ProjectDisplay(release); err == nil {
 				t.Fatal("expected provider identity mismatch")
 			}
 		})
@@ -144,7 +144,7 @@ func TestProjectPreparedReleaseDisplayRejectsProviderIdentityMismatch(t *testing
 	linkedOnly := canonicalDisplayFixtureRelease()
 	linkedOnly.ProviderMetadata.TMDB.TMDBID = 0
 	linkedOnly.ProviderMetadata.TMDB.IMDBID = linkedOnly.Identity.TMDBID
-	if _, err := projectPreparedReleaseDisplay(linkedOnly); err == nil {
+	if _, err := ProjectDisplay(linkedOnly); err == nil {
 		t.Fatal("linked provider ID satisfied missing TMDB own ID")
 	}
 }
@@ -160,11 +160,11 @@ func canonicalDisplayFixtureRelease() api.PreparedRelease {
 			MALID:    505,
 			Category: api.CanonicalCategoryMovie,
 			Provenance: api.IdentityProvenanceSet{
-				TMDB:    api.IdentityProvenanceExplicit,
-				IMDB:    api.IdentityProvenanceTracker,
-				TVDB:    api.IdentityProvenanceScene,
-				TVmaze:  api.IdentityProvenanceArr,
-				MAL:     api.IdentityProvenanceProvider,
+				TMDB:   api.IdentityProvenanceExplicit,
+				IMDB:   api.IdentityProvenanceTracker,
+				TVDB:   api.IdentityProvenanceScene,
+				TVmaze: api.IdentityProvenanceArr,
+				MAL:    api.IdentityProvenanceProvider,
 			},
 		},
 		ProviderMetadata: api.SourceScopedMetadata{
@@ -202,16 +202,16 @@ func canonicalDisplayFixtureRelease() api.PreparedRelease {
 				OriginalLanguage: "en",
 			},
 			TVDB: &api.TVDBMetadata{
-				TVDBID:            303,
-				Name:              "Example TVDB",
-				Overview:          "TVDB overview",
-				FirstAired:        "2024-03-04",
-				Year:              2024,
-				Type:              "series",
-				OriginalCountry:   "FR",
-				OriginalLanguage:  "fr",
-				Genres:            "Comedy",
-				Poster:            "https://img.example/tvdb-poster.jpg",
+				TVDBID:           303,
+				Name:             "Example TVDB",
+				Overview:         "TVDB overview",
+				FirstAired:       "2024-03-04",
+				Year:             2024,
+				Type:             "series",
+				OriginalCountry:  "FR",
+				OriginalLanguage: "fr",
+				Genres:           "Comedy",
+				Poster:           "https://img.example/tvdb-poster.jpg",
 			},
 			TVmaze: &api.TVmazeMetadata{
 				TVmazeID:       404,

--- a/internal/services/db/history_capability.go
+++ b/internal/services/db/history_capability.go
@@ -32,7 +32,7 @@ func (r *SQLiteRepository) LoadHistoryRecord(ctx context.Context, sourcePath str
 
 	prepared, preparedErr := r.LoadPreparedRelease(ctx, sourcePath)
 	if preparedErr == nil {
-		record.PreparedReleaseRef = &api.ReleaseRef{SourcePath: prepared.Source.SourcePath, Generation: prepared.Generation}
+		record.PreparedRelease = &prepared
 	} else if !errors.Is(preparedErr, internalerrors.ErrNotFound) {
 		return api.HistoryRecord{}, fmt.Errorf("db history record prepared release: %w", preparedErr)
 	}

--- a/pkg/api/history.go
+++ b/pkg/api/history.go
@@ -21,8 +21,7 @@ type HistoryEntry struct {
 	RuleAdvisoryCount int
 }
 
-// HistoryRecord is the persistence-facing history aggregate. Prepared facts
-// remain behind PreparedReleaseRepository and are referenced only by exact ID.
+// HistoryRecord is the persistence-facing history aggregate.
 type HistoryRecord struct {
 	SourcePath           string
 	ReleaseTitle         string
@@ -32,7 +31,7 @@ type HistoryRecord struct {
 	LatestUploadStatus   string
 	LatestUploadAt       time.Time `ts_type:"string"`
 	Metadata             FileMetadata
-	PreparedReleaseRef   *ReleaseRef
+	PreparedRelease      *PreparedRelease
 	ReleaseNameOverrides ReleaseNameOverrides
 	DescriptionOverride  DescriptionOverride
 	DescriptionOverrides []DescriptionOverride

--- a/webui/src/pages/history/index.test.tsx
+++ b/webui/src/pages/history/index.test.tsx
@@ -1,0 +1,86 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import type { HistoryEntry, HistoryOverview } from "../../types";
+import { installAppOperationMocks } from "../../test/appRequestMock";
+import { emptyExternalIdentity } from "../../utils/canonicalIdentity";
+import HistoryPage from ".";
+
+afterEach(cleanup);
+
+const entry = (sourcePath: string, title: string): HistoryEntry => ({
+  SourcePath: sourcePath,
+  ReleaseTitle: title,
+  ReleaseSource: "WEB",
+  ReleaseResolution: "1080p",
+  MetadataUpdatedAt: "2026-08-05T00:00:00Z",
+  LatestUploadStatus: "",
+  LatestUploadAt: "",
+  RuleFailureCount: 0,
+});
+
+const overview = (sourcePath: string, title: string): HistoryOverview => ({
+  SourcePath: sourcePath,
+  ReleaseTitle: title,
+  ReleaseSource: "WEB",
+  ReleaseResolution: "1080p",
+  MetadataUpdatedAt: "2026-08-05T00:00:00Z",
+  LatestUploadStatus: "",
+  LatestUploadAt: "",
+  StatusLabel: "Stored",
+  Metadata: {},
+  Release: { SourcePath: sourcePath, Generation: 1 },
+  Identity: emptyExternalIdentity(sourcePath),
+  Display: { ReleaseName: title, Providers: [] },
+  ReleaseNameOverrides: {},
+  DescriptionOverride: { SourcePath: sourcePath, GroupKey: "", Description: "", UpdatedAt: "" },
+  DescriptionOverrides: [],
+  PlaylistSelection: {
+    SourcePath: sourcePath,
+    SelectedPlaylists: [],
+    UseAll: false,
+    UpdatedAt: "",
+  },
+  TrackerMetadata: [],
+  TrackerRuleFailures: [],
+  Screenshots: [],
+  FinalSelections: [],
+  UploadedImages: [],
+  UploadHistory: [],
+});
+
+describe("HistoryPage", () => {
+  it("does not retain another release's details after a failed selection", async () => {
+    const unavailablePath = "C:\\media\\Example.Release.2026.1080p-GRP.mkv";
+    const storedPath = "C:\\media\\Second.Example.2026.1080p-GRP.mkv";
+    installAppOperationMocks({
+      ListHistory: async () => [
+        entry(unavailablePath, "Example Release 2026"),
+        entry(storedPath, "Second Example 2026"),
+      ],
+      GetHistoryOverview: async (sourcePath: string) => {
+        if (sourcePath === unavailablePath) {
+          throw new Error("stored preparation unavailable");
+        }
+        return overview(storedPath, "Second Example 2026");
+      },
+    });
+
+    render(<HistoryPage />);
+    expect(await screen.findByText("Error: stored preparation unavailable")).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Second Example 2026/ }));
+    expect(await screen.findByText(storedPath)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText("Error: stored preparation unavailable")).not.toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole("button", { name: /Example Release 2026/ }));
+    expect(await screen.findByText("Error: stored preparation unavailable")).toBeInTheDocument();
+    expect(screen.queryByText(storedPath)).not.toBeInTheDocument();
+  });
+});

--- a/webui/src/pages/history/index.test.tsx
+++ b/webui/src/pages/history/index.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026, Audionut and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 import type { HistoryEntry, HistoryOverview } from "../../types";
@@ -53,6 +53,40 @@ const overview = (sourcePath: string, title: string): HistoryOverview => ({
 });
 
 describe("HistoryPage", () => {
+  it("ignores superseded overview responses", async () => {
+    const firstPath = "C:\\media\\Example.Release.2026.1080p-GRP.mkv";
+    const secondPath = "C:\\media\\Second.Example.2026.1080p-GRP.mkv";
+    let resolveFirst: (value: HistoryOverview) => void = () => undefined;
+    const firstResponse = new Promise<HistoryOverview>((resolve) => {
+      resolveFirst = resolve;
+    });
+    installAppOperationMocks({
+      ListHistory: async () => [
+        entry(firstPath, "Example Release 2026"),
+        entry(secondPath, "Second Example 2026"),
+      ],
+      GetHistoryOverview: async (sourcePath: string) => {
+        if (sourcePath === firstPath) {
+          return firstResponse;
+        }
+        return overview(secondPath, "Second Example 2026");
+      },
+    });
+
+    render(<HistoryPage />);
+    expect(await screen.findByText("Loading overview...")).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Second Example 2026/ }));
+    expect(await screen.findByText(secondPath)).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFirst(overview(firstPath, "Example Release 2026"));
+    });
+    expect(screen.getByText(secondPath)).toBeInTheDocument();
+    expect(screen.queryByText(firstPath)).not.toBeInTheDocument();
+  });
+
   it("does not retain another release's details after a failed selection", async () => {
     const unavailablePath = "C:\\media\\Example.Release.2026.1080p-GRP.mkv";
     const storedPath = "C:\\media\\Second.Example.2026.1080p-GRP.mkv";

--- a/webui/src/pages/history/index.tsx
+++ b/webui/src/pages/history/index.tsx
@@ -131,6 +131,7 @@ export default function HistoryPage({ onReleaseDeleted }: Props) {
     const getHistoryOverview = historyClient.getOverview;
     const loadDetail = async () => {
       setDetailLoading(true);
+      setOverview(null);
       setError("");
       try {
         const next = await getHistoryOverview(selectedPath);

--- a/webui/src/pages/history/index.tsx
+++ b/webui/src/pages/history/index.tsx
@@ -128,6 +128,7 @@ export default function HistoryPage({ onReleaseDeleted }: Props) {
       setOverview(null);
       return;
     }
+    let active = true;
     const getHistoryOverview = historyClient.getOverview;
     const loadDetail = async () => {
       setDetailLoading(true);
@@ -135,15 +136,24 @@ export default function HistoryPage({ onReleaseDeleted }: Props) {
       setError("");
       try {
         const next = await getHistoryOverview(selectedPath);
-        setOverview(next);
+        if (active) {
+          setOverview(next);
+        }
       } catch (err) {
-        setError(String(err));
+        if (active) {
+          setError(String(err));
+        }
       } finally {
-        setDetailLoading(false);
+        if (active) {
+          setDetailLoading(false);
+        }
       }
     };
 
     void loadDetail();
+    return () => {
+      active = false;
+    };
   }, [selectedPath]);
 
   const selectedEntry = useMemo(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - History overviews and release details now reconstruct correctly from stored prepared-release data, including when no published session exists.
  - History selection updates now clear stale details and safely ignore outdated async overview responses.
  - If selection fails, the UI restores the correct error state and removes previously shown stale release information.

- **Tests**
  - Added/updated tests covering prepared-release-driven history reconstruction and history page selection/loading/error behavior.

- **Refactor**
  - Exported prepared-release display projection for consistent use across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->