### PR TITLE
fix(trackers): centralize provider genre rules

### DIFF
--- a/internal/trackers/impl/standalone/rtf/description.go
+++ b/internal/trackers/impl/standalone/rtf/description.go
@@ -39,17 +39,3 @@ func resolvePoster(meta api.UploadSubject) string {
 	}
 	return metautil.FirstNonEmptyTrimmed(meta.ProviderMetadata.TMDB.Poster)
 }
-
-func genresText(meta api.UploadSubject) string {
-	if meta.ProviderMetadata.TMDB != nil {
-		return metautil.FirstNonEmptyTrimmed(meta.ProviderMetadata.TMDB.Genres, meta.Release.Genre)
-	}
-	return metautil.FirstNonEmptyTrimmed(meta.Release.Genre)
-}
-
-func keywordsText(meta api.UploadSubject) string {
-	if meta.ProviderMetadata.TMDB == nil {
-		return ""
-	}
-	return strings.TrimSpace(meta.ProviderMetadata.TMDB.Keywords)
-}

--- a/internal/trackers/impl/standalone/rtf/rules.go
+++ b/internal/trackers/impl/standalone/rtf/rules.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/autobrr/upbrr/internal/trackers"
-	"github.com/autobrr/upbrr/internal/trackers/impl/standalone"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -20,7 +19,7 @@ const minimumContentAgeReason = "content must be at least 10 years and 1 month o
 // validationPolicy strictly blocks content newer than RTF's ten-year-and-one-month
 // eligibility cutoff and adult-classified releases.
 func validationPolicy() trackers.ValidationPolicyBinding {
-	return trackers.ValidationPolicyBinding{ID: "standalone-rtf-constructibility-v2", Check: checkRules}
+	return trackers.ValidationPolicyBinding{ID: "standalone-rtf-constructibility-v3", Check: checkRules}
 }
 
 func checkRules(ctx context.Context, meta api.TrackerValidationSubject, _ api.Logger) ([]api.RuleFailure, error) {
@@ -28,17 +27,12 @@ func checkRules(ctx context.Context, meta api.TrackerValidationSubject, _ api.Lo
 		return nil, fmt.Errorf("context canceled: %w", err)
 	}
 	failures := make([]api.RuleFailure, 0, 2)
-	uploadSubject := standalone.UploadSubjectForValidation(meta)
-	genres := strings.ToLower(genresText(uploadSubject) + "," + keywordsText(uploadSubject))
-	for _, value := range []string{"xxx", "erotic", "porn", "adult", "orgy"} {
-		if strings.Contains(genres, value) {
-			failures = append(failures, trackers.NewRuleFailure(
-				"block_adult",
-				"adult content is not allowed",
-				api.RuleDispositionStrict,
-			))
-			break
-		}
+	if trackers.AdultContent(trackers.RuleSubjectFromValidation(meta)) {
+		failures = append(failures, trackers.NewRuleFailure(
+			"block_adult",
+			"adult content is not allowed",
+			api.RuleDispositionStrict,
+		))
 	}
 	if minimumContentAgeViolation(meta, time.Now().UTC()) {
 		failures = append(failures, trackers.NewRuleFailure(

--- a/internal/trackers/impl/standalone/rtf/rules_test.go
+++ b/internal/trackers/impl/standalone/rtf/rules_test.go
@@ -11,6 +11,52 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+func TestRTFAdultRuleUsesSharedProviderGenres(t *testing.T) {
+	t.Parallel()
+
+	const sourcePath = "Example.Release.2000.1080p-GRP"
+	subject := api.TrackerValidationSubject{
+		SourcePath: sourcePath,
+		Release:    api.ReleaseInfo{Year: 2000, Genre: "Adult"},
+		Identity: api.ExternalIdentity{
+			SourcePath: sourcePath,
+			Generation: 3,
+		},
+		ProviderMetadata: api.SourceScopedMetadata{
+			SourcePath: sourcePath,
+			Generation: 3,
+			TMDB:       &api.TMDBMetadata{Keywords: "Adult"},
+			TVDB:       &api.TVDBMetadata{Genres: "Drama"},
+		},
+	}
+
+	failures, err := checkRules(context.Background(), subject, nil)
+	if err != nil {
+		t.Fatalf("check nonadult provider genres: %v", err)
+	}
+	if hasRTFRule(failures, "block_adult") {
+		t.Fatalf("release genre or keyword blocked RTF upload: %#v", failures)
+	}
+
+	subject.ProviderMetadata.TVDB.Genres = "Adult"
+	failures, err = checkRules(context.Background(), subject, nil)
+	if err != nil {
+		t.Fatalf("check adult provider genre: %v", err)
+	}
+	if !hasRTFRule(failures, "block_adult") {
+		t.Fatalf("shared adult genre did not block RTF upload: %#v", failures)
+	}
+}
+
+func hasRTFRule(failures []api.RuleFailure, rule string) bool {
+	for _, failure := range failures {
+		if failure.Rule == rule {
+			return true
+		}
+	}
+	return false
+}
+
 func TestMinimumContentAgeRuleIsStrict(t *testing.T) {
 	t.Parallel()
 
@@ -18,7 +64,7 @@ func TestMinimumContentAgeRuleIsStrict(t *testing.T) {
 	if policy.Check == nil {
 		t.Fatal("RTF minimum content age rule is not registered")
 	}
-	if policy.ID != "standalone-rtf-constructibility-v2" {
+	if policy.ID != "standalone-rtf-constructibility-v3" {
 		t.Fatalf("RTF validation policy ID = %q", policy.ID)
 	}
 	failures, err := policy.Check(context.Background(), api.TrackerValidationSubject{

--- a/internal/trackers/impl/unit3d/additional_rules.go
+++ b/internal/trackers/impl/unit3d/additional_rules.go
@@ -6,6 +6,7 @@ package unit3d
 import (
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -26,36 +27,7 @@ var ruleResolutionOrder = map[string]int{
 // ValidationRuleSubject projects the shared validation contract into the
 // narrower helpers used by existing Unit3D site policies.
 func ValidationRuleSubject(meta api.TrackerValidationSubject) api.RuleSubject {
-	return api.RuleSubject{
-		SourcePath:         meta.SourcePath,
-		VideoPath:          meta.VideoPath,
-		FileList:           append([]string(nil), meta.FileList...),
-		DiscType:           meta.DiscType,
-		Scene:              meta.Scene,
-		SceneRenamed:       meta.SceneRenamed,
-		SceneRenamedReason: meta.SceneRenamedReason,
-		PersonalRelease:    meta.PersonalRelease,
-		Release:            meta.Release,
-		ReleaseName:        meta.ReleaseName,
-		ReleaseNameNoTag:   meta.ReleaseNameNoTag,
-		Tag:                meta.Tag,
-		Identity:           meta.Identity,
-		ProviderMetadata:   meta.ProviderMetadata,
-		AudioLanguages:     append([]string(nil), meta.AudioLanguages...),
-		SubtitleLanguages:  append([]string(nil), meta.SubtitleLanguages...),
-		TVPack:             meta.TVPack,
-		Type:               meta.Type,
-		Source:             meta.Source,
-		Container:          meta.Container,
-		BitDepth:           meta.BitDepth,
-		VideoCodec:         meta.VideoCodec,
-		VideoEncode:        meta.VideoEncode,
-		HDR:                meta.HDR,
-		Region:             meta.Region,
-		WebDV:              meta.WebDV,
-		Anime:              meta.Anime,
-		Assessments:        meta.Assessments,
-	}
+	return trackers.RuleSubjectFromValidation(meta)
 }
 
 // ResolutionBelow reports whether value ranks below minimum in the Unit3D resolution order.
@@ -89,35 +61,12 @@ func DolbyVisionOnly(meta api.RuleSubject) bool {
 	return strings.Contains(hdr, "DV") && !strings.Contains(hdr, "HDR")
 }
 
-// RuleGenres returns normalized current-source release and provider genres.
-func RuleGenres(meta api.RuleSubject) []string {
-	values := splitRuleList(meta.Release.Genre)
-	if ruleMetadataMatchesSource(meta) && meta.ProviderMetadata.TMDB != nil {
-		values = append(values, splitRuleList(meta.ProviderMetadata.TMDB.Genres)...)
-	}
-	if ruleMetadataMatchesSource(meta) && meta.ProviderMetadata.IMDB != nil {
-		values = append(values, splitRuleList(meta.ProviderMetadata.IMDB.Genres)...)
-	}
-	return NormalizeRuleValues(values)
-}
-
 // RuleKeywords returns normalized current-source TMDB keywords.
 func RuleKeywords(meta api.RuleSubject) []string {
 	if !ruleMetadataMatchesSource(meta) || meta.ProviderMetadata.TMDB == nil {
 		return nil
 	}
 	return NormalizeRuleValues(splitRuleList(meta.ProviderMetadata.TMDB.Keywords))
-}
-
-// AdultContent reports whether current genres or keywords contain an adult marker.
-func AdultContent(meta api.RuleSubject) bool {
-	for _, token := range append(RuleGenres(meta), RuleKeywords(meta)...) {
-		switch token {
-		case "adult", "porn", "pornography", "xxx", "erotic":
-			return true
-		}
-	}
-	return false
 }
 
 // Anime reports whether current metadata classifies the release as anime.
@@ -130,7 +79,7 @@ func Anime(meta api.RuleSubject) bool {
 
 // Animation reports whether current metadata contains the animation genre.
 func Animation(meta api.RuleSubject) bool {
-	return ContainsRuleValue(RuleGenres(meta), []string{"animation"})
+	return ContainsRuleValue(trackers.RuleGenres(meta), []string{"animation"})
 }
 
 // NormalizeRuleValues trims, lowercases, and deduplicates values while preserving order.

--- a/internal/trackers/impl/unit3d/sites/otw/rules.go
+++ b/internal/trackers/impl/unit3d/sites/otw/rules.go
@@ -16,7 +16,7 @@ import (
 // ValidationPolicy returns OTW's waivable genre, adult-content,
 // reality-content, and release-group restrictions.
 func ValidationPolicy() trackers.ValidationPolicyBinding {
-	return trackers.ValidationPolicyBinding{ID: "unit3d-otw-policy-v2", Check: checkRequirements}
+	return trackers.ValidationPolicyBinding{ID: "unit3d-otw-policy-v3", Check: checkRequirements}
 }
 
 func checkGenres(ctx context.Context, meta api.TrackerValidationSubject, _ api.Logger) ([]api.RuleFailure, error) {
@@ -35,11 +35,11 @@ func checkGenres(ctx context.Context, meta api.TrackerValidationSubject, _ api.L
 			api.RuleDispositionStrict,
 		))
 	}
-	genres := unit3d.RuleGenres(ruleSubject)
+	genres := trackers.RuleGenres(ruleSubject)
 	if !unit3d.ContainsRuleValue(genres, []string{"animation", "family"}) {
 		failures = append(failures, trackers.NewRuleFailure("genre", "Genre does not match Animation or Family for OTW.", api.RuleDispositionWaivable))
 	}
-	if unit3d.AdultContent(ruleSubject) {
+	if trackers.AdultContent(ruleSubject) {
 		failures = append(failures, trackers.NewRuleFailure("block_adult", "Adult animation not allowed at OTW.", api.RuleDispositionWaivable))
 	}
 	if unit3d.ContainsRuleValue(genres, []string{"reality", "game show", "game-show", "reality tv", "reality television"}) {

--- a/internal/trackers/impl/unit3d/sites/otw/rules_test.go
+++ b/internal/trackers/impl/unit3d/sites/otw/rules_test.go
@@ -60,6 +60,51 @@ func TestFallbackMetadataRequiresCurrentTMDBUnavailableEvidence(t *testing.T) {
 	}
 }
 
+func TestGenreRulesUseSharedProviderGenres(t *testing.T) {
+	t.Parallel()
+
+	const sourcePath = "Example.Release.2026.1080p-GRP"
+	subject := api.TrackerValidationSubject{
+		SourcePath: sourcePath,
+		Release:    api.ReleaseInfo{Genre: "Adult"},
+		Identity: api.ExternalIdentity{
+			SourcePath: sourcePath,
+			Generation: 4,
+			TMDBID:     1234567,
+		},
+		ProviderMetadata: api.SourceScopedMetadata{
+			SourcePath: sourcePath,
+			Generation: 4,
+			TMDB: &api.TMDBMetadata{
+				TMDBID:   1234567,
+				Title:    "Example Release",
+				Genres:   "Animation",
+				Keywords: "Adult",
+			},
+			TVmaze: &api.TVmazeMetadata{Genres: "Family"},
+		},
+	}
+
+	failures, err := checkGenres(context.Background(), subject, nil)
+	if err != nil {
+		t.Fatalf("validate provider genres: %v", err)
+	}
+	for _, rule := range []string{"genre", "block_adult"} {
+		if hasRule(failures, rule) {
+			t.Fatalf("release genre or keyword caused %s failure: %#v", rule, failures)
+		}
+	}
+
+	subject.ProviderMetadata.TVmaze.Genres = "Adult Animation"
+	failures, err = checkGenres(context.Background(), subject, nil)
+	if err != nil {
+		t.Fatalf("validate adult provider genre: %v", err)
+	}
+	if !hasRule(failures, "block_adult") {
+		t.Fatalf("shared adult genre was not blocked: %#v", failures)
+	}
+}
+
 func hasRule(failures []api.RuleFailure, rule string) bool {
 	for _, failure := range failures {
 		if failure.Rule == rule {

--- a/internal/trackers/impl/unit3d/sites/otw/validation_test.go
+++ b/internal/trackers/impl/unit3d/sites/otw/validation_test.go
@@ -72,7 +72,7 @@ func TestOTWEvidencePolicyPassViolationAndMissingEvidence(t *testing.T) {
 
 func TestOTWValidationPolicyVersion(t *testing.T) {
 	t.Parallel()
-	if got := Profile().ValidationPolicy.ID; got != "unit3d-otw-policy-v2" {
+	if got := Profile().ValidationPolicy.ID; got != "unit3d-otw-policy-v3" {
 		t.Fatalf("validation policy ID = %q", got)
 	}
 }

--- a/internal/trackers/impl/unit3d/sites/sp/validation.go
+++ b/internal/trackers/impl/unit3d/sites/sp/validation.go
@@ -7,9 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"slices"
 	"strings"
-	"unicode"
 
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/internal/trackers/impl/unit3d"
@@ -20,7 +18,7 @@ import (
 // and resolution checks.
 func ValidationPolicy() trackers.ValidationPolicyBinding {
 	return trackers.ValidationPolicyBinding{
-		ID:    "unit3d-sp-policy-v3",
+		ID:    "unit3d-sp-policy-v4",
 		Check: checkRequirements,
 	}
 }
@@ -111,12 +109,13 @@ func spSoftwareFailures(subject api.TrackerValidationSubject) []api.RuleFailure 
 }
 
 func spAdultContentFailures(subject api.TrackerValidationSubject) []api.RuleFailure {
-	values := spClassificationValues(subject)
 	status := subject.ProvenanceFacts.Status
-	if len(values) > 0 && status == api.MetadataEvidenceStatusUnavailable {
+	ruleSubject := trackers.RuleSubjectFromValidation(subject)
+	genres := trackers.RuleGenres(ruleSubject)
+	if len(genres) > 0 && status == api.MetadataEvidenceStatusUnavailable {
 		status = api.MetadataEvidenceStatusPartial
 	}
-	if slices.ContainsFunc(values, spAdultValue) {
+	if trackers.AdultContent(ruleSubject) {
 		return []api.RuleFailure{trackers.NewEvidenceRuleFailure(
 			"sp_block_adult",
 			"pornographic content is not allowed",
@@ -133,35 +132,6 @@ func spAdultContentFailures(subject api.TrackerValidationSubject) []api.RuleFail
 		)}
 	}
 	return nil
-}
-
-func spClassificationValues(subject api.TrackerValidationSubject) []string {
-	values := []string{subject.Release.Genre}
-	if !subject.ProviderMetadata.IsCurrentFor(subject.SourcePath, subject.Identity) {
-		return values
-	}
-	if metadata := subject.ProviderMetadata.TMDB; metadata != nil {
-		values = append(values, metadata.Genres, metadata.Keywords)
-	}
-	if metadata := subject.ProviderMetadata.IMDB; metadata != nil {
-		values = append(values, metadata.Genres)
-	}
-	if metadata := subject.ProviderMetadata.TVDB; metadata != nil {
-		values = append(values, metadata.Genres)
-	}
-	return values
-}
-
-func spAdultValue(value string) bool {
-	for _, token := range strings.FieldsFunc(strings.ToLower(value), func(char rune) bool {
-		return !unicode.IsLetter(char) && !unicode.IsDigit(char)
-	}) {
-		switch token {
-		case "adult", "erotic", "hentai", "porn", "pornography", "xxx":
-			return true
-		}
-	}
-	return false
 }
 
 func spDiscStructureFailures(subject api.TrackerValidationSubject) []api.RuleFailure {

--- a/internal/trackers/impl/unit3d/sites/sp/validation_test.go
+++ b/internal/trackers/impl/unit3d/sites/sp/validation_test.go
@@ -67,11 +67,18 @@ func TestSPEvidencePolicyPassViolationAndMissingEvidence(t *testing.T) {
 				subject.Identity.Generation = 2
 				subject.ProviderMetadata.SourcePath = subject.SourcePath
 				subject.ProviderMetadata.Generation = 2
-				subject.ProviderMetadata.TMDB.Genres = "Adult"
+				subject.ProviderMetadata.TVmaze = &api.TVmazeMetadata{Genres: "Adult"}
 			},
 			wantRule:        "sp_block_adult",
 			wantDisposition: api.RuleDispositionStrict,
 			wantStatus:      api.MetadataEvidenceStatusComplete,
+		},
+		{
+			name: "release genre and provider keyword cannot classify adult content",
+			mutate: func(subject *api.TrackerValidationSubject) {
+				subject.Release.Genre = "Adult"
+				subject.ProviderMetadata.TMDB.Keywords = "Adult"
+			},
 		},
 		{
 			name: "stale provider source cannot block adult content",
@@ -120,7 +127,7 @@ func TestSPEvidencePolicyPassViolationAndMissingEvidence(t *testing.T) {
 
 func TestSPValidationPolicyVersion(t *testing.T) {
 	t.Parallel()
-	if got := Profile().ValidationPolicy.ID; got != "unit3d-sp-policy-v3" {
+	if got := Profile().ValidationPolicy.ID; got != "unit3d-sp-policy-v4" {
 		t.Fatalf("validation policy ID = %q", got)
 	}
 }

--- a/internal/trackers/rules.go
+++ b/internal/trackers/rules.go
@@ -68,7 +68,7 @@ func EvaluateTrackerValidationWithRegistry(
 	subject api.TrackerValidationSubject,
 	logger api.Logger,
 ) ([]api.RuleFailure, error) {
-	failures, err := evaluateRules(ctx, registry, tracker, ruleSubjectFromValidation(subject), logger)
+	failures, err := evaluateRules(ctx, registry, tracker, RuleSubjectFromValidation(subject), logger)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func evaluateRules(ctx context.Context, registry *Registry, tracker string, meta
 		}
 	}
 
-	if rules.BlockAdult && isAdultContent(meta) {
+	if rules.BlockAdult && AdultContent(meta) {
 		message := strings.TrimSpace(rules.AdultMessage)
 		if message == "" {
 			message = "adult content not allowed at " + name
@@ -266,7 +266,9 @@ func evaluateValidationPolicy(
 	return normalized, nil
 }
 
-func ruleSubjectFromValidation(subject api.TrackerValidationSubject) api.RuleSubject {
+// RuleSubjectFromValidation projects a tracker-validation subject into the
+// shared eligibility-rule contract.
+func RuleSubjectFromValidation(subject api.TrackerValidationSubject) api.RuleSubject {
 	sceneNFOPath := ""
 	if subject.SceneNFOReady {
 		sceneNFOPath = "ready"
@@ -425,28 +427,51 @@ func hasReleaseToken(meta api.RuleSubject, tokens []string) bool {
 	return false
 }
 
-func isAdultContent(meta api.RuleSubject) bool {
-	candidates := append([]string{}, splitCSV(meta.Release.Genre)...)
-	if meta.ProviderMetadata.TMDB != nil && externalMetadataMatchesCurrentSource(meta) {
-		candidates = append(candidates, splitCSV(meta.ProviderMetadata.TMDB.Genres)...)
-		candidates = append(candidates, splitCSV(meta.ProviderMetadata.TMDB.Keywords)...)
+// RuleGenres returns normalized, deduplicated genres from current TMDB, IMDb,
+// TVDB, and TVmaze metadata. Parsed release genres and provider keywords are
+// excluded.
+func RuleGenres(meta api.RuleSubject) []string {
+	if !ruleProviderMetadataCurrent(meta) {
+		return nil
 	}
-	if meta.ProviderMetadata.IMDB != nil && externalMetadataMatchesCurrentSource(meta) {
-		candidates = append(candidates, splitCSV(meta.ProviderMetadata.IMDB.Genres)...)
+	values := make([]string, 0)
+	if metadata := meta.ProviderMetadata.TMDB; metadata != nil {
+		values = append(values, splitCSV(metadata.Genres)...)
 	}
-	normalized := normalizeStrings(candidates)
-	for _, token := range normalized {
-		switch token {
-		case "adult", "porn", "pornography", "xxx", "erotic", "hentai", "adult animation", "softcore":
+	if metadata := meta.ProviderMetadata.IMDB; metadata != nil {
+		values = append(values, splitCSV(metadata.Genres)...)
+	}
+	if metadata := meta.ProviderMetadata.TVDB; metadata != nil {
+		values = append(values, splitCSV(metadata.Genres)...)
+	}
+	if metadata := meta.ProviderMetadata.TVmaze; metadata != nil {
+		values = append(values, splitCSV(metadata.Genres)...)
+	}
+	return normalizeStrings(values)
+}
+
+// AdultContent reports whether a current provider genre is classified as adult.
+func AdultContent(meta api.RuleSubject) bool {
+	for _, genre := range RuleGenres(meta) {
+		switch genre {
+		case "adult", "porn", "pornography", "xxx", "erotic", "hentai", "adult animation", "softcore", "orgy":
 			return true
 		}
 	}
 	return false
 }
 
-func externalMetadataMatchesCurrentSource(meta api.RuleSubject) bool {
-	storedSource := strings.TrimSpace(meta.ProviderMetadata.SourcePath)
-	return storedSource == "" || pathutil.SamePath(storedSource, strings.TrimSpace(meta.SourcePath))
+func ruleProviderMetadataCurrent(meta api.RuleSubject) bool {
+	if !providerMetadataCurrent(meta) {
+		return false
+	}
+	currentSource := strings.TrimSpace(meta.SourcePath)
+	for _, scopedSource := range []string{meta.Identity.SourcePath, meta.ProviderMetadata.SourcePath} {
+		if scopedSource = strings.TrimSpace(scopedSource); scopedSource != "" && !pathutil.SamePath(scopedSource, currentSource) {
+			return false
+		}
+	}
+	return true
 }
 
 func splitCSV(value string) []string {

--- a/internal/trackers/rules_test.go
+++ b/internal/trackers/rules_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -632,8 +633,9 @@ func TestEvaluateRulesBHDBlocksAdultContent(t *testing.T) {
 		Assessments: encodeAssessments(api.EncodeSettingsStatusPresent),
 		Identity:    api.ExternalIdentity{Category: "movie", IMDBID: 1234567},
 		ProviderMetadata: api.SourceScopedMetadata{
-			TMDB: &api.TMDBMetadata{Keywords: "adult"},
-			IMDB: &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release"},
+			TMDB:   &api.TMDBMetadata{},
+			IMDB:   &api.IMDBMetadata{IMDBID: 1234567, Title: "Example Release"},
+			TVmaze: &api.TVmazeMetadata{Genres: "Adult"},
 		},
 	}
 
@@ -679,13 +681,75 @@ func TestEvaluateRulesBHDBlocksAdultMetadataForExactSourcePath(t *testing.T) {
 		Assessments: encodeAssessments(api.EncodeSettingsStatusPresent),
 		ProviderMetadata: api.SourceScopedMetadata{
 			SourcePath: sourcePath,
-			TMDB:       &api.TMDBMetadata{Keywords: "adult"},
+			TMDB:       &api.TMDBMetadata{Genres: "adult"},
 		},
 	}
 
 	failures := evaluateBHDRulesWithRegistryForTest(context.Background(), meta)
 	if !hasRuleFailure(failures, "block_adult") {
 		t.Fatal("expected exact-source adult metadata to be applied")
+	}
+}
+
+func TestRuleGenresUsesOnlyCurrentProviderGenres(t *testing.T) {
+	t.Parallel()
+
+	const sourcePath = "Example.Release.2026.1080p-GRP"
+	meta := api.RuleSubject{
+		SourcePath: sourcePath,
+		Release:    api.ReleaseInfo{Genre: "Release Only"},
+		Identity: api.ExternalIdentity{
+			SourcePath: sourcePath,
+			Generation: 7,
+		},
+		ProviderMetadata: api.SourceScopedMetadata{
+			SourcePath: sourcePath,
+			Generation: 7,
+			TMDB:       &api.TMDBMetadata{Genres: "Drama, Mystery", Keywords: "Adult"},
+			IMDB:       &api.IMDBMetadata{Genres: "Comedy, Drama"},
+			TVDB:       &api.TVDBMetadata{Genres: "Animation"},
+			TVmaze:     &api.TVmazeMetadata{Genres: "Family"},
+		},
+	}
+
+	want := []string{"drama", "mystery", "comedy", "animation", "family"}
+	if got := trackers.RuleGenres(meta); !slices.Equal(got, want) {
+		t.Fatalf("rule genres = %v, want %v", got, want)
+	}
+	if trackers.AdultContent(meta) {
+		t.Fatal("release genre or provider keyword classified content as adult")
+	}
+
+	meta.ProviderMetadata.Generation = 6
+	if got := trackers.RuleGenres(meta); len(got) != 0 {
+		t.Fatalf("stale rule genres = %v, want none", got)
+	}
+}
+
+func TestAdultContentUsesEveryProviderGenre(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		apply func(*api.SourceScopedMetadata)
+	}{
+		{name: "TMDB", apply: func(metadata *api.SourceScopedMetadata) { metadata.TMDB = &api.TMDBMetadata{Genres: "Adult Animation"} }},
+		{name: "IMDb", apply: func(metadata *api.SourceScopedMetadata) { metadata.IMDB = &api.IMDBMetadata{Genres: "Adult Animation"} }},
+		{name: "TVDB", apply: func(metadata *api.SourceScopedMetadata) { metadata.TVDB = &api.TVDBMetadata{Genres: "Adult Animation"} }},
+		{name: "TVmaze", apply: func(metadata *api.SourceScopedMetadata) {
+			metadata.TVmaze = &api.TVmazeMetadata{Genres: "Adult Animation"}
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			meta := api.RuleSubject{}
+			test.apply(&meta.ProviderMetadata)
+			if !trackers.AdultContent(meta) {
+				t.Fatal("adult provider genre was not classified as adult")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- centralize eligibility genres in `trackers.RuleGenres`
- use only current TMDB, IMDb, TVDB, and TVmaze genre fields
- route generic, OTW, SP, and RTF adult checks through shared `trackers.AdultContent`
- version changed OTW, SP, and RTF validation policies

## Testing
- `make test-go`
- focused tracker race tests
- `make lint`
- `make logpolicy`
- `make gofix-check-changed`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Adult-content detection now uses current genre information from supported metadata providers.
  * Release-level genres, keywords, and outdated or mismatched provider metadata no longer incorrectly trigger adult-content blocking.
  * Validation behavior is now consistent across supported tracker integrations.
  * Metadata availability is handled more accurately when determining adult-content evidence.

* **Tests**
  * Added coverage for provider genre detection and cases where keywords or release metadata should not cause blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->