### PR TITLE
fix(otw): use shared package season facts

### DIFF
--- a/internal/trackers/impl/unit3d/sites/otw/name.go
+++ b/internal/trackers/impl/unit3d/sites/otw/name.go
@@ -4,7 +4,6 @@
 package otw
 
 import (
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -13,12 +12,7 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-var otwSeasonPattern = regexp.MustCompile(`(?i)(?:^|[^a-z0-9])(?:S|Season[ ._-]*)(\d{1,3})`)
-
 func buildName(meta api.UploadSubject, _ config.TrackerConfig) string {
-	if isOTWNonDiscMultiSeason(meta) {
-		return ""
-	}
 	title, year := currentOTWTMDBTitleYear(meta)
 	if title == "" {
 		title = strings.TrimSpace(meta.Release.Title)
@@ -114,25 +108,6 @@ func isOTWCompleteDisc(meta api.UploadSubject) bool {
 	return strings.EqualFold(strings.TrimSpace(meta.Type), "DISC") ||
 		unit3d.IsDiscType(meta.DiscType) ||
 		unit3d.IsDiscType(meta.Disc.Type)
-}
-
-func isOTWNonDiscMultiSeason(meta api.UploadSubject) bool {
-	if isOTWCompleteDisc(meta) {
-		return false
-	}
-	seasons := make(map[string]struct{})
-	for _, value := range append([]string{
-		meta.SeasonStr,
-		meta.ReleaseName,
-		meta.ReleaseNameNoTag,
-	}, meta.FileList...) {
-		for _, match := range otwSeasonPattern.FindAllStringSubmatch(value, -1) {
-			if len(match) > 1 {
-				seasons[match[1]] = struct{}{}
-			}
-		}
-	}
-	return len(seasons) > 1
 }
 
 func otwSource(meta api.UploadSubject) string {

--- a/internal/trackers/impl/unit3d/sites/otw/name_test.go
+++ b/internal/trackers/impl/unit3d/sites/otw/name_test.go
@@ -95,7 +95,7 @@ func TestBuildNameAllowsDistributorOnlyForCompleteDisc(t *testing.T) {
 	}
 }
 
-func TestBuildNameBlocksProvedNonDiscMultiSeason(t *testing.T) {
+func TestBuildNameUsesPreparedSeasonFactsOnly(t *testing.T) {
 	t.Parallel()
 	meta := api.UploadSubject{
 		Identity: api.ExternalIdentity{
@@ -110,19 +110,24 @@ func TestBuildNameBlocksProvedNonDiscMultiSeason(t *testing.T) {
 			},
 		},
 		FileList: []string{
-			filepath.Join("Example Show", "Season 01", "Example.Show.S01E01.mkv"),
-			filepath.Join("Example Show", "Season 02", "Example.Show.S02E01.mkv"),
+			filepath.Join("Example Show", "Season 1", "Example.Show.S02E01.mkv"),
+			filepath.Join("Example Show", "Season 1", "Example.Show.S02E02.mkv"),
 		},
-		Type: "WEBDL",
+		Release:   api.ReleaseInfo{Resolution: "1080p"},
+		SeasonInt: 2,
+		SeasonStr: "S02",
+		TVPack:    true,
+		Type:      "WEBDL",
 	}
-	if got := buildName(meta, config.TrackerConfig{}); got != "" {
-		t.Fatalf("OTW non-disc multi-season name = %q, want blocked empty name", got)
+	const want = "Example Show 2020 S02 1080p WEB-DL"
+	if got := buildName(meta, config.TrackerConfig{}); got != want {
+		t.Fatalf("OTW name = %q, want prepared season facts only: %q", got, want)
 	}
 }
 
 func TestProfileBuildNameVersion(t *testing.T) {
 	t.Parallel()
-	if got := Profile().Site.BuildNameVersion; got != "v2" {
-		t.Fatalf("OTW BuildNameVersion = %q, want v2", got)
+	if got := Profile().Site.BuildNameVersion; got != "v3" {
+		t.Fatalf("OTW BuildNameVersion = %q, want v3", got)
 	}
 }

--- a/internal/trackers/impl/unit3d/sites/otw/profile.go
+++ b/internal/trackers/impl/unit3d/sites/otw/profile.go
@@ -28,7 +28,7 @@ func Profile() unit3d.Profile {
 		},
 		Site: unit3d.SiteProfile{
 			BuildName:        buildName,
-			BuildNameVersion: "v2",
+			BuildNameVersion: "v3",
 			ResolveTypeID:    typeID,
 		},
 		DupePolicy: &trackers.DupePolicy{


### PR DESCRIPTION
## Summary

- Remove OTW's tracker-local season parser from release naming.
- Keep package season eligibility in shared `PackageFacts` validation.
- Bump OTW naming policy to v3 and cover parent-folder season text.

## Why

`FileList` entries contain full paths. Re-parsing them allowed a parent directory such as `Season 1` to conflict with prepared `S02` metadata and suppress the OTW name. Tracker naming must use prepared semantic facts only.

Supersedes #361.

## Checks

- `go test -race -v -timeout 20m ./internal/trackers/impl/unit3d/sites/otw`
- `make lint`
- `make gofix-check-changed`
- `git diff --check`
- pre-commit and pre-push hooks

## AI disclosure

Implemented with OpenAI Codex under maintainer direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTW release naming for non-disc releases containing multiple season identifiers.
  * Names are now generated using prepared season information and file paths instead of being suppressed.

* **Compatibility**
  * Updated the OTW naming version to reflect the revised naming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->