### PR TITLE
fix(build): update Go to 1.26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # below. The predefined platform args (BUILDPLATFORM, TARGET*) are auto-available
 # to FROM, and VERSION/BUILD_ID are declared inside the build stage where they are
 # consumed (see below), so they do not need global declarations.
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 
 FROM --platform=$BUILDPLATFORM node:24-alpine AS frontend
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/autobrr/upbrr
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/autobrr/go-bdinfo v0.4.0


### PR DESCRIPTION
## Description

Update the project and Docker build toolchain from Go 1.26.5 to 1.26.6. The repository remained pinned to the vulnerable patch release after new standard-library advisories were published; future binaries and images now use the patched toolchain.

Fixes #367

## How has this been tested?

- `go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...` (zero reachable vulnerabilities)
- `make test-go`
- `make precommit`

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/upbrr/blob/main/CONTRIBUTING.md)
- [x] I ran `make precommit`
- [x] CSS check not applicable; no CSS changed

## AI disclosure

Yes. Codex investigated the failure, authored both version-pin changes, and ran validation; effectively all changed lines were AI-written.
