### PR TITLE
fix(screenshots): retry timestamp offsets on FFmpeg black frame detection with corrupt frame detection

### DIFF
--- a/internal/core/workflow_media.go
+++ b/internal/core/workflow_media.go
@@ -413,6 +413,7 @@ func (b workflowMediaBuilder) Build(
 	snapshot := api.MediaArtifactSet{
 		CaptureFingerprint:      captureFingerprint,
 		RequirementsFingerprint: requirementsFingerprint,
+		Artifacts:               []api.MediaArtifact{},
 		Status:                  api.StageStatusCompleted,
 	}
 	projectedScreenshots, projectedDVDMenus := projectedMediaRequirements(projections.Projections)
@@ -1265,6 +1266,7 @@ func (b workflowMediaBuilder) mediaMutationBase(
 	return api.MediaArtifactSet{
 			CaptureFingerprint:      fingerprint,
 			RequirementsFingerprint: requirements,
+			Artifacts:               []api.MediaArtifact{},
 			Status:                  api.StageStatusCompleted,
 		}, workflowMediaPrivateArtifacts{
 			ArtifactImages:    make(map[api.PublicResourceID]api.ScreenshotImage),

--- a/internal/core/workflow_media.go
+++ b/internal/core/workflow_media.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/releaseworkflow"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -520,6 +521,9 @@ func (b workflowMediaBuilder) Build(
 			if err != nil {
 				if ctx.Err() != nil {
 					return api.MediaArtifactSet{}, nil, fmt.Errorf("workflow media screenshot capture: %w", ctx.Err())
+				}
+				if errors.Is(err, internalerrors.ErrFrameCorruption) {
+					return failedMediaSnapshot(snapshot, "Screenshot frame corruption detected. Repair source media before retrying."), privateArtifacts, nil
 				}
 				return failedMediaSnapshot(snapshot, "Screenshot capture failed. Retry media capture."), privateArtifacts, nil
 			}

--- a/internal/core/workflow_media.go
+++ b/internal/core/workflow_media.go
@@ -523,6 +523,15 @@ func (b workflowMediaBuilder) Build(
 					return api.MediaArtifactSet{}, nil, fmt.Errorf("workflow media screenshot capture: %w", ctx.Err())
 				}
 				if errors.Is(err, internalerrors.ErrFrameCorruption) {
+					api.EmitWorkflowProgress(ctx, api.WorkflowProgressUpdate{
+						Phase:   "screenshots",
+						ItemID:  "screenshots",
+						Kind:    "media",
+						Label:   "Screenshots",
+						Status:  api.StageStatusFailed,
+						Total:   screenshotCount,
+						Message: "Screenshot frame corruption detected. Repair source media before retrying.",
+					})
 					return failedMediaSnapshot(snapshot, "Screenshot frame corruption detected. Repair source media before retrying."), privateArtifacts, nil
 				}
 				return failedMediaSnapshot(snapshot, "Screenshot capture failed. Retry media capture."), privateArtifacts, nil

--- a/internal/core/workflow_media_test.go
+++ b/internal/core/workflow_media_test.go
@@ -43,6 +43,7 @@ type workflowScreenshotFake struct {
 	plans    int
 	captures int
 	deleted  []string
+	err      error
 }
 
 func (f *workflowScreenshotFake) Plan(
@@ -64,6 +65,9 @@ func (f *workflowScreenshotFake) Capture(
 	purpose api.ScreenshotPurpose,
 ) (api.ScreenshotResult, error) {
 	f.captures++
+	if f.err != nil {
+		return api.ScreenshotResult{}, f.err
+	}
 	images := make([]api.ScreenshotImage, len(selections))
 	for index, selection := range selections {
 		images[index] = api.ScreenshotImage{
@@ -201,6 +205,36 @@ func TestWorkflowMediaBuilderCapturesOnlyProjectedNormalScreenshots(t *testing.T
 	}
 	if changed.CaptureFingerprint == snapshot.CaptureFingerprint {
 		t.Fatal("media capture fingerprint ignored release generation")
+	}
+}
+
+func TestWorkflowMediaBuilderReportsFrameCorruption(t *testing.T) {
+	t.Parallel()
+
+	screenshots := &workflowScreenshotFake{root: t.TempDir(), err: fmt.Errorf("synthetic: %w", internalerrors.ErrFrameCorruption)}
+	builder := workflowMediaBuilder{resolver: workflowMediaResolverFake{}, screenshots: screenshots}
+	snapshot, _, err := builder.Build(
+		context.Background(),
+		api.ReleaseRef{SourcePath: "C:\\releases\\Example.Release.2026", Generation: 1},
+		api.TrackerReleaseProjectionSet{
+			ID:       "projections-corruption",
+			Revision: 1,
+			Projections: []api.TrackerReleaseProjection{{
+				TrackerID: "SYNTHETIC",
+				Artifacts: api.TrackerArtifactRequirements{ScreenshotCount: 1},
+			}},
+		},
+		api.MediaCaptureInstructions{},
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("build workflow media: %v", err)
+	}
+	if snapshot.Status != api.StageStatusFailed || len(snapshot.Failures) != 1 {
+		t.Fatalf("frame corruption snapshot = %#v", snapshot)
+	}
+	if got := snapshot.Failures[0].Failure.Message; got != "Screenshot frame corruption detected. Repair source media before retrying." {
+		t.Fatalf("frame corruption failure = %q", got)
 	}
 }
 

--- a/internal/core/workflow_media_test.go
+++ b/internal/core/workflow_media_test.go
@@ -237,6 +237,9 @@ func TestWorkflowMediaBuilderReportsFrameCorruption(t *testing.T) {
 	if snapshot.Status != api.StageStatusFailed || len(snapshot.Failures) != 1 {
 		t.Fatalf("frame corruption snapshot = %#v", snapshot)
 	}
+	if snapshot.Artifacts == nil {
+		t.Fatal("frame corruption artifacts = nil, want empty array")
+	}
 	if got := snapshot.Failures[0].Failure.Message; got != "Screenshot frame corruption detected. Repair source media before retrying." {
 		t.Fatalf("frame corruption failure = %q", got)
 	}

--- a/internal/core/workflow_media_test.go
+++ b/internal/core/workflow_media_test.go
@@ -213,9 +213,13 @@ func TestWorkflowMediaBuilderReportsFrameCorruption(t *testing.T) {
 
 	screenshots := &workflowScreenshotFake{root: t.TempDir(), err: fmt.Errorf("synthetic: %w", internalerrors.ErrFrameCorruption)}
 	builder := workflowMediaBuilder{resolver: workflowMediaResolverFake{}, screenshots: screenshots}
+	var progress []api.WorkflowProgressUpdate
+	ctx := api.WithWorkflowProgressReporter(context.Background(), func(update api.WorkflowProgressUpdate) {
+		progress = append(progress, update)
+	})
 	snapshot, _, err := builder.Build(
-		context.Background(),
-		api.ReleaseRef{SourcePath: "C:\\releases\\Example.Release.2026", Generation: 1},
+		ctx,
+		api.ReleaseRef{SourcePath: filepath.Join(t.TempDir(), "Example.Release.2026"), Generation: 1},
 		api.TrackerReleaseProjectionSet{
 			ID:       "projections-corruption",
 			Revision: 1,
@@ -235,6 +239,11 @@ func TestWorkflowMediaBuilderReportsFrameCorruption(t *testing.T) {
 	}
 	if got := snapshot.Failures[0].Failure.Message; got != "Screenshot frame corruption detected. Repair source media before retrying." {
 		t.Fatalf("frame corruption failure = %q", got)
+	}
+	if !slices.ContainsFunc(progress, func(update api.WorkflowProgressUpdate) bool {
+		return update.ItemID == "screenshots" && update.Status == api.StageStatusFailed
+	}) {
+		t.Fatalf("frame corruption progress was not emitted: %#v", progress)
 	}
 }
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -8,8 +8,9 @@ import "errors"
 
 // These sentinels may be wrapped; callers should classify them with [errors.Is].
 var (
-	ErrNotImplemented = errors.New("not implemented")
-	ErrInvalidInput   = errors.New("invalid input")
-	ErrNotFound       = errors.New("not found")
-	ErrBannedGroup    = errors.New("banned group")
+	ErrNotImplemented  = errors.New("not implemented")
+	ErrInvalidInput    = errors.New("invalid input")
+	ErrNotFound        = errors.New("not found")
+	ErrBannedGroup     = errors.New("banned group")
+	ErrFrameCorruption = errors.New("frame corruption detected")
 )

--- a/internal/services/screenshots/ffmpeg.go
+++ b/internal/services/screenshots/ffmpeg.go
@@ -172,10 +172,58 @@ var (
 	errFFmpegBlackImage = errors.New("ffmpeg produced black image")
 )
 
+// blackFrameTimestampOffsets lists relative timestamp adjustments (in seconds)
+// tried when FFmpeg produces a black image at the initial frame timestamp.
+var blackFrameTimestampOffsets = []float64{0, 1.0, 2.0, 3.0, 5.0, -1.0, -2.0}
+
 // captureFrame writes one PNG frame and returns whether the successful attempt
 // used libplacebo. Libplacebo captures retry once before falling back to the
 // software filter chain so transient Vulkan setup failures remain recoverable.
+// Black output images automatically retry near the requested timestamp using
+// relative offsets before failing.
 func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captureRequest, logger api.Logger) (bool, error) {
+	var lastErr error
+	var lastUsedLib bool
+
+	for _, offset := range blackFrameTimestampOffsets {
+		candidateTS := req.Timestamp + offset
+		if candidateTS < 0 {
+			continue
+		}
+		attemptReq := req
+		attemptReq.Timestamp = candidateTS
+
+		usedLib, err := captureFrameSingle(ctx, runner, cmdPath, attemptReq, logger)
+		if err == nil {
+			if offset != 0 {
+				l := screenshotLogger(logger)
+				l.Debugf(
+					"screenshots: black image recovered with timestamp offset original=%.3f offset=%.3f new=%.3f",
+					req.Timestamp,
+					offset,
+					candidateTS,
+				)
+			}
+			return usedLib, nil
+		}
+
+		lastErr = err
+		lastUsedLib = usedLib
+
+		if !errors.Is(err, errFFmpegBlackImage) {
+			break
+		}
+		l := screenshotLogger(logger)
+		l.Debugf(
+			"screenshots: ffmpeg capture produced black image at timestamp=%.3f, retrying timestamp offset",
+			candidateTS,
+		)
+	}
+
+	return lastUsedLib, lastErr
+}
+
+func captureFrameSingle(ctx context.Context, runner Runner, cmdPath string, req captureRequest, logger api.Logger) (bool, error) {
 	logger = screenshotLogger(logger)
 	if strings.TrimSpace(req.InputPath) == "" {
 		return false, errors.New("screenshots: input path required")
@@ -251,6 +299,9 @@ func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captur
 		stderr = err.Error()
 	}
 	logger.Debugf("screenshots: ffmpeg capture exhausted mode=%s reason=%s", ffmpegModeLabel(useLibplacebo), ffmpegResultPreview(result, err))
+	if err != nil {
+		return useLibplacebo, fmt.Errorf("screenshots: ffmpeg capture failed: %w", err)
+	}
 	return useLibplacebo, fmt.Errorf("screenshots: ffmpeg capture failed: %s", stderr)
 }
 

--- a/internal/services/screenshots/ffmpeg.go
+++ b/internal/services/screenshots/ffmpeg.go
@@ -184,6 +184,7 @@ var blackFrameTimestampOffsets = []float64{0, 1.0, 2.0, 3.0, 5.0, -1.0, -2.0}
 func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captureRequest, logger api.Logger) (bool, error) {
 	var lastErr error
 	var lastUsedLib bool
+	retryingBlackFrame := false
 
 	for _, offset := range blackFrameTimestampOffsets {
 		candidateTS := req.Timestamp + offset
@@ -210,12 +211,14 @@ func captureFrame(ctx context.Context, runner Runner, cmdPath string, req captur
 		lastErr = err
 		lastUsedLib = usedLib
 
-		if !errors.Is(err, errFFmpegBlackImage) {
+		if errors.Is(err, errFFmpegBlackImage) {
+			retryingBlackFrame = true
+		} else if !retryingBlackFrame || !errors.Is(err, errFFmpegNoImage) {
 			break
 		}
 		l := screenshotLogger(logger)
 		l.Debugf(
-			"screenshots: ffmpeg capture produced black image at timestamp=%.3f, retrying timestamp offset",
+			"screenshots: ffmpeg capture produced unusable image at timestamp=%.3f, retrying timestamp offset",
 			candidateTS,
 		)
 	}
@@ -230,6 +233,27 @@ func captureFrameSingle(ctx context.Context, runner Runner, cmdPath string, req 
 	}
 	if strings.TrimSpace(req.OutputPath) == "" {
 		return false, errors.New("screenshots: output path required")
+	}
+	if req.FrameOverlay {
+		// Validate before drawtext can make a black source frame appear usable.
+		validationFile, err := os.CreateTemp(filepath.Dir(req.OutputPath), ".upbrr-overlay-check-*.png")
+		if err != nil {
+			return false, fmt.Errorf("screenshots: create overlay validation output: %w", err)
+		}
+		validationPath := validationFile.Name()
+		if err := validationFile.Close(); err != nil {
+			_ = os.Remove(validationPath)
+			return false, fmt.Errorf("screenshots: close overlay validation output: %w", err)
+		}
+		defer func() { _ = os.Remove(validationPath) }()
+
+		validationReq := req
+		validationReq.OutputPath = validationPath
+		validationReq.FrameOverlay = false
+		validationReq.UseLibplacebo = false
+		if _, err := captureFrameSingle(ctx, runner, cmdPath, validationReq, logger); err != nil {
+			return false, err
+		}
 	}
 
 	useLibplacebo := req.UseLibplacebo && req.ToneMap && !req.FrameOverlay

--- a/internal/services/screenshots/ffmpeg.go
+++ b/internal/services/screenshots/ffmpeg.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -172,6 +173,15 @@ var (
 	errFFmpegBlackImage = errors.New("ffmpeg produced black image")
 )
 
+var ffmpegFrameCorruptionIndicators = []string{
+	"error while decoding",
+	"invalid data found when processing input",
+	"non-existing pps",
+	"incomplete frame",
+	"corrupt decoded frame",
+	"corrupt input packet",
+}
+
 // blackFrameTimestampOffsets lists relative timestamp adjustments (in seconds)
 // tried when FFmpeg produces a black image at the initial frame timestamp.
 var blackFrameTimestampOffsets = []float64{0, 1.0, 2.0, 3.0, 5.0, -1.0, -2.0}
@@ -267,6 +277,9 @@ func captureFrameSingle(ctx context.Context, runner Runner, cmdPath string, req 
 		ffmpegFilterFromArgs(args),
 	)
 	result, err := runner.Run(ctx, cmdPath, args, "")
+	if corruptionErr := rejectCorruptCaptureOutput(req.OutputPath, result); corruptionErr != nil {
+		return useLibplacebo, corruptionErr
+	}
 	if err == nil && result.ExitCode == 0 {
 		if err = validateCaptureOutput(req.OutputPath); err == nil {
 			logger.Tracef("screenshots: ffmpeg capture ok mode=%s exit_code=%d", ffmpegModeLabel(useLibplacebo), result.ExitCode)
@@ -287,6 +300,9 @@ func captureFrameSingle(ctx context.Context, runner Runner, cmdPath string, req 
 			ffmpegFilterFromArgs(args),
 		)
 		result, err = runner.Run(ctx, cmdPath, args, "")
+		if corruptionErr := rejectCorruptCaptureOutput(req.OutputPath, result); corruptionErr != nil {
+			return true, corruptionErr
+		}
 		if err == nil && result.ExitCode == 0 {
 			if err = validateCaptureOutput(req.OutputPath); err == nil {
 				logger.Tracef("screenshots: ffmpeg capture ok mode=%s retry=%t exit_code=%d", ffmpegModeLabel(true), true, result.ExitCode)
@@ -310,6 +326,9 @@ func captureFrameSingle(ctx context.Context, runner Runner, cmdPath string, req 
 			ffmpegFilterFromArgs(args),
 		)
 		result, err = runner.Run(ctx, cmdPath, args, "")
+		if corruptionErr := rejectCorruptCaptureOutput(req.OutputPath, result); corruptionErr != nil {
+			return false, corruptionErr
+		}
 		if err == nil && result.ExitCode == 0 {
 			if err = validateCaptureOutput(req.OutputPath); err == nil {
 				logger.Tracef("screenshots: ffmpeg capture ok mode=%s exit_code=%d", ffmpegModeLabel(false), result.ExitCode)
@@ -363,6 +382,9 @@ func captureFrameBytes(ctx context.Context, runner Runner, cmdPath string, req p
 	args := buildFFmpegPreviewArgs(req)
 	logger.Tracef("screenshots: ffmpeg preview attempt timestamp_seconds=%.3f input=%s", req.Timestamp, req.InputPath)
 	result, err := runner.Run(ctx, cmdPath, args, "")
+	if corruptionErr := ffmpegFrameCorruptionError(result.Stderr); corruptionErr != nil {
+		return nil, corruptionErr
+	}
 	if err == nil && result.ExitCode == 0 && len(result.Stdout) > 0 {
 		if err := validateImagePayload(result.Stdout); err != nil {
 			logger.Debugf("screenshots: ffmpeg preview rejected reason=%s", redaction.RedactValue(err.Error(), nil))
@@ -487,6 +509,26 @@ func ffmpegResultPreview(result CommandResult, err error) string {
 		message = message[:ffmpegLogPreviewLimit] + "...[truncated]"
 	}
 	return redaction.RedactValue(message, nil)
+}
+
+// ffmpegFrameCorruptionError maps allow-listed decoder diagnostics to a stable
+// hard failure without exposing FFmpeg's raw stderr.
+func ffmpegFrameCorruptionError(stderr []byte) error {
+	diagnostics := strings.ToLower(string(stderr))
+	for _, indicator := range ffmpegFrameCorruptionIndicators {
+		if strings.Contains(diagnostics, indicator) {
+			return fmt.Errorf("screenshots: %w: ffmpeg reported %q", internalerrors.ErrFrameCorruption, indicator)
+		}
+	}
+	return nil
+}
+
+func rejectCorruptCaptureOutput(outputPath string, result CommandResult) error {
+	err := ffmpegFrameCorruptionError(result.Stderr)
+	if err != nil {
+		_ = os.Remove(outputPath)
+	}
+	return err
 }
 
 func buildFFmpegPreviewArgs(req previewRequest) []string {

--- a/internal/services/screenshots/ffmpeg_test.go
+++ b/internal/services/screenshots/ffmpeg_test.go
@@ -187,26 +187,96 @@ func TestCaptureFrameRecoversFromBlackFrameWithTimestampOffset(t *testing.T) {
 	}
 }
 
+func TestCaptureFrameContinuesOffsetsAfterNoImage(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "screen.png")
+	runner := &timestampSensitiveRunner{
+		blackTimestamps: map[string]struct{}{"1.000": {}},
+		noImageTimestamps: map[string]struct{}{
+			"2.000": {},
+			"3.000": {},
+			"4.000": {},
+			"6.000": {},
+		},
+		blackPayload: testPNGBytes(t, color.RGBA{A: 255}),
+		validPayload: testPNGBytes(t, color.RGBA{R: 200, A: 255}),
+	}
+
+	_, err := captureFrame(context.Background(), runner, "ffmpeg", captureRequest{
+		InputPath:  "example.mkv",
+		OutputPath: output,
+		Timestamp:  1,
+	}, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("expected negative timestamp offset to recover after empty positive offsets, got error: %v", err)
+	}
+
+	wantTimestamps := []string{"1.000", "2.000", "3.000", "4.000", "6.000", "0.000"}
+	if !slices.Equal(runner.timestamps, wantTimestamps) {
+		t.Fatalf("attempted timestamps = %v, want %v", runner.timestamps, wantTimestamps)
+	}
+}
+
+func TestCaptureFrameValidatesBlackSourceBeforeOverlay(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "screen.png")
+	runner := &timestampSensitiveRunner{
+		sourceBlackTimestamps: map[string]struct{}{"1.000": {}},
+		blackPayload:          testPNGBytes(t, color.RGBA{A: 255}),
+		validPayload:          testPNGBytes(t, color.RGBA{G: 200, A: 255}),
+	}
+
+	_, err := captureFrame(context.Background(), runner, "ffmpeg", captureRequest{
+		InputPath:   "example.mkv",
+		OutputPath:  output,
+		Timestamp:   1,
+		FrameOverlay: true,
+	}, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("expected black source frame to recover before overlay, got error: %v", err)
+	}
+
+	wantTimestamps := []string{"1.000", "2.000", "2.000"}
+	if !slices.Equal(runner.timestamps, wantTimestamps) {
+		t.Fatalf("attempted timestamps = %v, want %v", runner.timestamps, wantTimestamps)
+	}
+	wantOverlays := []bool{false, false, true}
+	if !slices.Equal(runner.overlays, wantOverlays) {
+		t.Fatalf("overlay attempts = %v, want %v", runner.overlays, wantOverlays)
+	}
+}
+
 type timestampSensitiveRunner struct {
-	blackTimestamps map[string]struct{}
-	blackPayload    []byte
-	validPayload    []byte
-	timestamps      []string
+	blackTimestamps       map[string]struct{}
+	noImageTimestamps     map[string]struct{}
+	sourceBlackTimestamps map[string]struct{}
+	blackPayload          []byte
+	validPayload          []byte
+	timestamps            []string
+	overlays              []bool
 }
 
 func (r *timestampSensitiveRunner) Run(_ context.Context, _ string, args []string, _ string) (CommandResult, error) {
 	var ts string
+	hasOverlay := false
 	for i := 0; i+1 < len(args); i++ {
-		if args[i] == "-ss" {
+		switch args[i] {
+		case "-ss":
 			ts = args[i+1]
-			break
+		case "-vf":
+			hasOverlay = strings.Contains(args[i+1], "drawtext=")
 		}
 	}
 	if ts != "" {
 		r.timestamps = append(r.timestamps, ts)
+		r.overlays = append(r.overlays, hasOverlay)
+	}
+	if _, noImage := r.noImageTimestamps[ts]; noImage {
+		return CommandResult{ExitCode: 0}, nil
 	}
 	payload := r.validPayload
 	if _, isBlack := r.blackTimestamps[ts]; isBlack {
+		payload = r.blackPayload
+	}
+	if _, sourceIsBlack := r.sourceBlackTimestamps[ts]; sourceIsBlack && !hasOverlay {
 		payload = r.blackPayload
 	}
 	if len(args) > 0 {

--- a/internal/services/screenshots/ffmpeg_test.go
+++ b/internal/services/screenshots/ffmpeg_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -152,11 +153,11 @@ func TestCaptureFrameRecoversFromBlackFrameWithTimestampOffset(t *testing.T) {
 	output := filepath.Join(t.TempDir(), "screen.png")
 	blackPayload := testPNGBytes(t, color.RGBA{A: 255})
 	validPayload := testPNGBytes(t, color.RGBA{
-R: 200,
- G: 100,
- B: 50,
- A: 255,
-})
+		R: 200,
+		G: 100,
+		B: 50,
+		A: 255,
+	})
 	runner := &timestampSensitiveRunner{
 		blackTimestamps: map[string]struct{}{"1.000": {}},
 		blackPayload:    blackPayload,
@@ -179,12 +180,18 @@ R: 200,
 	if stat.Size() == 0 {
 		t.Fatal("expected non-empty output file")
 	}
+
+	wantTimestamps := []string{"1.000", "2.000"}
+	if !slices.Equal(runner.timestamps, wantTimestamps) {
+		t.Fatalf("attempted timestamps = %v, want %v", runner.timestamps, wantTimestamps)
+	}
 }
 
 type timestampSensitiveRunner struct {
 	blackTimestamps map[string]struct{}
 	blackPayload    []byte
 	validPayload    []byte
+	timestamps      []string
 }
 
 func (r *timestampSensitiveRunner) Run(_ context.Context, _ string, args []string, _ string) (CommandResult, error) {
@@ -194,6 +201,9 @@ func (r *timestampSensitiveRunner) Run(_ context.Context, _ string, args []strin
 			ts = args[i+1]
 			break
 		}
+	}
+	if ts != "" {
+		r.timestamps = append(r.timestamps, ts)
 	}
 	payload := r.validPayload
 	if _, isBlack := r.blackTimestamps[ts]; isBlack {

--- a/internal/services/screenshots/ffmpeg_test.go
+++ b/internal/services/screenshots/ffmpeg_test.go
@@ -148,6 +148,65 @@ func TestCaptureFrameRejectsBlackOutputFile(t *testing.T) {
 	}
 }
 
+func TestCaptureFrameRecoversFromBlackFrameWithTimestampOffset(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "screen.png")
+	blackPayload := testPNGBytes(t, color.RGBA{A: 255})
+	validPayload := testPNGBytes(t, color.RGBA{
+R: 200,
+ G: 100,
+ B: 50,
+ A: 255,
+})
+	runner := &timestampSensitiveRunner{
+		blackTimestamps: map[string]struct{}{"1.000": {}},
+		blackPayload:    blackPayload,
+		validPayload:    validPayload,
+	}
+
+	_, err := captureFrame(context.Background(), runner, "ffmpeg", captureRequest{
+		InputPath:  "example.mkv",
+		OutputPath: output,
+		Timestamp:  1,
+	}, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("expected black frame to recover with timestamp offset, got error: %v", err)
+	}
+
+	stat, statErr := os.Stat(output)
+	if statErr != nil {
+		t.Fatalf("expected output file to exist, got stat error: %v", statErr)
+	}
+	if stat.Size() == 0 {
+		t.Fatal("expected non-empty output file")
+	}
+}
+
+type timestampSensitiveRunner struct {
+	blackTimestamps map[string]struct{}
+	blackPayload    []byte
+	validPayload    []byte
+}
+
+func (r *timestampSensitiveRunner) Run(_ context.Context, _ string, args []string, _ string) (CommandResult, error) {
+	var ts string
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-ss" {
+			ts = args[i+1]
+			break
+		}
+	}
+	payload := r.validPayload
+	if _, isBlack := r.blackTimestamps[ts]; isBlack {
+		payload = r.blackPayload
+	}
+	if len(args) > 0 {
+		if err := os.WriteFile(args[len(args)-1], payload, 0o600); err != nil {
+			return CommandResult{ExitCode: 1}, fmt.Errorf("write output fixture: %w", err)
+		}
+	}
+	return CommandResult{ExitCode: 0}, nil
+}
+
 type singleResultRunner struct {
 	result CommandResult
 	err    error

--- a/internal/services/screenshots/ffmpeg_test.go
+++ b/internal/services/screenshots/ffmpeg_test.go
@@ -6,6 +6,7 @@ package screenshots
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -17,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -244,12 +246,53 @@ func TestCaptureFrameValidatesBlackSourceBeforeOverlay(t *testing.T) {
 	}
 }
 
+func TestCaptureFrameHardFailsOnDecoderCorruption(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "screen.png")
+	runner := &timestampSensitiveRunner{
+		validPayload: testPNGBytes(t, color.RGBA{R: 200, A: 255}),
+		stderr:       []byte("[h264] Error while decoding stream #0:0"),
+	}
+
+	_, err := captureFrame(context.Background(), runner, "ffmpeg", captureRequest{
+		InputPath:     "example.mkv",
+		OutputPath:    output,
+		Timestamp:     1,
+		UseLibplacebo: true,
+		ToneMap:       true,
+	}, api.NopLogger{})
+	if !errors.Is(err, internalerrors.ErrFrameCorruption) {
+		t.Fatalf("capture error = %v, want frame corruption", err)
+	}
+	if want := []string{"1.000"}; !slices.Equal(runner.timestamps, want) {
+		t.Fatalf("attempted timestamps = %v, want %v", runner.timestamps, want)
+	}
+	if _, statErr := os.Stat(output); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("corrupt capture output survived: %v", statErr)
+	}
+}
+
+func TestFFmpegFrameCorruptionIndicators(t *testing.T) {
+	for _, diagnostic := range []string{
+		"error while decoding",
+		"Invalid data found when processing input",
+		"non-existing PPS 0 referenced",
+		"incomplete frame",
+		"corrupt decoded frame in stream 0",
+		"corrupt input packet in stream 0",
+	} {
+		if err := ffmpegFrameCorruptionError([]byte(diagnostic)); !errors.Is(err, internalerrors.ErrFrameCorruption) {
+			t.Fatalf("diagnostic %q error = %v, want frame corruption", diagnostic, err)
+		}
+	}
+}
+
 type timestampSensitiveRunner struct {
 	blackTimestamps       map[string]struct{}
 	noImageTimestamps     map[string]struct{}
 	sourceBlackTimestamps map[string]struct{}
 	blackPayload          []byte
 	validPayload          []byte
+	stderr                []byte
 	timestamps            []string
 	overlays              []bool
 }
@@ -284,7 +327,7 @@ func (r *timestampSensitiveRunner) Run(_ context.Context, _ string, args []strin
 			return CommandResult{ExitCode: 1}, fmt.Errorf("write output fixture: %w", err)
 		}
 	}
-	return CommandResult{ExitCode: 0}, nil
+	return CommandResult{Stderr: r.stderr, ExitCode: 0}, nil
 }
 
 type singleResultRunner struct {

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -363,19 +363,19 @@ func (s *Service) Capture(
 		timestamp float64
 	}
 
-	errors := make([]api.ScreenshotError, 0)
+	captureErrors := make([]api.ScreenshotError, 0)
 	jobs := make([]captureJob, 0, len(selections))
 	for _, selection := range selections {
 		ts := selectionTimestamp(selection, info.FrameRate)
 		if ts <= 0 {
-			errors = append(errors, api.ScreenshotError{Index: selection.Index, Message: "invalid timestamp"})
+			captureErrors = append(captureErrors, api.ScreenshotError{Index: selection.Index, Message: "invalid timestamp"})
 			continue
 		}
 		jobs = append(jobs, captureJob{selection: selection, timestamp: ts})
 	}
 
 	if len(jobs) == 0 {
-		result.Errors = errors
+		result.Errors = captureErrors
 		return result, nil
 	}
 
@@ -400,7 +400,7 @@ func (s *Service) Capture(
 		purpose,
 		len(selections),
 		len(jobs),
-		len(errors),
+		len(captureErrors),
 		limit,
 		s.cfg.ScreenshotHandling.FrameOverlay,
 		tonemap,
@@ -412,6 +412,7 @@ func (s *Service) Capture(
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var usedLibplacebo atomic.Bool
+	var corruptionErr error
 	images := make([]api.ScreenshotImage, 0, len(jobs))
 
 	worker := func() {
@@ -462,6 +463,14 @@ func (s *Service) Capture(
 				if captureErr == nil {
 					break
 				}
+				if errors.Is(captureErr, internalerrors.ErrFrameCorruption) {
+					mu.Lock()
+					if corruptionErr == nil {
+						corruptionErr = captureErr
+					}
+					mu.Unlock()
+					break
+				}
 				s.logger.Debugf(
 					"screenshots: capture segment failed index=%d segment=%d fallback=%d err=%s",
 					selection.Index,
@@ -473,7 +482,7 @@ func (s *Service) Capture(
 			if captureErr != nil {
 				s.logger.Warnf("screenshots: capture frame failed index=%d err=%s", selection.Index, redaction.RedactValue(captureErr.Error(), nil))
 				mu.Lock()
-				errors = append(errors, api.ScreenshotError{Index: selection.Index, Message: logging.SanitizeMessage(captureErr.Error())})
+				captureErrors = append(captureErrors, api.ScreenshotError{Index: selection.Index, Message: logging.SanitizeMessage(captureErr.Error())})
 				mu.Unlock()
 				continue
 			}
@@ -535,12 +544,15 @@ func (s *Service) Capture(
 	if err := ctx.Err(); err != nil {
 		return result, fmt.Errorf("screenshots: generate canceled: %w", err)
 	}
+	if corruptionErr != nil {
+		return result, corruptionErr
+	}
 
 	sort.Slice(images, func(i, j int) bool { return images[i].Index < images[j].Index })
-	sort.Slice(errors, func(i, j int) bool { return errors[i].Index < errors[j].Index })
+	sort.Slice(captureErrors, func(i, j int) bool { return captureErrors[i].Index < captureErrors[j].Index })
 
 	result.Images = images
-	result.Errors = errors
+	result.Errors = captureErrors
 	result.UsedLibplacebo = usedLibplacebo.Load()
 	s.logger.Debugf("screenshots: capture result images=%d errors=%d libplacebo_used=%t", len(result.Images), len(result.Errors), result.UsedLibplacebo)
 
@@ -622,6 +634,9 @@ func (s *Service) PreviewFrame(ctx context.Context, meta api.ScreenshotSubject, 
 			Timestamp: candidate.Timestamp,
 		}, s.logger)
 		if err == nil {
+			break
+		}
+		if errors.Is(err, internalerrors.ErrFrameCorruption) {
 			break
 		}
 		s.logger.Debugf(

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -378,6 +378,8 @@ func (s *Service) Capture(
 		result.Errors = captureErrors
 		return result, nil
 	}
+	captureCtx, cancelCapture := context.WithCancel(ctx)
+	defer cancelCapture()
 
 	limit := len(jobs)
 	if s.cfg.ScreenshotHandling.FFmpegLimit {
@@ -418,7 +420,7 @@ func (s *Service) Capture(
 	worker := func() {
 		defer wg.Done()
 		for job := range jobCh {
-			if ctx.Err() != nil {
+			if captureCtx.Err() != nil {
 				return
 			}
 
@@ -459,7 +461,7 @@ func (s *Service) Capture(
 					HeightScale:   info.HeightScale,
 				}
 
-				usedLib, captureErr = captureFrame(ctx, s.runner, cmd, capture, s.logger)
+				usedLib, captureErr = captureFrame(captureCtx, s.runner, cmd, capture, s.logger)
 				if captureErr == nil {
 					break
 				}
@@ -469,6 +471,7 @@ func (s *Service) Capture(
 						corruptionErr = captureErr
 					}
 					mu.Unlock()
+					cancelCapture()
 					break
 				}
 				s.logger.Debugf(
@@ -480,6 +483,9 @@ func (s *Service) Capture(
 				)
 			}
 			if captureErr != nil {
+				if captureCtx.Err() != nil && ctx.Err() == nil {
+					return
+				}
 				s.logger.Warnf("screenshots: capture frame failed index=%d err=%s", selection.Index, redaction.RedactValue(captureErr.Error(), nil))
 				mu.Lock()
 				captureErrors = append(captureErrors, api.ScreenshotError{Index: selection.Index, Message: logging.SanitizeMessage(captureErr.Error())})
@@ -532,7 +538,7 @@ func (s *Service) Capture(
 		defer close(jobCh)
 		for _, job := range jobs {
 			select {
-			case <-ctx.Done():
+			case <-captureCtx.Done():
 				return
 			case jobCh <- job:
 			}

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -339,6 +339,7 @@ func (r *corruptionCancelRunner) Run(ctx context.Context, _ string, args []strin
 	select {
 	case <-r.allStarted:
 	case <-ctx.Done():
+		r.canceled.Add(1)
 		return CommandResult{ExitCode: 1}, fmt.Errorf("synthetic ffmpeg start: %w", ctx.Err())
 	}
 	if ffmpegValueAfter(args, "-ss") == "10.000" {

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -279,6 +279,36 @@ func TestPreviewFrameExcludesDVDMenuVOB(t *testing.T) {
 	}
 }
 
+func TestCaptureReturnsHardErrorForFrameCorruption(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "Example.Release.2026.1080p-GRP.mkv")
+	if err := os.WriteFile(sourcePath, []byte("synthetic video"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	mediaInfoPath := filepath.Join(root, "mediainfo.json")
+	if err := os.WriteFile(mediaInfoPath, []byte(`{"media":{"track":[{"@type":"General","Duration":"100"},{"@type":"Video","FrameRate":"25.000"}]}}`), 0o600); err != nil {
+		t.Fatalf("write mediainfo: %v", err)
+	}
+	ffmpegRoot := t.TempDir()
+	if err := writeTestBundledFFmpeg(ffmpegRoot); err != nil {
+		t.Fatalf("write bundled ffmpeg: %v", err)
+	}
+	t.Chdir(ffmpegRoot)
+
+	runner := &scriptedRunner{results: []CommandResult{{Stderr: []byte("corrupt decoded frame in stream 0"), ExitCode: 0}}}
+	service := NewService(config.Config{}, api.NopLogger{}, t.TempDir(), runner)
+	_, err := service.Capture(context.Background(), api.ScreenshotSubject{
+		SourcePath:        sourcePath,
+		MediaInfoJSONPath: mediaInfoPath,
+	}, []api.ScreenshotSelection{{Index: 0, TimestampSeconds: 30}}, api.ScreenshotPurposeFinal)
+	if !errors.Is(err, internalerrors.ErrFrameCorruption) {
+		t.Fatalf("capture error = %v, want frame corruption", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("ffmpeg calls = %d, want 1", len(runner.calls))
+	}
+}
+
 type runnerCall struct {
 	args []string
 }

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -279,7 +280,7 @@ func TestPreviewFrameExcludesDVDMenuVOB(t *testing.T) {
 	}
 }
 
-func TestCaptureReturnsHardErrorForFrameCorruption(t *testing.T) {
+func TestCaptureReturnsHardErrorAndCancelsSiblingFramesForCorruption(t *testing.T) {
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "Example.Release.2026.1080p-GRP.mkv")
 	if err := os.WriteFile(sourcePath, []byte("synthetic video"), 0o600); err != nil {
@@ -295,17 +296,24 @@ func TestCaptureReturnsHardErrorForFrameCorruption(t *testing.T) {
 	}
 	t.Chdir(ffmpegRoot)
 
-	runner := &scriptedRunner{results: []CommandResult{{Stderr: []byte("corrupt decoded frame in stream 0"), ExitCode: 0}}}
+	runner := &corruptionCancelRunner{allStarted: make(chan struct{})}
 	service := NewService(config.Config{}, api.NopLogger{}, t.TempDir(), runner)
-	_, err := service.Capture(context.Background(), api.ScreenshotSubject{
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := service.Capture(ctx, api.ScreenshotSubject{
 		SourcePath:        sourcePath,
 		MediaInfoJSONPath: mediaInfoPath,
-	}, []api.ScreenshotSelection{{Index: 0, TimestampSeconds: 30}}, api.ScreenshotPurposeFinal)
+	}, []api.ScreenshotSelection{
+		{Index: 0, TimestampSeconds: 10},
+		{Index: 1, TimestampSeconds: 20},
+		{Index: 2, TimestampSeconds: 30},
+		{Index: 3, TimestampSeconds: 40},
+	}, api.ScreenshotPurposeFinal)
 	if !errors.Is(err, internalerrors.ErrFrameCorruption) {
 		t.Fatalf("capture error = %v, want frame corruption", err)
 	}
-	if len(runner.calls) != 1 {
-		t.Fatalf("ffmpeg calls = %d, want 1", len(runner.calls))
+	if got := runner.canceled.Load(); got != 3 {
+		t.Fatalf("canceled sibling captures = %d, want 3", got)
 	}
 }
 
@@ -316,6 +324,29 @@ type runnerCall struct {
 type scriptedRunner struct {
 	results []CommandResult
 	calls   []runnerCall
+}
+
+type corruptionCancelRunner struct {
+	started    atomic.Int32
+	canceled   atomic.Int32
+	allStarted chan struct{}
+}
+
+func (r *corruptionCancelRunner) Run(ctx context.Context, _ string, args []string, _ string) (CommandResult, error) {
+	if r.started.Add(1) == 4 {
+		close(r.allStarted)
+	}
+	select {
+	case <-r.allStarted:
+	case <-ctx.Done():
+		return CommandResult{ExitCode: 1}, fmt.Errorf("synthetic ffmpeg start: %w", ctx.Err())
+	}
+	if ffmpegValueAfter(args, "-ss") == "10.000" {
+		return CommandResult{Stderr: []byte("corrupt decoded frame in stream 0"), ExitCode: 0}, nil
+	}
+	<-ctx.Done()
+	r.canceled.Add(1)
+	return CommandResult{ExitCode: 1}, fmt.Errorf("synthetic ffmpeg canceled: %w", ctx.Err())
 }
 
 func (r *scriptedRunner) Run(_ context.Context, _ string, args []string, _ string) (CommandResult, error) {


### PR DESCRIPTION
- Prevents failed screenshot generations by retrying frame extraction with slight timestamp offsets when FFmpeg renders a solid black image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot capture reliability by retrying when black, missing, or empty frames are detected.
  * Skips invalid negative retry timestamps and validates frames before applying overlays.
  * Detects decoder-corrupted frames, removes invalid output, and stops futile fallback attempts, including during previews.
  * Provides clearer failure messages when media requires repair.
  * Preserves useful underlying error details when screenshot capture ultimately fails.
  * Cancels related captures promptly after unrecoverable frame corruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->