### PR TITLE
fix(trackers): make language checks waivable

### DIFF
--- a/internal/trackers/impl/unit3d/sites/a4k/rules.go
+++ b/internal/trackers/impl/unit3d/sites/a4k/rules.go
@@ -5,7 +5,7 @@ package a4k
 
 import "github.com/autobrr/upbrr/internal/trackers"
 
-// Rules returns A4K's strict non-disc English audio-or-subtitle requirement,
+// Rules returns A4K's waivable non-disc English audio-or-subtitle requirement,
 // which accepts original-language audio when English subtitles are present.
 func Rules() *trackers.RuleSet {
 	return &trackers.RuleSet{Language: &trackers.LanguageRule{

--- a/internal/trackers/impl/unit3d/sites/aither/rules.go
+++ b/internal/trackers/impl/unit3d/sites/aither/rules.go
@@ -7,7 +7,7 @@ import (
 	"github.com/autobrr/upbrr/internal/trackers"
 )
 
-// Rules returns AITHER's strict unique-ID requirement and strict non-disc
+// Rules returns AITHER's strict unique-ID requirement and waivable non-disc
 // English audio-or-subtitle requirement, accepting original-language audio
 // when English subtitles are present.
 func Rules() *trackers.RuleSet {

--- a/internal/trackers/impl/unit3d/sites/aither/validation_test.go
+++ b/internal/trackers/impl/unit3d/sites/aither/validation_test.go
@@ -29,6 +29,16 @@ func TestAitherEvidencePolicyPassViolationAndMissingEvidence(t *testing.T) {
 	)
 
 	subject = aitherPassingSubject()
+	subject.MediaFileFacts.Files[0].SubtitleLanguages = []string{"Japanese"}
+	assertAitherFailure(
+		t,
+		evaluateAitherEvidence(t, subject),
+		"aither_language",
+		api.RuleDispositionWaivable,
+		api.MetadataEvidenceStatusComplete,
+	)
+
+	subject = aitherPassingSubject()
 	subject.PackageFacts.Status = api.MetadataEvidenceStatusPartial
 	assertAitherFailure(
 		t,

--- a/internal/trackers/impl/unit3d/sites/dp/rules.go
+++ b/internal/trackers/impl/unit3d/sites/dp/rules.go
@@ -9,7 +9,7 @@ var nordic = []string{"english", "norwegian", "norsk", "no", "nb", "nn", "swedis
 
 // Rules strictly blocks single-file folders and hardcoded subtitles. Its
 // release-group exception remains waivable; its Nordic language requirement is
-// strict.
+// also waivable.
 func Rules() *trackers.RuleSet {
 	return &trackers.RuleSet{
 		BlockSingleFileFolder: true,

--- a/internal/trackers/impl/unit3d/sites/lst/rules.go
+++ b/internal/trackers/impl/unit3d/sites/lst/rules.go
@@ -6,7 +6,7 @@ package lst
 import "github.com/autobrr/upbrr/internal/trackers"
 
 // Rules strictly requires valid MediaInfo encode settings and applies a
-// strict non-disc English audio-or-subtitle requirement.
+// waivable non-disc English audio-or-subtitle requirement.
 func Rules() *trackers.RuleSet {
 	return &trackers.RuleSet{RequireValidMISetting: true, Language: &trackers.LanguageRule{
 		Languages:      []string{"english", "en", "eng"},

--- a/internal/trackers/impl/unit3d/sites/lume/rules.go
+++ b/internal/trackers/impl/unit3d/sites/lume/rules.go
@@ -9,7 +9,7 @@ import (
 
 // Rules strictly requires valid MediaInfo encode settings and enforces LUME's
 // non-disc container, resolution, and language limits. Adult failures remain
-// waivable; language failures are strict.
+// waivable; language failures are also waivable.
 func Rules() *trackers.RuleSet {
 	return &trackers.RuleSet{
 		RequireValidMISetting: true,

--- a/internal/trackers/impl/unit3d/sites/ras/rules.go
+++ b/internal/trackers/impl/unit3d/sites/ras/rules.go
@@ -5,7 +5,7 @@ package ras
 
 import "github.com/autobrr/upbrr/internal/trackers"
 
-// Rules returns RAS's strict Nordic-or-English audio-or-subtitle requirement.
+// Rules returns RAS's waivable Nordic-or-English audio-or-subtitle requirement.
 func Rules() *trackers.RuleSet {
 	return &trackers.RuleSet{Language: &trackers.LanguageRule{
 		Languages:    []string{"english", "norwegian", "norsk", "no", "nb", "nn", "swedish", "sv", "danish", "da", "finnish", "fi", "icelandic", "is"},

--- a/internal/trackers/impl/unit3d/sites/ttr/rules.go
+++ b/internal/trackers/impl/unit3d/sites/ttr/rules.go
@@ -12,7 +12,7 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-// Rules returns TTR's strict Spanish audio-or-subtitle requirements.
+// Rules returns TTR's waivable Spanish audio-or-subtitle requirements.
 func Rules() *trackers.RuleSet {
 	return &trackers.RuleSet{Language: &trackers.LanguageRule{
 		Languages:    []string{"spanish", "es", "spa"},
@@ -37,7 +37,7 @@ func checkSubtitleOnly(ctx context.Context, meta api.TrackerValidationSubject, _
 		return []api.RuleFailure{trackers.NewRuleFailure(
 			"spanish_track_required",
 			"TTR requires at least one Spanish audio or subtitle track.",
-			api.RuleDispositionStrict,
+			api.RuleDispositionWaivable,
 		)}, nil
 	}
 	return nil, nil

--- a/internal/trackers/rule_contract.go
+++ b/internal/trackers/rule_contract.go
@@ -98,7 +98,7 @@ func RuleFailureBlocksExecution(failure api.RuleFailure, mode api.WorkflowExecut
 		api.NormalizeWorkflowExecutionMode(mode) != api.WorkflowExecutionModeDebug
 }
 
-// LanguageRule configures language requirements and the release types to which they apply.
+// LanguageRule configures waivable language requirements and the release types to which they apply.
 type LanguageRule struct {
 	// Languages lists normalized languages accepted by the tracker.
 	Languages []string
@@ -123,7 +123,7 @@ type RuleSet struct {
 	RequireUniqueID bool
 	// RequireValidMISetting requires a supported MediaInfo configuration.
 	RequireValidMISetting bool
-	// RequireAudioLanguages requires parsed audio-language metadata.
+	// RequireAudioLanguages requires parsed audio-language metadata as a waivable rule.
 	RequireAudioLanguages bool
 	// RequireDiscOnly rejects non-disc releases.
 	RequireDiscOnly bool

--- a/internal/trackers/rule_evidence.go
+++ b/internal/trackers/rule_evidence.go
@@ -211,11 +211,15 @@ func ValidatePerFileUniformity(facts api.MediaFileFacts, policy PerFileUniformit
 				continue
 			}
 			if !strings.EqualFold(expected, value) {
+				evidence := policy.Evidence
+				if field == MediaUniformityFieldAudioLanguages || field == MediaUniformityFieldSubtitleLanguages {
+					evidence.ViolationDisposition = api.RuleDispositionWaivable
+				}
 				return predicateViolation(
 					rule,
 					fmt.Sprintf("media files have non-uniform %s", field),
 					facts.Status,
-					policy.Evidence,
+					evidence,
 				)
 			}
 		}
@@ -552,9 +556,10 @@ type LanguageCombinationPolicy struct {
 	RequireEnglishSubtitleWithoutAudio bool
 }
 
-// ValidateLanguageCombination applies language requirements to every media
-// file without inferring absent tracks from incomplete evidence.
+// ValidateLanguageCombination applies waivable language requirements to every
+// media file without inferring absent tracks from incomplete evidence.
 func ValidateLanguageCombination(facts api.MediaFileFacts, policy LanguageCombinationPolicy) []api.RuleFailure {
+	policy.Evidence.ViolationDisposition = api.RuleDispositionWaivable
 	rule := predicateRule(policy.Evidence, "language_combination")
 	original := languageutil.NormalizeLanguageDisplay(facts.OriginalLanguage)
 	needsOriginal := policy.RequireOriginalAudio || policy.RequireOriginalOrEnglishAudio ||

--- a/internal/trackers/rule_evidence_test.go
+++ b/internal/trackers/rule_evidence_test.go
@@ -147,6 +147,16 @@ func TestValidatePerFileUniformity(t *testing.T) {
 		api.RuleDispositionWaivable,
 		api.MetadataEvidenceStatusComplete,
 	)
+	policy.Fields = []MediaUniformityField{MediaUniformityFieldSubtitleLanguages}
+	facts.Files[0].SubtitleLanguages = []string{"English"}
+	facts.Files[1].SubtitleLanguages = []string{"French"}
+	assertEvidenceFailure(
+		t,
+		ValidatePerFileUniformity(facts, policy),
+		"uniformity",
+		api.RuleDispositionWaivable,
+		api.MetadataEvidenceStatusComplete,
+	)
 	policy.Fields = []MediaUniformityField{MediaUniformityFieldVideoCodec}
 	facts.Files[1].VideoCodec = "H.265"
 	facts.Status = api.MetadataEvidenceStatusPartial

--- a/internal/trackers/rule_evidence_test.go
+++ b/internal/trackers/rule_evidence_test.go
@@ -137,6 +137,17 @@ func TestValidatePerFileUniformity(t *testing.T) {
 		api.RuleDispositionStrict,
 		api.MetadataEvidenceStatusComplete,
 	)
+	policy.Fields = []MediaUniformityField{MediaUniformityFieldAudioLanguages}
+	facts.Files[0].AudioLanguages = []string{"English"}
+	facts.Files[1].AudioLanguages = []string{"French"}
+	assertEvidenceFailure(
+		t,
+		ValidatePerFileUniformity(facts, policy),
+		"uniformity",
+		api.RuleDispositionWaivable,
+		api.MetadataEvidenceStatusComplete,
+	)
+	policy.Fields = []MediaUniformityField{MediaUniformityFieldVideoCodec}
 	facts.Files[1].VideoCodec = "H.265"
 	facts.Status = api.MetadataEvidenceStatusPartial
 	assertEvidenceFailure(
@@ -286,7 +297,7 @@ func TestValidateLanguageCombination(t *testing.T) {
 		t,
 		ValidateLanguageCombination(facts, policy),
 		"language",
-		api.RuleDispositionStrict,
+		api.RuleDispositionWaivable,
 		api.MetadataEvidenceStatusComplete,
 	)
 	facts.LanguageStatus = api.MetadataEvidenceStatusPartial

--- a/internal/trackers/rules.go
+++ b/internal/trackers/rules.go
@@ -229,12 +229,12 @@ func evaluateRules(ctx context.Context, registry *Registry, tracker string, meta
 	}
 
 	if rules.RequireAudioLanguages && !isDiscType(meta.DiscType) && len(meta.AudioLanguages) == 0 {
-		addStrict("require_audio_languages", "missing audio language data")
+		addWaivable("require_audio_languages", "missing audio language data")
 	}
 
 	if rules.Language != nil {
 		if ok, reason := evaluateLanguageRule(meta, rules.Language); !ok {
-			addStrict("language_rule", reason)
+			addWaivable("language_rule", reason)
 		}
 	}
 

--- a/internal/trackers/rules_internal_test.go
+++ b/internal/trackers/rules_internal_test.go
@@ -35,7 +35,7 @@ func TestResolveCategoryUsesCanonicalIdentityDespiteEmptyTVMetadata(t *testing.T
 	}
 }
 
-func TestConfiguredStrictRuleDispositions(t *testing.T) {
+func TestConfiguredRuleDispositions(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -148,6 +148,10 @@ func TestConfiguredStrictRuleDispositions(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+			wantDisposition := api.RuleDispositionStrict
+			if test.rule == "require_audio_languages" || test.rule == "language_rule" {
+				wantDisposition = api.RuleDispositionWaivable
+			}
 			registry := NewRegistry()
 			if err := registry.RegisterDescriptor(Descriptor{
 				Name:       "STRICT",
@@ -162,8 +166,8 @@ func TestConfiguredStrictRuleDispositions(t *testing.T) {
 			}
 			for _, failure := range failures {
 				if failure.Rule == test.rule {
-					if failure.Disposition != api.RuleDispositionStrict {
-						t.Fatalf("%s disposition = %q, want strict", test.rule, failure.Disposition)
+					if failure.Disposition != wantDisposition {
+						t.Fatalf("%s disposition = %q, want %q", test.rule, failure.Disposition, wantDisposition)
 					}
 					return
 				}

--- a/internal/trackers/rules_test.go
+++ b/internal/trackers/rules_test.go
@@ -365,8 +365,8 @@ func TestEvaluateRulesLanguageRuleMissingData(t *testing.T) {
 	if failures[0].Rule != "language_rule" {
 		t.Fatalf("unexpected rule key: %s", failures[0].Rule)
 	}
-	if failures[0].Disposition != api.RuleDispositionStrict {
-		t.Fatalf("language disposition = %q, want strict", failures[0].Disposition)
+	if failures[0].Disposition != api.RuleDispositionWaivable {
+		t.Fatalf("language disposition = %q, want waivable", failures[0].Disposition)
 	}
 }
 
@@ -873,6 +873,9 @@ func TestEvaluateRulesRHDRequiresGermanAudio(t *testing.T) {
 	if failures[0].Rule != "language_rule" {
 		t.Fatalf("unexpected rule key: %s", failures[0].Rule)
 	}
+	if failures[0].Disposition != api.RuleDispositionWaivable {
+		t.Fatalf("language disposition = %q, want waivable", failures[0].Disposition)
+	}
 }
 
 func TestEvaluateRulesRHDAllowsGermanAudio(t *testing.T) {
@@ -994,6 +997,9 @@ func TestEvaluateRulesAitherRequiresLanguageForNonDisc(t *testing.T) {
 	if failures[0].Rule != "language_rule" {
 		t.Fatalf("unexpected rule key: %s", failures[0].Rule)
 	}
+	if failures[0].Disposition != api.RuleDispositionWaivable {
+		t.Fatalf("language disposition = %q, want waivable", failures[0].Disposition)
+	}
 }
 
 func TestEvaluateRulesNonDiscLanguagePoliciesSkipDiscs(t *testing.T) {
@@ -1018,7 +1024,7 @@ func TestEvaluateRulesNonDiscLanguagePoliciesSkipDiscs(t *testing.T) {
 	}
 }
 
-func TestEvaluateRulesTTRLanguageFailuresAreStrict(t *testing.T) {
+func TestEvaluateRulesTTRLanguageFailuresAreWaivable(t *testing.T) {
 	t.Parallel()
 
 	meta := api.RuleSubject{
@@ -1029,7 +1035,7 @@ func TestEvaluateRulesTTRLanguageFailuresAreStrict(t *testing.T) {
 	failures := evaluateNonMetadataRulesForTest(context.Background(), "TTR", meta)
 	for _, rule := range []string{"language_rule", "spanish_track_required"} {
 		failure, found := findRuleFailure(failures, rule)
-		if !found || failure.Disposition != api.RuleDispositionStrict {
+		if !found || failure.Disposition != api.RuleDispositionWaivable {
 			t.Fatalf("%s = %#v, failures=%#v", rule, failure, failures)
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Language-related validation failures are now consistently marked as waivable instead of strict.
  * Updated tracker-specific language requirements to reflect waivable exceptions.
  * Improved handling of audio and subtitle language combinations and per-file consistency checks.

* **Documentation**
  * Clarified language requirements and waiver behavior across supported trackers.

* **Tests**
  * Expanded validation coverage for waivable language failures and complete evidence reporting.
  * Added checks for language combinations, missing languages, and per-file consistency results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->