### PR TITLE
fix(metadata): add AKA prefix to parsed alternate titles

### DIFF
--- a/internal/metadata/naming.go
+++ b/internal/metadata/naming.go
@@ -583,13 +583,13 @@ func namingSourceMatches(scopedPath, currentPath string) bool {
 	return trimmed == "" || strings.EqualFold(trimmed, strings.TrimSpace(currentPath))
 }
 
-// fillProviderAlternateTitle preserves a parsed alternate and otherwise returns
-// one normalized AKA title when the provider candidate differs from the primary.
+// fillProviderAlternateTitle prefers a parsed alternate and otherwise returns
+// one normalized AKA title when the chosen value differs from the primary.
 func fillProviderAlternateTitle(current, primary, candidate string) string {
-	if strings.TrimSpace(current) != "" {
-		return strings.TrimSpace(current)
+	alternate := strings.TrimSpace(current)
+	if alternate == "" {
+		alternate = strings.TrimSpace(candidate)
 	}
-	alternate := strings.TrimSpace(candidate)
 	if len(alternate) > len("AKA ") && strings.EqualFold(alternate[:len("AKA ")], "AKA ") {
 		alternate = strings.TrimSpace(alternate[len("AKA "):])
 	}

--- a/internal/metadata/naming_test.go
+++ b/internal/metadata/naming_test.go
@@ -911,6 +911,12 @@ func TestResolveReleaseNameTitleProviderAlternateRules(t *testing.T) {
 			wantAlt: "AKA Original Title",
 		},
 		{
+			name:       "adds prefix to parsed alternate",
+			releaseAlt: "Parsed Alternate",
+			imdbAKA:    "Original Title",
+			wantAlt:    "AKA Parsed Alternate",
+		},
+		{
 			name:       "preserves parsed alternate",
 			releaseAlt: "AKA Parsed Alternate",
 			imdbAKA:    "Original Title",


### PR DESCRIPTION
## Summary

- normalize parsed alternate titles through the existing AKA formatter
- preserve provider fallback behavior without duplicating an existing `AKA` prefix
- add regression coverage for unprefixed parsed alternates

## Root cause

`fillProviderAlternateTitle` returned parsed alternates before the normalization that adds the `AKA ` prefix.

## Impact

Generated release names now include `AKA` by default when an appropriate parsed alternate exists. Existing CLI and WebUI `NoAKA` controls and tracker-specific naming rules remain authoritative.

## Validation

- `go test -race -v -timeout 20m ./internal/metadata`
- `make gofix-check-changed`
- `make logpolicy`
- `make lint`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alternate-title handling when matching provider metadata.
  - Alternate titles are now normalized consistently, including the `AKA` prefix.
  - Duplicate alternate titles matching the primary title are omitted.
- **Tests**
  - Added coverage for alternate titles provided without an `AKA` prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->