### PR TITLE
fix: restore Pixhost upload domain

### DIFF
--- a/internal/imagehosting/uploaders.go
+++ b/internal/imagehosting/uploaders.go
@@ -957,7 +957,7 @@ type pixhostUploader struct {
 	client *http.Client
 }
 
-const pixhostUploadURL = "https://api.pixhost.cc/images"
+const pixhostUploadURL = "https://api.pixhost.to/images"
 
 func (u *pixhostUploader) Upload(ctx context.Context, imagePath string) (uploadResult, error) {
 	fields := map[string]string{

--- a/internal/imagehosting/uploaders_test.go
+++ b/internal/imagehosting/uploaders_test.go
@@ -600,7 +600,7 @@ func TestPixhostUploaderPostsCurrentDomain(t *testing.T) {
 
 	client := &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			if req.URL.String() != pixhostUploadURL {
+			if req.URL.String() != "https://api.pixhost.to/images" {
 				t.Fatalf("unexpected request URL: %s", req.URL.String())
 			}
 			mediaType, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))


### PR DESCRIPTION
## Summary

- Restore Pixhost uploads to https://api.pixhost.to/images.
- Keep .cc and .to response and URL compatibility.

## Root cause

Pixhost uploads still targeted the .cc API endpoint after the service returned its documented upload endpoint to .to.

## Validation

- go test -race -v -timeout 20m ./internal/imagehosting
- make gofix-check-changed
- make lint
- git diff --check