### PR TITLE
ci(release): select Netlify CLI executable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,4 +147,4 @@ jobs:
             throw "NETLIFY_SITE_ID is not configured"
           }
 
-          pnpm dlx netlify-cli@27.1.1 deploy --prod --dir=build --no-build --message "upbrr $env:RELEASE_TAG"
+          pnpm --package=netlify-cli@27.1.1 dlx netlify deploy --prod --dir=build --no-build --message "upbrr $env:RELEASE_TAG"


### PR DESCRIPTION
## Summary

- Select the Netlify CLI package and `netlify` executable explicitly during documentation deployment.
- Restore compatibility with pnpm 11.15.1, which rejects ambiguous multi-binary packages.

## Impact

- Fixes only the release workflow documentation publish command.
- Does not dispatch or otherwise alter a release.

## Checks

- `pnpm --package=netlify-cli@27.1.1 dlx netlify --version`
- `git diff --check`
- `make gofix-check-changed` (no changed Go files)

Failure: https://github.com/autobrr/upbrr/actions/runs/31886344034/job/95016341977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation publishing workflow to use the package-specific Netlify CLI invocation.
  * Documentation deployment behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->