### PR TITLE
fix(dupe): provider-anchored duplicate identity and canonical-name year precedence

### DIFF
--- a/internal/metadata/naming.go
+++ b/internal/metadata/naming.go
@@ -534,14 +534,17 @@ func resolveReleaseNameTitle(category string, meta preparationstate.State) (stri
 		tmdb := meta.ProviderMetadata.TMDB
 		title = strings.TrimSpace(tmdb.Title)
 		altTitle = fillProviderAlternateTitle(altTitle, title, tmdb.OriginalTitle)
-		if year == 0 && tmdb.Year > 0 {
+		// The matched provider owns the canonical year exactly like it owns the
+		// title: a filename-parsed year can lag provider corrections and then
+		// diverge from tracker-canonical names, defeating duplicate matching.
+		if tmdb.Year > 0 {
 			year = tmdb.Year
 		}
 	case matchingIMDBMetadataForNaming(meta):
 		imdb := meta.ProviderMetadata.IMDB
 		title = strings.TrimSpace(imdb.Title)
 		altTitle = fillProviderAlternateTitle(altTitle, title, imdb.AKA)
-		if year == 0 && imdb.Year > 0 {
+		if imdb.Year > 0 {
 			year = imdb.Year
 		}
 	}

--- a/internal/metadata/naming_test.go
+++ b/internal/metadata/naming_test.go
@@ -968,6 +968,63 @@ func TestResolveReleaseNameTitlePrefersTMDBForMovie(t *testing.T) {
 	}
 }
 
+func TestResolveReleaseNameTitleProviderYearOverridesParsedYear(t *testing.T) {
+	// A filename minted under since-corrected provider metadata (for example a
+	// release named 2002 for a movie TMDB now lists as 2003) must not leak the
+	// stale parsed year into the canonical name: the year follows the matched
+	// provider exactly like the title does.
+	meta := preparationstate.State{
+		Identity: api.ExternalIdentity{
+			Category: "MOVIE",
+			TMDBID:   13654,
+		},
+		Release: api.ReleaseInfo{Title: "Parsed Title", Year: 2002},
+		ProviderMetadata: api.SourceScopedMetadata{
+			TMDB: &api.TMDBMetadata{
+				TMDBID: 13654,
+				Title:  "TMDB Title",
+				Year:   2003,
+			},
+		},
+	}
+	_, _, year := resolveReleaseNameTitle("MOVIE", meta)
+	if year != 2003 {
+		t.Fatalf("expected provider year 2003 to override parsed year, got %d", year)
+	}
+
+	meta.ProviderMetadata.TMDB = nil
+	meta.Identity = api.ExternalIdentity{
+		Category: "MOVIE",
+		IMDBID:   324941,
+	}
+	meta.ProviderMetadata.IMDB = &api.IMDBMetadata{
+		IMDBID: 324941,
+		Title:  "IMDb Title",
+		Year:   2003,
+	}
+	_, _, year = resolveReleaseNameTitle("MOVIE", meta)
+	if year != 2003 {
+		t.Fatalf("expected IMDb year 2003 to override parsed year, got %d", year)
+	}
+}
+
+func TestResolveReleaseNameTitleKeepsParsedYearWithoutProviderYear(t *testing.T) {
+	meta := preparationstate.State{
+		Identity: api.ExternalIdentity{
+			Category: "MOVIE",
+			TMDBID:   1,
+		},
+		Release: api.ReleaseInfo{Title: "Parsed Title", Year: 2002},
+		ProviderMetadata: api.SourceScopedMetadata{
+			TMDB: &api.TMDBMetadata{TMDBID: 1, Title: "TMDB Title"},
+		},
+	}
+	_, _, year := resolveReleaseNameTitle("MOVIE", meta)
+	if year != 2002 {
+		t.Fatalf("expected parsed year 2002 to survive missing provider year, got %d", year)
+	}
+}
+
 func TestResolveReleaseNameTitleTVFallsBackFromUnusableTVDBToIMDb(t *testing.T) {
 	meta := preparationstate.State{
 		Identity: api.ExternalIdentity{

--- a/internal/trackers/data/unit3d.go
+++ b/internal/trackers/data/unit3d.go
@@ -567,6 +567,8 @@ func buildUnit3DSearchEntries(items []unit3dSearchItem, isDisc bool) []api.DupeE
 		rawType := strings.TrimSpace(item.Attributes.Type)
 		entry := api.DupeEntry{
 			Name:          strings.TrimSpace(item.Attributes.Name),
+			TMDBID:        item.Attributes.TMDBID,
+			IMDBID:        item.Attributes.IMDBID,
 			Trumpable:     item.Attributes.Trumpable,
 			Link:          strings.TrimSpace(item.Attributes.DetailsLink),
 			Download:      strings.TrimSpace(item.Attributes.DownloadLink),
@@ -1021,6 +1023,8 @@ type unit3dSearchItem struct {
 
 type unit3dSearchAttrs struct {
 	Name         string       `json:"name"`
+	TMDBID       int          `json:"tmdb_id"`
+	IMDBID       int          `json:"imdb_id"`
 	Size         json.Number  `json:"size"`
 	Files        []unit3dFile `json:"files"`
 	Trumpable    bool         `json:"trumpable"`

--- a/internal/trackers/data/unit3d_fixture_test.go
+++ b/internal/trackers/data/unit3d_fixture_test.go
@@ -46,6 +46,28 @@ func TestUnit3DSearchEntriesDeriveHDRFromMediaInfo(t *testing.T) {
 	}
 }
 
+func TestUnit3DSearchEntriesCarryProviderIDs(t *testing.T) {
+	t.Parallel()
+
+	entries := buildUnit3DSearchEntries([]unit3dSearchItem{
+		{Attributes: unit3dSearchAttrs{
+			Name:   "Example.Release.2026.1080p.WEB-DL-GRP",
+			TMDBID: 13654,
+			IMDBID: 324941,
+		}},
+		{Attributes: unit3dSearchAttrs{Name: "No.IDs.Release.2026.1080p.WEB-DL-GRP"}},
+	}, false)
+	if len(entries) != 2 {
+		t.Fatalf("entries = %d", len(entries))
+	}
+	if entries[0].TMDBID != 13654 || entries[0].IMDBID != 324941 {
+		t.Fatalf("provider IDs = %#v", entries[0])
+	}
+	if entries[1].TMDBID != 0 || entries[1].IMDBID != 0 {
+		t.Fatalf("absent provider IDs must stay zero: %#v", entries[1])
+	}
+}
+
 func TestUnit3DSearchEntriesPreserveRawAndCanonicalTypes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/dupe/candidate.go
+++ b/internal/trackers/dupe/candidate.go
@@ -23,6 +23,8 @@ var (
 type TrackerCandidate struct {
 	ID              string
 	Name            string
+	TMDBID          int
+	IMDBID          int
 	Files           []string
 	FileCount       int
 	SizeBytes       int64
@@ -58,6 +60,8 @@ func NormalizeCandidate(entry api.DupeEntry, _ string) TrackerCandidate {
 	candidate := TrackerCandidate{
 		ID:              strings.TrimSpace(entry.ID),
 		Name:            strings.TrimSpace(entry.Name),
+		TMDBID:          entry.TMDBID,
+		IMDBID:          entry.IMDBID,
 		Files:           append([]string(nil), entry.Files...),
 		FileCount:       entry.FileCount,
 		SizeBytes:       entry.SizeBytes,

--- a/internal/trackers/dupe/evaluator.go
+++ b/internal/trackers/dupe/evaluator.go
@@ -98,7 +98,7 @@ func exactCandidate(target api.TrackerDuplicateTarget, candidate TrackerCandidat
 		return !candidate.SizeKnown || target.SizeBytes == 0 || candidate.SizeBytes == target.SizeBytes
 	}
 	if slices.ContainsFunc(target.Names, func(name string) bool {
-		return sameCandidateName(name, candidate.Name)
+		return sameCandidateName(name, candidate.Name) || adjacentYearCandidateName(name, candidate.Name)
 	}) {
 		return true
 	}
@@ -117,6 +117,85 @@ func sameCandidateName(left string, right string) bool {
 	left = strings.ReplaceAll(left, `\`, "/")
 	right = strings.ReplaceAll(right, `\`, "/")
 	return strings.EqualFold(path.Base(left), path.Base(right))
+}
+
+// adjacentYearCandidateName reports whether two release names are identical
+// except for one four-digit year token whose values differ by at most one.
+// Provider year corrections (a movie listed as 2002 and later corrected to
+// 2003) leave otherwise-identical names disagreeing only on that token, which
+// must still count as exact identity. The comparison is deliberately narrow:
+// exactly one contiguous difference, confined to a standalone year-plausible
+// token, with every other byte equal case-insensitively.
+func adjacentYearCandidateName(left string, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return false
+	}
+	if namesDifferOnlyByAdjacentYear(left, right) {
+		return true
+	}
+	left = strings.ReplaceAll(left, `\`, "/")
+	right = strings.ReplaceAll(right, `\`, "/")
+	return namesDifferOnlyByAdjacentYear(path.Base(left), path.Base(right))
+}
+
+func namesDifferOnlyByAdjacentYear(left string, right string) bool {
+	l := strings.ToLower(left)
+	r := strings.ToLower(right)
+	if len(l) != len(r) || l == r {
+		return false
+	}
+	diff := 0
+	for diff < len(l) && l[diff] == r[diff] {
+		diff++
+	}
+	// Widen to the start of the digit run containing the first difference so
+	// the whole year token is compared, not just its differing suffix.
+	start := diff
+	for start > 0 && isASCIIDigit(l[start-1]) {
+		start--
+	}
+	if start+4 > len(l) {
+		return false
+	}
+	leftYear, leftOK := parseYearToken(l, start)
+	rightYear, rightOK := parseYearToken(r, start)
+	if !leftOK || !rightOK {
+		return false
+	}
+	delta := leftYear - rightYear
+	if delta < -1 || delta > 1 {
+		return false
+	}
+	return l[start+4:] == r[start+4:]
+}
+
+// parseYearToken parses a standalone four-digit year at start, requiring
+// non-digit boundaries on both sides and a plausible release-year range.
+func parseYearToken(value string, start int) (int, bool) {
+	if start > 0 && isASCIIDigit(value[start-1]) {
+		return 0, false
+	}
+	end := start + 4
+	if end < len(value) && isASCIIDigit(value[end]) {
+		return 0, false
+	}
+	year := 0
+	for index := start; index < end; index++ {
+		if !isASCIIDigit(value[index]) {
+			return 0, false
+		}
+		year = year*10 + int(value[index]-'0')
+	}
+	if year < 1880 || year > 2100 {
+		return 0, false
+	}
+	return year, true
+}
+
+func isASCIIDigit(value byte) bool {
+	return value >= '0' && value <= '9'
 }
 
 func releaseNameMatchesFile(fileName string, releaseName string) bool {

--- a/internal/trackers/dupe/evaluator.go
+++ b/internal/trackers/dupe/evaluator.go
@@ -81,7 +81,29 @@ func Evaluate(
 	return evaluation
 }
 
+// providerIdentityDiffers reports whether both sides carry the same provider's
+// work ID with different values, which is authoritative evidence the releases
+// belong to different works regardless of name similarity.
+func providerIdentityDiffers(target api.TrackerDuplicateTarget, candidate TrackerCandidate) bool {
+	if target.TMDBID > 0 && candidate.TMDBID > 0 && target.TMDBID != candidate.TMDBID {
+		return true
+	}
+	return target.IMDBID > 0 && candidate.IMDBID > 0 && target.IMDBID != candidate.IMDBID
+}
+
+// providerIdentityMatches reports whether both sides carry an equal non-zero
+// work ID from the same provider.
+func providerIdentityMatches(target api.TrackerDuplicateTarget, candidate TrackerCandidate) bool {
+	if target.TMDBID > 0 && candidate.TMDBID > 0 && target.TMDBID == candidate.TMDBID {
+		return true
+	}
+	return target.IMDBID > 0 && candidate.IMDBID > 0 && target.IMDBID == candidate.IMDBID
+}
+
 func exactCandidate(target api.TrackerDuplicateTarget, candidate TrackerCandidate) bool {
+	if providerIdentityDiffers(target, candidate) {
+		return false
+	}
 	filesComparable := len(target.FileNames) > 0 && len(candidate.Files) > 0
 	if filesComparable {
 		if candidate.FileCount > 0 && candidate.FileCount != len(candidate.Files) {
@@ -97,8 +119,14 @@ func exactCandidate(target api.TrackerDuplicateTarget, candidate TrackerCandidat
 		}
 		return !candidate.SizeKnown || target.SizeBytes == 0 || candidate.SizeBytes == target.SizeBytes
 	}
+	sameWork := providerIdentityMatches(target, candidate)
 	if slices.ContainsFunc(target.Names, func(name string) bool {
-		return sameCandidateName(name, candidate.Name) || adjacentYearCandidateName(name, candidate.Name)
+		if sameCandidateName(name, candidate.Name) || adjacentYearCandidateName(name, candidate.Name) {
+			return true
+		}
+		// When the provider work ID already proves both releases are the same
+		// work, the year token cannot distinguish them: accept any year delta.
+		return sameWork && yearInsensitiveCandidateName(name, candidate.Name)
 	}) {
 		return true
 	}
@@ -138,6 +166,39 @@ func adjacentYearCandidateName(left string, right string) bool {
 	left = strings.ReplaceAll(left, `\`, "/")
 	right = strings.ReplaceAll(right, `\`, "/")
 	return namesDifferOnlyByAdjacentYear(path.Base(left), path.Base(right))
+}
+
+// yearInsensitiveCandidateName reports whether two release names are identical
+// after masking standalone four-digit year tokens. Only meaningful when the
+// caller has already proven both releases are the same work via provider IDs.
+func yearInsensitiveCandidateName(left string, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return false
+	}
+	if maskYearTokens(strings.ToLower(left)) == maskYearTokens(strings.ToLower(right)) {
+		return true
+	}
+	left = strings.ReplaceAll(left, `\`, "/")
+	right = strings.ReplaceAll(right, `\`, "/")
+	return maskYearTokens(strings.ToLower(path.Base(left))) == maskYearTokens(strings.ToLower(path.Base(right)))
+}
+
+// maskYearTokens replaces each standalone year-plausible four-digit token with
+// a fixed placeholder so comparisons ignore the year values.
+func maskYearTokens(value string) string {
+	result := []byte(value)
+	for index := 0; index+4 <= len(result); index++ {
+		if index > 0 && isASCIIDigit(result[index-1]) {
+			continue
+		}
+		if _, ok := parseYearToken(value, index); !ok {
+			continue
+		}
+		copy(result[index:index+4], "0000")
+	}
+	return string(result)
 }
 
 func namesDifferOnlyByAdjacentYear(left string, right string) bool {

--- a/internal/trackers/dupe/evaluator_test.go
+++ b/internal/trackers/dupe/evaluator_test.go
@@ -129,6 +129,73 @@ func TestEvaluateReleaseNameIdentity(t *testing.T) {
 	}
 }
 
+func TestEvaluateProviderIdentity(t *testing.T) {
+	t.Parallel()
+
+	target := api.TrackerDuplicateTarget{
+		Names:  []string{"Example Movie 2003 1080p WEB-DL-GRP"},
+		TMDBID: 13654,
+	}
+
+	sameName := TrackerCandidate{
+		Name:   "Example Movie 2003 1080p WEB-DL-GRP",
+		TMDBID: 99999,
+	}
+	relation := Evaluate(target, []TrackerCandidate{sameName}, trackerspkg.DupePolicy{}, SearchEvidence{Complete: true}).Candidates[0].Relation
+	if relation == api.DupeRelationExactDuplicate {
+		t.Fatalf("conflicting provider IDs must veto exact identity, got %q", relation)
+	}
+
+	distantYear := TrackerCandidate{
+		Name:   "Example Movie 1971 1080p WEB-DL-GRP",
+		TMDBID: 13654,
+	}
+	relation = Evaluate(target, []TrackerCandidate{distantYear}, trackerspkg.DupePolicy{}, SearchEvidence{Complete: true}).Candidates[0].Relation
+	if relation != api.DupeRelationExactDuplicate {
+		t.Fatalf("matching provider IDs must make year tokens irrelevant, got %q", relation)
+	}
+
+	noIDsDistantYear := TrackerCandidate{Name: "Example Movie 1971 1080p WEB-DL-GRP"}
+	relation = Evaluate(target, []TrackerCandidate{noIDsDistantYear}, trackerspkg.DupePolicy{}, SearchEvidence{Complete: true}).Candidates[0].Relation
+	if relation == api.DupeRelationExactDuplicate {
+		t.Fatalf("year-insensitive identity requires provider ID agreement, got %q", relation)
+	}
+}
+
+func TestEvaluateProviderSizeIdentityRequiresReview(t *testing.T) {
+	t.Parallel()
+
+	target := api.TrackerDuplicateTarget{
+		Names:     []string{"Example Movie 2003 1080p WEB-DL-GRP"},
+		TMDBID:    13654,
+		SizeBytes: 4821745127,
+	}
+	renamed := TrackerCandidate{
+		Name:      "Totally Restyled Name 1080p WEB-DL-OTHER",
+		TMDBID:    13654,
+		SizeBytes: 4821745127,
+		SizeKnown: true,
+	}
+	evaluation := Evaluate(target, []TrackerCandidate{renamed}, trackerspkg.DupePolicy{}, SearchEvidence{Complete: true})
+	if relation := evaluation.Candidates[0].Relation; relation != api.DupeRelationManualReview {
+		t.Fatalf("same work with identical size and unmatched name must require review, got %q", relation)
+	}
+	if !evaluation.RequiresAction {
+		t.Fatalf("provider size identity must mark the evaluation actionable")
+	}
+
+	differentSize := TrackerCandidate{
+		Name:      "Totally Restyled Name 1080p WEB-DL-OTHER",
+		TMDBID:    13654,
+		SizeBytes: 123,
+		SizeKnown: true,
+	}
+	evaluation = Evaluate(target, []TrackerCandidate{differentSize}, trackerspkg.DupePolicy{}, SearchEvidence{Complete: true})
+	if relation := evaluation.Candidates[0].Relation; relation == api.DupeRelationManualReview {
+		t.Fatalf("differing sizes must not trigger provider size identity, got %q", relation)
+	}
+}
+
 func TestEvaluateANTGenericHDRIsInsufficientForHDR10Plus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/dupe/evaluator_test.go
+++ b/internal/trackers/dupe/evaluator_test.go
@@ -80,9 +80,9 @@ func TestEvaluateReleaseNameIdentity(t *testing.T) {
 		{
 			name: "adjacent year correction is exact identity",
 			target: api.TrackerDuplicateTarget{
-				Names: []string{"Patch's London Adventure 2002 1080p DSNP WEB-DL DD+ 5.1 H.264-HONE"},
+				Names: []string{"Patch's London Adventure 2002 1080p DSNP WEB-DL DD+ 5.1 H.264-GRP"},
 			},
-			candidate: "Patch's London Adventure 2003 1080p DSNP WEB-DL DD+ 5.1 H.264-HONE",
+			candidate: "Patch's London Adventure 2003 1080p DSNP WEB-DL DD+ 5.1 H.264-GRP",
 			wantExact: true,
 		},
 		{

--- a/internal/trackers/dupe/evaluator_test.go
+++ b/internal/trackers/dupe/evaluator_test.go
@@ -77,6 +77,43 @@ func TestEvaluateReleaseNameIdentity(t *testing.T) {
 			target:    api.TrackerDuplicateTarget{Names: []string{"Example.Release.2026.Generated-GRP"}},
 			candidate: "Example.Release.2026.Original-GRP",
 		},
+		{
+			name: "adjacent year correction is exact identity",
+			target: api.TrackerDuplicateTarget{
+				Names: []string{"Patch's London Adventure 2002 1080p DSNP WEB-DL DD+ 5.1 H.264-HONE"},
+			},
+			candidate: "Patch's London Adventure 2003 1080p DSNP WEB-DL DD+ 5.1 H.264-HONE",
+			wantExact: true,
+		},
+		{
+			name: "adjacent title-embedded year with matching release year",
+			target: api.TrackerDuplicateTarget{
+				Names: []string{"2001 A Space Odyssey 1968 2160p MA WEB-DL H.265-GRP"},
+			},
+			candidate: "2001 A Space Odyssey 1969 2160p MA WEB-DL H.265-GRP",
+			wantExact: true,
+		},
+		{
+			name: "year gap beyond one is not identity",
+			target: api.TrackerDuplicateTarget{
+				Names: []string{"Example Movie 2002 1080p WEB-DL-GRP"},
+			},
+			candidate: "Example Movie 2004 1080p WEB-DL-GRP",
+		},
+		{
+			name: "adjacent year with other differences is not identity",
+			target: api.TrackerDuplicateTarget{
+				Names: []string{"Example Movie 2002 1080p WEB-DL-GRP"},
+			},
+			candidate: "Example Movie 2003 1080p WEB-DL-OTHER",
+		},
+		{
+			name: "adjacent non-year number is not identity",
+			target: api.TrackerDuplicateTarget{
+				Names: []string{"Movie Part 101 2020 1080p WEB-DL-GRP"},
+			},
+			candidate: "Movie Part 102 2020 1080p WEB-DL-GRP",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			got := Evaluate(

--- a/internal/trackers/dupe/findings.go
+++ b/internal/trackers/dupe/findings.go
@@ -57,6 +57,7 @@ type factComparison struct {
 const (
 	findingPriorityExact           = 1000
 	findingPriorityDisjointContent = 900
+	findingPriorityProviderSize    = 850
 	findingPriorityTrackerMatched  = 800
 	findingPriorityTrackerMissing  = 700
 	findingPriorityGeneral         = 600
@@ -76,6 +77,9 @@ func collectCandidateFindings(
 ) []RuleFinding {
 	findings := make([]RuleFinding, 0, 12)
 	findings = append(findings, collectExactFindings(target, candidate)...)
+	if finding, ok := collectProviderSizeFinding(target, candidate); ok {
+		findings = append(findings, finding)
+	}
 	findings = append(findings, collectGeneralFindings(targetFacts, candidateFacts, policy)...)
 	findings = append(findings, collectTrackerRules(target, targetFacts, candidate, candidateFacts, policy)...)
 	if finding, ok := collectTrackerSlotFinding(target, targetFacts, candidate, candidateFacts, policy); ok {
@@ -115,6 +119,30 @@ func collectExactFindings(target api.TrackerDuplicateTarget, candidate TrackerCa
 		ReasonCode: "exact_identity",
 		Priority:   findingPriorityExact,
 	}}
+}
+
+// collectProviderSizeFinding surfaces a reviewable duplicate when provider
+// work IDs prove both releases are the same work and the byte sizes are
+// identical, but name identity still failed (for example a renamed or
+// re-styled duplicate). Exact-identity findings outrank it when both fire.
+func collectProviderSizeFinding(target api.TrackerDuplicateTarget, candidate TrackerCandidate) (RuleFinding, bool) {
+	if !providerIdentityMatches(target, candidate) {
+		return RuleFinding{}, false
+	}
+	if !candidate.SizeKnown || target.SizeBytes <= 0 || candidate.SizeBytes != target.SizeBytes {
+		return RuleFinding{}, false
+	}
+	if exactCandidate(target, candidate) {
+		return RuleFinding{}, false
+	}
+	return RuleFinding{
+		RuleID:     GeneralPolicyID + "/provider_size_identity",
+		Source:     "general",
+		Status:     RuleFindingMatched,
+		Relation:   api.DupeRelationManualReview,
+		ReasonCode: "provider_size_identity",
+		Priority:   findingPriorityProviderSize,
+	}, true
 }
 
 func collectGeneralFindings(target normalizedFacts, candidate normalizedFacts, policy trackerspkg.DupePolicy) []RuleFinding {

--- a/internal/trackers/projection.go
+++ b/internal/trackers/projection.go
@@ -535,6 +535,8 @@ func projectionDuplicateNames(projection api.TrackerReleaseProjection) []string 
 func duplicateTarget(subject api.UploadSubject) api.TrackerDuplicateTarget {
 	return api.TrackerDuplicateTarget{
 		Names:       []string{SourceReleaseName(subject)},
+		TMDBID:      subject.Identity.TMDBID,
+		IMDBID:      subject.Identity.IMDBID,
 		Category:    string(subject.Identity.Category),
 		Type:        strings.TrimSpace(subject.Type),
 		Source:      strings.TrimSpace(subject.Source),

--- a/internal/webserver/openapi/release-workflow-v1.json
+++ b/internal/webserver/openapi/release-workflow-v1.json
@@ -8030,6 +8030,9 @@
           "hdr": {
             "$ref": "#/components/schemas/HDRFacts"
           },
+          "imdbId": {
+            "type": "integer"
+          },
           "names": {
             "type": "array",
             "items": {
@@ -8062,6 +8065,9 @@
           },
           "threeD": {
             "type": "string"
+          },
+          "tmdbId": {
+            "type": "integer"
           },
           "type": {
             "type": "string"

--- a/pkg/api/dupes.go
+++ b/pkg/api/dupes.go
@@ -10,6 +10,8 @@ import (
 // DupeEntry is one backend adapter's private duplicate-search hit.
 type DupeEntry struct {
 	Name          string
+	TMDBID        int
+	IMDBID        int
 	SizeBytes     int64
 	SizeKnown     bool
 	SizeText      string

--- a/pkg/api/workflow_contracts.go
+++ b/pkg/api/workflow_contracts.go
@@ -185,6 +185,8 @@ type TrackerDuplicateCriteria struct {
 // for local duplicate policy evaluation.
 type TrackerDuplicateTarget struct {
 	Names       []string `json:"names,omitempty"`
+	TMDBID      int      `json:"tmdbId,omitempty"`
+	IMDBID      int      `json:"imdbId,omitempty"`
 	Category    string   `json:"category,omitempty"`
 	Type        string   `json:"type,omitempty"`
 	Source      string   `json:"source,omitempty"`

--- a/webui/src/api/generated/release-workflow.ts
+++ b/webui/src/api/generated/release-workflow.ts
@@ -1908,6 +1908,7 @@ export type TrackerDuplicateTarget = Readonly<{
   fileNames?: readonly string[];
   group?: string;
   hdr: HDRFacts;
+  imdbId?: number;
   names?: readonly string[];
   pack: boolean;
   provider?: string;
@@ -1918,6 +1919,7 @@ export type TrackerDuplicateTarget = Readonly<{
   sizeBytes?: number;
   source?: string;
   threeD?: string;
+  tmdbId?: number;
   type?: string;
   videoCodec?: string;
   videoEncode?: string;


### PR DESCRIPTION
Closes #325.

A byte-identical duplicate reached RF because the upload's canonical name resolved with year 2002 while the tracker's existing entry was titled 2003 (a TMDB year correction split the world into 2002-named and 2003-named copies), and name-identity matching treated the year as part of release identity. Three commits, deliberately separable so any layer can be backed out independently:

## 1. `fix(metadata): let matched provider year own the canonical release name`

`resolveReleaseNameTitle` canonicalized the **title** from matched TMDB/IMDB metadata unconditionally but only used the provider **year** when the filename parse produced none. The matched provider's year now takes precedence exactly like its title; the filename-parsed year remains the fallback when the provider has no year. `ManualYear`/`NoYear` overrides and the TV alias-year branch are unaffected. Regression tests model the exact incident (2002-named file, 2003 provider year) for both TMDB and IMDB, plus fallback preservation.

## 2. `fix(dupe): treat adjacent-year name variants as exact identity`

Defense-in-depth in the matcher, no plumbing required: exact-candidate matching also accepts names identical except for one standalone four-digit year token (1880–2100, non-digit boundaries) whose values differ by at most one. Deliberately narrow — a single contiguous difference confined to the year token; negative tests cover multi-year-token names (`2001.A.Space.Odyssey.1968…`), non-year numeric tokens, gaps > 1, and additional differences.

## 3. `feat(dupe): anchor duplicate identity on provider work IDs`

UNIT3D duplicate searches are already keyed by `tmdbId`, but the response's `tmdb_id`/`imdb_id` attributes were never decoded and neither candidates nor the duplicate target carried provider identity. This plumbs work IDs end-to-end (UNIT3D response → `api.DupeEntry` → `dupe.TrackerCandidate`; release identity → `api.TrackerDuplicateTarget`; workflow contracts regenerated) and uses them three ways:

- **Conflicting** non-zero work IDs veto exact identity (protects against coincidental name matches across works).
- **Matching** work IDs make year tokens irrelevant to name identity (any delta — the provider already proved same-work).
- Matching work IDs + byte-identical size + unmatched name → a reviewable `provider_size_identity` finding (`manual_review`, priority 850 between disjoint-content and tracker-matched) instead of a silent `coexists` — this alone would have caught the original incident as a renamed duplicate.

Candidates without IDs and non-UNIT3D trackers see zero behavior change: every new comparison requires non-zero IDs on both sides.

## Open decision

Commits 2–3 change `general/duplicate/v2` matching behavior without bumping the policy ID. There's no repo convention enforcing a bump (v1→v2 was a wholesale refactor and nothing asserts dupe-policy versions the way `validationPolicyIDIsVersioned` does for validation policies), and `DuplicatePolicyFingerprint` only hashes `{ID, policy struct}` — but if you'd prefer a `v3` bump for cache/fingerprint hygiene, it's a small follow-up; flagging rather than presuming.

## Validation

- `make test-go` (full race suite) green
- `make lint` (architecture/path/literal policies + golangci-lint) 0 issues
- `make logpolicy`, `make pathpolicy`, `make gofix-check-changed`, `git diff --check` clean
- `make workflow-contracts` regenerated (OpenAPI + webui TS); `pnpm --dir webui run typecheck` clean
- Real-world validation of the failure mode: the incident release re-checked against RF now reports both existing entries as `exact_duplicate`/`exact_identity` (see #325 evidence)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected release years using available TMDB or IMDb metadata.
  - Improved duplicate detection for adjacent year differences and matching provider identifiers.
  - Prevented duplicate matches when TMDB or IMDb identifiers conflict.

- **Enhancements**
  - Duplicate-search data now includes TMDB and IMDb identifiers.
  - Releases with matching provider IDs and sizes but uncertain names are flagged for manual review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->