### PR TITLE
fix(btn): retry mismatched autofill by release name

### DIFF
--- a/cmd/upbrr/composite_upload.go
+++ b/cmd/upbrr/composite_upload.go
@@ -171,7 +171,7 @@ func (s *cliWorkflowSession) collectCompositeUploadFeedback(
 			"upbrr: tracker authentication must be resolved outside the upload workflow; start a fresh attempt",
 		)
 	}
-	if s.intent.interaction == api.InteractionModeUnattended {
+	if s.intent.interaction == api.InteractionModeUnattended && action.Kind != api.RequiredActionResolveTrackerPreparation {
 		return feedback, false, fmt.Errorf("upbrr: strict unattended upload requires global action %s: %s", action.Kind, action.Prompt)
 	}
 
@@ -219,9 +219,13 @@ func (s *cliWorkflowSession) collectCompositeUploadFeedback(
 			api.ReleaseWorkflowUploadFeedbackRuleAuthorization,
 		)
 	case api.RequiredActionResolveTrackerPreparation:
-		confirmed, err := promptYesNo(reader, action.Prompt+" [y/N]: ", false)
-		if err != nil {
-			return feedback, false, err
+		confirmed := false
+		if s.intent.interaction != api.InteractionModeUnattended {
+			var err error
+			confirmed, err = promptYesNo(reader, action.Prompt+" [y/N]: ", false)
+			if err != nil {
+				return feedback, false, err
+			}
 		}
 		feedback.Response = api.ReleaseWorkflowUploadFeedbackResponse{
 			Kind: api.ReleaseWorkflowUploadFeedbackTrackerPreparation,

--- a/cmd/upbrr/composite_upload.go
+++ b/cmd/upbrr/composite_upload.go
@@ -218,6 +218,17 @@ func (s *cliWorkflowSession) collectCompositeUploadFeedback(
 			feedback,
 			api.ReleaseWorkflowUploadFeedbackRuleAuthorization,
 		)
+	case api.RequiredActionResolveTrackerPreparation:
+		confirmed, err := promptYesNo(reader, action.Prompt+" [y/N]: ", false)
+		if err != nil {
+			return feedback, false, err
+		}
+		feedback.Response = api.ReleaseWorkflowUploadFeedbackResponse{
+			Kind: api.ReleaseWorkflowUploadFeedbackTrackerPreparation,
+			TrackerPreparation: &api.ReleaseWorkflowUploadConfirmation{
+				Confirmed: confirmed,
+			},
+		}
 	case api.RequiredActionReviewDuplicates:
 		return s.collectCompositeDuplicateFeedback(reader, action, feedback)
 	case api.RequiredActionApproveTrackers:
@@ -279,6 +290,7 @@ func compositeCLIConfirmationFeedback(
 		legacyTrackerTwoFactorFeedbackKind,
 		api.ReleaseWorkflowUploadFeedbackTrackerInput,
 		api.ReleaseWorkflowUploadFeedbackQuestionnaire,
+		api.ReleaseWorkflowUploadFeedbackTrackerPreparation,
 		api.ReleaseWorkflowUploadFeedbackDuplicateReview,
 		api.ReleaseWorkflowUploadFeedbackTrackerApproval,
 		api.ReleaseWorkflowUploadFeedbackUploadApproval, //nolint:staticcheck // Reject retained v1 feedback explicitly.

--- a/cmd/upbrr/composite_upload_test.go
+++ b/cmd/upbrr/composite_upload_test.go
@@ -411,6 +411,35 @@ func TestCLICompositeRuleAuthorizationHonorsInteractionMode(t *testing.T) {
 	}
 }
 
+func TestCLICompositeTrackerPreparationDeclineReturnsFeedback(t *testing.T) {
+	session := &cliWorkflowSession{
+		intent: cliWorkflowIntent{interaction: api.InteractionModeUnattendedConfirm},
+	}
+	var (
+		feedback api.ReleaseWorkflowUploadFeedback
+		declined bool
+		err      error
+	)
+	captureStdout(t, func() {
+		feedback, declined, err = session.collectCompositeUploadFeedback(
+			context.Background(),
+			bufio.NewReader(strings.NewReader("n\n")),
+			config.Config{},
+			api.NopLogger{},
+			api.RequiredAction{
+				ID:               "action-btn-autofill",
+				Kind:             api.RequiredActionResolveTrackerPreparation,
+				WorkflowRevision: 4,
+				Prompt:           "Continue with BTN's autofill result?",
+			},
+		)
+	})
+	if err != nil || declined || feedback.Response.Kind != api.ReleaseWorkflowUploadFeedbackTrackerPreparation ||
+		feedback.Response.TrackerPreparation == nil || feedback.Response.TrackerPreparation.Confirmed {
+		t.Fatalf("tracker preparation feedback = %#v declined=%t err=%v", feedback, declined, err)
+	}
+}
+
 func TestCLICompositeDuplicateReviewPrintsMatchesAndSeparatesTrackers(t *testing.T) {
 	session := &cliWorkflowSession{
 		current: releaseworkflow.CommandResult{

--- a/cmd/upbrr/composite_upload_test.go
+++ b/cmd/upbrr/composite_upload_test.go
@@ -415,6 +415,12 @@ func TestCLICompositeTrackerPreparationDeclineReturnsFeedback(t *testing.T) {
 	session := &cliWorkflowSession{
 		intent: cliWorkflowIntent{interaction: api.InteractionModeUnattendedConfirm},
 	}
+	action := api.RequiredAction{
+		ID:               "action-btn-autofill",
+		Kind:             api.RequiredActionResolveTrackerPreparation,
+		WorkflowRevision: 4,
+		Prompt:           "Continue with BTN's autofill result?",
+	}
 	var (
 		feedback api.ReleaseWorkflowUploadFeedback
 		declined bool
@@ -426,17 +432,25 @@ func TestCLICompositeTrackerPreparationDeclineReturnsFeedback(t *testing.T) {
 			bufio.NewReader(strings.NewReader("n\n")),
 			config.Config{},
 			api.NopLogger{},
-			api.RequiredAction{
-				ID:               "action-btn-autofill",
-				Kind:             api.RequiredActionResolveTrackerPreparation,
-				WorkflowRevision: 4,
-				Prompt:           "Continue with BTN's autofill result?",
-			},
+			action,
 		)
 	})
 	if err != nil || declined || feedback.Response.Kind != api.ReleaseWorkflowUploadFeedbackTrackerPreparation ||
 		feedback.Response.TrackerPreparation == nil || feedback.Response.TrackerPreparation.Confirmed {
 		t.Fatalf("tracker preparation feedback = %#v declined=%t err=%v", feedback, declined, err)
+	}
+
+	session.intent.interaction = api.InteractionModeUnattended
+	feedback, declined, err = session.collectCompositeUploadFeedback(
+		context.Background(),
+		nil,
+		config.Config{},
+		api.NopLogger{},
+		action,
+	)
+	if err != nil || declined || feedback.Response.Kind != api.ReleaseWorkflowUploadFeedbackTrackerPreparation ||
+		feedback.Response.TrackerPreparation == nil || feedback.Response.TrackerPreparation.Confirmed {
+		t.Fatalf("strict unattended tracker preparation feedback = %#v declined=%t err=%v", feedback, declined, err)
 	}
 }
 

--- a/cmd/upbrr/release_workflow.go
+++ b/cmd/upbrr/release_workflow.go
@@ -719,6 +719,19 @@ func (s *cliWorkflowSession) collectContinuationActionAnswers(
 				WorkflowRevision: s.current.Workflow.Revision,
 				Confirmed:        &confirmed,
 			})
+		case api.RequiredActionResolveTrackerPreparation:
+			if s.intent.interaction == api.InteractionModeUnattended {
+				continue
+			}
+			confirmed, err := promptYesNo(reader, action.Prompt+" [y/N]: ", false)
+			if err != nil {
+				return nil, false, err
+			}
+			answers = append(answers, api.RequiredActionAnswer{
+				ActionID:         action.ID,
+				WorkflowRevision: s.current.Workflow.Revision,
+				Confirmed:        &confirmed,
+			})
 		case api.RequiredActionReconcileSubmission:
 			if s.intent.interaction == api.InteractionModeUnattended {
 				return nil, false, errors.New("upbrr: unattended external-effect reconciliation requires manual confirmation")

--- a/cmd/workflowcontractgen/main.go
+++ b/cmd/workflowcontractgen/main.go
@@ -1135,6 +1135,7 @@ func newSchemaBuilder() *schemaBuilder {
 				"trackerInput",
 				"questionnaire",
 				"ruleAuthorization",
+				"trackerPreparation",
 				"duplicateReview",
 				"trackerApproval",
 				"uploadApproval",

--- a/cmd/workflowcontractgen/main_test.go
+++ b/cmd/workflowcontractgen/main_test.go
@@ -450,7 +450,7 @@ func TestCompositeUploadRoutesAndSchemasAreGenerated(t *testing.T) {
 		t.Fatalf("composite request required fields = %#v", requestSchema)
 	}
 	kindSchema := builder.schemas["ReleaseWorkflowUploadFeedbackKind"]
-	if kindSchema == nil || len(kindSchema.Enum) != 13 {
+	if kindSchema == nil || len(kindSchema.Enum) != 14 {
 		t.Fatalf("composite feedback enum = %#v", kindSchema)
 	}
 }

--- a/cmd/workflowcontractgen/main_test.go
+++ b/cmd/workflowcontractgen/main_test.go
@@ -450,7 +450,7 @@ func TestCompositeUploadRoutesAndSchemasAreGenerated(t *testing.T) {
 		t.Fatalf("composite request required fields = %#v", requestSchema)
 	}
 	kindSchema := builder.schemas["ReleaseWorkflowUploadFeedbackKind"]
-	if kindSchema == nil || len(kindSchema.Enum) != 14 {
+	if kindSchema == nil || len(kindSchema.Enum) != 14 || !slices.Contains(kindSchema.Enum, "trackerPreparation") {
 		t.Fatalf("composite feedback enum = %#v", kindSchema)
 	}
 }

--- a/internal/core/e2e_enabled.go
+++ b/internal/core/e2e_enabled.go
@@ -1000,6 +1000,15 @@ func (p *e2eRetainedUploadPlan) Preparations() []trackers.RetainedTrackerPrepara
 	return append([]trackers.RetainedTrackerPreparation(nil), p.preparations...)
 }
 
+func (p *e2eRetainedUploadPlan) ResolveAction(
+	context.Context,
+	string,
+	api.RequiredActionKind,
+	bool,
+) (trackers.RetainedTrackerPreparation, error) {
+	return trackers.RetainedTrackerPreparation{}, trackers.ErrPlanActionUnavailable
+}
+
 func (p *e2eRetainedUploadPlan) Execute(ctx context.Context) ([]trackers.RetainedTrackerResult, error) {
 	if p == nil {
 		return nil, errors.New("e2e tracker: retained plan is unavailable")

--- a/internal/core/workflow_upload_plan.go
+++ b/internal/core/workflow_upload_plan.go
@@ -400,17 +400,7 @@ func (b workflowUploadPlanBuilder) Build(
 			tracker.Endpoint, tracker.Fields, tracker.Files = sanitizeWorkflowUploadPreview(preparation.Preview)
 			tracker.RequiredActions = append([]api.RequiredAction(nil), preparation.Preview.RequiredActions...)
 			if identityErr != nil || torrentArtifactID == "" {
-				tracker.Status = api.StageStatusFailed
-				tracker.Warnings = []string{"No exact prepared tracker torrent is available. Prepare the tracker again."}
-				tracker.Failures = []api.WorkflowFailure{{
-					Failure: api.OperationFailure{
-						Code:      api.OperationFailureMissingExactTorrent,
-						Operation: api.OperationKindUploadDryRun,
-						Message:   "No exact prepared tracker torrent is available. Prepare the tracker again.",
-						Recovery:  api.OperationRecoveryReprepare,
-					},
-					TrackerID: projection.TrackerID,
-				}}
+				markWorkflowUploadTrackerMissingExactTorrent(&tracker, projection.TrackerID)
 				break
 			}
 			tracker.Eligible = true
@@ -457,15 +447,7 @@ func (b workflowUploadPlanBuilder) Build(
 			}
 		}
 		if options.DryRun && tracker.ClientInjectionStatus == "" {
-			tracker.ClientInjectionStatus = api.StageStatusSkipped
-			switch {
-			case options.NoSeed:
-				tracker.ClientInjectionMessage = "Client injection disabled by the skip option."
-			case tracker.Status == api.StageStatusReady:
-				tracker.ClientInjectionMessage = "Client injection deferred until tracker submission completes."
-			default:
-				tracker.ClientInjectionMessage = "Client injection skipped because the tracker upload was not ready."
-			}
+			projectDeferredWorkflowClientInjection(&tracker, options.NoSeed)
 		}
 		semanticFingerprint, err := workflowUploadTrackerSemanticFingerprint(projection, tracker)
 		if err != nil {
@@ -668,6 +650,36 @@ func uploadPreparationProgressMessage(tracker api.UploadPlanTracker) string {
 		}
 	}
 	return "Tracker upload preparation failed."
+}
+
+func markWorkflowUploadTrackerMissingExactTorrent(tracker *api.UploadPlanTracker, trackerID api.TrackerID) {
+	const message = "No exact prepared tracker torrent is available. Prepare the tracker again."
+
+	tracker.Eligible = false
+	tracker.Status = api.StageStatusFailed
+	tracker.Warnings = []string{message}
+	tracker.Failures = []api.WorkflowFailure{{
+		Failure: api.OperationFailure{
+			Code:      api.OperationFailureMissingExactTorrent,
+			Operation: api.OperationKindUploadDryRun,
+			Message:   message,
+			Recovery:  api.OperationRecoveryReprepare,
+		},
+		TrackerID: trackerID,
+	}}
+}
+
+func projectDeferredWorkflowClientInjection(tracker *api.UploadPlanTracker, noSeed bool) {
+	tracker.ClientInjectionStatus = api.StageStatusSkipped
+	tracker.ClientFailureCode = ""
+	switch {
+	case noSeed:
+		tracker.ClientInjectionMessage = "Client injection disabled by the skip option."
+	case tracker.Status == api.StageStatusReady:
+		tracker.ClientInjectionMessage = "Client injection deferred until tracker submission completes."
+	default:
+		tracker.ClientInjectionMessage = "Client injection skipped because the tracker upload was not ready."
+	}
 }
 
 func workflowTrackerArtifactIdentity(
@@ -916,6 +928,7 @@ func (e *workflowUploadExecution) ResolveAction(
 		return api.UploadPlanTracker{}, fmt.Errorf("workflow upload action: %w", err)
 	}
 	updated := e.trackers[index]
+	previousTorrentFingerprint := updated.TorrentFingerprint
 	updated.RequiredActions = nil
 	updated.Warnings = nil
 	updated.Failures = nil
@@ -961,8 +974,16 @@ func (e *workflowUploadExecution) ResolveAction(
 		if err != nil {
 			return api.UploadPlanTracker{}, err
 		}
-		updated.Eligible = true
-		updated.Status = api.StageStatusReady
+		if updated.TorrentArtifactID == "" {
+			markWorkflowUploadTrackerMissingExactTorrent(&updated, trackerID)
+		} else {
+			updated.Eligible = true
+			updated.Status = api.StageStatusReady
+		}
+	}
+	projectDeferredWorkflowClientInjection(&updated, e.noSeed)
+	if updated.TorrentFingerprint != previousTorrentFingerprint {
+		delete(e.dryRunInjected, trackerID)
 	}
 	updated.SemanticFingerprint, err = workflowUploadTrackerSemanticFingerprint(projection, updated)
 	if err != nil {

--- a/internal/core/workflow_upload_plan.go
+++ b/internal/core/workflow_upload_plan.go
@@ -33,6 +33,7 @@ type workflowRetainedUploadService interface {
 
 type workflowRetainedUploadPlan interface {
 	Preparations() []trackers.RetainedTrackerPreparation
+	ResolveAction(context.Context, string, api.RequiredActionKind, bool) (trackers.RetainedTrackerPreparation, error)
 	Execute(context.Context) ([]trackers.RetainedTrackerResult, error)
 	ExecuteSelected(context.Context, []string) ([]trackers.RetainedTrackerResult, error)
 	Release() error
@@ -70,6 +71,9 @@ type workflowUploadExecution struct {
 	dryRunInjected      map[api.TrackerID]struct{}
 	registeredArtifacts map[api.TrackerID]api.TorrentResult
 	crossSeeds          []api.UploadedTorrent
+	projections         map[api.TrackerID]api.TrackerReleaseProjection
+	inputFingerprint    api.WorkflowFingerprint
+	trackers            []api.UploadPlanTracker
 }
 
 func newWorkflowUploadPlanBuilder(
@@ -463,31 +467,7 @@ func (b workflowUploadPlanBuilder) Build(
 				tracker.ClientInjectionMessage = "Client injection skipped because the tracker upload was not ready."
 			}
 		}
-		semanticFingerprint, err := api.CanonicalWorkflowFingerprint(struct {
-			Projection          api.TrackerReleaseProjection
-			Endpoint            string
-			Fields              []api.UploadPlanField
-			Files               []api.UploadPlanFile
-			Eligible            bool
-			Status              api.StageStatus
-			Warnings            []string
-			RequiredActions     []api.RequiredAction
-			PreparedOperationID api.PublicResourceID
-			TorrentArtifactID   api.PublicResourceID
-			TorrentFingerprint  api.WorkflowFingerprint
-		}{
-			projection,
-			tracker.Endpoint,
-			tracker.Fields,
-			tracker.Files,
-			tracker.Eligible,
-			tracker.Status,
-			tracker.Warnings,
-			tracker.RequiredActions,
-			tracker.PreparedOperationID,
-			tracker.TorrentArtifactID,
-			tracker.TorrentFingerprint,
-		})
+		semanticFingerprint, err := workflowUploadTrackerSemanticFingerprint(projection, tracker)
 		if err != nil {
 			if retained != nil {
 				_ = retained.Release()
@@ -529,13 +509,59 @@ func (b workflowUploadPlanBuilder) Build(
 		plan.Status = api.StageStatusSkipped
 	}
 	return plan, &workflowUploadExecution{
-		plan:           retained,
-		clients:        b.clients,
-		clientSubject:  clientSubject,
-		noSeed:         options.NoSeed,
-		dryRunInjected: dryRunInjected,
-		crossSeeds:     append([]api.UploadedTorrent(nil), subject.CrossSeedTorrents...),
+		plan:             retained,
+		clients:          b.clients,
+		clientSubject:    clientSubject,
+		noSeed:           options.NoSeed,
+		dryRunInjected:   dryRunInjected,
+		crossSeeds:       append([]api.UploadedTorrent(nil), subject.CrossSeedTorrents...),
+		projections:      workflowProjectionMap(planProjections),
+		inputFingerprint: inputFingerprint,
+		trackers:         append([]api.UploadPlanTracker(nil), plan.Trackers...),
 	}, nil
+}
+
+func workflowProjectionMap(projections []api.TrackerReleaseProjection) map[api.TrackerID]api.TrackerReleaseProjection {
+	result := make(map[api.TrackerID]api.TrackerReleaseProjection, len(projections))
+	for _, projection := range projections {
+		result[projection.TrackerID] = projection
+	}
+	return result
+}
+
+func workflowUploadTrackerSemanticFingerprint(
+	projection api.TrackerReleaseProjection,
+	tracker api.UploadPlanTracker,
+) (api.WorkflowFingerprint, error) {
+	fingerprint, err := api.CanonicalWorkflowFingerprint(struct {
+		Projection          api.TrackerReleaseProjection
+		Endpoint            string
+		Fields              []api.UploadPlanField
+		Files               []api.UploadPlanFile
+		Eligible            bool
+		Status              api.StageStatus
+		Warnings            []string
+		RequiredActions     []api.RequiredAction
+		PreparedOperationID api.PublicResourceID
+		TorrentArtifactID   api.PublicResourceID
+		TorrentFingerprint  api.WorkflowFingerprint
+	}{
+		projection,
+		tracker.Endpoint,
+		tracker.Fields,
+		tracker.Files,
+		tracker.Eligible,
+		tracker.Status,
+		tracker.Warnings,
+		tracker.RequiredActions,
+		tracker.PreparedOperationID,
+		tracker.TorrentArtifactID,
+		tracker.TorrentFingerprint,
+	})
+	if err != nil {
+		return "", fmt.Errorf("workflow upload tracker semantic fingerprint: %w", err)
+	}
+	return fingerprint, nil
 }
 
 // workflowSkipIfRehashTrackers returns eligible tracker names whose config
@@ -866,6 +892,84 @@ func workflowClientInjectionFingerprint(
 		return "", fmt.Errorf("workflow client injection fingerprint: %w", err)
 	}
 	return fingerprint, nil
+}
+
+func (e *workflowUploadExecution) ResolveAction(
+	ctx context.Context,
+	trackerID api.TrackerID,
+	kind api.RequiredActionKind,
+	confirmed bool,
+) (api.UploadPlanTracker, error) {
+	if e == nil || e.plan == nil {
+		return api.UploadPlanTracker{}, trackers.ErrPlanNotSubmittable
+	}
+	trackerID = api.TrackerID(strings.ToUpper(strings.TrimSpace(string(trackerID))))
+	index := slices.IndexFunc(e.trackers, func(tracker api.UploadPlanTracker) bool {
+		return tracker.TrackerID == trackerID
+	})
+	projection, hasProjection := e.projections[trackerID]
+	if index < 0 || !hasProjection {
+		return api.UploadPlanTracker{}, fmt.Errorf("workflow upload action: tracker %s is unavailable", trackerID)
+	}
+	preparation, err := e.plan.ResolveAction(ctx, string(trackerID), kind, confirmed)
+	if err != nil {
+		return api.UploadPlanTracker{}, fmt.Errorf("workflow upload action: %w", err)
+	}
+	updated := e.trackers[index]
+	updated.RequiredActions = nil
+	updated.Warnings = nil
+	updated.Failures = nil
+	if preparation.Failure != nil {
+		updated.Endpoint = ""
+		updated.Fields = nil
+		updated.Files = nil
+		updated.Eligible = false
+		updated.PreparedOperationID = ""
+		updated.TorrentArtifactID = ""
+		updated.TorrentFingerprint = ""
+		message := strings.TrimSpace(logging.SanitizeMessage(preparation.Failure.Message))
+		if message == "" {
+			if preparation.Failure.Code == trackers.PreparationFailureCodeSkipped {
+				message = "Tracker skipped during preparation."
+			} else {
+				message = "Tracker operation could not be prepared. Review prerequisites and retry."
+			}
+		}
+		updated.Warnings = []string{message}
+		if preparation.Failure.Code == trackers.PreparationFailureCodeSkipped {
+			updated.Status = api.StageStatusSkipped
+		} else {
+			updated.Status = api.StageStatusFailed
+			updated.Failures = []api.WorkflowFailure{{
+				Failure: api.OperationFailure{
+					Code:      api.OperationFailureMissingPreparedTracker,
+					Operation: api.OperationKindUploadDryRun,
+					Message:   message,
+					Recovery:  api.OperationRecoveryReprepare,
+				},
+				TrackerID: trackerID,
+			}}
+		}
+	} else {
+		updated.Endpoint, updated.Fields, updated.Files = sanitizeWorkflowUploadPreview(preparation.Preview)
+		updated.RequiredActions = append([]api.RequiredAction(nil), preparation.Preview.RequiredActions...)
+		updated.PreparedOperationID, updated.TorrentArtifactID, updated.TorrentFingerprint, err = workflowTrackerArtifactIdentity(
+			trackerID,
+			preparation.TorrentPath,
+			e.inputFingerprint,
+		)
+		if err != nil {
+			return api.UploadPlanTracker{}, err
+		}
+		updated.Eligible = true
+		updated.Status = api.StageStatusReady
+	}
+	updated.SemanticFingerprint, err = workflowUploadTrackerSemanticFingerprint(projection, updated)
+	if err != nil {
+		return api.UploadPlanTracker{}, fmt.Errorf("workflow upload action fingerprint %s: %w", trackerID, err)
+	}
+	e.trackers[index] = updated
+	return updated, nil
 }
 
 func (e *workflowUploadExecution) Execute(

--- a/internal/core/workflow_upload_plan_test.go
+++ b/internal/core/workflow_upload_plan_test.go
@@ -71,6 +71,20 @@ func (f *workflowRetainedUploadPlanFake) Preparations() []trackers.RetainedTrack
 	return append([]trackers.RetainedTrackerPreparation(nil), f.preparations...)
 }
 
+func (f *workflowRetainedUploadPlanFake) ResolveAction(
+	_ context.Context,
+	trackerID string,
+	_ api.RequiredActionKind,
+	_ bool,
+) (trackers.RetainedTrackerPreparation, error) {
+	for _, preparation := range f.preparations {
+		if strings.EqualFold(preparation.Tracker, trackerID) {
+			return preparation, nil
+		}
+	}
+	return trackers.RetainedTrackerPreparation{}, trackers.ErrPlanActionUnavailable
+}
+
 func (f *workflowRetainedUploadPlanFake) Execute(context.Context) ([]trackers.RetainedTrackerResult, error) {
 	return append([]trackers.RetainedTrackerResult(nil), f.results...), nil
 }

--- a/internal/core/workflow_upload_plan_test.go
+++ b/internal/core/workflow_upload_plan_test.go
@@ -108,6 +108,89 @@ func (f *workflowRetainedUploadPlanFake) ExecuteSelected(
 
 func (*workflowRetainedUploadPlanFake) Release() error { return nil }
 
+func TestWorkflowUploadExecutionResolveActionReprojectsResolvedPreparation(t *testing.T) {
+	t.Parallel()
+
+	torrentPath := filepath.Join(t.TempDir(), "Example.Release.2026.BTN-GRP.torrent")
+	writeWorkflowRegisteredTorrent(t, torrentPath, "BTN")
+	tests := []struct {
+		name            string
+		torrentPath     string
+		wantStatus      api.StageStatus
+		wantEligible    bool
+		wantMessage     string
+		wantArtifact    bool
+		wantFailureCode api.OperationFailureCode
+	}{
+		{
+			name:         "ready replacement",
+			torrentPath:  torrentPath,
+			wantStatus:   api.StageStatusReady,
+			wantEligible: true,
+			wantMessage:  "deferred",
+			wantArtifact: true,
+		},
+		{
+			name:            "missing exact torrent",
+			wantStatus:      api.StageStatusFailed,
+			wantMessage:     "not ready",
+			wantFailureCode: api.OperationFailureMissingExactTorrent,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			execution := &workflowUploadExecution{
+				plan: &workflowRetainedUploadPlanFake{preparations: []trackers.RetainedTrackerPreparation{{
+					Tracker:     "BTN",
+					TorrentPath: test.torrentPath,
+				}}},
+				projections: map[api.TrackerID]api.TrackerReleaseProjection{
+					"BTN": {TrackerID: "BTN"},
+				},
+				inputFingerprint: api.WorkflowFingerprint(strings.Repeat("a", 64)),
+				dryRunInjected:   map[api.TrackerID]struct{}{"BTN": {}},
+				trackers: []api.UploadPlanTracker{{
+					TrackerID:              "BTN",
+					Eligible:               true,
+					Status:                 api.StageStatusReady,
+					RequiredActions:        []api.RequiredAction{{Kind: api.RequiredActionResolveTrackerPreparation}},
+					TorrentFingerprint:     api.WorkflowFingerprint(strings.Repeat("b", 64)),
+					ClientInjectionStatus:  api.StageStatusFailed,
+					ClientInjectionMessage: "stale client injection failure",
+					ClientFailureCode:      api.OperationFailureDryRunClientInjection,
+				}},
+			}
+			resolved, err := execution.ResolveAction(
+				context.Background(),
+				"BTN",
+				api.RequiredActionResolveTrackerPreparation,
+				false,
+			)
+			if err != nil {
+				t.Fatalf("resolve tracker preparation: %v", err)
+			}
+			if resolved.Status != test.wantStatus || resolved.Eligible != test.wantEligible ||
+				resolved.ClientInjectionStatus != api.StageStatusSkipped ||
+				!strings.Contains(resolved.ClientInjectionMessage, test.wantMessage) || resolved.ClientFailureCode != "" ||
+				(resolved.TorrentArtifactID != "") != test.wantArtifact || len(resolved.RequiredActions) != 0 {
+				t.Fatalf("resolved tracker = %#v", resolved)
+			}
+			if test.wantFailureCode == "" {
+				if len(resolved.Failures) != 0 {
+					t.Fatalf("resolved tracker failures = %#v", resolved.Failures)
+				}
+			} else if len(resolved.Failures) != 1 || resolved.Failures[0].Failure.Code != test.wantFailureCode {
+				t.Fatalf("resolved tracker failures = %#v", resolved.Failures)
+			}
+			if _, retained := execution.dryRunInjected["BTN"]; retained {
+				t.Fatal("resolved replacement retained stale client-injection receipt")
+			}
+		})
+	}
+}
+
 type workflowRetainedUploadServiceFake struct {
 	projections  []api.TrackerReleaseProjection
 	failures     map[api.TrackerID]trackers.TrackerFailure

--- a/internal/releaseworkflow/composite_upload.go
+++ b/internal/releaseworkflow/composite_upload.go
@@ -1493,6 +1493,8 @@ func compositeUploadFeedbackActionKind(kind api.ReleaseWorkflowUploadFeedbackKin
 		return api.RequiredActionAnswerQuestionnaire
 	case api.ReleaseWorkflowUploadFeedbackRuleAuthorization:
 		return api.RequiredActionAuthorizeRules
+	case api.ReleaseWorkflowUploadFeedbackTrackerPreparation:
+		return api.RequiredActionResolveTrackerPreparation
 	case api.ReleaseWorkflowUploadFeedbackDuplicateReview:
 		return api.RequiredActionReviewDuplicates
 	case api.ReleaseWorkflowUploadFeedbackTrackerApproval:
@@ -1530,6 +1532,8 @@ func normalizedCompositeFeedback(feedback api.ReleaseWorkflowUploadFeedback) com
 		response.Questionnaire = cloneStringPointerMap(feedback.Response.Questionnaire.Answers)
 	case api.ReleaseWorkflowUploadFeedbackRuleAuthorization:
 		response.Confirmed = feedback.Response.RuleAuthorization.Confirmed
+	case api.ReleaseWorkflowUploadFeedbackTrackerPreparation:
+		response.Confirmed = feedback.Response.TrackerPreparation.Confirmed
 	case api.ReleaseWorkflowUploadFeedbackDuplicateReview:
 		response.TrackerID = normalizeCompositeTrackerID(feedback.Response.DuplicateReview.TrackerID)
 		response.DuplicateDecision = feedback.Response.DuplicateReview.Decision
@@ -1857,6 +1861,21 @@ func (m *Module) applyCompositeUploadFeedback(
 		state.Composite.Intent.Preparation.Force = true
 	case api.ReleaseWorkflowUploadFeedbackRuleAuthorization:
 		confirmed := true
+		if _, err := m.resolveAction(ctx, ownerID, state, nextRevision, now, ResolveActionCommand{
+			WorkflowID:       command.WorkflowID,
+			ExpectedRevision: command.ExpectedRevision,
+			Answer: api.RequiredActionAnswer{
+				ActionID:         action.ID,
+				WorkflowRevision: command.ExpectedRevision,
+				Confirmed:        &confirmed,
+			},
+			IdempotencyKey: command.IdempotencyKey,
+		}); err != nil {
+			return CommandResult{}, err
+		}
+		resolvedByCommand = true
+	case api.ReleaseWorkflowUploadFeedbackTrackerPreparation:
+		confirmed := command.Response.Confirmed
 		if _, err := m.resolveAction(ctx, ownerID, state, nextRevision, now, ResolveActionCommand{
 			WorkflowID:       command.WorkflowID,
 			ExpectedRevision: command.ExpectedRevision,

--- a/internal/releaseworkflow/contracts.go
+++ b/internal/releaseworkflow/contracts.go
@@ -943,6 +943,7 @@ type ExecuteUploadsCommand struct {
 	ExpectedRevision api.WorkflowRevision
 	NoSeed           bool
 	TrackerIDs       []api.TrackerID
+	Interaction      api.InteractionMode
 	IdempotencyKey   string
 }
 
@@ -952,6 +953,14 @@ func (ExecuteUploadsCommand) operationKind() api.OperationKind {
 	return api.OperationKindUploadExecute
 }
 func (c ExecuteUploadsCommand) commandFingerprint() (api.WorkflowFingerprint, error) {
+	if c.Interaction != "" && c.Interaction != api.InteractionModeInteractive {
+		return canonicalCommandFingerprint(struct {
+			ExpectedRevision api.WorkflowRevision
+			NoSeed           bool
+			TrackerIDs       []api.TrackerID
+			Interaction      api.InteractionMode
+		}{c.ExpectedRevision, c.NoSeed, c.TrackerIDs, c.Interaction})
+	}
 	return canonicalCommandFingerprint(struct {
 		ExpectedRevision api.WorkflowRevision
 		NoSeed           bool

--- a/internal/releaseworkflow/contracts.go
+++ b/internal/releaseworkflow/contracts.go
@@ -285,6 +285,7 @@ type DescriptionBuilder interface {
 // RetainedUploadExecution is private single-use execution authority. Execute
 // must submit already-prepared operations without rebuilding semantic payloads.
 type RetainedUploadExecution interface {
+	ResolveAction(context.Context, api.TrackerID, api.RequiredActionKind, bool) (api.UploadPlanTracker, error)
 	Execute(context.Context, []api.TrackerID) ([]api.UploadTrackerResult, error)
 	RegisteredArtifactAuthority() RegisteredArtifactAuthority
 	Release() error

--- a/internal/releaseworkflow/module.go
+++ b/internal/releaseworkflow/module.go
@@ -2345,6 +2345,8 @@ func (m *Module) recoverAfterRestart(ctx context.Context, ownerID string, state 
 			api.RequiredActionAnswerQuestionnaire,
 			api.RequiredActionAuthorizeRules:
 			return false
+		case api.RequiredActionResolveTrackerPreparation:
+			return workflow.DryRun == nil
 		case legacyTrackerAuthActionKind,
 			legacyTrackerTwoFactorActionKind:
 			return true
@@ -5481,6 +5483,117 @@ func (m *Module) dryRunUploads(
 	return CommandResult{DryRun: &snapshot}, nil
 }
 
+func (m *Module) resolveTrackerPreparationAction(
+	ctx context.Context,
+	ownerID string,
+	state *State,
+	nextRevision api.WorkflowRevision,
+	now time.Time,
+	action api.RequiredAction,
+	answer api.RequiredActionAnswer,
+) (CommandResult, error) {
+	if answer.Confirmed == nil || answer.TextValue != nil || len(answer.SelectedValues) > 0 {
+		return CommandResult{}, fmt.Errorf("%w: tracker preparation requires an explicit decision", ErrInvalidTransition)
+	}
+	if action.TrackerID == "" || state.Workflow.DryRun == nil {
+		return CommandResult{}, fmt.Errorf("%w: retained tracker preparation is unavailable", ErrInvalidTransition)
+	}
+	ref := *state.Workflow.DryRun
+	prior, ok := state.DryRuns[ref.ID]
+	if !ok || prior.Revision != ref.Revision {
+		return CommandResult{}, fmt.Errorf("%w: retained upload dry run is stale", ErrInvalidTransition)
+	}
+	resourceID := uploadPlanPrivateResourceID(ref.ID)
+	value, err := m.private.Consume(ownerID, state.Workflow.ID, resourceID, now)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("release workflow resolve tracker preparation: %w", err)
+	}
+	prepared, ok := value.(*preparedUploads)
+	if !ok || prepared == nil || prepared.execution == nil || !prepared.dryRun || !prepared.plan.ExpiresAt.After(now) {
+		releasePrivateResource(value)
+		return CommandResult{}, fmt.Errorf("%w: retained tracker preparation has invalid private authority", ErrInvalidTransition)
+	}
+	restore := true
+	resolved := false
+	defer func() {
+		switch {
+		case restore && !resolved:
+			_ = m.private.Put(ownerID, state.Workflow.ID, resourceID, prepared, prepared.plan.ExpiresAt)
+		case restore:
+			_ = prepared.Release()
+		}
+	}()
+	resolved = true
+	tracker, err := prepared.execution.ResolveAction(ctx, action.TrackerID, action.Kind, *answer.Confirmed)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("release workflow resolve tracker preparation: %w", err)
+	}
+	index := slices.IndexFunc(prepared.plan.Trackers, func(candidate api.UploadPlanTracker) bool {
+		return candidate.TrackerID == action.TrackerID
+	})
+	if index < 0 || tracker.TrackerID != action.TrackerID {
+		return CommandResult{}, fmt.Errorf("%w: resolved tracker preparation does not match the action", ErrInvalidTransition)
+	}
+	prepared.plan.Trackers[index] = tracker
+	prepared.plan.Revision = nextRevision
+	prepared.plan.Status = api.StageStatusBlocked
+	readyCount := 0
+	skippedCount := 0
+	for _, candidate := range prepared.plan.Trackers {
+		if candidate.Eligible && candidate.Status == api.StageStatusReady {
+			readyCount++
+		}
+		if candidate.Status == api.StageStatusSkipped {
+			skippedCount++
+		}
+	}
+	if readyCount > 0 {
+		prepared.plan.Status = api.StageStatusReady
+	} else if len(prepared.plan.Trackers) > 0 && skippedCount == len(prepared.plan.Trackers) {
+		prepared.plan.Status = api.StageStatusSkipped
+	}
+	uploadActions, err := m.stampUploadPlanActions(prepared.plan, nextRevision, now)
+	if err != nil {
+		return CommandResult{}, err
+	}
+	reports := uploadDryRunReports(prepared.plan.Trackers)
+	succeededCount, failedCount, skippedCount, status := reduceUploadDryRunReports(reports)
+	id, err := m.newID("upload_dry_run")
+	if err != nil {
+		return CommandResult{}, err
+	}
+	snapshot := prior
+	snapshot.ID = api.UploadDryRunResultID(id)
+	snapshot.Revision = nextRevision
+	snapshot.Reports = reports
+	snapshot.SucceededCount = succeededCount
+	snapshot.FailedCount = failedCount
+	snapshot.SkippedCount = skippedCount
+	snapshot.Status = status
+	snapshot.CreatedAt = now
+	if err := snapshot.Validate(); err != nil {
+		return CommandResult{}, fmt.Errorf("release workflow publish resolved upload dry run: %w", err)
+	}
+	reconcileActions, reconcileFailures, err := m.reconcileActionsForDryRun(snapshot, nextRevision, now)
+	if err != nil {
+		return CommandResult{}, err
+	}
+	if err := m.private.Put(
+		ownerID,
+		state.Workflow.ID,
+		uploadPlanPrivateResourceID(snapshot.ID),
+		prepared,
+		prepared.plan.ExpiresAt,
+	); err != nil {
+		return CommandResult{}, fmt.Errorf("release workflow retain resolved upload plan: %w", err)
+	}
+	restore = false
+	state.DryRuns[snapshot.ID] = snapshot
+	state.Workflow.DryRun = &api.UploadDryRunResultRef{ID: snapshot.ID, Revision: snapshot.Revision}
+	setWorkflowStageStatus(&state.Workflow, snapshot.Status, slices.Concat(uploadActions, reconcileActions), reconcileFailures)
+	return CommandResult{DryRun: &snapshot}, nil
+}
+
 // stampUploadPlanActions prepares tracker actions for workflow presentation.
 // It assigns missing IDs and expiry while resetting status, revision, and creation time.
 func (m *Module) stampUploadPlanActions(
@@ -5653,12 +5766,13 @@ func (m *Module) executeUploads(
 		return CommandResult{}, fmt.Errorf("%w: upload already has a retained result; retry failed trackers or change workflow inputs", ErrInvalidTransition)
 	}
 	if slices.ContainsFunc(state.Workflow.RequiredActions, func(action api.RequiredAction) bool {
-		return action.Kind == api.RequiredActionAuthorizeRules && action.Status == api.RequiredActionStatusPending
+		return (action.Kind == api.RequiredActionAuthorizeRules || action.Kind == api.RequiredActionResolveTrackerPreparation) &&
+			action.Status == api.RequiredActionStatusPending
 	}) {
 		return CommandResult{}, api.NewOperationError(api.OperationFailure{
 			Code:      api.OperationFailureConfirmationRequired,
 			Operation: api.OperationKindUploadExecute,
-			Message:   "Upload requires confirmation of a pending tracker rule.",
+			Message:   "Upload requires resolution of a pending tracker decision.",
 			Recovery:  api.OperationRecoveryConfirm,
 		}, ErrInvalidTransition)
 	}
@@ -6374,6 +6488,9 @@ func (m *Module) resolveAction(
 	action := state.Workflow.RequiredActions[index]
 	if action.Kind == api.RequiredActionReprepare {
 		return CommandResult{}, fmt.Errorf("%w: reprepare action must be completed by preparing the release", ErrInvalidTransition)
+	}
+	if action.Kind == api.RequiredActionResolveTrackerPreparation {
+		return m.resolveTrackerPreparationAction(ctx, ownerID, state, nextRevision, now, action, command.Answer)
 	}
 	if action.Kind == api.RequiredActionAuthorizeRules &&
 		(command.Answer.Confirmed == nil || !*command.Answer.Confirmed || command.Answer.TextValue != nil || len(command.Answer.SelectedValues) > 0) {

--- a/internal/releaseworkflow/module.go
+++ b/internal/releaseworkflow/module.go
@@ -5523,11 +5523,11 @@ func (m *Module) resolveTrackerPreparationAction(
 			_ = prepared.Release()
 		}
 	}()
-	resolved = true
 	tracker, err := prepared.execution.ResolveAction(ctx, action.TrackerID, action.Kind, *answer.Confirmed)
 	if err != nil {
 		return CommandResult{}, fmt.Errorf("release workflow resolve tracker preparation: %w", err)
 	}
+	resolved = true
 	index := slices.IndexFunc(prepared.plan.Trackers, func(candidate api.UploadPlanTracker) bool {
 		return candidate.TrackerID == action.TrackerID
 	})
@@ -5765,9 +5765,12 @@ func (m *Module) executeUploads(
 	if state.Workflow.UploadResult != nil {
 		return CommandResult{}, fmt.Errorf("%w: upload already has a retained result; retry failed trackers or change workflow inputs", ErrInvalidTransition)
 	}
+	intent := api.WorkflowIntent{Interaction: command.Interaction}
 	if slices.ContainsFunc(state.Workflow.RequiredActions, func(action api.RequiredAction) bool {
 		return (action.Kind == api.RequiredActionAuthorizeRules || action.Kind == api.RequiredActionResolveTrackerPreparation) &&
-			action.Status == api.RequiredActionStatusPending
+			action.Status == api.RequiredActionStatusPending &&
+			uploadTrackerSelected(action.TrackerID, command.TrackerIDs) &&
+			!continuationUnattendedSkipsTrackerAction(intent, action)
 	}) {
 		return CommandResult{}, api.NewOperationError(api.OperationFailure{
 			Code:      api.OperationFailureConfirmationRequired,
@@ -5781,8 +5784,9 @@ func (m *Module) executeUploads(
 		return CommandResult{}, err
 	}
 	defer func() { _ = prepared.Release() }()
+	skipUnattendedUploadTrackers(&prepared.plan, command)
 	if slices.ContainsFunc(prepared.plan.Trackers, func(tracker api.UploadPlanTracker) bool {
-		return len(tracker.RequiredActions) > 0
+		return uploadTrackerSelected(tracker.TrackerID, command.TrackerIDs) && len(tracker.RequiredActions) > 0
 	}) && state.Workflow.DryRun == nil {
 		return CommandResult{}, api.NewOperationError(api.OperationFailure{
 			Code:      api.OperationFailureConfirmationRequired,
@@ -5803,6 +5807,33 @@ func (m *Module) executeUploads(
 	results = completeUploadExecutionResults(prepared.plan.Trackers, results, executionErr, trackerIDs)
 	authority := prepared.execution.RegisteredArtifactAuthority()
 	return m.publishUploadResult(ownerID, state, nextRevision, now, prepared, results, authority)
+}
+
+func uploadTrackerSelected(trackerID api.TrackerID, requested []api.TrackerID) bool {
+	if trackerID == "" || len(requested) == 0 {
+		return true
+	}
+	trackerID = api.TrackerID(strings.ToUpper(strings.TrimSpace(string(trackerID))))
+	return slices.Contains(normalizeContinuationTrackerIDs(requested), trackerID)
+}
+
+func skipUnattendedUploadTrackers(plan *api.UploadPlan, command ExecuteUploadsCommand) {
+	intent := api.WorkflowIntent{Interaction: command.Interaction}
+	for index := range plan.Trackers {
+		tracker := &plan.Trackers[index]
+		if !uploadTrackerSelected(tracker.TrackerID, command.TrackerIDs) || !slices.ContainsFunc(tracker.RequiredActions, func(action api.RequiredAction) bool {
+			action.TrackerID = tracker.TrackerID
+			return continuationUnattendedSkipsTrackerAction(intent, action)
+		}) {
+			continue
+		}
+		tracker.Eligible = false
+		tracker.Status = api.StageStatusSkipped
+		tracker.RequiredActions = nil
+		tracker.ClientInjectionStatus = api.StageStatusSkipped
+		tracker.ClientInjectionMessage = "Client injection skipped because unattended mode cannot resolve the required tracker decision."
+		tracker.ClientFailureCode = ""
+	}
 }
 
 func (m *Module) preparedUploadsForExecution(

--- a/internal/releaseworkflow/module_test.go
+++ b/internal/releaseworkflow/module_test.go
@@ -342,11 +342,30 @@ func (f *retainedMediaResourceFake) Commit(context.Context) error {
 }
 
 type retainedUploadExecutionFake struct {
-	executions int
-	releases   int
-	trackers   []api.TrackerID
-	selected   []api.TrackerID
-	failed     map[api.TrackerID]bool
+	executions          int
+	releases            int
+	trackers            []api.TrackerID
+	selected            []api.TrackerID
+	failed              map[api.TrackerID]bool
+	resolved            map[api.TrackerID]api.UploadPlanTracker
+	resolutionConfirmed []bool
+}
+
+func (f *retainedUploadExecutionFake) ResolveAction(
+	_ context.Context,
+	trackerID api.TrackerID,
+	_ api.RequiredActionKind,
+	confirmed bool,
+) (api.UploadPlanTracker, error) {
+	f.resolutionConfirmed = append(f.resolutionConfirmed, confirmed)
+	if tracker, ok := f.resolved[trackerID]; ok {
+		return tracker, nil
+	}
+	return api.UploadPlanTracker{
+TrackerID: trackerID,
+ Eligible: true,
+ Status: api.StageStatusReady,
+}, nil
 }
 
 func (f *retainedUploadExecutionFake) Execute(_ context.Context, trackerIDs []api.TrackerID) ([]api.UploadTrackerResult, error) {
@@ -3962,6 +3981,121 @@ func TestResolveRuleAuthorizationRequiresExplicitConfirmation(t *testing.T) {
 	}
 	if len(state.Workflow.RequiredActions) != 0 || state.Workflow.Status != api.WorkflowStatusActive {
 		t.Fatalf("resolved rule authorization workflow = %#v", state.Workflow)
+	}
+}
+
+func TestResolveTrackerPreparationReplacesRetainedDryRun(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC)
+	module, _ := newTestModule(t, testPreparer())
+	action := api.RequiredAction{
+		ID:               "action-btn-autofill",
+		Kind:             api.RequiredActionResolveTrackerPreparation,
+		Status:           api.RequiredActionStatusPending,
+		WorkflowRevision: 2,
+		TrackerID:        "BTN",
+		Prompt:           "Continue with BTN's TVDB autofill result?",
+		CreatedAt:        now,
+	}
+	initialTracker := api.UploadPlanTracker{
+		TrackerID:              "BTN",
+		DisplayName:            "BTN",
+		UploadReleaseName:      "Example.Release.2026.1080p-GRP",
+		Eligible:               true,
+		Status:                 api.StageStatusReady,
+		ClientInjectionStatus:  api.StageStatusSkipped,
+		ClientInjectionMessage: "Client injection disabled by the skip option.",
+		RequiredActions: []api.RequiredAction{{
+			Kind:   api.RequiredActionResolveTrackerPreparation,
+			Prompt: action.Prompt,
+		}},
+		SemanticFingerprint: testFingerprint(t, "btn-initial-plan"),
+	}
+	fallbackTracker := initialTracker
+	fallbackTracker.RequiredActions = []api.RequiredAction{{
+		Kind:   api.RequiredActionResolveTrackerPreparation,
+		Prompt: "BTN release-name autofill also mismatched. Continue?",
+	}}
+	fallbackTracker.SemanticFingerprint = testFingerprint(t, "btn-fallback-plan")
+	execution := &retainedUploadExecutionFake{
+		resolved: map[api.TrackerID]api.UploadPlanTracker{"BTN": fallbackTracker},
+	}
+	prepared := &preparedUploads{
+		trackerIDs: []api.TrackerID{"BTN"},
+		plan: api.UploadPlan{
+			Revision:  2,
+			Trackers:  []api.UploadPlanTracker{initialTracker},
+			Status:    api.StageStatusReady,
+			ExpiresAt: now.Add(time.Hour),
+		},
+		execution: execution,
+		dryRun:    true,
+	}
+	prior := api.UploadDryRunResult{
+		ID:               "dry-run-btn-initial",
+		WorkflowID:       "workflow-btn-autofill",
+		Revision:         2,
+		ProjectionSet:    api.TrackerReleaseProjectionSetRef{ID: "projections-btn", Revision: 1},
+		Dupes:            api.DupeAssessmentRef{ID: "dupes-btn", Revision: 1},
+		Media:            api.MediaArtifactSetRef{ID: "media-btn", Revision: 1},
+		Descriptions:     api.DescriptionSetRef{ID: "descriptions-btn", Revision: 1},
+		InputFingerprint: testFingerprint(t, "btn-upload-input"),
+		NoSeed:           true,
+		TrackerIDs:       []api.TrackerID{"BTN"},
+		Reports:          uploadDryRunReports([]api.UploadPlanTracker{initialTracker}),
+		SucceededCount:   1,
+		Status:           api.StageStatusCompleted,
+		CreatedAt:        now,
+	}
+	state := State{
+		Workflow: api.ReleaseWorkflow{
+			ID:              prior.WorkflowID,
+			Revision:        2,
+			Status:          api.WorkflowStatusBlocked,
+			DryRun:          &api.UploadDryRunResultRef{ID: prior.ID, Revision: prior.Revision},
+			RequiredActions: []api.RequiredAction{action},
+		},
+		DryRuns: map[api.UploadDryRunResultID]api.UploadDryRunResult{prior.ID: prior},
+	}
+	if err := module.private.Put(
+		testOwnerID,
+		state.Workflow.ID,
+		uploadPlanPrivateResourceID(prior.ID),
+		prepared,
+		prepared.plan.ExpiresAt,
+	); err != nil {
+		t.Fatalf("retain upload plan: %v", err)
+	}
+	confirmed := false
+	result, err := module.resolveAction(context.Background(), testOwnerID, &state, 3, now, ResolveActionCommand{
+		WorkflowID:       state.Workflow.ID,
+		ExpectedRevision: 2,
+		Answer: api.RequiredActionAnswer{
+			ActionID:         action.ID,
+			WorkflowRevision: 2,
+			Confirmed:        &confirmed,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve tracker preparation: %v", err)
+	}
+	if result.DryRun == nil || state.Workflow.DryRun == nil || result.DryRun.ID == prior.ID || state.Workflow.DryRun.ID != result.DryRun.ID ||
+		state.Workflow.Status != api.WorkflowStatusBlocked || len(state.Workflow.RequiredActions) != 1 ||
+		state.Workflow.RequiredActions[0].Prompt != fallbackTracker.RequiredActions[0].Prompt ||
+		state.Workflow.RequiredActions[0].WorkflowRevision != 3 {
+		t.Fatalf("resolved dry run=%#v workflow=%#v", result.DryRun, state.Workflow)
+	}
+	if len(execution.resolutionConfirmed) != 1 || execution.resolutionConfirmed[0] {
+		t.Fatalf("resolution decisions = %#v", execution.resolutionConfirmed)
+	}
+	if _, err := module.private.Get(
+		testOwnerID,
+		state.Workflow.ID,
+		uploadPlanPrivateResourceID(result.DryRun.ID),
+		now,
+	); err != nil {
+		t.Fatalf("resolved private upload plan: %v", err)
 	}
 }
 

--- a/internal/releaseworkflow/module_test.go
+++ b/internal/releaseworkflow/module_test.go
@@ -348,6 +348,7 @@ type retainedUploadExecutionFake struct {
 	selected            []api.TrackerID
 	failed              map[api.TrackerID]bool
 	resolved            map[api.TrackerID]api.UploadPlanTracker
+	resolutionErr       error
 	resolutionConfirmed []bool
 }
 
@@ -358,14 +359,17 @@ func (f *retainedUploadExecutionFake) ResolveAction(
 	confirmed bool,
 ) (api.UploadPlanTracker, error) {
 	f.resolutionConfirmed = append(f.resolutionConfirmed, confirmed)
+	if f.resolutionErr != nil {
+		return api.UploadPlanTracker{}, f.resolutionErr
+	}
 	if tracker, ok := f.resolved[trackerID]; ok {
 		return tracker, nil
 	}
 	return api.UploadPlanTracker{
-TrackerID: trackerID,
- Eligible: true,
- Status: api.StageStatusReady,
-}, nil
+		TrackerID: trackerID,
+		Eligible:  true,
+		Status:    api.StageStatusReady,
+	}, nil
 }
 
 func (f *retainedUploadExecutionFake) Execute(_ context.Context, trackerIDs []api.TrackerID) ([]api.UploadTrackerResult, error) {
@@ -452,6 +456,122 @@ func TestValidateUploadExecutionTrackerIDsOmitsSkippedTrackers(t *testing.T) {
 	}
 	if _, err := validateUploadExecutionTrackerIDs(trackers, []api.TrackerID{"GAMMA"}); !errors.Is(err, ErrInvalidTransition) {
 		t.Fatalf("failed tracker selection error = %v", err)
+	}
+}
+
+func TestExecuteUploadsPendingTrackerActionRespectsSelectionAndInteraction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		trackerIDs  []api.TrackerID
+		interaction api.InteractionMode
+		wantBlocked bool
+	}{
+		{name: "selected ready sibling", trackerIDs: []api.TrackerID{"ALPHA"}},
+		{
+name: "all interactive",
+ interaction: api.InteractionModeInteractive,
+ wantBlocked: true,
+},
+		{name: "all unattended", interaction: api.InteractionModeUnattended},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+			module, _ := newTestModule(t, testPreparer())
+			projectionRef := api.TrackerReleaseProjectionSetRef{ID: "projections-pending-action", Revision: 1}
+			dupeRef := api.DupeAssessmentRef{ID: "dupes-pending-action", Revision: 1}
+			mediaRef := api.MediaArtifactSetRef{ID: "media-pending-action", Revision: 1}
+			descriptionRef := api.DescriptionSetRef{ID: "descriptions-pending-action", Revision: 1}
+			dryRunRef := api.UploadDryRunResultRef{ID: "dry-run-pending-action", Revision: 2}
+			action := api.RequiredAction{
+				Kind:      api.RequiredActionResolveTrackerPreparation,
+				Status:    api.RequiredActionStatusPending,
+				TrackerID: "BTN",
+			}
+			execution := &retainedUploadExecutionFake{trackers: []api.TrackerID{"BTN", "ALPHA"}}
+			prepared := &preparedUploads{
+				trackerIDs: []api.TrackerID{"BTN", "ALPHA"},
+				projections: api.TrackerReleaseProjectionSet{
+					ID:       projectionRef.ID,
+					Revision: projectionRef.Revision,
+				},
+				dupes: api.DupeAssessment{ID: dupeRef.ID, Revision: dupeRef.Revision},
+				media: api.MediaArtifactSet{ID: mediaRef.ID, Revision: mediaRef.Revision},
+				descriptions: api.DescriptionSet{
+					ID:       descriptionRef.ID,
+					Revision: descriptionRef.Revision,
+				},
+				plan: api.UploadPlan{
+					Revision:         dryRunRef.Revision,
+					ProjectionSet:    projectionRef,
+					Dupes:            dupeRef,
+					Media:            &mediaRef,
+					Descriptions:     &descriptionRef,
+					InputFingerprint: testFingerprint(t, "pending-tracker-action"),
+					Trackers: []api.UploadPlanTracker{
+						{
+							TrackerID:       "BTN",
+							Eligible:        true,
+							Status:          api.StageStatusReady,
+							RequiredActions: []api.RequiredAction{{Kind: action.Kind}},
+						},
+						{
+TrackerID: "ALPHA",
+ Eligible: true,
+ Status: api.StageStatusReady,
+},
+					},
+					Status:    api.StageStatusReady,
+					ExpiresAt: now.Add(time.Hour),
+				},
+				execution: execution,
+				dryRun:    true,
+			}
+			state := State{
+				Workflow: api.ReleaseWorkflow{
+					ID:                 "workflow-pending-action",
+					Revision:           2,
+					Status:             api.WorkflowStatusBlocked,
+					TrackerProjections: &projectionRef,
+					Dupes:              &dupeRef,
+					Media:              &mediaRef,
+					Descriptions:       &descriptionRef,
+					DryRun:             &dryRunRef,
+					RequiredActions:    []api.RequiredAction{action},
+				},
+				UploadResults: make(map[api.UploadResultID]api.UploadResult),
+			}
+			if err := module.private.Put(
+				testOwnerID,
+				state.Workflow.ID,
+				uploadPlanPrivateResourceID(dryRunRef.ID),
+				prepared,
+				prepared.plan.ExpiresAt,
+			); err != nil {
+				t.Fatalf("retain upload plan: %v", err)
+			}
+
+			result, err := module.executeUploads(context.Background(), testOwnerID, &state, 3, now, ExecuteUploadsCommand{
+				TrackerIDs:  test.trackerIDs,
+				Interaction: test.interaction,
+			})
+			if test.wantBlocked {
+				if !errors.Is(err, ErrInvalidTransition) || execution.executions != 0 {
+					t.Fatalf("interactive execution: result=%#v err=%v executions=%d", result, err, execution.executions)
+				}
+				return
+			}
+			if err != nil || result.UploadResult == nil || execution.executions != 1 ||
+				!slices.Equal(execution.selected, []api.TrackerID{"ALPHA"}) || len(result.UploadResult.Results) != 2 ||
+				result.UploadResult.Results[0].TrackerID != "BTN" || result.UploadResult.Results[0].Status != api.StageStatusSkipped ||
+				result.UploadResult.Results[1].TrackerID != "ALPHA" || result.UploadResult.Results[1].Status != api.StageStatusCompleted {
+				t.Fatalf("lane-aware execution: result=%#v err=%v selected=%v executions=%d", result, err, execution.selected, execution.executions)
+			}
+		})
 	}
 }
 
@@ -4068,6 +4188,28 @@ func TestResolveTrackerPreparationReplacesRetainedDryRun(t *testing.T) {
 		t.Fatalf("retain upload plan: %v", err)
 	}
 	confirmed := false
+	execution.resolutionErr = errors.New("synthetic tracker preparation failure")
+	_, err := module.resolveAction(context.Background(), testOwnerID, &state, 3, now, ResolveActionCommand{
+		WorkflowID:       state.Workflow.ID,
+		ExpectedRevision: 2,
+		Answer: api.RequiredActionAnswer{
+			ActionID:         action.ID,
+			WorkflowRevision: 2,
+			Confirmed:        &confirmed,
+		},
+	})
+	if err == nil {
+		t.Fatal("resolve tracker preparation accepted resolver failure")
+	}
+	if _, err := module.private.Get(
+		testOwnerID,
+		state.Workflow.ID,
+		uploadPlanPrivateResourceID(prior.ID),
+		now,
+	); err != nil || execution.releases != 0 {
+		t.Fatalf("resolver failure did not restore retained plan: err=%v releases=%d", err, execution.releases)
+	}
+	execution.resolutionErr = nil
 	result, err := module.resolveAction(context.Background(), testOwnerID, &state, 3, now, ResolveActionCommand{
 		WorkflowID:       state.Workflow.ID,
 		ExpectedRevision: 2,
@@ -4086,7 +4228,7 @@ func TestResolveTrackerPreparationReplacesRetainedDryRun(t *testing.T) {
 		state.Workflow.RequiredActions[0].WorkflowRevision != 3 {
 		t.Fatalf("resolved dry run=%#v workflow=%#v", result.DryRun, state.Workflow)
 	}
-	if len(execution.resolutionConfirmed) != 1 || execution.resolutionConfirmed[0] {
+	if len(execution.resolutionConfirmed) != 2 || execution.resolutionConfirmed[0] || execution.resolutionConfirmed[1] {
 		t.Fatalf("resolution decisions = %#v", execution.resolutionConfirmed)
 	}
 	if _, err := module.private.Get(

--- a/internal/releaseworkflow/module_test.go
+++ b/internal/releaseworkflow/module_test.go
@@ -470,10 +470,10 @@ func TestExecuteUploadsPendingTrackerActionRespectsSelectionAndInteraction(t *te
 	}{
 		{name: "selected ready sibling", trackerIDs: []api.TrackerID{"ALPHA"}},
 		{
-name: "all interactive",
- interaction: api.InteractionModeInteractive,
- wantBlocked: true,
-},
+			name:        "all interactive",
+			interaction: api.InteractionModeInteractive,
+			wantBlocked: true,
+		},
 		{name: "all unattended", interaction: api.InteractionModeUnattended},
 	}
 	for _, test := range tests {
@@ -520,10 +520,10 @@ name: "all interactive",
 							RequiredActions: []api.RequiredAction{{Kind: action.Kind}},
 						},
 						{
-TrackerID: "ALPHA",
- Eligible: true,
- Status: api.StageStatusReady,
-},
+							TrackerID: "ALPHA",
+							Eligible:  true,
+							Status:    api.StageStatusReady,
+						},
 					},
 					Status:    api.StageStatusReady,
 					ExpiresAt: now.Add(time.Hour),

--- a/internal/releaseworkflow/planner.go
+++ b/internal/releaseworkflow/planner.go
@@ -536,6 +536,7 @@ func planContinuationCommand(
 		ExpectedRevision: revision,
 		NoSeed:           request.Intent.NoSeed,
 		TrackerIDs:       append([]api.TrackerID(nil), request.Intent.UploadTrackerIDs...),
+		Interaction:      continuationInteractionMode(request.Intent),
 		IdempotencyKey:   key("execute-uploads"),
 	}, "execute-uploads"
 }

--- a/internal/releaseworkflow/planner.go
+++ b/internal/releaseworkflow/planner.go
@@ -289,6 +289,7 @@ func continuationIntentResolvesAction(intent api.WorkflowIntent, current Command
 		return ok && len(instruction.Questionnaire) > 0
 	case api.RequiredActionSelectPlaylist, api.RequiredActionSelectMetadata, api.RequiredActionConfirmRescan,
 		legacyTrackerAuthActionKind, legacyTrackerTwoFactorActionKind, api.RequiredActionAuthorizeRules,
+		api.RequiredActionResolveTrackerPreparation,
 		api.RequiredActionApproveTrackers,
 		api.RequiredActionApproveUpload, //nolint:staticcheck // Retained v1 actions cannot be satisfied by desired intent.
 		api.RequiredActionReprepare,
@@ -717,7 +718,8 @@ func continuationUnattendedSkipsTrackerAction(intent api.WorkflowIntent, action 
 		legacyTrackerTwoFactorActionKind,
 		api.RequiredActionProvideTrackerInput,
 		api.RequiredActionAnswerQuestionnaire,
-		api.RequiredActionAuthorizeRules:
+		api.RequiredActionAuthorizeRules,
+		api.RequiredActionResolveTrackerPreparation:
 		return true
 	case api.RequiredActionSelectPlaylist,
 		api.RequiredActionSelectMetadata,

--- a/internal/trackers/impl/standalone/btn/media.go
+++ b/internal/trackers/impl/standalone/btn/media.go
@@ -81,9 +81,12 @@ func prepareUploadDataWithAutofill(
 		return nil, fmt.Errorf("trackers: BTN reviewed upload name: %w", err)
 	}
 
-	autofillPayload, uploadType := buildBTNAutofillPayload(req.Meta, releaseName)
+	var autofillPayload url.Values
+	var uploadType string
 	if releaseNameAutofill {
 		autofillPayload, uploadType = buildBTNReleaseNameAutofillPayload(req.Meta, releaseName)
+	} else {
+		autofillPayload, uploadType = buildBTNAutofillPayload(req.Meta, releaseName)
 	}
 	fields, err := requestBTNAutofillFields(ctx, uploadCtx, autofillPayload, uploadType)
 	if err != nil {

--- a/internal/trackers/impl/standalone/btn/media.go
+++ b/internal/trackers/impl/standalone/btn/media.go
@@ -20,6 +20,7 @@ import (
 	xhtml "golang.org/x/net/html"
 
 	pathutil "github.com/autobrr/upbrr/internal/pathing"
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -28,27 +29,67 @@ import (
 // POST. TVDB-backed uploads submit the series id plus season or episode token;
 // scene-name autofill is used only when no TVDB series id is available.
 func buildBTNAutofillPayload(meta api.UploadSubject, releaseName string) (url.Values, string) {
+	if meta.Identity.TVDBID <= 0 {
+		return buildBTNReleaseNameAutofillPayload(meta, releaseName)
+	}
 	autofillPayload := url.Values{}
 	uploadType := resolveUploadType(meta)
 	season, episode := resolveBTNTVSeasonEpisode(meta)
 	autofillPayload.Set("type", uploadType)
 	autofillPayload.Set("tvdb", "Get Info")
 
-	if meta.Identity.TVDBID > 0 {
-		autofillPayload.Set("scene_yesno", "No")
-		autofillPayload.Set("auto_series", strconv.Itoa(meta.Identity.TVDBID))
+	autofillPayload.Set("scene_yesno", "No")
+	autofillPayload.Set("auto_series", strconv.Itoa(meta.Identity.TVDBID))
 
-		if uploadType == "Episode" {
-			autofillPayload.Set("auto_title", fmt.Sprintf("S%02dE%02d", season, episode))
-		} else {
-			autofillPayload.Set("auto_season", fmt.Sprintf("S%02d", season))
-		}
+	if uploadType == "Episode" {
+		autofillPayload.Set("auto_title", fmt.Sprintf("S%02dE%02d", season, episode))
 	} else {
-		autofillPayload.Set("scene_yesno", "Yes")
-		autofillPayload.Set("autofill", strings.TrimSpace(releaseName))
+		autofillPayload.Set("auto_season", fmt.Sprintf("S%02d", season))
 	}
 
 	return autofillPayload, uploadType
+}
+
+// buildBTNReleaseNameAutofillPayload forces BTN's scene-name autofill even
+// when upbrr has a TVDB series ID.
+func buildBTNReleaseNameAutofillPayload(meta api.UploadSubject, releaseName string) (url.Values, string) {
+	uploadType := resolveUploadType(meta)
+	autofillPayload := url.Values{}
+	autofillPayload.Set("type", uploadType)
+	autofillPayload.Set("tvdb", "Get Info")
+	autofillPayload.Set("scene_yesno", "Yes")
+	autofillPayload.Set("autofill", strings.TrimSpace(releaseName))
+	return autofillPayload, uploadType
+}
+
+func prepareUploadDataWithAutofill(
+	ctx context.Context,
+	req trackers.PreparationInput,
+	uploadCtx uploadContext,
+	releaseNameAutofill bool,
+) (map[string]string, error) {
+	var nameFailure *trackers.PreparationFailure
+	req, nameFailure = trackers.PrepareInputWithReleaseNamePolicy(req, Profile().ReleaseNamePolicy)
+	if nameFailure != nil {
+		return nil, nameFailure
+	}
+	if _, err := validateBTNTVPayloadMetadata(req.Meta); err != nil {
+		return nil, err
+	}
+	releaseName, err := req.ReviewedUploadName()
+	if err != nil {
+		return nil, fmt.Errorf("trackers: BTN reviewed upload name: %w", err)
+	}
+
+	autofillPayload, uploadType := buildBTNAutofillPayload(req.Meta, releaseName)
+	if releaseNameAutofill {
+		autofillPayload, uploadType = buildBTNReleaseNameAutofillPayload(req.Meta, releaseName)
+	}
+	fields, err := requestBTNAutofillFields(ctx, uploadCtx, autofillPayload, uploadType)
+	if err != nil {
+		return nil, err
+	}
+	return buildBTNUploadPayload(req, fields)
 }
 
 // preferredBTNTVDBSeriesName returns the English TVDB name, falling back to the native name.
@@ -64,7 +105,7 @@ func preferredBTNTVDBSeriesName(meta api.UploadSubject) string {
 
 // btnAutofillArtistAction requests confirmation unless BTN's artist exactly matches a TVDB name or alias.
 // Missing TVDB identity or primary-name metadata disables the check.
-func btnAutofillArtistAction(meta api.UploadSubject, artist string) *api.RequiredAction {
+func btnAutofillArtistAction(meta api.UploadSubject, artist string, releaseNameTried bool) *api.RequiredAction {
 	if meta.Identity.TVDBID <= 0 || meta.ProviderMetadata.TVDB == nil {
 		return nil
 	}
@@ -82,14 +123,19 @@ func btnAutofillArtistAction(meta api.UploadSubject, artist string) *api.Require
 	if expected == "" {
 		return nil
 	}
+	prompt := "BTN autofill returned series %q, but upbrr tvdb is a different series %q. Continue uploading this result to BTN?"
+	declineLabel := "Try release-name autofill"
+	if releaseNameTried {
+		prompt = "BTN release-name autofill also returned series %q, but upbrr tvdb is a different series %q. Continue uploading this result to BTN?"
+		declineLabel = "Skip BTN"
+	}
 	return &api.RequiredAction{
-		Kind: api.RequiredActionAuthorizeRules,
-		Prompt: fmt.Sprintf(
-			"BTN autofill returned series %q, but TVDB %d identifies %q. Continue uploading this result to BTN?",
-			artist,
-			meta.Identity.TVDBID,
-			expected,
-		),
+		Kind:   api.RequiredActionResolveTrackerPreparation,
+		Prompt: fmt.Sprintf(prompt, artist, expected),
+		Options: []api.RequiredActionOption{
+			{Value: "confirm", Label: "Continue upload"},
+			{Value: "resolve", Label: declineLabel},
+		},
 	}
 }
 

--- a/internal/trackers/impl/standalone/btn/upload.go
+++ b/internal/trackers/impl/standalone/btn/upload.go
@@ -112,12 +112,21 @@ func prepareUploadAt(ctx context.Context, req trackers.PreparationInput, baseURL
 	if err := checkBTNSeasonPackReservation(ctx, uploadCtx, req); err != nil {
 		return trackers.PreparedOperation{}, err
 	}
+	return prepareBTNPreparedOperation(ctx, req, uploadCtx, torrentPath, false)
+}
 
-	data, err := prepareUploadData(ctx, req, uploadCtx)
+func prepareBTNPreparedOperation(
+	ctx context.Context,
+	req trackers.PreparationInput,
+	uploadCtx uploadContext,
+	torrentPath string,
+	releaseNameTried bool,
+) (trackers.PreparedOperation, error) {
+	data, err := prepareUploadDataWithAutofill(ctx, req, uploadCtx, releaseNameTried)
 	if err != nil {
 		return trackers.PreparedOperation{}, err
 	}
-	autofillAction := btnAutofillArtistAction(req.Meta, data["artist"])
+	autofillAction := btnAutofillArtistAction(req.Meta, data["artist"], releaseNameTried)
 	if autofillAction != nil {
 		if req.Meta.Options.InteractionMode == api.InteractionModeUnattended {
 			if req.Logger != nil {
@@ -160,9 +169,26 @@ func prepareUploadAt(ctx context.Context, req trackers.PreparationInput, baseURL
 	if autofillAction != nil {
 		preview.RequiredActions = []api.RequiredAction{*autofillAction}
 	}
-	return trackers.NewPreparedOperation(preview, func(submitCtx context.Context) (api.UploadSummary, error) {
+	submit := func(submitCtx context.Context) (api.UploadSummary, error) {
 		return submitPreparedUpload(submitCtx, req, uploadCtx, trackerTorrentPath, body, contentType)
-	}, nil), nil
+	}
+	if autofillAction == nil {
+		return trackers.NewPreparedOperation(preview, submit, nil), nil
+	}
+	return trackers.NewPreparedOperationWithResolver(preview, submit, nil, func(resolveCtx context.Context) (trackers.PreparedOperation, error) {
+		if releaseNameTried {
+			return trackers.PreparedOperation{}, trackers.NewPreparationFailure(
+				"BTN",
+				trackers.PreparationFailureCodeSkipped,
+				autofillAction.Prompt+" Tracker skipped.",
+				nil,
+			)
+		}
+		if req.Logger != nil {
+			req.Logger.Infof("trackers: BTN trying release-name scene autofill source=release_name reason=series_mismatch")
+		}
+		return prepareBTNPreparedOperation(resolveCtx, req, uploadCtx, torrentPath, true)
+	}), nil
 }
 
 func submitPreparedUpload(
@@ -368,7 +394,7 @@ func buildUploadDryRunAt(ctx context.Context, req trackers.PreparationInput, bas
 		if err != nil {
 			return api.TrackerDryRunEntry{}, err
 		}
-		if action := btnAutofillArtistAction(req.Meta, fields["artist"]); action != nil {
+		if action := btnAutofillArtistAction(req.Meta, fields["artist"], false); action != nil {
 			if req.Meta.Options.InteractionMode == api.InteractionModeUnattended {
 				status = "skipped"
 				message += "; BTN autofill series mismatched TVDB metadata; skipped in unattended mode"
@@ -418,25 +444,7 @@ func newUploadContextAt(ctx context.Context, req trackers.PreparationInput, base
 }
 
 func prepareUploadData(ctx context.Context, req trackers.PreparationInput, uploadCtx uploadContext) (map[string]string, error) {
-	var nameFailure *trackers.PreparationFailure
-	req, nameFailure = trackers.PrepareInputWithReleaseNamePolicy(req, Profile().ReleaseNamePolicy)
-	if nameFailure != nil {
-		return nil, nameFailure
-	}
-	if _, err := validateBTNTVPayloadMetadata(req.Meta); err != nil {
-		return nil, err
-	}
-	releaseName, err := req.ReviewedUploadName()
-	if err != nil {
-		return nil, fmt.Errorf("trackers: BTN reviewed upload name: %w", err)
-	}
-
-	autofillPayload, uploadType := buildBTNAutofillPayload(req.Meta, releaseName)
-	fields, err := requestBTNAutofillFields(ctx, uploadCtx, autofillPayload, uploadType)
-	if err != nil {
-		return nil, err
-	}
-	return buildBTNUploadPayload(req, fields)
+	return prepareUploadDataWithAutofill(ctx, req, uploadCtx, false)
 }
 
 // buildBTNUploadPayload merges BTN autofill fields with local metadata for the

--- a/internal/trackers/impl/standalone/btn/upload_integration_test.go
+++ b/internal/trackers/impl/standalone/btn/upload_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -782,12 +783,14 @@ func TestBTNDirectUploadBlocksMismatchedAutofillArtist(t *testing.T) {
 		t.Fatalf("SaveTrackerCookieMap: %v", err)
 	}
 
+	var autofillCalls atomic.Int32
 	var uploadCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/upload.php":
 			_, _ = io.WriteString(w, `<form action="/upload.php"><input name="autofill"></form>`)
 		case r.Method == http.MethodPost && r.URL.Path == "/upload.php" && strings.HasPrefix(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded"):
+			autofillCalls.Add(1)
 			_, _ = io.WriteString(w, `
 				<input name="artist" value="Unexpected Show">
 				<input name="seriesid" value="999">
@@ -830,6 +833,158 @@ func TestBTNDirectUploadBlocksMismatchedAutofillArtist(t *testing.T) {
 	if !logger.containsWarning("BTN autofill series mismatch decision=confirmation_required") ||
 		logger.containsWarning("Unexpected Show") || logger.containsWarning("Expected Show") {
 		t.Fatal("expected fixed mismatch warning without provider values")
+	}
+	req.Meta.Options.InteractionMode = api.InteractionModeUnattended
+	_, err = uploadAt(context.Background(), req, server.URL)
+	if !errors.As(err, &failure) || failure.Code() != trackers.PreparationFailureCodeSkipped {
+		t.Fatalf("unattended mismatch failure = %v", err)
+	}
+	if autofillCalls.Load() != 2 || uploadCalls.Load() != 0 ||
+		!logger.containsWarning("BTN autofill series mismatch decision=skip") {
+		t.Fatalf("unattended autofills=%d uploads=%d", autofillCalls.Load(), uploadCalls.Load())
+	}
+}
+
+func TestBTNPreparedUploadRetriesMismatchWithReleaseNameAutofill(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newBTNAuthDB(t)
+	if err := cookies.SaveTrackerCookieMap(context.Background(), dbPath, "BTN", map[string]string{"session": "imported"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	var autofillCalls atomic.Int32
+	var uploadCalls atomic.Int32
+	var formsMu sync.Mutex
+	forms := make([]url.Values, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/upload.php":
+			_, _ = io.WriteString(w, `<form action="/upload.php"><input name="autofill"></form>`)
+		case r.Method == http.MethodPost && r.URL.Path == "/upload.php" && strings.HasPrefix(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded"):
+			if err := r.ParseForm(); err != nil {
+				http.Error(w, "bad form", http.StatusBadRequest)
+				return
+			}
+			formsMu.Lock()
+			forms = append(forms, maps.Clone(r.PostForm))
+			formsMu.Unlock()
+			artist := "Unexpected Show"
+			if autofillCalls.Add(1) == 2 {
+				artist = "Expected Show"
+			}
+			writeBTNTestAutofillResponse(w, artist)
+		case r.Method == http.MethodPost && r.URL.Path == "/upload.php":
+			uploadCalls.Add(1)
+			w.Header().Set("Location", "/torrents.php?id=123&torrentid=456")
+			w.WriteHeader(http.StatusFound)
+		case r.URL.Path == "/torrents.php" && r.URL.Query().Get("action") == "download":
+			_, _ = w.Write(btnRegisteredTorrentFixture())
+		case r.URL.Path == "/torrents.php":
+			_, _ = io.WriteString(w, "ok")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	logger := &captureBTNLogger{}
+	req := newBTNDryRunTestRequest(t, dbPath)
+	req.Logger = logger
+	req.Meta.MediaInfoTextPath = writeBTNTestMediaInfo(t, filepath.Dir(req.Meta.SourcePath), "General\nFormat: Matroska")
+	req.Meta.Identity.TVDBID = 12345
+	req.Meta.ProviderMetadata.TVDB = &api.TVDBMetadata{
+		TVDBID:           12345,
+		NameEnglish:      "Expected Show",
+		EpisodeSeason:    1,
+		EpisodeNumber:    1,
+		OriginalLanguage: "en",
+	}
+	plan := prepareBTNTestUploadPlan(t, req, server.URL)
+	initial := plan.DryRun()
+	if len(initial.RequiredActions) != 1 || initial.RequiredActions[0].Kind != api.RequiredActionResolveTrackerPreparation ||
+		initial.RequiredActions[0].Prompt != `BTN autofill returned series "Unexpected Show", but upbrr tvdb is a different series "Expected Show". Continue uploading this result to BTN?` {
+		t.Fatalf("initial required action = %#v", initial.RequiredActions)
+	}
+	resolved, err := plan.ResolveAction(context.Background(), api.RequiredActionResolveTrackerPreparation, false)
+	if err != nil {
+		t.Fatalf("resolve mismatch: %v", err)
+	}
+	if len(resolved.DryRun().RequiredActions) != 0 {
+		t.Fatalf("fallback required actions = %#v", resolved.DryRun().RequiredActions)
+	}
+	formsMu.Lock()
+	gotForms := append([]url.Values(nil), forms...)
+	formsMu.Unlock()
+	if len(gotForms) != 2 || gotForms[0].Get("scene_yesno") != "No" || gotForms[0].Get("auto_series") != "12345" ||
+		gotForms[1].Get("scene_yesno") != "Yes" || gotForms[1].Get("autofill") != initial.ReleaseName || gotForms[1].Get("auto_series") != "" {
+		t.Fatalf("autofill forms = %#v", gotForms)
+	}
+	if !logger.containsInfo("BTN trying release-name scene autofill") {
+		t.Fatal("missing release-name autofill info log")
+	}
+	summary, err := resolved.Submit(context.Background())
+	if err != nil || summary.Uploaded != 1 || uploadCalls.Load() != 1 {
+		t.Fatalf("fallback submit summary=%#v uploads=%d err=%v", summary, uploadCalls.Load(), err)
+	}
+}
+
+func TestBTNPreparedUploadPromptsAgainWhenReleaseNameAutofillMismatches(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newBTNAuthDB(t)
+	if err := cookies.SaveTrackerCookieMap(context.Background(), dbPath, "BTN", map[string]string{"session": "imported"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	var autofillCalls atomic.Int32
+	var uploadCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/upload.php":
+			_, _ = io.WriteString(w, `<form action="/upload.php"><input name="autofill"></form>`)
+		case r.Method == http.MethodPost && r.URL.Path == "/upload.php" && strings.HasPrefix(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded"):
+			artist := "First Unexpected Show"
+			if autofillCalls.Add(1) == 2 {
+				artist = "Second Unexpected Show"
+			}
+			writeBTNTestAutofillResponse(w, artist)
+		case r.Method == http.MethodPost && r.URL.Path == "/upload.php":
+			uploadCalls.Add(1)
+			http.Error(w, "unexpected upload", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	logger := &captureBTNLogger{}
+	req := newBTNDryRunTestRequest(t, dbPath)
+	req.Logger = logger
+	req.Meta.MediaInfoTextPath = writeBTNTestMediaInfo(t, filepath.Dir(req.Meta.SourcePath), "General\nFormat: Matroska")
+	req.Meta.Identity.TVDBID = 12345
+	req.Meta.ProviderMetadata.TVDB = &api.TVDBMetadata{
+		TVDBID:           12345,
+		NameEnglish:      "Expected Show",
+		EpisodeSeason:    1,
+		EpisodeNumber:    1,
+		OriginalLanguage: "en",
+	}
+	plan := prepareBTNTestUploadPlan(t, req, server.URL)
+	resolved, err := plan.ResolveAction(context.Background(), api.RequiredActionResolveTrackerPreparation, false)
+	if err != nil {
+		t.Fatalf("resolve first mismatch: %v", err)
+	}
+	actions := resolved.DryRun().RequiredActions
+	if len(actions) != 1 || !strings.Contains(actions[0].Prompt, `BTN release-name autofill also returned series "Second Unexpected Show"`) ||
+		!strings.Contains(actions[0].Prompt, `upbrr tvdb is a different series "Expected Show"`) {
+		t.Fatalf("fallback required action = %#v", actions)
+	}
+	_, err = resolved.ResolveAction(context.Background(), api.RequiredActionResolveTrackerPreparation, false)
+	var failure *trackers.PreparationFailure
+	if !errors.As(err, &failure) || failure.Code() != trackers.PreparationFailureCodeSkipped {
+		t.Fatalf("second decline error = %v", err)
+	}
+	if autofillCalls.Load() != 2 || uploadCalls.Load() != 0 || !logger.containsInfo("BTN trying release-name scene autofill") {
+		t.Fatalf("autofills=%d uploads=%d info=%v", autofillCalls.Load(), uploadCalls.Load(), logger.containsInfo("BTN trying release-name scene autofill"))
 	}
 }
 
@@ -1166,11 +1321,11 @@ func TestBTNAutofillArtistActionMatchesTVDBNamesExactly(t *testing.T) {
 		}},
 	}
 	for _, artist := range []string{"Native Show", "English Show", "Alias Show", " English Show "} {
-		if action := btnAutofillArtistAction(meta, artist); action != nil {
+		if action := btnAutofillArtistAction(meta, artist, false); action != nil {
 			t.Fatalf("artist %q unexpectedly required confirmation: %#v", artist, action)
 		}
 	}
-	if action := btnAutofillArtistAction(meta, "english show"); action == nil {
+	if action := btnAutofillArtistAction(meta, "english show", false); action == nil {
 		t.Fatal("case-mismatched artist did not require confirmation")
 	}
 }
@@ -2435,4 +2590,39 @@ func newBTNDryRunTestRequest(t *testing.T, dbPath string) trackers.PreparationIn
 			}},
 		}),
 	}
+}
+
+func prepareBTNTestUploadPlan(t *testing.T, req trackers.PreparationInput, baseURL string) trackers.TrackerPlan {
+	t.Helper()
+	req.Intent = trackers.PreparationIntentUpload
+	var nameFailure *trackers.PreparationFailure
+	req, nameFailure = trackers.PrepareInputWithReleaseNamePolicy(req, Profile().ReleaseNamePolicy)
+	if nameFailure != nil {
+		t.Fatalf("prepare release name: %v", nameFailure)
+	}
+	plan, failure := trackers.PrepareAdapter(
+		context.Background(),
+		req,
+		nil,
+		func(ctx context.Context, input trackers.PreparationInput) (trackers.PreparedOperation, error) {
+			return prepareUploadAt(ctx, input, baseURL)
+		},
+	)
+	if failure != nil {
+		t.Fatalf("prepare BTN upload plan: %v", failure)
+	}
+	return plan
+}
+
+func writeBTNTestAutofillResponse(w io.Writer, artist string) {
+	_, _ = fmt.Fprintf(w, `
+		<input name="artist" value="%s">
+		<input name="seriesid" value="999">
+		<input name="title" value="Episode One">
+		<input name="year" value="2026">
+		<select name="format"><option selected value="MKV">MKV</option></select>
+		<select name="bitrate"><option selected value="H.265">H.265</option></select>
+		<select name="media"><option selected value="WEB-DL">WEB-DL</option></select>
+		<select name="resolution"><option selected value="1080p">1080p</option></select>
+	`, artist)
 }

--- a/internal/trackers/plan.go
+++ b/internal/trackers/plan.go
@@ -388,7 +388,7 @@ func (p TrackerPlan) ResolveAction(
 	p.state.mu.Unlock()
 	if release != nil {
 		if err := release(); err != nil {
-			return TrackerPlan{}, err
+			return TrackerPlan{}, NewPreparationFailure(p.tracker, "upload", "tracker prepared upload release failed", err)
 		}
 	}
 	resolved, failure := resolve(ctx)

--- a/internal/trackers/plan.go
+++ b/internal/trackers/plan.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 	"sync"
 
@@ -36,6 +37,10 @@ var (
 	ErrPlanAlreadyUsed = errors.New("tracker plan already submitted")
 	// ErrPlanReleased indicates that plan resources were released before submission.
 	ErrPlanReleased = errors.New("tracker plan already released")
+	// ErrPlanActionUnavailable indicates that the requested prepared action is absent.
+	ErrPlanActionUnavailable = errors.New("tracker plan action is unavailable")
+	// ErrPlanActionNotResolvable indicates that a negative answer has no tracker-owned resolution.
+	ErrPlanActionNotResolvable = errors.New("tracker plan action is not resolvable")
 )
 
 // PreparationFailure is a tracker-local, presentation-safe preparation failure.
@@ -109,8 +114,10 @@ type planState struct {
 	mu       sync.Mutex
 	used     bool
 	released bool
+	resolved bool
 	submit   func(context.Context) (api.UploadSummary, error)
 	release  func() error
+	resolve  func(context.Context) (TrackerPlan, *PreparationFailure)
 }
 
 // TrackerPlan is an immutable operation-scoped adapter plan. Its private state
@@ -129,6 +136,7 @@ type PreparedOperation struct {
 	preview api.TrackerDryRunEntry
 	submit  func(context.Context) (api.UploadSummary, error)
 	release func() error
+	resolve func(context.Context) (PreparedOperation, error)
 }
 
 // UploadPreparer builds canonical upload state once for the requested intent.
@@ -145,6 +153,22 @@ func NewPreparedOperation(
 		preview: cloneTrackerDryRunEntry(preview),
 		submit:  submit,
 		release: release,
+	}
+}
+
+// NewPreparedOperationWithResolver captures an upload operation whose pending
+// tracker action can be replaced by one fresh tracker-owned preparation.
+func NewPreparedOperationWithResolver(
+	preview api.TrackerDryRunEntry,
+	submit func(context.Context) (api.UploadSummary, error),
+	release func() error,
+	resolve func(context.Context) (PreparedOperation, error),
+) PreparedOperation {
+	return PreparedOperation{
+		preview: cloneTrackerDryRunEntry(preview),
+		submit:  submit,
+		release: release,
+		resolve: resolve,
 	}
 }
 
@@ -223,24 +247,42 @@ func PrepareAdapter(
 			}
 			return TrackerPlan{}, NewPreparationFailure(input.Tracker, "upload", err.Error(), err)
 		}
-		if operation.submit == nil {
-			cleanupErr := error(nil)
-			if operation.release != nil {
-				cleanupErr = operation.release()
-			}
-			cause := errors.New("prepared operation has no submission")
-			if cleanupErr != nil {
-				cause = errors.Join(cause, cleanupErr)
-			}
-			return TrackerPlan{}, NewPreparationFailure(input.Tracker, "upload", "tracker upload preparation is not submittable", cause)
-		}
-		if err := validatePreparedProjection(input, operation.preview); err != nil {
-			return TrackerPlan{}, projectionPreparationFailure(input.Tracker, operation, err)
-		}
-		return NewUploadPlan(input.Tracker, operation.preview, operation.submit, operation.release), nil
+		return preparedUploadPlan(input, operation)
 	default:
 		return TrackerPlan{}, NewPreparationFailure(input.Tracker, "intent", "unsupported preparation intent", nil)
 	}
+}
+
+func preparedUploadPlan(input PreparationInput, operation PreparedOperation) (TrackerPlan, *PreparationFailure) {
+	if operation.submit == nil {
+		cleanupErr := error(nil)
+		if operation.release != nil {
+			cleanupErr = operation.release()
+		}
+		cause := errors.New("prepared operation has no submission")
+		if cleanupErr != nil {
+			cause = errors.Join(cause, cleanupErr)
+		}
+		return TrackerPlan{}, NewPreparationFailure(input.Tracker, "upload", "tracker upload preparation is not submittable", cause)
+	}
+	if err := validatePreparedProjection(input, operation.preview); err != nil {
+		return TrackerPlan{}, projectionPreparationFailure(input.Tracker, operation, err)
+	}
+	plan := NewUploadPlan(input.Tracker, operation.preview, operation.submit, operation.release)
+	if operation.resolve != nil {
+		plan.state.resolve = func(ctx context.Context) (TrackerPlan, *PreparationFailure) {
+			next, err := operation.resolve(ctx)
+			if err != nil {
+				var failure *PreparationFailure
+				if errors.As(err, &failure) {
+					return TrackerPlan{}, failure
+				}
+				return TrackerPlan{}, NewPreparationFailure(input.Tracker, "upload", err.Error(), err)
+			}
+			return preparedUploadPlan(input, next)
+		}
+	}
+	return plan, nil
 }
 
 func projectionPreparationFailure(tracker string, operation PreparedOperation, err error) *PreparationFailure {
@@ -296,6 +338,66 @@ func (p TrackerPlan) Submit(ctx context.Context) (api.UploadSummary, error) {
 	return submit(ctx)
 }
 
+// ResolveAction keeps the current prepared payload when confirmed, or replaces
+// it through the tracker-owned resolver when declined.
+func (p TrackerPlan) ResolveAction(
+	ctx context.Context,
+	kind api.RequiredActionKind,
+	confirmed bool,
+) (TrackerPlan, error) {
+	if p.state == nil || p.intent != PreparationIntentUpload {
+		return TrackerPlan{}, ErrPlanNotSubmittable
+	}
+	if len(p.dryRun.RequiredActions) != 1 || p.dryRun.RequiredActions[0].Kind != kind {
+		return TrackerPlan{}, ErrPlanActionUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		return TrackerPlan{}, fmt.Errorf("tracker plan resolve action: %w", err)
+	}
+	p.state.mu.Lock()
+	switch {
+	case p.state.released:
+		p.state.mu.Unlock()
+		return TrackerPlan{}, ErrPlanReleased
+	case p.state.used:
+		p.state.mu.Unlock()
+		return TrackerPlan{}, ErrPlanAlreadyUsed
+	case p.state.resolved:
+		p.state.mu.Unlock()
+		return TrackerPlan{}, ErrPlanActionUnavailable
+	}
+	if confirmed {
+		p.state.resolved = true
+		p.state.mu.Unlock()
+		resolved := p
+		resolved.dryRun = cloneTrackerDryRunEntry(p.dryRun)
+		resolved.dryRun.RequiredActions = slices.DeleteFunc(resolved.dryRun.RequiredActions, func(action api.RequiredAction) bool {
+			return action.Kind == kind
+		})
+		return resolved, nil
+	}
+	if p.state.resolve == nil {
+		p.state.mu.Unlock()
+		return TrackerPlan{}, ErrPlanActionNotResolvable
+	}
+	resolve := p.state.resolve
+	release := p.state.release
+	p.state.used = true
+	p.state.released = true
+	p.state.resolved = true
+	p.state.mu.Unlock()
+	if release != nil {
+		if err := release(); err != nil {
+			return TrackerPlan{}, err
+		}
+	}
+	resolved, failure := resolve(ctx)
+	if failure != nil {
+		return TrackerPlan{}, failure
+	}
+	return resolved, nil
+}
+
 // Release invokes plan cleanup at most once and prevents later submission.
 // Repeated calls are no-ops and return nil.
 func (p TrackerPlan) Release() error {
@@ -321,6 +423,9 @@ func cloneTrackerDryRunEntry(entry api.TrackerDryRunEntry) api.TrackerDryRunEntr
 	entry.Files = append([]api.TrackerDryRunFile(nil), entry.Files...)
 	entry.DebugSections = append([]api.TrackerDryRunDebugSection(nil), entry.DebugSections...)
 	entry.RequiredActions = append([]api.RequiredAction(nil), entry.RequiredActions...)
+	for idx := range entry.RequiredActions {
+		entry.RequiredActions[idx].Options = append([]api.RequiredActionOption(nil), entry.RequiredActions[idx].Options...)
+	}
 	for idx := range entry.DebugSections {
 		entry.DebugSections[idx].Payload = maps.Clone(entry.DebugSections[idx].Payload)
 		entry.DebugSections[idx].Files = append([]api.TrackerDryRunFile(nil), entry.DebugSections[idx].Files...)

--- a/internal/trackers/plan.go
+++ b/internal/trackers/plan.go
@@ -279,6 +279,7 @@ func preparedUploadPlan(input PreparationInput, operation PreparedOperation) (Tr
 				}
 				return TrackerPlan{}, NewPreparationFailure(input.Tracker, "upload", err.Error(), err)
 			}
+			// Resolver replacements remain bound to the original reviewed input and projection authority.
 			return preparedUploadPlan(input, next)
 		}
 	}

--- a/internal/trackers/plan_test.go
+++ b/internal/trackers/plan_test.go
@@ -50,6 +50,10 @@ func TestTrackerPlanIsImmutableSingleUseAndExactOnceRelease(t *testing.T) {
 			Path:    "example.torrent",
 			Present: true,
 		}},
+		RequiredActions: []api.RequiredAction{{
+			Kind:    api.RequiredActionResolveTrackerPreparation,
+			Options: []api.RequiredActionOption{{Value: "resolve", Label: "Try alternative"}},
+		}},
 	}
 	var submits atomic.Int32
 	var releases atomic.Int32
@@ -63,12 +67,16 @@ func TestTrackerPlanIsImmutableSingleUseAndExactOnceRelease(t *testing.T) {
 
 	preview.Payload["name"] = "mutated"
 	preview.Files[0].Path = "mutated"
+	preview.RequiredActions[0].Options[0].Label = "mutated"
 	first := plan.DryRun()
-	if first.Payload["name"] != "Example.Release.2026.1080p-GRP" || first.Files[0].Path != "example.torrent" {
+	if first.Payload["name"] != "Example.Release.2026.1080p-GRP" || first.Files[0].Path != "example.torrent" ||
+		first.RequiredActions[0].Options[0].Label != "Try alternative" {
 		t.Fatalf("plan retained caller mutation: %#v", first)
 	}
 	first.Payload["name"] = "mutated again"
-	if plan.DryRun().Payload["name"] != "Example.Release.2026.1080p-GRP" {
+	first.RequiredActions[0].Options[0].Label = "mutated again"
+	if plan.DryRun().Payload["name"] != "Example.Release.2026.1080p-GRP" ||
+		plan.DryRun().RequiredActions[0].Options[0].Label != "Try alternative" {
 		t.Fatal("dry-run accessor exposes mutable plan state")
 	}
 
@@ -208,6 +216,87 @@ func TestPrepareAdapterBuildsUploadOperationOnce(t *testing.T) {
 	if builds.Load() != 1 {
 		t.Fatalf("upload preparation builds = %d", builds.Load())
 	}
+}
+
+func TestTrackerPlanResolveActionKeepsOrReplacesPreparedOperation(t *testing.T) {
+	t.Parallel()
+
+	newPlan := func(t *testing.T) (TrackerPlan, *atomic.Int32) {
+		t.Helper()
+		var resolutions atomic.Int32
+		plan, failure := PrepareAdapter(
+			context.Background(),
+			PreparationInput{Intent: PreparationIntentUpload, Tracker: "BTN"},
+			nil,
+			func(context.Context, PreparationInput) (PreparedOperation, error) {
+				preview := api.TrackerDryRunEntry{
+					Tracker: "BTN",
+					Payload: map[string]string{"source": "tvdb"},
+					RequiredActions: []api.RequiredAction{{
+						Kind: api.RequiredActionResolveTrackerPreparation,
+					}},
+				}
+				return NewPreparedOperationWithResolver(
+					preview,
+					func(context.Context) (api.UploadSummary, error) {
+						return api.UploadSummary{Uploaded: 1}, nil
+					},
+					nil,
+					func(context.Context) (PreparedOperation, error) {
+						resolutions.Add(1)
+						return NewPreparedOperation(
+							api.TrackerDryRunEntry{Tracker: "BTN", Payload: map[string]string{"source": "release_name"}},
+							func(context.Context) (api.UploadSummary, error) {
+								return api.UploadSummary{Uploaded: 1}, nil
+							},
+							nil,
+						), nil
+					},
+				), nil
+			},
+		)
+		if failure != nil {
+			t.Fatalf("prepare plan: %v", failure)
+		}
+		return plan, &resolutions
+	}
+
+	t.Run("confirm keeps current payload", func(t *testing.T) {
+		plan, resolutions := newPlan(t)
+		resolved, err := plan.ResolveAction(context.Background(), api.RequiredActionResolveTrackerPreparation, true)
+		if err != nil {
+			t.Fatalf("resolve action: %v", err)
+		}
+		if len(resolved.DryRun().RequiredActions) != 0 || resolved.DryRun().Payload["source"] != "tvdb" {
+			t.Fatalf("resolved preview = %#v", resolved.DryRun())
+		}
+		if resolutions.Load() != 0 {
+			t.Fatalf("tracker resolutions = %d", resolutions.Load())
+		}
+		if _, err := plan.ResolveAction(context.Background(), api.RequiredActionResolveTrackerPreparation, false); !errors.Is(err, ErrPlanActionUnavailable) {
+			t.Fatalf("replayed action error = %v", err)
+		}
+		if _, err := resolved.Submit(context.Background()); err != nil {
+			t.Fatalf("submit retained payload: %v", err)
+		}
+	})
+
+	t.Run("decline replaces payload", func(t *testing.T) {
+		plan, resolutions := newPlan(t)
+		resolved, err := plan.ResolveAction(context.Background(), api.RequiredActionResolveTrackerPreparation, false)
+		if err != nil {
+			t.Fatalf("resolve action: %v", err)
+		}
+		if resolved.DryRun().Payload["source"] != "release_name" || resolutions.Load() != 1 {
+			t.Fatalf("resolved preview = %#v resolutions=%d", resolved.DryRun(), resolutions.Load())
+		}
+		if _, err := plan.Submit(context.Background()); !errors.Is(err, ErrPlanReleased) {
+			t.Fatalf("replaced plan submit error = %v", err)
+		}
+		if _, err := resolved.Submit(context.Background()); err != nil {
+			t.Fatalf("submit replacement payload: %v", err)
+		}
+	})
 }
 
 func TestPrepareAdapterPreservesPreparationFailure(t *testing.T) {

--- a/internal/trackers/plan_test.go
+++ b/internal/trackers/plan_test.go
@@ -311,7 +311,7 @@ func TestTrackerPlanResolveActionKeepsOrReplacesPreparedOperation(t *testing.T) 
 		plan := newTestTrackerActionPlan(nil, func(context.Context) (TrackerPlan, *PreparationFailure) {
 			return TrackerPlan{}, want
 		})
-		if _, err := plan.ResolveAction(context.Background(), api.RequiredActionResolveTrackerPreparation, false); err != want {
+		if _, err := plan.ResolveAction(context.Background(), api.RequiredActionResolveTrackerPreparation, false); !errors.Is(err, want) {
 			t.Fatalf("resolver failure = %v, want %v", err, want)
 		}
 	})

--- a/internal/trackers/plan_test.go
+++ b/internal/trackers/plan_test.go
@@ -297,6 +297,41 @@ func TestTrackerPlanResolveActionKeepsOrReplacesPreparedOperation(t *testing.T) 
 			t.Fatalf("submit replacement payload: %v", err)
 		}
 	})
+
+	t.Run("decline requires resolver", func(t *testing.T) {
+		plan := newTestTrackerActionPlan(nil, nil)
+		defer func() { _ = plan.Release() }()
+		if _, err := plan.ResolveAction(context.Background(), api.RequiredActionResolveTrackerPreparation, false); !errors.Is(err, ErrPlanActionNotResolvable) {
+			t.Fatalf("unresolvable action error = %v", err)
+		}
+	})
+
+	t.Run("decline surfaces resolver failure", func(t *testing.T) {
+		want := NewPreparationFailure("BTN", PreparationFailureCodeSkipped, "Tracker skipped.", nil)
+		plan := newTestTrackerActionPlan(nil, func(context.Context) (TrackerPlan, *PreparationFailure) {
+			return TrackerPlan{}, want
+		})
+		if _, err := plan.ResolveAction(context.Background(), api.RequiredActionResolveTrackerPreparation, false); err != want {
+			t.Fatalf("resolver failure = %v, want %v", err, want)
+		}
+	})
+
+	t.Run("decline wraps release failure", func(t *testing.T) {
+		releaseErr := errors.New("release failed")
+		plan := newTestTrackerActionPlan(func() error { return releaseErr }, func(context.Context) (TrackerPlan, *PreparationFailure) {
+			return NewUploadPlan(
+				"BTN",
+				api.TrackerDryRunEntry{Tracker: "BTN"},
+				func(context.Context) (api.UploadSummary, error) { return api.UploadSummary{}, nil },
+				nil,
+			), nil
+		})
+		_, err := plan.ResolveAction(context.Background(), api.RequiredActionResolveTrackerPreparation, false)
+		var preparationFailure *PreparationFailure
+		if !errors.As(err, &preparationFailure) || preparationFailure.Code() != "upload" || !errors.Is(err, releaseErr) {
+			t.Fatalf("release failure = %v", err)
+		}
+	})
 }
 
 func TestPrepareAdapterPreservesPreparationFailure(t *testing.T) {

--- a/internal/trackers/plan_test_helpers_test.go
+++ b/internal/trackers/plan_test_helpers_test.go
@@ -53,3 +53,25 @@ func prepareTestDefinition(ctx context.Context, input PreparationInput, definiti
 	}
 	return PrepareAdapter(ctx, input, description, prepareUpload)
 }
+
+func newTestTrackerActionPlan(
+	release func() error,
+	resolve func(context.Context) (TrackerPlan, *PreparationFailure),
+) TrackerPlan {
+	return TrackerPlan{
+		tracker: "BTN",
+		intent:  PreparationIntentUpload,
+		dryRun: api.TrackerDryRunEntry{
+			Tracker: "BTN",
+			Payload: map[string]string{"source": "tvdb"},
+			RequiredActions: []api.RequiredAction{{
+				Kind: api.RequiredActionResolveTrackerPreparation,
+			}},
+		},
+		state: &planState{
+			submit:  func(context.Context) (api.UploadSummary, error) { return api.UploadSummary{}, nil },
+			release: release,
+			resolve: resolve,
+		},
+	}
+}

--- a/internal/trackers/service_plan_test.go
+++ b/internal/trackers/service_plan_test.go
@@ -289,6 +289,144 @@ func (d retainedProjectionDefinition) submit(_ context.Context, input Preparatio
 	}, nil
 }
 
+func TestRetainedUploadPlanResolvesOutsideLifecycleLock(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+	plan := newTestTrackerActionPlan(nil, func(ctx context.Context) (TrackerPlan, *PreparationFailure) {
+		close(started)
+		select {
+		case <-proceed:
+		case <-ctx.Done():
+			return TrackerPlan{}, NewPreparationFailure("BTN", "canceled", "resolution canceled", ctx.Err())
+		}
+		return NewUploadPlan(
+			"BTN",
+			api.TrackerDryRunEntry{
+				Tracker: "BTN",
+				Payload: map[string]string{"source": "release_name"},
+			},
+			func(context.Context) (api.UploadSummary, error) { return api.UploadSummary{}, nil },
+			nil,
+		), nil
+	})
+	retained := &RetainedUploadPlan{
+		service: &Service{},
+		slots: []trackerPlanSlot{{
+			tracker: "BTN",
+			plan:    plan,
+		}},
+	}
+	resolution := make(chan error, 1)
+	go func() {
+		_, err := retained.ResolveAction(context.Background(), "BTN", api.RequiredActionResolveTrackerPreparation, false)
+		resolution <- err
+	}()
+	<-started
+
+	preparations := make(chan []RetainedTrackerPreparation, 1)
+	go func() { preparations <- retained.Preparations() }()
+	select {
+	case current := <-preparations:
+		if len(current) != 1 || current[0].Preview.Payload["source"] != "tvdb" {
+			t.Fatalf("pre-resolution snapshot = %#v", current)
+		}
+	case <-time.After(2 * time.Second):
+		close(proceed)
+		t.Fatal("preparations blocked on tracker resolution")
+	}
+	if _, err := retained.ResolveAction(context.Background(), "BTN", api.RequiredActionResolveTrackerPreparation, false); !errors.Is(err, ErrPlanActionUnavailable) {
+		close(proceed)
+		t.Fatalf("concurrent resolution error = %v", err)
+	}
+	if _, err := retained.Execute(context.Background()); !errors.Is(err, ErrPlanActionUnavailable) {
+		close(proceed)
+		t.Fatalf("concurrent execution error = %v", err)
+	}
+	close(proceed)
+	if err := <-resolution; err != nil {
+		t.Fatalf("resolve action: %v", err)
+	}
+	current := retained.Preparations()
+	if len(current) != 1 || current[0].Preview.Payload["source"] != "release_name" {
+		t.Fatalf("resolved preparation = %#v", current)
+	}
+	if err := retained.Release(); err != nil {
+		t.Fatalf("release retained plan: %v", err)
+	}
+}
+
+func TestRetainedUploadPlanReleasesReplacementWhenReleasedDuringResolution(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+	var replacementReleases atomic.Int32
+	plan := newTestTrackerActionPlan(nil, func(ctx context.Context) (TrackerPlan, *PreparationFailure) {
+		close(started)
+		select {
+		case <-proceed:
+		case <-ctx.Done():
+			return TrackerPlan{}, NewPreparationFailure("BTN", "canceled", "resolution canceled", ctx.Err())
+		}
+		return NewUploadPlan(
+			"BTN",
+			api.TrackerDryRunEntry{Tracker: "BTN"},
+			func(context.Context) (api.UploadSummary, error) { return api.UploadSummary{}, nil },
+			func() error {
+				replacementReleases.Add(1)
+				return nil
+			},
+		), nil
+	})
+	retained := &RetainedUploadPlan{
+		service: &Service{},
+		slots: []trackerPlanSlot{{
+			tracker: "BTN",
+			plan:    plan,
+		}},
+	}
+	resolution := make(chan error, 1)
+	go func() {
+		_, err := retained.ResolveAction(context.Background(), "BTN", api.RequiredActionResolveTrackerPreparation, false)
+		resolution <- err
+	}()
+	<-started
+	if err := retained.Release(); err != nil {
+		t.Fatalf("release retained plan: %v", err)
+	}
+	close(proceed)
+	if err := <-resolution; !errors.Is(err, ErrPlanReleased) {
+		t.Fatalf("released resolution error = %v", err)
+	}
+	if replacementReleases.Load() != 1 {
+		t.Fatalf("replacement releases = %d", replacementReleases.Load())
+	}
+}
+
+func TestRetainedUploadPlanRecordsResolutionFailure(t *testing.T) {
+	t.Parallel()
+
+	want := NewPreparationFailure("BTN", PreparationFailureCodeSkipped, "Tracker skipped.", nil)
+	plan := newTestTrackerActionPlan(nil, func(context.Context) (TrackerPlan, *PreparationFailure) {
+		return TrackerPlan{}, want
+	})
+	retained := &RetainedUploadPlan{
+		slots: []trackerPlanSlot{{
+			tracker: "BTN",
+			plan:    plan,
+		}},
+	}
+	preparation, err := retained.ResolveAction(context.Background(), "BTN", api.RequiredActionResolveTrackerPreparation, false)
+	if err != nil {
+		t.Fatalf("resolve action: %v", err)
+	}
+	if preparation.Failure == nil || preparation.Failure.Code != PreparationFailureCodeSkipped || preparation.Failure.cause != want {
+		t.Fatalf("recorded preparation = %#v", preparation)
+	}
+}
+
 func TestRetainedUploadPlanExecutesExactReviewedProjectionWithoutRepreparing(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/service_plan_test.go
+++ b/internal/trackers/service_plan_test.go
@@ -422,7 +422,7 @@ func TestRetainedUploadPlanRecordsResolutionFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve action: %v", err)
 	}
-	if preparation.Failure == nil || preparation.Failure.Code != PreparationFailureCodeSkipped || preparation.Failure.cause != want {
+	if preparation.Failure == nil || preparation.Failure.Code != PreparationFailureCodeSkipped || !errors.Is(preparation.Failure.cause, want) {
 		t.Fatalf("recorded preparation = %#v", preparation)
 	}
 }

--- a/internal/trackers/service_upload_plan.go
+++ b/internal/trackers/service_upload_plan.go
@@ -380,18 +380,73 @@ func (p *RetainedUploadPlan) Preparations() []RetainedTrackerPreparation {
 	if p == nil {
 		return nil
 	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	result := make([]RetainedTrackerPreparation, 0, len(p.slots))
 	for _, slot := range p.slots {
-		preparation := RetainedTrackerPreparation{Tracker: slot.tracker, TorrentPath: slot.torrentPath}
-		if slot.failure != nil {
-			failure := *slot.failure
-			preparation.Failure = &failure
-		} else {
-			preparation.Preview = slot.plan.DryRun()
-		}
-		result = append(result, preparation)
+		result = append(result, retainedTrackerPreparation(slot))
 	}
 	return result
+}
+
+// ResolveAction updates one retained tracker operation without rebuilding
+// unrelated tracker plans.
+func (p *RetainedUploadPlan) ResolveAction(
+	ctx context.Context,
+	tracker string,
+	kind api.RequiredActionKind,
+	confirmed bool,
+) (RetainedTrackerPreparation, error) {
+	if p == nil {
+		return RetainedTrackerPreparation{}, ErrPlanNotSubmittable
+	}
+	tracker = normalizeTrackerName(tracker)
+	if tracker == "" {
+		return RetainedTrackerPreparation{}, fmt.Errorf("%w: tracker is required", ErrPlanActionUnavailable)
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	switch {
+	case p.released:
+		return RetainedTrackerPreparation{}, ErrPlanReleased
+	case p.executed:
+		return RetainedTrackerPreparation{}, ErrPlanAlreadyUsed
+	}
+	index := slices.IndexFunc(p.slots, func(slot trackerPlanSlot) bool {
+		return normalizeTrackerName(slot.tracker) == tracker
+	})
+	if index < 0 || p.slots[index].failure != nil {
+		return RetainedTrackerPreparation{}, fmt.Errorf("%w: tracker %s", ErrPlanActionUnavailable, tracker)
+	}
+	plan, err := p.slots[index].plan.ResolveAction(ctx, kind, confirmed)
+	if err != nil {
+		var failure *PreparationFailure
+		if !errors.As(err, &failure) {
+			return RetainedTrackerPreparation{}, err
+		}
+		p.slots[index].plan = TrackerPlan{}
+		p.slots[index].failure = &TrackerFailure{
+			Tracker: tracker,
+			Code:    failure.Code(),
+			Message: safeTrackerMessage(failure),
+			cause:   failure,
+		}
+		return retainedTrackerPreparation(p.slots[index]), nil
+	}
+	p.slots[index].plan = plan
+	p.slots[index].failure = nil
+	return retainedTrackerPreparation(p.slots[index]), nil
+}
+
+func retainedTrackerPreparation(slot trackerPlanSlot) RetainedTrackerPreparation {
+	preparation := RetainedTrackerPreparation{Tracker: slot.tracker, TorrentPath: slot.torrentPath}
+	if slot.failure != nil {
+		failure := *slot.failure
+		preparation.Failure = &failure
+	} else {
+		preparation.Preview = slot.plan.DryRun()
+	}
+	return preparation
 }
 
 // Execute consumes all retained tracker plans without rebuilding payloads.

--- a/internal/trackers/service_upload_plan.go
+++ b/internal/trackers/service_upload_plan.go
@@ -75,6 +75,7 @@ type trackerPlanSlot struct {
 	torrentPath              string
 	plan                     TrackerPlan
 	failure                  *TrackerFailure
+	resolving                bool
 	summary                  api.UploadSummary
 	ruleFailures             []api.TrackerRuleFailure
 	canceledDuringSubmission bool
@@ -405,23 +406,46 @@ func (p *RetainedUploadPlan) ResolveAction(
 		return RetainedTrackerPreparation{}, fmt.Errorf("%w: tracker is required", ErrPlanActionUnavailable)
 	}
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	switch {
 	case p.released:
+		p.mu.Unlock()
 		return RetainedTrackerPreparation{}, ErrPlanReleased
 	case p.executed:
+		p.mu.Unlock()
 		return RetainedTrackerPreparation{}, ErrPlanAlreadyUsed
 	}
 	index := slices.IndexFunc(p.slots, func(slot trackerPlanSlot) bool {
 		return normalizeTrackerName(slot.tracker) == tracker
 	})
-	if index < 0 || p.slots[index].failure != nil {
+	if index < 0 || p.slots[index].failure != nil || p.slots[index].resolving {
+		p.mu.Unlock()
 		return RetainedTrackerPreparation{}, fmt.Errorf("%w: tracker %s", ErrPlanActionUnavailable, tracker)
 	}
-	plan, err := p.slots[index].plan.ResolveAction(ctx, kind, confirmed)
+	p.slots[index].resolving = true
+	plan := p.slots[index].plan
+	p.mu.Unlock()
+
+	resolved, err := plan.ResolveAction(ctx, kind, confirmed)
+	p.mu.Lock()
+	p.slots[index].resolving = false
+	switch {
+	case p.released:
+		p.mu.Unlock()
+		if err == nil {
+			_ = resolved.Release()
+		}
+		return RetainedTrackerPreparation{}, ErrPlanReleased
+	case p.executed:
+		p.mu.Unlock()
+		if err == nil {
+			_ = resolved.Release()
+		}
+		return RetainedTrackerPreparation{}, ErrPlanAlreadyUsed
+	}
 	if err != nil {
 		var failure *PreparationFailure
 		if !errors.As(err, &failure) {
+			p.mu.Unlock()
 			return RetainedTrackerPreparation{}, err
 		}
 		p.slots[index].plan = TrackerPlan{}
@@ -431,11 +455,15 @@ func (p *RetainedUploadPlan) ResolveAction(
 			Message: safeTrackerMessage(failure),
 			cause:   failure,
 		}
-		return retainedTrackerPreparation(p.slots[index]), nil
+		preparation := retainedTrackerPreparation(p.slots[index])
+		p.mu.Unlock()
+		return preparation, nil
 	}
-	p.slots[index].plan = plan
+	p.slots[index].plan = resolved
 	p.slots[index].failure = nil
-	return retainedTrackerPreparation(p.slots[index]), nil
+	preparation := retainedTrackerPreparation(p.slots[index])
+	p.mu.Unlock()
+	return preparation, nil
 }
 
 func retainedTrackerPreparation(slot trackerPlanSlot) RetainedTrackerPreparation {
@@ -481,6 +509,10 @@ func (p *RetainedUploadPlan) execute(
 	if p.executed {
 		p.mu.Unlock()
 		return nil, ErrPlanAlreadyUsed
+	}
+	if slices.ContainsFunc(p.slots, func(slot trackerPlanSlot) bool { return slot.resolving }) {
+		p.mu.Unlock()
+		return nil, fmt.Errorf("%w: tracker action resolution is in progress", ErrPlanActionUnavailable)
 	}
 	selectedSlots, unselectedSlots, err := selectRetainedTrackerPlanSlots(p.slots, trackerIDs)
 	if err != nil {
@@ -563,10 +595,14 @@ func (p *RetainedUploadPlan) Release() error {
 		return nil
 	}
 	p.released = true
+	plans := make([]TrackerPlan, len(p.slots))
+	for index := range p.slots {
+		plans[index] = p.slots[index].plan
+	}
 	p.mu.Unlock()
 	var errs []error
-	for _, slot := range p.slots {
-		if err := slot.plan.Release(); err != nil {
+	for _, plan := range plans {
+		if err := plan.Release(); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/internal/webserver/openapi/release-workflow-v1.json
+++ b/internal/webserver/openapi/release-workflow-v1.json
@@ -5076,6 +5076,7 @@
           "trackerInput",
           "questionnaire",
           "ruleAuthorization",
+          "trackerPreparation",
           "duplicateReview",
           "trackerApproval",
           "uploadApproval",
@@ -5193,6 +5194,16 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/ReleaseWorkflowUploadTrackerInput"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "trackerPreparation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReleaseWorkflowUploadConfirmation"
               },
               {
                 "type": "null"

--- a/pkg/api/workflow_ids.go
+++ b/pkg/api/workflow_ids.go
@@ -267,6 +267,8 @@ const (
 	RequiredActionAnswerQuestionnaire RequiredActionKind = "answer_questionnaire"
 	// RequiredActionAuthorizeRules requests acknowledgement of waivable rules.
 	RequiredActionAuthorizeRules RequiredActionKind = "authorize_rules"
+	// RequiredActionResolveTrackerPreparation requests a decision about one prepared tracker payload.
+	RequiredActionResolveTrackerPreparation RequiredActionKind = "resolve_tracker_preparation"
 	// RequiredActionReviewDuplicates requests duplicate acceptance or rejection.
 	RequiredActionReviewDuplicates RequiredActionKind = "review_duplicates"
 	// RequiredActionApproveTrackers requests one exact post-dupe tracker subset.

--- a/pkg/api/workflow_presence.go
+++ b/pkg/api/workflow_presence.go
@@ -9,6 +9,25 @@ import (
 	"fmt"
 )
 
+// UnmarshalJSON preserves whether confirmation was omitted while keeping
+// explicit false distinct for tracker-preparation decisions.
+func (c *ReleaseWorkflowUploadConfirmation) UnmarshalJSON(payload []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		return fmt.Errorf("unmarshal workflow confirmation: %w", err)
+	}
+	*c = ReleaseWorkflowUploadConfirmation{confirmedOmitted: true}
+	raw, ok := fields["confirmed"]
+	if !ok || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil
+	}
+	if err := json.Unmarshal(raw, &c.Confirmed); err != nil {
+		return fmt.Errorf("unmarshal workflow confirmation value: %w", err)
+	}
+	c.confirmedOmitted = false
+	return nil
+}
+
 // WorkflowPatch preserves JSON absence, null/reset, and explicit values including zero values.
 // Present=false means leave unchanged; Present=true with Reset=true means return to automatic.
 type WorkflowPatch[T any] struct {

--- a/pkg/api/workflow_upload.go
+++ b/pkg/api/workflow_upload.go
@@ -412,12 +412,13 @@ const (
 	// Deprecated: tracker authentication must be resolved outside upload workflows.
 	ReleaseWorkflowUploadFeedbackTrackerAuthentication ReleaseWorkflowUploadFeedbackKind = "trackerAuthentication"
 	// Deprecated: tracker two-factor authentication must be resolved outside upload workflows.
-	ReleaseWorkflowUploadFeedbackTwoFactor         ReleaseWorkflowUploadFeedbackKind = "twoFactor"
-	ReleaseWorkflowUploadFeedbackTrackerInput      ReleaseWorkflowUploadFeedbackKind = "trackerInput"
-	ReleaseWorkflowUploadFeedbackQuestionnaire     ReleaseWorkflowUploadFeedbackKind = "questionnaire"
-	ReleaseWorkflowUploadFeedbackRuleAuthorization ReleaseWorkflowUploadFeedbackKind = "ruleAuthorization"
-	ReleaseWorkflowUploadFeedbackDuplicateReview   ReleaseWorkflowUploadFeedbackKind = "duplicateReview"
-	ReleaseWorkflowUploadFeedbackTrackerApproval   ReleaseWorkflowUploadFeedbackKind = "trackerApproval"
+	ReleaseWorkflowUploadFeedbackTwoFactor          ReleaseWorkflowUploadFeedbackKind = "twoFactor"
+	ReleaseWorkflowUploadFeedbackTrackerInput       ReleaseWorkflowUploadFeedbackKind = "trackerInput"
+	ReleaseWorkflowUploadFeedbackQuestionnaire      ReleaseWorkflowUploadFeedbackKind = "questionnaire"
+	ReleaseWorkflowUploadFeedbackRuleAuthorization  ReleaseWorkflowUploadFeedbackKind = "ruleAuthorization"
+	ReleaseWorkflowUploadFeedbackTrackerPreparation ReleaseWorkflowUploadFeedbackKind = "trackerPreparation"
+	ReleaseWorkflowUploadFeedbackDuplicateReview    ReleaseWorkflowUploadFeedbackKind = "duplicateReview"
+	ReleaseWorkflowUploadFeedbackTrackerApproval    ReleaseWorkflowUploadFeedbackKind = "trackerApproval"
 	// Deprecated: final upload approval is no longer emitted by runtime workflows.
 	ReleaseWorkflowUploadFeedbackUploadApproval ReleaseWorkflowUploadFeedbackKind = "uploadApproval"
 	ReleaseWorkflowUploadFeedbackReprepare      ReleaseWorkflowUploadFeedbackKind = "reprepare"
@@ -449,6 +450,7 @@ type ReleaseWorkflowUploadFeedbackResponse struct {
 	TrackerInput          *ReleaseWorkflowUploadTrackerInput          `json:"trackerInput,omitempty"`
 	Questionnaire         *ReleaseWorkflowUploadQuestionnaire         `json:"questionnaire,omitempty"`
 	RuleAuthorization     *ReleaseWorkflowUploadConfirmation          `json:"ruleAuthorization,omitempty"`
+	TrackerPreparation    *ReleaseWorkflowUploadConfirmation          `json:"trackerPreparation,omitempty"`
 	DuplicateReview       *ReleaseWorkflowUploadDuplicateReview       `json:"duplicateReview,omitempty"`
 	TrackerApproval       *ReleaseWorkflowUploadTrackerApproval       `json:"trackerApproval,omitempty"`
 	// Deprecated: retained for v1 decoding compatibility.
@@ -470,7 +472,7 @@ type ReleaseWorkflowUploadMetadataSelection struct {
 	Facts          *ReleaseWorkflowUploadFacts `json:"facts,omitempty"`
 }
 
-// ReleaseWorkflowUploadConfirmation positively acknowledges a gated action.
+// ReleaseWorkflowUploadConfirmation carries one confirmation-style decision.
 type ReleaseWorkflowUploadConfirmation struct {
 	Confirmed bool `json:"confirmed"`
 }
@@ -558,6 +560,7 @@ func (f ReleaseWorkflowUploadFeedback) Validate() error {
 		{ReleaseWorkflowUploadFeedbackTrackerInput, f.Response.TrackerInput != nil},
 		{ReleaseWorkflowUploadFeedbackQuestionnaire, f.Response.Questionnaire != nil},
 		{ReleaseWorkflowUploadFeedbackRuleAuthorization, f.Response.RuleAuthorization != nil},
+		{ReleaseWorkflowUploadFeedbackTrackerPreparation, f.Response.TrackerPreparation != nil},
 		{ReleaseWorkflowUploadFeedbackDuplicateReview, f.Response.DuplicateReview != nil},
 		{ReleaseWorkflowUploadFeedbackTrackerApproval, f.Response.TrackerApproval != nil},
 		{ReleaseWorkflowUploadFeedbackUploadApproval, f.Response.UploadApproval != nil},
@@ -607,6 +610,8 @@ func (f ReleaseWorkflowUploadFeedback) Validate() error {
 		if !f.Response.RuleAuthorization.Confirmed {
 			return errors.New("rule authorization feedback requires confirmation")
 		}
+	case ReleaseWorkflowUploadFeedbackTrackerPreparation:
+		// Both answers are meaningful: true keeps the current payload; false asks the tracker to resolve it.
 	case ReleaseWorkflowUploadFeedbackTrackerApproval:
 		if !f.Response.TrackerApproval.Confirmed {
 			return errors.New("tracker approval feedback requires confirmation")

--- a/pkg/api/workflow_upload.go
+++ b/pkg/api/workflow_upload.go
@@ -474,7 +474,8 @@ type ReleaseWorkflowUploadMetadataSelection struct {
 
 // ReleaseWorkflowUploadConfirmation carries one confirmation-style decision.
 type ReleaseWorkflowUploadConfirmation struct {
-	Confirmed bool `json:"confirmed"`
+	Confirmed        bool `json:"confirmed"`
+	confirmedOmitted bool
 }
 
 // ReleaseWorkflowUploadApproval authorizes an exact subset of the reviewed tracker operations.
@@ -611,7 +612,9 @@ func (f ReleaseWorkflowUploadFeedback) Validate() error {
 			return errors.New("rule authorization feedback requires confirmation")
 		}
 	case ReleaseWorkflowUploadFeedbackTrackerPreparation:
-		// Both answers are meaningful: true keeps the current payload; false asks the tracker to resolve it.
+		if f.Response.TrackerPreparation.confirmedOmitted {
+			return errors.New("tracker preparation feedback requires an explicit confirmed member")
+		}
 	case ReleaseWorkflowUploadFeedbackTrackerApproval:
 		if !f.Response.TrackerApproval.Confirmed {
 			return errors.New("tracker approval feedback requires confirmation")

--- a/pkg/api/workflow_upload_test.go
+++ b/pkg/api/workflow_upload_test.go
@@ -186,15 +186,15 @@ func TestReleaseWorkflowUploadFeedbackRequiresExplicitTrackerPreparationDecision
 		{name: "omitted", decision: `{}`},
 		{name: "null", decision: `{"confirmed":null}`},
 		{
-name: "false",
- decision: `{"confirmed":false}`,
- wantValid: true,
-},
+			name:      "false",
+			decision:  `{"confirmed":false}`,
+			wantValid: true,
+		},
 		{
-name: "true",
- decision: `{"confirmed":true}`,
- wantValid: true,
-},
+			name:      "true",
+			decision:  `{"confirmed":true}`,
+			wantValid: true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/api/workflow_upload_test.go
+++ b/pkg/api/workflow_upload_test.go
@@ -151,6 +151,29 @@ func TestReleaseWorkflowUploadFeedbackRequiresMatchingDiscriminatedMember(t *tes
 	}
 }
 
+func TestReleaseWorkflowUploadFeedbackAcceptsBothTrackerPreparationDecisions(t *testing.T) {
+	t.Parallel()
+
+	for _, confirmed := range []bool{false, true} {
+		feedback := ReleaseWorkflowUploadFeedback{
+			Action: ReleaseWorkflowUploadActionIdentity{
+				ID:               "action-btn-autofill",
+				WorkflowRevision: 4,
+			},
+			Response: ReleaseWorkflowUploadFeedbackResponse{
+				Kind: ReleaseWorkflowUploadFeedbackTrackerPreparation,
+				TrackerPreparation: &ReleaseWorkflowUploadConfirmation{
+					Confirmed: confirmed,
+				},
+			},
+			IdempotencyKey: "btn-autofill-decision",
+		}
+		if err := feedback.Validate(); err != nil {
+			t.Fatalf("confirmed=%t: %v", confirmed, err)
+		}
+	}
+}
+
 func TestReleaseWorkflowUploadFeedbackRejectsDuplicateApprovalTrackers(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/workflow_upload_test.go
+++ b/pkg/api/workflow_upload_test.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -171,6 +172,50 @@ func TestReleaseWorkflowUploadFeedbackAcceptsBothTrackerPreparationDecisions(t *
 		if err := feedback.Validate(); err != nil {
 			t.Fatalf("confirmed=%t: %v", confirmed, err)
 		}
+	}
+}
+
+func TestReleaseWorkflowUploadFeedbackRequiresExplicitTrackerPreparationDecisionInJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name      string
+		decision  string
+		wantValid bool
+	}{
+		{name: "omitted", decision: `{}`},
+		{name: "null", decision: `{"confirmed":null}`},
+		{
+name: "false",
+ decision: `{"confirmed":false}`,
+ wantValid: true,
+},
+		{
+name: "true",
+ decision: `{"confirmed":true}`,
+ wantValid: true,
+},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			payload := fmt.Sprintf(`{
+				"action":{"id":"action-btn-autofill","workflowRevision":4},
+				"response":{"kind":"trackerPreparation","trackerPreparation":%s},
+				"idempotencyKey":"btn-autofill-decision"
+			}`, test.decision)
+			var feedback ReleaseWorkflowUploadFeedback
+			if err := json.Unmarshal([]byte(payload), &feedback); err != nil {
+				t.Fatalf("unmarshal feedback: %v", err)
+			}
+			feedback.IdempotencyKey = "btn-autofill-decision"
+			err := feedback.Validate()
+			if test.wantValid && err != nil {
+				t.Fatalf("explicit decision rejected: %v", err)
+			}
+			if !test.wantValid && err == nil {
+				t.Fatal("missing explicit decision was accepted")
+			}
+		})
 	}
 }
 

--- a/webui/src/api/generated/release-workflow.ts
+++ b/webui/src/api/generated/release-workflow.ts
@@ -1221,7 +1221,7 @@ export type ReleaseWorkflowUploadFeedback = Readonly<{
   response: ReleaseWorkflowUploadFeedbackResponse;
 }>;
 
-export type ReleaseWorkflowUploadFeedbackKind = "playlistSelection" | "metadataSelection" | "rescanConfirmation" | "trackerAuthentication" | "twoFactor" | "trackerInput" | "questionnaire" | "ruleAuthorization" | "duplicateReview" | "trackerApproval" | "uploadApproval" | "reprepare" | "reconciliation";
+export type ReleaseWorkflowUploadFeedbackKind = "playlistSelection" | "metadataSelection" | "rescanConfirmation" | "trackerAuthentication" | "twoFactor" | "trackerInput" | "questionnaire" | "ruleAuthorization" | "trackerPreparation" | "duplicateReview" | "trackerApproval" | "uploadApproval" | "reprepare" | "reconciliation";
 
 export type ReleaseWorkflowUploadFeedbackResponse = Readonly<{
   duplicateReview?: ReleaseWorkflowUploadDuplicateReview | null;
@@ -1236,6 +1236,7 @@ export type ReleaseWorkflowUploadFeedbackResponse = Readonly<{
   trackerApproval?: ReleaseWorkflowUploadTrackerApproval | null;
   trackerAuthentication?: ReleaseWorkflowUploadTrackerAuthentication | null;
   trackerInput?: ReleaseWorkflowUploadTrackerInput | null;
+  trackerPreparation?: ReleaseWorkflowUploadConfirmation | null;
   twoFactor?: ReleaseWorkflowUploadTwoFactor | null;
   /** @deprecated */
   uploadApproval?: ReleaseWorkflowUploadApproval | null;

--- a/webui/src/app.tsx
+++ b/webui/src/app.tsx
@@ -458,7 +458,9 @@ function AppShell() {
           <WorkflowOperationProgress operation={releaseSession.workflow.view.current?.operation} />
           <WorkflowRequiredActions
             continuation={releaseSession.workflow.view.current?.continuation}
-            onConfirm={(action) => void releaseSession.workflow.confirmAction(action)}
+            onConfirm={(action, confirmed) =>
+              void releaseSession.workflow.confirmAction(action, confirmed)
+            }
             onNavigate={(route) => openReleaseTab(releaseRouteTabs[route], route)}
           />
           {activeTab === "settings" ? (

--- a/webui/src/components/WorkflowRequiredActions.test.tsx
+++ b/webui/src/components/WorkflowRequiredActions.test.tsx
@@ -203,6 +203,35 @@ describe("WorkflowRequiredActions", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Continue upload" }));
-    expect(confirm).toHaveBeenCalledWith(expect.objectContaining({ kind: "authorize_rules" }));
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "authorize_rules" }),
+      true,
+    );
+  });
+
+  it("offers both tracker preparation decisions", () => {
+    const confirm = vi.fn();
+    render(
+      <WorkflowRequiredActions
+        continuation={continuation([
+          action({
+            kind: "resolve_tracker_preparation",
+            prompt: "BTN autofill mismatched.",
+            options: [
+              { value: "confirm", label: "Continue upload" },
+              { value: "resolve", label: "Try release-name autofill" },
+            ],
+          }),
+        ])}
+        onConfirm={confirm}
+        onNavigate={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Try release-name autofill" }));
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "resolve_tracker_preparation" }),
+      false,
+    );
   });
 });

--- a/webui/src/components/WorkflowRequiredActions.tsx
+++ b/webui/src/components/WorkflowRequiredActions.tsx
@@ -32,14 +32,14 @@ function actionScope(action: RequiredAction): string {
   return "Workflow action";
 }
 
-/** Shows pending non-dupe actions and lets users confirm tracker rules or open the owning workflow step. */
+/** Shows pending non-dupe actions and lets users resolve confirmations or open the owning workflow step. */
 export function WorkflowRequiredActions({
   continuation,
   onConfirm,
   onNavigate,
 }: Readonly<{
   continuation?: WorkflowContinuation | null;
-  onConfirm: (action: RequiredAction) => void;
+  onConfirm: (action: RequiredAction, confirmed?: boolean) => void;
   onNavigate: (route: ReleaseRoute) => void;
 }>) {
   const actions = (continuation?.requiredActions || []).filter(
@@ -68,8 +68,19 @@ export function WorkflowRequiredActions({
               <p className="muted text-xs">Action: {action.kind.replaceAll("_", " ")}</p>
               {action.kind === "authorize_rules" ? (
                 <div>
-                  <button className="ghost" type="button" onClick={() => onConfirm(action)}>
+                  <button className="ghost" type="button" onClick={() => onConfirm(action, true)}>
                     Continue upload
+                  </button>
+                </div>
+              ) : action.kind === "resolve_tracker_preparation" ? (
+                <div className="flex flex-wrap gap-2">
+                  <button className="ghost" type="button" onClick={() => onConfirm(action, true)}>
+                    {action.options?.find((option) => option.value === "confirm")?.label ||
+                      "Continue upload"}
+                  </button>
+                  <button className="ghost" type="button" onClick={() => onConfirm(action, false)}>
+                    {action.options?.find((option) => option.value === "resolve")?.label ||
+                      "Try alternative"}
                   </button>
                 </div>
               ) : route ? (

--- a/webui/src/releaseSession/index.test.tsx
+++ b/webui/src/releaseSession/index.test.tsx
@@ -727,6 +727,51 @@ describe("useReleaseSession", () => {
     window.sessionStorage.removeItem("upbrr.activeReleaseWorkflow");
   });
 
+  it("declines a tracker preparation action to request its fallback", async () => {
+    const workflowID = "workflow-resolve-tracker-preparation";
+    window.sessionStorage.setItem("upbrr.activeReleaseWorkflow", workflowID);
+    const action = {
+      createdAt: "2026-07-20T00:00:00Z",
+      id: "action-btn-autofill",
+      kind: "resolve_tracker_preparation" as const,
+      prompt: "Continue with BTN's autofill result?",
+      status: "pending" as const,
+      workflowRevision: 7,
+    };
+    const base = workflowCurrent(workflowID, 7);
+    const retained: ReleaseWorkflowCurrent = {
+      ...base,
+      workflow: { ...base.workflow, status: "blocked", requiredActions: [action] },
+      continuation: { ...base.continuation, requiredActions: [action] },
+    };
+    const continueWorkflow = vi.fn(async () => retained);
+    const { result, unmount } = renderHook(useReleaseSession, {
+      wrapper: wrapperFor(
+        portsFor({
+          workflow: workflowPorts({
+            current: async () => retained,
+            continue: continueWorkflow,
+          }),
+        }),
+      ),
+    });
+
+    await waitFor(() => expect(result.current.workflow.view.status).toBe("ready"));
+    await act(async () => {
+      expect(await result.current.workflow.confirmAction(action, false)).toBe(true);
+    });
+    expect(continueWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        goal: "uploaded",
+        answers: [{ actionId: action.id, workflowRevision: 7, confirmed: false }],
+      }),
+      expect.any(AbortSignal),
+    );
+
+    unmount();
+    window.sessionStorage.removeItem("upbrr.activeReleaseWorkflow");
+  });
+
   it("executes a direct upload through one workflow command", async () => {
     const workflowID = "workflow-skipped-upload";
     window.sessionStorage.setItem("upbrr.activeReleaseWorkflow", workflowID);

--- a/webui/src/releaseSession/index.tsx
+++ b/webui/src/releaseSession/index.tsx
@@ -1524,8 +1524,13 @@ export function ReleaseSessionProvider({
           continueBackendGoal(current, "dry_run", backendResolvedUploadIntent(), commandID, signal),
         ),
       executeUploads: () => executeExactUpload(),
-      confirmAction: (action: RequiredAction) => {
-        if (action.kind !== "authorize_rules") return Promise.resolve(false);
+      confirmAction: (action: RequiredAction, confirmed = true) => {
+        if (
+          (action.kind !== "authorize_rules" && action.kind !== "resolve_tracker_preparation") ||
+          (action.kind === "authorize_rules" && !confirmed)
+        ) {
+          return Promise.resolve(false);
+        }
         return runBackendWorkflow((current, commandID, signal) =>
           continueBackendGoal(
             current,
@@ -1538,7 +1543,7 @@ export function ReleaseSessionProvider({
                 {
                   actionId: action.id,
                   workflowRevision: current.workflow.revision,
-                  confirmed: true,
+                  confirmed,
                 },
               ],
             },

--- a/webui/src/releaseSession/types.ts
+++ b/webui/src/releaseSession/types.ts
@@ -320,8 +320,8 @@ export type WorkflowFacet = Readonly<{
   generateDescriptions(instructions: DescriptionInstructions): Promise<boolean>;
   dryRunUploads(): Promise<boolean>;
   executeUploads(): Promise<boolean>;
-  /** Submits an `authorize_rules` confirmation and resumes upload; unsupported kinds resolve to false. */
-  confirmAction(action: RequiredAction): Promise<boolean>;
+  /** Resolves a supported upload action and resumes the workflow. */
+  confirmAction(action: RequiredAction, confirmed?: boolean): Promise<boolean>;
   retryFailedUploads(): Promise<boolean>;
   retryClientInjections(): Promise<boolean>;
   invalidateTrackers(trackerIDs: readonly string[], reason: string): Promise<boolean>;


### PR DESCRIPTION
## Summary

- Detect BTN autofill series mismatches against TVDB names and aliases.
- Let operators keep the prepared payload or retry with release-name autofill; safely skip BTN when the fallback still mismatches or strict unattended mode cannot prompt.
- Carry the tracker-owned decision through retained plans, workflow continuation, CLI, WebUI, OpenAPI, generated TypeScript contracts, and tests.

## Root cause

BTN's TVDB-ID autofill can return a different series. upbrr previously retained that payload without a workflow action or a safe way to replace only the BTN preparation.

## User impact

Interactive users can inspect the mismatch, continue with BTN's payload, or retry through release-name autofill. Strict unattended mode skips the ambiguous BTN lane while other viable trackers continue.

## Validation

- Focused Go race tests for CLI, workflow contracts, core, release workflow, trackers, BTN, webserver, and API
- `make test-go`
- `make test-frontend`
- `make lint`
- `make logpolicy`
- `make gofix-check-changed`
- `make backend`
- `make e2e-build`
- `git diff --check origin/main...HEAD`
- pre-push hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracker-preparation decisions to upload workflows, allowing users to confirm or decline prepared tracker actions.
  * Added web interface controls for resolving tracker-preparation actions.
  * Added BTN autofill fallback using release-name matching when series information does not match.
  * Updated upload feedback contracts to support tracker-preparation confirmations.
  * Added unattended workflow handling for pending tracker decisions.

* **Bug Fixes**
  * Prevented repeated fallback attempts after a release-name autofill mismatch.
  * Preserved pending tracker decisions during workflow continuation and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->