### PR TITLE
fix(screenshots): expand black frame retry offsets

### DIFF
--- a/internal/services/screenshots/ffmpeg.go
+++ b/internal/services/screenshots/ffmpeg.go
@@ -187,7 +187,7 @@ var ffmpegFrameCorruptionIndicators = []string{
 
 // blackFrameTimestampOffsets lists relative timestamp adjustments (in seconds)
 // tried when FFmpeg produces a black image at the initial frame timestamp.
-var blackFrameTimestampOffsets = []float64{0, 1.0, 2.0, 3.0, 5.0, -1.0, -2.0}
+var blackFrameTimestampOffsets = []float64{0, 2, 4, 8, 16, 32, 64, -2, -4, -8, -16, -32, -64}
 
 // captureFrame writes one PNG frame and returns whether the successful attempt
 // used libplacebo. Libplacebo captures retry once before falling back to the

--- a/internal/services/screenshots/ffmpeg_test.go
+++ b/internal/services/screenshots/ffmpeg_test.go
@@ -200,7 +200,7 @@ func TestCaptureFrameRecoversFromBlackFrameWithTimestampOffset(t *testing.T) {
 		t.Fatal("expected non-empty output file")
 	}
 
-	wantTimestamps := []string{"1.000", "2.000"}
+	wantTimestamps := []string{"1.000", "3.000"}
 	if !slices.Equal(runner.timestamps, wantTimestamps) {
 		t.Fatalf("attempted timestamps = %v, want %v", runner.timestamps, wantTimestamps)
 	}
@@ -209,12 +209,19 @@ func TestCaptureFrameRecoversFromBlackFrameWithTimestampOffset(t *testing.T) {
 func TestCaptureFrameContinuesOffsetsAfterNoImage(t *testing.T) {
 	output := filepath.Join(t.TempDir(), "screen.png")
 	runner := &timestampSensitiveRunner{
-		blackTimestamps: map[string]struct{}{"1.000": {}},
+		blackTimestamps: map[string]struct{}{"64.000": {}},
 		noImageTimestamps: map[string]struct{}{
-			"2.000": {},
-			"3.000": {},
-			"4.000": {},
-			"6.000": {},
+			"66.000":  {},
+			"68.000":  {},
+			"72.000":  {},
+			"80.000":  {},
+			"96.000":  {},
+			"128.000": {},
+			"62.000":  {},
+			"60.000":  {},
+			"56.000":  {},
+			"48.000":  {},
+			"32.000":  {},
 		},
 		blackPayload: testPNGBytes(t, color.RGBA{A: 255}),
 		validPayload: testPNGBytes(t, color.RGBA{R: 200, A: 255}),
@@ -223,13 +230,16 @@ func TestCaptureFrameContinuesOffsetsAfterNoImage(t *testing.T) {
 	_, err := captureFrame(context.Background(), runner, "ffmpeg", captureRequest{
 		InputPath:  "example.mkv",
 		OutputPath: output,
-		Timestamp:  1,
+		Timestamp:  64,
 	}, api.NopLogger{})
 	if err != nil {
-		t.Fatalf("expected negative timestamp offset to recover after empty positive offsets, got error: %v", err)
+		t.Fatalf("expected final timestamp offset to recover after empty earlier offsets, got error: %v", err)
 	}
 
-	wantTimestamps := []string{"1.000", "2.000", "3.000", "4.000", "6.000", "0.000"}
+	wantTimestamps := []string{
+		"64.000", "66.000", "68.000", "72.000", "80.000", "96.000", "128.000",
+		"62.000", "60.000", "56.000", "48.000", "32.000", "0.000",
+	}
 	if !slices.Equal(runner.timestamps, wantTimestamps) {
 		t.Fatalf("attempted timestamps = %v, want %v", runner.timestamps, wantTimestamps)
 	}
@@ -244,16 +254,16 @@ func TestCaptureFrameValidatesBlackSourceBeforeOverlay(t *testing.T) {
 	}
 
 	_, err := captureFrame(context.Background(), runner, "ffmpeg", captureRequest{
-		InputPath:   "example.mkv",
-		OutputPath:  output,
-		Timestamp:   1,
+		InputPath:    "example.mkv",
+		OutputPath:   output,
+		Timestamp:    1,
 		FrameOverlay: true,
 	}, api.NopLogger{})
 	if err != nil {
 		t.Fatalf("expected black source frame to recover before overlay, got error: %v", err)
 	}
 
-	wantTimestamps := []string{"1.000", "2.000", "2.000"}
+	wantTimestamps := []string{"1.000", "3.000", "3.000"}
 	if !slices.Equal(runner.timestamps, wantTimestamps) {
 		t.Fatalf("attempted timestamps = %v, want %v", runner.timestamps, wantTimestamps)
 	}

--- a/internal/services/screenshots/ffmpeg_test.go
+++ b/internal/services/screenshots/ffmpeg_test.go
@@ -245,6 +245,45 @@ func TestCaptureFrameContinuesOffsetsAfterNoImage(t *testing.T) {
 	}
 }
 
+func TestCaptureFrameSkipsNegativeTimestampOffsets(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "screen.png")
+	runner := &timestampSensitiveRunner{
+		blackTimestamps: map[string]struct{}{"1.000": {}},
+		noImageTimestamps: map[string]struct{}{
+			"3.000":  {},
+			"5.000":  {},
+			"9.000":  {},
+			"17.000": {},
+			"33.000": {},
+			"65.000": {},
+		},
+		blackPayload: testPNGBytes(t, color.RGBA{A: 255}),
+	}
+
+	_, err := captureFrame(context.Background(), runner, "ffmpeg", captureRequest{
+		InputPath:  "example.mkv",
+		OutputPath: output,
+		Timestamp:  1,
+	}, api.NopLogger{})
+	if !errors.Is(err, errFFmpegNoImage) {
+		t.Fatalf("capture error = %v, want no image after all non-negative offsets", err)
+	}
+
+	wantTimestamps := []string{"1.000", "3.000", "5.000", "9.000", "17.000", "33.000", "65.000"}
+	if !slices.Equal(runner.timestamps, wantTimestamps) {
+		t.Fatalf("attempted timestamps = %v, want %v", runner.timestamps, wantTimestamps)
+	}
+	for _, timestamp := range runner.timestamps {
+		value, parseErr := strconv.ParseFloat(timestamp, 64)
+		if parseErr != nil {
+			t.Fatalf("parse attempted timestamp %q: %v", timestamp, parseErr)
+		}
+		if value < 0 {
+			t.Fatalf("runner received negative timestamp %q", timestamp)
+		}
+	}
+}
+
 func TestCaptureFrameValidatesBlackSourceBeforeOverlay(t *testing.T) {
 	output := filepath.Join(t.TempDir(), "screen.png")
 	runner := &timestampSensitiveRunner{


### PR DESCRIPTION
## Summary

- Retry black FFmpeg frames at ±2, ±4, ±8, ±16, ±32, and ±64 seconds.
- Keep positive offsets first and skip candidates before timestamp zero.
- Update regression coverage for recovery, full retry order, and overlay validation.

## Why

The previous retry window could remain inside an extended black segment. Wider exponential offsets sample farther from the requested frame without changing successful first-attempt captures.

Black-frame captures can recover from longer title cards or fades. Persistently unusable frames may require more FFmpeg attempts.

## Testing

- `go test -race -v -timeout 20m ./internal/services/screenshots`
- `make lint`
- `make logpolicy`
- `make gofix-check-changed`
- pre-commit and pre-push hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot recovery when captured frames are black or contain no image.
  * Added retries across a wider range of forward and backward timestamps.
  * Improved reliability when recovering screenshots near difficult or invalid timestamps.
  * Prevented retries at invalid negative timestamps when no suitable image is available.
  * Expanded recovery coverage for screenshots affected by overlays, black frames, or missing image content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->