### PR TITLE
fix(webui): clarify reusable torrent preference

### DIFF
--- a/documentation/docs/web-ui/settings/torrent-specific.md
+++ b/documentation/docs/web-ui/settings/torrent-specific.md
@@ -7,12 +7,12 @@ description: Prefer reusable torrents with smaller pieces and delay rehash-depen
 
 Use **Settings → Torrent Specific** for torrent reuse and rehash scheduling.
 
-| Field                     | Default | Effect                                                                                                      |
-| ------------------------- | ------- | ----------------------------------------------------------------------------------------------------------- |
-| **Prefer max 16 torrent** | Off     | During torrent-client search, prefers a validated reusable torrent whose piece size is at most 16 MiB.      |
-| **Rehash cooldown**       | `0`     | Waits this many seconds after reusable-torrent submissions finish before starting rehash-dependent uploads. |
+| Field                                     | Default | Effect                                                                                                      |
+| ----------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| **Prefer reusable torrents up to 16 MiB** | Off     | During torrent-client search, prefers a validated reusable torrent whose piece size is at most 16 MiB.      |
+| **Rehash cooldown**                       | `0`     | Waits this many seconds after reusable-torrent submissions finish before starting rehash-dependent uploads. |
 
-**Prefer max 16 torrent** affects selection among reusable client torrents; it does not impose a piece size on every newly generated torrent. A negative rehash cooldown behaves as zero.
+**Prefer reusable torrents up to 16 MiB** affects selection among reusable client torrents; it does not impose a piece size on every newly generated torrent. A negative rehash cooldown behaves as zero.
 
 :::note Compatibility field
 

--- a/webui/src/hooks/useSettingsState.test.ts
+++ b/webui/src/hooks/useSettingsState.test.ts
@@ -160,6 +160,25 @@ function ClientSetupHarness() {
   );
 }
 
+function TorrentCreationHarness() {
+  const state = useSettingsState({ activeTab: "settings" });
+  const torrentCreation = state.configData?.TorrentCreation;
+
+  if (!torrentCreation || typeof torrentCreation !== "object" || Array.isArray(torrentCreation)) {
+    return createElement("div", null);
+  }
+
+  const meta = state.sectionFieldMeta.TorrentCreation ?? {};
+
+  return createElement(
+    "div",
+    null,
+    ...Object.entries(torrentCreation).map(([key, value]) =>
+      state.renderField(key, value, ["TorrentCreation", key], meta[key]),
+    ),
+  );
+}
+
 function TrackerSettingsHarness() {
   const state = useSettingsState({ activeTab: "settings" });
 
@@ -350,6 +369,21 @@ describe("settings advanced fields", () => {
     expect(advancedBySection.PostUpload).toEqual(["InjectDelay", "MaxConcurrentTrackers"]);
     expect(advancedBySection.TorrentCreation).toEqual([]);
     expect(advancedBySection.TorrentClients).toEqual(["VerifyWebUICertificate"]);
+  });
+});
+
+describe("torrent creation settings", () => {
+  it("identifies the 16 MiB preference as reusable-torrent selection", async () => {
+    installAppOperationMocks({
+      GetConfig: async () => JSON.stringify({ TorrentCreation: { PreferMax16: false } }),
+      GetDefaultConfig: async () => JSON.stringify({}),
+      ListTrackerCatalog: async () => trackerCatalog(),
+      GetImageHostPolicyMetadata: async () => ({}),
+    });
+
+    render(createElement(TorrentCreationHarness));
+
+    expect(await screen.findByLabelText("Prefer reusable torrents up to 16 MiB")).not.toBeChecked();
   });
 });
 

--- a/webui/src/hooks/useSettingsState.tsx
+++ b/webui/src/hooks/useSettingsState.tsx
@@ -281,7 +281,12 @@ const sectionFieldMeta: Record<string, Record<string, FieldMeta>> = {
     EmbyDir: { key: "EmbyDir", advanced: true },
     EmbyTVDir: { key: "EmbyTVDir", advanced: true },
   },
-  TorrentCreation: {},
+  TorrentCreation: {
+    PreferMax16: {
+      key: "PreferMax16",
+      label: "Prefer reusable torrents up to 16 MiB",
+    },
+  },
   PostUpload: {
     InjectDelay: { key: "InjectDelay", advanced: true },
     MaxConcurrentTrackers: { key: "MaxConcurrentTrackers", advanced: true },


### PR DESCRIPTION
## Summary

- clarify that **Prefer Max16** selects reusable client torrents rather than setting generated torrent size
- add a WebUI rendering regression test for the new label
- synchronize the public settings reference

## Why

Issue #362 reports that the setting appears to force 16 MiB pieces instead of using automatic sizing. Investigation confirmed mkbrr still auto-sizes newly generated torrents; this preference only affects validated torrents found during client search. The persisted config key and torrent sizing behavior remain unchanged.

Closes #362

## Checks

- `go test -race -v -timeout 20m ./internal/torrentclient ./internal/torrent`
- `pnpm --dir webui run lint`
- `pnpm --dir webui run lint:dead`
- `pnpm --dir webui run typecheck`
- `pnpm --dir webui run test:unit`
- `pnpm --dir webui run format:check`
- `pnpm --dir documentation run check`
- pre-push Go lint and repository policy checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the “Prefer reusable torrents up to 16 MiB” option to the torrent creation settings.
  * Updated the setting description to clarify its behavior.

* **Documentation**
  * Updated the web UI settings documentation to reflect the renamed torrent option.

* **Tests**
  * Added coverage verifying the setting appears correctly as an unchecked control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->