### PR TITLE
fix(otw): align responsibility ledger version

### DIFF
--- a/internal/trackers/impl/responsibility_ledger_test.go
+++ b/internal/trackers/impl/responsibility_ledger_test.go
@@ -94,7 +94,7 @@ var trackerResponsibilityLedger = []trackerResponsibilityRow{
 	unit3DResponsibilityVersion("LUME", "lume", "", "v2"),
 	unit3DResponsibility("MNS", "canonical", ""),
 	unit3DResponsibility("OE", "oe", ""),
-	unit3DResponsibilityVersion("OTW", "otw", "", "v2"),
+	unit3DResponsibilityVersion("OTW", "otw", "", "v3"),
 	unit3DResponsibility("PT", "canonical", ""),
 	unit3DResponsibility("PTT", "canonical", ""),
 	unit3DResponsibility("R4E", "canonical", ""),


### PR DESCRIPTION
## Summary
- Update OTW’s responsibility ledger entry from naming v2 to v3.
- Restore the full Go test matrix after #369 changed the OTW naming policy version.

## Why
PR #369 correctly bumped BuildNameVersion to v3 but left the cross-tracker responsibility ledger at v2. TestTrackerResponsibilityLedgerCoversEveryBuiltIn/OTW therefore failed deterministically on Ubuntu, macOS, and Windows.

## Checks
- go test -race -v -timeout 20m ./internal/trackers/impl
- make test-go
- make lint
- make gofix-check-changed
- git diff --check
- make precommit
- pre-push hook

## AI disclosure
Implemented with OpenAI Codex under maintainer direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tracker validation to align with release policy version `v3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->