### PR TITLE
fix(webui): hide enabled tracker-owned image host selection

### DIFF
--- a/webui/src/hooks/useSettingsState.test.ts
+++ b/webui/src/hooks/useSettingsState.test.ts
@@ -989,7 +989,7 @@ describe("Tracker client selectors", () => {
     expect(screen.getByLabelText("Announce URL")).toHaveValue("");
   });
 
-  it("shows Lostimg as an LST image host only when configured in image hosting", async () => {
+  it("hides LST image host selection when Lostimg is enabled", async () => {
     installAppOperationMocks({
       GetConfig: async () =>
         JSON.stringify({
@@ -1035,8 +1035,7 @@ describe("Tracker client selectors", () => {
     );
     fireEvent.click(screen.getByText("LST", { selector: ".settings-card__summary-name" }));
 
-    const imageHostSelect = screen.getByLabelText("Image host") as HTMLSelectElement;
-    expect(Array.from(imageHostSelect.options).map((option) => option.value)).toContain("lostimg");
+    expect(screen.queryByLabelText("Image host")).not.toBeInTheDocument();
   });
 
   it("shows configured global hosts for LST when Lostimg is disabled", async () => {
@@ -1093,7 +1092,7 @@ describe("Tracker client selectors", () => {
     expect(values).not.toContain("lostimg");
   });
 
-  it("shows ReelFliX as an RF image host when configured in image hosting", async () => {
+  it("hides RF image host selection when ReelFliX is enabled", async () => {
     installAppOperationMocks({
       GetConfig: async () =>
         JSON.stringify({
@@ -1139,8 +1138,7 @@ describe("Tracker client selectors", () => {
     );
     fireEvent.click(screen.getByText("RF", { selector: ".settings-card__summary-name" }));
 
-    const imageHostSelect = screen.getByLabelText("Image host") as HTMLSelectElement;
-    expect(Array.from(imageHostSelect.options).map((option) => option.value)).toContain("reelflix");
+    expect(screen.queryByLabelText("Image host")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Image API")).not.toBeInTheDocument();
   });
 

--- a/webui/src/hooks/useSettingsState.tsx
+++ b/webui/src/hooks/useSettingsState.tsx
@@ -1655,9 +1655,31 @@ export const useSettingsState = (options: UseSettingsStateOptions): UseSettingsS
       const trackerOptions = catalogEntries.map((entry) => entry.name);
       const availableTrackers = trackerOptions.filter((name) => !visibleTrackerSet.has(name));
       const trackerClientOptions = [{ value: "", label: "" }, ...torrentClientOptions];
+      const imageCfg =
+        configData.ImageHosting &&
+        typeof configData.ImageHosting === "object" &&
+        !Array.isArray(configData.ImageHosting)
+          ? (configData.ImageHosting as ConfigMap)
+          : null;
+
+      const trackerHasEnabledOwnedImageHost = (trackerName: string) => {
+        const trackerKey = trackerName.trim().toUpperCase();
+        const ownerByHost = imageHostPolicyMetadata?.OwnedHosts ?? {};
+        return (imageHostPolicyMetadata?.TrackerUploadHosts?.[trackerKey] ?? []).some((host) => {
+          const normalizedHost = normalizeImageHostValue(host);
+          const enabledKey = conditionalImageHostEnabledKeys[normalizedHost];
+          return (
+            ownerByHost[normalizedHost]?.trim().toUpperCase() === trackerKey &&
+            Boolean(enabledKey && imageCfg?.[enabledKey])
+          );
+        });
+      };
 
       const trackerSchemaFor = (entry: TrackerCatalogEntry) => {
-        return entry.fields.map((field) => {
+        const fields = trackerHasEnabledOwnedImageHost(entry.name)
+          ? entry.fields.filter((field) => field.key !== "ImageHost")
+          : entry.fields;
+        return fields.map((field) => {
           const base = trackerFieldPresentation(field.key);
           if (field.key === "ImageHost") {
             return { ...base, options: trackerOptionsForImageHost(entry.name) };


### PR DESCRIPTION
## Summary

- hide tracker image-host selection while its globally configured owned host is enabled
- keep global image-host configuration as the single visible source of truth
- restore tracker image-host selection when the owned host is disabled

## Root cause

ReelFliX was offered as an RF tracker selection even though recurring legacy normalization clears that tracker value. Lostimg has the same globally owned configuration shape. Hiding the redundant tracker field avoids presenting state that global configuration already owns.

## Validation

- pnpm --dir webui run lint
- pnpm --dir webui run lint:dead
- pnpm --dir webui run typecheck
- pnpm --dir webui run test:unit
- pnpm --dir webui run format:check
- git diff --check

Closes #333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tracker-specific image-host options are now hidden when the corresponding global image-host integration is enabled.
  * Tracker image-host settings continue to display correctly when no global integration is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->