### PR TITLE
fix(metadata): stop filename lookup after tracker ID

### DIFF
--- a/internal/metadata/tracker_data.go
+++ b/internal/metadata/tracker_data.go
@@ -903,7 +903,7 @@ func searchFileName(meta preparationstate.State) string {
 }
 
 func trackerLookupFileName(meta preparationstate.State, trackerID string, skipFilenameLookup bool) string {
-	if skipFilenameLookup && strings.TrimSpace(trackerID) == "" {
+	if skipFilenameLookup || strings.TrimSpace(trackerID) != "" {
 		return ""
 	}
 	return searchFileName(meta)

--- a/internal/metadata/tracker_data_test.go
+++ b/internal/metadata/tracker_data_test.go
@@ -117,13 +117,13 @@ func TestTrackerLookupFileNameKeepsFilenameWhenDefaultEnabled(t *testing.T) {
 	}
 }
 
-func TestTrackerLookupFileNameKeepsFilenameWithTrackerID(t *testing.T) {
+func TestTrackerLookupFileNameSkipsFilenameWithTrackerID(t *testing.T) {
 	meta := preparationstate.State{
 		SourcePath: `D:\Movies\Example.Show.S04E01.2160p.WEB.h265-GRP.mkv`,
 	}
 
-	if got := trackerLookupFileName(meta, "12345", true); got != "Example.Show.S04E01.2160p.WEB.h265-GRP.mkv" {
-		t.Fatalf("expected filename to remain available with tracker id, got %q", got)
+	if got := trackerLookupFileName(meta, "12345", false); got != "" {
+		t.Fatalf("expected filename lookup to stop when tracker id is known, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- stop passing filename-search input once a tracker ID is known
- cover the known-ID path with a regression test

## Why

A known tracker ID already selects the tracker result. Keeping filename search enabled lets filename-only adapters perform an unnecessary second lookup.

## Checks

- `go test -race -v -timeout 20m ./internal/metadata`
- `make test-go`
- `make lint`
- `make logpolicy`
- `make pathpolicy`
- `make gofix-check-changed`
- `make backend`
- pre-push frontend typecheck

Fixes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracker metadata handling to avoid unnecessary filename lookups when a tracker ID is already available.
  * Ensured filename information is correctly omitted in this scenario, even when filename lookup is otherwise enabled.

* **Tests**
  * Updated coverage to verify the corrected tracker filename behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->