### PR TITLE
fix(workflow): handle skipped tracker naming failures

### DIFF
--- a/internal/trackers/impl/unit3d/sites/otw/name.go
+++ b/internal/trackers/impl/unit3d/sites/otw/name.go
@@ -120,7 +120,7 @@ func isOTWNonDiscMultiSeason(meta api.UploadSubject) bool {
 	if isOTWCompleteDisc(meta) {
 		return false
 	}
-	seasons := make(map[string]struct{})
+	seasons := make(map[int]struct{})
 	for _, value := range append([]string{
 		meta.SeasonStr,
 		meta.ReleaseName,
@@ -128,7 +128,10 @@ func isOTWNonDiscMultiSeason(meta api.UploadSubject) bool {
 	}, meta.FileList...) {
 		for _, match := range otwSeasonPattern.FindAllStringSubmatch(value, -1) {
 			if len(match) > 1 {
-				seasons[match[1]] = struct{}{}
+				season, err := strconv.Atoi(match[1])
+				if err == nil {
+					seasons[season] = struct{}{}
+				}
 			}
 		}
 	}

--- a/internal/trackers/impl/unit3d/sites/otw/name_test.go
+++ b/internal/trackers/impl/unit3d/sites/otw/name_test.go
@@ -120,6 +120,21 @@ func TestBuildNameBlocksProvedNonDiscMultiSeason(t *testing.T) {
 	}
 }
 
+func TestOTWMultiSeasonDetectionNormalizesSeasonPadding(t *testing.T) {
+	t.Parallel()
+	meta := api.UploadSubject{
+		SeasonStr: "S01",
+		FileList: []string{
+			filepath.Join("Example Show - Season 1", "Example.Show.S01E01.mkv"),
+			filepath.Join("Example Show - Season 1", "Example.Show.S01E02.mkv"),
+		},
+		Type: "ENCODE",
+	}
+	if isOTWNonDiscMultiSeason(meta) {
+		t.Fatal("OTW treated Season 1 and S01 as different seasons")
+	}
+}
+
 func TestProfileBuildNameVersion(t *testing.T) {
 	t.Parallel()
 	if got := Profile().Site.BuildNameVersion; got != "v2" {

--- a/pkg/api/workflow_contracts.go
+++ b/pkg/api/workflow_contracts.go
@@ -424,7 +424,8 @@ type DupeMatchProjection struct {
 
 // TrackerDupeAssessment is one retained projection-bound duplicate result.
 type TrackerDupeAssessment struct {
-	TrackerID             TrackerID                `json:"trackerId"`
+	TrackerID TrackerID `json:"trackerId"`
+	// UploadReleaseName may be empty only when Decision is DupeDecisionSkipped.
 	UploadReleaseName     string                   `json:"uploadReleaseName"`
 	ProjectionFingerprint WorkflowFingerprint      `json:"projectionFingerprint"`
 	CriteriaFingerprint   WorkflowFingerprint      `json:"criteriaFingerprint"`

--- a/pkg/api/workflow_contracts_test.go
+++ b/pkg/api/workflow_contracts_test.go
@@ -295,6 +295,43 @@ func TestReleaseWorkflowRejectsInvalidLineageAndBlockedStatus(t *testing.T) {
 	}
 }
 
+func TestDupeAssessmentAllowsNamelessSkippedResult(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 20, 1, 2, 3, 0, time.UTC)
+	fingerprint := workflowTestFingerprint(t, "nameless-skipped-dupe")
+	assessment := DupeAssessment{
+		ID:               "dupes-1",
+		WorkflowID:       "workflow-1",
+		Revision:         1,
+		Release:          ReleaseSnapshotRef{ID: "release-1", Revision: 1},
+		ReleaseRef:       ReleaseRef{SourcePath: "Example.Release.2026", Generation: 1},
+		Selection:        TrackerSelectionRef{ID: "selection-1", Revision: 1},
+		ProjectionSet:    TrackerReleaseProjectionSetRef{ID: "projections-1", Revision: 1},
+		InputFingerprint: fingerprint,
+		Results: []TrackerDupeAssessment{{
+			TrackerID:             "OTW",
+			ProjectionFingerprint: fingerprint,
+			CriteriaFingerprint:   fingerprint,
+			Decision:              DupeDecisionSkipped,
+			Status:                StageStatusSkipped,
+			CheckedAt:             now,
+			FreshUntil:            now.Add(time.Hour),
+		}},
+		Status:    StageStatusCompleted,
+		CreatedAt: now,
+		ExpiresAt: now.Add(time.Hour),
+	}
+	if err := assessment.Validate(); err != nil {
+		t.Fatalf("validate nameless skipped dupe result: %v", err)
+	}
+
+	assessment.Results[0].Decision = DupeDecisionNoMatch
+	if err := assessment.Validate(); err == nil || !strings.Contains(err.Error(), "requires upload release name") {
+		t.Fatalf("expected nameless non-skipped result rejection, got %v", err)
+	}
+}
+
 func TestDirectUploadContractsValidateExactLineageAndTerminalOutcomes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/workflow_contracts_validation.go
+++ b/pkg/api/workflow_contracts_validation.go
@@ -778,8 +778,11 @@ func (s DupeAssessment) Validate() error {
 	hasFailed := false
 	for _, result := range s.Results {
 		id := normalizeTrackerID(result.TrackerID)
-		if id == "" || strings.TrimSpace(result.UploadReleaseName) == "" {
-			return errors.New("dupe result requires tracker id and upload release name")
+		if id == "" {
+			return errors.New("dupe result requires tracker id")
+		}
+		if strings.TrimSpace(result.UploadReleaseName) == "" && result.Decision != DupeDecisionSkipped {
+			return fmt.Errorf("dupe result %s requires upload release name", id)
 		}
 		if _, ok := seen[id]; ok {
 			return fmt.Errorf("dupe assessment contains duplicate tracker %s", id)


### PR DESCRIPTION
## Description

- Normalize OTW season captures so `Season 1` and `S01` identify the same season.
- Retain nameless duplicate results only when the tracker is explicitly skipped.
- Add tracker and API contract regression coverage.

This prevents one ineligible tracker naming failure from aborting duplicate checks for every tracker. Non-skipped results still require an upload release name.

No linked issue.

## How has this been tested?

- `go test -race -v -timeout 20m ./internal/trackers/impl/unit3d/sites/otw ./pkg/api`
- `go test -race -v -timeout 20m ./cmd/upbrr ./internal/core ./internal/releaseworkflow ./pkg/api`
- `make test-go`
- `make precommit`
- `make lint`
- `make gofix-check-changed`
- `git diff --check`

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/upbrr/blob/main/CONTRIBUTING.md)
- [x] I ran `make precommit`
- [x] For CSS changes, I ran `pnpm --dir webui run lint:style` (not applicable; no CSS changes)

## AI disclosure

Yes. Nearly all changed code was written with OpenAI Codex (GPT-5), guided and approved by the maintainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multi-season release detection by recognizing season information in release names and treating padded and unpadded season numbers consistently.
  - Skipped duplicate assessments can now omit an upload release name, while other assessment decisions still require one.

- **Documentation**
  - Clarified when an upload release name may be empty in duplicate-assessment results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->