### PR TITLE
ci: build Docker image on pull requests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,34 @@
+name: docker
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=docker-pr-amd64
+          cache-to: type=gha,scope=docker-pr-amd64,mode=min

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -31,4 +33,4 @@ jobs:
           platforms: linux/amd64
           push: false
           cache-from: type=gha,scope=docker-pr-amd64
-          cache-to: type=gha,scope=docker-pr-amd64,mode=min
+          cache-to: type=gha,scope=docker-pr-amd64,mode=min,ignore-error=true


### PR DESCRIPTION
## Summary
- build the Dockerfile on every pull request
- use the existing Buildx amd64 build path without publishing an image
- cancel superseded builds

## Validation
- `actionlint .github/workflows/docker.yml`
- `git diff --check`
- `make lint`
- pre-push frontend typecheck and Go lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Docker image builds for pull requests.
  * Enabled build caching and automatic cancellation of outdated workflow runs.
  * Docker images are validated without being published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->