### PR TITLE
fix: retain in-client dupe matches

### DIFF
--- a/internal/core/workflow_dupes.go
+++ b/internal/core/workflow_dupes.go
@@ -50,6 +50,11 @@ func (b workflowDupeBuilder) Build(
 	for _, result := range preflight.Results {
 		preflightByTracker[result.TrackerID] = result
 	}
+	inClient := func(trackerID api.TrackerID) bool {
+		return slices.ContainsFunc(subject.MatchedTrackers, func(candidate string) bool {
+			return strings.EqualFold(strings.TrimSpace(candidate), string(trackerID))
+		})
+	}
 	eligibleProjections := projections
 	eligibleProjections.Projections = make([]api.TrackerReleaseProjection, 0, len(projections.Projections))
 	for _, projection := range projections.Projections {
@@ -62,7 +67,8 @@ func (b workflowDupeBuilder) Build(
 			)
 		}
 		result, ok := preflightByTracker[projection.TrackerID]
-		if ok && projection.Readiness == api.ReadinessStatusReady && projection.DupeReady && result.State == api.TrackerPreflightStateReady {
+		if inClient(projection.TrackerID) ||
+			(ok && projection.Readiness == api.ReadinessStatusReady && projection.DupeReady && result.State == api.TrackerPreflightStateReady) {
 			eligibleProjections.Projections = append(eligibleProjections.Projections, projection)
 			continue
 		}
@@ -122,7 +128,9 @@ func (b workflowDupeBuilder) Build(
 		if !preflightOK {
 			return api.DupeAssessment{}, nil, fmt.Errorf("workflow duplicate check: tracker %s has no preflight result", projection.TrackerID)
 		}
-		if projection.Readiness != api.ReadinessStatusReady || !projection.DupeReady || preflightResult.State != api.TrackerPreflightStateReady {
+		result, resultOK := resultsByTracker[projection.TrackerID]
+		if !inClient(projection.TrackerID) &&
+			(projection.Readiness != api.ReadinessStatusReady || !projection.DupeReady || preflightResult.State != api.TrackerPreflightStateReady) {
 			trackerResult.Decision = api.DupeDecisionSkipped
 			trackerResult.Status = api.StageStatusSkipped
 			trackerResult.RequiredActions = append([]api.RequiredAction(nil), preflightResult.RequiredActions...)
@@ -148,8 +156,7 @@ func (b workflowDupeBuilder) Build(
 			results = append(results, trackerResult)
 			continue
 		}
-		result, ok := resultsByTracker[projection.TrackerID]
-		if !ok {
+		if !resultOK {
 			return api.DupeAssessment{}, nil, fmt.Errorf("workflow duplicate check: eligible tracker %s returned no result", projection.TrackerID)
 		}
 		trackerResult.Matches = publicDupeMatches(result)

--- a/internal/core/workflow_dupes_test.go
+++ b/internal/core/workflow_dupes_test.go
@@ -17,8 +17,10 @@ import (
 )
 
 type workflowDupeServiceFake struct {
-	queries []string
-	result  *api.DupeCheckResult
+	queries     []string
+	projections []api.TrackerReleaseProjection
+	result      *api.DupeCheckResult
+	results     []api.DupeCheckResult
 }
 
 type workflowProjectionDupeServiceFake struct {
@@ -86,6 +88,13 @@ func (f *workflowDupeServiceFake) CheckProjectionSet(
 	projections api.TrackerReleaseProjectionSet,
 	_ api.ProjectionDupeCheckOptions,
 ) (api.DupeCheckSummary, api.DupeAssessmentEvidence, error) {
+	f.projections = append(f.projections, projections.Projections...)
+	if f.results != nil {
+		return api.DupeCheckSummary{
+			SourcePath: subject.SourcePath,
+			Results:    append([]api.DupeCheckResult(nil), f.results...),
+		}, dupechecking.EmptyAssessment(), nil
+	}
 	trackers := make([]string, 0, len(projections.Projections))
 	for _, projection := range projections.Projections {
 		trackers = append(trackers, string(projection.TrackerID))
@@ -383,7 +392,7 @@ func TestWorkflowDupeOutcomeIncompleteSearchWithoutCandidatesRequiresReview(t *t
 	}
 }
 
-func TestWorkflowDupeBuilderSearchesReadySiblingAndRetainsAuthBlockedRow(t *testing.T) {
+func TestWorkflowDupeBuilderRetainsBlockedLocalClientAndSkippedAuthRows(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC)
@@ -411,6 +420,13 @@ func TestWorkflowDupeBuilderSearchesReadySiblingAndRetainsAuthBlockedRow(t *test
 	}
 	ready := projection("ALPHA", api.ReadinessStatusReady, true)
 	authBlocked := projection("BETA", api.ReadinessStatusBlocked, false)
+	clientBlocked := projection("GAMMA", api.ReadinessStatusIneligible, false)
+	clientBlocked.PolicyDecisions = []api.TrackerPolicyDecision{{
+		Code:        "unsupported_source",
+		Decision:    "ineligible",
+		Blocking:    true,
+		Disposition: api.RuleDispositionStrict,
+	}}
 	authBlocked.Failures = []api.WorkflowFailure{{
 		TrackerID: "BETA",
 		Failure: api.OperationFailure{
@@ -432,16 +448,41 @@ func TestWorkflowDupeBuilderSearchesReadySiblingAndRetainsAuthBlockedRow(t *test
 				State:     api.TrackerPreflightStateRetryable,
 				Failures:  authBlocked.Failures,
 			},
+			{TrackerID: "GAMMA", State: api.TrackerPreflightStateActionRequired},
 		},
 	}
-	service := &workflowDupeServiceFake{}
+	service := &workflowDupeServiceFake{results: []api.DupeCheckResult{
+		{
+			Tracker: "ALPHA",
+			Search:  api.DupeSearchEvidence{Complete: true},
+			Status:  "completed",
+		},
+		{
+			Tracker:  "GAMMA",
+			HasDupes: true,
+			Evaluations: []api.DupeCandidateEvaluation{{
+				Name:     clientBlocked.CanonicalReleaseName,
+				Relation: api.DupeRelationExactDuplicate,
+				Reasons:  []api.DupeReason{{Code: "in_client"}},
+			}},
+			Search: api.DupeSearchEvidence{
+				Complete:       true,
+				CandidateCount: 1,
+				Scope:          "local_client",
+			},
+			Status: "completed",
+		},
+	}}
 	snapshot, _, err := (workflowDupeBuilder{service: service}).Build(
 		context.Background(),
-		api.DuplicateSubject{SourcePath: "C:\\releases\\Example.Release.2026.mkv"},
+		api.DuplicateSubject{
+			SourcePath:      "C:\\releases\\Example.Release.2026.mkv",
+			MatchedTrackers: []string{" gamma "},
+		},
 		api.TrackerReleaseProjectionSet{
 			ID:          "projections-1",
 			Revision:    4,
-			Projections: []api.TrackerReleaseProjection{ready, authBlocked},
+			Projections: []api.TrackerReleaseProjection{ready, authBlocked, clientBlocked},
 		},
 		preflight,
 		now,
@@ -450,12 +491,14 @@ func TestWorkflowDupeBuilderSearchesReadySiblingAndRetainsAuthBlockedRow(t *test
 	if err != nil {
 		t.Fatalf("build mixed workflow dupes: %v", err)
 	}
-	if len(service.queries) != 1 || service.queries[0] != ready.DuplicateCriteria.Name {
-		t.Fatalf("eligible duplicate queries = %v", service.queries)
+	if len(service.projections) != 2 || service.projections[0].TrackerID != "ALPHA" || service.projections[1].TrackerID != "GAMMA" {
+		t.Fatalf("checked duplicate projections = %#v", service.projections)
 	}
-	if len(snapshot.Results) != 2 || snapshot.Results[1].TrackerID != "BETA" ||
+	if len(snapshot.Results) != 3 || snapshot.Results[1].TrackerID != "BETA" ||
 		snapshot.Results[1].Decision != api.DupeDecisionSkipped || snapshot.Results[1].Status != api.StageStatusSkipped ||
-		len(snapshot.Results[1].Failures) != 1 {
+		len(snapshot.Results[1].Failures) != 1 || snapshot.Results[2].TrackerID != "GAMMA" ||
+		snapshot.Results[2].Decision != api.DupeDecisionAccepted || snapshot.Results[2].Status != api.StageStatusCompleted ||
+		len(snapshot.Results[2].Matches) != 1 || snapshot.Results[2].Matches[0].Reason != "in_client" {
 		t.Fatalf("mixed duplicate snapshot = %#v", snapshot)
 	}
 }

--- a/internal/trackers/dupe/service.go
+++ b/internal/trackers/dupe/service.go
@@ -44,7 +44,7 @@ type CheckOptions struct {
 	BypassBannedGroups bool
 }
 
-// CheckProjectionSet searches only dupe-ready projections from one exact set.
+// CheckProjectionSet searches dupe-ready projections and preserves definitive local-client matches from one exact set.
 func (s *Service) CheckProjectionSet(
 	ctx context.Context,
 	meta api.DuplicateSubject,
@@ -61,10 +61,10 @@ func (s *Service) CheckProjectionSet(
 	projections := make(map[string]api.TrackerReleaseProjection, len(projectionSet.Projections))
 	trackers := make([]string, 0, len(projectionSet.Projections))
 	for _, projection := range projectionSet.Projections {
-		if projection.Readiness != api.ReadinessStatusReady || !projection.DupeReady {
+		tracker := normalizeTracker(string(projection.TrackerID))
+		if (projection.Readiness != api.ReadinessStatusReady || !projection.DupeReady) && !containsTracker(meta.MatchedTrackers, tracker) {
 			continue
 		}
-		tracker := normalizeTracker(string(projection.TrackerID))
 		projections[tracker] = projection
 		trackers = append(trackers, tracker)
 	}
@@ -304,6 +304,15 @@ func duplicateSubjectForProjection(
 		return meta, errors.New("tracker projection is missing")
 	}
 	meta.Projection = &projection
+	if containsTracker(meta.MatchedTrackers, tracker) {
+		for _, name := range []string{projection.DuplicateCriteria.Name, projection.UploadReleaseName, projection.CanonicalReleaseName} {
+			if name = strings.TrimSpace(name); name != "" {
+				meta.ReleaseName = name
+				break
+			}
+		}
+		return meta, nil
+	}
 	criteria := projection.DuplicateCriteria
 	name := strings.TrimSpace(criteria.Name)
 	if name == "" {

--- a/internal/trackers/dupe/service_test.go
+++ b/internal/trackers/dupe/service_test.go
@@ -463,13 +463,18 @@ func TestAdapterResultDefensiveCopies(t *testing.T) {
 	}
 }
 
-func TestCheckProjectionSetUsesExactCriteriaAndProjectsUploadName(t *testing.T) {
+func TestCheckProjectionSetUsesExactCriteriaAndRetainsBlockedClientMatch(t *testing.T) {
 	t.Parallel()
 
 	var received api.DuplicateSubject
+	var blockedAdapterCalls atomic.Int32
 	service := testService(map[string]Adapter{
 		"A": AdapterFunc(func(_ context.Context, subject api.DuplicateSubject) AdapterResult {
 			received = subject
+			return Resolved(nil, nil)
+		}),
+		"B": AdapterFunc(func(context.Context, api.DuplicateSubject) AdapterResult {
+			blockedAdapterCalls.Add(1)
 			return Resolved(nil, nil)
 		}),
 	})
@@ -531,9 +536,28 @@ func TestCheckProjectionSetUsesExactCriteriaAndProjectsUploadName(t *testing.T) 
 		Status:    api.StageStatusReady,
 		CreatedAt: now,
 	}
+	blockedProjection := projectionSet.Projections[0]
+	blockedProjection.TrackerID = "B"
+	blockedProjection.DisplayName = "Tracker B"
+	blockedProjection.CanonicalReleaseName = "Example.Release.2026.BLOCKED-GRP"
+	blockedProjection.UploadReleaseName = ""
+	blockedProjection.DuplicateCriteria = api.TrackerDuplicateCriteria{}
+	blockedProjection.ProjectorFingerprint = mustDupeFingerprint(t, "blocked-projection")
+	blockedProjection.CriteriaFingerprint = mustDupeFingerprint(t, "blocked-criteria")
+	blockedProjection.Readiness = api.ReadinessStatusIneligible
+	blockedProjection.DupeReady = false
+	blockedProjection.UploadReady = false
+	blockedProjection.PolicyDecisions = []api.TrackerPolicyDecision{{
+		Code:        "unsupported_source",
+		Decision:    "ineligible",
+		Blocking:    true,
+		Disposition: api.RuleDispositionStrict,
+	}}
+	projectionSet.Projections = append(projectionSet.Projections, blockedProjection)
 	summary, _, err := service.CheckProjectionSet(context.Background(), api.DuplicateSubject{
-		SourcePath:  projectionSet.ReleaseRef.SourcePath,
-		ReleaseName: projectionSet.Projections[0].CanonicalReleaseName,
+		SourcePath:      projectionSet.ReleaseRef.SourcePath,
+		ReleaseName:     projectionSet.Projections[0].CanonicalReleaseName,
+		MatchedTrackers: []string{" b "},
 	}, projectionSet, api.ProjectionDupeCheckOptions{})
 	if err != nil {
 		t.Fatalf("check projection set: %v", err)
@@ -541,7 +565,7 @@ func TestCheckProjectionSetUsesExactCriteriaAndProjectsUploadName(t *testing.T) 
 	if received.Projection == nil || received.ReleaseName != "Example Release 2026" || received.SeasonInt != 2 {
 		t.Fatalf("adapter subject = %#v", received)
 	}
-	if len(summary.Results) != 1 {
+	if len(summary.Results) != 2 {
 		t.Fatalf("duplicate results = %#v", summary.Results)
 	}
 	result := summary.Results[0]
@@ -550,6 +574,13 @@ func TestCheckProjectionSetUsesExactCriteriaAndProjectsUploadName(t *testing.T) 
 		result.ProjectionFingerprint != projectionFingerprint || result.CriteriaFingerprint != criteriaFingerprint ||
 		result.ProjectionStatus != api.ReadinessStatusReady {
 		t.Fatalf("projected duplicate result = %#v", result)
+	}
+	clientResult := summary.Results[1]
+	if blockedAdapterCalls.Load() != 0 || clientResult.Tracker != "B" || !clientResult.HasDupes ||
+		len(clientResult.Evaluations) != 1 || clientResult.Evaluations[0].Name != blockedProjection.CanonicalReleaseName ||
+		len(clientResult.Evaluations[0].Reasons) != 1 || clientResult.Evaluations[0].Reasons[0].Code != "in_client" ||
+		clientResult.Search.Scope != "local_client" {
+		t.Fatalf("blocked local-client result = %#v adapter_calls=%d", clientResult, blockedAdapterCalls.Load())
 	}
 }
 

--- a/webui/src/pages/dupe_check/index.test.tsx
+++ b/webui/src/pages/dupe_check/index.test.tsx
@@ -367,7 +367,9 @@ describe("DupeCheckPage", () => {
             {
               trackerId: "EXAMPLE",
               displayName: "Example Tracker",
+              canonicalReleaseName: "Example Release 2026 1080p-GRP",
               uploadReleaseName: "Example.Release.2026.1080p-GRP",
+              duplicateCriteria: { name: "Example Release 2026" },
               readiness: "ineligible",
               policyDecisions: [
                 {
@@ -412,6 +414,8 @@ describe("DupeCheckPage", () => {
     expect(screen.queryByText("Advisories")).not.toBeInTheDocument();
     expect(screen.queryByText("Poster metadata is not available.")).not.toBeInTheDocument();
     expect(screen.queryByText(/Evidence complete/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Canonical:")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tracker upload:")).not.toBeInTheDocument();
   });
 
   it("renders auth failure as retryable blocked lane evidence without an action card", () => {
@@ -521,14 +525,23 @@ describe("DupeCheckPage", () => {
               displayName: trackerId,
               canonicalReleaseName: "Example Release S01E01 1080p-GRP",
               uploadReleaseName: "Example.Release.S01E01.1080p-GRP",
-              policyDecisions: [],
-              readiness: "ready",
+              policyDecisions:
+                trackerId === "AITHER"
+                  ? [
+                      {
+                        code: "release_name_confirmation",
+                        decision: "confirmation_required",
+                        blocking: false,
+                      },
+                    ]
+                  : [],
+              readiness: trackerId === "AITHER" ? "ineligible" : "ready",
             })),
           } as unknown as NonNullable<DuplicatesFacet["view"]["projections"]>,
           preflight: {
             results: ["AITHER", "REMOTE"].map((trackerId) => ({
               trackerId,
-              state: "ready",
+              state: trackerId === "AITHER" ? "action_required" : "ready",
             })),
           } as unknown as NonNullable<DuplicatesFacet["view"]["preflight"]>,
         },
@@ -539,6 +552,22 @@ describe("DupeCheckPage", () => {
 
     expect(screen.getByText("In client")).toBeInTheDocument();
     expect(screen.getByText("Already in client: Strict match")).toBeInTheDocument();
+    const inClientCard = screen.getByRole("heading", { name: "AITHER" }).closest("article");
+    expect(inClientCard).toHaveClass("gap-1", "px-3", "py-2");
+    expect(within(inClientCard as HTMLElement).queryByText("Canonical:")).not.toBeInTheDocument();
+    expect(
+      within(inClientCard as HTMLElement).queryByText("Tracker upload:"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(inClientCard as HTMLElement).queryByRole("textbox", {
+        name: "Release name for AITHER",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(inClientCard as HTMLElement).queryByRole("switch", {
+        name: "Confirm release name for AITHER",
+      }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("Strict match")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("checkbox", { name: "Ignore dupes for AITHER" }),

--- a/webui/src/pages/dupe_check/index.tsx
+++ b/webui/src/pages/dupe_check/index.tsx
@@ -112,12 +112,12 @@ const trackerSummary = (
   readiness: TrackerPreflightAssessment["results"][number] | undefined,
   result: DupeAssessment["results"][number] | undefined,
 ) => {
+  if (hasInClientMatch(result)) return "In client";
   if (projection?.readiness !== "ready" || (readiness && readiness.state !== "ready")) {
     return "Blocked";
   }
   if (!result) return "Not checked";
   if (result.status === "failed") return "Check failed";
-  if (hasInClientMatch(result)) return "In client";
   const count = actionMatches(result).length;
   switch (result.decision) {
     case "accepted":
@@ -221,18 +221,26 @@ function WorkflowDupeAssessmentView({
         const readiness = preflightByTracker.get(trackerID);
         const nameConfirmation = releaseNameConfirmationState(projection);
         const releaseName = releaseNameOverrides[trackerID] ?? projection?.uploadReleaseName ?? "";
+        const inClient = hasInClientMatch(result);
+        const strictBlocked =
+          inClient ||
+          Boolean(
+            projection?.policyDecisions?.some(
+              (decision) => decision.blocking && decision.disposition === "strict",
+            ),
+          );
         const canonicalName = projection?.canonicalReleaseName?.trim() || "";
         const uploadName =
           result?.uploadReleaseName?.trim() || projection?.uploadReleaseName?.trim() || "";
         const searchName =
           result?.criteria?.name?.trim() || projection?.duplicateCriteria?.name?.trim() || "";
         const namesModified = Boolean(
+          !strictBlocked &&
           canonicalName &&
           ((uploadName && uploadName !== canonicalName) ||
             (searchName && searchName !== canonicalName)),
         );
         const blockReasons = trackerBlockReasons(projection, readiness, result);
-        const inClient = hasInClientMatch(result);
         const riskAcknowledgement = requiresRiskAcknowledgement(result);
         const canOverride = Boolean(
           result &&
@@ -249,7 +257,7 @@ function WorkflowDupeAssessmentView({
           ).values(),
         );
         return (
-          <article className="panel grid gap-2 py-3" key={trackerID}>
+          <article className="panel grid gap-1 px-3 py-2" key={trackerID}>
             <div className="flex flex-wrap items-center justify-between gap-2">
               <h2 className="text-base">{projection?.displayName || trackerID}</h2>
               <Badge
@@ -298,7 +306,7 @@ function WorkflowDupeAssessmentView({
 
             <CandidateList matches={matches} />
 
-            {nameConfirmation.pending || nameConfirmation.confirmed ? (
+            {!strictBlocked && (nameConfirmation.pending || nameConfirmation.confirmed) ? (
               <div
                 aria-label={`Tracker naming for ${trackerID}`}
                 className="grid gap-2 rounded border border-[var(--border)] bg-black/10 p-2"


### PR DESCRIPTION
## Summary

- retain local-client duplicate matches even when tracker projection or preflight readiness blocks remote checking
- keep those matches strict and bypass tracker duplicate-search adapters
- hide pointless naming details and release-name confirmation controls for strict-blocked lanes
- reduce whitespace in each tracker result card

## Root cause

The workflow removed non-dupe-ready tracker projections before the duplicate service could apply its existing local-client short circuit. That discarded `in_client` evidence for blocked trackers. The frontend also rendered tracker naming details and confirmation controls independently of the strict-blocked state.

## Impact

Locally matched tracker lanes now remain visible as `in_client`, cannot be overridden, and do not make remote duplicate-search calls. Strict-blocked cards show only useful blocker evidence in a denser layout.

## Validation

- `go test -race -v -timeout 20m ./internal/core ./internal/trackers/dupe`
- `make test-go`
- `make test-frontend`
- `make lint`
- `make precommit`
- `make backend`
- `pnpm --dir webui run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate checking for trackers with confirmed in-client matches, even when normal readiness checks are incomplete.
  * Preserved valid local-client duplicate results while excluding blocked tracker checks.
  * Standardized tracker matching regardless of capitalization or surrounding whitespace.
  * Updated duplicate-result displays to prioritize “In client” status and hide unnecessary name confirmation controls.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->