### PR TITLE
fix(clientdiscovery): degrade client search failures

### DIFF
--- a/internal/clientdiscovery/discovery.go
+++ b/internal/clientdiscovery/discovery.go
@@ -119,6 +119,7 @@ func (m *Module) Discover(ctx context.Context, input SearchInput) (Evidence, err
 		return Evidence{}, fmt.Errorf("client discovery: search canceled: %w", ctxErr)
 	}
 	if err != nil {
+		m.logger.Debugf("client discovery: decision=degrade reason=search_failed")
 		return Evidence{Disposition: DispositionUnavailable}, nil
 	}
 	evidence := normalizeEvidence(result)

--- a/internal/clientdiscovery/discovery.go
+++ b/internal/clientdiscovery/discovery.go
@@ -115,10 +115,10 @@ func (m *Module) Discover(ctx context.Context, input SearchInput) (Evidence, err
 			ForceRecheck: cloneBool(input.ForceRecheck),
 		},
 	})
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return Evidence{}, fmt.Errorf("client discovery: search canceled: %w", ctxErr)
+	}
 	if err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return Evidence{}, fmt.Errorf("client discovery: search canceled: %w", ctxErr)
-		}
 		return Evidence{Disposition: DispositionUnavailable}, nil
 	}
 	evidence := normalizeEvidence(result)

--- a/internal/clientdiscovery/discovery.go
+++ b/internal/clientdiscovery/discovery.go
@@ -32,7 +32,7 @@ type SearchInput struct {
 }
 
 // Disposition identifies whether a discovery request searched, was explicitly
-// skipped, or could not search because no client adapter exists.
+// skipped, or could not search because no usable client adapter was available.
 type Disposition string
 
 const (
@@ -81,7 +81,8 @@ func New(clients api.ClientService, logger api.Logger) *Module {
 }
 
 // Discover obtains one current client snapshot and always reports why a search
-// did or did not execute.
+// did or did not execute. Client failures produce unavailable evidence, while
+// request validation and cancellation remain fatal.
 func (m *Module) Discover(ctx context.Context, input SearchInput) (Evidence, error) {
 	if m == nil {
 		return Evidence{}, errors.New("client discovery: module is not initialized")
@@ -115,7 +116,10 @@ func (m *Module) Discover(ctx context.Context, input SearchInput) (Evidence, err
 		},
 	})
 	if err != nil {
-		return Evidence{}, fmt.Errorf("client discovery: search pathed torrents: %w", err)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return Evidence{}, fmt.Errorf("client discovery: search canceled: %w", ctxErr)
+		}
+		return Evidence{Disposition: DispositionUnavailable}, nil
 	}
 	evidence := normalizeEvidence(result)
 	evidence.Disposition = DispositionSearched

--- a/internal/clientdiscovery/discovery_test.go
+++ b/internal/clientdiscovery/discovery_test.go
@@ -129,4 +129,11 @@ func TestDiscoverDegradesSearchErrorsAndPreservesCancellation(t *testing.T) {
 	if !errors.Is(err, context.Canceled) || client.calls != 1 {
 		t.Fatalf("successful canceled error=%v calls=%d", err, client.calls)
 	}
+	ctx, cancel = context.WithCancel(context.Background())
+	cancel()
+	client = &recordingClient{}
+	_, err = New(client, api.NopLogger{}).Discover(ctx, SearchInput{SourcePath: "Example.Release.2026.mkv"})
+	if !errors.Is(err, context.Canceled) || client.calls != 0 {
+		t.Fatalf("pre-search canceled error=%v calls=%d", err, client.calls)
+	}
 }

--- a/internal/clientdiscovery/discovery_test.go
+++ b/internal/clientdiscovery/discovery_test.go
@@ -17,6 +17,7 @@ type recordingClient struct {
 	input  api.ClientSubject
 	result api.ClientSearchResult
 	err    error
+	cancel context.CancelFunc
 }
 
 func (*recordingClient) Inject(context.Context, api.ClientSubject, api.TorrentResult) error {
@@ -26,6 +27,9 @@ func (*recordingClient) Inject(context.Context, api.ClientSubject, api.TorrentRe
 func (c *recordingClient) SearchPathedTorrents(_ context.Context, input api.ClientSubject) (api.ClientSearchResult, error) {
 	c.calls++
 	c.input = input
+	if c.cancel != nil {
+		c.cancel()
+	}
 	return c.result, c.err
 }
 
@@ -102,22 +106,21 @@ func TestDiscoverSkipAndUnavailableAreSuccessfulEmptySnapshots(t *testing.T) {
 	}
 }
 
-func TestDiscoverPreservesSearchErrorsAndCancellation(t *testing.T) {
+func TestDiscoverDegradesSearchErrorsAndPreservesCancellation(t *testing.T) {
 	t.Parallel()
 
 	searchErr := errors.New("search failed")
-	_, err := New(&recordingClient{err: searchErr}, api.NopLogger{}).Discover(
+	evidence, err := New(&recordingClient{err: searchErr}, api.NopLogger{}).Discover(
 		context.Background(),
 		SearchInput{SourcePath: "Example.Release.2026.mkv"},
 	)
-	if !errors.Is(err, searchErr) {
-		t.Fatalf("search error = %v", err)
+	if err != nil || evidence.Disposition != DispositionUnavailable {
+		t.Fatalf("search evidence=%#v err=%v", evidence, err)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	client := &recordingClient{}
+	client := &recordingClient{err: searchErr, cancel: cancel}
 	_, err = New(client, api.NopLogger{}).Discover(ctx, SearchInput{SourcePath: "Example.Release.2026.mkv"})
-	if !errors.Is(err, context.Canceled) || client.calls != 0 {
+	if !errors.Is(err, context.Canceled) || client.calls != 1 {
 		t.Fatalf("canceled error=%v calls=%d", err, client.calls)
 	}
 }

--- a/internal/clientdiscovery/discovery_test.go
+++ b/internal/clientdiscovery/discovery_test.go
@@ -123,4 +123,10 @@ func TestDiscoverDegradesSearchErrorsAndPreservesCancellation(t *testing.T) {
 	if !errors.Is(err, context.Canceled) || client.calls != 1 {
 		t.Fatalf("canceled error=%v calls=%d", err, client.calls)
 	}
+	ctx, cancel = context.WithCancel(context.Background())
+	client = &recordingClient{cancel: cancel}
+	_, err = New(client, api.NopLogger{}).Discover(ctx, SearchInput{SourcePath: "Example.Release.2026.mkv"})
+	if !errors.Is(err, context.Canceled) || client.calls != 1 {
+		t.Fatalf("successful canceled error=%v calls=%d", err, client.calls)
+	}
 }


### PR DESCRIPTION
## Summary

- Treat configured torrent-client search failures as unavailable evidence instead of blocking metadata preparation.
- Preserve caller cancellation as a fatal result.
- Add regression coverage for both paths.

## Root cause

`clientdiscovery.Module.Discover` promoted every configured client search error to a fatal metadata-preparation error, even though local client discovery is optional enrichment and already models unavailable clients.

## Impact

Metadata preview and upload preparation now continue when a Qui or qBittorrent search fails. The torrent-client warning remains visible, while explicit cancellation still stops work.

## Validation

- `go test -race -v -timeout 20m ./internal/clientdiscovery`
- `go test -race -v -timeout 20m ./internal/metadata`
- `make gofix-check-changed`
- `make logpolicy`
- `make lint`
- `git diff --check`
- Lefthook pre-commit and pre-push hooks

Closes #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Client discovery now reports unavailable evidence when adapters or searches are unavailable, rather than failing the entire discovery process.
  * Context cancellation and validation failures continue to be returned as fatal errors.
  * Cancellation that occurs during or after a search is preserved correctly.
  * Pre-canceled requests continue to prevent unnecessary search attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->