### PR TITLE
fix(bhd): update supported image hosts

### DIFF
--- a/internal/trackers/impl/registry_test.go
+++ b/internal/trackers/impl/registry_test.go
@@ -709,7 +709,6 @@ func TestNewRegistryIncludesImageHostPolicies(t *testing.T) {
 		disableWithoutAPI    bool
 	}{
 		{tracker: "A4K", host: "onlyimage"},
-		{tracker: "BHD", host: "bhd"},
 		{
 			tracker:              "HDB",
 			host:                 "hdb",
@@ -736,6 +735,10 @@ func TestNewRegistryIncludesImageHostPolicies(t *testing.T) {
 		if policy.ConditionalHost != test.conditionalHost {
 			t.Errorf("%s conditional image host = %q", test.tracker, policy.ConditionalHost)
 		}
+	}
+	bhdPolicy, ok := registry.LookupImageHostPolicy("BHD")
+	if !ok || !slices.Equal(bhdPolicy.AllowedHosts, []string{"imgbox", "imgbb", "pixhost", "passtheimage"}) {
+		t.Errorf("BHD image policy = %#v, %t", bhdPolicy, ok)
 	}
 }
 

--- a/internal/trackers/impl/registry_test.go
+++ b/internal/trackers/impl/registry_test.go
@@ -737,7 +737,9 @@ func TestNewRegistryIncludesImageHostPolicies(t *testing.T) {
 		}
 	}
 	bhdPolicy, ok := registry.LookupImageHostPolicy("BHD")
-	if !ok || !slices.Equal(bhdPolicy.AllowedHosts, []string{"imgbox", "imgbb", "pixhost", "bhd", "passtheimage"}) {
+	if !ok ||
+		!slices.Equal(bhdPolicy.AllowedHosts, []string{"imgbox", "imgbb", "pixhost", "bhd", "passtheimage"}) ||
+		bhdPolicy.DisableWithoutRehost || bhdPolicy.DisableWithoutAPI || bhdPolicy.ConditionalHost != "" {
 		t.Errorf("BHD image policy = %#v, %t", bhdPolicy, ok)
 	}
 }

--- a/internal/trackers/impl/registry_test.go
+++ b/internal/trackers/impl/registry_test.go
@@ -737,7 +737,7 @@ func TestNewRegistryIncludesImageHostPolicies(t *testing.T) {
 		}
 	}
 	bhdPolicy, ok := registry.LookupImageHostPolicy("BHD")
-	if !ok || !slices.Equal(bhdPolicy.AllowedHosts, []string{"imgbox", "imgbb", "pixhost", "passtheimage"}) {
+	if !ok || !slices.Equal(bhdPolicy.AllowedHosts, []string{"imgbox", "imgbb", "pixhost", "bhd", "passtheimage"}) {
 		t.Errorf("BHD image policy = %#v, %t", bhdPolicy, ok)
 	}
 }

--- a/internal/trackers/impl/standalone/bhd/profile.go
+++ b/internal/trackers/impl/standalone/bhd/profile.go
@@ -30,7 +30,7 @@ func Profile() standalone.Profile {
 		BannedGroups:         bannedGroups(),
 		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: "BHD"},
 		AudioPolicy:          &trackers.AudioPolicy{BlockEnglishOriginalWithForeign: true},
-		ImageHostPolicy:      &trackers.ImageHostPolicy{AllowedHosts: []string{"imgbox", "imgbb", "pixhost", "bhd", "bam"}},
+		ImageHostPolicy:      &trackers.ImageHostPolicy{AllowedHosts: []string{"imgbox", "imgbb", "pixhost", "passtheimage"}},
 		DupePolicy: &trackers.DupePolicy{
 			ID:         "bhd/duplicate/v2",
 			EvidenceID: "bhd-upload-rules",

--- a/internal/trackers/impl/standalone/bhd/profile.go
+++ b/internal/trackers/impl/standalone/bhd/profile.go
@@ -30,7 +30,7 @@ func Profile() standalone.Profile {
 		BannedGroups:         bannedGroups(),
 		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: "BHD"},
 		AudioPolicy:          &trackers.AudioPolicy{BlockEnglishOriginalWithForeign: true},
-		ImageHostPolicy:      &trackers.ImageHostPolicy{AllowedHosts: []string{"imgbox", "imgbb", "pixhost", "passtheimage"}},
+		ImageHostPolicy:      &trackers.ImageHostPolicy{AllowedHosts: []string{"imgbox", "imgbb", "pixhost", "bhd", "passtheimage"}},
 		DupePolicy: &trackers.DupePolicy{
 			ID:         "bhd/duplicate/v2",
 			EvidenceID: "bhd-upload-rules",


### PR DESCRIPTION
## Summary

- update BHD's supported image hosts to imgbox, ImgBB, Pixhost, BHD, and PassTheImage
- remove the stale BAM host entry
- assert the exact BHD host policy in the registry test

## Why

BHD now accepts image URLs from `imgbox.com`, `ibb.co`, `pixhost.to`, `beyondhd.co`, and `passtheima.ge`. The tracker profile omitted PassTheImage and still allowed BAM.

## Validation

- `go test -race -v -timeout 20m ./internal/trackers/impl ./internal/trackers/impl/standalone/bhd`
- `go test -race -run TestNewRegistryIncludesImageHostPolicies -count=1 ./internal/trackers/impl`
- `make gofix-check-changed`
- `make lint`
- `make logpolicy`
- pre-commit and pre-push hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated BHD image-host support to allow images hosted on Passtheimage.
  * Removed support for the outdated Bam image host.
  * Improved image-host policy validation to ensure BHD image sources follow the expected configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->