### PR TITLE
fix: repair Blu-ray preparation and disc dupe checking

### DIFF
--- a/internal/metadata/discparse/bdinfo.go
+++ b/internal/metadata/discparse/bdinfo.go
@@ -42,7 +42,9 @@ func NormalizePlaylistName(name string) string {
 	return strings.ToUpper(filepath.Base(trimmed))
 }
 
-// SplitBDInfoReport extracts summary and files sections from a BDInfo report.
+// SplitBDInfoReport extracts quick-summary, files, and extended-summary sections
+// from a full report. A persisted standalone quick summary is returned as the
+// summary when it contains playlist and length fields.
 func SplitBDInfoReport(text string) (summary string, files string, extSummary string) {
 	parts := strings.SplitN(text, "QUICK SUMMARY:", 2)
 	if len(parts) == 2 {
@@ -61,6 +63,8 @@ func SplitBDInfoReport(text string) (summary string, files string, extSummary st
 		remaining := strings.TrimRight(parts[1], " \n")
 		summary = strings.TrimRight(strings.SplitN(remaining, "********************", 2)[0], " \n")
 		summary = normalizeSummarySpaces(summary)
+	} else if isStandaloneBDInfoSummary(text) {
+		summary = normalizeSummarySpaces(strings.TrimSpace(text))
 	}
 
 	// Legacy Python logic selects the segment after the second [code] marker.
@@ -73,6 +77,19 @@ func SplitBDInfoReport(text string) (summary string, files string, extSummary st
 	}
 
 	return summary, files, extSummary
+}
+
+// isStandaloneBDInfoSummary recognizes the minimum fields emitted in a
+// persisted playlist quick summary without accepting arbitrary report text.
+func isStandaloneBDInfoSummary(text string) bool {
+	hasPlaylist := false
+	hasLength := false
+	for raw := range strings.SplitSeq(text, "\n") {
+		line := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(raw), "*")))
+		hasPlaylist = hasPlaylist || strings.HasPrefix(line, "playlist:")
+		hasLength = hasLength || strings.HasPrefix(line, "length:")
+	}
+	return hasPlaylist && hasLength
 }
 
 func normalizeSummarySpaces(text string) string {
@@ -167,7 +184,7 @@ func ExtractPlaylistReports(text string, selected []string) ([]PlaylistReport, e
 // ParseBDInfoFiles parses the FILES section of a BDInfo report.
 func ParseBDInfoFiles(files string) []BDFile {
 	var result []BDFile
-	for _, line := range strings.Split(files, "\n") {
+	for line := range strings.SplitSeq(files, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
 			continue
@@ -196,11 +213,11 @@ func ParseBDInfoFiles(files string) []BDFile {
 // ParseBDInfoSummary parses a BDInfo summary and files section.
 func ParseBDInfoSummary(summary string, files string, path string) *BDInfo {
 	info := &BDInfo{Path: path}
-	for _, raw := range strings.Split(summary, "\n") {
+	for raw := range strings.SplitSeq(summary, "\n") {
 		line := strings.TrimSpace(raw)
 		lower := strings.ToLower(line)
-		if strings.HasPrefix(lower, "*") {
-			lower = strings.TrimSpace(strings.TrimPrefix(lower, "*"))
+		if after, ok := strings.CutPrefix(lower, "*"); ok {
+			lower = strings.TrimSpace(after)
 			line = strings.TrimSpace(strings.TrimPrefix(line, "*"))
 		}
 

--- a/internal/metadata/discparse/bdinfo_test.go
+++ b/internal/metadata/discparse/bdinfo_test.go
@@ -54,6 +54,14 @@ func TestSplitBDInfoReport(t *testing.T) {
 	}
 }
 
+func TestSplitBDInfoStandaloneSummary(t *testing.T) {
+	report := "Disc Title: Example Release 2026\nPlaylist: 00001.MPLS\nLength: 01:30:00.000\nVideo: MPEG-4 AVC Video / 30000 kbps / 1080p"
+	summary, files, ext := SplitBDInfoReport(report)
+	if summary != report || files != "" || ext != "" {
+		t.Fatalf("unexpected standalone summary split: summary=%q files=%q ext=%q", summary, files, ext)
+	}
+}
+
 func TestSplitBDInfoReportExtSummaryUsesSecondCodeMarker(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -57,11 +57,18 @@ func (s *Service) deriveMediaFacts(ctx context.Context, meta preparationstate.St
 		s.logger.Warnf("metadata: mediainfo validation failed (missing unique id)")
 	}
 	meta.AudioLanguages, meta.SubtitleLanguages = extractMediaInfoLanguages(miDoc)
+
+	bdinfo := loadBDInfo(meta, s.cfg.MainSettings.DBPath)
+	bdAudioLanguages, bdSubtitleLanguages := extractBDInfoLanguages(bdinfo)
+	if len(meta.AudioLanguages) == 0 {
+		meta.AudioLanguages = bdAudioLanguages
+	}
+	if len(meta.SubtitleLanguages) == 0 {
+		meta.SubtitleLanguages = bdSubtitleLanguages
+	}
 	if s.logger != nil && (len(meta.AudioLanguages) > 0 || len(meta.SubtitleLanguages) > 0) {
 		s.logger.Debugf("metadata: media languages audio=%v subs=%v", meta.AudioLanguages, meta.SubtitleLanguages)
 	}
-
-	bdinfo := loadBDInfo(meta, s.cfg.MainSettings.DBPath)
 
 	meta.Container = containerFromMeta(meta)
 	if s.logger != nil {

--- a/internal/metadata/mediainfo_languages.go
+++ b/internal/metadata/mediainfo_languages.go
@@ -10,6 +10,7 @@ import (
 	preparationstate "github.com/autobrr/upbrr/internal/preparedrelease/state"
 
 	"github.com/autobrr/upbrr/internal/languageutil"
+	"github.com/autobrr/upbrr/internal/metadata/discparse"
 )
 
 func validateMediaInfoUniqueID(meta preparationstate.State, doc mediaInfoDoc) (string, bool) {
@@ -66,6 +67,23 @@ func extractMediaInfoLanguages(doc mediaInfoDoc) ([]string, []string) {
 		}
 	}
 
+	return uniqueStrings(audio), uniqueStrings(subs)
+}
+
+// extractBDInfoLanguages returns normalized, case-insensitively deduplicated
+// audio and subtitle languages from a parsed quick summary.
+func extractBDInfoLanguages(info *discparse.BDInfo) ([]string, []string) {
+	if info == nil {
+		return nil, nil
+	}
+	audio := make([]string, 0, len(info.Audio))
+	for _, track := range info.Audio {
+		audio = append(audio, normalizeLanguage(track.Language))
+	}
+	subs := make([]string, 0, len(info.Subtitles))
+	for _, language := range info.Subtitles {
+		subs = append(subs, normalizeLanguage(language))
+	}
 	return uniqueStrings(audio), uniqueStrings(subs)
 }
 

--- a/internal/metadata/mediainfo_languages_test.go
+++ b/internal/metadata/mediainfo_languages_test.go
@@ -3,7 +3,11 @@
 
 package metadata
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/metadata/discparse"
+)
 
 func TestExtractMediaInfoLanguagesSkipsCommentary(t *testing.T) {
 	doc := mediaInfoDoc{}
@@ -38,5 +42,22 @@ func TestExtractMediaInfoLanguagesSkipsCompatibility(t *testing.T) {
 	audio, _ := extractMediaInfoLanguages(doc)
 	if len(audio) != 1 || audio[0] != "Japanese" {
 		t.Fatalf("unexpected audio languages: %#v", audio)
+	}
+}
+
+func TestExtractBDInfoLanguages(t *testing.T) {
+	audio, subs := extractBDInfoLanguages(&discparse.BDInfo{
+		Audio: []discparse.BDAudio{
+			{Language: "en"},
+			{Language: "French"},
+			{Language: "English"},
+		},
+		Subtitles: []string{"es", "Spanish"},
+	})
+	if len(audio) != 2 || audio[0] != "English" || audio[1] != "French" {
+		t.Fatalf("unexpected audio languages: %#v", audio)
+	}
+	if len(subs) != 1 || subs[0] != "Spanish" {
+		t.Fatalf("unexpected subtitle languages: %#v", subs)
 	}
 }

--- a/internal/metadata/playlist_selection.go
+++ b/internal/metadata/playlist_selection.go
@@ -37,7 +37,10 @@ func (s *Service) resolveBDMVPlaylistSelection(ctx context.Context, request prep
 		stored, lookupErr := s.repo.GetPlaylistSelection(ctx, playlistSelectionKey(request.Layout.SourcePath))
 		if lookupErr != nil {
 			if errors.Is(lookupErr, internalerrors.ErrNotFound) {
-				return nil, &api.PlaylistSelectionRequiredError{SourcePath: request.Layout.SourcePath}
+				return nil, &api.PlaylistSelectionRequiredError{
+					SourcePath: request.Layout.SourcePath,
+					Candidates: apiPlaylists(discovered),
+				}
 			}
 			return nil, fmt.Errorf("metadata: load remembered playlist selection: %w", lookupErr)
 		}
@@ -49,7 +52,10 @@ func (s *Service) resolveBDMVPlaylistSelection(ctx context.Context, request prep
 		return apiPlaylists(discovered), nil
 	}
 	if len(selected) == 0 {
-		return nil, &api.PlaylistSelectionRequiredError{SourcePath: request.Layout.SourcePath}
+		return nil, &api.PlaylistSelectionRequiredError{
+			SourcePath: request.Layout.SourcePath,
+			Candidates: apiPlaylists(discovered),
+		}
 	}
 
 	byName := make(map[string]filesystem.PlaylistInfo, len(discovered))

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -351,13 +351,13 @@ func cloneTrackerIDs(values map[string]string) map[string]string {
 func (s *Service) collectSourceEvidence(ctx context.Context, request preparationstate.Request) (meta preparationstate.State, err error) {
 	bdinfoActive := false
 	bdinfoTerminal := false
+	reportBDInfo := func(status api.PreparationProgressStatus, message string) {
+		api.EmitPreparationProgress(ctx, api.NewPreparationProgressUpdate(api.PreparationPhaseBDInfo, status, message))
+	}
 	defer func() {
 		if err != nil {
 			if bdinfoActive && !bdinfoTerminal {
-				api.EmitPreparationProgress(
-					ctx,
-					api.NewPreparationProgressUpdate(api.PreparationPhaseBDInfo, api.PreparationProgressFailed, "Blu-ray analysis failed."),
-				)
+				reportBDInfo(api.PreparationProgressFailed, "Blu-ray analysis failed.")
 			}
 			s.logger.Warnf("metadata: preparation blocked err=%s", redaction.RedactValue(err.Error(), nil))
 		}
@@ -441,17 +441,11 @@ func (s *Service) collectSourceEvidence(ctx context.Context, request preparation
 			// Execute BDInfo on selected playlists
 			if s.bdinfo != nil {
 				bdinfoActive = true
-				api.EmitPreparationProgress(
-					ctx,
-					api.NewPreparationProgressUpdate(api.PreparationPhaseBDInfo, api.PreparationProgressRunning, "Preparing Blu-ray analysis."),
-				)
+				reportBDInfo(api.PreparationProgressRunning, "Analyzing selected Blu-ray playlists.")
 				tmpRoot, rerr := db.Subdir(s.cfg.MainSettings.DBPath, "tmp")
 				if rerr != nil {
 					bdinfoTerminal = true
-					api.EmitPreparationProgress(
-						ctx,
-						api.NewPreparationProgressUpdate(api.PreparationPhaseBDInfo, api.PreparationProgressFailed, "Blu-ray analysis failed."),
-					)
+					reportBDInfo(api.PreparationProgressFailed, "Blu-ray analysis failed.")
 					return preparationstate.State{}, fmt.Errorf("metadata: resolve tmp root: %w", rerr)
 				}
 				tmpDir, _, rerr := paths.ReleaseTempDir(tmpRoot, meta, primary)
@@ -463,13 +457,13 @@ func (s *Service) collectSourceEvidence(ctx context.Context, request preparation
 					return preparationstate.State{}, fmt.Errorf("metadata: create bdinfo temp dir: %w", err)
 				}
 
-				outputPath, needScan, berr := s.resolveOrCreateBDMVSummaries(ctx, input, tmpDir, playlistPath, selectedPlaylistNames)
+				analysisCtx := bdinfo.WithProgressReporter(ctx, func(message string) {
+					reportBDInfo(api.PreparationProgressRunning, message)
+				})
+				outputPath, needScan, berr := s.resolveOrCreateBDMVSummaries(analysisCtx, input, tmpDir, playlistPath, selectedPlaylistNames)
 				if berr != nil {
 					bdinfoTerminal = true
-					api.EmitPreparationProgress(
-						ctx,
-						api.NewPreparationProgressUpdate(api.PreparationPhaseBDInfo, api.PreparationProgressFailed, "Blu-ray analysis failed."),
-					)
+					reportBDInfo(api.PreparationProgressFailed, "Blu-ray analysis failed.")
 					return preparationstate.State{}, berr
 				}
 				if strings.TrimSpace(outputPath) != "" {
@@ -483,13 +477,10 @@ func (s *Service) collectSourceEvidence(ctx context.Context, request preparation
 				}
 				if needScan {
 					s.logger.Debugf("metadata: bdinfo scan completed for %d selected playlists", len(selectedPlaylistNames))
-					api.EmitPreparationProgress(
-						ctx,
-						api.NewPreparationProgressUpdate(api.PreparationPhaseBDInfo, api.PreparationProgressCompleted, "Blu-ray analysis complete."),
-					)
+					reportBDInfo(api.PreparationProgressCompleted, "Blu-ray analysis complete.")
 					bdinfoTerminal = true
 				} else {
-					api.SkipPreparationProgress(ctx, api.PreparationPhaseBDInfo, "Reused cached Blu-ray analysis.")
+					reportBDInfo(api.PreparationProgressSkipped, "Reused cached Blu-ray analysis.")
 					bdinfoTerminal = true
 				}
 			} else {

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -705,6 +705,31 @@ func TestResolveBDMVPlaylistSelectionRejectsUnknownDirectPlaylist(t *testing.T) 
 	}
 }
 
+func TestResolveBDMVPlaylistSelectionRequiredIncludesCandidates(t *testing.T) {
+	originalDiscover := discoverBDMVPlaylists
+	t.Cleanup(func() {
+		discoverBDMVPlaylists = originalDiscover
+	})
+
+	discoverBDMVPlaylists = func(_ context.Context, _ string) ([]filesystem.PlaylistInfo, error) {
+		return []filesystem.PlaylistInfo{{
+			File:     "00001.MPLS",
+			Duration: 5400,
+			Items:    []filesystem.PlaylistItem{{File: "00001.m2ts", Size: 100}},
+			Score:    75,
+		}}, nil
+	}
+
+	_, err := (&Service{repo: &fakeRepo{}}).resolveBDMVPlaylistSelection(context.Background(), preparationstate.Request{
+		Layout: sourcelayout.Layout{SourcePath: `D:\Disc`, BDMVRoot: `D:\Disc\BDMV`},
+	})
+	var required *api.PlaylistSelectionRequiredError
+	if !errors.As(err, &required) || len(required.Candidates) != 1 || required.Candidates[0].File != "00001.MPLS" ||
+		required.Candidates[0].Duration != 5400 || len(required.Candidates[0].Items) != 1 {
+		t.Fatalf("playlist selection error candidates = %#v", required)
+	}
+}
+
 func TestDiscoverBDMVSummaryCache(t *testing.T) {
 	tmpDir := t.TempDir()
 	writeBDMVSummaryFixture(t, tmpDir, "00002.MPLS", "extended summary two")

--- a/internal/preparedrelease/module.go
+++ b/internal/preparedrelease/module.go
@@ -22,8 +22,8 @@ import (
 )
 
 // ContractVersion changes whenever prepared fact semantics or the private seed
-// contract become incompatible with an earlier generation.
-const ContractVersion = "prepared-release-v2"
+// contract become incompatible, forcing persisted generations to be recomputed.
+const ContractVersion = "prepared-release-v3"
 
 // Store is the prepared-release persistence port. Implementations must commit
 // facts, identity, and provider metadata as one generation transaction.

--- a/internal/releaseworkflow/module.go
+++ b/internal/releaseworkflow/module.go
@@ -43,6 +43,8 @@ const (
 	workflowWorkLeaseTTL  = time.Minute
 	workflowWorkHeartbeat = 20 * time.Second
 	workflowCommandTTL    = 24 * time.Hour
+	// maxPlaylistActionOptions bounds the selectable playlist details retained in one action.
+	maxPlaylistActionOptions = 10
 )
 
 // Option configures a workflow module.
@@ -2873,6 +2875,30 @@ func (m *Module) prepareRelease(
 	command.Input.Instructions = facts.Instructions
 	prepared, err := m.preparer.Prepare(ctx, command.Input)
 	if err != nil {
+		var playlistRequired *api.PlaylistSelectionRequiredError
+		if errors.As(err, &playlistRequired) {
+			options := make([]api.RequiredActionOption, 0, min(len(playlistRequired.Candidates), maxPlaylistActionOptions))
+			for _, candidate := range playlistRequired.Candidates {
+				playlist := strings.TrimSpace(candidate.File)
+				if playlist != "" {
+					candidate.File = playlist
+					options = append(options, api.RequiredActionOption{
+						Value:    playlist,
+						Label:    playlist,
+						Playlist: &candidate,
+					})
+					if len(options) == maxPlaylistActionOptions {
+						break
+					}
+				}
+			}
+			if len(options) > 0 {
+				if actionErr := m.blockForPlaylistSelection(state, nextRevision, now, options); actionErr != nil {
+					return CommandResult{}, actionErr
+				}
+				return CommandResult{}, nil
+			}
+		}
 		return CommandResult{}, fmt.Errorf("release workflow prepare canonical release: %w", err)
 	}
 	ref := api.ReleaseRef{SourcePath: prepared.Release.Source.SourcePath, Generation: prepared.Release.Generation}
@@ -2924,25 +2950,43 @@ func (m *Module) prepareRelease(
 				continue
 			}
 			options = append(options, api.RequiredActionOption{Value: playlist, Label: playlist})
+			if len(options) == maxPlaylistActionOptions {
+				break
+			}
 		}
 		if len(options) > 0 {
-			actionID, actionErr := m.newID("action")
-			if actionErr != nil {
-				return CommandResult{}, actionErr
+			if err := m.blockForPlaylistSelection(state, nextRevision, now, options); err != nil {
+				return CommandResult{}, err
 			}
-			state.Workflow.Status = api.WorkflowStatusBlocked
-			state.Workflow.RequiredActions = []api.RequiredAction{{
-				ID:               api.RequiredActionID(actionID),
-				Kind:             api.RequiredActionSelectPlaylist,
-				Status:           api.RequiredActionStatusPending,
-				WorkflowRevision: nextRevision,
-				Prompt:           "Select one or more Blu-ray playlists to analyze.",
-				Options:          options,
-				CreatedAt:        now,
-			}}
 		}
 	}
 	return CommandResult{Release: &snapshot}, nil
+}
+
+// blockForPlaylistSelection replaces workflow failures with one pending,
+// revision-bound Blu-ray playlist action and marks the workflow blocked.
+func (m *Module) blockForPlaylistSelection(
+	state *State,
+	nextRevision api.WorkflowRevision,
+	now time.Time,
+	options []api.RequiredActionOption,
+) error {
+	actionID, err := m.newID("action")
+	if err != nil {
+		return err
+	}
+	state.Workflow.Status = api.WorkflowStatusBlocked
+	state.Workflow.RequiredActions = []api.RequiredAction{{
+		ID:               api.RequiredActionID(actionID),
+		Kind:             api.RequiredActionSelectPlaylist,
+		Status:           api.RequiredActionStatusPending,
+		WorkflowRevision: nextRevision,
+		Prompt:           "Select one or more Blu-ray playlists to analyze.",
+		Options:          options,
+		CreatedAt:        now,
+	}}
+	state.Workflow.Failures = nil
+	return nil
 }
 
 func (m *Module) resetRelease(

--- a/internal/releaseworkflow/module_test.go
+++ b/internal/releaseworkflow/module_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -831,8 +832,24 @@ func TestModuleBDMVPreparationRequiresTypedPlaylistSelection(t *testing.T) {
 	t.Parallel()
 
 	base := testPreparer()
+	candidates := make([]api.PlaylistInfo, 12)
+	for index := range candidates {
+		candidates[index] = api.PlaylistInfo{
+			File:     fmt.Sprintf("%05d.mpls", index+1),
+			Duration: float64(7200 - index),
+			Items:    []api.PlaylistItem{{File: fmt.Sprintf("%05d.m2ts", index+1), Size: int64(1000 - index)}},
+			Score:    float64(100 - index),
+			Edition:  "Example Edition",
+		}
+	}
 	preparer := ReleasePreparerFunc{
 		PrepareFunc: func(_ context.Context, input api.PrepareInput) (api.PrepareResult, error) {
+			if !input.Instructions.Playlist.Set {
+				return api.PrepareResult{}, &api.PlaylistSelectionRequiredError{
+					SourcePath: input.SourcePath,
+					Candidates: candidates,
+				}
+			}
 			return api.PrepareResult{Release: api.PreparedRelease{
 				Generation: 1,
 				Source: api.SourceManifest{
@@ -868,8 +885,12 @@ func TestModuleBDMVPreparationRequiresTypedPlaylistSelection(t *testing.T) {
 		t.Fatalf("playlist preparation workflow = %#v", result.Workflow)
 	}
 	action := result.Workflow.RequiredActions[0]
-	if action.Kind != api.RequiredActionSelectPlaylist || len(action.Options) != 1 || action.Options[0].Value != "00001.mpls" {
+	if action.Kind != api.RequiredActionSelectPlaylist || len(action.Options) != maxPlaylistActionOptions || action.Options[0].Value != "00001.mpls" {
 		t.Fatalf("playlist action = %#v", action)
+	}
+	if action.Options[0].Playlist == nil || !reflect.DeepEqual(*action.Options[0].Playlist, candidates[0]) ||
+		action.Options[len(action.Options)-1].Value != "00010.mpls" {
+		t.Fatalf("playlist action details = %#v", action.Options)
 	}
 
 	instructions := api.ReleaseFactInstructions{

--- a/internal/services/bdinfo/service.go
+++ b/internal/services/bdinfo/service.go
@@ -13,6 +13,7 @@ import (
 
 	bdrunner "github.com/autobrr/go-bdinfo/pkg/bdinfo"
 
+	"github.com/autobrr/upbrr/internal/metadata/discparse"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -228,9 +229,9 @@ func (s *Service) execute(ctx context.Context, bdmvPath string, playlistName str
 	}, nil
 }
 
-// ParseOutput extracts the title, label, size, length, and quick-summary fields
-// present in a persisted BDInfo report. Missing fields are omitted without an
-// error.
+// ParseOutput extracts title, label, size, length, and quick-summary fields from
+// either a full BDInfo report or a persisted standalone quick summary. Missing
+// fields are omitted without an error.
 func (s *Service) ParseOutput(filePath string) (map[string]any, error) {
 	content, err := os.ReadFile(filePath)
 	if err != nil {
@@ -269,12 +270,8 @@ func (s *Service) ParseOutput(filePath string) (map[string]any, error) {
 		}
 	}
 
-	// Extract summary section
-	if idx := strings.Index(text, "QUICK SUMMARY:"); idx >= 0 {
-		end := strings.Index(text[idx:], "********************")
-		if end > 0 {
-			result["summary"] = strings.TrimSpace(text[idx+14 : idx+end])
-		}
+	if summary, _, _ := discparse.SplitBDInfoReport(text); strings.TrimSpace(summary) != "" {
+		result["summary"] = summary
 	}
 
 	s.logger.Debugf("bdinfo: parsed output with %d fields", len(result))

--- a/internal/services/bdinfo/service_test.go
+++ b/internal/services/bdinfo/service_test.go
@@ -89,6 +89,22 @@ without specific fields`
 	}
 }
 
+func TestParseOutputStandaloneSummary(t *testing.T) {
+	testFile := filepath.Join(t.TempDir(), "BD_SUMMARY_00001.MPLS.txt")
+	content := "Disc Title: Example Release 2026\nPlaylist: 00001.MPLS\nLength: 01:30:00.000\nVideo: MPEG-4 AVC Video / 30000 kbps / 1080p"
+	if err := os.WriteFile(testFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("write standalone summary: %v", err)
+	}
+
+	result, err := New(api.NopLogger{}).ParseOutput(testFile)
+	if err != nil {
+		t.Fatalf("parse standalone summary: %v", err)
+	}
+	if result["summary"] != content {
+		t.Fatalf("summary = %q, want %q", result["summary"], content)
+	}
+}
+
 func TestContextCancellation(t *testing.T) {
 	svc := New(api.NopLogger{})
 

--- a/internal/trackers/dupe/evaluator.go
+++ b/internal/trackers/dupe/evaluator.go
@@ -278,6 +278,8 @@ func dupeReasonMessage(reason string) string {
 	switch strings.TrimSpace(reason) {
 	case "exact_identity":
 		return "Candidate has identical release or file identity."
+	case "existing_full_disc":
+		return "Tracker permits only one full disc for this work."
 	case "existing_season_pack":
 		return "Existing season pack contains the proposed episode slot."
 	case "proposed_season_pack":

--- a/internal/trackers/dupe/normalize.go
+++ b/internal/trackers/dupe/normalize.go
@@ -296,6 +296,7 @@ func normalizeTargetFacts(target api.TrackerDuplicateTarget) normalizedFacts {
 	facts.MediaKind, facts.MediaClass, facts.SourceFamily = deriveMediaFacts(
 		facts.Type.Value,
 		facts.Source.Value,
+		facts.Container.Value,
 		target.VideoEncode,
 		title.MediaKind,
 	)
@@ -430,6 +431,7 @@ func normalizeCandidateFacts(candidate TrackerCandidate) normalizedFacts {
 	facts.MediaKind, facts.MediaClass, facts.SourceFamily = deriveMediaFacts(
 		facts.Type.Value,
 		facts.Source.Value,
+		facts.Container.Value,
 		"",
 		title.MediaKind,
 	)
@@ -574,6 +576,7 @@ func webCodecTokenFollows(tokens []string, start int) bool {
 
 func mediaKindFromText(value string) mediaKind {
 	normalized := strings.NewReplacer(".", " ", "_", " ", "-", " ").Replace(strings.ToUpper(value))
+	compact := compactAlphaNumeric(value)
 	switch {
 	case strings.Contains(normalized, "REMUX"):
 		return mediaKindRemux
@@ -587,22 +590,42 @@ func mediaKindFromText(value string) mediaKind {
 		return mediaKindSDTV
 	case strings.Contains(normalized, "DVD RIP"), strings.Contains(normalized, "DVDRIP"):
 		return mediaKindDVDRip
-	case strings.Contains(normalized, "BD25"), strings.Contains(normalized, "BD50"), strings.Contains(normalized, "BD66"),
-		strings.Contains(normalized, "BD100"), strings.Contains(normalized, "FULL DISC"), strings.Contains(normalized, "BLU RAY DISC"),
-		strings.Contains(normalized, "UHD DISC"), strings.Contains(normalized, "DVD5"), strings.Contains(normalized, "DVD9"):
+	case strings.Contains(compact, "bd25"), strings.Contains(compact, "bd50"), strings.Contains(compact, "bd66"),
+		strings.Contains(compact, "bd100"), strings.Contains(normalized, "FULL DISC"), strings.Contains(normalized, "BLU RAY DISC"),
+		strings.Contains(normalized, "UHD DISC"), strings.Contains(normalized, "BLURAY RAW"), strings.Contains(compact, "dvd5"),
+		strings.Contains(compact, "dvd9"):
 		return mediaKindFullDisc
-	case strings.Contains(normalized, "BD RIP"), strings.Contains(normalized, "BDRIP"), strings.Contains(normalized, "BLU RAY"),
-		strings.Contains(normalized, "BLURAY"):
+	case strings.Contains(normalized, "BD RIP"), strings.Contains(normalized, "BDRIP"),
+		(strings.Contains(normalized, "BLU RAY") || strings.Contains(normalized, "BLURAY")) &&
+			(strings.Contains(compact, "x264") || strings.Contains(compact, "x265") || strings.Contains(compact, "xvid") ||
+				strings.Contains(compact, "divx")):
 		return mediaKindDiscEncode
 	default:
 		return mediaKindUnknown
 	}
 }
 
-func deriveMediaFacts(typeValue string, sourceValue string, encodeValue string, titleKind mediaKind) (mediaKind, mediaClass, sourceFamily) {
+// deriveMediaFacts classifies media from structured type and container evidence before falling back to title and source evidence.
+func deriveMediaFacts(
+	typeValue string,
+	sourceValue string,
+	containerValue string,
+	encodeValue string,
+	titleKind mediaKind,
+) (mediaKind, mediaClass, sourceFamily) {
 	kind := mediaKindFromText(strings.Join([]string{typeValue, encodeValue}, " "))
 	if strings.Contains(strings.ToUpper(typeValue), "DISC") {
 		kind = mediaKindFullDisc
+	}
+	if kind == mediaKindUnknown {
+		switch canonicalContainer(containerValue) {
+		case "m2ts", "vob_ifo":
+			kind = mediaKindFullDisc
+		case "iso":
+			if family := canonicalSource(sourceValue); family == "bluray" || family == "uhd_bluray" || family == "hd_dvd" || family == "dvd" {
+				kind = mediaKindFullDisc
+			}
+		}
 	}
 	if kind == mediaKindUnknown {
 		kind = titleKind

--- a/internal/trackers/dupe/normalize_test.go
+++ b/internal/trackers/dupe/normalize_test.go
@@ -44,6 +44,43 @@ func TestNormalizeTitleRemuxOutranksStructuredDiscSource(t *testing.T) {
 	}
 }
 
+func TestNormalizeFullDiscFromStructuredAndTrackerLabels(t *testing.T) {
+	t.Parallel()
+
+	for _, entry := range []api.DupeEntry{
+		{Type: "DISC"},
+		{Type: "Full Disc"},
+		{Type: "BD 50"},
+		{Type: "BluRay Raw"},
+		{Name: "Example Release 2026 1080p Blu-ray AVC-GRP", Container: "m2ts"},
+		{
+Name: "Example Release 2026 576i DVD-GRP",
+ Source: "DVD",
+ Container: "ISO",
+},
+	} {
+		facts := normalizeCandidateFacts(NormalizeCandidate(entry, "TEST"))
+		if facts.MediaKind != mediaKindFullDisc || facts.MediaClass != mediaClassFullDisc || facts.SourceFamily != sourceFamilyDisc {
+			t.Fatalf("full-disc facts = %#v for entry %#v", facts, entry)
+		}
+	}
+}
+
+func TestAmbiguousBluRayTitleDoesNotDisproveFullDiscDuplicate(t *testing.T) {
+	t.Parallel()
+
+	target := api.TrackerDuplicateTarget{
+Names: []string{"Example Release 2026 Proposed-GRP"},
+ Type: "DISC",
+ Source: "Blu-ray",
+}
+	candidate := NormalizeCandidate(api.DupeEntry{Name: "Example Release 2026 1080p Blu-ray AVC TrueHD 7.1-GRP"}, "TEST")
+	result := Evaluate(target, []TrackerCandidate{candidate}, trackerspkg.DupePolicy{}, SearchEvidence{Complete: true})
+	if got := result.Candidates[0].Relation; got != api.DupeRelationSameSlot || !result.RequiresAction {
+		t.Fatalf("ambiguous Blu-ray relation = %#v", result.Candidates[0])
+	}
+}
+
 func TestNormalizeProviderFromAutobrrRLSCollection(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/dupe/normalize_test.go
+++ b/internal/trackers/dupe/normalize_test.go
@@ -54,10 +54,10 @@ func TestNormalizeFullDiscFromStructuredAndTrackerLabels(t *testing.T) {
 		{Type: "BluRay Raw"},
 		{Name: "Example Release 2026 1080p Blu-ray AVC-GRP", Container: "m2ts"},
 		{
-Name: "Example Release 2026 576i DVD-GRP",
- Source: "DVD",
- Container: "ISO",
-},
+			Name:      "Example Release 2026 576i DVD-GRP",
+			Source:    "DVD",
+			Container: "ISO",
+		},
 	} {
 		facts := normalizeCandidateFacts(NormalizeCandidate(entry, "TEST"))
 		if facts.MediaKind != mediaKindFullDisc || facts.MediaClass != mediaClassFullDisc || facts.SourceFamily != sourceFamilyDisc {
@@ -70,10 +70,10 @@ func TestAmbiguousBluRayTitleDoesNotDisproveFullDiscDuplicate(t *testing.T) {
 	t.Parallel()
 
 	target := api.TrackerDuplicateTarget{
-Names: []string{"Example Release 2026 Proposed-GRP"},
- Type: "DISC",
- Source: "Blu-ray",
-}
+		Names:  []string{"Example Release 2026 Proposed-GRP"},
+		Type:   "DISC",
+		Source: "Blu-ray",
+	}
 	candidate := NormalizeCandidate(api.DupeEntry{Name: "Example Release 2026 1080p Blu-ray AVC TrueHD 7.1-GRP"}, "TEST")
 	result := Evaluate(target, []TrackerCandidate{candidate}, trackerspkg.DupePolicy{}, SearchEvidence{Complete: true})
 	if got := result.Candidates[0].Relation; got != api.DupeRelationSameSlot || !result.RequiresAction {

--- a/internal/trackers/impl/azfamily/dupe.go
+++ b/internal/trackers/impl/azfamily/dupe.go
@@ -176,11 +176,33 @@ func (h dupeSearcher) fetchTorrentList(
 			if ripType != "" && !containsFlag(entry.Flags, ripType) {
 				continue
 			}
+			entry.Type = ripType
+			entry.CanonicalType = azCanonicalCandidateType(ripType)
 			results = append(results, entry)
 		}
 		pageURL = nextAZPage(root, site.baseURL)
 	}
 	return results, nil
+}
+
+// azCanonicalCandidateType maps an AZ-family rip filter value to the shared duplicate type vocabulary.
+func azCanonicalCandidateType(ripType string) string {
+	switch strings.ToLower(strings.TrimSpace(ripType)) {
+	case "bluray raw", "dvd":
+		return "DISC"
+	case "bluray remux", "dvd remux":
+		return "REMUX"
+	case "web-dl":
+		return "WEBDL"
+	case "webrip":
+		return "WEBRIP"
+	case "hdtv", "sdtv":
+		return "HDTV"
+	case "bdrip", "bluray", "brrip", "dvdrip", "hdrip":
+		return "ENCODE"
+	default:
+		return ""
+	}
 }
 
 type azDupeSiteDef struct {

--- a/internal/trackers/impl/azfamily/dupe_test.go
+++ b/internal/trackers/impl/azfamily/dupe_test.go
@@ -70,4 +70,15 @@ func TestAZNetworkHandlerSearchParsesHTMLResults(t *testing.T) {
 	if entries[0].ID != "123" {
 		t.Fatalf("expected torrent id 123, got %q", entries[0].ID)
 	}
+	if entries[0].Type != "WEB-DL" || entries[0].CanonicalType != "WEBDL" {
+		t.Fatalf("unexpected AZ candidate type %#v", entries[0])
+	}
+}
+
+func TestAZCanonicalCandidateTypePreservesFilteredDiscEvidence(t *testing.T) {
+	t.Parallel()
+
+	if got := azCanonicalCandidateType("BluRay Raw"); got != "DISC" {
+		t.Fatalf("BluRay Raw type = %q", got)
+	}
 }

--- a/internal/trackers/impl/azfamily/dupe_test.go
+++ b/internal/trackers/impl/azfamily/dupe_test.go
@@ -75,10 +75,26 @@ func TestAZNetworkHandlerSearchParsesHTMLResults(t *testing.T) {
 	}
 }
 
-func TestAZCanonicalCandidateTypePreservesFilteredDiscEvidence(t *testing.T) {
+func TestAZCanonicalCandidateType(t *testing.T) {
 	t.Parallel()
 
-	if got := azCanonicalCandidateType("BluRay Raw"); got != "DISC" {
-		t.Fatalf("BluRay Raw type = %q", got)
+	for input, want := range map[string]string{
+		"BluRay Raw":  "DISC",
+		"DVD":          "DISC",
+		"BluRay Remux": "REMUX",
+		"DVD Remux":    "REMUX",
+		"WEB-DL":       "WEBDL",
+		"WEBRip":       "WEBRIP",
+		"HDTV":         "HDTV",
+		"SDTV":         "HDTV",
+		"BDRip":        "ENCODE",
+		"BluRay":       "ENCODE",
+		"BRRip":        "ENCODE",
+		"DVDRip":       "ENCODE",
+		"HDRip":        "ENCODE",
+	} {
+		if got := azCanonicalCandidateType(input); got != want {
+			t.Errorf("azCanonicalCandidateType(%q) = %q, want %q", input, got, want)
+		}
 	}
 }

--- a/internal/trackers/impl/registry_test.go
+++ b/internal/trackers/impl/registry_test.go
@@ -427,7 +427,7 @@ func TestNewRegistryCapabilityInventory(t *testing.T) {
 	if _, ok := registry.LookupMetadataPolicy("ANT"); !ok {
 		t.Fatal("expected ANT tracker-owned metadata policy")
 	}
-	if policy, ok := registry.LookupDupePolicy("ANT"); !ok || policy.ID != "ant/duplicate/v2" ||
+	if policy, ok := registry.LookupDupePolicy("ANT"); !ok || policy.ID != "ant/duplicate/v3" ||
 		policy.EvidenceID != "ant-dupes-trumping" {
 		t.Fatalf("ANT dupe policy = %#v, %t", policy, ok)
 	}

--- a/internal/trackers/impl/standalone/ant/dupe.go
+++ b/internal/trackers/impl/standalone/ant/dupe.go
@@ -151,17 +151,18 @@ func antDupeEntries(payload map[string]any, _ string) []api.DupeEntry {
 			fileCount = len(files)
 		}
 		entry := api.DupeEntry{
-			Name:      antString(item["fileName"]),
-			Files:     files,
-			FileCount: fileCount,
-			Link:      antString(item["guid"]),
-			Download:  strings.ReplaceAll(antString(item["link"]), "&amp;", "&"),
-			Res:       antString(item["resolution"]),
-			Type:      antString(item["type"]),
-			Source:    antString(item["source"]),
-		}
-		if entry.Name == "" && len(files) > 0 {
-			entry.Name = files[0]
+			Name:          antCandidateName(item, files),
+			Files:         files,
+			FileCount:     fileCount,
+			Link:          antString(item["guid"]),
+			Download:      strings.ReplaceAll(antString(item["link"]), "&amp;", "&"),
+			Res:           antString(item["resolution"]),
+			Type:          antString(item["type"]),
+			CanonicalType: antCandidateType(item),
+			Source:        antCandidateSource(item),
+			Codec:         antString(item["codec"]),
+			Container:     antString(item["container"]),
+			Group:         antString(item["releaseGroup"]),
 		}
 		if size := antInt(item["size"]); size > 0 {
 			entry.SizeKnown, entry.SizeBytes = true, size
@@ -179,6 +180,38 @@ func antDupeEntries(payload map[string]any, _ string) []api.DupeEntry {
 		entries = append(entries, entry)
 	}
 	return entries
+}
+
+// antCandidateName prefers the listed content name for single-file torrents and ANT's torrent filename for multi-file torrents.
+func antCandidateName(item map[string]any, files []string) string {
+	if len(files) == 1 {
+		return files[0]
+	}
+	for _, field := range []string{"fileName", "releaseName", "name", "title"} {
+		if value := antString(item[field]); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+// antCandidateSource falls back to ANT's media field when the response omits source.
+func antCandidateSource(item map[string]any) string {
+	if source := antString(item["source"]); source != "" {
+		return source
+	}
+	return antString(item["media"])
+}
+
+// antCandidateType classifies disc containers explicitly and otherwise preserves ANT's type value.
+func antCandidateType(item map[string]any) string {
+	typeValue := antString(item["type"])
+	switch strings.ToLower(antString(item["container"])) {
+	case "m2ts", "bdmv", "vob/ifo", "video_ts", "iso":
+		return "DISC"
+	default:
+		return typeValue
+	}
 }
 
 type antPagination struct {

--- a/internal/trackers/impl/standalone/ant/dupe_test.go
+++ b/internal/trackers/impl/standalone/ant/dupe_test.go
@@ -163,6 +163,98 @@ func TestDupeSearcherMissingCredentialsSkips(t *testing.T) {
 	}
 }
 
+func TestANTFullDiscEvidenceUsesIdentityThenSingleDiscRule(t *testing.T) {
+	t.Parallel()
+
+	target := api.TrackerDuplicateTarget{
+		Type:       "DISC",
+		Source:     "Blu-ray",
+		Resolution: "1080p",
+		VideoCodec: "AVC",
+		Group:      "GRP",
+		SizeBytes:  1000,
+	}
+	entry := api.DupeEntry{
+		Name:          "Example.Release.2026.1080p.Blu-ray.AVC-GRP",
+		CanonicalType: "DISC",
+		Source:        "Blu-ray",
+		Res:           "1080p",
+		Codec:         "AVC",
+		Container:     "m2ts",
+		Group:         "GRP",
+		SizeBytes:     1000,
+		SizeKnown:     true,
+	}
+	policy := *Profile().DupePolicy
+	result := dupe.Evaluate(target, []dupe.TrackerCandidate{dupe.NormalizeCandidate(entry, "ANT")}, policy, dupe.SearchEvidence{Complete: true})
+	if got := result.Candidates[0].Relation; got != api.DupeRelationExactDuplicate {
+		t.Fatalf("same ANT full disc relation = %q", got)
+	}
+
+	entry.Group = "OTHER"
+	entry.SizeBytes = 900
+	result = dupe.Evaluate(target, []dupe.TrackerCandidate{dupe.NormalizeCandidate(entry, "ANT")}, policy, dupe.SearchEvidence{Complete: true})
+	if got := result.Candidates[0].Relation; got != api.DupeRelationExistingPreferred {
+		t.Fatalf("second ANT full disc relation = %q", got)
+	}
+}
+
+func TestANTCandidatePreservesDiscFields(t *testing.T) {
+	t.Parallel()
+
+	entries := antDupeEntries(map[string]any{"item": []any{map[string]any{
+		"title":        "Example Release 2026",
+		"fileName":     "generated.123.torrent",
+		"container":    "m2ts",
+		"releaseGroup": "GRP",
+		"flags":        []any{"HDR10"},
+		"files": []any{
+			map[string]any{"name": "BDMV/BACKUP/BDJO/00000.bdjo"},
+			map[string]any{"name": "BDMV/index.bdmv"},
+		},
+	}}}, "")
+	if len(entries) != 1 || entries[0].Name != "generated.123.torrent" || entries[0].CanonicalType != "DISC" ||
+		entries[0].Container != "m2ts" || entries[0].Group != "GRP" || len(entries[0].Flags) != 1 {
+		t.Fatalf("ANT disc entry = %#v", entries)
+	}
+}
+
+func TestANTListedWEBFileCoexistsWithDisc(t *testing.T) {
+	t.Parallel()
+
+	entries := antDupeEntries(map[string]any{"item": []any{map[string]any{
+		"title":        "Example Release 2026",
+		"media":        "WEB",
+		"resolution":   "1080p",
+		"codec":        "H264",
+		"container":    "MKV",
+		"releaseGroup": "WEBGRP",
+		"files": []any{map[string]any{
+			"name": "Example.Release.2026.1080p.WEB-DL.H.264-WEBGRP.mkv",
+		}},
+	}}}, "")
+	if len(entries) != 1 || entries[0].Name != "Example.Release.2026.1080p.WEB-DL.H.264-WEBGRP.mkv" || entries[0].Source != "WEB" {
+		t.Fatalf("ANT WEB entry = %#v", entries)
+	}
+
+	target := api.TrackerDuplicateTarget{
+		Type:       "DISC",
+		Source:     "Blu-ray",
+		Resolution: "1080p",
+		VideoCodec: "AVC",
+		Group:      "GRP",
+	}
+	result := dupe.Evaluate(
+		target,
+		[]dupe.TrackerCandidate{dupe.NormalizeCandidate(entries[0], "ANT")},
+		*Profile().DupePolicy,
+		dupe.SearchEvidence{Complete: true},
+	)
+	if got := result.Candidates[0].Relation; got != api.DupeRelationCoexists {
+		t.Fatalf("ANT WEB candidate relation = %q", got)
+	}
+}
+
 func antSearchPageJSON(t *testing.T, offset int, total int, count int, includePagination bool) string {
 	t.Helper()
 	items := make([]map[string]any, count)

--- a/internal/trackers/impl/standalone/ant/profile.go
+++ b/internal/trackers/impl/standalone/ant/profile.go
@@ -31,7 +31,7 @@ func Profile() standalone.Profile {
 		BannedGroups:         bannedGroups(),
 		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: "ANT"},
 		DupePolicy: &trackers.DupePolicy{
-			ID:         "ant/duplicate/v2",
+			ID:         "ant/duplicate/v3",
 			EvidenceID: "ant-dupes-trumping",
 			SearchScope: trackers.DupeSearchScope{
 				MaxPages: 100,
@@ -45,6 +45,40 @@ func Profile() standalone.Profile {
 			},
 			HDRPartialMode:       trackers.DupeHDRPartialGenericMarker,
 			HDRCompatibilityMode: trackers.DupeHDRCompatibilityDirectional,
+			PrecedenceRules: []trackers.DupeRule{
+				{
+					ID:         "ant/duplicate/v3/exact_full_disc",
+					Relation:   string(api.DupeRelationExactDuplicate),
+					ReasonCode: "exact_identity",
+					Conditions: []trackers.DupeCondition{
+						{
+							Dimension:       trackers.DupeDimensionMediaKind,
+							TargetValues:    []string{"full_disc"},
+							CandidateValues: []string{"full_disc"},
+						},
+						{
+							Dimension:        trackers.DupeDimensionGroup,
+							ValuesEqual:      true,
+							RequiresComplete: true,
+						},
+						{
+							Dimension:        trackers.DupeDimensionSize,
+							ValuesEqual:      true,
+							RequiresComplete: true,
+						},
+					},
+				},
+				{
+					ID:         "ant/duplicate/v3/single_full_disc",
+					Relation:   string(api.DupeRelationExistingPreferred),
+					ReasonCode: "existing_full_disc",
+					Conditions: []trackers.DupeCondition{{
+						Dimension:       trackers.DupeDimensionMediaKind,
+						TargetValues:    []string{"full_disc"},
+						CandidateValues: []string{"full_disc"},
+					}},
+				},
+			},
 		},
 		AudioPolicy: &trackers.AudioPolicy{
 			AllowedLanguages: []string{"english"}, BlockEnglishOriginalWithForeign: true,

--- a/internal/trackers/impl/standalone/hdb/dupe.go
+++ b/internal/trackers/impl/standalone/hdb/dupe.go
@@ -148,12 +148,26 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 				continue
 			}
 			seenIDs[id] = struct{}{}
+			flags, flagsPresent := hdbTags(item)
+			candidateType := hdbCandidateType(item["medium"])
 			entry := api.DupeEntry{
-				Name:      hdbString(item["name"]),
-				ID:        id,
-				Link:      "https://hdbits.org/details.php?id=" + id,
-				Download:  "https://hdbits.org/download.php/" + url.QueryEscape(filename) + "?id=" + id + "&passkey=" + passkey,
-				FileCount: hdbInt(item["numfiles"]),
+				Name:          hdbString(item["name"]),
+				ID:            id,
+				Link:          "https://hdbits.org/details.php?id=" + id,
+				Download:      "https://hdbits.org/download.php/" + url.QueryEscape(filename) + "?id=" + id + "&passkey=" + passkey,
+				FileCount:     hdbInt(item["numfiles"]),
+				Category:      hdbCandidateCategory(item["category"]),
+				Type:          candidateType,
+				CanonicalType: candidateType,
+				Res:           hdbString(item["resolution"]),
+				Codec:         hdbCandidateCodec(item["codec"]),
+				Container:     hdbString(item["container"]),
+				Group:         firstHDBText(hdbString(item["releaseGroup"]), hdbString(item["group"])),
+				Flags:         flags,
+				FlagsPresent:  flagsPresent,
+				HDR:           dupe.NormalizeTrackerHDRFlags(flags, flagsPresent, false),
+				Internal:      hdbInt(item["origin"]) == 1,
+				Description:   hdbString(item["descr"]),
 			}
 			if size := hdbInt(item["size"]); size > 0 {
 				entry.SizeKnown, entry.SizeBytes = true, int64(size)
@@ -240,6 +254,93 @@ func firstHDBText(values ...string) string {
 		}
 	}
 	return ""
+}
+
+// hdbCandidateCategory maps HDB category IDs to the shared movie and TV vocabulary.
+func hdbCandidateCategory(value any) string {
+	switch hdbInt(value) {
+	case 1, 3, 4:
+		return string(api.CanonicalCategoryMovie)
+	case 2:
+		return string(api.CanonicalCategoryTV)
+	default:
+		return hdbString(value)
+	}
+}
+
+// hdbCandidateCodec maps HDB codec IDs to names understood by duplicate normalization.
+func hdbCandidateCodec(value any) string {
+	switch hdbInt(value) {
+	case 1:
+		return "H.264"
+	case 2:
+		return "MPEG-2"
+	case 3:
+		return "VC-1"
+	case 4:
+		return "XviD"
+	case 5:
+		return "H.265"
+	case 6:
+		return "VP9"
+	default:
+		return hdbString(value)
+	}
+}
+
+// hdbCandidateType maps HDB medium IDs and labels to the shared duplicate type vocabulary.
+func hdbCandidateType(value any) string {
+	switch hdbInt(value) {
+	case 1:
+		return "DISC"
+	case 3:
+		return "ENCODE"
+	case 4:
+		return "HDTV"
+	case 5:
+		return "REMUX"
+	case 6:
+		return "WEBDL"
+	}
+	normalized := normalizeHDBType(hdbString(value))
+	switch normalized {
+	case "BLURAY", "HDDVD", "DISC":
+		return "DISC"
+	case "ENCODE", "HDTV", "REMUX", "WEBDL", "WEBRIP":
+		return normalized
+	default:
+		return ""
+	}
+}
+
+// hdbTags normalizes array or comma-delimited tags and reports whether the response supplied tag evidence.
+func hdbTags(item map[string]any) ([]string, bool) {
+	value, present := item["tags"]
+	if !present {
+		return nil, false
+	}
+	var tags []string
+	switch typed := value.(type) {
+	case []any:
+		for _, raw := range typed {
+			if tag := hdbString(raw); tag != "" {
+				tags = append(tags, tag)
+			}
+		}
+	case []string:
+		for _, raw := range typed {
+			if tag := strings.TrimSpace(raw); tag != "" {
+				tags = append(tags, tag)
+			}
+		}
+	case string:
+		for raw := range strings.SplitSeq(typed, ",") {
+			if tag := strings.TrimSpace(raw); tag != "" {
+				tags = append(tags, tag)
+			}
+		}
+	}
+	return tags, true
 }
 
 func isHDBDupeTVCategory(meta api.DuplicateSubject) bool {

--- a/internal/trackers/impl/standalone/hdb/dupe_integration_test.go
+++ b/internal/trackers/impl/standalone/hdb/dupe_integration_test.go
@@ -133,7 +133,7 @@ func TestHDBHandlerSearchBuildsPayloadAndParsesResults(t *testing.T) {
 				t.Fatalf("unexpected page %d", got)
 			}
 
-			body := `{"status":0,"data":[{"id":42,"name":"Movie.Title.2024.1080p.WEB-DL.DDP5.1.H.265-GRP","filename":"Movie Title (2024).torrent","size":1234567890,"numfiles":3}]}`
+			body := `{"status":0,"data":[{"id":42,"name":"Movie.Title.2024.1080p.WEB-DL.DDP5.1.H.265-GRP","filename":"Movie Title (2024).torrent","size":1234567890,"numfiles":3,"category":1,"codec":5,"medium":6,"origin":1,"tags":["HDR10"],"descr":"Example description"}]}`
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader(body)),
@@ -199,6 +199,10 @@ func TestHDBHandlerSearchBuildsPayloadAndParsesResults(t *testing.T) {
 	if entry.FileCount != 3 {
 		t.Fatalf("unexpected file count %d", entry.FileCount)
 	}
+	if entry.Category != string(api.CanonicalCategoryMovie) || entry.Type != "WEBDL" || entry.CanonicalType != "WEBDL" || entry.Codec != "H.265" ||
+		!entry.Internal || len(entry.Flags) != 1 || entry.Flags[0] != "HDR10" || entry.Description != "Example description" {
+		t.Fatalf("unexpected structured HDB evidence %#v", entry)
+	}
 	logs := strings.Join(logger.debug, "\n")
 	if strings.Contains(logs, `"username":"user"`) || strings.Contains(logs, `"passkey":"pk"`) {
 		t.Fatal("HDB request log exposed credentials")
@@ -209,6 +213,34 @@ func TestHDBHandlerSearchBuildsPayloadAndParsesResults(t *testing.T) {
 	search := result.SearchEvidence()
 	if !search.Complete || search.Pages != 1 || search.Scope != "work_identity" {
 		t.Fatalf("unexpected search evidence %#v", search)
+	}
+}
+
+func TestHDBFullDiscUsesMediumAndGroupSlot(t *testing.T) {
+	t.Parallel()
+
+	target := api.TrackerDuplicateTarget{
+		Type:       "DISC",
+		Source:     "Blu-ray",
+		Resolution: "1080p",
+		VideoCodec: "AVC",
+		Group:      "GRP",
+	}
+	entry := api.DupeEntry{
+		Name:          "Example Release 2026 1080p Blu-ray AVC TrueHD 7.1-GRP",
+		CanonicalType: "DISC",
+		Codec:         "H.264",
+	}
+	policy := *Profile().DupePolicy
+	result := dupe.Evaluate(target, []dupe.TrackerCandidate{dupe.NormalizeCandidate(entry, "HDB")}, policy, dupe.SearchEvidence{Complete: true})
+	if got := result.Candidates[0].Relation; got != api.DupeRelationSameSlot || !result.RequiresAction {
+		t.Fatalf("same-group HDB disc evaluation = %#v", result.Candidates[0])
+	}
+
+	entry.Name = "Example Release 2026 1080p Blu-ray AVC TrueHD 7.1-OTHER"
+	result = dupe.Evaluate(target, []dupe.TrackerCandidate{dupe.NormalizeCandidate(entry, "HDB")}, policy, dupe.SearchEvidence{Complete: true})
+	if got := result.Candidates[0].Relation; got != api.DupeRelationCoexists {
+		t.Fatalf("different-group HDB disc relation = %q", got)
 	}
 }
 

--- a/internal/trackers/impl/standalone/hdb/dupe_integration_test.go
+++ b/internal/trackers/impl/standalone/hdb/dupe_integration_test.go
@@ -200,7 +200,8 @@ func TestHDBHandlerSearchBuildsPayloadAndParsesResults(t *testing.T) {
 		t.Fatalf("unexpected file count %d", entry.FileCount)
 	}
 	if entry.Category != string(api.CanonicalCategoryMovie) || entry.Type != "WEBDL" || entry.CanonicalType != "WEBDL" || entry.Codec != "H.265" ||
-		!entry.Internal || len(entry.Flags) != 1 || entry.Flags[0] != "HDR10" || entry.Description != "Example description" {
+		!entry.Internal || len(entry.Flags) != 1 || entry.Flags[0] != "HDR10" || len(entry.HDR.Formats) != 1 ||
+		entry.HDR.Formats[0] != api.HDRFormatHDR10 || entry.Description != "Example description" {
 		t.Fatalf("unexpected structured HDB evidence %#v", entry)
 	}
 	logs := strings.Join(logger.debug, "\n")

--- a/internal/trackers/impl/standalone/hdb/profile.go
+++ b/internal/trackers/impl/standalone/hdb/profile.go
@@ -31,7 +31,7 @@ func Profile() standalone.Profile {
 		},
 		NewDuplicateAdapter: func(deps dupe.Dependencies) dupe.Adapter { return newDuplicateAdapterAt(deps, hdbBaseURL) },
 		DupePolicy: &trackers.DupePolicy{
-			ID:         "hdb/duplicate/v2",
+			ID:         "hdb/duplicate/v3",
 			EvidenceID: "hdb-rules",
 			SearchScope: trackers.DupeSearchScope{
 				MaxPages: 100,

--- a/internal/webserver/openapi/release-workflow-v1.json
+++ b/internal/webserver/openapi/release-workflow-v1.json
@@ -6274,6 +6274,16 @@
           "label": {
             "type": "string"
           },
+          "playlist": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PlaylistInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "value": {
             "type": "string"
           }

--- a/pkg/api/metadata_errors.go
+++ b/pkg/api/metadata_errors.go
@@ -34,6 +34,8 @@ func (e *BDMVRescanRequiredError) Error() string {
 type PlaylistSelectionRequiredError struct {
 	// SourcePath identifies the requested local Blu-ray source.
 	SourcePath string
+	// Candidates contains the discovered playlists available for selection.
+	Candidates []PlaylistInfo
 }
 
 // Error returns the stable playlist-selection-required message.

--- a/pkg/api/workflow_ids.go
+++ b/pkg/api/workflow_ids.go
@@ -297,6 +297,8 @@ const (
 type RequiredActionOption struct {
 	Value string `json:"value"`
 	Label string `json:"label"`
+	// Playlist carries detached display details when the option selects a Blu-ray playlist.
+	Playlist *PlaylistInfo `json:"playlist,omitempty"`
 }
 
 // RequiredAction is a transport-safe backend-defined manual action.

--- a/webui/src/api/generated/release-workflow.ts
+++ b/webui/src/api/generated/release-workflow.ts
@@ -1463,6 +1463,7 @@ export type RequiredActionKind = string;
 
 export type RequiredActionOption = Readonly<{
   label: string;
+  playlist?: PlaylistInfo | null;
   value: string;
 }>;
 

--- a/webui/src/components/WorkflowOperationProgress.tsx
+++ b/webui/src/components/WorkflowOperationProgress.tsx
@@ -5,7 +5,7 @@ import type { Operation as WorkflowOperationStatus } from "../api/generated/rele
 
 const visibleStatuses = new Set(["queued", "running", "blocked", "failed", "interrupted"]);
 
-/** Shows durable progress except for duplicate checks, which render on their owning route. */
+/** Shows stable operation snapshots plus transient event detail; duplicate checks render on their owning route. */
 export function WorkflowOperationProgress({
   operation,
 }: Readonly<{ operation?: WorkflowOperationStatus | null }>) {
@@ -14,7 +14,7 @@ export function WorkflowOperationProgress({
   const events = operation.events || [];
   const scopedEvents = events.filter(
     (event) =>
-      event.scope !== "workflow" &&
+      event.scopeId !== operation.workflowId &&
       (["queued", "running"].includes(event.lifecycle) ||
         event.severity === "warn" ||
         event.severity === "error"),
@@ -28,7 +28,9 @@ export function WorkflowOperationProgress({
   const completed = Math.min(operation.completed, operation.total || operation.completed);
   const progress = Math.max(0, Math.min(100, operation.progress));
   const failure = operation.failures?.find((entry) => entry.failure.Message)?.failure;
-  const rootEvent = [...events].reverse().find((event) => event.scope === "workflow");
+  const rootEvent = [...events]
+    .reverse()
+    .find((event) => event.scope === "workflow" && event.scopeId === operation.workflowId);
   const latestFailureEvent = [...events]
     .reverse()
     .find((event) => event.severity === "error" || event.severity === "warn");
@@ -40,11 +42,12 @@ export function WorkflowOperationProgress({
       : failure?.Recovery && failure.Recovery !== "none"
         ? `Recovery: ${failure.Recovery.replaceAll("_", " ")}.`
         : "";
-  const activeItems = events.length
-    ? []
-    : (operation.items || []).filter(
-        (item) => item.status === "queued" || item.status === "running" || item.status === "failed",
-      );
+  const eventScopeIds = new Set(scopedEvents.map((event) => event.scopeId));
+  const activeItems = (operation.items || []).filter(
+    (item) =>
+      (item.status === "queued" || item.status === "running" || item.status === "failed") &&
+      !eventScopeIds.has(item.id),
+  );
 
   return (
     <section className="panel mb-3 grid gap-2 py-3" role="status" aria-live="polite">
@@ -83,7 +86,11 @@ export function WorkflowOperationProgress({
               className="flex flex-wrap items-center justify-between gap-2 rounded border border-white/10 bg-white/5 px-2 py-1.5"
               key={`${event.sequence}-${event.scope}-${event.scopeId || "workflow"}`}
             >
-              <span className="font-semibold">{event.scopeId || event.scope}</span>
+              <span className="font-semibold">
+                {operation.items?.find((item) => item.id === event.scopeId)?.label ||
+                  event.scopeId ||
+                  event.scope}
+              </span>
               <span
                 className={
                   event.severity === "error"

--- a/webui/src/components/WorkflowRequiredActions.test.tsx
+++ b/webui/src/components/WorkflowRequiredActions.test.tsx
@@ -33,6 +33,71 @@ const continuation = (requiredActions: readonly RequiredAction[]): WorkflowConti
 });
 
 describe("WorkflowRequiredActions", () => {
+  it("keeps source evidence visible while showing Blu-ray playlist progress", () => {
+    render(
+      <WorkflowOperationProgress
+        operation={
+          {
+            command: "prepare_release",
+            completed: 300,
+            events: [
+              {
+                command: "prepare_release",
+                disposition: "none",
+                lifecycle: "running",
+                message: "PLAYLIST: 7/26",
+                operationId: "operation-1",
+                phase: "bdinfo",
+                scope: "workflow",
+                scopeId: "bdinfo",
+                sequence: 1,
+                severity: "info",
+                state: "running",
+                timestamp: "2026-07-26T00:00:00Z",
+                workflowId: "workflow-1",
+              },
+            ],
+            id: "operation-1",
+            items: [
+              {
+                completed: 0,
+                id: "source_evidence",
+                kind: "preparation_phase",
+                label: "Collect source evidence",
+                phase: "source_evidence",
+                status: "running",
+                total: 1,
+              },
+              {
+                completed: 0,
+                id: "bdinfo",
+                kind: "preparation_phase",
+                label: "Analyze Blu-ray playlists",
+                phase: "bdinfo",
+                status: "running",
+                total: 1200,
+              },
+            ],
+            message: "Analyzing selected Blu-ray playlists.",
+            operation: "preparation",
+            progress: 25,
+            revision: 1,
+            sequence: 1,
+            startedAt: "2026-07-26T00:00:00Z",
+            status: "running",
+            total: 1200,
+            updatedAt: "2026-07-26T00:00:00Z",
+            workflowId: "workflow-1",
+          } as WorkflowOperationStatus
+        }
+      />,
+    );
+
+    expect(screen.getByText("Collect source evidence")).toBeInTheDocument();
+    expect(screen.getByText("Analyze Blu-ray playlists")).toBeInTheDocument();
+    expect(screen.getByText("PLAYLIST: 7/26")).toBeInTheDocument();
+  });
+
   it("stays visible after operation progress is complete and routes non-dupe actions", () => {
     const navigate = vi.fn();
     const completed = {

--- a/webui/src/releaseSession/index.test.tsx
+++ b/webui/src/releaseSession/index.test.tsx
@@ -973,7 +973,9 @@ describe("useReleaseSession", () => {
       required: boolean,
     ): ReleaseWorkflowCurrent =>
       ({
-        ...workflowCurrentFromPreview(current, preview(sourcePath, current.workflow.revision)),
+        ...(required
+          ? current
+          : workflowCurrentFromPreview(current, preview(sourcePath, current.workflow.revision))),
         workflow: {
           ...current.workflow,
           status: required ? "blocked" : "active",
@@ -985,7 +987,19 @@ describe("useReleaseSession", () => {
                   status: "pending",
                   workflowRevision: current.workflow.revision,
                   prompt: "Select one or more Blu-ray playlists to analyze.",
-                  options: [{ value: "00001.mpls", label: "00001.mpls" }],
+                  options: [
+                    {
+                      value: "00001.mpls",
+                      label: "00001.mpls",
+                      playlist: {
+                        file: "00001.mpls",
+                        duration: 7200,
+                        items: [{ file: "00001.m2ts", size: 4_000_000_000 }],
+                        score: 91.25,
+                        edition: "Example Edition",
+                      },
+                    },
+                  ],
                   createdAt: "2026-07-20T00:00:00Z",
                 },
               ]
@@ -996,12 +1010,13 @@ describe("useReleaseSession", () => {
       .fn()
       .mockResolvedValueOnce(withRelease(workflowCurrent("workflow-playlist-browser", 2), true))
       .mockResolvedValueOnce(withRelease(workflowCurrent("workflow-playlist-browser", 4), false));
+    const create = vi.fn(async () => workflowCurrent("workflow-playlist-browser", 1));
     const replaceFacts = vi.fn(async () => workflowCurrent("workflow-playlist-browser", 3));
     const { result, unmount } = renderHook(useReleaseSession, {
       wrapper: wrapperFor(
         portsFor({
           workflow: workflowPorts({
-            create: async () => workflowCurrent("workflow-playlist-browser", 1),
+            create,
             prepare: prepareWorkflow,
             replaceFacts,
           }),
@@ -1017,12 +1032,21 @@ describe("useReleaseSession", () => {
       expect.objectContaining({
         required: true,
         selected: ["00001.mpls"],
-        candidates: [expect.objectContaining({ file: "00001.mpls" })],
+        candidates: [
+          {
+            file: "00001.mpls",
+            duration: 7200,
+            items: [{ file: "00001.m2ts", size: 4_000_000_000 }],
+            score: 91.25,
+            edition: "Example Edition",
+          },
+        ],
       }),
     );
 
     await act(() => result.current.input.confirmPlaylists());
 
+    expect(create).toHaveBeenCalledOnce();
     expect(replaceFacts).not.toHaveBeenCalled();
     expect(prepareWorkflow).toHaveBeenLastCalledWith(
       expect.anything(),
@@ -1035,6 +1059,8 @@ describe("useReleaseSession", () => {
       expect.any(AbortSignal),
     );
     expect(result.current.input.view.status).toBe("ready");
+    expect(result.current.workflow.view.status).toBe("ready");
+    expect(result.current.duplicates.view.status).toBe("idle");
     expect(result.current.workflow.view.current?.workflow.revision).toBe(4);
 
     unmount();

--- a/webui/src/releaseSession/index.tsx
+++ b/webui/src/releaseSession/index.tsx
@@ -467,13 +467,17 @@ export function ReleaseSessionProvider({
       sourcePath,
       commandRevision,
       correlationID,
-      candidates: (action.options || []).map((option) => ({
-        file: option.value,
-        duration: 0,
-        items: [],
-        score: 0,
-        edition: "",
-      })),
+      candidates: (action.options || []).map((option) =>
+        option.playlist
+          ? { ...option.playlist, items: [...option.playlist.items] }
+          : {
+              file: option.value,
+              duration: 0,
+              items: [],
+              score: 0,
+              edition: "",
+            },
+      ),
       error: "",
     });
     return true;
@@ -572,7 +576,7 @@ export function ReleaseSessionProvider({
       );
       releaseWorkflowController(controller);
       if (controller.signal.aborted) return null;
-      return acceptWorkflowCurrent(prepared);
+      return prepared;
     } catch (error) {
       releaseWorkflowController(controller);
       lastWorkflowError.current = error;
@@ -814,11 +818,7 @@ export function ReleaseSessionProvider({
           commandID,
           controller.signal,
         );
-      } else if (
-        intent.playlist.Set &&
-        pendingPlaylist &&
-        workflowView.current?.release?.release.Source.SourcePath === sourcePath
-      ) {
+      } else if (intent.playlist.Set && pendingPlaylist && workflowView.current) {
         setWorkflowView((view) => ({
           ...view,
           status: "running",
@@ -845,6 +845,7 @@ export function ReleaseSessionProvider({
           lastWorkflowError.current || new Error("Canonical workflow preparation did not complete.")
         );
       }
+      acceptWorkflowCurrent(current);
       if (dispatchPlaylistAction(current, sourcePath, commandRevision, correlationID)) {
         return false;
       }


### PR DESCRIPTION
## Summary

- return enriched Blu-ray playlist candidates as a required workflow action, cap selectable details at 10, and resume canonical preparation after selection
- keep preparation progress stable in the WebUI and show human-readable item labels without duplicate workflow/item events
- reuse persisted standalone BDInfo summaries, derive missing audio/subtitle languages from BDInfo, and preserve prepared BDInfo/MediaInfo assets for tracker validation
- classify full discs from structured containers and tracker labels while keeping ambiguous Blu-ray titles conservative
- preserve AZ-family filtered rip types so raw discs, remuxes, WEB releases, broadcasts, and encodes occupy the correct duplicate slots
- use ANT media/container/codec/group/flags/size evidence, show the listed file for single-file torrents and `fileName` for multi-file torrents, identify exact group/size matches, and enforce ANT's one-full-disc policy
- use HDB category/medium/codec/tags/internal/group/size/description evidence, require review for same-group discs, and allow different release-group discs to coexist

## Testing

- `make test-go`
- focused race tests for shared dupe, tracker registry, AZ-family, ANT, and HDB packages
- `make precommit`
- `make lint`
- `make logpolicy`
- `make build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blu-ray playlist selection now displays up to 10 candidates with duration, score, edition, and stream details.
  * Blu-ray audio and subtitle languages can be identified from BDInfo when other metadata is unavailable.
  * Standalone BDInfo quick summaries are now supported.
  * Workflow progress provides clearer Blu-ray playlist analysis updates.

* **Bug Fixes**
  * Improved full-disc duplicate detection across Blu-ray, DVD, and tracker releases.
  * Improved duplicate classification for tracker release types and metadata.
  * Playlist selection workflows now resume and complete more reliably.
  * Duplicate decisions include clearer explanations when a full disc already exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->