### PR TITLE
fix(metadata): preserve parsed Hybrid in release names

### DIFF
--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -1596,6 +1596,7 @@ func editionFromMeta(meta preparationstate.State, doc mediaInfoDoc) (string, str
 	if hasNoEditionOverride(meta.ReleaseNameOverrides) {
 		return "", ""
 	}
+	hybrid := containsExactHybrid(meta.Release.Other)
 	if !hasManualEditionOverride(meta.ReleaseNameOverrides) {
 		edition = strings.TrimSpace(resolveIMDbEditionFromMediaDuration(meta, doc))
 		isIMDbEdition = edition != ""
@@ -1611,7 +1612,7 @@ func editionFromMeta(meta preparationstate.State, doc mediaInfoDoc) (string, str
 		edition = strings.TrimSpace(strings.Join(meta.Release.Edition, " "))
 	}
 	repack := repackFromMeta(meta, edition)
-	if edition == "" {
+	if edition == "" && !hybrid {
 		return "", repack
 	}
 	if repackPattern.MatchString(edition) {
@@ -1621,9 +1622,20 @@ func editionFromMeta(meta preparationstate.State, doc mediaInfoDoc) (string, str
 		edition = strings.TrimSpace(repackPattern.ReplaceAllString(edition, ""))
 	}
 	if isIMDbEdition {
-		return cleanIMDbEditionText(edition), strings.ToUpper(repack)
+		edition = cleanIMDbEditionText(edition)
+	} else {
+		edition = cleanEditionText(edition)
 	}
-	return cleanEditionText(edition), strings.ToUpper(repack)
+	if hybrid && !containsExactHybrid(strings.Fields(edition)) {
+		edition = strings.TrimSpace(edition + " Hybrid")
+	}
+	return edition, strings.ToUpper(repack)
+}
+
+func containsExactHybrid(values []string) bool {
+	return slices.ContainsFunc(values, func(value string) bool {
+		return strings.EqualFold(strings.TrimSpace(value), "Hybrid")
+	})
 }
 
 // repackFromMeta scans source basenames and parsed release tokens so repack

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -369,12 +369,44 @@ func TestEditionFromMetaSkipsIMDbRuntimeWhenManualEditionOverridePresent(t *test
 	}
 }
 
+func TestEditionFromMetaPromotesOnlyExactHybridOther(t *testing.T) {
+	tests := []struct {
+		name    string
+		release api.ReleaseInfo
+		want    string
+	}{
+		{
+			name:    "exact case insensitive value",
+			release: api.ReleaseInfo{Other: []string{" HYBRiD "}},
+			want:    "Hybrid",
+		},
+		{
+			name:    "keeps existing edition",
+			release: api.ReleaseInfo{Edition: []string{"Extended"}, Other: []string{"HYBRiD", "RETAiL"}},
+			want:    "Extended Hybrid",
+		},
+		{
+			name:    "ignores unrelated values",
+			release: api.ReleaseInfo{Other: []string{"RETAiL", "REMUX", "Hybridish", "HYBRiD REMUX"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			edition, _ := editionFromMeta(preparationstate.State{Release: tc.release}, mediaInfoDoc{})
+			if edition != tc.want {
+				t.Fatalf("expected edition %q, got %q", tc.want, edition)
+			}
+		})
+	}
+}
+
 func TestEditionFromMetaSkipsIMDbRuntimeWhenNoEditionOverridePresent(t *testing.T) {
 	noEdition := true
 	meta := preparationstate.State{
 		ReleaseNameOverrides: api.ReleaseNameOverrides{NoEdition: &noEdition},
 		Edition:              "IMAX",
-		Release:              api.ReleaseInfo{Edition: []string{"Collector's", "Edition"}},
+		Release:              api.ReleaseInfo{Edition: []string{"Collector's", "Edition"}, Other: []string{"HYBRiD"}},
 		Identity:             api.ExternalIdentity{Category: "MOVIE"},
 		ProviderMetadata: api.SourceScopedMetadata{
 			IMDB: &api.IMDBMetadata{

--- a/internal/metadata/naming.go
+++ b/internal/metadata/naming.go
@@ -98,11 +98,11 @@ func buildReleaseName(req api.ReleaseNameRequest, logger api.Logger) api.Release
 	dvdSize := strings.TrimSpace(req.DVDSize)
 	edition := strings.TrimSpace(req.Edition)
 
-	edition = removeHybrid(edition)
 	hybrid := ""
-	if req.WebDV {
+	if req.WebDV || containsExactHybrid(strings.Fields(edition)) {
 		hybrid = "Hybrid"
 	}
+	edition = removeHybrid(edition)
 
 	if category == "TV" && !req.ManualEpisodeTitle && episode == "" && !req.ManualDate {
 		episodeTitle = ""

--- a/internal/metadata/naming_test.go
+++ b/internal/metadata/naming_test.go
@@ -69,22 +69,26 @@ func TestBuildReleaseNameMovieBareWebEncodeUsesWebDLNaming(t *testing.T) {
 }
 
 func TestBuildReleaseNameHybridEdition(t *testing.T) {
-	result := BuildReleaseName(api.ReleaseNameRequest{
-		Category:    "MOVIE",
-		Type:        "ENCODE",
-		Title:       "Hybrid Cut",
-		Year:        2020,
-		Edition:     "Hybrid Director",
-		WebDV:       true,
-		Resolution:  "1080p",
-		Source:      "BluRay",
-		Audio:       "DTS",
-		VideoEncode: "x264",
-	}, api.NopLogger{})
+	for _, webDV := range []bool{false, true} {
+		t.Run(fmt.Sprintf("webdv_%t", webDV), func(t *testing.T) {
+			result := BuildReleaseName(api.ReleaseNameRequest{
+				Category:    "MOVIE",
+				Type:        "ENCODE",
+				Title:       "Hybrid Cut",
+				Year:        2020,
+				Edition:     "Hybrid Director",
+				WebDV:       webDV,
+				Resolution:  "1080p",
+				Source:      "BluRay",
+				Audio:       "DTS",
+				VideoEncode: "x264",
+			}, api.NopLogger{})
 
-	expected := "Hybrid Cut 2020 Director Hybrid 1080p BluRay DTS x264"
-	if result.NameNoTag != expected {
-		t.Fatalf("expected %q, got %q", expected, result.NameNoTag)
+			expected := "Hybrid Cut 2020 Director Hybrid 1080p BluRay DTS x264"
+			if result.NameNoTag != expected {
+				t.Fatalf("expected %q, got %q", expected, result.NameNoTag)
+			}
+		})
 	}
 }
 

--- a/internal/metadata/release_test.go
+++ b/internal/metadata/release_test.go
@@ -3,7 +3,17 @@
 
 package metadata
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseReleaseInfoPreservesHybridOther(t *testing.T) {
+	release := ParseReleaseInfo("Example.Release.2026.2160p.WEB-DL.HYBRiD.DDP5.1.Atmos.DV.H.265-GRP.mkv")
+	if !slices.Equal(release.Other, []string{"HYBRiD"}) {
+		t.Fatalf("expected exact Hybrid parser output, got %#v", release.Other)
+	}
+}
 
 func TestParseReleaseInfo(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- restore parsed `Hybrid` markers in canonical release names without requiring `-webdv`
- accept only a trimmed, case-insensitive `Release.Other` value exactly equal to `Hybrid`
- keep `WebDV` and `NoEdition` semantics unchanged

## Root cause

`rls` classifies `HYBRiD` as `Release.Other`. Metadata preparation ignored it, while naming removed `Hybrid` from the edition and re-added it only for `WebDV`.

## Impact

Upload names and duplicate-search names retain `Hybrid`; unrelated `Release.Other` values remain ignored.

## Validation

- `go test -race -v -timeout 20m ./internal/metadata ./internal/preparedrelease`
- `go test -race -v -timeout 20m ./internal/trackers ./internal/trackers/impl/unit3d/sites/aither ./internal/trackers/impl/unit3d/sites/ulcx ./internal/trackers/impl/standalone/bhd`
- `make lint`
- `make logpolicy`
- `make gofix-check-changed`
- `git diff --check`

Closes #332


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recognition of hybrid editions from release metadata.
  * Hybrid editions are now reflected consistently in generated release names, including when WebDV is not enabled.
  * Existing edition details are preserved while redundant hybrid labels are cleaned up.

* **Bug Fixes**
  * Prevented hybrid releases from being incorrectly treated as having no edition.
  * Improved handling of capitalization, whitespace, and unrelated metadata values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->