### PR TITLE
fix(sam): map TV anime to Animes category

### DIFF
--- a/internal/trackers/impl/unit3d/sites/sam/profile.go
+++ b/internal/trackers/impl/unit3d/sites/sam/profile.go
@@ -13,8 +13,9 @@ func Profile() unit3d.Profile {
 		Name:    "SAM",
 		BaseURL: "https://samaritano.cc",
 		Site: unit3d.SiteProfile{
-			BuildName:        buildName,
-			BuildNameVersion: "v1",
+			BuildName:         buildName,
+			BuildNameVersion:  "v1",
+			ResolveCategoryID: categoryID,
 		},
 	}
 }

--- a/internal/trackers/impl/unit3d/sites/sam/taxonomy.go
+++ b/internal/trackers/impl/unit3d/sites/sam/taxonomy.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package sam
+
+import (
+	"github.com/autobrr/upbrr/internal/trackers/impl/unit3d"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func categoryID(meta api.UploadSubject) string {
+	if unit3d.Category(meta) == "TV" && meta.Anime {
+		return "3"
+	}
+	return unit3d.DefaultCategoryID(meta)
+}

--- a/internal/trackers/impl/unit3d/sites/sam/taxonomy_test.go
+++ b/internal/trackers/impl/unit3d/sites/sam/taxonomy_test.go
@@ -14,6 +14,20 @@ func TestCategoryID(t *testing.T) {
 	if got := resolveCategoryID(api.UploadSubject{Identity: api.ExternalIdentity{Category: api.CanonicalCategoryTV}, Anime: true}); got != "3" {
 		t.Fatalf("anime TV category ID = %q, want 3", got)
 	}
+	if got := resolveCategoryID(api.UploadSubject{
+		Identity: api.ExternalIdentity{Category: api.CanonicalCategoryTV},
+		Anime:    true,
+		TVPack:   true,
+	}); got != "3" {
+		t.Fatalf("anime TV season category ID = %q, want 3", got)
+	}
+	if got := resolveCategoryID(api.UploadSubject{
+		Identity:   api.ExternalIdentity{Category: api.CanonicalCategoryTV},
+		Anime:      true,
+		EpisodeInt: 1,
+	}); got != "3" {
+		t.Fatalf("anime TV episode category ID = %q, want 3", got)
+	}
 	if got := resolveCategoryID(api.UploadSubject{Identity: api.ExternalIdentity{Category: api.CanonicalCategoryTV}}); got != "2" {
 		t.Fatalf("non-anime TV category ID = %q, want 2", got)
 	}

--- a/internal/trackers/impl/unit3d/sites/sam/taxonomy_test.go
+++ b/internal/trackers/impl/unit3d/sites/sam/taxonomy_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package sam
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestCategoryID(t *testing.T) {
+	resolveCategoryID := Profile().Site.ResolveCategoryID
+	if got := resolveCategoryID(api.UploadSubject{Identity: api.ExternalIdentity{Category: api.CanonicalCategoryTV}, Anime: true}); got != "3" {
+		t.Fatalf("anime TV category ID = %q, want 3", got)
+	}
+	if got := resolveCategoryID(api.UploadSubject{Identity: api.ExternalIdentity{Category: api.CanonicalCategoryTV}}); got != "2" {
+		t.Fatalf("non-anime TV category ID = %q, want 2", got)
+	}
+	if got := resolveCategoryID(api.UploadSubject{Identity: api.ExternalIdentity{Category: api.CanonicalCategoryMovie}, Anime: true}); got != "1" {
+		t.Fatalf("anime movie category ID = %q, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

- route SAM anime TV uploads to the `Animes` category (ID `3`)
- preserve normal TV and anime movie category mappings
- add focused regression coverage

## Why

SAM has a tracker-specific anime category, but inherited the generic Unit3D TV category mapping.

## Impact

SAM TV anime uploads only.

## Checks

- `go test -race -v -timeout 20m ./internal/trackers/impl/unit3d/sites/sam ./internal/trackers/impl/unit3d ./internal/trackers/impl`
- `make gofix-check-changed`
- `make logpolicy`
- `make lint`
- pre-push Go lint and frontend typecheck

Closes #282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SAM-specific category assignment for uploads.
  * Anime TV uploads are now categorized correctly, while other uploads continue using standard category mappings.

* **Tests**
  * Added coverage for anime TV, non-anime TV, and anime movie category handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->