### PR TITLE
fix(trackers): allow incomplete season pack confirmation

### DIFF
--- a/internal/trackers/impl/standalone/btn/definition_test.go
+++ b/internal/trackers/impl/standalone/btn/definition_test.go
@@ -32,7 +32,7 @@ func TestBTNProfileOwnsPreparationAndPolicies(t *testing.T) {
 	if profile.PrepareUpload == nil || profile.NewDuplicateAdapter == nil {
 		t.Fatal("BTN profile must own upload preparation and duplicate search")
 	}
-	if profile.ReleaseNamePolicy.ID != "standalone/btn/v3" || profile.ValidationPolicy.ID != "standalone-btn-constructibility-v2" {
+	if profile.ReleaseNamePolicy.ID != "standalone/btn/v3" || profile.ValidationPolicy.ID != "standalone-btn-constructibility-v3" {
 		t.Fatalf("unexpected BTN naming/validation policies: %q %q", profile.ReleaseNamePolicy.ID, profile.ValidationPolicy.ID)
 	}
 	if profile.DupePolicy == nil || profile.DupePolicy.ID != "standalone/btn/duplicate/v1" {

--- a/internal/trackers/impl/standalone/btn/validation.go
+++ b/internal/trackers/impl/standalone/btn/validation.go
@@ -15,7 +15,7 @@ import (
 
 func validationPolicy() trackers.ValidationPolicyBinding {
 	return trackers.ValidationPolicyBinding{
-		ID:    "standalone-btn-constructibility-v2",
+		ID:    "standalone-btn-constructibility-v3",
 		Check: checkRequirements,
 	}
 }
@@ -56,7 +56,7 @@ func checkRequirements(ctx context.Context, subject api.TrackerValidationSubject
 	)...)
 	if subject.TVPack {
 		failures = append(failures, trackers.ValidateCompleteEpisodeRange(subject.PackageFacts, trackers.EpisodeRangePolicy{
-			Evidence: btnEvidencePolicy("btn_episode_range", api.RuleDispositionStrict),
+			Evidence: btnEvidencePolicy("btn_episode_range", api.RuleDispositionWaivable),
 			Season:   subject.SeasonInt,
 		})...)
 		failures = append(failures, trackers.ValidatePerFileUniformity(subject.MediaFileFacts, trackers.PerFileUniformityPolicy{

--- a/internal/trackers/impl/standalone/btn/validation_test.go
+++ b/internal/trackers/impl/standalone/btn/validation_test.go
@@ -90,6 +90,17 @@ func TestBTNValidationObjectiveRules(t *testing.T) {
 			wantRule:        "btn_mixed_pack",
 			wantDisposition: api.RuleDispositionWaivable,
 		},
+		{
+			name: "incomplete season pack",
+			mutate: func(subject *api.TrackerValidationSubject) {
+				makeBTNValidationPack(subject)
+				subject.FileList[1] = "Example.Show.S01E03.1080p.WEB-DL.H.264-GRP.mkv"
+				subject.PackageFacts.DetectedEpisodes[0].Episodes = []int{1, 3}
+				subject.MediaFileFacts.Files[1].FileName = "Example.Show.S01E03.1080p.WEB-DL.H.264-GRP.mkv"
+			},
+			wantRule:        "btn_episode_range",
+			wantDisposition: api.RuleDispositionWaivable,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/trackers/impl/standalone/btn/validation_test.go
+++ b/internal/trackers/impl/standalone/btn/validation_test.go
@@ -18,6 +18,7 @@ func TestBTNValidationObjectiveRules(t *testing.T) {
 		mutate          func(*api.TrackerValidationSubject)
 		wantRule        string
 		wantDisposition api.RuleDisposition
+		wantStatus      api.MetadataEvidenceStatus
 	}{
 		{
 			name: "archive",
@@ -26,6 +27,7 @@ func TestBTNValidationObjectiveRules(t *testing.T) {
 			},
 			wantRule:        "btn_package_safety",
 			wantDisposition: api.RuleDispositionStrict,
+			wantStatus:      api.MetadataEvidenceStatusComplete,
 		},
 		{
 			name: "extra file",
@@ -34,6 +36,7 @@ func TestBTNValidationObjectiveRules(t *testing.T) {
 			},
 			wantRule:        "btn_package_safety",
 			wantDisposition: api.RuleDispositionStrict,
+			wantStatus:      api.MetadataEvidenceStatusComplete,
 		},
 		{
 			name: "single file folder",
@@ -42,6 +45,7 @@ func TestBTNValidationObjectiveRules(t *testing.T) {
 			},
 			wantRule:        "btn_single_file_layout",
 			wantDisposition: api.RuleDispositionStrict,
+			wantStatus:      api.MetadataEvidenceStatusComplete,
 		},
 		{
 			name: "multi season",
@@ -50,6 +54,7 @@ func TestBTNValidationObjectiveRules(t *testing.T) {
 			},
 			wantRule:        "btn_multi_season_package",
 			wantDisposition: api.RuleDispositionStrict,
+			wantStatus:      api.MetadataEvidenceStatusComplete,
 		},
 		{
 			name: "unsupported codec",
@@ -58,6 +63,7 @@ func TestBTNValidationObjectiveRules(t *testing.T) {
 			},
 			wantRule:        "btn_media_constraints",
 			wantDisposition: api.RuleDispositionStrict,
+			wantStatus:      api.MetadataEvidenceStatusComplete,
 		},
 		{
 			name: "dvd remux",
@@ -67,6 +73,7 @@ func TestBTNValidationObjectiveRules(t *testing.T) {
 			},
 			wantRule:        "btn_dvd_remux",
 			wantDisposition: api.RuleDispositionStrict,
+			wantStatus:      api.MetadataEvidenceStatusComplete,
 		},
 		{
 			name: "scene dvd image",
@@ -77,6 +84,7 @@ func TestBTNValidationObjectiveRules(t *testing.T) {
 			},
 			wantRule:        "btn_scene_dvd_image",
 			wantDisposition: api.RuleDispositionStrict,
+			wantStatus:      api.MetadataEvidenceStatusComplete,
 		},
 		{
 			name: "mixed pack",
@@ -89,6 +97,7 @@ func TestBTNValidationObjectiveRules(t *testing.T) {
 			},
 			wantRule:        "btn_mixed_pack",
 			wantDisposition: api.RuleDispositionWaivable,
+			wantStatus:      api.MetadataEvidenceStatusComplete,
 		},
 		{
 			name: "incomplete season pack",
@@ -100,6 +109,17 @@ func TestBTNValidationObjectiveRules(t *testing.T) {
 			},
 			wantRule:        "btn_episode_range",
 			wantDisposition: api.RuleDispositionWaivable,
+			wantStatus:      api.MetadataEvidenceStatusComplete,
+		},
+		{
+			name: "missing season pack evidence",
+			mutate: func(subject *api.TrackerValidationSubject) {
+				makeBTNValidationPack(subject)
+				subject.PackageFacts.Status = api.MetadataEvidenceStatusUnavailable
+			},
+			wantRule:        "btn_episode_range",
+			wantDisposition: api.RuleDispositionAdvisory,
+			wantStatus:      api.MetadataEvidenceStatusUnavailable,
 		},
 	}
 	for _, test := range tests {
@@ -112,7 +132,7 @@ func TestBTNValidationObjectiveRules(t *testing.T) {
 				t.Fatalf("check requirements: %v", err)
 			}
 			failure, ok := btnValidationFailure(failures, test.wantRule)
-			if !ok || failure.Disposition != test.wantDisposition {
+			if !ok || failure.Disposition != test.wantDisposition || failure.EvidenceStatus != test.wantStatus {
 				t.Fatalf("failure %q = %#v in %#v", test.wantRule, failure, failures)
 			}
 		})

--- a/internal/trackers/impl/unit3d/sites/sp/validation.go
+++ b/internal/trackers/impl/unit3d/sites/sp/validation.go
@@ -18,7 +18,7 @@ import (
 // and resolution checks.
 func ValidationPolicy() trackers.ValidationPolicyBinding {
 	return trackers.ValidationPolicyBinding{
-		ID:    "unit3d-sp-policy-v4",
+		ID:    "unit3d-sp-policy-v5",
 		Check: checkRequirements,
 	}
 }
@@ -47,7 +47,7 @@ func checkRequirements(ctx context.Context, subject api.TrackerValidationSubject
 	failures = append(failures, trackers.ValidatePackageExtensions(
 		subject.PackageFacts,
 		trackers.PackageExtensionPolicy{
-			Evidence:          spEvidencePolicy("sp_package_safety"),
+			Evidence:          spEvidencePolicy("sp_package_safety", api.RuleDispositionStrict),
 			BlockArchives:     true,
 			BlockedExtraKinds: extraKinds,
 		},
@@ -56,14 +56,14 @@ func checkRequirements(ctx context.Context, subject api.TrackerValidationSubject
 		failures = append(failures, trackers.ValidateCompleteEpisodeRange(
 			subject.PackageFacts,
 			trackers.EpisodeRangePolicy{
-				Evidence: spEvidencePolicy("sp_pack_completeness"),
+				Evidence: spEvidencePolicy("sp_pack_completeness", api.RuleDispositionWaivable),
 				Season:   subject.SeasonInt,
 			},
 		)...)
 		failures = append(failures, trackers.ValidatePerFileUniformity(
 			subject.MediaFileFacts,
 			trackers.PerFileUniformityPolicy{
-				Evidence: spEvidencePolicy("sp_pack_uniformity"),
+				Evidence: spEvidencePolicy("sp_pack_uniformity", api.RuleDispositionStrict),
 				Fields: []trackers.MediaUniformityField{
 					trackers.MediaUniformityFieldSource,
 					trackers.MediaUniformityFieldResolution,
@@ -82,10 +82,10 @@ func checkRequirements(ctx context.Context, subject api.TrackerValidationSubject
 	return failures, nil
 }
 
-func spEvidencePolicy(rule string) trackers.EvidencePredicatePolicy {
+func spEvidencePolicy(rule string, violation api.RuleDisposition) trackers.EvidencePredicatePolicy {
 	return trackers.EvidencePredicatePolicy{
 		Rule:                       rule,
-		ViolationDisposition:       api.RuleDispositionStrict,
+		ViolationDisposition:       violation,
 		MissingEvidenceDisposition: api.RuleDispositionAdvisory,
 	}
 }

--- a/internal/trackers/impl/unit3d/sites/sp/validation_test.go
+++ b/internal/trackers/impl/unit3d/sites/sp/validation_test.go
@@ -39,12 +39,12 @@ func TestSPEvidencePolicyPassViolationAndMissingEvidence(t *testing.T) {
 			wantStatus:      api.MetadataEvidenceStatusUnavailable,
 		},
 		{
-			name: "incomplete local pack is strict",
+			name: "incomplete local pack is waivable",
 			mutate: func(subject *api.TrackerValidationSubject) {
 				subject.PackageFacts.DetectedEpisodes[0].Episodes = []int{1, 3}
 			},
 			wantRule:        "sp_pack_completeness",
-			wantDisposition: api.RuleDispositionStrict,
+			wantDisposition: api.RuleDispositionWaivable,
 			wantStatus:      api.MetadataEvidenceStatusComplete,
 		},
 		{
@@ -127,7 +127,7 @@ func TestSPEvidencePolicyPassViolationAndMissingEvidence(t *testing.T) {
 
 func TestSPValidationPolicyVersion(t *testing.T) {
 	t.Parallel()
-	if got := Profile().ValidationPolicy.ID; got != "unit3d-sp-policy-v4" {
+	if got := Profile().ValidationPolicy.ID; got != "unit3d-sp-policy-v5" {
 		t.Fatalf("validation policy ID = %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Make incomplete BTN and SP season-pack episode ranges waivable.
- Route the warning through the existing exact-fingerprint CLI and WebUI confirmation flow.
- Bump both validation policy versions and cover the behavior with tracker regressions.

## Why

Lost-media seasons can remain permanently incomplete while still being valid uploads. The strict validation result left no path to continue.

## Impact

Only complete-evidence episode gaps change from strict to waivable. Missing evidence remains advisory, unrelated tracker failures remain strict, and unattended mode remains non-prompting.

## Checks

- `go test -race -v -timeout 20m ./internal/trackers ./internal/trackers/impl/standalone/btn ./internal/trackers/impl/unit3d/sites/sp`
- `make gofix-check-changed`
- `make logpolicy`
- `make lint`
- `git diff --check`
- pre-commit and pre-push hooks

Closes #230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Validation Updates**
  - Updated standalone BTN and SP validation policies to their latest versions.
  - TV pack episode-range and completeness issues can now be waived.
  - Package-safety and pack-uniformity violations remain strict.

- **Bug Fixes**
  - Improved validation handling for incomplete TV season packs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->