### PR TITLE
fix(webui): clear references when removing torrent clients

### DIFF
--- a/webui/src/hooks/useSettingsState.test.ts
+++ b/webui/src/hooks/useSettingsState.test.ts
@@ -446,6 +446,71 @@ describe("renderTorrentClientsSection", () => {
       AutomaticManagementPaths: ["/media"],
     });
   });
+
+  it("clears selectors that reference a removed client", async () => {
+    installAppOperationMocks({
+      GetConfig: async () =>
+        JSON.stringify({
+          ClientSetup: {
+            DefaultClient: "primary",
+            InjectClients: ["primary", "backup"],
+            SearchClients: [" PRIMARY ", "backup"],
+          },
+          Trackers: {
+            Trackers: {
+              AITHER: { TorrentClient: "PRIMARY" },
+              BLU: { TorrentClient: "backup" },
+            },
+          },
+          TorrentClients: {
+            primary: {
+              Type: "watch",
+              WatchFolder: "incoming-primary",
+              StorageDir: "library-primary",
+            },
+            backup: {
+              Type: "watch",
+              WatchFolder: "incoming-backup",
+              StorageDir: "library-backup",
+            },
+          },
+        }),
+      GetDefaultConfig: async () => JSON.stringify({}),
+      ListTrackerCatalog: async () =>
+        trackerCatalog(
+          trackerCatalogEntry("AITHER", [["TorrentClient", ""]]),
+          trackerCatalogEntry("BLU", [["TorrentClient", ""]]),
+        ),
+      GetImageHostPolicyMetadata: async () => ({}),
+    });
+
+    render(createElement(TorrentClientsHarness));
+
+    await waitFor(() => expect(screen.getByText("primary")).toBeInTheDocument());
+    const primaryCard = screen.getByText("primary").closest(".settings-card");
+    expect(primaryCard).toBeTruthy();
+    fireEvent.click(within(primaryCard as HTMLElement).getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => expect(screen.queryByText("primary")).not.toBeInTheDocument());
+    const payload = readPayload<{
+      ClientSetup?: {
+        DefaultClient?: string;
+        InjectClients?: string[];
+        SearchClients?: string[];
+      };
+      Trackers?: { Trackers?: Record<string, { TorrentClient?: string }> };
+      TorrentClients?: Record<string, Record<string, unknown>>;
+    }>();
+    expect(payload.TorrentClients?.primary).toBeUndefined();
+    expect(payload.TorrentClients?.backup).toBeDefined();
+    expect(payload.ClientSetup).toEqual({
+      DefaultClient: "",
+      InjectClients: ["backup"],
+      SearchClients: ["backup"],
+    });
+    expect(payload.Trackers?.Trackers?.AITHER?.TorrentClient).toBe("");
+    expect(payload.Trackers?.Trackers?.BLU?.TorrentClient).toBe("backup");
+  });
 });
 
 describe("ClientSetup client selectors", () => {

--- a/webui/src/hooks/useSettingsState.tsx
+++ b/webui/src/hooks/useSettingsState.tsx
@@ -848,6 +848,60 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
         return prev;
       }
       delete cursor[key];
+
+      if (path.length === 1 && path[0] === "TorrentClients") {
+        const removedName = key.trim().toLowerCase();
+        const remainingNames = Object.keys(cursor);
+        const isRemovedReference = (value: ConfigValue) => {
+          if (typeof value !== "string" || value.trim().toLowerCase() !== removedName) {
+            return false;
+          }
+          const selected = value.trim();
+          const exactMatches = remainingNames.filter((name) => name.trim() === selected).length;
+          if (exactMatches > 0) {
+            return exactMatches !== 1;
+          }
+          return (
+            remainingNames.filter((name) => name.trim().toLowerCase() === selected.toLowerCase())
+              .length !== 1
+          );
+        };
+
+        const clientSetup = clone.ClientSetup;
+        if (clientSetup && typeof clientSetup === "object" && !Array.isArray(clientSetup)) {
+          if (isRemovedReference(clientSetup.DefaultClient)) {
+            clientSetup.DefaultClient = "";
+          }
+          for (const field of ["InjectClients", "SearchClients"]) {
+            const selected = clientSetup[field];
+            if (Array.isArray(selected)) {
+              clientSetup[field] = selected.filter((value) => !isRemovedReference(value));
+            }
+          }
+        }
+
+        const trackers = clone.Trackers;
+        const trackerEntries =
+          trackers && typeof trackers === "object" && !Array.isArray(trackers)
+            ? trackers.Trackers
+            : null;
+        if (
+          trackerEntries &&
+          typeof trackerEntries === "object" &&
+          !Array.isArray(trackerEntries)
+        ) {
+          Object.values(trackerEntries).forEach((tracker) => {
+            if (
+              tracker &&
+              typeof tracker === "object" &&
+              !Array.isArray(tracker) &&
+              isRemovedReference(tracker.TorrentClient)
+            ) {
+              tracker.TorrentClient = "";
+            }
+          });
+        }
+      }
       return clone;
     });
   };


### PR DESCRIPTION
## Summary

- Clear default, injection, search, and per-tracker selectors when their torrent client is removed.
- Preserve unrelated selectors and configured clients.
- Add regression coverage for trimmed and case-insensitive references.

## Root cause

The Torrent Clients remove action deleted only the client map entry, leaving selectors elsewhere in the frontend config state pointing at a missing client. Backend validation then rejected the complete save before persistence.

## Impact

Removing a torrent client now produces one valid config update, allowing the backend to persist the client removal and reference cleanup atomically.

## Validation

- `pnpm --dir webui run lint`
- `pnpm --dir webui run lint:dead`
- `pnpm --dir webui run typecheck`
- `pnpm --dir webui run test:unit` (212 tests)
- `pnpm --dir webui run format:check`
- `git diff --check`

Closes #314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removing a torrent client now also clears related default, injection, search, and tracker settings.
  * References to other valid torrent clients are preserved, including when client names differ only by letter casing.
* **Tests**
  * Added coverage to verify removed clients are deleted while other clients and valid references remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->