### PR TITLE
fix(upload): handle waivable tracker rule decisions

### DIFF
--- a/ADDING_TRACKERS.md
+++ b/ADDING_TRACKERS.md
@@ -403,12 +403,12 @@ family policy.
 Choose dispositions deliberately:
 
 - `advisory` records a decision but never blocks;
-- `waivable` requires exact user authorization, then permits normal live execution; debug mode bypasses it automatically;
+- `waivable` records an upload warning; exact user approval permits that tracker, while no response leaves only that tracker excluded; debug mode bypasses it automatically;
 - `strict` blocks in every execution mode.
 
-The workflow emits one tracker-scoped authorization action for the exact current set of waivable
-failures. A changed failure set invalidates that authority and requires a new confirmation. Strict
-failures never emit an authorization action and cannot be overridden.
+The workflow emits one tracker-scoped override for the exact current warning set. WebUI places it
+on that tracker's duplicate-review card; interactive CLI prompts for it. A changed set invalidates
+that authority and requires new approval. Strict failures cannot be overridden.
 
 Every constructibility predicate whose result depends on a required mapping or resource, including
 a missing resolution, category, type, questionnaire answer, or prepared media fact, must be

--- a/cmd/upbrr/composite_upload.go
+++ b/cmd/upbrr/composite_upload.go
@@ -212,12 +212,7 @@ func (s *cliWorkflowSession) collectCompositeUploadFeedback(
 	case api.RequiredActionProvideTrackerInput, api.RequiredActionAnswerQuestionnaire:
 		return s.collectCompositeTrackerFeedback(reader, action, feedback)
 	case api.RequiredActionAuthorizeRules:
-		return compositeCLIConfirmationFeedback(
-			reader,
-			action,
-			feedback,
-			api.ReleaseWorkflowUploadFeedbackRuleAuthorization,
-		)
+		return s.collectCompositeRuleOverrideFeedback(reader, action, feedback)
 	case api.RequiredActionResolveTrackerPreparation:
 		confirmed := false
 		if s.intent.interaction != api.InteractionModeUnattended {
@@ -266,6 +261,41 @@ func (s *cliWorkflowSession) collectCompositeUploadFeedback(
 	return feedback, false, nil
 }
 
+func (s *cliWorkflowSession) collectCompositeRuleOverrideFeedback(
+	reader *bufio.Reader,
+	action api.RequiredAction,
+	feedback api.ReleaseWorkflowUploadFeedback,
+) (api.ReleaseWorkflowUploadFeedback, bool, error) {
+	confirmed, err := promptYesNo(reader, action.Prompt+" [y/N]: ", false)
+	if err != nil {
+		return feedback, false, err
+	}
+	feedback.Response = api.ReleaseWorkflowUploadFeedbackResponse{
+		Kind: api.ReleaseWorkflowUploadFeedbackRuleAuthorization,
+		RuleAuthorization: &api.ReleaseWorkflowUploadConfirmation{
+			Confirmed: confirmed,
+		},
+	}
+	if confirmed {
+		return feedback, false, nil
+	}
+	trackerID := api.TrackerID(strings.ToUpper(strings.TrimSpace(string(action.TrackerID))))
+	if !s.hasTrackerAfterRuleSkip(trackerID) {
+		return feedback, true, nil
+	}
+	return feedback, false, nil
+}
+
+func (s *cliWorkflowSession) hasTrackerAfterRuleSkip(skipped api.TrackerID) bool {
+	if s.current.Projections == nil {
+		return false
+	}
+	return slices.ContainsFunc(s.current.Projections.Projections, func(projection api.TrackerReleaseProjection) bool {
+		return projection.TrackerID != skipped &&
+			projection.Readiness != api.ReadinessStatusIneligible
+	})
+}
+
 func compositeCLIConfirmationFeedback(
 	reader *bufio.Reader,
 	action api.RequiredAction,
@@ -284,8 +314,6 @@ func compositeCLIConfirmationFeedback(
 	switch kind {
 	case api.ReleaseWorkflowUploadFeedbackRescanConfirmation:
 		feedback.Response.RescanConfirmation = confirmation
-	case api.ReleaseWorkflowUploadFeedbackRuleAuthorization:
-		feedback.Response.RuleAuthorization = confirmation
 	case api.ReleaseWorkflowUploadFeedbackReprepare:
 		feedback.Response.Reprepare = &api.ReleaseWorkflowUploadReprepare{Confirmed: true}
 	case api.ReleaseWorkflowUploadFeedbackPlaylistSelection,
@@ -294,6 +322,7 @@ func compositeCLIConfirmationFeedback(
 		legacyTrackerTwoFactorFeedbackKind,
 		api.ReleaseWorkflowUploadFeedbackTrackerInput,
 		api.ReleaseWorkflowUploadFeedbackQuestionnaire,
+		api.ReleaseWorkflowUploadFeedbackRuleAuthorization,
 		api.ReleaseWorkflowUploadFeedbackTrackerPreparation,
 		api.ReleaseWorkflowUploadFeedbackDuplicateReview,
 		api.ReleaseWorkflowUploadFeedbackTrackerApproval,

--- a/cmd/upbrr/composite_upload.go
+++ b/cmd/upbrr/composite_upload.go
@@ -171,7 +171,8 @@ func (s *cliWorkflowSession) collectCompositeUploadFeedback(
 			"upbrr: tracker authentication must be resolved outside the upload workflow; start a fresh attempt",
 		)
 	}
-	if s.intent.interaction == api.InteractionModeUnattended && action.Kind != api.RequiredActionResolveTrackerPreparation {
+	if s.intent.interaction == api.InteractionModeUnattended &&
+		action.Kind != api.RequiredActionAuthorizeRules && action.Kind != api.RequiredActionResolveTrackerPreparation {
 		return feedback, false, fmt.Errorf("upbrr: strict unattended upload requires global action %s: %s", action.Kind, action.Prompt)
 	}
 
@@ -266,9 +267,13 @@ func (s *cliWorkflowSession) collectCompositeRuleOverrideFeedback(
 	action api.RequiredAction,
 	feedback api.ReleaseWorkflowUploadFeedback,
 ) (api.ReleaseWorkflowUploadFeedback, bool, error) {
-	confirmed, err := promptYesNo(reader, action.Prompt+" [y/N]: ", false)
-	if err != nil {
-		return feedback, false, err
+	confirmed := false
+	if s.intent.interaction != api.InteractionModeUnattended {
+		var err error
+		confirmed, err = promptYesNo(reader, action.Prompt+" [y/N]: ", false)
+		if err != nil {
+			return feedback, false, err
+		}
 	}
 	feedback.Response = api.ReleaseWorkflowUploadFeedbackResponse{
 		Kind: api.ReleaseWorkflowUploadFeedbackRuleAuthorization,

--- a/cmd/upbrr/composite_upload_test.go
+++ b/cmd/upbrr/composite_upload_test.go
@@ -421,7 +421,7 @@ func TestCLICompositeRuleAuthorizationHonorsInteractionMode(t *testing.T) {
 
 	session.current.Projections.Projections = session.current.Projections.Projections[:1]
 	captureStdout(t, func() {
-		_, declined, err = session.collectCompositeUploadFeedback(
+		feedback, declined, err = session.collectCompositeUploadFeedback(
 			context.Background(),
 			bufio.NewReader(strings.NewReader("n\n")),
 			config.Config{},
@@ -429,8 +429,10 @@ func TestCLICompositeRuleAuthorizationHonorsInteractionMode(t *testing.T) {
 			action,
 		)
 	})
-	if err != nil || !declined {
-		t.Fatalf("last tracker rejection declined=%t err=%v", declined, err)
+	if err != nil || !declined ||
+		feedback.Response.Kind != api.ReleaseWorkflowUploadFeedbackRuleAuthorization ||
+		feedback.Response.RuleAuthorization == nil || feedback.Response.RuleAuthorization.Confirmed {
+		t.Fatalf("last tracker rejection = %#v declined=%t err=%v", feedback, declined, err)
 	}
 
 	session.intent.interaction = api.InteractionModeUnattended
@@ -450,15 +452,17 @@ func TestCLICompositeRuleAuthorizationHonorsInteractionMode(t *testing.T) {
 	}
 
 	session.current.Projections.Projections = session.current.Projections.Projections[:1]
-	_, declined, err = session.collectCompositeUploadFeedback(
+	feedback, declined, err = session.collectCompositeUploadFeedback(
 		context.Background(),
 		nil,
 		config.Config{},
 		api.NopLogger{},
 		action,
 	)
-	if err != nil || !declined {
-		t.Fatalf("strict unattended last tracker rejection declined=%t err=%v", declined, err)
+	if err != nil || !declined ||
+		feedback.Response.Kind != api.ReleaseWorkflowUploadFeedbackRuleAuthorization ||
+		feedback.Response.RuleAuthorization == nil || feedback.Response.RuleAuthorization.Confirmed {
+		t.Fatalf("strict unattended last tracker rejection = %#v declined=%t err=%v", feedback, declined, err)
 	}
 }
 

--- a/cmd/upbrr/composite_upload_test.go
+++ b/cmd/upbrr/composite_upload_test.go
@@ -373,11 +373,18 @@ func TestCLICompositeRuleAuthorizationHonorsInteractionMode(t *testing.T) {
 	action := api.RequiredAction{
 		ID:               "action-waive-rules",
 		Kind:             api.RequiredActionAuthorizeRules,
+		TrackerID:        "ALPHA",
 		WorkflowRevision: 4,
-		Prompt:           "EXAMPLE has waivable rule failures. Continue with this tracker?",
+		Prompt:           "ALPHA rule warning: language rule. Upload to this tracker anyway?",
 	}
 	session := &cliWorkflowSession{
 		intent: cliWorkflowIntent{interaction: api.InteractionModeUnattendedConfirm},
+		current: releaseworkflow.CommandResult{
+			Projections: &api.TrackerReleaseProjectionSet{Projections: []api.TrackerReleaseProjection{
+				{TrackerID: "ALPHA", Readiness: api.ReadinessStatusBlocked},
+				{TrackerID: "BETA", Readiness: api.ReadinessStatusReady},
+			}},
+		},
 	}
 	var (
 		feedback api.ReleaseWorkflowUploadFeedback
@@ -397,6 +404,33 @@ func TestCLICompositeRuleAuthorizationHonorsInteractionMode(t *testing.T) {
 		feedback.Response.Kind != api.ReleaseWorkflowUploadFeedbackRuleAuthorization ||
 		feedback.Response.RuleAuthorization == nil || !feedback.Response.RuleAuthorization.Confirmed {
 		t.Fatalf("rule authorization feedback = %#v declined=%t err=%v", feedback, declined, err)
+	}
+
+	captureStdout(t, func() {
+		feedback, declined, err = session.collectCompositeUploadFeedback(
+			context.Background(),
+			bufio.NewReader(strings.NewReader("n\n")),
+			config.Config{},
+			api.NopLogger{},
+			action,
+		)
+	})
+	if err != nil || declined || feedback.Response.RuleAuthorization == nil || feedback.Response.RuleAuthorization.Confirmed {
+		t.Fatalf("rule rejection feedback = %#v declined=%t err=%v", feedback, declined, err)
+	}
+
+	session.current.Projections.Projections = session.current.Projections.Projections[:1]
+	captureStdout(t, func() {
+		_, declined, err = session.collectCompositeUploadFeedback(
+			context.Background(),
+			bufio.NewReader(strings.NewReader("n\n")),
+			config.Config{},
+			api.NopLogger{},
+			action,
+		)
+	})
+	if err != nil || !declined {
+		t.Fatalf("last tracker rejection declined=%t err=%v", declined, err)
 	}
 
 	session.intent.interaction = api.InteractionModeUnattended

--- a/cmd/upbrr/composite_upload_test.go
+++ b/cmd/upbrr/composite_upload_test.go
@@ -434,14 +434,31 @@ func TestCLICompositeRuleAuthorizationHonorsInteractionMode(t *testing.T) {
 	}
 
 	session.intent.interaction = api.InteractionModeUnattended
-	if _, _, err := session.collectCompositeUploadFeedback(
+	session.current.Projections.Projections = append(
+		session.current.Projections.Projections,
+		api.TrackerReleaseProjection{TrackerID: "BETA", Readiness: api.ReadinessStatusReady},
+	)
+	feedback, declined, err = session.collectCompositeUploadFeedback(
 		context.Background(),
 		nil,
 		config.Config{},
 		api.NopLogger{},
 		action,
-	); err == nil || !strings.Contains(err.Error(), "strict unattended upload requires global action") {
-		t.Fatalf("strict unattended rule authorization error = %v", err)
+	)
+	if err != nil || declined || feedback.Response.RuleAuthorization == nil || feedback.Response.RuleAuthorization.Confirmed {
+		t.Fatalf("strict unattended rule rejection = %#v declined=%t err=%v", feedback, declined, err)
+	}
+
+	session.current.Projections.Projections = session.current.Projections.Projections[:1]
+	_, declined, err = session.collectCompositeUploadFeedback(
+		context.Background(),
+		nil,
+		config.Config{},
+		api.NopLogger{},
+		action,
+	)
+	if err != nil || !declined {
+		t.Fatalf("strict unattended last tracker rejection declined=%t err=%v", declined, err)
 	}
 }
 

--- a/internal/releaseworkflow/composite_upload.go
+++ b/internal/releaseworkflow/composite_upload.go
@@ -1860,20 +1860,31 @@ func (m *Module) applyCompositeUploadFeedback(
 		}
 		state.Composite.Intent.Preparation.Force = true
 	case api.ReleaseWorkflowUploadFeedbackRuleAuthorization:
-		confirmed := true
-		if _, err := m.resolveAction(ctx, ownerID, state, nextRevision, now, ResolveActionCommand{
-			WorkflowID:       command.WorkflowID,
-			ExpectedRevision: command.ExpectedRevision,
-			Answer: api.RequiredActionAnswer{
-				ActionID:         action.ID,
-				WorkflowRevision: command.ExpectedRevision,
-				Confirmed:        &confirmed,
-			},
-			IdempotencyKey: command.IdempotencyKey,
-		}); err != nil {
-			return CommandResult{}, err
+		if command.Response.Confirmed {
+			confirmed := true
+			if _, err := m.resolveAction(ctx, ownerID, state, nextRevision, now, ResolveActionCommand{
+				WorkflowID:       command.WorkflowID,
+				ExpectedRevision: command.ExpectedRevision,
+				Answer: api.RequiredActionAnswer{
+					ActionID:         action.ID,
+					WorkflowRevision: command.ExpectedRevision,
+					Confirmed:        &confirmed,
+				},
+				IdempotencyKey: command.IdempotencyKey,
+			}); err != nil {
+				return CommandResult{}, err
+			}
+			resolvedByCommand = true
+			break
 		}
-		resolvedByCommand = true
+		trackerID := normalizeCompositeTrackerID(action.TrackerID)
+		if trackerID == "" {
+			return CommandResult{}, fmt.Errorf("%w: tracker rule rejection requires tracker ID", ErrInvalidTransition)
+		}
+		if !slices.Contains(state.Composite.RemoveTrackers, trackerID) {
+			state.Composite.RemoveTrackers = append(state.Composite.RemoveTrackers, trackerID)
+		}
+		m.logger.Infof("release workflow: declined tracker rule override tracker=%s decision=skip", trackerID)
 	case api.ReleaseWorkflowUploadFeedbackTrackerPreparation:
 		confirmed := command.Response.Confirmed
 		if _, err := m.resolveAction(ctx, ownerID, state, nextRevision, now, ResolveActionCommand{

--- a/internal/releaseworkflow/composite_upload_test.go
+++ b/internal/releaseworkflow/composite_upload_test.go
@@ -231,6 +231,55 @@ func TestCompositeUploadRuleAuthorizationResumesLiveUpload(t *testing.T) {
 	}
 }
 
+func TestCompositeUploadRuleRejectionSkipsOnlyThatTracker(t *testing.T) {
+	t.Parallel()
+
+	module, _, uploads := newCompositeUploadWaiverTestModule(t)
+	request := compositeUploadTestRequest(true, api.ReleaseWorkflowUploadModeUpload, "composite-rule-rejection")
+	started, err := module.StartUpload(context.Background(), testOwnerID, request)
+	if err != nil {
+		t.Fatalf("start composite upload: %v", err)
+	}
+	blocked := waitCompositeUploadTestOperation(t, module, started)
+	actionIndex := slices.IndexFunc(blocked.Continuation.RequiredActions, func(action api.RequiredAction) bool {
+		return action.Kind == api.RequiredActionAuthorizeRules && action.TrackerID == "ALPHA" &&
+			action.Status == api.RequiredActionStatusPending
+	})
+	if actionIndex < 0 {
+		t.Fatalf("tracker rule action = %#v", blocked.Continuation.RequiredActions)
+	}
+	action := blocked.Continuation.RequiredActions[actionIndex]
+	resumed, err := module.SubmitUploadFeedback(context.Background(), testOwnerID, blocked.Workflow.ID, api.ReleaseWorkflowUploadFeedback{
+		Action: api.ReleaseWorkflowUploadActionIdentity{
+			ID:               action.ID,
+			WorkflowRevision: blocked.Workflow.Revision,
+		},
+		Response: api.ReleaseWorkflowUploadFeedbackResponse{
+			Kind: api.ReleaseWorkflowUploadFeedbackRuleAuthorization,
+			RuleAuthorization: &api.ReleaseWorkflowUploadConfirmation{
+				Confirmed: false,
+			},
+		},
+		IdempotencyKey: "reject-composite-rules",
+	})
+	if err != nil {
+		t.Fatalf("reject composite tracker rules: %v", err)
+	}
+	review := waitCompositeUploadTestOperation(t, module, resumed)
+	approval := pendingCompositeTrackerApproval(t, review)
+	if len(review.Selection.TrackerIDs) != 1 || review.Selection.TrackerIDs[0] != "BETA" ||
+		review.Projections == nil || len(review.Projections.Projections) != 1 || review.Projections.Projections[0].TrackerID != "BETA" ||
+		len(approval.Options) != 1 || approval.Options[0].Value != "BETA" || uploads.execution != nil {
+		t.Fatalf(
+			"tracker rule rejection = selection=%#v projections=%#v approval=%#v execution=%#v",
+			review.Selection,
+			review.Projections,
+			approval,
+			uploads.execution,
+		)
+	}
+}
+
 func TestCompositeUploadStrictUnattendedSkipsWaivableTracker(t *testing.T) {
 	t.Parallel()
 
@@ -650,7 +699,7 @@ func newCompositeUploadTestModuleWithWaiver(
 					projection.PolicyDecisions[0].Blocking = true
 					projection.RequiredActions = []api.RequiredAction{{
 						Kind:   api.RequiredActionAuthorizeRules,
-						Prompt: "Alpha has waivable language rules. Continue with this tracker?",
+						Prompt: "Alpha rule warning: language rule. Upload to this tracker anyway?",
 					}}
 					actions = append(actions, projection.RequiredActions...)
 					projectionInput = "composite-projection-input-pending"

--- a/internal/releaseworkflow/eligibility_test.go
+++ b/internal/releaseworkflow/eligibility_test.go
@@ -97,6 +97,35 @@ func TestDownstreamEligibleProjectionsAfterMediaExcludesOnlyFailedImageHostTrack
 	}
 }
 
+func TestDownstreamEligibleProjectionsExcludesUnapprovedRuleWarning(t *testing.T) {
+	t.Parallel()
+
+	projections := api.TrackerReleaseProjectionSet{Projections: []api.TrackerReleaseProjection{
+		{
+			TrackerID:   "ALPHA",
+			Readiness:   api.ReadinessStatusBlocked,
+			UploadReady: false,
+		},
+		{
+			TrackerID:   "BETA",
+			Readiness:   api.ReadinessStatusReady,
+			UploadReady: true,
+		},
+	}}
+	dupes := api.DupeAssessment{Results: []api.TrackerDupeAssessment{
+		{
+			TrackerID: "BETA",
+			Decision:  api.DupeDecisionNoMatch,
+			Status:    api.StageStatusCompleted,
+		},
+	}}
+
+	eligible := DownstreamEligibleProjections(projections, dupes)
+	if len(eligible.Projections) != 1 || eligible.Projections[0].TrackerID != "BETA" {
+		t.Fatalf("eligible projections = %#v", eligible.Projections)
+	}
+}
+
 func TestDownstreamTrackerSetEnforcesModeAndExactApproval(t *testing.T) {
 	t.Parallel()
 
@@ -113,17 +142,17 @@ func TestDownstreamTrackerSetEnforcesModeAndExactApproval(t *testing.T) {
 		Status:    api.StageStatusReady,
 		Projections: []api.TrackerReleaseProjection{
 			{
-TrackerID: "ALPHA",
- DisplayName: "Alpha",
- Readiness: api.ReadinessStatusReady,
- UploadReady: true,
-},
+				TrackerID:   "ALPHA",
+				DisplayName: "Alpha",
+				Readiness:   api.ReadinessStatusReady,
+				UploadReady: true,
+			},
 			{
-TrackerID: "BETA",
- DisplayName: "Beta",
- Readiness: api.ReadinessStatusReady,
- UploadReady: true,
-},
+				TrackerID:   "BETA",
+				DisplayName: "Beta",
+				Readiness:   api.ReadinessStatusReady,
+				UploadReady: true,
+			},
 		},
 	}
 	preflight := api.TrackerPreflightAssessment{
@@ -142,15 +171,15 @@ TrackerID: "BETA",
 		ExpiresAt:        now.Add(time.Hour),
 		Results: []api.TrackerDupeAssessment{
 			{
-TrackerID: "ALPHA",
- Decision: api.DupeDecisionNoMatch,
- Status: api.StageStatusCompleted,
-},
+				TrackerID: "ALPHA",
+				Decision:  api.DupeDecisionNoMatch,
+				Status:    api.StageStatusCompleted,
+			},
 			{
-TrackerID: "BETA",
- Decision: api.DupeDecisionNoMatch,
- Status: api.StageStatusCompleted,
-},
+				TrackerID: "BETA",
+				Decision:  api.DupeDecisionNoMatch,
+				Status:    api.StageStatusCompleted,
+			},
 		},
 	}
 	state := State{
@@ -218,7 +247,7 @@ TrackerID: "BETA",
 		ID:       "media-authority",
 		Revision: 8,
 		Failures: []api.WorkflowFailure{{
-			Failure: api.OperationFailure{Operation: api.OperationKindImageHosting},
+			Failure:   api.OperationFailure{Operation: api.OperationKindImageHosting},
 			TrackerID: "BETA",
 		}},
 	}

--- a/internal/releaseworkflow/module_test.go
+++ b/internal/releaseworkflow/module_test.go
@@ -3989,7 +3989,7 @@ func TestResolveProjectionRuleAuthorizationReprojectsWithExactServerAuthority(t 
 			projection.PolicyDecisions[0].Blocking = true
 			projection.RequiredActions = []api.RequiredAction{{
 				Kind:   api.RequiredActionAuthorizeRules,
-				Prompt: "Alpha has waivable rule failures. Continue with this tracker?",
+				Prompt: "Alpha rule warning. Upload to this tracker anyway?",
 			}}
 			status = api.StageStatusBlocked
 		}

--- a/internal/releaseworkflow/planner.go
+++ b/internal/releaseworkflow/planner.go
@@ -314,7 +314,7 @@ func continuationActionBlocksAllLanesForMode(
 	mode TrackerDecisionMode,
 ) bool {
 	if _, _, projectionAuthorization := projectionRuleAuthorizationAction(current.Projections, action.ID); projectionAuthorization {
-		return true
+		return normalizeTrackerDecisionMode(mode) == TrackerDecisionModePostDupeGate
 	}
 	if normalizeTrackerDecisionMode(mode) == TrackerDecisionModePostDupeGate &&
 		action.Kind == api.RequiredActionReviewDuplicates {

--- a/internal/releaseworkflow/planner_test.go
+++ b/internal/releaseworkflow/planner_test.go
@@ -741,6 +741,25 @@ func TestContinuationPlannerAdvancesRunnableSiblingPastPendingDupe(t *testing.T)
 	if continuationActionBlocksAllLanesForMode(current, action, TrackerDecisionModeWebUIControls) {
 		t.Fatal("WebUI duplicate review blocked runnable sibling lane")
 	}
+	waivableFingerprint := testFingerprint(t, "planner-waivable-rule")
+	ruleAction := api.RequiredAction{
+		ID:        "authorize-beta-rules",
+		Kind:      api.RequiredActionAuthorizeRules,
+		TrackerID: "BETA",
+		Status:    api.RequiredActionStatusPending,
+	}
+	current.Projections.Projections[1].WaivableRuleFingerprint = waivableFingerprint
+	current.Projections.Projections[1].RequiredActions = []api.RequiredAction{ruleAction}
+	if !continuationActionBlocksAllLanesForMode(current, ruleAction, TrackerDecisionModePostDupeGate) {
+		t.Fatal("CLI tracker rule prompt did not retain its explicit gate")
+	}
+	if continuationActionBlocksAllLanesForMode(current, ruleAction, TrackerDecisionModeWebUIControls) {
+		t.Fatal("WebUI tracker rule warning blocked runnable workflow lanes")
+	}
+	current.Projections.Projections = current.Projections.Projections[1:]
+	if continuationActionBlocksAllLanesForMode(current, ruleAction, TrackerDecisionModeWebUIControls) {
+		t.Fatal("WebUI tracker rule warning blocked its dupe-card workflow")
+	}
 }
 
 func TestContinuationPlannerPreservesAuthBlockedLaneWhileCheckingReadySibling(t *testing.T) {

--- a/internal/trackers/projection.go
+++ b/internal/trackers/projection.go
@@ -716,5 +716,15 @@ func waivableRuleAuthorizationPrompt(projection api.TrackerReleaseProjection, fa
 	if tracker == "" {
 		tracker = string(projection.TrackerID)
 	}
-	return fmt.Sprintf("%s has waivable rule failures: %s. Continue with this tracker?", tracker, strings.Join(details, "; "))
+	label := "rule warning"
+	if len(details) != 1 {
+		label = "rule warnings"
+	}
+	detail := strings.Join(details, "; ")
+	if detail == "" {
+		detail = "Review required."
+	} else if !strings.ContainsAny(detail[len(detail)-1:], ".!?") {
+		detail += "."
+	}
+	return fmt.Sprintf("%s %s: %s Upload to this tracker anyway?", tracker, label, detail)
 }

--- a/internal/trackers/projection_test.go
+++ b/internal/trackers/projection_test.go
@@ -348,7 +348,7 @@ func TestApplyProjectionRuleFailuresRequiresExactNormalAuthorization(t *testing.
 	}
 	waivable := []api.RuleFailure{NewEvidenceRuleFailure(
 		"runtime_gate",
-		"waivable gate",
+		"waivable gate.",
 		api.RuleDispositionWaivable,
 		api.MetadataEvidenceStatusPartial,
 	)}
@@ -382,6 +382,9 @@ func TestApplyProjectionRuleFailuresRequiresExactNormalAuthorization(t *testing.
 	}
 	if normal.WaivableRuleFingerprint != waivableFingerprint || normal.RuleAuthorizationFingerprint != "" {
 		t.Fatalf("normal rule authority = %#v", normal)
+	}
+	if prompt := normal.RequiredActions[0].Prompt; prompt != "EXAMPLE rule warning: runtime_gate: waivable gate. Upload to this tracker anyway?" {
+		t.Fatalf("normal rule prompt = %q", prompt)
 	}
 
 	authorized := readyProjection()

--- a/pkg/api/workflow_presence.go
+++ b/pkg/api/workflow_presence.go
@@ -10,7 +10,7 @@ import (
 )
 
 // UnmarshalJSON preserves whether confirmation was omitted while keeping
-// explicit false distinct for tracker-preparation decisions.
+// explicit false distinct for tracker-rule and tracker-preparation decisions.
 func (c *ReleaseWorkflowUploadConfirmation) UnmarshalJSON(payload []byte) error {
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(payload, &fields); err != nil {

--- a/pkg/api/workflow_upload.go
+++ b/pkg/api/workflow_upload.go
@@ -608,8 +608,8 @@ func (f ReleaseWorkflowUploadFeedback) Validate() error {
 			return errors.New("rescan feedback requires confirmation")
 		}
 	case ReleaseWorkflowUploadFeedbackRuleAuthorization:
-		if !f.Response.RuleAuthorization.Confirmed {
-			return errors.New("rule authorization feedback requires confirmation")
+		if f.Response.RuleAuthorization.confirmedOmitted {
+			return errors.New("tracker rule feedback requires an explicit confirmed member")
 		}
 	case ReleaseWorkflowUploadFeedbackTrackerPreparation:
 		if f.Response.TrackerPreparation.confirmedOmitted {

--- a/pkg/api/workflow_upload_test.go
+++ b/pkg/api/workflow_upload_test.go
@@ -175,6 +175,69 @@ func TestReleaseWorkflowUploadFeedbackAcceptsBothTrackerPreparationDecisions(t *
 	}
 }
 
+func TestReleaseWorkflowUploadFeedbackAcceptsBothTrackerRuleDecisions(t *testing.T) {
+	t.Parallel()
+
+	for _, confirmed := range []bool{false, true} {
+		feedback := ReleaseWorkflowUploadFeedback{
+			Action: ReleaseWorkflowUploadActionIdentity{
+				ID:               "tracker-rule-decision",
+				WorkflowRevision: 2,
+			},
+			Response: ReleaseWorkflowUploadFeedbackResponse{
+				Kind: ReleaseWorkflowUploadFeedbackRuleAuthorization,
+				RuleAuthorization: &ReleaseWorkflowUploadConfirmation{
+					Confirmed: confirmed,
+				},
+			},
+			IdempotencyKey: "tracker-rule-decision",
+		}
+		if err := feedback.Validate(); err != nil {
+			t.Fatalf("confirmed=%t: %v", confirmed, err)
+		}
+	}
+}
+
+func TestReleaseWorkflowUploadFeedbackRequiresExplicitTrackerRuleDecisionInJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name      string
+		decision  string
+		wantValid bool
+	}{
+		{name: "omitted", decision: `{}`},
+		{name: "null", decision: `{"confirmed":null}`},
+		{
+			name:      "false",
+			decision:  `{"confirmed":false}`,
+			wantValid: true,
+		},
+		{
+			name:      "true",
+			decision:  `{"confirmed":true}`,
+			wantValid: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			payload := fmt.Sprintf(`{
+				"action":{"id":"tracker-rule-decision","workflowRevision":2},
+				"response":{"kind":"ruleAuthorization","ruleAuthorization":%s},
+				"idempotencyKey":"tracker-rule-decision"
+			}`, test.decision)
+			var feedback ReleaseWorkflowUploadFeedback
+			if err := json.Unmarshal([]byte(payload), &feedback); err != nil {
+				t.Fatalf("unmarshal feedback: %v", err)
+			}
+			feedback.IdempotencyKey = "tracker-rule-decision"
+			if err := feedback.Validate(); (err == nil) != test.wantValid {
+				t.Fatalf("Validate() error = %v, wantValid %t", err, test.wantValid)
+			}
+		})
+	}
+}
+
 func TestReleaseWorkflowUploadFeedbackRequiresExplicitTrackerPreparationDecisionInJSON(t *testing.T) {
 	t.Parallel()
 

--- a/webui/src/components/WorkflowRequiredActions.test.tsx
+++ b/webui/src/components/WorkflowRequiredActions.test.tsx
@@ -174,6 +174,11 @@ describe("WorkflowRequiredActions", () => {
             kind: "provide_tracker_input",
             prompt: "Confirm the tracker release name.",
           }),
+          action({
+            id: "action-3",
+            kind: "authorize_rules",
+            prompt: "Review the tracker rule warning.",
+          }),
         ])}
         onConfirm={vi.fn()}
         onNavigate={navigate}
@@ -182,6 +187,7 @@ describe("WorkflowRequiredActions", () => {
 
     expect(screen.queryByText("Review the duplicate match.")).not.toBeInTheDocument();
     expect(screen.queryByText("Confirm the tracker release name.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Review the tracker rule warning.")).not.toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
     expect(navigate).not.toHaveBeenCalled();
   });

--- a/webui/src/components/WorkflowRequiredActions.tsx
+++ b/webui/src/components/WorkflowRequiredActions.tsx
@@ -22,6 +22,7 @@ const actionLabels: Readonly<Record<string, string>> = {
 
 const actionOwnedByDupeCard = (action: RequiredAction) =>
   action.kind === "review_duplicates" ||
+  (action.kind === "authorize_rules" && Boolean(action.trackerId)) ||
   (action.kind === "provide_tracker_input" && Boolean(action.trackerId));
 
 function actionScope(action: RequiredAction): string {

--- a/webui/src/pages/dupe_check/index.test.tsx
+++ b/webui/src/pages/dupe_check/index.test.tsx
@@ -32,6 +32,7 @@ const facetFor = (
   chooseTrackers: vi.fn(),
   confirmReleaseName: vi.fn(),
   acknowledgeReleaseName: vi.fn(async () => true),
+  overrideRules: vi.fn(async () => true),
   setIgnored: vi.fn(),
   ...commands,
 });
@@ -416,6 +417,52 @@ describe("DupeCheckPage", () => {
     expect(screen.queryByText(/Evidence complete/)).not.toBeInTheDocument();
     expect(screen.queryByText("Canonical:")).not.toBeInTheDocument();
     expect(screen.queryByText("Tracker upload:")).not.toBeInTheDocument();
+  });
+
+  it("keeps tracker rule overrides in the owning dupe card", () => {
+    const overrideRules = vi.fn(async () => true);
+    renderPage(
+      facetFor(
+        {
+          projections: {
+            projections: [
+              {
+                trackerId: "EXAMPLE",
+                displayName: "Example Tracker",
+                readiness: "blocked",
+                policyDecisions: [
+                  {
+                    code: "genre",
+                    decision: "authorization_required",
+                    blocking: true,
+                    disposition: "waivable",
+                    message: "Genre does not match Animation or Family.",
+                  },
+                ],
+                requiredActions: [
+                  {
+                    id: "authorize-example-rules",
+                    kind: "authorize_rules",
+                    trackerId: "EXAMPLE",
+                    status: "pending",
+                    workflowRevision: 4,
+                    prompt:
+                      "Example Tracker rule warning: genre: Genre does not match Animation or Family. Upload to this tracker anyway?",
+                    createdAt: "2026-08-15T00:00:00Z",
+                  },
+                ],
+              },
+            ],
+          } as unknown as NonNullable<DuplicatesFacet["view"]["projections"]>,
+        },
+        { overrideRules },
+      ),
+    );
+
+    expect(screen.getByText("Upload approval needed")).toBeInTheDocument();
+    expect(screen.queryByText("Genre does not match Animation or Family.")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Upload to EXAMPLE anyway" }));
+    expect(overrideRules).toHaveBeenCalledWith("EXAMPLE");
   });
 
   it("renders auth failure as retryable blocked lane evidence without an action card", () => {

--- a/webui/src/pages/dupe_check/index.tsx
+++ b/webui/src/pages/dupe_check/index.tsx
@@ -88,18 +88,27 @@ const uniqueMessages = (values: readonly (string | undefined)[]) => {
   });
 };
 
+const ruleOverrideAction = (projection: TrackerReleaseProjection | undefined) =>
+  projection?.requiredActions?.find(
+    (action) => action.kind === "authorize_rules" && action.status === "pending",
+  );
+
 const trackerBlockReasons = (
   projection: TrackerReleaseProjection | undefined,
   readiness: TrackerPreflightAssessment["results"][number] | undefined,
   result: DupeAssessment["results"][number] | undefined,
 ) => {
+  const hasRuleOverride = Boolean(ruleOverrideAction(projection));
   const inClientMatches = (result?.matches || []).filter(
     (match) => match.reason?.trim().toLowerCase() === "in_client",
   );
   return uniqueMessages([
     ...inClientMatches.map((match) => `Already in client: ${match.name}`),
     ...(projection?.policyDecisions || [])
-      .filter((decision) => decision.blocking)
+      .filter(
+        (decision) =>
+          decision.blocking && (!hasRuleOverride || decision.disposition !== "waivable"),
+      )
       .map((decision) => decision.message || decision.code.replaceAll("_", " ")),
     ...(projection?.failures || []).map((failure) => failure.failure.Message),
     ...(readiness?.failures || []).map((failure) => failure.failure.Message),
@@ -114,6 +123,7 @@ const trackerSummary = (
   result: DupeAssessment["results"][number] | undefined,
 ) => {
   if (hasInClientMatch(result)) return "In client";
+  if (ruleOverrideAction(projection)) return "Upload approval needed";
   if (projection?.readiness !== "ready" || (readiness && readiness.state !== "ready")) {
     return "Blocked";
   }
@@ -192,6 +202,7 @@ function WorkflowDupeAssessmentView({
   busy,
   confirmReleaseName,
   acknowledgeReleaseName,
+  overrideRules,
   setIgnored,
 }: Readonly<{
   assessment: DupeAssessment | null;
@@ -202,6 +213,7 @@ function WorkflowDupeAssessmentView({
   busy: boolean;
   confirmReleaseName(tracker: string, value: string): void;
   acknowledgeReleaseName(tracker: string, acknowledged: boolean): Promise<boolean>;
+  overrideRules(tracker: string): Promise<boolean>;
   setIgnored(tracker: string, ignored: boolean): void;
 }>) {
   const projectionsByTracker = new Map(
@@ -221,6 +233,7 @@ function WorkflowDupeAssessmentView({
         const projection = projectionsByTracker.get(trackerID);
         const readiness = preflightByTracker.get(trackerID);
         const nameConfirmation = releaseNameConfirmationState(projection);
+        const ruleOverride = ruleOverrideAction(projection);
         const releaseName = releaseNameOverrides[trackerID] ?? projection?.uploadReleaseName ?? "";
         const inClient = hasInClientMatch(result);
         const strictBlocked =
@@ -263,12 +276,14 @@ function WorkflowDupeAssessmentView({
               <h2 className="text-base">{projection?.displayName || trackerID}</h2>
               <Badge
                 tone={
-                  inClient ||
-                  result?.status === "failed" ||
-                  projection?.readiness !== "ready" ||
-                  (readiness && readiness.state !== "ready")
-                    ? "danger"
-                    : "info"
+                  ruleOverride
+                    ? "info"
+                    : inClient ||
+                        result?.status === "failed" ||
+                        projection?.readiness !== "ready" ||
+                        (readiness && readiness.state !== "ready")
+                      ? "danger"
+                      : "info"
                 }
               >
                 {trackerSummary(projection, readiness, result)}
@@ -282,6 +297,20 @@ function WorkflowDupeAssessmentView({
                     {message}
                   </p>
                 ))}
+              </div>
+            ) : null}
+
+            {ruleOverride ? (
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded border border-amber-300/25 bg-amber-300/5 p-2 text-sm">
+                <p>{ruleOverride.prompt}</p>
+                <Button
+                  aria-label={`Upload to ${trackerID} anyway`}
+                  disabled={busy}
+                  type="button"
+                  onClick={() => void overrideRules(trackerID)}
+                >
+                  Upload anyway
+                </Button>
               </div>
             ) : null}
 
@@ -458,6 +487,7 @@ export default function DupeCheckPage({
           busy={dupeLoading}
           confirmReleaseName={facet.confirmReleaseName}
           ignoredTrackers={ignoredTrackers}
+          overrideRules={facet.overrideRules}
           preflight={preflight}
           projections={projections}
           releaseNameOverrides={view.releaseNameOverrides}

--- a/webui/src/releaseSession/index.test.tsx
+++ b/webui/src/releaseSession/index.test.tsx
@@ -727,6 +727,68 @@ describe("useReleaseSession", () => {
     window.sessionStorage.removeItem("upbrr.activeReleaseWorkflow");
   });
 
+  it("accepts a tracker rule warning from the dupe facet", async () => {
+    const workflowID = "workflow-dupe-rule-override";
+    window.sessionStorage.setItem("upbrr.activeReleaseWorkflow", workflowID);
+    const action = {
+      createdAt: "2026-08-15T00:00:00Z",
+      id: "action-authorize-alpha",
+      kind: "authorize_rules" as const,
+      prompt: "ALPHA rule warning. Upload to this tracker anyway?",
+      status: "pending" as const,
+      trackerId: "ALPHA",
+      workflowRevision: 7,
+    };
+    const base = workflowCurrent(workflowID, 7);
+    const retained: ReleaseWorkflowCurrent = {
+      ...base,
+      workflow: { ...base.workflow, status: "blocked", requiredActions: [action] },
+      continuation: { ...base.continuation, requiredActions: [action] },
+      projections: {
+        projections: [
+          {
+            trackerId: "ALPHA",
+            displayName: "ALPHA",
+            readiness: "blocked",
+            artifacts: {
+              screenshotCount: 0,
+              dvdMenuCount: 0,
+              imageHosting: false,
+              description: false,
+            },
+            requiredActions: [action],
+          },
+        ],
+      } as unknown as NonNullable<ReleaseWorkflowCurrent["projections"]>,
+    };
+    const continueWorkflow = vi.fn(async () => retained);
+    const { result, unmount } = renderHook(useReleaseSession, {
+      wrapper: wrapperFor(
+        portsFor({
+          workflow: workflowPorts({
+            current: async () => retained,
+            continue: continueWorkflow,
+          }),
+        }),
+      ),
+    });
+
+    await waitFor(() => expect(result.current.workflow.view.status).toBe("ready"));
+    await act(async () => {
+      expect(await result.current.duplicates.overrideRules("alpha")).toBe(true);
+    });
+    expect(continueWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        goal: "duplicates_decided",
+        answers: [{ actionId: action.id, workflowRevision: 7, confirmed: true }],
+      }),
+      expect.any(AbortSignal),
+    );
+
+    unmount();
+    window.sessionStorage.removeItem("upbrr.activeReleaseWorkflow");
+  });
+
   it("declines a tracker preparation action to request its fallback", async () => {
     const workflowID = "workflow-resolve-tracker-preparation";
     window.sessionStorage.setItem("upbrr.activeReleaseWorkflow", workflowID);

--- a/webui/src/releaseSession/index.tsx
+++ b/webui/src/releaseSession/index.tsx
@@ -1780,6 +1780,34 @@ export function ReleaseSessionProvider({
           }),
         );
       },
+      overrideRules: async (tracker) => {
+        const normalizedTracker = tracker.trim().toUpperCase();
+        const current = workflowView.current;
+        const projection = current?.projections?.projections.find(
+          (candidate) => candidate.trackerId === normalizedTracker,
+        );
+        const action = [
+          ...(current?.workflow.requiredActions || []),
+          ...(projection?.requiredActions || []),
+        ].find(
+          (candidate) =>
+            candidate.kind === "authorize_rules" &&
+            candidate.trackerId === normalizedTracker &&
+            candidate.status === "pending",
+        );
+        if (!current || !action) return false;
+        return runBackendWorkflow((latest, commandID, signal) =>
+          continueBackendGoal(latest, "duplicates_decided", {}, commandID, signal, {
+            answers: [
+              {
+                actionId: action.id,
+                workflowRevision: latest.workflow.revision,
+                confirmed: true,
+              },
+            ],
+          }),
+        );
+      },
       cancel: async () => {
         if (!workflowView.current) return false;
         return cancelBackendWorkflow("duplicate check canceled");

--- a/webui/src/releaseSession/types.ts
+++ b/webui/src/releaseSession/types.ts
@@ -154,6 +154,8 @@ export type DuplicatesFacet = Readonly<{
   confirmReleaseName(tracker: string, value: string): void;
   /** Resolves or reopens the backend naming action using the current local edit. */
   acknowledgeReleaseName(tracker: string, acknowledged: boolean): Promise<boolean>;
+  /** Accepts the current exact tracker rule warning and rechecks that tracker. */
+  overrideRules(tracker: string): Promise<boolean>;
   setIgnored(tracker: string, ignored: boolean): void;
 }>;
 


### PR DESCRIPTION
## Summary

- Treat waivable tracker rules as tracker-scoped upload warnings.
- Keep CLI and WebUI continuation behavior aligned when warnings are accepted or declined.
- Require explicit rule feedback and cover selection, projection, prompt, and UI behavior with regressions.

## Testing

- `make precommit`
- `go test -race -v -timeout 20m ./cmd/upbrr ./internal/releaseworkflow ./internal/trackers ./pkg/api`
- `make test-go`
- `make test-frontend`
- `pnpm --dir webui run build`
- `make lint`
- `make backend`
- `make logpolicy`
- `make gofix-check-changed`
- `git diff --check`
- Embedded WebUI smoke test at `http://localhost:7480`

## AI disclosure

Yes. Codex reviewed and revised an existing uncommitted implementation, authored a minority of the final diff, and ran validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracker-specific approval for waivable rule warnings.
  * WebUI now shows “Upload approval needed” with an “Upload anyway” action.
  * Declining approval skips only the affected tracker when others remain eligible.
  * Approval requests are invalidated when warning details change.
  * Debug mode can bypass waivable warnings.

* **Bug Fixes**
  * Strict failures remain non-overridable.
  * Improved approval handling across CLI and WebUI workflows.
  * Clarified warning prompts and validation for explicit decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->