### PR TITLE
fix(torrentclient): ignore relative FileList entries for qbit save path

### DIFF
--- a/internal/torrentclient/linking.go
+++ b/internal/torrentclient/linking.go
@@ -320,10 +320,12 @@ func (s *Service) trackerLinkDirName(tracker string) string {
 
 // sourcePathForLinking returns an existing local source path suitable for link
 // creation. It stats candidate paths because link staging must copy or link real
-// filesystem content.
+// filesystem content. Relative FileList entries are ignored: they are
+// torrent-internal names, and resolving them would match against the process
+// working directory instead of the prepared source.
 func sourcePathForLinking(meta api.ClientSubject) (string, error) {
 	if len(meta.FileList) == 1 {
-		if candidate := strings.TrimSpace(meta.FileList[0]); candidate != "" {
+		if candidate := strings.TrimSpace(meta.FileList[0]); candidate != "" && filepath.IsAbs(candidate) {
 			info, err := os.Stat(candidate)
 			if err == nil && !info.IsDir() {
 				return absLocalPath("linking candidate", candidate)
@@ -350,10 +352,12 @@ func sourcePathForLinking(meta api.ClientSubject) (string, error) {
 // sourcePathForQbitSavePath returns the prepared content path used for
 // qBittorrent savepath mapping. Resolution is lexical because client-visible content need
 // not be available to stat locally. A torrent artifact path or URL is separate
-// from the prepared content source and cannot replace it.
+// from the prepared content source and cannot replace it. Relative FileList
+// entries are ignored: they are torrent-internal names, and resolving them
+// lexically would anchor the save path to the process working directory.
 func sourcePathForQbitSavePath(meta api.ClientSubject) (string, error) {
 	if len(meta.FileList) == 1 {
-		if candidate := strings.TrimSpace(meta.FileList[0]); candidate != "" {
+		if candidate := strings.TrimSpace(meta.FileList[0]); candidate != "" && filepath.IsAbs(candidate) {
 			return absLocalPath("qbit mapping source", candidate)
 		}
 	}

--- a/internal/torrentclient/linking_test.go
+++ b/internal/torrentclient/linking_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package torrentclient
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestSourcePathForQbitSavePathIgnoresRelativeFileListEntry(t *testing.T) {
+	// No t.Parallel: t.Chdir forbids it. The chdir into an empty directory
+	// proves relative FileList entries can no longer anchor the save path to
+	// the process working directory.
+	t.Chdir(t.TempDir())
+
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "Movie.2024.1080p-GRP.mkv")
+
+	got, err := sourcePathForQbitSavePath(api.ClientSubject{
+		SourcePath: sourcePath,
+		FileList:   []string{"Movie.2024.1080p-GRP.mkv"},
+	})
+	if err != nil {
+		t.Fatalf("sourcePathForQbitSavePath: %v", err)
+	}
+	if got != sourcePath {
+		t.Fatalf("expected relative FileList entry to fall back to source path %q, got %q", sourcePath, got)
+	}
+}
+
+func TestSourcePathForQbitSavePathPrefersAbsoluteSingleFileEntry(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	sourceDir := filepath.Join(root, "Fixture.Title.2024")
+	filePath := filepath.Join(sourceDir, "Fixture.Title.2024.mkv")
+
+	// Nothing is created on disk: resolution must stay lexical because the
+	// content may only exist on the remote client host.
+	got, err := sourcePathForQbitSavePath(api.ClientSubject{
+		SourcePath: sourceDir,
+		FileList:   []string{filePath},
+	})
+	if err != nil {
+		t.Fatalf("sourcePathForQbitSavePath: %v", err)
+	}
+	if got != filePath {
+		t.Fatalf("expected absolute single-file entry %q, got %q", filePath, got)
+	}
+}
+
+func TestSourcePathForLinkingIgnoresRelativeFileListEntryMatchingCWDFile(t *testing.T) {
+	// No t.Parallel: t.Chdir forbids it. A same-named file exists in the
+	// working directory so the os.Stat probe would succeed if relative
+	// entries were still honored.
+	trapDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(trapDir, "Movie.mkv"), []byte("wrong file"), 0o600); err != nil {
+		t.Fatalf("write trap file: %v", err)
+	}
+	t.Chdir(trapDir)
+
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "Movie.mkv")
+	if err := os.WriteFile(sourcePath, []byte("media"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	got, err := sourcePathForLinking(api.ClientSubject{
+		SourcePath: sourcePath,
+		FileList:   []string{"Movie.mkv"},
+	})
+	if err != nil {
+		t.Fatalf("sourcePathForLinking: %v", err)
+	}
+	if got != sourcePath {
+		t.Fatalf("expected relative FileList entry to fall back to source path %q, got %q", sourcePath, got)
+	}
+}

--- a/internal/torrentclient/service_test.go
+++ b/internal/torrentclient/service_test.go
@@ -928,6 +928,118 @@ func TestInjectQbitClientURLLinkingFallsBackWithoutStaging(t *testing.T) {
 	}
 }
 
+func TestInjectQbitClientURLFallbackRelativeFileListUsesSourceParentSavePath(t *testing.T) {
+	// No t.Parallel: t.Chdir forbids it. The chdir into an empty directory
+	// reproduces #317: a torrent-relative FileList entry must not anchor the
+	// savepath to the process working directory.
+	t.Chdir(t.TempDir())
+
+	server, capture := newQbitAddCaptureServer(t)
+	root := t.TempDir()
+	source := filepath.Join(root, "Fixture.Title.2024.mkv")
+	if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	linkRoot := filepath.Join(root, "links")
+	if err := os.MkdirAll(linkRoot, 0o700); err != nil {
+		t.Fatalf("mkdir links: %v", err)
+	}
+
+	svc := NewService(config.Config{
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:                     "qbit",
+				URL:                      server.URL,
+				Username:                 "user",
+				Password:                 "pass",
+				Linking:                  "hardlink",
+				LinkedFolder:             config.StringList{linkRoot},
+				AutomaticManagementPaths: config.StringList{root},
+			},
+		},
+	}, nil)
+
+	meta := api.ClientSubject{SourcePath: source, FileList: []string{"Fixture.Title.2024.mkv"}}
+	if err := svc.Inject(context.Background(), meta, api.TorrentResult{URL: "https://tracker.example/torrent/1", Tracker: "RF"}); err != nil {
+		t.Fatalf("inject URL fallback: %v", err)
+	}
+	select {
+	case err := <-capture.errCh:
+		t.Fatalf("handler: %v", err)
+	default:
+	}
+
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	//pathpolicy:allow qBittorrent savepath is slash-delimited API data.
+	wantSavePath := filepath.ToSlash(root) + "/"
+	if capture.savePath != wantSavePath {
+		t.Fatalf("expected source-parent savepath %q, got %q", wantSavePath, capture.savePath)
+	}
+	if capture.autoTMM != "true" {
+		t.Fatalf("expected autoTMM true, got %q", capture.autoTMM)
+	}
+}
+
+func TestInjectQbitClientPathMappingRelativeFileListMapsSourceParent(t *testing.T) {
+	// No t.Parallel: t.Chdir forbids it. Path mapping must apply to the
+	// prepared source parent even when the FileList entry is torrent-relative.
+	t.Chdir(t.TempDir())
+
+	server, capture := newQbitAddCaptureServer(t)
+
+	root := t.TempDir()
+	localRoot := filepath.Join(root, "local")
+	releaseDir := filepath.Join(localRoot, "Movies", "Fixture.Title.2024")
+	if err := os.MkdirAll(releaseDir, 0o700); err != nil {
+		t.Fatalf("mkdir release: %v", err)
+	}
+	source := filepath.Join(releaseDir, "video.mkv")
+	if err := os.WriteFile(source, []byte("media"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	torrentPath := filepath.Join(root, "sample.torrent")
+	if err := os.WriteFile(torrentPath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+
+	remoteRoot := "/remote/media"
+	svc := NewService(config.Config{
+		TorrentClients: map[string]config.TorrentClientConfig{
+			"qbit": {
+				Type:                     "qbit",
+				URL:                      server.URL,
+				Username:                 "user",
+				Password:                 "pass",
+				LocalPath:                config.StringList{localRoot},
+				RemotePath:               config.StringList{remoteRoot},
+				AutomaticManagementPaths: config.StringList{localRoot},
+			},
+		},
+	}, nil)
+
+	meta := api.ClientSubject{SourcePath: source, FileList: []string{"video.mkv"}}
+	if err := svc.Inject(context.Background(), meta, api.TorrentResult{Path: torrentPath}); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	select {
+	case err := <-capture.errCh:
+		t.Fatalf("handler: %v", err)
+	default:
+	}
+
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	wantSavePath := "/remote/media/Movies/Fixture.Title.2024/"
+	if capture.savePath != wantSavePath {
+		t.Fatalf("expected mapped savepath %q, got %q", wantSavePath, capture.savePath)
+	}
+	if capture.autoTMM != "true" {
+		t.Fatalf("expected autoTMM true, got %q", capture.autoTMM)
+	}
+}
+
 func TestInjectQbitClientInvalidLinkPlanFallbackSkipsHashCheck(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #317.

## Defect

`sourcePathForQbitSavePath` (and the stat-based `sourcePathForLinking`) honored a single-entry `FileList` even when the entry was a torrent-relative bare filename (`Movie.mkv`). `filepath.Abs` then anchored the save path — and autoTMM containment, which shares the helper — to the process working directory, producing `save_path=/data` + `state=missingFiles` on URL-only injections with `allow_fallback` enabled. The tracker upload itself reported success, so the torrent silently never seeded.

## Fix

Honor `FileList[0]` only when `filepath.IsAbs`; relative entries fall back to `SourcePath`. Same guard on `sourcePathForLinking`, where a same-named file in the CWD could otherwise pass the `os.Stat` probe and link the wrong file.

Preserved behaviors:
- Absolute single-file entries keep the directory-source behavior (`Dir(FileList[0]) == SourcePath` for a folder containing exactly one wanted file) — pinned by `TestSourcePathForQbitSavePathPrefersAbsoluteSingleFileEntry`.
- Resolution stays lexical/no-stat (content may only exist on the remote client host) — the regression tests create nothing on disk.
- `local_path`/`remote_path` mapping semantics unchanged; mapping now applies to the correct resolved source.

## Testing

- New unit tests (`linking_test.go`) plus two integration tests use `t.Chdir` traps to prove CWD independence; all regression tests fail on `main` and pass with the fix.
- `go test -race ./internal/torrentclient` green; `make lint`, `make pathpolicy`, `make logpolicy`, `make gofix-check-changed`, `git diff --check` all clean.

## Note

An earlier revision of this PR also changed duplicate-add (HTTP 409) handling in `injectQbit`; that was withdrawn — a same-hash conflict at injection time can indicate an upstream problem (e.g. a dupe check that failed to block a re-upload), and masking it as success would hide that signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed torrent linking to safely handle relative file-list paths.
  * Prevented torrent-internal filenames from being incorrectly resolved against the application’s working directory.
  * Improved fallback behavior for source and save paths.
  * Corrected path mappings and automatic torrent management when using qBittorrent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->