### PR TITLE
fix: allow live uploads after waivable rule approval

### DIFF
--- a/ADDING_TRACKERS.md
+++ b/ADDING_TRACKERS.md
@@ -403,8 +403,12 @@ family policy.
 Choose dispositions deliberately:
 
 - `advisory` records a decision but never blocks;
-- `waivable` blocks normal execution and is reported as bypassed only in debug mode;
+- `waivable` requires exact user authorization, then permits normal live execution; debug mode bypasses it automatically;
 - `strict` blocks in every execution mode.
+
+The workflow emits one tracker-scoped authorization action for the exact current set of waivable
+failures. A changed failure set invalidates that authority and requires a new confirmation. Strict
+failures never emit an authorization action and cannot be overridden.
 
 Every constructibility predicate whose result depends on a required mapping or resource, including
 a missing resolution, category, type, questionnaire answer, or prepared media fact, must be

--- a/cmd/upbrr/composite_upload_test.go
+++ b/cmd/upbrr/composite_upload_test.go
@@ -369,6 +369,48 @@ func TestCLICompositeTrackerFeedbackConfirmsOrEditsReleaseName(t *testing.T) {
 	}
 }
 
+func TestCLICompositeRuleAuthorizationHonorsInteractionMode(t *testing.T) {
+	action := api.RequiredAction{
+		ID:               "action-waive-rules",
+		Kind:             api.RequiredActionAuthorizeRules,
+		WorkflowRevision: 4,
+		Prompt:           "EXAMPLE has waivable rule failures. Continue with this tracker?",
+	}
+	session := &cliWorkflowSession{
+		intent: cliWorkflowIntent{interaction: api.InteractionModeUnattendedConfirm},
+	}
+	var (
+		feedback api.ReleaseWorkflowUploadFeedback
+		declined bool
+		err      error
+	)
+	captureStdout(t, func() {
+		feedback, declined, err = session.collectCompositeUploadFeedback(
+			context.Background(),
+			bufio.NewReader(strings.NewReader("y\n")),
+			config.Config{},
+			api.NopLogger{},
+			action,
+		)
+	})
+	if err != nil || declined ||
+		feedback.Response.Kind != api.ReleaseWorkflowUploadFeedbackRuleAuthorization ||
+		feedback.Response.RuleAuthorization == nil || !feedback.Response.RuleAuthorization.Confirmed {
+		t.Fatalf("rule authorization feedback = %#v declined=%t err=%v", feedback, declined, err)
+	}
+
+	session.intent.interaction = api.InteractionModeUnattended
+	if _, _, err := session.collectCompositeUploadFeedback(
+		context.Background(),
+		nil,
+		config.Config{},
+		api.NopLogger{},
+		action,
+	); err == nil || !strings.Contains(err.Error(), "strict unattended upload requires global action") {
+		t.Fatalf("strict unattended rule authorization error = %v", err)
+	}
+}
+
 func TestCLICompositeDuplicateReviewPrintsMatchesAndSeparatesTrackers(t *testing.T) {
 	session := &cliWorkflowSession{
 		current: releaseworkflow.CommandResult{

--- a/cmd/workflowcontractgen/main.go
+++ b/cmd/workflowcontractgen/main.go
@@ -1218,9 +1218,8 @@ func (b *schemaBuilder) definition(value reflect.Type) *schema {
 					Type:                 "object",
 					AdditionalProperties: stringOrNull(),
 				},
-				"trackerConfig":             b.inline(reflect.TypeFor[api.TrackerConfigOverrides]()),
-				"trackerSite":               b.inline(reflect.TypeFor[api.TrackerSiteOverrides]()),
-				"authorizedRuleFingerprint": b.inline(reflect.TypeFor[api.WorkflowFingerprint]()),
+				"trackerConfig": b.inline(reflect.TypeFor[api.TrackerConfigOverrides]()),
+				"trackerSite":   b.inline(reflect.TypeFor[api.TrackerSiteOverrides]()),
 			},
 		}
 	}

--- a/cmd/workflowcontractgen/main.go
+++ b/cmd/workflowcontractgen/main.go
@@ -1218,8 +1218,9 @@ func (b *schemaBuilder) definition(value reflect.Type) *schema {
 					Type:                 "object",
 					AdditionalProperties: stringOrNull(),
 				},
-				"trackerConfig": b.inline(reflect.TypeFor[api.TrackerConfigOverrides]()),
-				"trackerSite":   b.inline(reflect.TypeFor[api.TrackerSiteOverrides]()),
+				"trackerConfig":             b.inline(reflect.TypeFor[api.TrackerConfigOverrides]()),
+				"trackerSite":               b.inline(reflect.TypeFor[api.TrackerSiteOverrides]()),
+				"authorizedRuleFingerprint": b.inline(reflect.TypeFor[api.WorkflowFingerprint]()),
 			},
 		}
 	}

--- a/cmd/workflowcontractgen/main_test.go
+++ b/cmd/workflowcontractgen/main_test.go
@@ -34,9 +34,8 @@ func TestTrackerProjectionInstructionsSchemaPreservesTriStateFields(t *testing.T
 			t.Fatalf("%s schema = %#v", field, property)
 		}
 	}
-	authorization := definition.Properties["authorizedRuleFingerprint"]
-	if authorization == nil || renderTypeScript(authorization, 0) != "WorkflowFingerprint" {
-		t.Fatalf("rule authorization schema = %#v", authorization)
+	if _, exists := definition.Properties["authorizedRuleFingerprint"]; exists {
+		t.Fatal("projection instructions expose server rule authorization")
 	}
 }
 

--- a/cmd/workflowcontractgen/main_test.go
+++ b/cmd/workflowcontractgen/main_test.go
@@ -34,6 +34,10 @@ func TestTrackerProjectionInstructionsSchemaPreservesTriStateFields(t *testing.T
 			t.Fatalf("%s schema = %#v", field, property)
 		}
 	}
+	authorization := definition.Properties["authorizedRuleFingerprint"]
+	if authorization == nil || renderTypeScript(authorization, 0) != "WorkflowFingerprint" {
+		t.Fatalf("rule authorization schema = %#v", authorization)
+	}
 }
 
 func TestWorkflowPatchStringSchemaPreservesAbsentNullAndString(t *testing.T) {

--- a/internal/core/workflow_preflight.go
+++ b/internal/core/workflow_preflight.go
@@ -105,12 +105,20 @@ func (b workflowPreflightBuilder) Build(
 				)
 			}
 			projection.PreparedResourceFingerprint = checkedFingerprint
-			trackers.ApplyProjectionRuleFailures(
+			authorizedFingerprint := projection.RuleAuthorizationFingerprint
+			if err := trackers.ApplyProjectionRuleFailures(
 				projection,
-				newProjectionRuleFailures(*projection, failures),
+				failures,
 				executionMode,
+				authorizedFingerprint,
 				b.logger,
-			)
+			); err != nil {
+				return api.TrackerPreflightAssessment{}, nil, fmt.Errorf(
+					"tracker preflight: apply local resource rules for %s: %w",
+					projection.TrackerID,
+					err,
+				)
+			}
 		}
 	}
 	descriptorByID := make(map[api.TrackerID]api.TrackerCatalogDescriptor, len(catalog.Trackers))
@@ -470,21 +478,6 @@ func subjectWithAvailablePreparedResources(subject api.UploadSubject) (api.Uploa
 		changed = true
 	}
 	return checked, changed, nil
-}
-
-func newProjectionRuleFailures(projection api.TrackerReleaseProjection, failures []api.RuleFailure) []api.RuleFailure {
-	existing := make(map[string]struct{}, len(projection.PolicyDecisions))
-	for _, decision := range projection.PolicyDecisions {
-		existing[strings.TrimSpace(decision.Code)] = struct{}{}
-	}
-	result := make([]api.RuleFailure, 0, len(failures))
-	for _, failure := range failures {
-		if _, ok := existing[strings.TrimSpace(failure.Rule)]; ok {
-			continue
-		}
-		result = append(result, failure)
-	}
-	return result
 }
 
 func appendBypassedRuntimeDecision(projection *api.TrackerReleaseProjection, code string, message string) {

--- a/internal/core/workflow_preflight.go
+++ b/internal/core/workflow_preflight.go
@@ -82,6 +82,9 @@ func (b workflowPreflightBuilder) Build(
 		initial.Projections = append([]api.TrackerReleaseProjection(nil), initial.Projections...)
 		for index := range initial.Projections {
 			projection := &initial.Projections[index]
+			projection.PolicyDecisions = slices.Clone(projection.PolicyDecisions)
+			projection.RequiredActions = slices.Clone(projection.RequiredActions)
+			projection.Failures = slices.Clone(projection.Failures)
 			if projection.Readiness != api.ReadinessStatusReady || !projection.DupeReady {
 				continue
 			}

--- a/internal/core/workflow_preflight_test.go
+++ b/internal/core/workflow_preflight_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"syscall"
@@ -698,7 +699,28 @@ func TestWorkflowPreflightRejectsMissingPreparedResourceBeforeAuth(t *testing.T)
 		Readiness:                   api.ReadinessStatusReady,
 		DupeReady:                   true,
 		UploadReady:                 true,
+		PolicyDecisions: []api.TrackerPolicyDecision{
+			{Code: "previous_rule", Disposition: api.RuleDispositionWaivable},
+			{Code: "retained_decision", Decision: "allowed"},
+		},
+		RequiredActions: []api.RequiredAction{
+			{Kind: api.RequiredActionAuthorizeRules, TrackerID: "RESOURCE"},
+			{Kind: api.RequiredActionReviewDuplicates, TrackerID: "RESOURCE"},
+		},
+		Failures: []api.WorkflowFailure{
+			{
+				Failure:   api.OperationFailure{Code: api.OperationFailureNoEligibleTrackers, Operation: api.OperationKindDuplicateCheck},
+				TrackerID: "RESOURCE",
+			},
+			{
+				Failure:   api.OperationFailure{Code: api.OperationFailureMissingPrerequisite, Operation: api.OperationKindPreparation},
+				TrackerID: "RESOURCE",
+			},
+		},
 	}
+	originalDecisions := slices.Clone(projection.PolicyDecisions)
+	originalActions := slices.Clone(projection.RequiredActions)
+	originalFailures := slices.Clone(projection.Failures)
 	capabilityCalls := 0
 	validateCalls := 0
 	builder := workflowPreflightBuilder{
@@ -736,6 +758,11 @@ func TestWorkflowPreflightRejectsMissingPreparedResourceBeforeAuth(t *testing.T)
 		return decision.Code == "required_media_resource" && decision.Blocking
 	}) {
 		t.Fatalf("missing local-resource decision: %#v", finalized[0].PolicyDecisions)
+	}
+	if !reflect.DeepEqual(projection.PolicyDecisions, originalDecisions) ||
+		!reflect.DeepEqual(projection.RequiredActions, originalActions) ||
+		!reflect.DeepEqual(projection.Failures, originalFailures) {
+		t.Fatalf("input projection mutated: %#v", projection)
 	}
 }
 

--- a/internal/core/workflow_preflight_test.go
+++ b/internal/core/workflow_preflight_test.go
@@ -718,9 +718,15 @@ func TestWorkflowPreflightRejectsMissingPreparedResourceBeforeAuth(t *testing.T)
 			},
 		},
 	}
-	originalDecisions := slices.Clone(projection.PolicyDecisions)
-	originalActions := slices.Clone(projection.RequiredActions)
-	originalFailures := slices.Clone(projection.Failures)
+	projectionSet := api.TrackerReleaseProjectionSet{
+		ID:          "projection-set-resource",
+		Revision:    1,
+		Projections: []api.TrackerReleaseProjection{projection},
+	}
+	originalProjectionSet, err := projectionSet.Clone()
+	if err != nil {
+		t.Fatalf("clone input projection set: %v", err)
+	}
 	capabilityCalls := 0
 	validateCalls := 0
 	builder := workflowPreflightBuilder{
@@ -737,11 +743,7 @@ func TestWorkflowPreflightRejectsMissingPreparedResourceBeforeAuth(t *testing.T)
 		subject,
 		api.TrackerCatalogSnapshot{Trackers: []api.TrackerCatalogDescriptor{{TrackerID: "RESOURCE"}}},
 		api.TrackerRuntimeSnapshot{Fingerprint: fingerprint("runtime")},
-		api.TrackerReleaseProjectionSet{
-			ID:          "projection-set-resource",
-			Revision:    1,
-			Projections: []api.TrackerReleaseProjection{projection},
-		},
+		projectionSet,
 		time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC),
 	)
 	if err != nil {
@@ -759,10 +761,8 @@ func TestWorkflowPreflightRejectsMissingPreparedResourceBeforeAuth(t *testing.T)
 	}) {
 		t.Fatalf("missing local-resource decision: %#v", finalized[0].PolicyDecisions)
 	}
-	if !reflect.DeepEqual(projection.PolicyDecisions, originalDecisions) ||
-		!reflect.DeepEqual(projection.RequiredActions, originalActions) ||
-		!reflect.DeepEqual(projection.Failures, originalFailures) {
-		t.Fatalf("input projection mutated: %#v", projection)
+	if !reflect.DeepEqual(projectionSet, originalProjectionSet) {
+		t.Fatalf("input projection set mutated: got=%#v want=%#v", projectionSet, originalProjectionSet)
 	}
 }
 

--- a/internal/releaseworkflow/composite_upload_test.go
+++ b/internal/releaseworkflow/composite_upload_test.go
@@ -603,7 +603,8 @@ func newCompositeUploadTestModuleWithWaiver(
 		_ api.ReleaseSnapshot,
 		_ api.UploadSubject,
 		trackerIDs []api.TrackerID,
-		instructions map[api.TrackerID]api.TrackerProjectionInstructions,
+		_ map[api.TrackerID]api.TrackerProjectionInstructions,
+		ruleAuthorizations map[api.TrackerID]api.WorkflowFingerprint,
 		executionMode api.WorkflowExecutionMode,
 	) (
 		api.TrackerCatalogSnapshot,
@@ -637,10 +638,9 @@ func newCompositeUploadTestModuleWithWaiver(
 					Message:     "language waiver required",
 					Disposition: api.RuleDispositionWaivable,
 				}}
-				if instructions[trackerID].AuthorizedRuleFingerprint == waivableFingerprint {
+				if ruleAuthorizations[trackerID] == waivableFingerprint {
 					projection.RuleAuthorizationFingerprint = waivableFingerprint
 					projection.PolicyDecisions[0].Decision = "authorized"
-					projection.PolicyDecisions[0].Authorized = true
 					projectionInput = "composite-projection-input-authorized"
 				} else {
 					projection.Readiness = api.ReadinessStatusBlocked

--- a/internal/releaseworkflow/composite_upload_test.go
+++ b/internal/releaseworkflow/composite_upload_test.go
@@ -176,6 +176,80 @@ func TestCompositeUploadConfirmFeedbackResumesWithServerApproval(t *testing.T) {
 	}
 }
 
+func TestCompositeUploadRuleAuthorizationResumesLiveUpload(t *testing.T) {
+	t.Parallel()
+
+	module, _, uploads := newCompositeUploadWaiverTestModule(t)
+	request := compositeUploadTestRequest(true, api.ReleaseWorkflowUploadModeUpload, "composite-rule-authorization")
+	started, err := module.StartUpload(context.Background(), testOwnerID, request)
+	if err != nil {
+		t.Fatalf("start composite upload: %v", err)
+	}
+	blocked := waitCompositeUploadTestOperation(t, module, started)
+	actionIndex := slices.IndexFunc(blocked.Continuation.RequiredActions, func(action api.RequiredAction) bool {
+		return action.Kind == api.RequiredActionAuthorizeRules && action.TrackerID == "ALPHA" &&
+			action.Status == api.RequiredActionStatusPending
+	})
+	if actionIndex < 0 || blocked.UploadResult != nil || uploads.execution != nil {
+		t.Fatalf("waivable-rule stop = %#v execution=%#v", blocked, uploads.execution)
+	}
+	action := blocked.Continuation.RequiredActions[actionIndex]
+	resumed, err := module.SubmitUploadFeedback(context.Background(), testOwnerID, blocked.Workflow.ID, api.ReleaseWorkflowUploadFeedback{
+		Action: api.ReleaseWorkflowUploadActionIdentity{
+			ID:               action.ID,
+			WorkflowRevision: blocked.Workflow.Revision,
+		},
+		Response: api.ReleaseWorkflowUploadFeedbackResponse{
+			Kind: api.ReleaseWorkflowUploadFeedbackRuleAuthorization,
+			RuleAuthorization: &api.ReleaseWorkflowUploadConfirmation{
+				Confirmed: true,
+			},
+		},
+		IdempotencyKey: "authorize-composite-rules",
+	})
+	if err != nil {
+		t.Fatalf("submit composite rule authorization: %v", err)
+	}
+	review := waitCompositeUploadTestOperation(t, module, resumed)
+	projectionIndex := slices.IndexFunc(review.Projections.Projections, func(projection api.TrackerReleaseProjection) bool {
+		return projection.TrackerID == "ALPHA"
+	})
+	if projectionIndex < 0 || review.Projections.Projections[projectionIndex].RuleAuthorizationFingerprint == "" ||
+		!review.Projections.Projections[projectionIndex].UploadReady {
+		t.Fatalf("authorized composite projection = %#v", review.Projections)
+	}
+	completed := approveCompositeUploadTrackers(
+		t,
+		module,
+		review,
+		[]api.TrackerID{"ALPHA", "BETA"},
+		"approve-authorized-trackers",
+	)
+	if completed.UploadResult == nil || completed.Operation == nil ||
+		completed.Operation.Status != api.StageStatusExecuted || uploads.execution == nil || uploads.execution.executions != 1 {
+		t.Fatalf("authorized composite upload = %#v execution=%#v", completed, uploads.execution)
+	}
+}
+
+func TestCompositeUploadStrictUnattendedSkipsWaivableTracker(t *testing.T) {
+	t.Parallel()
+
+	module, _, uploads := newCompositeUploadWaiverTestModule(t)
+	request := compositeUploadTestRequest(false, api.ReleaseWorkflowUploadModeUpload, "composite-skip-waivable")
+	started, err := module.StartUpload(context.Background(), testOwnerID, request)
+	if err != nil {
+		t.Fatalf("start composite upload: %v", err)
+	}
+	blocked := waitCompositeUploadTestOperation(t, module, started)
+	action := pendingCompositeTrackerApproval(t, blocked)
+	if len(action.Options) != 1 || action.Options[0].Value != "BETA" || uploads.execution != nil ||
+		slices.ContainsFunc(blocked.Continuation.RequiredActions, func(action api.RequiredAction) bool {
+			return action.Kind == api.RequiredActionAuthorizeRules
+		}) {
+		t.Fatalf("strict unattended waiver handling = %#v execution=%#v", blocked, uploads.execution)
+	}
+}
+
 func TestMergeCompositeProjectionDefaultsPreservesTrackerSpecificValues(t *testing.T) {
 	t.Parallel()
 
@@ -510,13 +584,26 @@ func compositeUploadTestRequest(
 func newCompositeUploadTestModule(
 	t *testing.T,
 ) (*Module, *MemoryRepository, *uploadPlanBuilderFake) {
+	return newCompositeUploadTestModuleWithWaiver(t, false)
+}
+
+func newCompositeUploadWaiverTestModule(
+	t *testing.T,
+) (*Module, *MemoryRepository, *uploadPlanBuilderFake) {
+	return newCompositeUploadTestModuleWithWaiver(t, true)
+}
+
+func newCompositeUploadTestModuleWithWaiver(
+	t *testing.T,
+	waivableRules bool,
+) (*Module, *MemoryRepository, *uploadPlanBuilderFake) {
 	t.Helper()
 	projections := trackerProjectionBuilderFunc(func(
 		_ context.Context,
 		_ api.ReleaseSnapshot,
 		_ api.UploadSubject,
 		trackerIDs []api.TrackerID,
-		_ map[api.TrackerID]api.TrackerProjectionInstructions,
+		instructions map[api.TrackerID]api.TrackerProjectionInstructions,
 		executionMode api.WorkflowExecutionMode,
 	) (
 		api.TrackerCatalogSnapshot,
@@ -537,17 +624,47 @@ func newCompositeUploadTestModule(
 			return !slices.Contains(trackerIDs, entry.TrackerID)
 		})
 		projected := make([]api.TrackerReleaseProjection, 0, len(trackerIDs))
+		actions := make([]api.RequiredAction, 0, 1)
+		projectionInput := "composite-projection-input"
 		for _, trackerID := range trackerIDs {
 			projection := testProjection(t, trackerID, "Example.Release.2026."+string(trackerID)+"-GRP")
 			projection.DescriptionGroup = "alpha"
+			if waivableRules && trackerID == "ALPHA" {
+				waivableFingerprint := testFingerprint(t, "composite-waivable-rules")
+				projection.WaivableRuleFingerprint = waivableFingerprint
+				projection.PolicyDecisions = []api.TrackerPolicyDecision{{
+					Code:        "language_rule",
+					Message:     "language waiver required",
+					Disposition: api.RuleDispositionWaivable,
+				}}
+				if instructions[trackerID].AuthorizedRuleFingerprint == waivableFingerprint {
+					projection.RuleAuthorizationFingerprint = waivableFingerprint
+					projection.PolicyDecisions[0].Decision = "authorized"
+					projection.PolicyDecisions[0].Authorized = true
+					projectionInput = "composite-projection-input-authorized"
+				} else {
+					projection.Readiness = api.ReadinessStatusBlocked
+					projection.DupeReady = false
+					projection.UploadReady = false
+					projection.PolicyDecisions[0].Decision = "authorization_required"
+					projection.PolicyDecisions[0].Blocking = true
+					projection.RequiredActions = []api.RequiredAction{{
+						Kind:   api.RequiredActionAuthorizeRules,
+						Prompt: "Alpha has waivable language rules. Continue with this tracker?",
+					}}
+					actions = append(actions, projection.RequiredActions...)
+					projectionInput = "composite-projection-input-pending"
+				}
+			}
 			projected = append(projected, projection)
 		}
 		return catalog, runtime, api.TrackerSelection{TrackerIDs: trackerIDs}, api.TrackerReleaseProjectionSet{
-			InputFingerprint:  testFingerprint(t, "composite-projection-input"),
+			InputFingerprint:  testFingerprint(t, projectionInput),
 			PolicyFingerprint: testFingerprint(t, "composite-projection-policy"),
 			ExecutionMode:     executionMode,
 			Projections:       projected,
 			Status:            api.StageStatusReady,
+			RequiredActions:   actions,
 		}, nil
 	})
 	dupes := dupeAssessmentBuilderFunc(func(

--- a/internal/releaseworkflow/contracts.go
+++ b/internal/releaseworkflow/contracts.go
@@ -144,7 +144,10 @@ func (f ReleasePreparerFunc) ResolveDuplicateSubject(ctx context.Context, input 
 	return f.DuplicateFunc(ctx, input)
 }
 
-// TrackerProjectionBuilder hides catalog/config resolution and tracker-local projection semantics.
+// TrackerProjectionBuilder hides catalog/config resolution and tracker-local
+// projection semantics. Rule authorization inputs are tracker-scoped,
+// server-held fingerprints that implementations accept only for an identical
+// freshly evaluated waivable-failure set.
 type TrackerProjectionBuilder interface {
 	Build(
 		context.Context,
@@ -152,6 +155,7 @@ type TrackerProjectionBuilder interface {
 		api.UploadSubject,
 		[]api.TrackerID,
 		map[api.TrackerID]api.TrackerProjectionInstructions,
+		map[api.TrackerID]api.WorkflowFingerprint,
 		api.WorkflowExecutionMode,
 	) (
 		api.TrackerCatalogSnapshot,

--- a/internal/releaseworkflow/module.go
+++ b/internal/releaseworkflow/module.go
@@ -3193,11 +3193,6 @@ func (m *Module) projectTrackersWithRuleAuthorizations(
 	if !ok || release.Revision != state.Workflow.Release.Revision {
 		return CommandResult{}, fmt.Errorf("%w: release snapshot is unavailable", ErrInvalidTransition)
 	}
-	instructions, err := trustedProjectionInstructions(command.Instructions, authorizations)
-	if err != nil {
-		return CommandResult{}, fmt.Errorf("release workflow projection instructions: %w", err)
-	}
-	command.Instructions = instructions
 	trackerNames := make([]string, len(command.TrackerIDs))
 	for index, trackerID := range command.TrackerIDs {
 		trackerNames[index] = string(trackerID)
@@ -3218,6 +3213,7 @@ func (m *Module) projectTrackersWithRuleAuthorizations(
 		subject,
 		command.TrackerIDs,
 		command.Instructions,
+		authorizations,
 		command.ExecutionMode,
 	)
 	if err != nil {

--- a/internal/releaseworkflow/module.go
+++ b/internal/releaseworkflow/module.go
@@ -3171,6 +3171,18 @@ func (m *Module) projectTrackers(
 	now time.Time,
 	command ProjectTrackersCommand,
 ) (CommandResult, error) {
+	return m.projectTrackersWithRuleAuthorizations(ctx, ownerID, state, nextRevision, now, command, nil)
+}
+
+func (m *Module) projectTrackersWithRuleAuthorizations(
+	ctx context.Context,
+	ownerID string,
+	state *State,
+	nextRevision api.WorkflowRevision,
+	now time.Time,
+	command ProjectTrackersCommand,
+	authorizations map[api.TrackerID]api.WorkflowFingerprint,
+) (CommandResult, error) {
 	if m.trackerProjector == nil {
 		return CommandResult{}, fmt.Errorf("%w: tracker projection builder is unavailable", ErrInvalidTransition)
 	}
@@ -3181,6 +3193,11 @@ func (m *Module) projectTrackers(
 	if !ok || release.Revision != state.Workflow.Release.Revision {
 		return CommandResult{}, fmt.Errorf("%w: release snapshot is unavailable", ErrInvalidTransition)
 	}
+	instructions, err := trustedProjectionInstructions(command.Instructions, authorizations)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("release workflow projection instructions: %w", err)
+	}
+	command.Instructions = instructions
 	trackerNames := make([]string, len(command.TrackerIDs))
 	for index, trackerID := range command.TrackerIDs {
 		trackerNames[index] = string(trackerID)
@@ -6348,6 +6365,9 @@ func (m *Module) resolveAction(
 	}
 	if action, ok := releaseNameConfirmationAction(currentProjections, command.Answer.ActionID); ok {
 		return m.reviewTrackerReleaseName(ctx, ownerID, state, nextRevision, now, action, command.Answer)
+	}
+	if projection, action, ok := projectionRuleAuthorizationAction(currentProjections, command.Answer.ActionID); ok {
+		return m.authorizeTrackerRules(ctx, ownerID, state, nextRevision, now, projection, action, command.Answer)
 	}
 	index := slices.IndexFunc(state.Workflow.RequiredActions, func(action api.RequiredAction) bool {
 		return action.ID == command.Answer.ActionID && action.Status == api.RequiredActionStatusPending

--- a/internal/releaseworkflow/module_test.go
+++ b/internal/releaseworkflow/module_test.go
@@ -3789,6 +3789,13 @@ func TestTrustedProjectionInstructionsOnlyAcceptsServerRuleAuthority(t *testing.
 	if trusted["ALPHA"].AuthorizedRuleFingerprint != fingerprint {
 		t.Fatalf("trusted rule authority = %#v", trusted)
 	}
+	duplicateTrackerID := api.TrackerID(" alpha ")
+	if _, err := trustedProjectionInstructions(map[api.TrackerID]api.TrackerProjectionInstructions{
+		"ALPHA":            {},
+		duplicateTrackerID: {},
+	}, nil); err == nil {
+		t.Fatal("expected duplicate normalized tracker instructions to be rejected")
+	}
 }
 
 func TestResolveProjectionRuleAuthorizationReprojectsWithExactServerAuthority(t *testing.T) {
@@ -3849,7 +3856,7 @@ func TestResolveProjectionRuleAuthorizationReprojectsWithExactServerAuthority(t 
 	result = executeCommand(t, module, PrepareReleaseCommand{
 		WorkflowID:       result.Workflow.ID,
 		ExpectedRevision: result.Workflow.Revision,
-		Input:            api.PrepareInput{SourcePath: "C:\\releases\\Example.Release.2026.1080p-GRP"},
+		Input:            api.PrepareInput{SourcePath: "Example.Release.2026.1080p-GRP"},
 	})
 	result = executeCommand(t, module, ProjectTrackersCommand{
 		WorkflowID:       result.Workflow.ID,

--- a/internal/releaseworkflow/module_test.go
+++ b/internal/releaseworkflow/module_test.go
@@ -208,6 +208,7 @@ type trackerProjectionBuilderFunc func(
 	api.UploadSubject,
 	[]api.TrackerID,
 	map[api.TrackerID]api.TrackerProjectionInstructions,
+	map[api.TrackerID]api.WorkflowFingerprint,
 	api.WorkflowExecutionMode,
 ) (
 	api.TrackerCatalogSnapshot,
@@ -223,6 +224,7 @@ func (f trackerProjectionBuilderFunc) Build(
 	subject api.UploadSubject,
 	trackerIDs []api.TrackerID,
 	instructions map[api.TrackerID]api.TrackerProjectionInstructions,
+	ruleAuthorizations map[api.TrackerID]api.WorkflowFingerprint,
 	executionMode api.WorkflowExecutionMode,
 ) (
 	api.TrackerCatalogSnapshot,
@@ -231,7 +233,7 @@ func (f trackerProjectionBuilderFunc) Build(
 	api.TrackerReleaseProjectionSet,
 	error,
 ) {
-	return f(ctx, release, subject, trackerIDs, instructions, executionMode)
+	return f(ctx, release, subject, trackerIDs, instructions, ruleAuthorizations, executionMode)
 }
 
 type trackerPreflightBuilderFunc func(
@@ -1049,6 +1051,7 @@ func TestModuleProjectTrackersOwnsCatalogRuntimeSelectionAndProjectionLineage(t 
 		subject api.UploadSubject,
 		trackerIDs []api.TrackerID,
 		_ map[api.TrackerID]api.TrackerProjectionInstructions,
+		_ map[api.TrackerID]api.WorkflowFingerprint,
 		_ api.WorkflowExecutionMode,
 	) (
 		api.TrackerCatalogSnapshot,
@@ -1104,12 +1107,15 @@ func TestModuleReviewsTrackerReleaseNameWithoutRepeatingDupeSearch(t *testing.T)
 	if err != nil {
 		t.Fatalf("fingerprint review catalog: %v", err)
 	}
+	waivableFingerprint := testFingerprint(t, "name-review-waivable-rules")
+	var reviewedRuleAuthorization api.WorkflowFingerprint
 	projector := trackerProjectionBuilderFunc(func(
 		_ context.Context,
 		_ api.ReleaseSnapshot,
 		_ api.UploadSubject,
 		trackerIDs []api.TrackerID,
 		instructions map[api.TrackerID]api.TrackerProjectionInstructions,
+		ruleAuthorizations map[api.TrackerID]api.WorkflowFingerprint,
 		_ api.WorkflowExecutionMode,
 	) (
 		api.TrackerCatalogSnapshot,
@@ -1119,11 +1125,16 @@ func TestModuleReviewsTrackerReleaseNameWithoutRepeatingDupeSearch(t *testing.T)
 		error,
 	) {
 		projection := testProjection(t, "ALPHA", automaticName)
-		projection.PolicyDecisions = []api.TrackerPolicyDecision{{
-			Code:     releaseNameConfirmationDecisionCode,
-			Decision: "confirmation_required",
-			Blocking: false,
-		}}
+		projection.WaivableRuleFingerprint = waivableFingerprint
+		projection.RuleAuthorizationFingerprint = waivableFingerprint
+		projection.PolicyDecisions = []api.TrackerPolicyDecision{
+			{
+				Code:        "language_rule",
+				Decision:    "authorized",
+				Disposition: api.RuleDispositionWaivable,
+			},
+			{Code: releaseNameConfirmationDecisionCode, Decision: "confirmation_required"},
+		}
 		projection.RequiredActions = []api.RequiredAction{{
 			Kind:           api.RequiredActionProvideTrackerInput,
 			TrackerID:      "ALPHA",
@@ -1134,17 +1145,21 @@ func TestModuleReviewsTrackerReleaseNameWithoutRepeatingDupeSearch(t *testing.T)
 		inputFingerprint := testFingerprint(t, "name-review-automatic")
 		policyFingerprint := testFingerprint(t, "name-review-policy-automatic")
 		if instruction := instructions["ALPHA"]; instruction.UploadReleaseName.Present {
+			reviewedRuleAuthorization = ruleAuthorizations["ALPHA"]
 			projection.UploadReleaseName = instruction.UploadReleaseName.Value
 			projection.AdditionalNames = []api.TrackerReleaseName{{
 				Role:  api.TrackerReleaseNameRoleSearch,
 				Value: automaticName,
 			}}
 			projection.ProjectorFingerprint = testFingerprint(t, "ALPHA-projector-reviewed")
-			projection.PolicyDecisions = []api.TrackerPolicyDecision{{
-				Code:     releaseNameConfirmationDecisionCode,
-				Decision: "confirmed",
-				Blocking: false,
-			}}
+			projection.PolicyDecisions = []api.TrackerPolicyDecision{
+				{
+					Code:        "language_rule",
+					Decision:    "authorized",
+					Disposition: api.RuleDispositionWaivable,
+				},
+				{Code: releaseNameConfirmationDecisionCode, Decision: "confirmed"},
+			}
 			projection.RequiredActions = nil
 			projection.UploadReady = true
 			inputFingerprint = testFingerprint(t, "name-review-reviewed")
@@ -1297,6 +1312,7 @@ func TestModuleReviewsTrackerReleaseNameWithoutRepeatingDupeSearch(t *testing.T)
 		IdempotencyKey: "review-tracker-name",
 	})
 	if dupeChecks != 1 || result.Projections == nil || result.Dupes == nil ||
+		reviewedRuleAuthorization != waivableFingerprint ||
 		result.Projections.Projections[0].UploadReleaseName != reviewedName ||
 		result.Projections.Projections[0].DuplicateCriteria.Name != automaticName ||
 		result.Dupes.Results[0].UploadReleaseName != reviewedName ||
@@ -3766,35 +3782,31 @@ func TestResolveReconciliationRequiresExactAnswerAndForcesFreshReview(t *testing
 	}
 }
 
-func TestTrustedProjectionInstructionsOnlyAcceptsServerRuleAuthority(t *testing.T) {
+func TestProjectionRuleAuthorizationsRetainsOnlyExactAuthority(t *testing.T) {
 	t.Parallel()
 
-	fingerprint := testFingerprint(t, "trusted-rule-authority")
-	requested := map[api.TrackerID]api.TrackerProjectionInstructions{
-		"ALPHA": {AuthorizedRuleFingerprint: fingerprint},
-	}
-	sanitized, err := trustedProjectionInstructions(requested, nil)
-	if err != nil {
-		t.Fatalf("sanitize projection instructions: %v", err)
-	}
-	if sanitized["ALPHA"].AuthorizedRuleFingerprint != "" {
-		t.Fatalf("caller rule authority survived sanitization: %#v", sanitized)
-	}
-	trusted, err := trustedProjectionInstructions(requested, map[api.TrackerID]api.WorkflowFingerprint{
-		"ALPHA": fingerprint,
-	})
-	if err != nil {
-		t.Fatalf("apply trusted projection instructions: %v", err)
-	}
-	if trusted["ALPHA"].AuthorizedRuleFingerprint != fingerprint {
-		t.Fatalf("trusted rule authority = %#v", trusted)
-	}
-	duplicateTrackerID := api.TrackerID(" alpha ")
-	if _, err := trustedProjectionInstructions(map[api.TrackerID]api.TrackerProjectionInstructions{
-		"ALPHA":            {},
-		duplicateTrackerID: {},
-	}, nil); err == nil {
-		t.Fatal("expected duplicate normalized tracker instructions to be rejected")
+	fingerprint := testFingerprint(t, "retained-rule-authority")
+	secondFingerprint := testFingerprint(t, "second-retained-rule-authority")
+	authorizations := projectionRuleAuthorizations(api.TrackerReleaseProjectionSet{Projections: []api.TrackerReleaseProjection{
+		{
+			TrackerID:                    "ALPHA",
+			WaivableRuleFingerprint:      fingerprint,
+			RuleAuthorizationFingerprint: fingerprint,
+		},
+		{
+			TrackerID:                    "BETA",
+			WaivableRuleFingerprint:      secondFingerprint,
+			RuleAuthorizationFingerprint: secondFingerprint,
+		},
+		{
+			TrackerID:                    "GAMMA",
+			WaivableRuleFingerprint:      fingerprint,
+			RuleAuthorizationFingerprint: testFingerprint(t, "stale-rule-authority"),
+		},
+		{TrackerID: "DELTA", WaivableRuleFingerprint: fingerprint},
+	}})
+	if len(authorizations) != 2 || authorizations["ALPHA"] != fingerprint || authorizations["BETA"] != secondFingerprint {
+		t.Fatalf("retained rule authorizations = %#v", authorizations)
 	}
 }
 
@@ -3807,7 +3819,8 @@ func TestResolveProjectionRuleAuthorizationReprojectsWithExactServerAuthority(t 
 		_ api.ReleaseSnapshot,
 		_ api.UploadSubject,
 		trackerIDs []api.TrackerID,
-		instructions map[api.TrackerID]api.TrackerProjectionInstructions,
+		_ map[api.TrackerID]api.TrackerProjectionInstructions,
+		ruleAuthorizations map[api.TrackerID]api.WorkflowFingerprint,
 		executionMode api.WorkflowExecutionMode,
 	) (
 		api.TrackerCatalogSnapshot,
@@ -3825,10 +3838,9 @@ func TestResolveProjectionRuleAuthorizationReprojectsWithExactServerAuthority(t 
 		}}
 		status := api.StageStatusReady
 		inputFingerprint := testFingerprint(t, "authorized-rule-projection")
-		if instructions["ALPHA"].AuthorizedRuleFingerprint == waivableFingerprint {
+		if ruleAuthorizations["ALPHA"] == waivableFingerprint {
 			projection.RuleAuthorizationFingerprint = waivableFingerprint
 			projection.PolicyDecisions[0].Decision = "authorized"
-			projection.PolicyDecisions[0].Authorized = true
 		} else {
 			inputFingerprint = testFingerprint(t, "pending-rule-projection")
 			projection.Readiness = api.ReadinessStatusBlocked
@@ -3862,13 +3874,10 @@ func TestResolveProjectionRuleAuthorizationReprojectsWithExactServerAuthority(t 
 		WorkflowID:       result.Workflow.ID,
 		ExpectedRevision: result.Workflow.Revision,
 		TrackerIDs:       []api.TrackerID{"ALPHA"},
-		Instructions: map[api.TrackerID]api.TrackerProjectionInstructions{
-			"ALPHA": {AuthorizedRuleFingerprint: waivableFingerprint},
-		},
+		Instructions:     map[api.TrackerID]api.TrackerProjectionInstructions{"ALPHA": {}},
 	})
-	if result.Workflow.Status != api.WorkflowStatusBlocked || len(result.Workflow.RequiredActions) != 1 ||
-		result.ProjectionInstructions.Instructions["ALPHA"].AuthorizedRuleFingerprint != "" {
-		t.Fatalf("forged rule authority was accepted: %#v", result)
+	if result.Workflow.Status != api.WorkflowStatusBlocked || len(result.Workflow.RequiredActions) != 1 {
+		t.Fatalf("initial rule authorization state = %#v", result)
 	}
 	action := result.Workflow.RequiredActions[0]
 	confirmed := true
@@ -3885,14 +3894,11 @@ func TestResolveProjectionRuleAuthorizationReprojectsWithExactServerAuthority(t 
 	projection := result.Projections.Projections[0]
 	if result.Workflow.Status != api.WorkflowStatusActive || len(result.Workflow.RequiredActions) != 0 ||
 		projection.Readiness != api.ReadinessStatusReady || !projection.UploadReady ||
-		projection.RuleAuthorizationFingerprint != waivableFingerprint ||
-		!projection.PolicyDecisions[0].Authorized ||
-		result.ProjectionInstructions.Instructions["ALPHA"].AuthorizedRuleFingerprint != waivableFingerprint {
+		projection.RuleAuthorizationFingerprint != waivableFingerprint {
 		t.Fatalf(
-			"resolved rule authorization: status=%s actions=%#v instruction=%q projection=%#v",
+			"resolved rule authorization: status=%s actions=%#v projection=%#v",
 			result.Workflow.Status,
 			result.Workflow.RequiredActions,
-			result.ProjectionInstructions.Instructions["ALPHA"].AuthorizedRuleFingerprint,
 			projection,
 		)
 	}
@@ -3900,9 +3906,9 @@ func TestResolveProjectionRuleAuthorizationReprojectsWithExactServerAuthority(t 
 	if err != nil {
 		t.Fatalf("reload authorized workflow: %v", err)
 	}
-	stored := state.ProjectionInstructions[state.Workflow.ProjectionInstructions.ID]
-	if stored.Instructions["ALPHA"].AuthorizedRuleFingerprint != waivableFingerprint {
-		t.Fatalf("stored rule authority = %#v", stored)
+	stored := state.Projections[state.Workflow.TrackerProjections.ID]
+	if stored.Projections[0].RuleAuthorizationFingerprint != waivableFingerprint {
+		t.Fatalf("stored rule authority = %#v", stored.Projections)
 	}
 	if _, err := module.Execute(context.Background(), testOwnerID, ResolveActionCommand{
 		WorkflowID:       result.Workflow.ID,

--- a/internal/releaseworkflow/module_test.go
+++ b/internal/releaseworkflow/module_test.go
@@ -838,7 +838,7 @@ func TestModuleResetAndBlurayCandidateSelectionUseExactRetainedAuthority(t *test
 	result = executeCommand(t, module, PrepareReleaseCommand{
 		WorkflowID:       result.Workflow.ID,
 		ExpectedRevision: result.Workflow.Revision,
-		Input:            api.PrepareInput{SourcePath: "C:\\releases\\Example.Release.2026.1080p-GRP"},
+		Input:            api.PrepareInput{SourcePath: "Example.Release.2026.1080p-GRP"},
 		IdempotencyKey:   "prepare-reset-candidate",
 	})
 	result = executeCommand(t, module, ResetReleaseCommand{
@@ -3763,6 +3763,151 @@ func TestResolveReconciliationRequiresExactAnswerAndForcesFreshReview(t *testing
 	retry.UpdatedAt = retry.StartedAt
 	if _, idempotent, err := repository.BeginEffect(ctx, retry); err != nil || idempotent {
 		t.Fatalf("begin reconciled retry idempotent=%v err=%v", idempotent, err)
+	}
+}
+
+func TestTrustedProjectionInstructionsOnlyAcceptsServerRuleAuthority(t *testing.T) {
+	t.Parallel()
+
+	fingerprint := testFingerprint(t, "trusted-rule-authority")
+	requested := map[api.TrackerID]api.TrackerProjectionInstructions{
+		"ALPHA": {AuthorizedRuleFingerprint: fingerprint},
+	}
+	sanitized, err := trustedProjectionInstructions(requested, nil)
+	if err != nil {
+		t.Fatalf("sanitize projection instructions: %v", err)
+	}
+	if sanitized["ALPHA"].AuthorizedRuleFingerprint != "" {
+		t.Fatalf("caller rule authority survived sanitization: %#v", sanitized)
+	}
+	trusted, err := trustedProjectionInstructions(requested, map[api.TrackerID]api.WorkflowFingerprint{
+		"ALPHA": fingerprint,
+	})
+	if err != nil {
+		t.Fatalf("apply trusted projection instructions: %v", err)
+	}
+	if trusted["ALPHA"].AuthorizedRuleFingerprint != fingerprint {
+		t.Fatalf("trusted rule authority = %#v", trusted)
+	}
+}
+
+func TestResolveProjectionRuleAuthorizationReprojectsWithExactServerAuthority(t *testing.T) {
+	t.Parallel()
+
+	waivableFingerprint := testFingerprint(t, "alpha-waivable-rules")
+	projector := trackerProjectionBuilderFunc(func(
+		_ context.Context,
+		_ api.ReleaseSnapshot,
+		_ api.UploadSubject,
+		trackerIDs []api.TrackerID,
+		instructions map[api.TrackerID]api.TrackerProjectionInstructions,
+		executionMode api.WorkflowExecutionMode,
+	) (
+		api.TrackerCatalogSnapshot,
+		api.TrackerRuntimeSnapshot,
+		api.TrackerSelection,
+		api.TrackerReleaseProjectionSet,
+		error,
+	) {
+		projection := testProjection(t, "ALPHA", "Example.Release.2026.ALPHA-GRP")
+		projection.WaivableRuleFingerprint = waivableFingerprint
+		projection.PolicyDecisions = []api.TrackerPolicyDecision{{
+			Code:        "language_rule",
+			Message:     "language waiver required",
+			Disposition: api.RuleDispositionWaivable,
+		}}
+		status := api.StageStatusReady
+		inputFingerprint := testFingerprint(t, "authorized-rule-projection")
+		if instructions["ALPHA"].AuthorizedRuleFingerprint == waivableFingerprint {
+			projection.RuleAuthorizationFingerprint = waivableFingerprint
+			projection.PolicyDecisions[0].Decision = "authorized"
+			projection.PolicyDecisions[0].Authorized = true
+		} else {
+			inputFingerprint = testFingerprint(t, "pending-rule-projection")
+			projection.Readiness = api.ReadinessStatusBlocked
+			projection.DupeReady = false
+			projection.UploadReady = false
+			projection.PolicyDecisions[0].Decision = "authorization_required"
+			projection.PolicyDecisions[0].Blocking = true
+			projection.RequiredActions = []api.RequiredAction{{
+				Kind:   api.RequiredActionAuthorizeRules,
+				Prompt: "Alpha has waivable rule failures. Continue with this tracker?",
+			}}
+			status = api.StageStatusBlocked
+		}
+		return testCatalog(t), testRuntime(t), api.TrackerSelection{TrackerIDs: trackerIDs}, api.TrackerReleaseProjectionSet{
+			InputFingerprint:  inputFingerprint,
+			PolicyFingerprint: testFingerprint(t, "waivable-rule-policy"),
+			ExecutionMode:     executionMode,
+			Projections:       []api.TrackerReleaseProjection{projection},
+			Status:            status,
+			RequiredActions:   append([]api.RequiredAction(nil), projection.RequiredActions...),
+		}, nil
+	})
+	module, repository := newTestModule(t, testPreparer(), WithTrackerProjectionBuilder(projector))
+	result := executeCommand(t, module, CreateWorkflowCommand{WorkflowID: "workflow-rule-authorization"})
+	result = executeCommand(t, module, PrepareReleaseCommand{
+		WorkflowID:       result.Workflow.ID,
+		ExpectedRevision: result.Workflow.Revision,
+		Input:            api.PrepareInput{SourcePath: "C:\\releases\\Example.Release.2026.1080p-GRP"},
+	})
+	result = executeCommand(t, module, ProjectTrackersCommand{
+		WorkflowID:       result.Workflow.ID,
+		ExpectedRevision: result.Workflow.Revision,
+		TrackerIDs:       []api.TrackerID{"ALPHA"},
+		Instructions: map[api.TrackerID]api.TrackerProjectionInstructions{
+			"ALPHA": {AuthorizedRuleFingerprint: waivableFingerprint},
+		},
+	})
+	if result.Workflow.Status != api.WorkflowStatusBlocked || len(result.Workflow.RequiredActions) != 1 ||
+		result.ProjectionInstructions.Instructions["ALPHA"].AuthorizedRuleFingerprint != "" {
+		t.Fatalf("forged rule authority was accepted: %#v", result)
+	}
+	action := result.Workflow.RequiredActions[0]
+	confirmed := true
+	blockedRevision := result.Workflow.Revision
+	result = executeCommand(t, module, ResolveActionCommand{
+		WorkflowID:       result.Workflow.ID,
+		ExpectedRevision: result.Workflow.Revision,
+		Answer: api.RequiredActionAnswer{
+			ActionID:         action.ID,
+			WorkflowRevision: action.WorkflowRevision,
+			Confirmed:        &confirmed,
+		},
+	})
+	projection := result.Projections.Projections[0]
+	if result.Workflow.Status != api.WorkflowStatusActive || len(result.Workflow.RequiredActions) != 0 ||
+		projection.Readiness != api.ReadinessStatusReady || !projection.UploadReady ||
+		projection.RuleAuthorizationFingerprint != waivableFingerprint ||
+		!projection.PolicyDecisions[0].Authorized ||
+		result.ProjectionInstructions.Instructions["ALPHA"].AuthorizedRuleFingerprint != waivableFingerprint {
+		t.Fatalf(
+			"resolved rule authorization: status=%s actions=%#v instruction=%q projection=%#v",
+			result.Workflow.Status,
+			result.Workflow.RequiredActions,
+			result.ProjectionInstructions.Instructions["ALPHA"].AuthorizedRuleFingerprint,
+			projection,
+		)
+	}
+	state, err := repository.Load(context.Background(), testOwnerID, result.Workflow.ID)
+	if err != nil {
+		t.Fatalf("reload authorized workflow: %v", err)
+	}
+	stored := state.ProjectionInstructions[state.Workflow.ProjectionInstructions.ID]
+	if stored.Instructions["ALPHA"].AuthorizedRuleFingerprint != waivableFingerprint {
+		t.Fatalf("stored rule authority = %#v", stored)
+	}
+	if _, err := module.Execute(context.Background(), testOwnerID, ResolveActionCommand{
+		WorkflowID:       result.Workflow.ID,
+		ExpectedRevision: blockedRevision,
+		Answer: api.RequiredActionAnswer{
+			ActionID:         action.ID,
+			WorkflowRevision: action.WorkflowRevision,
+			Confirmed:        &confirmed,
+		},
+		IdempotencyKey: "stale-rule-authorization",
+	}); !errors.Is(err, ErrRevisionConflict) {
+		t.Fatalf("stale rule authorization error = %v", err)
 	}
 }
 

--- a/internal/releaseworkflow/module_test.go
+++ b/internal/releaseworkflow/module_test.go
@@ -845,7 +845,7 @@ func TestModuleResetAndBlurayCandidateSelectionUseExactRetainedAuthority(t *test
 		WorkflowID:       result.Workflow.ID,
 		ExpectedRevision: result.Workflow.Revision,
 		Input: api.PrepareInput{
-			SourcePath:   "C:\\releases\\Example.Release.2026.1080p-GRP",
+			SourcePath:   "Example.Release.2026.1080p-GRP",
 			Instructions: api.ReleaseFactInstructions{SourceLookup: "Reset Example Release"},
 		},
 		IdempotencyKey: "reset-release",

--- a/internal/releaseworkflow/persistent_test.go
+++ b/internal/releaseworkflow/persistent_test.go
@@ -45,6 +45,7 @@ func TestPersistentWorkflowRestartRetriesAuthBlockedProjectionOnce(t *testing.T)
 		_ api.UploadSubject,
 		trackerIDs []api.TrackerID,
 		_ map[api.TrackerID]api.TrackerProjectionInstructions,
+		_ map[api.TrackerID]api.WorkflowFingerprint,
 		executionMode api.WorkflowExecutionMode,
 	) (
 		api.TrackerCatalogSnapshot,
@@ -293,6 +294,7 @@ func TestPersistentRestartHandlesLegacyAuthStateSafely(t *testing.T) {
 		_ api.UploadSubject,
 		trackerIDs []api.TrackerID,
 		_ map[api.TrackerID]api.TrackerProjectionInstructions,
+		_ map[api.TrackerID]api.WorkflowFingerprint,
 		executionMode api.WorkflowExecutionMode,
 	) (
 		api.TrackerCatalogSnapshot,

--- a/internal/releaseworkflow/planner.go
+++ b/internal/releaseworkflow/planner.go
@@ -312,6 +312,9 @@ func continuationActionBlocksAllLanesForMode(
 	action api.RequiredAction,
 	mode TrackerDecisionMode,
 ) bool {
+	if _, _, projectionAuthorization := projectionRuleAuthorizationAction(current.Projections, action.ID); projectionAuthorization {
+		return true
+	}
 	if normalizeTrackerDecisionMode(mode) == TrackerDecisionModePostDupeGate &&
 		action.Kind == api.RequiredActionReviewDuplicates {
 		return true
@@ -673,6 +676,8 @@ func effectiveProjectionInstructions(
 ) map[api.TrackerID]api.TrackerProjectionInstructions {
 	effective := make(map[api.TrackerID]api.TrackerProjectionInstructions, len(instructions))
 	for trackerID, instruction := range instructions {
+		// Rule authorization is retained server authority, not caller intent.
+		instruction.AuthorizedRuleFingerprint = ""
 		if projectionInstructionIsEmpty(instruction) {
 			continue
 		}
@@ -692,7 +697,8 @@ func projectionInstructionIsEmpty(instruction api.TrackerProjectionInstructions)
 		instruction.TrackerSite.TIK.Foreign == nil &&
 		instruction.TrackerSite.TIK.Opera == nil &&
 		instruction.TrackerSite.TIK.Asian == nil &&
-		instruction.TrackerSite.TIK.DiscType == nil
+		instruction.TrackerSite.TIK.DiscType == nil &&
+		instruction.AuthorizedRuleFingerprint == ""
 }
 
 func continuationInteractionMode(intent api.WorkflowIntent) api.InteractionMode {

--- a/internal/releaseworkflow/planner.go
+++ b/internal/releaseworkflow/planner.go
@@ -676,8 +676,6 @@ func effectiveProjectionInstructions(
 ) map[api.TrackerID]api.TrackerProjectionInstructions {
 	effective := make(map[api.TrackerID]api.TrackerProjectionInstructions, len(instructions))
 	for trackerID, instruction := range instructions {
-		// Rule authorization is retained server authority, not caller intent.
-		instruction.AuthorizedRuleFingerprint = ""
 		if projectionInstructionIsEmpty(instruction) {
 			continue
 		}
@@ -697,8 +695,7 @@ func projectionInstructionIsEmpty(instruction api.TrackerProjectionInstructions)
 		instruction.TrackerSite.TIK.Foreign == nil &&
 		instruction.TrackerSite.TIK.Opera == nil &&
 		instruction.TrackerSite.TIK.Asian == nil &&
-		instruction.TrackerSite.TIK.DiscType == nil &&
-		instruction.AuthorizedRuleFingerprint == ""
+		instruction.TrackerSite.TIK.DiscType == nil
 }
 
 func continuationInteractionMode(intent api.WorkflowIntent) api.InteractionMode {

--- a/internal/releaseworkflow/planner_test.go
+++ b/internal/releaseworkflow/planner_test.go
@@ -346,41 +346,6 @@ func TestContinuationPlannerIgnoresSemanticallyEmptyProjectionInstructions(t *te
 	}
 }
 
-func TestContinuationPlannerRetainsServerRuleAuthorization(t *testing.T) {
-	t.Parallel()
-
-	now := time.Date(2026, time.July, 23, 1, 2, 3, 0, time.UTC)
-	current := CommandResult{
-		Workflow: api.ReleaseWorkflow{ID: "workflow-rule-authorization", Revision: 7},
-		Release:  &api.ReleaseSnapshot{ID: "release-rule-authorization", Revision: 2},
-		Selection: &api.TrackerSelection{
-			TrackerIDs: []api.TrackerID{"ALPHA"},
-		},
-		ProjectionInstructions: &api.TrackerProjectionInstructionSnapshot{
-			Instructions: map[api.TrackerID]api.TrackerProjectionInstructions{
-				"ALPHA": {AuthorizedRuleFingerprint: testFingerprint(t, "authorized-rules")},
-			},
-		},
-		Projections: &api.TrackerReleaseProjectionSet{
-			ID:               "projections-rule-authorization",
-			Revision:         3,
-			InputFingerprint: testFingerprint(t, "projection-rule-authorization"),
-		},
-	}
-	request := api.ContinueReleaseWorkflowRequest{
-		IdempotencyKey: "continue-rule-authorization",
-		Goal:           api.WorkflowGoalTrackersAssessed,
-		Intent: api.WorkflowIntent{
-			TrackerIDs:             []api.TrackerID{"ALPHA"},
-			ProjectionInstructions: map[api.TrackerID]api.TrackerProjectionInstructions{},
-		},
-	}
-	command, stage := planContinuationCommand(request, current, now)
-	if _, ok := command.(PreflightTrackersCommand); !ok || stage != "preflight-trackers" {
-		t.Fatalf("retained rule-authorization plan: stage=%q command=%#v", stage, command)
-	}
-}
-
 func TestContinuationPlannerReprojectsWhenExecutionModeChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/releaseworkflow/planner_test.go
+++ b/internal/releaseworkflow/planner_test.go
@@ -346,6 +346,41 @@ func TestContinuationPlannerIgnoresSemanticallyEmptyProjectionInstructions(t *te
 	}
 }
 
+func TestContinuationPlannerRetainsServerRuleAuthorization(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 23, 1, 2, 3, 0, time.UTC)
+	current := CommandResult{
+		Workflow: api.ReleaseWorkflow{ID: "workflow-rule-authorization", Revision: 7},
+		Release:  &api.ReleaseSnapshot{ID: "release-rule-authorization", Revision: 2},
+		Selection: &api.TrackerSelection{
+			TrackerIDs: []api.TrackerID{"ALPHA"},
+		},
+		ProjectionInstructions: &api.TrackerProjectionInstructionSnapshot{
+			Instructions: map[api.TrackerID]api.TrackerProjectionInstructions{
+				"ALPHA": {AuthorizedRuleFingerprint: testFingerprint(t, "authorized-rules")},
+			},
+		},
+		Projections: &api.TrackerReleaseProjectionSet{
+			ID:               "projections-rule-authorization",
+			Revision:         3,
+			InputFingerprint: testFingerprint(t, "projection-rule-authorization"),
+		},
+	}
+	request := api.ContinueReleaseWorkflowRequest{
+		IdempotencyKey: "continue-rule-authorization",
+		Goal:           api.WorkflowGoalTrackersAssessed,
+		Intent: api.WorkflowIntent{
+			TrackerIDs:             []api.TrackerID{"ALPHA"},
+			ProjectionInstructions: map[api.TrackerID]api.TrackerProjectionInstructions{},
+		},
+	}
+	command, stage := planContinuationCommand(request, current, now)
+	if _, ok := command.(PreflightTrackersCommand); !ok || stage != "preflight-trackers" {
+		t.Fatalf("retained rule-authorization plan: stage=%q command=%#v", stage, command)
+	}
+}
+
 func TestContinuationPlannerReprojectsWhenExecutionModeChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/releaseworkflow/release_name_review.go
+++ b/internal/releaseworkflow/release_name_review.go
@@ -123,6 +123,7 @@ func (m *Module) reviewTrackerReleaseName(
 		subject,
 		selection.TrackerIDs,
 		instructionSnapshot.Instructions,
+		projectionRuleAuthorizations(currentProjections),
 		currentProjections.ExecutionMode,
 	)
 	if err != nil {

--- a/internal/releaseworkflow/rule_authorization.go
+++ b/internal/releaseworkflow/rule_authorization.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package releaseworkflow
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func projectionRuleAuthorizationAction(
+	projections *api.TrackerReleaseProjectionSet,
+	actionID api.RequiredActionID,
+) (api.TrackerReleaseProjection, api.RequiredAction, bool) {
+	if projections == nil || actionID == "" {
+		return api.TrackerReleaseProjection{}, api.RequiredAction{}, false
+	}
+	for _, projection := range projections.Projections {
+		if projection.WaivableRuleFingerprint == "" || projection.RuleAuthorizationFingerprint != "" {
+			continue
+		}
+		index := slices.IndexFunc(projection.RequiredActions, func(action api.RequiredAction) bool {
+			return action.ID == actionID &&
+				action.Kind == api.RequiredActionAuthorizeRules &&
+				action.TrackerID == projection.TrackerID &&
+				action.Status == api.RequiredActionStatusPending
+		})
+		if index >= 0 {
+			return projection, projection.RequiredActions[index], true
+		}
+	}
+	return api.TrackerReleaseProjection{}, api.RequiredAction{}, false
+}
+
+func (m *Module) authorizeTrackerRules(
+	ctx context.Context,
+	ownerID string,
+	state *State,
+	nextRevision api.WorkflowRevision,
+	now time.Time,
+	projection api.TrackerReleaseProjection,
+	action api.RequiredAction,
+	answer api.RequiredActionAnswer,
+) (CommandResult, error) {
+	if answer.Confirmed == nil || !*answer.Confirmed || answer.TextValue != nil || len(answer.SelectedValues) > 0 {
+		return CommandResult{}, fmt.Errorf("%w: rule authorization requires explicit confirmation", ErrInvalidTransition)
+	}
+	workflow := state.Workflow
+	if workflow.Selection == nil || workflow.ProjectionInstructions == nil || workflow.TrackerProjections == nil {
+		return CommandResult{}, fmt.Errorf("%w: rule authorization dependencies are incomplete", ErrInvalidTransition)
+	}
+	selection, selectionOK := state.Selections[workflow.Selection.ID]
+	instructionSnapshot, instructionsOK := state.ProjectionInstructions[workflow.ProjectionInstructions.ID]
+	currentProjections, projectionsOK := state.Projections[workflow.TrackerProjections.ID]
+	workflowActionIndex := slices.IndexFunc(workflow.RequiredActions, func(candidate api.RequiredAction) bool {
+		return candidate.ID == action.ID &&
+			candidate.Kind == api.RequiredActionAuthorizeRules &&
+			candidate.TrackerID == projection.TrackerID &&
+			candidate.Status == api.RequiredActionStatusPending
+	})
+	if !selectionOK || !instructionsOK || !projectionsOK ||
+		selection.Revision != workflow.Selection.Revision ||
+		instructionSnapshot.Revision != workflow.ProjectionInstructions.Revision ||
+		currentProjections.Revision != workflow.TrackerProjections.Revision ||
+		currentProjections.Instructions == nil || *currentProjections.Instructions != *workflow.ProjectionInstructions ||
+		workflowActionIndex < 0 || workflow.RequiredActions[workflowActionIndex].WorkflowRevision != workflow.Revision ||
+		action.TrackerID != projection.TrackerID {
+		return CommandResult{}, fmt.Errorf("%w: rule authorization dependencies are stale", ErrInvalidTransition)
+	}
+	cloned, err := instructionSnapshot.Clone()
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("release workflow clone rule authorization instructions: %w", err)
+	}
+	if cloned.Instructions == nil {
+		cloned.Instructions = make(map[api.TrackerID]api.TrackerProjectionInstructions)
+	}
+	instruction := cloned.Instructions[projection.TrackerID]
+	instruction.AuthorizedRuleFingerprint = projection.WaivableRuleFingerprint
+	cloned.Instructions[projection.TrackerID] = instruction
+	authorizations := make(map[api.TrackerID]api.WorkflowFingerprint)
+	for trackerID, candidate := range cloned.Instructions {
+		if candidate.AuthorizedRuleFingerprint != "" {
+			authorizations[trackerID] = candidate.AuthorizedRuleFingerprint
+		}
+	}
+	return m.projectTrackersWithRuleAuthorizations(ctx, ownerID, state, nextRevision, now, ProjectTrackersCommand{
+		WorkflowID:       workflow.ID,
+		ExpectedRevision: workflow.Revision,
+		TrackerIDs:       append([]api.TrackerID(nil), selection.TrackerIDs...),
+		Instructions:     cloned.Instructions,
+		ExecutionMode:    currentProjections.ExecutionMode,
+	}, authorizations)
+}
+
+func trustedProjectionInstructions(
+	instructions map[api.TrackerID]api.TrackerProjectionInstructions,
+	authorizations map[api.TrackerID]api.WorkflowFingerprint,
+) (map[api.TrackerID]api.TrackerProjectionInstructions, error) {
+	cloned, err := (api.TrackerProjectionInstructionSnapshot{Instructions: instructions}).Clone()
+	if err != nil {
+		return nil, fmt.Errorf("clone projection instructions: %w", err)
+	}
+	for trackerID, instruction := range cloned.Instructions {
+		instruction.AuthorizedRuleFingerprint = ""
+		cloned.Instructions[trackerID] = instruction
+	}
+	cloned, err = cloned.Normalize()
+	if err != nil {
+		return nil, fmt.Errorf("normalize projection instructions: %w", err)
+	}
+	if cloned.Instructions == nil {
+		cloned.Instructions = make(map[api.TrackerID]api.TrackerProjectionInstructions)
+	}
+	for trackerID, fingerprint := range authorizations {
+		trackerID = api.TrackerID(strings.ToUpper(strings.TrimSpace(string(trackerID))))
+		if trackerID == "" || fingerprint == "" {
+			continue
+		}
+		instruction := cloned.Instructions[trackerID]
+		instruction.AuthorizedRuleFingerprint = fingerprint
+		cloned.Instructions[trackerID] = instruction
+	}
+	cloned, err = cloned.Normalize()
+	if err != nil {
+		return nil, fmt.Errorf("normalize trusted rule authorization: %w", err)
+	}
+	return cloned.Instructions, nil
+}

--- a/internal/releaseworkflow/rule_authorization.go
+++ b/internal/releaseworkflow/rule_authorization.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+// projectionRuleAuthorizationAction finds a pending authorization action bound
+// to a projection whose current waivable rules remain unauthorized.
 func projectionRuleAuthorizationAction(
 	projections *api.TrackerReleaseProjectionSet,
 	actionID api.RequiredActionID,
@@ -37,6 +38,8 @@ func projectionRuleAuthorizationAction(
 	return api.TrackerReleaseProjection{}, api.RequiredAction{}, false
 }
 
+// authorizeTrackerRules validates explicit confirmation and current snapshot
+// lineage, then reprojects with server-held authority for the accepted rules.
 func (m *Module) authorizeTrackerRules(
 	ctx context.Context,
 	ownerID string,
@@ -72,64 +75,27 @@ func (m *Module) authorizeTrackerRules(
 		action.TrackerID != projection.TrackerID {
 		return CommandResult{}, fmt.Errorf("%w: rule authorization dependencies are stale", ErrInvalidTransition)
 	}
-	cloned, err := instructionSnapshot.Normalize()
-	if err != nil {
-		return CommandResult{}, fmt.Errorf("release workflow normalize rule authorization instructions: %w", err)
-	}
-	if cloned.Instructions == nil {
-		cloned.Instructions = make(map[api.TrackerID]api.TrackerProjectionInstructions)
-	}
-	trackerID := api.TrackerID(strings.ToUpper(strings.TrimSpace(string(projection.TrackerID))))
-	instruction := cloned.Instructions[trackerID]
-	instruction.AuthorizedRuleFingerprint = projection.WaivableRuleFingerprint
-	cloned.Instructions[trackerID] = instruction
-	authorizations := make(map[api.TrackerID]api.WorkflowFingerprint)
-	for trackerID, candidate := range cloned.Instructions {
-		if candidate.AuthorizedRuleFingerprint != "" {
-			authorizations[trackerID] = candidate.AuthorizedRuleFingerprint
-		}
-	}
-	m.logger.Infof("release workflow: accepted tracker rule authorization tracker=%s decision=authorized", trackerID)
+	authorizations := projectionRuleAuthorizations(currentProjections)
+	authorizations[projection.TrackerID] = projection.WaivableRuleFingerprint
+	m.logger.Infof("release workflow: accepted tracker rule authorization tracker=%s decision=authorized", projection.TrackerID)
 	return m.projectTrackersWithRuleAuthorizations(ctx, ownerID, state, nextRevision, now, ProjectTrackersCommand{
 		WorkflowID:       workflow.ID,
 		ExpectedRevision: workflow.Revision,
 		TrackerIDs:       append([]api.TrackerID(nil), selection.TrackerIDs...),
-		Instructions:     cloned.Instructions,
+		Instructions:     instructionSnapshot.Instructions,
 		ExecutionMode:    currentProjections.ExecutionMode,
 	}, authorizations)
 }
 
-func trustedProjectionInstructions(
-	instructions map[api.TrackerID]api.TrackerProjectionInstructions,
-	authorizations map[api.TrackerID]api.WorkflowFingerprint,
-) (map[api.TrackerID]api.TrackerProjectionInstructions, error) {
-	cloned, err := (api.TrackerProjectionInstructionSnapshot{Instructions: instructions}).Clone()
-	if err != nil {
-		return nil, fmt.Errorf("clone projection instructions: %w", err)
-	}
-	for trackerID, instruction := range cloned.Instructions {
-		instruction.AuthorizedRuleFingerprint = ""
-		cloned.Instructions[trackerID] = instruction
-	}
-	cloned, err = cloned.Normalize()
-	if err != nil {
-		return nil, fmt.Errorf("normalize projection instructions: %w", err)
-	}
-	if cloned.Instructions == nil {
-		cloned.Instructions = make(map[api.TrackerID]api.TrackerProjectionInstructions)
-	}
-	for trackerID, fingerprint := range authorizations {
-		trackerID = api.TrackerID(strings.ToUpper(strings.TrimSpace(string(trackerID))))
-		if trackerID == "" || fingerprint == "" {
-			continue
+// projectionRuleAuthorizations returns only recorded authorizations that still
+// match their projection's current waivable rules.
+func projectionRuleAuthorizations(projections api.TrackerReleaseProjectionSet) map[api.TrackerID]api.WorkflowFingerprint {
+	authorizations := make(map[api.TrackerID]api.WorkflowFingerprint, len(projections.Projections))
+	for _, projection := range projections.Projections {
+		if projection.RuleAuthorizationFingerprint != "" &&
+			projection.RuleAuthorizationFingerprint == projection.WaivableRuleFingerprint {
+			authorizations[projection.TrackerID] = projection.RuleAuthorizationFingerprint
 		}
-		instruction := cloned.Instructions[trackerID]
-		instruction.AuthorizedRuleFingerprint = fingerprint
-		cloned.Instructions[trackerID] = instruction
 	}
-	cloned, err = cloned.Normalize()
-	if err != nil {
-		return nil, fmt.Errorf("normalize trusted rule authorization: %w", err)
-	}
-	return cloned.Instructions, nil
+	return authorizations
 }

--- a/internal/releaseworkflow/rule_authorization.go
+++ b/internal/releaseworkflow/rule_authorization.go
@@ -72,22 +72,24 @@ func (m *Module) authorizeTrackerRules(
 		action.TrackerID != projection.TrackerID {
 		return CommandResult{}, fmt.Errorf("%w: rule authorization dependencies are stale", ErrInvalidTransition)
 	}
-	cloned, err := instructionSnapshot.Clone()
+	cloned, err := instructionSnapshot.Normalize()
 	if err != nil {
-		return CommandResult{}, fmt.Errorf("release workflow clone rule authorization instructions: %w", err)
+		return CommandResult{}, fmt.Errorf("release workflow normalize rule authorization instructions: %w", err)
 	}
 	if cloned.Instructions == nil {
 		cloned.Instructions = make(map[api.TrackerID]api.TrackerProjectionInstructions)
 	}
-	instruction := cloned.Instructions[projection.TrackerID]
+	trackerID := api.TrackerID(strings.ToUpper(strings.TrimSpace(string(projection.TrackerID))))
+	instruction := cloned.Instructions[trackerID]
 	instruction.AuthorizedRuleFingerprint = projection.WaivableRuleFingerprint
-	cloned.Instructions[projection.TrackerID] = instruction
+	cloned.Instructions[trackerID] = instruction
 	authorizations := make(map[api.TrackerID]api.WorkflowFingerprint)
 	for trackerID, candidate := range cloned.Instructions {
 		if candidate.AuthorizedRuleFingerprint != "" {
 			authorizations[trackerID] = candidate.AuthorizedRuleFingerprint
 		}
 	}
+	m.logger.Infof("release workflow: accepted tracker rule authorization tracker=%s decision=authorized", trackerID)
 	return m.projectTrackersWithRuleAuthorizations(ctx, ownerID, state, nextRevision, now, ProjectTrackersCommand{
 		WorkflowID:       workflow.ID,
 		ExpectedRevision: workflow.Revision,

--- a/internal/trackers/definition.go
+++ b/internal/trackers/definition.go
@@ -72,6 +72,9 @@ type PreparationInput struct {
 	Meta api.UploadSubject
 	// Projection locks reviewed tracker-local names and taxonomy for final preparation.
 	Projection *api.TrackerReleaseProjection
+	// AuthorizedRuleFingerprint is server-owned projection authority for one
+	// exact set of waivable failures.
+	AuthorizedRuleFingerprint api.WorkflowFingerprint
 	// RequestedUploadName is an optional user instruction consumed by the
 	// tracker naming policy before projection. A non-nil empty value is invalid.
 	RequestedUploadName *string

--- a/internal/trackers/definition.go
+++ b/internal/trackers/definition.go
@@ -72,8 +72,9 @@ type PreparationInput struct {
 	Meta api.UploadSubject
 	// Projection locks reviewed tracker-local names and taxonomy for final preparation.
 	Projection *api.TrackerReleaseProjection
-	// AuthorizedRuleFingerprint is server-owned projection authority for one
-	// exact set of waivable failures.
+	// AuthorizedRuleFingerprint carries server-owned authority into projection
+	// for one exact tracker-local set of waivable failures. A mismatch grants no
+	// authorization.
 	AuthorizedRuleFingerprint api.WorkflowFingerprint
 	// RequestedUploadName is an optional user instruction consumed by the
 	// tracker naming policy before projection. A non-nil empty value is invalid.

--- a/internal/trackers/description_assets_test.go
+++ b/internal/trackers/description_assets_test.go
@@ -38,6 +38,7 @@ type stubRepo struct {
 	uploadsCalls           int
 	deletedUploads         []string
 	createdUploads         []api.UploadRecord
+	ruleFailureSaves       []ruleFailureSave
 	statusUpdates          []uploadStatusUpdate
 	descriptionOverride    string
 	descriptionOverrideErr error
@@ -48,6 +49,12 @@ type stubRepo struct {
 type uploadStatusUpdate struct {
 	tracker string
 	status  string
+}
+
+type ruleFailureSave struct {
+	sourcePath string
+	tracker    string
+	failures   []api.TrackerRuleFailure
 }
 
 type descriptionAssetsTestDefinition struct {
@@ -192,7 +199,14 @@ func (s *stubRepo) UpdateLatestUploadRecordStatus(_ context.Context, _ string, t
 	s.statusUpdates = append(s.statusUpdates, uploadStatusUpdate{tracker: tracker, status: status})
 	return nil
 }
-func (s *stubRepo) SaveTrackerRuleFailures(context.Context, string, string, []api.TrackerRuleFailure) error {
+func (s *stubRepo) SaveTrackerRuleFailures(_ context.Context, sourcePath string, tracker string, failures []api.TrackerRuleFailure) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ruleFailureSaves = append(s.ruleFailureSaves, ruleFailureSave{
+		sourcePath: sourcePath,
+		tracker:    tracker,
+		failures:   append([]api.TrackerRuleFailure(nil), failures...),
+	})
 	return nil
 }
 func (s *stubRepo) ListTrackerRuleFailuresByPath(context.Context, string) ([]api.TrackerRuleFailure, error) {

--- a/internal/trackers/impl/standalone/validation.go
+++ b/internal/trackers/impl/standalone/validation.go
@@ -118,12 +118,13 @@ func ValidatePreparation(
 	if err != nil {
 		return fmt.Errorf("trackers: %s constructibility: %w", strings.ToUpper(strings.TrimSpace(input.Tracker)), err)
 	}
-	var blockingFailure *api.RuleFailure
-	for i := range failures {
-		if trackers.RuleFailureBlocksExecution(failures[i], input.ExecutionMode) {
-			blockingFailure = &failures[i]
-			break
-		}
+	blockingFailure, err := trackers.FirstBlockingRuleFailure(input.Tracker, failures, input.ExecutionMode, input.Projection)
+	if err != nil {
+		return fmt.Errorf(
+			"trackers: %s rule authorization: %w",
+			strings.ToUpper(strings.TrimSpace(input.Tracker)),
+			err,
+		)
 	}
 	if blockingFailure == nil {
 		return nil

--- a/internal/trackers/impl/standalone/validation_test.go
+++ b/internal/trackers/impl/standalone/validation_test.go
@@ -36,6 +36,31 @@ func TestValidatePreparationExecutionPolicy(t *testing.T) {
 	if err := ValidatePreparation(context.Background(), input, policy(api.RuleDispositionWaivable)); err == nil {
 		t.Fatal("waivable failure must block normal direct preparation")
 	}
+	waivableFingerprint, err := trackers.WaivableRuleFailureFingerprint("EXAMPLE", []api.RuleFailure{
+		trackers.NewRuleFailure("test_rule", "test reason", api.RuleDispositionWaivable),
+	})
+	if err != nil {
+		t.Fatalf("fingerprint waivable failure: %v", err)
+	}
+	input.Projection = &api.TrackerReleaseProjection{
+		WaivableRuleFingerprint:      waivableFingerprint,
+		RuleAuthorizationFingerprint: waivableFingerprint,
+	}
+	if err := ValidatePreparation(context.Background(), input, policy(api.RuleDispositionWaivable)); err != nil {
+		t.Fatalf("exactly authorized waivable failure must pass normal direct preparation: %v", err)
+	}
+	changedPolicy := trackers.ValidationPolicyBinding{
+		ID: "test-policy-v2",
+		Check: func(context.Context, api.TrackerValidationSubject, api.Logger) ([]api.RuleFailure, error) {
+			return []api.RuleFailure{
+				trackers.NewRuleFailure("test_rule", "changed reason", api.RuleDispositionWaivable),
+			}, nil
+		},
+	}
+	if err := ValidatePreparation(context.Background(), input, changedPolicy); err == nil {
+		t.Fatal("changed waivable failure must invalidate retained authorization")
+	}
+	input.Projection = nil
 	input.ExecutionMode = api.WorkflowExecutionModeDebug
 	if err := ValidatePreparation(context.Background(), input, policy(api.RuleDispositionWaivable)); err != nil {
 		t.Fatalf("debug must bypass waivable direct-preparation policy: %v", err)

--- a/internal/trackers/impl/unit3d/definition.go
+++ b/internal/trackers/impl/unit3d/definition.go
@@ -259,10 +259,17 @@ func (d *Definition) prepareUpload(ctx context.Context, req trackers.Preparation
 	if err != nil {
 		return trackers.PreparedOperation{}, fmt.Errorf("trackers: %s constructibility: %w", d.profile.Name, err)
 	}
-	for _, failure := range failures {
-		if trackers.RuleFailureBlocksExecution(failure, req.ExecutionMode) {
-			return trackers.PreparedOperation{}, fmt.Errorf("trackers: %s constructibility %s: %s", d.profile.Name, failure.Rule, failure.Reason)
-		}
+	blockingFailure, err := trackers.FirstBlockingRuleFailure(req.Tracker, failures, req.ExecutionMode, req.Projection)
+	if err != nil {
+		return trackers.PreparedOperation{}, fmt.Errorf("trackers: %s rule authorization: %w", d.profile.Name, err)
+	}
+	if blockingFailure != nil {
+		return trackers.PreparedOperation{}, fmt.Errorf(
+			"trackers: %s constructibility %s: %s",
+			d.profile.Name,
+			blockingFailure.Rule,
+			blockingFailure.Reason,
+		)
 	}
 	if d.profile.BaseURL != "" {
 		return prepareUnit3DUpload(ctx, req, d.profile.BaseURL, d.profile.Site)

--- a/internal/trackers/persistence.go
+++ b/internal/trackers/persistence.go
@@ -22,6 +22,7 @@ type UploadPersistence interface {
 	ReplaceScreenshotSlots(context.Context, string, []api.ScreenshotSlot) error
 	UpsertScreenshotSlotVariants(context.Context, string, []api.ScreenshotSlotVariant) error
 	DeleteUploadedImage(context.Context, string, string, string) error
+	SaveTrackerRuleFailures(context.Context, string, string, []api.TrackerRuleFailure) error
 	CreateUploadRecord(context.Context, api.UploadRecord) error
 	UpdateLatestUploadRecordStatus(context.Context, string, string, string) error
 }

--- a/internal/trackers/persistence.go
+++ b/internal/trackers/persistence.go
@@ -10,7 +10,8 @@ import (
 )
 
 // UploadPersistence exposes only persisted state used by tracker preparation,
-// description assets, image-host resolution, and upload-ledger finalization.
+// rule-decision audit, description assets, image-host resolution, and
+// upload-ledger finalization.
 // Implementations preserve canonical query ordering and atomic slot updates.
 type UploadPersistence interface {
 	GetDescriptionOverride(context.Context, string, string) (api.DescriptionOverride, error)

--- a/internal/trackers/projection.go
+++ b/internal/trackers/projection.go
@@ -595,8 +595,10 @@ func duplicatePolicyID(descriptor Descriptor) string {
 	return strings.ToLower(strings.TrimSpace(descriptor.Name)) + "/duplicate/v1"
 }
 
-// ApplyProjectionRuleFailures records validation failures and updates tracker
-// eligibility using exact rule authorization and the shared execution-mode policy.
+// ApplyProjectionRuleFailures replaces prior rule-derived projection state,
+// fingerprints the current waivable failures, and updates tracker eligibility.
+// Authorization is retained only for an exact fingerprint match. A nil
+// projection is a no-op; fingerprinting failures are returned.
 func ApplyProjectionRuleFailures(
 	projection *api.TrackerReleaseProjection,
 	failures []api.RuleFailure,
@@ -628,14 +630,14 @@ func ApplyProjectionRuleFailures(
 	if authorized {
 		projection.RuleAuthorizationFingerprint = waivableFingerprint
 	}
-	hasStrict := slices.ContainsFunc(failures, api.IsStrictRuleFailure)
+	hasStrict := false
 	for _, failure := range failures {
 		disposition := api.NormalizeRuleDisposition(failure.Disposition)
 		blocking := RuleFailureBlocksExecution(failure, executionMode, authorized)
 		decision := string(disposition)
-		decisionAuthorized := false
 		switch {
 		case disposition == api.RuleDispositionStrict:
+			hasStrict = true
 			decision = "ineligible"
 			if logger != nil {
 				logger.Warnf(
@@ -644,9 +646,6 @@ func ApplyProjectionRuleFailures(
 					strings.TrimSpace(failure.Rule),
 				)
 			}
-			projection.Readiness = api.ReadinessStatusIneligible
-			projection.DupeReady = false
-			projection.UploadReady = false
 			projection.Failures = append(projection.Failures, api.WorkflowFailure{
 				Failure: api.OperationFailure{
 					Code:      api.OperationFailureNoEligibleTrackers,
@@ -658,7 +657,6 @@ func ApplyProjectionRuleFailures(
 			})
 		case disposition == api.RuleDispositionWaivable && authorized:
 			decision = "authorized"
-			decisionAuthorized = true
 		case disposition == api.RuleDispositionWaivable && !blocking:
 			decision = "bypassed"
 		case disposition == api.RuleDispositionWaivable:
@@ -676,7 +674,6 @@ func ApplyProjectionRuleFailures(
 			Decision:       decision,
 			Blocking:       blocking,
 			Message:        strings.TrimSpace(failure.Reason),
-			Authorized:     decisionAuthorized,
 			Disposition:    disposition,
 			EvidenceStatus: failure.EvidenceStatus,
 		})

--- a/internal/trackers/projection.go
+++ b/internal/trackers/projection.go
@@ -447,8 +447,18 @@ func (r *Registry) ProjectRelease(
 			projection.DupeReady = false
 			projection.UploadReady = false
 		} else {
-			ApplyProjectionRuleFailures(&projection, ruleFailures, input.ExecutionMode, input.Logger)
-			if projection.Readiness == api.ReadinessStatusUnknown {
+			if applyErr := ApplyProjectionRuleFailures(
+				&projection,
+				ruleFailures,
+				input.ExecutionMode,
+				input.AuthorizedRuleFingerprint,
+				input.Logger,
+			); applyErr != nil {
+				failure = NewPreparationFailure(input.Tracker, "rules", "tracker projection rule authorization failed", applyErr)
+				projection.Readiness = api.ReadinessStatusBlocked
+				projection.DupeReady = false
+				projection.UploadReady = false
+			} else if projection.Readiness == api.ReadinessStatusUnknown {
 				projection.Readiness = api.ReadinessStatusReady
 				projection.DupeReady = true
 				projection.UploadReady = true
@@ -586,24 +596,46 @@ func duplicatePolicyID(descriptor Descriptor) string {
 }
 
 // ApplyProjectionRuleFailures records validation failures and updates tracker
-// eligibility using the shared execution-mode policy.
+// eligibility using exact rule authorization and the shared execution-mode policy.
 func ApplyProjectionRuleFailures(
 	projection *api.TrackerReleaseProjection,
 	failures []api.RuleFailure,
 	executionMode api.WorkflowExecutionMode,
+	authorizedFingerprint api.WorkflowFingerprint,
 	logger api.Logger,
-) {
+) error {
 	if projection == nil {
-		return
+		return nil
 	}
+	projection.PolicyDecisions = slices.DeleteFunc(projection.PolicyDecisions, func(decision api.TrackerPolicyDecision) bool {
+		return decision.Disposition != ""
+	})
+	projection.RequiredActions = slices.DeleteFunc(projection.RequiredActions, func(action api.RequiredAction) bool {
+		return action.Kind == api.RequiredActionAuthorizeRules
+	})
+	projection.Failures = slices.DeleteFunc(projection.Failures, func(failure api.WorkflowFailure) bool {
+		return failure.Failure.Code == api.OperationFailureNoEligibleTrackers &&
+			failure.Failure.Operation == api.OperationKindDuplicateCheck
+	})
+	projection.WaivableRuleFingerprint = ""
+	projection.RuleAuthorizationFingerprint = ""
+	waivableFingerprint, err := WaivableRuleFailureFingerprint(string(projection.TrackerID), failures)
+	if err != nil {
+		return err
+	}
+	projection.WaivableRuleFingerprint = waivableFingerprint
+	authorized := waivableFingerprint != "" && authorizedFingerprint == waivableFingerprint
+	if authorized {
+		projection.RuleAuthorizationFingerprint = waivableFingerprint
+	}
+	hasStrict := slices.ContainsFunc(failures, api.IsStrictRuleFailure)
 	for _, failure := range failures {
 		disposition := api.NormalizeRuleDisposition(failure.Disposition)
-		blocking := RuleFailureBlocksExecution(failure, executionMode)
+		blocking := RuleFailureBlocksExecution(failure, executionMode, authorized)
 		decision := string(disposition)
-		if disposition == api.RuleDispositionWaivable && !blocking {
-			decision = "bypassed"
-		}
-		if blocking {
+		decisionAuthorized := false
+		switch {
+		case disposition == api.RuleDispositionStrict:
 			decision = "ineligible"
 			if logger != nil {
 				logger.Warnf(
@@ -624,14 +656,68 @@ func ApplyProjectionRuleFailures(
 				},
 				TrackerID: projection.TrackerID,
 			})
+		case disposition == api.RuleDispositionWaivable && authorized:
+			decision = "authorized"
+			decisionAuthorized = true
+		case disposition == api.RuleDispositionWaivable && !blocking:
+			decision = "bypassed"
+		case disposition == api.RuleDispositionWaivable:
+			decision = "authorization_required"
+			if logger != nil {
+				logger.Warnf(
+					"trackers: projection validation requires authorization tracker=%s rule=%s decision=authorization_required",
+					projection.TrackerID,
+					strings.TrimSpace(failure.Rule),
+				)
+			}
 		}
 		projection.PolicyDecisions = append(projection.PolicyDecisions, api.TrackerPolicyDecision{
 			Code:           strings.TrimSpace(failure.Rule),
 			Decision:       decision,
 			Blocking:       blocking,
 			Message:        strings.TrimSpace(failure.Reason),
+			Authorized:     decisionAuthorized,
 			Disposition:    disposition,
 			EvidenceStatus: failure.EvidenceStatus,
 		})
 	}
+	if hasStrict {
+		projection.Readiness = api.ReadinessStatusIneligible
+		projection.DupeReady = false
+		projection.UploadReady = false
+		return nil
+	}
+	if waivableFingerprint != "" && !authorized &&
+		api.NormalizeWorkflowExecutionMode(executionMode) != api.WorkflowExecutionModeDebug {
+		projection.Readiness = api.ReadinessStatusBlocked
+		projection.DupeReady = false
+		projection.UploadReady = false
+		projection.RequiredActions = append(projection.RequiredActions, api.RequiredAction{
+			Kind:      api.RequiredActionAuthorizeRules,
+			TrackerID: projection.TrackerID,
+			Prompt:    waivableRuleAuthorizationPrompt(*projection, failures),
+		})
+	}
+	return nil
+}
+
+func waivableRuleAuthorizationPrompt(projection api.TrackerReleaseProjection, failures []api.RuleFailure) string {
+	details := make([]string, 0, len(failures))
+	for _, failure := range failures {
+		failure = NormalizeRuleFailure(failure)
+		if failure.Disposition != api.RuleDispositionWaivable {
+			continue
+		}
+		detail := failure.Rule
+		if failure.Reason != "" {
+			detail += ": " + failure.Reason
+		}
+		details = append(details, detail)
+	}
+	slices.Sort(details)
+	tracker := strings.TrimSpace(projection.DisplayName)
+	if tracker == "" {
+		tracker = string(projection.TrackerID)
+	}
+	return fmt.Sprintf("%s has waivable rule failures: %s. Continue with this tracker?", tracker, strings.Join(details, "; "))
 }

--- a/internal/trackers/projection_test.go
+++ b/internal/trackers/projection_test.go
@@ -335,7 +335,7 @@ func TestDuplicateTargetPrefersProviderCode(t *testing.T) {
 	}
 }
 
-func TestApplyProjectionRuleFailuresHonorsExplicitDebugWaivers(t *testing.T) {
+func TestApplyProjectionRuleFailuresRequiresExactNormalAuthorization(t *testing.T) {
 	t.Parallel()
 
 	readyProjection := func() api.TrackerReleaseProjection {
@@ -358,29 +358,80 @@ func TestApplyProjectionRuleFailuresHonorsExplicitDebugWaivers(t *testing.T) {
 		api.RuleDispositionStrict,
 		api.MetadataEvidenceStatusComplete,
 	)}
+	waivableFingerprint, err := WaivableRuleFailureFingerprint("EXAMPLE", waivable)
+	if err != nil {
+		t.Fatalf("fingerprint waivable rules: %v", err)
+	}
+	apply := func(projection *api.TrackerReleaseProjection, failures []api.RuleFailure, mode api.WorkflowExecutionMode, authorization api.WorkflowFingerprint, logger api.Logger) {
+		t.Helper()
+		if err := ApplyProjectionRuleFailures(projection, failures, mode, authorization, logger); err != nil {
+			t.Fatalf("apply projection rule failures: %v", err)
+		}
+	}
 
 	normal := readyProjection()
-	ApplyProjectionRuleFailures(&normal, waivable, api.WorkflowExecutionModeNormal, nil)
-	if normal.Readiness != api.ReadinessStatusIneligible || normal.DupeReady || !normal.PolicyDecisions[0].Blocking {
+	apply(&normal, waivable, api.WorkflowExecutionModeNormal, "", nil)
+	if normal.Readiness != api.ReadinessStatusBlocked || normal.DupeReady || normal.UploadReady ||
+		len(normal.RequiredActions) != 1 || normal.RequiredActions[0].Kind != api.RequiredActionAuthorizeRules ||
+		normal.PolicyDecisions[0].Decision != "authorization_required" || !normal.PolicyDecisions[0].Blocking {
 		t.Fatalf("normal waivable outcome = %#v", normal)
 	}
 	if normal.PolicyDecisions[0].Disposition != api.RuleDispositionWaivable ||
 		normal.PolicyDecisions[0].EvidenceStatus != api.MetadataEvidenceStatusPartial {
 		t.Fatalf("normal public policy evidence = %#v", normal.PolicyDecisions[0])
 	}
+	if normal.WaivableRuleFingerprint != waivableFingerprint || normal.RuleAuthorizationFingerprint != "" {
+		t.Fatalf("normal rule authority = %#v", normal)
+	}
+
+	authorized := readyProjection()
+	apply(&authorized, waivable, api.WorkflowExecutionModeNormal, waivableFingerprint, nil)
+	if authorized.Readiness != api.ReadinessStatusReady || !authorized.DupeReady || !authorized.UploadReady ||
+		len(authorized.RequiredActions) != 0 || authorized.PolicyDecisions[0].Decision != "authorized" ||
+		authorized.PolicyDecisions[0].Blocking || !authorized.PolicyDecisions[0].Authorized ||
+		authorized.RuleAuthorizationFingerprint != waivableFingerprint {
+		t.Fatalf("authorized waivable outcome = %#v", authorized)
+	}
+
+	strictWithAuthorization := readyProjection()
+	combinedFailures := append(append([]api.RuleFailure(nil), waivable...), strict...)
+	apply(
+		&strictWithAuthorization,
+		combinedFailures,
+		api.WorkflowExecutionModeNormal,
+		waivableFingerprint,
+		nil,
+	)
+	if strictWithAuthorization.Readiness != api.ReadinessStatusIneligible || strictWithAuthorization.DupeReady ||
+		strictWithAuthorization.UploadReady || len(strictWithAuthorization.RequiredActions) != 0 ||
+		!strictWithAuthorization.PolicyDecisions[1].Blocking ||
+		strictWithAuthorization.PolicyDecisions[1].Disposition != api.RuleDispositionStrict {
+		t.Fatalf("strict failure with waivable authorization = %#v", strictWithAuthorization)
+	}
+
+	changed := readyProjection()
+	changedFailures := append(append([]api.RuleFailure(nil), waivable...), NewRuleFailure(
+		"second_gate",
+		"another waiver is required",
+		api.RuleDispositionWaivable,
+	))
+	apply(&changed, changedFailures, api.WorkflowExecutionModeNormal, waivableFingerprint, nil)
+	if changed.Readiness != api.ReadinessStatusBlocked || changed.RuleAuthorizationFingerprint != "" || len(changed.RequiredActions) != 1 {
+		t.Fatalf("changed waivable outcome = %#v", changed)
+	}
 
 	debug := readyProjection()
-	ApplyProjectionRuleFailures(&debug, waivable, api.WorkflowExecutionModeDebug, nil)
+	apply(&debug, waivable, api.WorkflowExecutionModeDebug, "", nil)
 	if debug.Readiness != api.ReadinessStatusReady || !debug.DupeReady || debug.PolicyDecisions[0].Decision != "bypassed" ||
-		debug.PolicyDecisions[0].Blocking {
+		debug.PolicyDecisions[0].Blocking || debug.PolicyDecisions[0].Authorized || len(debug.RequiredActions) != 0 {
 		t.Fatalf("debug waivable outcome = %#v", debug)
 	}
 
 	debugStrict := readyProjection()
 	logger := &warningLogger{}
-	ApplyProjectionRuleFailures(&debugStrict, strict, api.WorkflowExecutionModeDebug, logger)
+	apply(&debugStrict, strict, api.WorkflowExecutionModeDebug, "", logger)
 	if debugStrict.Readiness != api.ReadinessStatusIneligible || debugStrict.DupeReady ||
-		debugStrict.PolicyDecisions[0].Decision != "ineligible" {
+		debugStrict.PolicyDecisions[0].Decision != "ineligible" || len(debugStrict.RequiredActions) != 0 {
 		t.Fatalf("debug strict outcome = %#v", debugStrict)
 	}
 	if len(logger.warnings) != 1 || logger.warnings[0] != "trackers: projection validation blocked tracker=EXAMPLE rule=constructibility decision=ineligible" {

--- a/internal/trackers/projection_test.go
+++ b/internal/trackers/projection_test.go
@@ -388,8 +388,7 @@ func TestApplyProjectionRuleFailuresRequiresExactNormalAuthorization(t *testing.
 	apply(&authorized, waivable, api.WorkflowExecutionModeNormal, waivableFingerprint, nil)
 	if authorized.Readiness != api.ReadinessStatusReady || !authorized.DupeReady || !authorized.UploadReady ||
 		len(authorized.RequiredActions) != 0 || authorized.PolicyDecisions[0].Decision != "authorized" ||
-		authorized.PolicyDecisions[0].Blocking || !authorized.PolicyDecisions[0].Authorized ||
-		authorized.RuleAuthorizationFingerprint != waivableFingerprint {
+		authorized.PolicyDecisions[0].Blocking || authorized.RuleAuthorizationFingerprint != waivableFingerprint {
 		t.Fatalf("authorized waivable outcome = %#v", authorized)
 	}
 
@@ -423,7 +422,7 @@ func TestApplyProjectionRuleFailuresRequiresExactNormalAuthorization(t *testing.
 	debug := readyProjection()
 	apply(&debug, waivable, api.WorkflowExecutionModeDebug, "", nil)
 	if debug.Readiness != api.ReadinessStatusReady || !debug.DupeReady || debug.PolicyDecisions[0].Decision != "bypassed" ||
-		debug.PolicyDecisions[0].Blocking || debug.PolicyDecisions[0].Authorized || len(debug.RequiredActions) != 0 {
+		debug.PolicyDecisions[0].Blocking || len(debug.RequiredActions) != 0 {
 		t.Fatalf("debug waivable outcome = %#v", debug)
 	}
 

--- a/internal/trackers/rule_contract.go
+++ b/internal/trackers/rule_contract.go
@@ -91,8 +91,9 @@ func normalizeRuleEvidenceStatus(status api.MetadataEvidenceStatus) api.Metadata
 }
 
 // RuleFailureBlocksExecution reports whether a validation failure blocks the
-// selected workflow execution mode. Waivable failures require exact authority
-// in normal mode and remain automatically bypassed in debug mode.
+// selected workflow execution mode. Strict failures always block, advisory
+// failures never block, and authorized waivable failures do not block. Debug
+// mode also bypasses unauthorized waivable failures.
 func RuleFailureBlocksExecution(failure api.RuleFailure, mode api.WorkflowExecutionMode, authorized bool) bool {
 	disposition := api.NormalizeRuleDisposition(failure.Disposition)
 	if disposition == api.RuleDispositionAdvisory {
@@ -111,8 +112,9 @@ type waivableRuleIdentity struct {
 	EvidenceStatus api.MetadataEvidenceStatus
 }
 
-// WaivableRuleFailureFingerprint identifies one exact tracker-local set of
-// waivable failures independently of evaluator return order.
+// WaivableRuleFailureFingerprint identifies the normalized tracker-local
+// waivable failures independently of evaluator return order. It returns an
+// empty fingerprint when failures contains no waivable result.
 func WaivableRuleFailureFingerprint(tracker string, failures []api.RuleFailure) (api.WorkflowFingerprint, error) {
 	identities := make([]waivableRuleIdentity, 0, len(failures))
 	for _, failure := range failures {
@@ -131,13 +133,11 @@ func WaivableRuleFailureFingerprint(tracker string, failures []api.RuleFailure) 
 		return "", nil
 	}
 	slices.SortFunc(identities, func(left, right waivableRuleIdentity) int {
-		if result := cmp.Compare(left.Rule, right.Rule); result != 0 {
-			return result
-		}
-		if result := cmp.Compare(left.Reason, right.Reason); result != 0 {
-			return result
-		}
-		return cmp.Compare(string(left.EvidenceStatus), string(right.EvidenceStatus))
+		return cmp.Or(
+			cmp.Compare(left.Rule, right.Rule),
+			cmp.Compare(left.Reason, right.Reason),
+			cmp.Compare(left.EvidenceStatus, right.EvidenceStatus),
+		)
 	})
 	fingerprint, err := api.CanonicalWorkflowFingerprint(struct {
 		Contract string
@@ -154,36 +154,25 @@ func WaivableRuleFailureFingerprint(tracker string, failures []api.RuleFailure) 
 	return fingerprint, nil
 }
 
-// ProjectionAuthorizesRuleFailures reports whether a retained projection
-// authorizes the exact current waivable failure set.
-func ProjectionAuthorizesRuleFailures(
-	tracker string,
-	failures []api.RuleFailure,
-	projection *api.TrackerReleaseProjection,
-) (bool, error) {
-	if projection == nil || projection.RuleAuthorizationFingerprint == "" {
-		return false, nil
-	}
-	fingerprint, err := WaivableRuleFailureFingerprint(tracker, failures)
-	if err != nil {
-		return false, err
-	}
-	return fingerprint != "" &&
-		projection.WaivableRuleFingerprint == fingerprint &&
-		projection.RuleAuthorizationFingerprint == fingerprint, nil
-}
-
-// FirstBlockingRuleFailure returns the first failure that remains unresolved
-// for tracker preparation.
+// FirstBlockingRuleFailure returns the first input failure that blocks tracker
+// preparation. Projection authorization applies only when both stored
+// fingerprints match the current normalized waivable failures; nil means no
+// failure blocks.
 func FirstBlockingRuleFailure(
 	tracker string,
 	failures []api.RuleFailure,
 	mode api.WorkflowExecutionMode,
 	projection *api.TrackerReleaseProjection,
 ) (*api.RuleFailure, error) {
-	authorized, err := ProjectionAuthorizesRuleFailures(tracker, failures, projection)
-	if err != nil {
-		return nil, err
+	authorized := false
+	if projection != nil && projection.RuleAuthorizationFingerprint != "" {
+		fingerprint, err := WaivableRuleFailureFingerprint(tracker, failures)
+		if err != nil {
+			return nil, err
+		}
+		authorized = fingerprint != "" &&
+			projection.WaivableRuleFingerprint == fingerprint &&
+			projection.RuleAuthorizationFingerprint == fingerprint
 	}
 	for index := range failures {
 		if RuleFailureBlocksExecution(failures[index], mode, authorized) {

--- a/internal/trackers/rule_contract.go
+++ b/internal/trackers/rule_contract.go
@@ -4,8 +4,11 @@
 package trackers
 
 import (
+	"cmp"
 	"context"
 	"errors"
+	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/autobrr/upbrr/pkg/api"
@@ -87,15 +90,107 @@ func normalizeRuleEvidenceStatus(status api.MetadataEvidenceStatus) api.Metadata
 	}
 }
 
-// RuleFailureBlocksExecution reports whether a validation failure makes the
-// tracker ineligible in the selected workflow execution mode.
-func RuleFailureBlocksExecution(failure api.RuleFailure, mode api.WorkflowExecutionMode) bool {
+// RuleFailureBlocksExecution reports whether a validation failure blocks the
+// selected workflow execution mode. Waivable failures require exact authority
+// in normal mode and remain automatically bypassed in debug mode.
+func RuleFailureBlocksExecution(failure api.RuleFailure, mode api.WorkflowExecutionMode, authorized bool) bool {
 	disposition := api.NormalizeRuleDisposition(failure.Disposition)
 	if disposition == api.RuleDispositionAdvisory {
 		return false
 	}
-	return disposition != api.RuleDispositionWaivable ||
-		api.NormalizeWorkflowExecutionMode(mode) != api.WorkflowExecutionModeDebug
+	if disposition == api.RuleDispositionStrict {
+		return true
+	}
+	return !authorized && api.NormalizeWorkflowExecutionMode(mode) != api.WorkflowExecutionModeDebug
+}
+
+type waivableRuleIdentity struct {
+	Rule           string
+	Reason         string
+	Disposition    api.RuleDisposition
+	EvidenceStatus api.MetadataEvidenceStatus
+}
+
+// WaivableRuleFailureFingerprint identifies one exact tracker-local set of
+// waivable failures independently of evaluator return order.
+func WaivableRuleFailureFingerprint(tracker string, failures []api.RuleFailure) (api.WorkflowFingerprint, error) {
+	identities := make([]waivableRuleIdentity, 0, len(failures))
+	for _, failure := range failures {
+		failure = NormalizeRuleFailure(failure)
+		if failure.Disposition != api.RuleDispositionWaivable {
+			continue
+		}
+		identities = append(identities, waivableRuleIdentity{
+			Rule:           failure.Rule,
+			Reason:         failure.Reason,
+			Disposition:    failure.Disposition,
+			EvidenceStatus: failure.EvidenceStatus,
+		})
+	}
+	if len(identities) == 0 {
+		return "", nil
+	}
+	slices.SortFunc(identities, func(left, right waivableRuleIdentity) int {
+		if result := cmp.Compare(left.Rule, right.Rule); result != 0 {
+			return result
+		}
+		if result := cmp.Compare(left.Reason, right.Reason); result != 0 {
+			return result
+		}
+		return cmp.Compare(string(left.EvidenceStatus), string(right.EvidenceStatus))
+	})
+	fingerprint, err := api.CanonicalWorkflowFingerprint(struct {
+		Contract string
+		Tracker  string
+		Failures []waivableRuleIdentity
+	}{
+		Contract: "tracker-waivable-rules-v1",
+		Tracker:  strings.ToUpper(strings.TrimSpace(tracker)),
+		Failures: identities,
+	})
+	if err != nil {
+		return "", fmt.Errorf("fingerprint waivable tracker rules: %w", err)
+	}
+	return fingerprint, nil
+}
+
+// ProjectionAuthorizesRuleFailures reports whether a retained projection
+// authorizes the exact current waivable failure set.
+func ProjectionAuthorizesRuleFailures(
+	tracker string,
+	failures []api.RuleFailure,
+	projection *api.TrackerReleaseProjection,
+) (bool, error) {
+	if projection == nil || projection.RuleAuthorizationFingerprint == "" {
+		return false, nil
+	}
+	fingerprint, err := WaivableRuleFailureFingerprint(tracker, failures)
+	if err != nil {
+		return false, err
+	}
+	return fingerprint != "" &&
+		projection.WaivableRuleFingerprint == fingerprint &&
+		projection.RuleAuthorizationFingerprint == fingerprint, nil
+}
+
+// FirstBlockingRuleFailure returns the first failure that remains unresolved
+// for tracker preparation.
+func FirstBlockingRuleFailure(
+	tracker string,
+	failures []api.RuleFailure,
+	mode api.WorkflowExecutionMode,
+	projection *api.TrackerReleaseProjection,
+) (*api.RuleFailure, error) {
+	authorized, err := ProjectionAuthorizesRuleFailures(tracker, failures, projection)
+	if err != nil {
+		return nil, err
+	}
+	for index := range failures {
+		if RuleFailureBlocksExecution(failures[index], mode, authorized) {
+			return &failures[index], nil
+		}
+	}
+	return nil, nil
 }
 
 // LanguageRule configures waivable language requirements and the release types to which they apply.

--- a/internal/trackers/service_plan_test.go
+++ b/internal/trackers/service_plan_test.go
@@ -375,7 +375,6 @@ func TestRetainedUploadPlanPersistsAuthorizedRuleAudit(t *testing.T) {
 					Code:        "language_rule",
 					Decision:    "authorized",
 					Message:     "language waiver accepted",
-					Authorized:  true,
 					Disposition: api.RuleDispositionWaivable,
 				},
 				{

--- a/internal/trackers/service_plan_test.go
+++ b/internal/trackers/service_plan_test.go
@@ -405,6 +405,31 @@ func TestRetainedUploadPlanPersistsAuthorizedRuleAudit(t *testing.T) {
 	}
 }
 
+func TestProjectedRuleFailureRecordsReturnsNilWithoutRecords(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		projection api.TrackerReleaseProjection
+	}{
+		{name: "no decisions"},
+		{
+			name: "all decisions filtered",
+			projection: api.TrackerReleaseProjection{PolicyDecisions: []api.TrackerPolicyDecision{
+				{Disposition: api.RuleDispositionWaivable},
+				{Code: "missing_disposition"},
+			}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if records := projectedRuleFailureRecords(test.projection); records != nil {
+				t.Fatalf("rule failure records = %#v, want nil", records)
+			}
+		})
+	}
+}
+
 func TestRetainedUploadPlanLogsReturnedTorrentPageURL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/service_plan_test.go
+++ b/internal/trackers/service_plan_test.go
@@ -340,6 +340,72 @@ func TestRetainedUploadPlanExecutesExactReviewedProjectionWithoutRepreparing(t *
 	}
 }
 
+func TestRetainedUploadPlanPersistsAuthorizedRuleAudit(t *testing.T) {
+	t.Parallel()
+
+	var prepared atomic.Int32
+	var submitted atomic.Int32
+	repository := &stubRepo{}
+	registry := NewRegistry()
+	if err := registry.Register(retainedProjectionDefinition{
+		name:      "EXAMPLE",
+		prepared:  &prepared,
+		submitted: &submitted,
+		input:     make(chan PreparationInput, 1),
+	}); err != nil {
+		t.Fatalf("register retained definition: %v", err)
+	}
+	service := NewServiceWithRegistry(config.Config{}, nil, repository, registry)
+	fingerprint, err := api.CanonicalWorkflowFingerprint("authorized-waivable-rules")
+	if err != nil {
+		t.Fatalf("fingerprint waivable rules: %v", err)
+	}
+	retained, err := service.PrepareRetainedUploadPlan(
+		context.Background(),
+		api.UploadSubject{SourcePath: "Example.Release.2026", ReleaseName: "Example.Release.2026-GRP"},
+		[]api.TrackerReleaseProjection{{
+			TrackerID:                    "EXAMPLE",
+			UploadReleaseName:            "Example.Release.2026-GRP",
+			Readiness:                    api.ReadinessStatusReady,
+			UploadReady:                  true,
+			WaivableRuleFingerprint:      fingerprint,
+			RuleAuthorizationFingerprint: fingerprint,
+			PolicyDecisions: []api.TrackerPolicyDecision{
+				{
+					Code:        "language_rule",
+					Decision:    "authorized",
+					Message:     "language waiver accepted",
+					Authorized:  true,
+					Disposition: api.RuleDispositionWaivable,
+				},
+				{
+					Code:        "metadata_note",
+					Decision:    string(api.RuleDispositionAdvisory),
+					Message:     "advisory evidence",
+					Disposition: api.RuleDispositionAdvisory,
+				},
+			},
+		}},
+	)
+	if err != nil {
+		t.Fatalf("prepare retained upload plan: %v", err)
+	}
+	if _, err := retained.Execute(context.Background()); err != nil {
+		t.Fatalf("execute retained upload plan: %v", err)
+	}
+	repository.mu.Lock()
+	saves := append([]ruleFailureSave(nil), repository.ruleFailureSaves...)
+	repository.mu.Unlock()
+	if len(saves) != 1 || saves[0].sourcePath != "Example.Release.2026" || saves[0].tracker != "EXAMPLE" ||
+		len(saves[0].failures) != 2 {
+		t.Fatalf("rule audit saves = %#v", saves)
+	}
+	if !saves[0].failures[0].Authorized || saves[0].failures[0].Disposition != api.RuleDispositionWaivable ||
+		saves[0].failures[1].Authorized || saves[0].failures[1].Disposition != api.RuleDispositionAdvisory {
+		t.Fatalf("persisted rule audit = %#v", saves[0].failures)
+	}
+}
+
 func TestRetainedUploadPlanLogsReturnedTorrentPageURL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/service_upload_plan.go
+++ b/internal/trackers/service_upload_plan.go
@@ -597,7 +597,7 @@ func (s *Service) createPendingRecords(ctx context.Context, meta api.UploadSubje
 
 // projectedRuleFailureRecords converts rule decisions into persisted audit
 // rows. A waivable decision is marked authorized only when both projection
-// fingerprints match exactly.
+// fingerprints match exactly. It returns nil when no decision qualifies.
 func projectedRuleFailureRecords(projection api.TrackerReleaseProjection) []api.TrackerRuleFailure {
 	records := make([]api.TrackerRuleFailure, 0, len(projection.PolicyDecisions))
 	authorized := projection.RuleAuthorizationFingerprint != "" &&
@@ -614,6 +614,9 @@ func projectedRuleFailureRecords(projection api.TrackerReleaseProjection) []api.
 			Disposition: disposition,
 			Authorized:  disposition == api.RuleDispositionWaivable && authorized,
 		})
+	}
+	if len(records) == 0 {
+		return nil
 	}
 	return records
 }

--- a/internal/trackers/service_upload_plan.go
+++ b/internal/trackers/service_upload_plan.go
@@ -76,6 +76,8 @@ type trackerPlanSlot struct {
 	plan                     TrackerPlan
 	failure                  *TrackerFailure
 	summary                  api.UploadSummary
+	ruleFailures             []api.TrackerRuleFailure
+	ruleFailuresKnown        bool
 	canceledDuringSubmission bool
 }
 
@@ -186,6 +188,10 @@ func (s *Service) prepareUploadPlans(
 		for idx := range jobs {
 			tracker := resolved[idx]
 			slot := trackerPlanSlot{tracker: tracker}
+			if projection, ok := projections[normalizeTrackerName(tracker)]; ok {
+				slot.ruleFailures = projectedRuleFailureRecords(projection)
+				slot.ruleFailuresKnown = true
+			}
 			emitTrackerPlanProgress(ctx, meta.SourcePath, tracker, "tracker_preparation", "running", "Preparing tracker plan")
 			if failure := banned[normalizeTrackerName(tracker)]; failure != nil {
 				slot.failure = failure
@@ -561,6 +567,16 @@ func (s *Service) createPendingRecords(ctx context.Context, meta api.UploadSubje
 		if slot.failure != nil || slot.plan.Intent() != PreparationIntentUpload {
 			continue
 		}
+		if slot.ruleFailuresKnown {
+			if err := s.repo.SaveTrackerRuleFailures(ctx, meta.SourcePath, slot.tracker, slot.ruleFailures); err != nil {
+				slot.failure = trackerFailure(slot.tracker, "rule_history", err)
+				if releaseErr := slot.plan.Release(); releaseErr != nil {
+					s.warnPlanRelease(slot.tracker, releaseErr)
+				}
+				emitTrackerPlanProgress(ctx, meta.SourcePath, slot.tracker, "tracker_upload", "failed", slot.failure.Message)
+				continue
+			}
+		}
 		status := "pending"
 		if IsInternalGroup(s.cfg, slot.tracker, meta) {
 			status = "pending-internal"
@@ -579,6 +595,24 @@ func (s *Service) createPendingRecords(ctx context.Context, meta api.UploadSubje
 			continue
 		}
 	}
+}
+
+func projectedRuleFailureRecords(projection api.TrackerReleaseProjection) []api.TrackerRuleFailure {
+	records := make([]api.TrackerRuleFailure, 0, len(projection.PolicyDecisions))
+	for _, decision := range projection.PolicyDecisions {
+		if strings.TrimSpace(decision.Code) == "" || decision.Disposition == "" {
+			continue
+		}
+		disposition := api.NormalizeRuleDisposition(decision.Disposition)
+		records = append(records, api.TrackerRuleFailure{
+			Tracker:     string(projection.TrackerID),
+			Rule:        strings.TrimSpace(decision.Code),
+			Reason:      strings.TrimSpace(decision.Message),
+			Disposition: disposition,
+			Authorized:  disposition == api.RuleDispositionWaivable && decision.Authorized,
+		})
+	}
+	return records
 }
 
 // submitTrackerPlans finishes reusable-base uploads first, then waits the

--- a/internal/trackers/service_upload_plan.go
+++ b/internal/trackers/service_upload_plan.go
@@ -77,7 +77,6 @@ type trackerPlanSlot struct {
 	failure                  *TrackerFailure
 	summary                  api.UploadSummary
 	ruleFailures             []api.TrackerRuleFailure
-	ruleFailuresKnown        bool
 	canceledDuringSubmission bool
 }
 
@@ -190,7 +189,6 @@ func (s *Service) prepareUploadPlans(
 			slot := trackerPlanSlot{tracker: tracker}
 			if projection, ok := projections[normalizeTrackerName(tracker)]; ok {
 				slot.ruleFailures = projectedRuleFailureRecords(projection)
-				slot.ruleFailuresKnown = true
 			}
 			emitTrackerPlanProgress(ctx, meta.SourcePath, tracker, "tracker_preparation", "running", "Preparing tracker plan")
 			if failure := banned[normalizeTrackerName(tracker)]; failure != nil {
@@ -567,7 +565,7 @@ func (s *Service) createPendingRecords(ctx context.Context, meta api.UploadSubje
 		if slot.failure != nil || slot.plan.Intent() != PreparationIntentUpload {
 			continue
 		}
-		if slot.ruleFailuresKnown {
+		if slot.ruleFailures != nil {
 			if err := s.repo.SaveTrackerRuleFailures(ctx, meta.SourcePath, slot.tracker, slot.ruleFailures); err != nil {
 				slot.failure = trackerFailure(slot.tracker, "rule_history", err)
 				if releaseErr := slot.plan.Release(); releaseErr != nil {
@@ -597,8 +595,13 @@ func (s *Service) createPendingRecords(ctx context.Context, meta api.UploadSubje
 	}
 }
 
+// projectedRuleFailureRecords converts rule decisions into persisted audit
+// rows. A waivable decision is marked authorized only when both projection
+// fingerprints match exactly.
 func projectedRuleFailureRecords(projection api.TrackerReleaseProjection) []api.TrackerRuleFailure {
 	records := make([]api.TrackerRuleFailure, 0, len(projection.PolicyDecisions))
+	authorized := projection.RuleAuthorizationFingerprint != "" &&
+		projection.RuleAuthorizationFingerprint == projection.WaivableRuleFingerprint
 	for _, decision := range projection.PolicyDecisions {
 		if strings.TrimSpace(decision.Code) == "" || decision.Disposition == "" {
 			continue
@@ -609,7 +612,7 @@ func projectedRuleFailureRecords(projection api.TrackerReleaseProjection) []api.
 			Rule:        strings.TrimSpace(decision.Code),
 			Reason:      strings.TrimSpace(decision.Message),
 			Disposition: disposition,
-			Authorized:  disposition == api.RuleDispositionWaivable && decision.Authorized,
+			Authorized:  disposition == api.RuleDispositionWaivable && authorized,
 		})
 	}
 	return records

--- a/internal/trackers/workflow_projector.go
+++ b/internal/trackers/workflow_projector.go
@@ -37,13 +37,16 @@ func NewWorkflowProjector(registry *Registry, cfg config.Config, logger api.Logg
 }
 
 // Build creates unstamped snapshot content; the workflow module owns IDs,
-// revisions, lineage refs, timestamps, and publication.
+// revisions, lineage refs, timestamps, and publication. Rule authorizations are
+// tracker-scoped server authority and apply only to an identical freshly
+// evaluated waivable-failure fingerprint.
 func (p *WorkflowProjector) Build(
 	ctx context.Context,
 	release api.ReleaseSnapshot,
 	subject api.UploadSubject,
 	trackerIDs []api.TrackerID,
 	instructions map[api.TrackerID]api.TrackerProjectionInstructions,
+	ruleAuthorizations map[api.TrackerID]api.WorkflowFingerprint,
 	executionMode api.WorkflowExecutionMode,
 ) (
 	api.TrackerCatalogSnapshot,
@@ -83,11 +86,12 @@ func (p *WorkflowProjector) Build(
 			fmt.Errorf("trackers: selection fingerprint: %w", err)
 	}
 	inputFingerprint, err := api.CanonicalWorkflowFingerprint(struct {
-		Release       api.WorkflowFingerprint
-		TrackerIDs    []api.TrackerID
-		Instructions  map[api.TrackerID]api.TrackerProjectionInstructions
-		ExecutionMode api.WorkflowExecutionMode
-	}{release.Fingerprint, selected, instructions, api.NormalizeWorkflowExecutionMode(executionMode)})
+		Release            api.WorkflowFingerprint
+		TrackerIDs         []api.TrackerID
+		Instructions       map[api.TrackerID]api.TrackerProjectionInstructions
+		RuleAuthorizations map[api.TrackerID]api.WorkflowFingerprint
+		ExecutionMode      api.WorkflowExecutionMode
+	}{release.Fingerprint, selected, instructions, ruleAuthorizations, api.NormalizeWorkflowExecutionMode(executionMode)})
 	if err != nil {
 		return api.TrackerCatalogSnapshot{}, api.TrackerRuntimeSnapshot{}, api.TrackerSelection{}, api.TrackerReleaseProjectionSet{},
 			fmt.Errorf("trackers: projection input fingerprint: %w", err)
@@ -97,6 +101,7 @@ func (p *WorkflowProjector) Build(
 		subject,
 		selected,
 		instructions,
+		ruleAuthorizations,
 		inputFingerprint,
 		catalog.Fingerprint,
 		configFingerprints,
@@ -206,6 +211,7 @@ func (p *WorkflowProjector) projectSelected(
 	subject api.UploadSubject,
 	selected []api.TrackerID,
 	instructions map[api.TrackerID]api.TrackerProjectionInstructions,
+	ruleAuthorizations map[api.TrackerID]api.WorkflowFingerprint,
 	inputFingerprint api.WorkflowFingerprint,
 	catalogFingerprint api.WorkflowFingerprint,
 	configFingerprints map[api.TrackerID]api.WorkflowFingerprint,
@@ -238,7 +244,7 @@ func (p *WorkflowProjector) projectSelected(
 			Meta:                      trackerSubject,
 			RequestedUploadName:       requestedName,
 			AdditionalReleaseNames:    projectionAdditionalNames(instruction),
-			AuthorizedRuleFingerprint: instruction.AuthorizedRuleFingerprint,
+			AuthorizedRuleFingerprint: ruleAuthorizations[trackerID],
 			TrackerConfig:             applyTrackerConfigOverrides(trackerConfigFor(p.config, string(trackerID)), instruction.TrackerConfig),
 			Runtime:                   PreparationRuntimeFromConfig(p.config),
 			Logger:                    p.logger,

--- a/internal/trackers/workflow_projector.go
+++ b/internal/trackers/workflow_projector.go
@@ -233,14 +233,15 @@ func (p *WorkflowProjector) projectSelected(
 		applyQuestionnaireInstruction(&trackerSubject, trackerID, instruction)
 		requestedName := projectionRequestedUploadName(instruction)
 		projection, failure := p.registry.ProjectRelease(ctx, PreparationInput{
-			ExecutionMode:          executionMode,
-			Tracker:                string(trackerID),
-			Meta:                   trackerSubject,
-			RequestedUploadName:    requestedName,
-			AdditionalReleaseNames: projectionAdditionalNames(instruction),
-			TrackerConfig:          applyTrackerConfigOverrides(trackerConfigFor(p.config, string(trackerID)), instruction.TrackerConfig),
-			Runtime:                PreparationRuntimeFromConfig(p.config),
-			Logger:                 p.logger,
+			ExecutionMode:             executionMode,
+			Tracker:                   string(trackerID),
+			Meta:                      trackerSubject,
+			RequestedUploadName:       requestedName,
+			AdditionalReleaseNames:    projectionAdditionalNames(instruction),
+			AuthorizedRuleFingerprint: instruction.AuthorizedRuleFingerprint,
+			TrackerConfig:             applyTrackerConfigOverrides(trackerConfigFor(p.config, string(trackerID)), instruction.TrackerConfig),
+			Runtime:                   PreparationRuntimeFromConfig(p.config),
+			Logger:                    p.logger,
 		}, inputFingerprint, catalogFingerprint, configFingerprints[trackerID])
 		if descriptor, ok := p.registry.LookupDescriptor(string(trackerID)); ok {
 			applyWorkflowProjectionRequirements(&projection, descriptor, subject, p.config)
@@ -259,7 +260,10 @@ func (p *WorkflowProjector) projectSelected(
 		projections = append(projections, projection)
 		itemStatus := api.StageStatusCompleted
 		message := "Tracker projection complete."
-		if projection.Readiness != api.ReadinessStatusReady || !projection.DupeReady {
+		if len(projection.RequiredActions) > 0 {
+			itemStatus = api.StageStatusBlocked
+			message = strings.TrimSpace(projection.RequiredActions[0].Prompt)
+		} else if projection.Readiness != api.ReadinessStatusReady || !projection.DupeReady {
 			itemStatus = api.StageStatusSkipped
 			message = projectionIneligibleProgressMessage(projection)
 		}

--- a/internal/webserver/openapi/release-workflow-v1.json
+++ b/internal/webserver/openapi/release-workflow-v1.json
@@ -8185,6 +8185,9 @@
       "TrackerPolicyDecision": {
         "type": "object",
         "properties": {
+          "authorized": {
+            "type": "boolean"
+          },
           "blocking": {
             "type": "boolean"
           },
@@ -8481,6 +8484,9 @@
               ]
             }
           },
+          "authorizedRuleFingerprint": {
+            "$ref": "#/components/schemas/WorkflowFingerprint"
+          },
           "questionnaire": {
             "type": "object",
             "additionalProperties": {
@@ -8684,6 +8690,9 @@
               "$ref": "#/components/schemas/RequiredAction"
             }
           },
+          "ruleAuthorizationFingerprint": {
+            "$ref": "#/components/schemas/WorkflowFingerprint"
+          },
           "taxonomy": {
             "$ref": "#/components/schemas/TrackerTaxonomy"
           },
@@ -8695,6 +8704,9 @@
           },
           "uploadReleaseName": {
             "type": "string"
+          },
+          "waivableRuleFingerprint": {
+            "$ref": "#/components/schemas/WorkflowFingerprint"
           }
         },
         "required": [

--- a/internal/webserver/openapi/release-workflow-v1.json
+++ b/internal/webserver/openapi/release-workflow-v1.json
@@ -8185,9 +8185,6 @@
       "TrackerPolicyDecision": {
         "type": "object",
         "properties": {
-          "authorized": {
-            "type": "boolean"
-          },
           "blocking": {
             "type": "boolean"
           },
@@ -8483,9 +8480,6 @@
                 }
               ]
             }
-          },
-          "authorizedRuleFingerprint": {
-            "$ref": "#/components/schemas/WorkflowFingerprint"
           },
           "questionnaire": {
             "type": "object",

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -1488,12 +1488,13 @@ func HasBlockingRuleFailures(failures []RuleFailure) bool {
 	return slices.ContainsFunc(failures, IsBlockingRuleFailure)
 }
 
-// CountBlockingRuleFailures returns the number of rule results that block
-// tracker work. Legacy and unrecognized dispositions are counted as blocking.
+// CountBlockingRuleFailures returns the number of unresolved rule results that
+// block tracker work. Authorized waivable results do not block.
 func CountBlockingRuleFailures(failures []TrackerRuleFailure) int {
 	count := 0
 	for _, failure := range failures {
-		if NormalizeRuleDisposition(failure.Disposition) != RuleDispositionAdvisory {
+		disposition := NormalizeRuleDisposition(failure.Disposition)
+		if disposition != RuleDispositionAdvisory && (disposition != RuleDispositionWaivable || !failure.Authorized) {
 			count++
 		}
 	}

--- a/pkg/api/services_test.go
+++ b/pkg/api/services_test.go
@@ -252,15 +252,15 @@ func TestNewTrackerValidationSubjectProjectsFinalTrackerDescription(t *testing.T
 		DescriptionGroupsFinal: true,
 		DescriptionGroups: []DescriptionBuilderGroup{
 			{
-				GroupKey:   "other",
-				Trackers:   []string{"OTHER"},
+				GroupKey:    "other",
+				Trackers:    []string{"OTHER"},
 				Description: "Other description.",
 			},
 			{
-				GroupKey:      "hdb",
-				Trackers:      []string{"HDB"},
-				Description:   "Manual synopsis.\n[img]https://img.example/poster.jpg[/img]",
-				HasOverride:   true,
+				GroupKey:       "hdb",
+				Trackers:       []string{"HDB"},
+				Description:    "Manual synopsis.\n[img]https://img.example/poster.jpg[/img]",
+				HasOverride:    true,
 				RawDescription: "unused raw description",
 			},
 		},
@@ -315,6 +315,11 @@ func TestRuleFailureDispositionFailClosed(t *testing.T) {
 		{Rule: "legacy"},
 		{Rule: "advisory", Disposition: RuleDispositionAdvisory},
 		{Rule: "unknown", Disposition: "unexpected"},
+		{
+			Rule:        "accepted",
+			Disposition: RuleDispositionWaivable,
+			Authorized:  true,
+		},
 	}
 	if got := CountBlockingRuleFailures(storedFailures); got != 2 {
 		t.Fatalf("blocking count = %d, want 2", got)

--- a/pkg/api/workflow_contracts.go
+++ b/pkg/api/workflow_contracts.go
@@ -112,9 +112,6 @@ type TrackerProjectionInstructions struct {
 	Questionnaire     map[string]*string     `json:"questionnaire,omitempty"`
 	TrackerConfig     TrackerConfigOverrides `json:"trackerConfig,omitempty"`
 	TrackerSite       TrackerSiteOverrides   `json:"trackerSite,omitempty"`
-	// AuthorizedRuleFingerprint is server-owned authority for one exact set of
-	// waivable rule failures. Caller-supplied values are ignored.
-	AuthorizedRuleFingerprint WorkflowFingerprint `json:"authorizedRuleFingerprint,omitempty"`
 }
 
 // TrackerProjectionInstructionSnapshot retains tracker-local projection instructions.
@@ -246,8 +243,6 @@ type TrackerPolicyDecision struct {
 	Decision string `json:"decision"`
 	Blocking bool   `json:"blocking"`
 	Message  string `json:"message,omitempty"`
-	// Authorized reports that the exact waivable result was accepted by the user.
-	Authorized bool `json:"authorized,omitempty"`
 	// Disposition is the backend-owned execution effect of a failed rule.
 	Disposition RuleDisposition `json:"disposition,omitempty"`
 	// EvidenceStatus states how completely the backend could evaluate the rule.
@@ -283,9 +278,11 @@ type TrackerReleaseProjection struct {
 	EpisodeTitleMode  EpisodeTitleMode        `json:"episodeTitleMode"`
 	NamingFingerprint WorkflowFingerprint     `json:"namingFingerprint"`
 	PolicyDecisions   []TrackerPolicyDecision `json:"policyDecisions,omitempty"`
-	// WaivableRuleFingerprint identifies the exact current set of waivable failures.
+	// WaivableRuleFingerprint identifies the normalized, tracker-local current set
+	// of waivable failures. It is empty when no waiver is required.
 	WaivableRuleFingerprint WorkflowFingerprint `json:"waivableRuleFingerprint,omitempty"`
-	// RuleAuthorizationFingerprint matches WaivableRuleFingerprint only after exact user authorization.
+	// RuleAuthorizationFingerprint records exact user authorization and is valid
+	// only while it matches WaivableRuleFingerprint.
 	RuleAuthorizationFingerprint WorkflowFingerprint               `json:"ruleAuthorizationFingerprint,omitempty"`
 	Artifacts                    TrackerArtifactRequirements       `json:"artifacts"`
 	DescriptionGroup             string                            `json:"descriptionGroup,omitempty"`

--- a/pkg/api/workflow_contracts.go
+++ b/pkg/api/workflow_contracts.go
@@ -112,6 +112,9 @@ type TrackerProjectionInstructions struct {
 	Questionnaire     map[string]*string     `json:"questionnaire,omitempty"`
 	TrackerConfig     TrackerConfigOverrides `json:"trackerConfig,omitempty"`
 	TrackerSite       TrackerSiteOverrides   `json:"trackerSite,omitempty"`
+	// AuthorizedRuleFingerprint is server-owned authority for one exact set of
+	// waivable rule failures. Caller-supplied values are ignored.
+	AuthorizedRuleFingerprint WorkflowFingerprint `json:"authorizedRuleFingerprint,omitempty"`
 }
 
 // TrackerProjectionInstructionSnapshot retains tracker-local projection instructions.
@@ -243,6 +246,8 @@ type TrackerPolicyDecision struct {
 	Decision string `json:"decision"`
 	Blocking bool   `json:"blocking"`
 	Message  string `json:"message,omitempty"`
+	// Authorized reports that the exact waivable result was accepted by the user.
+	Authorized bool `json:"authorized,omitempty"`
 	// Disposition is the backend-owned execution effect of a failed rule.
 	Disposition RuleDisposition `json:"disposition,omitempty"`
 	// EvidenceStatus states how completely the backend could evaluate the rule.
@@ -275,25 +280,29 @@ type TrackerReleaseProjection struct {
 	NamingElementPolicyVersion string `json:"namingElementPolicyVersion"`
 	// EpisodeTitleMode records the normalized structural decision included in
 	// NamingFingerprint.
-	EpisodeTitleMode            EpisodeTitleMode                  `json:"episodeTitleMode"`
-	NamingFingerprint           WorkflowFingerprint               `json:"namingFingerprint"`
-	PolicyDecisions             []TrackerPolicyDecision           `json:"policyDecisions,omitempty"`
-	Artifacts                   TrackerArtifactRequirements       `json:"artifacts"`
-	DescriptionGroup            string                            `json:"descriptionGroup,omitempty"`
-	MetadataLocale              string                            `json:"metadataLocale,omitempty"`
-	Questionnaire               []TrackerQuestionnaireRequirement `json:"questionnaire,omitempty"`
-	DerivedFlags                []TrackerDerivedFlag              `json:"derivedFlags,omitempty"`
-	InputFingerprint            WorkflowFingerprint               `json:"inputFingerprint"`
-	CatalogFingerprint          WorkflowFingerprint               `json:"catalogFingerprint"`
-	ConfigFingerprint           WorkflowFingerprint               `json:"configFingerprint"`
-	ProjectorFingerprint        WorkflowFingerprint               `json:"projectorFingerprint"`
-	CriteriaFingerprint         WorkflowFingerprint               `json:"criteriaFingerprint"`
-	PreparedResourceFingerprint WorkflowFingerprint               `json:"preparedResourceFingerprint,omitempty"`
-	Readiness                   ReadinessStatus                   `json:"readiness"`
-	DupeReady                   bool                              `json:"dupeReady"`
-	UploadReady                 bool                              `json:"uploadReady"`
-	RequiredActions             []RequiredAction                  `json:"requiredActions,omitempty"`
-	Failures                    []WorkflowFailure                 `json:"failures,omitempty"`
+	EpisodeTitleMode  EpisodeTitleMode        `json:"episodeTitleMode"`
+	NamingFingerprint WorkflowFingerprint     `json:"namingFingerprint"`
+	PolicyDecisions   []TrackerPolicyDecision `json:"policyDecisions,omitempty"`
+	// WaivableRuleFingerprint identifies the exact current set of waivable failures.
+	WaivableRuleFingerprint WorkflowFingerprint `json:"waivableRuleFingerprint,omitempty"`
+	// RuleAuthorizationFingerprint matches WaivableRuleFingerprint only after exact user authorization.
+	RuleAuthorizationFingerprint WorkflowFingerprint               `json:"ruleAuthorizationFingerprint,omitempty"`
+	Artifacts                    TrackerArtifactRequirements       `json:"artifacts"`
+	DescriptionGroup             string                            `json:"descriptionGroup,omitempty"`
+	MetadataLocale               string                            `json:"metadataLocale,omitempty"`
+	Questionnaire                []TrackerQuestionnaireRequirement `json:"questionnaire,omitempty"`
+	DerivedFlags                 []TrackerDerivedFlag              `json:"derivedFlags,omitempty"`
+	InputFingerprint             WorkflowFingerprint               `json:"inputFingerprint"`
+	CatalogFingerprint           WorkflowFingerprint               `json:"catalogFingerprint"`
+	ConfigFingerprint            WorkflowFingerprint               `json:"configFingerprint"`
+	ProjectorFingerprint         WorkflowFingerprint               `json:"projectorFingerprint"`
+	CriteriaFingerprint          WorkflowFingerprint               `json:"criteriaFingerprint"`
+	PreparedResourceFingerprint  WorkflowFingerprint               `json:"preparedResourceFingerprint,omitempty"`
+	Readiness                    ReadinessStatus                   `json:"readiness"`
+	DupeReady                    bool                              `json:"dupeReady"`
+	UploadReady                  bool                              `json:"uploadReady"`
+	RequiredActions              []RequiredAction                  `json:"requiredActions,omitempty"`
+	Failures                     []WorkflowFailure                 `json:"failures,omitempty"`
 }
 
 // TrackerReleaseProjectionSet is an immutable projection for every selected tracker.

--- a/pkg/api/workflow_contracts_test.go
+++ b/pkg/api/workflow_contracts_test.go
@@ -179,21 +179,19 @@ func TestTrackerProjectionInstructionsPreserveAbsentNullAndEmptyName(t *testing.
 	}
 }
 
-func TestTrackerProjectionInstructionsPreserveRuleAuthorization(t *testing.T) {
+func TestTrackerProjectionInstructionsIgnoreRuleAuthorization(t *testing.T) {
 	t.Parallel()
 
-	fingerprint := workflowTestFingerprint(t, "authorized-waivable-rules")
-	instructions := TrackerProjectionInstructions{AuthorizedRuleFingerprint: fingerprint}
+	var instructions TrackerProjectionInstructions
+	if err := json.Unmarshal([]byte(`{"authorizedRuleFingerprint":"forged"}`), &instructions); err != nil {
+		t.Fatalf("unmarshal projection rule authorization: %v", err)
+	}
 	payload, err := json.Marshal(instructions)
 	if err != nil {
 		t.Fatalf("marshal projection rule authorization: %v", err)
 	}
-	var roundTrip TrackerProjectionInstructions
-	if err := json.Unmarshal(payload, &roundTrip); err != nil {
-		t.Fatalf("unmarshal projection rule authorization: %v", err)
-	}
-	if roundTrip.AuthorizedRuleFingerprint != fingerprint {
-		t.Fatalf("rule authorization = %q, want %q", roundTrip.AuthorizedRuleFingerprint, fingerprint)
+	if strings.Contains(string(payload), "authorizedRuleFingerprint") {
+		t.Fatalf("caller rule authorization survived: %s", payload)
 	}
 }
 

--- a/pkg/api/workflow_contracts_test.go
+++ b/pkg/api/workflow_contracts_test.go
@@ -197,6 +197,19 @@ func TestTrackerProjectionInstructionsPreserveRuleAuthorization(t *testing.T) {
 	}
 }
 
+func TestTrackerProjectionInstructionNormalizationRejectsDuplicateTrackerIDs(t *testing.T) {
+	t.Parallel()
+
+	duplicateTrackerID := TrackerID(" alpha ")
+	_, err := (TrackerProjectionInstructionSnapshot{Instructions: map[TrackerID]TrackerProjectionInstructions{
+		"ALPHA":            {},
+		duplicateTrackerID: {},
+	}}).Normalize()
+	if err == nil || !strings.Contains(err.Error(), "duplicate tracker id ALPHA") {
+		t.Fatalf("duplicate normalized tracker ID error = %v", err)
+	}
+}
+
 func TestTrackerCatalogNormalizesAliasesAndFingerprintsDeterministically(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/workflow_contracts_test.go
+++ b/pkg/api/workflow_contracts_test.go
@@ -179,6 +179,24 @@ func TestTrackerProjectionInstructionsPreserveAbsentNullAndEmptyName(t *testing.
 	}
 }
 
+func TestTrackerProjectionInstructionsPreserveRuleAuthorization(t *testing.T) {
+	t.Parallel()
+
+	fingerprint := workflowTestFingerprint(t, "authorized-waivable-rules")
+	instructions := TrackerProjectionInstructions{AuthorizedRuleFingerprint: fingerprint}
+	payload, err := json.Marshal(instructions)
+	if err != nil {
+		t.Fatalf("marshal projection rule authorization: %v", err)
+	}
+	var roundTrip TrackerProjectionInstructions
+	if err := json.Unmarshal(payload, &roundTrip); err != nil {
+		t.Fatalf("unmarshal projection rule authorization: %v", err)
+	}
+	if roundTrip.AuthorizedRuleFingerprint != fingerprint {
+		t.Fatalf("rule authorization = %q, want %q", roundTrip.AuthorizedRuleFingerprint, fingerprint)
+	}
+}
+
 func TestTrackerCatalogNormalizesAliasesAndFingerprintsDeterministically(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/workflow_contracts_validation.go
+++ b/pkg/api/workflow_contracts_validation.go
@@ -428,7 +428,9 @@ func (s TrackerProjectionInstructionSnapshot) Clone() (TrackerProjectionInstruct
 	return cloneWorkflowValue(s)
 }
 
-// Normalize returns projection instructions keyed by normalized stable tracker ID.
+// Normalize returns detached projection instructions keyed by normalized stable
+// tracker ID. Blank IDs are omitted; IDs that collide after normalization return
+// an error.
 func (s TrackerProjectionInstructionSnapshot) Normalize() (TrackerProjectionInstructionSnapshot, error) {
 	normalized, err := s.Clone()
 	if err != nil {
@@ -440,11 +442,6 @@ func (s TrackerProjectionInstructionSnapshot) Normalize() (TrackerProjectionInst
 		if trackerID != "" {
 			if _, exists := instructions[trackerID]; exists {
 				return TrackerProjectionInstructionSnapshot{}, fmt.Errorf("tracker projection instructions contain duplicate tracker id %s", trackerID)
-			}
-			if value.AuthorizedRuleFingerprint != "" {
-				if err := validateWorkflowFingerprint(value.AuthorizedRuleFingerprint); err != nil {
-					return TrackerProjectionInstructionSnapshot{}, fmt.Errorf("tracker %s rule authorization: %w", trackerID, err)
-				}
 			}
 			instructions[trackerID] = value
 		}
@@ -597,18 +594,9 @@ func (s TrackerReleaseProjectionSet) Validate() error {
 			if disposition == RuleDispositionWaivable {
 				hasWaivableDecision = true
 			}
-			if decision.Authorized && disposition != RuleDispositionWaivable {
-				return fmt.Errorf("tracker projection %s authorizes a non-waivable policy decision", id)
-			}
-			if decision.Authorized && projection.RuleAuthorizationFingerprint == "" {
-				return fmt.Errorf("tracker projection %s authorizes a policy decision without exact rule authority", id)
-			}
-			if decision.Authorized && decision.Blocking {
-				return fmt.Errorf("tracker projection %s marks an authorized policy decision as blocking", id)
-			}
 			if projection.RuleAuthorizationFingerprint != "" &&
-				disposition == RuleDispositionWaivable && !decision.Authorized {
-				return fmt.Errorf("tracker projection %s has incomplete waivable rule authority", id)
+				disposition == RuleDispositionWaivable && decision.Blocking {
+				return fmt.Errorf("tracker projection %s has blocking waivable rule authority", id)
 			}
 		}
 		if projection.WaivableRuleFingerprint != "" && !hasWaivableDecision {

--- a/pkg/api/workflow_contracts_validation.go
+++ b/pkg/api/workflow_contracts_validation.go
@@ -438,6 +438,9 @@ func (s TrackerProjectionInstructionSnapshot) Normalize() (TrackerProjectionInst
 	for trackerID, value := range normalized.Instructions {
 		trackerID = normalizeTrackerID(trackerID)
 		if trackerID != "" {
+			if _, exists := instructions[trackerID]; exists {
+				return TrackerProjectionInstructionSnapshot{}, fmt.Errorf("tracker projection instructions contain duplicate tracker id %s", trackerID)
+			}
 			if value.AuthorizedRuleFingerprint != "" {
 				if err := validateWorkflowFingerprint(value.AuthorizedRuleFingerprint); err != nil {
 					return TrackerProjectionInstructionSnapshot{}, fmt.Errorf("tracker %s rule authorization: %w", trackerID, err)

--- a/pkg/api/workflow_contracts_validation.go
+++ b/pkg/api/workflow_contracts_validation.go
@@ -438,6 +438,11 @@ func (s TrackerProjectionInstructionSnapshot) Normalize() (TrackerProjectionInst
 	for trackerID, value := range normalized.Instructions {
 		trackerID = normalizeTrackerID(trackerID)
 		if trackerID != "" {
+			if value.AuthorizedRuleFingerprint != "" {
+				if err := validateWorkflowFingerprint(value.AuthorizedRuleFingerprint); err != nil {
+					return TrackerProjectionInstructionSnapshot{}, fmt.Errorf("tracker %s rule authorization: %w", trackerID, err)
+				}
+			}
 			instructions[trackerID] = value
 		}
 	}
@@ -567,6 +572,44 @@ func (s TrackerReleaseProjectionSet) Validate() error {
 			if err := validateWorkflowFingerprint(fingerprint); err != nil {
 				return fmt.Errorf("tracker projection %s %s: %w", id, label, err)
 			}
+		}
+		for label, fingerprint := range map[string]WorkflowFingerprint{
+			"waivable rules":     projection.WaivableRuleFingerprint,
+			"rule authorization": projection.RuleAuthorizationFingerprint,
+		} {
+			if fingerprint == "" {
+				continue
+			}
+			if err := validateWorkflowFingerprint(fingerprint); err != nil {
+				return fmt.Errorf("tracker projection %s %s: %w", id, label, err)
+			}
+		}
+		if projection.RuleAuthorizationFingerprint != "" &&
+			projection.RuleAuthorizationFingerprint != projection.WaivableRuleFingerprint {
+			return fmt.Errorf("tracker projection %s rule authorization does not match current waivable rules", id)
+		}
+		hasWaivableDecision := false
+		for _, decision := range projection.PolicyDecisions {
+			disposition := NormalizeRuleDisposition(decision.Disposition)
+			if disposition == RuleDispositionWaivable {
+				hasWaivableDecision = true
+			}
+			if decision.Authorized && disposition != RuleDispositionWaivable {
+				return fmt.Errorf("tracker projection %s authorizes a non-waivable policy decision", id)
+			}
+			if decision.Authorized && projection.RuleAuthorizationFingerprint == "" {
+				return fmt.Errorf("tracker projection %s authorizes a policy decision without exact rule authority", id)
+			}
+			if decision.Authorized && decision.Blocking {
+				return fmt.Errorf("tracker projection %s marks an authorized policy decision as blocking", id)
+			}
+			if projection.RuleAuthorizationFingerprint != "" &&
+				disposition == RuleDispositionWaivable && !decision.Authorized {
+				return fmt.Errorf("tracker projection %s has incomplete waivable rule authority", id)
+			}
+		}
+		if projection.WaivableRuleFingerprint != "" && !hasWaivableDecision {
+			return fmt.Errorf("tracker projection %s has a waivable rule fingerprint without a waivable decision", id)
 		}
 		hasExtendedLineage := projection.NamingPolicyID != "" || projection.NamingFingerprint != "" ||
 			projection.DuplicatePolicyID != "" || projection.DuplicatePolicyFingerprint != "" ||

--- a/pkg/api/workflow_presence.go
+++ b/pkg/api/workflow_presence.go
@@ -91,7 +91,7 @@ func (u *ReleaseFactInstructionUpdate) UnmarshalJSON(payload []byte) error {
 
 // MarshalJSON preserves tracker projection instruction absence, null/reset, and explicit empty names.
 func (i TrackerProjectionInstructions) MarshalJSON() ([]byte, error) {
-	fields := make(map[string]any, 6)
+	fields := make(map[string]any, 5)
 	if i.UploadReleaseName.Present {
 		if i.UploadReleaseName.Reset {
 			fields["uploadReleaseName"] = nil
@@ -110,9 +110,6 @@ func (i TrackerProjectionInstructions) MarshalJSON() ([]byte, error) {
 	}
 	if i.TrackerSite.TIK.Foreign != nil || i.TrackerSite.TIK.Opera != nil || i.TrackerSite.TIK.Asian != nil || i.TrackerSite.TIK.DiscType != nil {
 		fields["trackerSite"] = i.TrackerSite
-	}
-	if i.AuthorizedRuleFingerprint != "" {
-		fields["authorizedRuleFingerprint"] = i.AuthorizedRuleFingerprint
 	}
 	payload, err := json.Marshal(fields)
 	if err != nil {
@@ -151,11 +148,6 @@ func (i *TrackerProjectionInstructions) UnmarshalJSON(payload []byte) error {
 	if raw, ok := fields["trackerSite"]; ok {
 		if err := json.Unmarshal(raw, &i.TrackerSite); err != nil {
 			return fmt.Errorf("unmarshal tracker projection site: %w", err)
-		}
-	}
-	if raw, ok := fields["authorizedRuleFingerprint"]; ok {
-		if err := json.Unmarshal(raw, &i.AuthorizedRuleFingerprint); err != nil {
-			return fmt.Errorf("unmarshal tracker projection rule authorization: %w", err)
 		}
 	}
 	return nil

--- a/pkg/api/workflow_presence.go
+++ b/pkg/api/workflow_presence.go
@@ -91,7 +91,7 @@ func (u *ReleaseFactInstructionUpdate) UnmarshalJSON(payload []byte) error {
 
 // MarshalJSON preserves tracker projection instruction absence, null/reset, and explicit empty names.
 func (i TrackerProjectionInstructions) MarshalJSON() ([]byte, error) {
-	fields := make(map[string]any, 5)
+	fields := make(map[string]any, 6)
 	if i.UploadReleaseName.Present {
 		if i.UploadReleaseName.Reset {
 			fields["uploadReleaseName"] = nil
@@ -110,6 +110,9 @@ func (i TrackerProjectionInstructions) MarshalJSON() ([]byte, error) {
 	}
 	if i.TrackerSite.TIK.Foreign != nil || i.TrackerSite.TIK.Opera != nil || i.TrackerSite.TIK.Asian != nil || i.TrackerSite.TIK.DiscType != nil {
 		fields["trackerSite"] = i.TrackerSite
+	}
+	if i.AuthorizedRuleFingerprint != "" {
+		fields["authorizedRuleFingerprint"] = i.AuthorizedRuleFingerprint
 	}
 	payload, err := json.Marshal(fields)
 	if err != nil {
@@ -148,6 +151,11 @@ func (i *TrackerProjectionInstructions) UnmarshalJSON(payload []byte) error {
 	if raw, ok := fields["trackerSite"]; ok {
 		if err := json.Unmarshal(raw, &i.TrackerSite); err != nil {
 			return fmt.Errorf("unmarshal tracker projection site: %w", err)
+		}
+	}
+	if raw, ok := fields["authorizedRuleFingerprint"]; ok {
+		if err := json.Unmarshal(raw, &i.AuthorizedRuleFingerprint); err != nil {
+			return fmt.Errorf("unmarshal tracker projection rule authorization: %w", err)
 		}
 	}
 	return nil

--- a/webui/src/api/generated/release-workflow.ts
+++ b/webui/src/api/generated/release-workflow.ts
@@ -1947,6 +1947,7 @@ export type TrackerLaneOutcome = Readonly<{
 }>;
 
 export type TrackerPolicyDecision = Readonly<{
+  authorized?: boolean;
   blocking: boolean;
   code: string;
   decision: string;
@@ -2029,6 +2030,7 @@ export type TrackerProjectionInstructionSnapshotRef = Readonly<{
 
 export type TrackerProjectionInstructions = Readonly<{
   additionalNames?: Readonly<Record<string, string | null>>;
+  authorizedRuleFingerprint?: WorkflowFingerprint;
   questionnaire?: Readonly<Record<string, string | null>>;
   trackerConfig?: TrackerConfigOverrides;
   trackerSite?: TrackerSiteOverrides;
@@ -2085,10 +2087,12 @@ export type TrackerReleaseProjection = Readonly<{
   questionnaire?: readonly TrackerQuestionnaireRequirement[];
   readiness: ReadinessStatus;
   requiredActions?: readonly RequiredAction[];
+  ruleAuthorizationFingerprint?: WorkflowFingerprint;
   taxonomy: TrackerTaxonomy;
   trackerId: TrackerID;
   uploadReady: boolean;
   uploadReleaseName: string;
+  waivableRuleFingerprint?: WorkflowFingerprint;
 }>;
 
 export type TrackerReleaseProjectionSet = Readonly<{

--- a/webui/src/api/generated/release-workflow.ts
+++ b/webui/src/api/generated/release-workflow.ts
@@ -1947,7 +1947,6 @@ export type TrackerLaneOutcome = Readonly<{
 }>;
 
 export type TrackerPolicyDecision = Readonly<{
-  authorized?: boolean;
   blocking: boolean;
   code: string;
   decision: string;
@@ -2030,7 +2029,6 @@ export type TrackerProjectionInstructionSnapshotRef = Readonly<{
 
 export type TrackerProjectionInstructions = Readonly<{
   additionalNames?: Readonly<Record<string, string | null>>;
-  authorizedRuleFingerprint?: WorkflowFingerprint;
   questionnaire?: Readonly<Record<string, string | null>>;
   trackerConfig?: TrackerConfigOverrides;
   trackerSite?: TrackerSiteOverrides;


### PR DESCRIPTION
## Summary
- Require explicit user confirmation for the exact current set of waivable tracker-rule failures.
- Retain server-owned authority through CLI and WebUI continuations, revalidate it before live submission, and never bypass strict rules.
- Persist authorized rule outcomes and update workflow contracts, docs, and regression coverage.

## Validation
- `make test-go`
- `make test-frontend`
- `make lint`
- `make backend`
- `make e2e-build`
- `make precommit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authorization for waivable validation failures during normal execution.
  * Workflows pause for approval and resume after authorization.
  * Authorizations are tracker-specific and apply only to the exact current failure set.
  * Added workflow status details for rule fingerprints and authorization state.
  * Rule-failure decisions are recorded for upload auditing.

* **Bug Fixes**
  * Strict failures remain blocking and cannot be overridden.
  * Debug mode bypasses waivable failures while respecting strict failures.
  * Stale authorizations are invalidated when validation results change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->