### PR TITLE
fix(screenshots): retain and tonemap preview captures

### DIFF
--- a/internal/releaseworkflow/planner.go
+++ b/internal/releaseworkflow/planner.go
@@ -550,9 +550,25 @@ func continuationPreflightCurrent(current CommandResult, now time.Time) bool {
 		current.Preflight.ProjectionSet.Revision == current.Projections.Revision
 }
 
+// continuationMediaCaptureSatisfied treats explicit final selections as
+// satisfied only when each screenshot index is retained.
 func continuationMediaCaptureSatisfied(current CommandResult, desired *api.MediaCaptureInstructions) bool {
 	if desired == nil || current.Media == nil {
 		return desired == nil && current.Media != nil
+	}
+	if (desired.Purpose == "" || desired.Purpose == api.ScreenshotPurposeFinal) && desired.Selections != nil {
+		retained := make(map[int]struct{}, len(current.Media.Artifacts))
+		for _, artifact := range current.Media.Artifacts {
+			if artifact.Kind == api.MediaArtifactScreenshot {
+				retained[artifact.Index] = struct{}{}
+			}
+		}
+		for _, selection := range desired.Selections {
+			if _, ok := retained[selection.Index]; !ok {
+				return false
+			}
+		}
+		return true
 	}
 	expected, err := api.CanonicalWorkflowFingerprint(struct {
 		Release      api.ReleaseRef

--- a/internal/releaseworkflow/planner_test.go
+++ b/internal/releaseworkflow/planner_test.go
@@ -991,6 +991,52 @@ func TestContinuationPlannerRecapturesRequestedMediaAfterArtifactsDeleted(t *tes
 	}
 }
 
+func TestContinuationPlannerCapturesEachNewExplicitScreenshotIndex(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 23, 1, 2, 3, 0, time.UTC)
+	current := readyContinuationPlannerResult(t, now)
+	current.Media = &api.MediaArtifactSet{
+		Status: api.StageStatusBlocked,
+		Artifacts: []api.MediaArtifact{{
+			ID:       "screen-3",
+			Kind:     api.MediaArtifactScreenshot,
+			Index:    3,
+			Selected: true,
+		}},
+		RequiredActions: []api.RequiredAction{{
+			ID:     "media-required",
+			Kind:   api.RequiredActionProvideTrackerInput,
+			Status: api.RequiredActionStatusPending,
+		}},
+	}
+	request := api.ContinueReleaseWorkflowRequest{
+		IdempotencyKey: "continue-capture-explicit",
+		Goal:           api.WorkflowGoalMediaReady,
+		Intent: api.WorkflowIntent{
+			TrackerIDs:             []api.TrackerID{"ALPHA"},
+			ProjectionInstructions: map[api.TrackerID]api.TrackerProjectionInstructions{},
+			Media: &api.MediaCaptureInstructions{
+				Purpose: api.ScreenshotPurposeFinal,
+				Selections: []api.ScreenshotSelection{{
+					Index: 4,
+				}},
+			},
+		},
+	}
+
+	command, stage := planContinuationCommand(request, current, now)
+	if _, ok := command.(CaptureMediaCommand); !ok || stage != "capture-media" {
+		t.Fatalf("new explicit screenshot plan: stage=%q command=%#v", stage, command)
+	}
+
+	request.Intent.Media.Selections[0].Index = 3
+	command, stage = planContinuationCommand(request, current, now)
+	if command != nil || stage != "capture-media" {
+		t.Fatalf("retained explicit screenshot plan: stage=%q command=%#v", stage, command)
+	}
+}
+
 func TestContinuationMediaIntentCanResolveItsPendingGlobalAction(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/screenshots/ffmpeg.go
+++ b/internal/services/screenshots/ffmpeg.go
@@ -153,6 +153,9 @@ type frameInfoResult struct {
 type previewRequest struct {
 	InputPath string
 	Timestamp float64
+	ToneMap   bool
+	Algorithm string
+	Desat     float64
 }
 
 const (
@@ -542,7 +545,11 @@ func buildFFmpegPreviewArgs(req previewRequest) []string {
 		"-sn",
 		"-dn",
 		"-frames:v", "1",
-		"-vf", "format=rgb24",
+		"-vf", buildFilterChain(captureRequest{
+			ToneMap:   req.ToneMap,
+			Algorithm: req.Algorithm,
+			Desat:     req.Desat,
+		}, false),
 		"-f", "image2pipe",
 		"-vcodec", "png",
 		"-",

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -584,7 +584,8 @@ func (s *Service) Capture(
 
 // PreviewFrame captures one decodable, non-black PNG into memory without
 // persisting it. DVD inputs try the selected VOB segment followed by later
-// segments when a candidate yields no usable frame.
+// segments when a candidate yields no usable frame. When enabled for HDR/DV
+// inputs, it applies configured software tone mapping before returning.
 func (s *Service) PreviewFrame(ctx context.Context, meta api.ScreenshotSubject, timestampSeconds float64) (preview api.ScreenshotPreview, err error) {
 	defer func() {
 		if err != nil {
@@ -638,6 +639,9 @@ func (s *Service) PreviewFrame(ctx context.Context, meta api.ScreenshotSubject, 
 		payload, err = captureFrameBytes(ctx, s.runner, cmd, previewRequest{
 			InputPath: candidate.SourcePath,
 			Timestamp: candidate.Timestamp,
+			ToneMap:   shouldTonemap(meta, s.cfg),
+			Algorithm: s.cfg.ScreenshotHandling.TonemapAlgorithm,
+			Desat:     s.cfg.ScreenshotHandling.Desat,
 		}, s.logger)
 		if err == nil {
 			break

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -280,6 +280,41 @@ func TestPreviewFrameExcludesDVDMenuVOB(t *testing.T) {
 	}
 }
 
+func TestPreviewFrameTonemapsHDR(t *testing.T) {
+	ffmpegRoot := t.TempDir()
+	if err := writeTestBundledFFmpeg(ffmpegRoot); err != nil {
+		t.Fatalf("write bundled ffmpeg: %v", err)
+	}
+	t.Chdir(ffmpegRoot)
+
+	runner := &scriptedRunner{results: []CommandResult{{
+		Stdout: testPNGBytes(t, color.RGBA{
+			R: 16,
+			G: 16,
+			B: 16,
+			A: 255,
+		}),
+		ExitCode: 0,
+	}}}
+	service := NewService(config.Config{ScreenshotHandling: config.ScreenshotHandlingConfig{
+		ToneMap:          true,
+		TonemapAlgorithm: "hable",
+		Desat:            0.25,
+	}}, api.NopLogger{}, t.TempDir(), runner)
+	_, err := service.PreviewFrame(context.Background(), api.ScreenshotSubject{
+		SourcePath: "Example.Release.2026.1080p-GRP.mkv",
+		HDR:        "HDR10",
+	}, 1)
+	if err != nil {
+		t.Fatalf("preview frame: %v", err)
+	}
+
+	want := "zscale=transfer=linear,tonemap=tonemap=hable:desat=0.25,zscale=transfer=bt709,format=rgb24"
+	if got := ffmpegValueAfter(runner.calls[0].args, "-vf"); got != want {
+		t.Fatalf("preview filter = %q, want %q", got, want)
+	}
+}
+
 func TestCaptureReturnsHardErrorAndCancelsSiblingFramesForCorruption(t *testing.T) {
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "Example.Release.2026.1080p-GRP.mkv")

--- a/webui/src/pages/screenshots/index.test.tsx
+++ b/webui/src/pages/screenshots/index.test.tsx
@@ -51,6 +51,7 @@ const facet = (): ScreenshotsFacet => {
         artifacts: [
           {
             id: "artifact-1",
+            index: 3,
             kind: "screenshot",
             purpose: "final",
             selected: true,
@@ -274,6 +275,34 @@ describe("ScreenshotsPage", () => {
     );
     expect(frameDetails).not.toHaveAttribute("open");
     vi.unstubAllGlobals();
+  });
+
+  it("captures the live preview as a new retained screenshot", () => {
+    const screenshots = facet();
+    render(
+      <ScreenshotsPage
+        facet={screenshots}
+        screenshotConfig={{ Screens: 4, ToneMap: false }}
+        updateScreenshotConfigValue={vi.fn()}
+        loadSettings={vi.fn()}
+        settingsLoading={false}
+        settingsDirty={false}
+        settingsSaved=""
+        settingsError=""
+        applyScreenshotSettings={vi.fn()}
+        setLightboxImage={vi.fn()}
+        setLightboxAlt={vi.fn()}
+      />,
+    );
+
+    const preview = screen.getByRole("heading", { name: "Live Preview" }).closest("section");
+    if (!preview) throw new Error("live preview missing");
+    fireEvent.change(within(preview).getByLabelText("Seconds"), { target: { value: "37.5" } });
+    fireEvent.click(within(preview).getByRole("button", { name: "Capture preview" }));
+
+    expect(screenshots.generate).toHaveBeenCalledWith("final", [
+      { Index: 4, TimestampSeconds: 37.5, Frame: 900, Source: "manual" },
+    ]);
   });
 
   it("excludes DVD menus and hosted menu variants from normal screenshot counts", () => {

--- a/webui/src/pages/screenshots/index.tsx
+++ b/webui/src/pages/screenshots/index.tsx
@@ -20,7 +20,7 @@ type Props = Readonly<{
   setLightboxAlt: (value: string) => void;
 }>;
 
-/** Presents screenshot planning, generation, ordering, preview, and final selection. */
+/** Presents screenshot planning, live previews, retained capture, ordering, and final selection. */
 export default function ScreenshotsPage({
   facet,
   screenshotConfig,
@@ -88,22 +88,19 @@ export default function ScreenshotsPage({
   };
 
   const captureLivePreview = () => {
-    if (selections.length === 0) return;
-
-    const closest = selections.reduce<ScreenshotSelection | null>((current, selection) => {
-      if (!current) return selection;
-      return Math.abs(selection.TimestampSeconds - livePreviewSeconds) <
-        Math.abs(current.TimestampSeconds - livePreviewSeconds)
-        ? selection
-        : current;
-    }, null);
+    const nextIndex =
+      Math.max(
+        -1,
+        ...selections.map((selection) => selection.Index),
+        ...workflowImages.map((artifact) => artifact.index ?? -1),
+      ) + 1;
     const selection: ScreenshotSelection = {
-      Index: closest?.Index ?? 0,
+      Index: nextIndex,
       TimestampSeconds: clampPreviewSeconds(livePreviewSeconds),
       Frame: livePreviewFrame,
       Source: "manual",
     };
-    void facet.generate("preview", [selection]);
+    void facet.generate("final", [selection]);
   };
 
   return (
@@ -537,7 +534,7 @@ export default function ScreenshotsPage({
                   className="primary"
                   type="button"
                   onClick={captureLivePreview}
-                  disabled={previewTimingDisabled || busy || selections.length === 0}
+                  disabled={previewTimingDisabled || busy}
                 >
                   {busy ? "Capturing..." : "Capture preview"}
                 </button>


### PR DESCRIPTION
## Summary

- apply configured software tonemapping to HDR/DV live preview frames
- retain "Capture preview" frames as final workflow screenshot artifacts with fresh indexes
- keep incremental capture planning active until each requested screenshot index is retained

## Root cause

The live preview FFmpeg path always converted directly to RGB and skipped configured tonemapping. The capture button also used the non-authoritative preview operation; after routing it through retained capture, count-only planner idempotency incorrectly suppressed later one-frame requests.

## Validation

- `go test -race -v -timeout 20m ./internal/services/screenshots`
- `go test -race -v -timeout 20m ./internal/core`
- `go test -race -v -timeout 20m ./internal/releaseworkflow`
- `make test-frontend`
- `make lint`
- `make gofix-check-changed`
- `git diff --check`

Closes #310


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Capture a new retained screenshot directly from the live preview, even when no screenshots are currently selected.
  * New captures use the next available index and preserve their selected timestamp.
  * HDR and Dolby Vision preview frames now support configured tone mapping and desaturation settings.

* **Bug Fixes**
  * Existing retained screenshots are no longer unnecessarily recaptured when reused.
  * Selecting a new screenshot correctly triggers an additional capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->