### PR TITLE
fix(tmdb): handle anilist rate limits

### DIFF
--- a/internal/metadata/tmdb/anilist.go
+++ b/internal/metadata/tmdb/anilist.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	"github.com/autobrr/upbrr/internal/redaction"
@@ -22,6 +23,9 @@ import (
 
 const anilistURL = "https://graphql.anilist.co"
 const anilistRetryCount = 3
+
+// ponytail: one minute of cumulative retry wait; add shared pacing if AniList publishes a longer rate-limit window.
+const anilistMaxRetryWait = time.Minute
 
 // maxAniListMetadataResponseBytes caps rich AniList metadata responses before
 // JSON decode so malformed or unexpected GraphQL responses cannot grow
@@ -55,10 +59,11 @@ func (c *Client) ResolveAnime(ctx context.Context, tmdbName string, input Metada
 			if c.logger != nil {
 				c.logger.Warnf("tmdb: anilist search failed mal=%d err=%s", result.MALID, redaction.RedactValue(err.Error(), nil))
 			}
-			continue
-		}
-		if len(items) > 0 {
+		} else if len(items) > 0 {
 			media = items
+			break
+		}
+		if result.MALID != 0 {
 			break
 		}
 	}
@@ -117,8 +122,9 @@ func (c *Client) ResolveAnime(ctx context.Context, tmdbName string, input Metada
 //
 // A non-positive ID or missing AniList media returns an empty result without
 // error. GraphQL errors, oversized responses, HTTP failures, and canceled
-// contexts return an error; transient timeout-style failures are retried before
-// the final error is surfaced.
+// contexts return an error. Transient timeouts and HTTP 429 responses are
+// retried; rate-limit waits honor provider hints within a one-minute cumulative
+// budget.
 func (c *Client) FetchAniListMetadata(ctx context.Context, malID int) (AniListMetadataResult, error) {
 	if malID <= 0 {
 		return AniListMetadataResult{}, nil
@@ -132,6 +138,7 @@ func (c *Client) FetchAniListMetadata(ctx context.Context, malID int) (AniListMe
 		return AniListMetadataResult{}, fmt.Errorf("anilist: marshal metadata payload: %w", err)
 	}
 
+	retryWaitRemaining := anilistMaxRetryWait
 	for attempt := range anilistRetryCount {
 		response, err := c.doAniListMetadata(ctx, body)
 		if err == nil {
@@ -150,7 +157,12 @@ func (c *Client) FetchAniListMetadata(ctx context.Context, malID int) (AniListMe
 			return AniListMetadataResult{}, err
 		}
 		if c.logger != nil {
-			c.logger.Warnf("tmdb: anilist metadata request timed out for mal=%d, retrying (%d/%d)", malID, attempt+2, anilistRetryCount)
+			c.logger.Warnf("tmdb: anilist metadata request retrying mal=%d retry=%d/%d", malID, attempt+2, anilistRetryCount)
+		}
+		delay := min(anilistRetryDelay(err), retryWaitRemaining)
+		retryWaitRemaining -= delay
+		if err := waitForAniListRetry(ctx, delay); err != nil {
+			return AniListMetadataResult{}, err
 		}
 	}
 	return AniListMetadataResult{}, nil
@@ -171,6 +183,7 @@ func (c *Client) anilistSearch(ctx context.Context, term string, malID int) ([]a
 	}
 
 	var lastErr error
+	retryWaitRemaining := anilistMaxRetryWait
 	for attempt := range anilistRetryCount {
 		response, err := c.doAniListSearch(ctx, body)
 		if err == nil {
@@ -184,7 +197,12 @@ func (c *Client) anilistSearch(ctx context.Context, term string, malID int) ([]a
 		}
 		lastErr = err
 		if c.logger != nil {
-			c.logger.Warnf("tmdb: anilist request timed out mal=%d retry=%d/%d", malID, attempt+2, anilistRetryCount)
+			c.logger.Warnf("tmdb: anilist request retrying mal=%d retry=%d/%d", malID, attempt+2, anilistRetryCount)
+		}
+		delay := min(anilistRetryDelay(err), retryWaitRemaining)
+		retryWaitRemaining -= delay
+		if err := waitForAniListRetry(ctx, delay); err != nil {
+			return nil, err
 		}
 	}
 	if lastErr != nil {
@@ -209,7 +227,7 @@ func (c *Client) doAniListSearch(ctx context.Context, body []byte) (anilistRespo
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return response, fmt.Errorf("anilist: http %d", resp.StatusCode)
+		return response, newAniListHTTPError(resp)
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return response, fmt.Errorf("anilist: decode search response: %w", err)
@@ -234,8 +252,11 @@ func (c *Client) doAniListMetadata(ctx context.Context, body []byte) (anilistMet
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusNotFound {
+		return response, nil
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return response, fmt.Errorf("anilist: http %d", resp.StatusCode)
+		return response, newAniListHTTPError(resp)
 	}
 	payload, err := io.ReadAll(io.LimitReader(resp.Body, maxAniListMetadataResponseBytes+1))
 	if err != nil {
@@ -260,8 +281,69 @@ func isRetryableAniListError(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
+	var rateLimitErr *anilistRateLimitError
+	if errors.As(err, &rateLimitErr) {
+		return true
+	}
 	var netErr net.Error
 	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+type anilistRateLimitError struct {
+	retryAfter time.Duration
+}
+
+func (e *anilistRateLimitError) Error() string {
+	return "anilist: http 429"
+}
+
+func newAniListHTTPError(response *http.Response) error {
+	if response.StatusCode == http.StatusTooManyRequests {
+		return &anilistRateLimitError{retryAfter: parseAniListRetryDelay(response.Header, time.Now())}
+	}
+	return fmt.Errorf("anilist: http %d", response.StatusCode)
+}
+
+func parseAniListRetryDelay(header http.Header, now time.Time) time.Duration {
+	retryAfter := strings.TrimSpace(header.Get("Retry-After"))
+	if seconds, err := strconv.ParseInt(retryAfter, 10, 64); err == nil && seconds >= 0 {
+		if seconds >= int64(anilistMaxRetryWait/time.Second) {
+			return anilistMaxRetryWait
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	if retryAt, err := http.ParseTime(retryAfter); err == nil && retryAt.After(now) {
+		return min(retryAt.Sub(now), anilistMaxRetryWait)
+	}
+
+	reset, err := strconv.ParseInt(strings.TrimSpace(header.Get("X-Ratelimit-Reset")), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return min(max(time.Unix(reset, 0).Sub(now), 0), anilistMaxRetryWait)
+}
+
+func anilistRetryDelay(err error) time.Duration {
+	var rateLimitErr *anilistRateLimitError
+	if !errors.As(err, &rateLimitErr) {
+		return 0
+	}
+	return rateLimitErr.retryAfter
+}
+
+func waitForAniListRetry(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("anilist retry wait: %w", ctx.Err())
+	case <-timer.C:
+		return nil
+	}
 }
 
 func anilistQuery(byID bool) string {

--- a/internal/metadata/tmdb/anilist.go
+++ b/internal/metadata/tmdb/anilist.go
@@ -26,6 +26,7 @@ const anilistRetryCount = 3
 
 // ponytail: one minute of cumulative retry wait; add shared pacing if AniList publishes a longer rate-limit window.
 const anilistMaxRetryWait = time.Minute
+const anilistRetryDelayOverBudget = anilistMaxRetryWait + time.Nanosecond
 
 // maxAniListMetadataResponseBytes caps rich AniList metadata responses before
 // JSON decode so malformed or unexpected GraphQL responses cannot grow
@@ -122,9 +123,9 @@ func (c *Client) ResolveAnime(ctx context.Context, tmdbName string, input Metada
 //
 // A non-positive ID or missing AniList media returns an empty result without
 // error. GraphQL errors, oversized responses, HTTP failures, and canceled
-// contexts return an error. Transient timeouts and HTTP 429 responses are
-// retried; rate-limit waits honor provider hints within a one-minute cumulative
-// budget.
+// contexts return an error. Transient timeouts are retried. HTTP 429 responses
+// are retried only when the provider delay fits within a one-minute cumulative
+// wait budget.
 func (c *Client) FetchAniListMetadata(ctx context.Context, malID int) (AniListMetadataResult, error) {
 	if malID <= 0 {
 		return AniListMetadataResult{}, nil
@@ -156,10 +157,13 @@ func (c *Client) FetchAniListMetadata(ctx context.Context, malID int) (AniListMe
 		if !isRetryableAniListError(err) || attempt == anilistRetryCount-1 {
 			return AniListMetadataResult{}, err
 		}
+		delay := anilistRetryDelay(err)
+		if delay > retryWaitRemaining {
+			return AniListMetadataResult{}, err
+		}
 		if c.logger != nil {
 			c.logger.Warnf("tmdb: anilist metadata request retrying mal=%d retry=%d/%d", malID, attempt+2, anilistRetryCount)
 		}
-		delay := min(anilistRetryDelay(err), retryWaitRemaining)
 		retryWaitRemaining -= delay
 		if err := waitForAniListRetry(ctx, delay); err != nil {
 			return AniListMetadataResult{}, err
@@ -196,10 +200,13 @@ func (c *Client) anilistSearch(ctx context.Context, term string, malID int) ([]a
 			return nil, err
 		}
 		lastErr = err
+		delay := anilistRetryDelay(err)
+		if delay > retryWaitRemaining {
+			return nil, err
+		}
 		if c.logger != nil {
 			c.logger.Warnf("tmdb: anilist request retrying mal=%d retry=%d/%d", malID, attempt+2, anilistRetryCount)
 		}
-		delay := min(anilistRetryDelay(err), retryWaitRemaining)
 		retryWaitRemaining -= delay
 		if err := waitForAniListRetry(ctx, delay); err != nil {
 			return nil, err
@@ -307,20 +314,20 @@ func newAniListHTTPError(response *http.Response) error {
 func parseAniListRetryDelay(header http.Header, now time.Time) time.Duration {
 	retryAfter := strings.TrimSpace(header.Get("Retry-After"))
 	if seconds, err := strconv.ParseInt(retryAfter, 10, 64); err == nil && seconds >= 0 {
-		if seconds >= int64(anilistMaxRetryWait/time.Second) {
-			return anilistMaxRetryWait
+		if seconds > int64(anilistMaxRetryWait/time.Second) {
+			return anilistRetryDelayOverBudget
 		}
 		return time.Duration(seconds) * time.Second
 	}
 	if retryAt, err := http.ParseTime(retryAfter); err == nil && retryAt.After(now) {
-		return min(retryAt.Sub(now), anilistMaxRetryWait)
+		return min(retryAt.Sub(now), anilistRetryDelayOverBudget)
 	}
 
 	reset, err := strconv.ParseInt(strings.TrimSpace(header.Get("X-Ratelimit-Reset")), 10, 64)
 	if err != nil {
 		return 0
 	}
-	return min(max(time.Unix(reset, 0).Sub(now), 0), anilistMaxRetryWait)
+	return min(max(time.Unix(reset, 0).Sub(now), 0), anilistRetryDelayOverBudget)
 }
 
 func anilistRetryDelay(err error) time.Duration {

--- a/internal/metadata/tmdb/anilist_test.go
+++ b/internal/metadata/tmdb/anilist_test.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -53,12 +55,44 @@ func TestAniListSearchRetriesTimeouts(t *testing.T) {
 		t.Fatalf("expected two timeout warnings, got %#v", warnings)
 	}
 	for _, warning := range warnings {
-		if !strings.HasPrefix(warning, "tmdb: anilist request timed out mal=0 retry=") {
+		if !strings.HasPrefix(warning, "tmdb: anilist request retrying mal=0 retry=") {
 			t.Fatalf("expected stable timeout warning fields, got %q", warning)
 		}
 		if strings.Contains(warning, "Example") || strings.Contains(warning, "GRP") {
 			t.Fatalf("expected timeout warning to omit the search term, got %q", warning)
 		}
+	}
+}
+
+func TestAniListSearchRetriesRateLimit(t *testing.T) {
+	attempts := 0
+	client := &Client{
+		anilistURL: testAnilistURL,
+		http: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				attempts++
+				if attempts == 1 {
+					return &http.Response{
+						StatusCode: http.StatusTooManyRequests,
+						Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Too Many Requests"}]}`)),
+						Header:     http.Header{"Retry-After": []string{"0"}},
+					}, nil
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"data":{"Page":{"media":[]}}}`)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+		logger: api.NopLogger{},
+	}
+
+	if _, err := client.anilistSearch(t.Context(), "Example Anime", 0); err != nil {
+		t.Fatalf("expected success after rate-limit retry, got %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
 	}
 }
 
@@ -110,6 +144,71 @@ func TestFetchAniListMetadataReturnsGraphQLErrors(t *testing.T) {
 	}
 	if attempts != 1 {
 		t.Fatalf("expected one request, got %d", attempts)
+	}
+}
+
+func TestFetchAniListMetadataRetriesRateLimit(t *testing.T) {
+	attempts := 0
+	client := &Client{
+		anilistURL: testAnilistURL,
+		http: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				attempts++
+				if attempts == 1 {
+					return &http.Response{
+						StatusCode: http.StatusTooManyRequests,
+						Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Too Many Requests"}]}`)),
+						Header:     http.Header{"Retry-After": []string{"0"}},
+					}, nil
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"data":{"Media":{"id":1,"idMal":20}}}`)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+		logger: api.NopLogger{},
+	}
+
+	result, err := client.FetchAniListMetadata(t.Context(), 20)
+	if err != nil {
+		t.Fatalf("expected success after rate-limit retry, got %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+	if result.AniListID != 1 || result.MALID != 20 {
+		t.Fatalf("unexpected mapped result: %#v", result)
+	}
+}
+
+func TestFetchAniListMetadataReturnsEmptyOnNotFound(t *testing.T) {
+	attempts := 0
+	client := &Client{
+		anilistURL: testAnilistURL,
+		http: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				attempts++
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Not Found"}]}`)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+		logger: api.NopLogger{},
+	}
+
+	result, err := client.FetchAniListMetadata(t.Context(), 999999)
+	if err != nil {
+		t.Fatalf("expected missing media to return no error, got %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected one request, got %d", attempts)
+	}
+	if result.AniListID != 0 || result.MALID != 0 || result.TitleRomaji != "" {
+		t.Fatalf("expected empty metadata, got %#v", result)
 	}
 }
 
@@ -245,6 +344,106 @@ func TestResolveAnimeWarnsSanitizedOnSearchFailure(t *testing.T) {
 		if strings.Contains(warning, "Example") || strings.Contains(warning, "GRP") {
 			t.Fatalf("expected warning to omit the search term, got %q", warning)
 		}
+	}
+}
+
+func TestResolveAnimeSearchesKnownMALIDOnce(t *testing.T) {
+	attempts := 0
+	client := &Client{
+		anilistURL: testAnilistURL,
+		http: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				attempts++
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"data":{"Page":{"media":[]}}}`)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+		logger: api.NopLogger{},
+	}
+
+	result, err := client.ResolveAnime(t.Context(), "Example Anime", MetadataInput{
+		Filename:  "Example.Anime.2026.S01.1080p.WEB-DL-GRP",
+		MALManual: 20,
+	})
+	if err != nil {
+		t.Fatalf("expected best-effort resolve to succeed, got %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected one MAL ID search, got %d", attempts)
+	}
+	if result.MALID != 20 {
+		t.Fatalf("expected explicit MAL ID to be retained, got %d", result.MALID)
+	}
+}
+
+func TestParseAniListRetryDelay(t *testing.T) {
+	now := time.Date(2026, time.August, 15, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		retryAfter string
+		reset      string
+		want       time.Duration
+	}{
+		{
+			name:       "delta seconds",
+			retryAfter: "51",
+			want:       51 * time.Second,
+		},
+		{
+			name:       "http date",
+			retryAfter: now.Add(20 * time.Second).Format(http.TimeFormat),
+			want:       20 * time.Second,
+		},
+		{
+			name:  "reset fallback",
+			reset: strconv.FormatInt(now.Add(30*time.Second).Unix(), 10),
+			want:  30 * time.Second,
+		},
+		{
+			name:       "retry after precedence",
+			retryAfter: "10",
+			reset:      strconv.FormatInt(now.Add(30*time.Second).Unix(), 10),
+			want:       10 * time.Second,
+		},
+		{
+			name:       "invalid and past",
+			retryAfter: "invalid",
+			reset:      strconv.FormatInt(now.Add(-time.Second).Unix(), 10),
+			want:       0,
+		},
+		{
+			name:       "bounded",
+			retryAfter: "120",
+			want:       anilistMaxRetryWait,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := make(http.Header)
+			if tt.retryAfter != "" {
+				header.Set("Retry-After", tt.retryAfter)
+			}
+			if tt.reset != "" {
+				header.Set("X-Ratelimit-Reset", tt.reset)
+			}
+			if got := parseAniListRetryDelay(header, now); got != tt.want {
+				t.Fatalf("parseAniListRetryDelay() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaitForAniListRetryReturnsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := waitForAniListRetry(ctx, anilistMaxRetryWait)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForAniListRetry() error = %v, want context canceled", err)
 	}
 }
 

--- a/internal/metadata/tmdb/anilist_test.go
+++ b/internal/metadata/tmdb/anilist_test.go
@@ -96,6 +96,32 @@ func TestAniListSearchRetriesRateLimit(t *testing.T) {
 	}
 }
 
+func TestAniListSearchStopsWhenRetryDelayExceedsBudget(t *testing.T) {
+	attempts := 0
+	client := &Client{
+		anilistURL: testAnilistURL,
+		http: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				attempts++
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Too Many Requests"}]}`)),
+					Header:     http.Header{"Retry-After": []string{"120"}},
+				}, nil
+			}),
+		},
+		logger: api.NopLogger{},
+	}
+
+	_, err := client.anilistSearch(t.Context(), "Example Anime", 0)
+	if err == nil || !strings.Contains(err.Error(), "http 429") {
+		t.Fatalf("expected rate-limit error, got %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 attempt when retry delay exceeds budget, got %d", attempts)
+	}
+}
+
 func TestAniListSearchDoesNotRetryNonTimeoutErrors(t *testing.T) {
 	attempts := 0
 	client := &Client{
@@ -180,6 +206,32 @@ func TestFetchAniListMetadataRetriesRateLimit(t *testing.T) {
 	}
 	if result.AniListID != 1 || result.MALID != 20 {
 		t.Fatalf("unexpected mapped result: %#v", result)
+	}
+}
+
+func TestFetchAniListMetadataStopsWhenRetryDelayExceedsBudget(t *testing.T) {
+	attempts := 0
+	client := &Client{
+		anilistURL: testAnilistURL,
+		http: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				attempts++
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"Too Many Requests"}]}`)),
+					Header:     http.Header{"Retry-After": []string{"120"}},
+				}, nil
+			}),
+		},
+		logger: api.NopLogger{},
+	}
+
+	_, err := client.FetchAniListMetadata(t.Context(), 20)
+	if err == nil || !strings.Contains(err.Error(), "http 429") {
+		t.Fatalf("expected rate-limit error, got %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 attempt when retry delay exceeds budget, got %d", attempts)
 	}
 }
 
@@ -415,9 +467,14 @@ func TestParseAniListRetryDelay(t *testing.T) {
 			want:       0,
 		},
 		{
-			name:       "bounded",
+			name:       "over budget",
 			retryAfter: "120",
-			want:       anilistMaxRetryWait,
+			want:       anilistRetryDelayOverBudget,
+		},
+		{
+			name:  "reset over budget",
+			reset: strconv.FormatInt(now.Add(120*time.Second).Unix(), 10),
+			want:  anilistRetryDelayOverBudget,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- retry AniList HTTP 429 responses using `Retry-After` or `X-Ratelimit-Reset`, with context cancellation and a one-minute cumulative wait budget
- treat missing AniList metadata (HTTP 404) as the documented empty result
- avoid repeating the same MAL-ID search for title and filename terms
- add regression coverage for rate-limit parsing/retries, 404 handling, cancellation, and request count

## Checks

- `go test -race -v -timeout 20m ./internal/metadata/tmdb`
- `make gofix-check-changed`
- `make logpolicy`
- `make lint`
- pre-commit and pre-push hooks, including frontend typecheck

Closes #255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of AniList rate limits with automatic, bounded retries.
  - Retry delays now honor server guidance and stop promptly when requests are canceled.
  - Missing metadata now returns an empty result instead of an error.
  - Preserved rate-limit details in HTTP error responses.
  - Avoided redundant searches when a known MAL ID is available.

- **Tests**
  - Added coverage for rate-limit retries, retry-delay handling, cancellations, missing metadata, and search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->