### PR TITLE
fix(config): apply metadata preparation defaults

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -62,8 +62,10 @@ func workflowPrivateVaultRoot(dbPath string) string {
 	return filepath.Join(filepath.Dir(dbPath), "workflow-private", hex.EncodeToString(sum[:16]))
 }
 
-func applySkipAutoTorrentDefault(input api.PrepareInput, configured bool) api.PrepareInput {
-	input.Search.Skip = input.Search.Skip || configured
+func applyMetadataDefaults(input api.PrepareInput, configured config.MetadataConfig) api.PrepareInput {
+	input.Search.Skip = input.Search.Skip || configured.SkipAutoTorrent
+	input.Policy.KeepImages = input.Policy.KeepImages || configured.KeepImages
+	input.Policy.OnlyID = input.Policy.OnlyID || configured.OnlyID
 	return input
 }
 
@@ -283,7 +285,7 @@ func newCoreWithHooks(ctx context.Context, deps api.CoreDependencies, hooks core
 	}
 	workflowPreparer := releaseworkflow.ReleasePreparerFunc{
 		PrepareFunc: func(ctx context.Context, input api.PrepareInput) (api.PrepareResult, error) {
-			return preparedFacts.Prepare(ctx, applySkipAutoTorrentDefault(input, cfg.Metadata.SkipAutoTorrent))
+			return preparedFacts.Prepare(ctx, applyMetadataDefaults(input, cfg.Metadata))
 		},
 		DisplayFunc: func(ctx context.Context, ref api.ReleaseRef) (api.PreparedReleaseDisplay, error) {
 			display, displayErr := preparedFacts.ResolveDisplay(ctx, ref)

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -7,17 +7,28 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-func TestApplySkipAutoTorrentDefault(t *testing.T) {
+func TestApplyMetadataDefaults(t *testing.T) {
 	t.Parallel()
 
-	if !applySkipAutoTorrentDefault(api.PrepareInput{}, true).Search.Skip {
-		t.Fatal("configured skip_auto_torrent was not applied")
+	configured := applyMetadataDefaults(api.PrepareInput{}, config.MetadataConfig{
+		SkipAutoTorrent: true,
+		KeepImages:      true,
+		OnlyID:          true,
+	})
+	if !configured.Search.Skip || !configured.Policy.KeepImages || !configured.Policy.OnlyID {
+		t.Fatalf("configured metadata defaults were not applied: %#v", configured)
 	}
-	if !applySkipAutoTorrentDefault(api.PrepareInput{Search: api.ClientSearchPolicy{Skip: true}}, false).Search.Skip {
-		t.Fatal("request skip_auto_torrent was not preserved")
+
+	requested := applyMetadataDefaults(api.PrepareInput{
+		Search: api.ClientSearchPolicy{Skip: true},
+		Policy: api.PreparationPolicy{KeepImages: true, OnlyID: true},
+	}, config.MetadataConfig{})
+	if !requested.Search.Skip || !requested.Policy.KeepImages || !requested.Policy.OnlyID {
+		t.Fatalf("request metadata options were not preserved: %#v", requested)
 	}
 }
 


### PR DESCRIPTION
## Summary

- apply only_id and keep_images config defaults at the shared preparation seam
- preserve explicit request options and existing skip_auto_torrent behavior
- cover configured and request-provided metadata options with a regression test

## Root cause

Core applied only skip_auto_torrent from MetadataConfig; only_id and keep_images were loaded and persisted but never copied into preparation policy.

## Checks

- go test -race -v -timeout 20m ./internal/core
- go test -race -v -timeout 20m ./cmd/upbrr ./internal/core ./pkg/api
- make test-go
- make backend
- make lint
- make gofix-check-changed
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application of metadata defaults for automatic torrent skipping, image retention, and ID-only mode.
  * Ensured explicitly selected metadata options continue to take precedence over defaults.

* **Tests**
  * Expanded coverage for configured and explicitly requested metadata behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->