### PR TITLE
fix(upload): preserve tracker failure details

### DIFF
--- a/cmd/upbrr/release_workflow.go
+++ b/cmd/upbrr/release_workflow.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/logging"
 	"github.com/autobrr/upbrr/internal/releaseworkflow"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -871,8 +872,15 @@ func printCLIWorkflowUploadResult(result *api.UploadResult) (int, error) {
 		submissionStatus := tracker.EffectiveSubmissionStatus()
 		clientStatus := tracker.EffectiveClientInjectionStatus()
 		fmt.Printf("Upload %s: submission=%s client-injection=%s\n", tracker.TrackerID, submissionStatus, clientStatus)
-		if tracker.ClientInjectionMessage != "" {
-			fmt.Printf("  client injection: %s\n", tracker.ClientInjectionMessage)
+		clientMessage := strings.TrimSpace(logging.SanitizeMessage(tracker.ClientInjectionMessage))
+		if clientMessage != "" {
+			fmt.Printf("  client injection: %s\n", clientMessage)
+		}
+		for _, failure := range tracker.Failures {
+			message := strings.TrimSpace(logging.SanitizeMessage(failure.Failure.Message))
+			if message != "" && message != clientMessage {
+				fmt.Printf("  failure: %s\n", message)
+			}
 		}
 		switch submissionStatus {
 		case api.StageStatusCompleted:

--- a/cmd/upbrr/release_workflow_test.go
+++ b/cmd/upbrr/release_workflow_test.go
@@ -144,6 +144,33 @@ func TestPrintCLIWorkflowDryRunIncludesClientOutcome(t *testing.T) {
 	}
 }
 
+func TestPrintCLIWorkflowUploadResultIncludesRedactedTrackerFailure(t *testing.T) {
+	var (
+		uploaded  int
+		resultErr error
+	)
+	output := captureStdout(t, func() {
+		uploaded, resultErr = printCLIWorkflowUploadResult(&api.UploadResult{Results: []api.UploadTrackerResult{{
+			TrackerID:             "EXAMPLE",
+			Status:                api.StageStatusFailed,
+			SubmissionStatus:      api.StageStatusFailed,
+			ClientInjectionStatus: api.StageStatusPending,
+			Failures: []api.WorkflowFailure{{Failure: api.OperationFailure{
+				Code:      api.OperationFailureInternal,
+				Operation: api.OperationKindUploadExecute,
+				Message:   "Tracker rejected payload passkey=never-print-this.",
+				Recovery:  api.OperationRecoveryRetry,
+			}}},
+		}}})
+	})
+	if uploaded != 0 || resultErr == nil || !strings.Contains(resultErr.Error(), "1 tracker upload(s) failed") {
+		t.Fatalf("upload result = %d, %v", uploaded, resultErr)
+	}
+	if !strings.Contains(output, "failure: Tracker rejected payload passkey=[REDACTED]") || strings.Contains(output, "never-print-this") {
+		t.Fatal("upload output did not retain a safely redacted tracker failure")
+	}
+}
+
 func TestPrintCLIWorkflowDryRunSeparatesTrackersAndHighlightsRenames(t *testing.T) {
 	output := captureStdout(t, func() {
 		printCLIWorkflowDryRun(

--- a/internal/core/workflow_upload_plan.go
+++ b/internal/core/workflow_upload_plan.go
@@ -1021,7 +1021,10 @@ func (e *workflowUploadExecution) Execute(
 		if result.Failure != nil {
 			failureCode := api.OperationFailureInternal
 			recovery := api.OperationRecoveryRetry
-			message := "Tracker upload failed. Review the tracker result and retry after correcting the failure."
+			message := strings.TrimSpace(logging.SanitizeMessage(result.Failure.Message))
+			if message == "" {
+				message = "Tracker upload failed. Review the tracker result and retry after correcting the failure."
+			}
 			submissionStatus := api.StageStatusFailed
 			if result.Failure.Code == "unknown_outcome" {
 				failureCode = api.OperationFailureUnknownOutcome

--- a/internal/core/workflow_upload_plan_test.go
+++ b/internal/core/workflow_upload_plan_test.go
@@ -1061,6 +1061,72 @@ func TestWorkflowUploadExecutionDoesNotRepeatSuccessfulDryRunInjection(t *testin
 	}
 }
 
+func TestWorkflowUploadExecutionRetainsSafeTrackerFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		code             string
+		message          string
+		wantMessage      string
+		wantSubmission   api.StageStatus
+		wantRedaction    bool
+		wantPathSanitize bool
+	}{
+		{
+			name:             "submission detail",
+			code:             "submit",
+			message:          `Tracker rejected payload passkey=never-print-this source=C:\releases\Example.Release.2026`,
+			wantMessage:      "Tracker rejected payload",
+			wantSubmission:   api.StageStatusFailed,
+			wantRedaction:    true,
+			wantPathSanitize: true,
+		},
+		{
+			name:           "empty detail fallback",
+			code:           "submit",
+			message:        " ",
+			wantMessage:    "Tracker upload failed. Review the tracker result and retry after correcting the failure.",
+			wantSubmission: api.StageStatusFailed,
+		},
+		{
+			name:           "unknown outcome semantics",
+			code:           "unknown_outcome",
+			message:        "Workflow receipt unavailable.",
+			wantMessage:    "Tracker submission may have succeeded, but no terminal receipt was retained. Verify the tracker before continuing.",
+			wantSubmission: api.StageStatusUnavailable,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			execution := &workflowUploadExecution{
+				plan: &workflowRetainedUploadPlanFake{results: []trackers.RetainedTrackerResult{{
+					Tracker: "EXAMPLE",
+					Failure: &trackers.TrackerFailure{Code: test.code, Message: test.message},
+				}}},
+			}
+			results, err := execution.Execute(t.Context(), nil)
+			if err != nil {
+				t.Fatalf("execute workflow upload: %v", err)
+			}
+			if len(results) != 1 || len(results[0].Failures) != 1 {
+				t.Fatalf("upload execution results = %#v", results)
+			}
+			failure := results[0].Failures[0].Failure
+			if results[0].SubmissionStatus != test.wantSubmission || !strings.Contains(failure.Message, test.wantMessage) {
+				t.Fatalf("upload failure = %#v", results[0])
+			}
+			if test.wantRedaction && (!strings.Contains(failure.Message, "passkey=[REDACTED]") || strings.Contains(failure.Message, "never-print-this")) {
+				t.Fatal("upload failure did not redact the tracker detail")
+			}
+			if test.wantPathSanitize && (!strings.Contains(failure.Message, "source=[local path]") || strings.Contains(failure.Message, `C:\releases`)) {
+				t.Fatal("upload failure did not sanitize the local path")
+			}
+		})
+	}
+}
+
 func TestWorkflowUploadExecutionInjectsExactRegisteredTrackerTorrent(t *testing.T) {
 	t.Parallel()
 

--- a/webui/src/pages/tracker_upload/index.test.tsx
+++ b/webui/src/pages/tracker_upload/index.test.tsx
@@ -234,6 +234,16 @@ describe("TrackerUploadPage", () => {
           status: "failed",
           submissionStatus: "failed",
           clientInjectionStatus: "pending",
+          failures: [
+            {
+              failure: {
+                Code: "internal",
+                Operation: "upload_execute",
+                Message: "Tracker rejected the synthetic payload.",
+                Recovery: "retry",
+              },
+            },
+          ],
         },
       ],
     } as unknown as NonNullable<UploadFacet["view"]["result"]>;
@@ -242,6 +252,7 @@ describe("TrackerUploadPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Expand Example Tracker" }));
     expect(screen.getByText("Example.Release.2026.1080p-GRP")).toBeInTheDocument();
     expect(screen.getByText("category: 1")).toBeInTheDocument();
+    expect(screen.getByText("Tracker rejected the synthetic payload.")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Retry failed uploads" }));
     expect(retry).toHaveBeenCalledOnce();
   });

--- a/webui/src/pages/tracker_upload/index.test.tsx
+++ b/webui/src/pages/tracker_upload/index.test.tsx
@@ -269,10 +269,20 @@ describe("TrackerUploadPage", () => {
           clientInjectionStatus: "failed",
           clientFailureCode: "client_injection",
           clientInjectionMessage: "Exact-torrent client injection failed.",
+          failures: [
+            {
+              failure: {
+                Code: "client_injection_failed",
+                Operation: "client_injection",
+                Message: "Exact-torrent client injection failed.",
+                Recovery: "retry",
+              },
+            },
+          ],
         },
       ],
     } as unknown as NonNullable<UploadFacet["view"]["result"]>;
-    renderPage(uploadFacet({ result }, { retryClientInjection }));
+    const { container } = renderPage(uploadFacet({ result }, { retryClientInjection }));
 
     expect(screen.queryByRole("button", { name: "Retry failed uploads" })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Retry client injection" }));
@@ -282,5 +292,8 @@ describe("TrackerUploadPage", () => {
         "Submission: completed · Client injection: failed · Exact-torrent client injection failed.",
       ),
     ).toBeInTheDocument();
+    expect(container.textContent?.match(/Exact-torrent client injection failed\./g)).toHaveLength(
+      1,
+    );
   });
 });

--- a/webui/src/pages/tracker_upload/index.tsx
+++ b/webui/src/pages/tracker_upload/index.tsx
@@ -308,6 +308,11 @@ export default function TrackerUploadPage({ facet }: Props) {
                 Client injection: {result.clientInjectionStatus || "unavailable"}
                 {result.clientInjectionMessage ? ` · ${result.clientInjectionMessage}` : ""}
               </span>
+              {result.failures?.map((failure, index) => (
+                <p className="error basis-full" key={`${failure.failure.Code}-${index}`}>
+                  {failure.failure.Message}
+                </p>
+              ))}
             </div>
           ))}
         </section>

--- a/webui/src/pages/tracker_upload/index.tsx
+++ b/webui/src/pages/tracker_upload/index.tsx
@@ -308,11 +308,13 @@ export default function TrackerUploadPage({ facet }: Props) {
                 Client injection: {result.clientInjectionStatus || "unavailable"}
                 {result.clientInjectionMessage ? ` · ${result.clientInjectionMessage}` : ""}
               </span>
-              {result.failures?.map((failure, index) => (
-                <p className="error basis-full" key={`${failure.failure.Code}-${index}`}>
-                  {failure.failure.Message}
-                </p>
-              ))}
+              {result.failures
+                ?.filter((failure) => failure.failure.Message !== result.clientInjectionMessage)
+                .map((failure, index) => (
+                  <p className="error basis-full" key={`${failure.failure.Code}-${index}`}>
+                    {failure.failure.Message}
+                  </p>
+                ))}
             </div>
           ))}
         </section>


### PR DESCRIPTION
## Description

Preserve each tracker's actionable upload failure through the shared workflow instead of replacing it with generic text. Secrets and local paths remain sanitized, and CLI/WebUI upload results now render retained failures.

## How has this been tested?

- `make test-go`
- `make precommit`
- `go test -race -v -timeout 20m ./cmd/upbrr ./internal/core ./pkg/api ./internal/trackers`
- `go test -race -v -timeout 20m ./internal/webserver/... ./pkg/api`
- `make backend`

## Screenshots (for UI changes)

Not included. The change adds backend-provided failure text to existing result cards; component tests cover rendering.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/upbrr/blob/main/CONTRIBUTING.md)
- [x] I ran `make precommit`
- [x] CSS unchanged; Stylelint is not applicable

## AI disclosure

Yes. Codex produced most code and tests; CodeRabbitAI will review the result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Sensitive information is now redacted from upload failure messages.
  - Upload errors consistently identify failed trackers without exposing secrets.
  - Duplicate and empty failure messages now use clearer, safe fallback messaging.

- **User Interface**
  - Tracker upload results display detailed rejection messages beneath the relevant status.
  - Failure details appear in a clearer, full-width format for easier troubleshooting.
  - Client injection errors are displayed once without redundant messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->