### PR TITLE
feat(webui): add no-hash upload toggle

### DIFF
--- a/internal/core/workflow_upload_plan.go
+++ b/internal/core/workflow_upload_plan.go
@@ -236,6 +236,16 @@ func (b workflowUploadPlanBuilder) Build(
 		eligible = append(eligible, projection)
 		planProjections = append(planProjections, projection)
 	}
+	if options.NoHash != nil {
+		api.EmitWorkflowProgress(ctx, api.WorkflowProgressUpdate{
+			Phase:   "upload_plan",
+			Kind:    "policy",
+			Label:   "Torrent preparation policy",
+			Status:  api.StageStatusCompleted,
+			Total:   len(eligible),
+			Message: fmt.Sprintf("Torrent preparation policy selected no_hash=%t tracker_count=%d.", *options.NoHash, len(eligible)),
+		})
+	}
 	for _, projection := range planProjections {
 		api.EmitWorkflowProgress(ctx, api.WorkflowProgressUpdate{
 			Phase:     "upload_plan",

--- a/internal/core/workflow_upload_plan.go
+++ b/internal/core/workflow_upload_plan.go
@@ -115,6 +115,7 @@ func (b workflowUploadPlanBuilder) Fingerprint(
 		Descriptions     api.DescriptionSetRef
 		Description      api.WorkflowFingerprint
 		NoSeed           bool
+		NoHash           *bool `json:"NoHash,omitempty"`
 		RehashCooldown   int
 		TrackerIDs       []api.TrackerID
 		TrackerApproval  *api.TrackerApprovalSnapshotRef
@@ -130,6 +131,7 @@ func (b workflowUploadPlanBuilder) Fingerprint(
 		Descriptions:     api.DescriptionSetRef{ID: descriptions.ID, Revision: descriptions.Revision},
 		Description:      descriptions.InputFingerprint,
 		NoSeed:           options.NoSeed,
+		NoHash:           options.NoHash,
 		RehashCooldown:   b.config.TorrentCreation.RehashCooldown,
 		TrackerIDs:       append([]api.TrackerID(nil), options.TrackerIDs...),
 		TrackerApproval:  options.TrackerApproval,
@@ -172,6 +174,10 @@ func (b workflowUploadPlanBuilder) Build(
 		return api.UploadPlan{}, nil, errors.New("workflow upload plan: description inputs are incompatible")
 	}
 	descriptionInstructions.Options.NoSeed = options.NoSeed
+	if options.NoHash != nil {
+		noHash := *options.NoHash
+		descriptionInstructions.Torrent.NoHash = &noHash
+	}
 	inputFingerprint, err := b.Fingerprint(ctx, projections, dupes, media, descriptions, options)
 	if err != nil {
 		return api.UploadPlan{}, nil, err

--- a/internal/core/workflow_upload_plan_test.go
+++ b/internal/core/workflow_upload_plan_test.go
@@ -410,12 +410,16 @@ func TestWorkflowDryRunClientFailureRetainsReconciliationIdentity(t *testing.T) 
 	}
 }
 
-func TestWorkflowUploadPlanPassesSavedClientTorrentForValidation(t *testing.T) {
+func TestWorkflowUploadPlanAppliesNoHashOverrideAndReportsPolicy(t *testing.T) {
 	t.Parallel()
 
 	clientTorrent := "C:\\client\\BT_backup\\example.torrent"
 	savedNoHash := false
 	requestedNoHash := true
+	var updates []api.WorkflowProgressUpdate
+	ctx := api.WithWorkflowProgressReporter(context.Background(), func(update api.WorkflowProgressUpdate) {
+		updates = append(updates, update)
+	})
 	torrents := &workflowTorrentServiceCapture{}
 	builder := workflowUploadPlanBuilder{
 		resolver: workflowUploadResolverFixed{subject: api.UploadSubject{
@@ -426,7 +430,7 @@ func TestWorkflowUploadPlanPassesSavedClientTorrentForValidation(t *testing.T) {
 		torrents: torrents,
 	}
 	_, execution, err := builder.Build(
-		context.Background(),
+		ctx,
 		api.TrackerReleaseProjectionSet{Projections: []api.TrackerReleaseProjection{{
 			TrackerID:   "PTP",
 			Readiness:   api.ReadinessStatusReady,
@@ -454,6 +458,13 @@ func TestWorkflowUploadPlanPassesSavedClientTorrentForValidation(t *testing.T) {
 	}
 	if torrents.subject.TorrentOverrides.NoHash == nil || !*torrents.subject.TorrentOverrides.NoHash {
 		t.Fatalf("torrent no-hash override = %#v, want true", torrents.subject.TorrentOverrides.NoHash)
+	}
+	if !slices.ContainsFunc(updates, func(update api.WorkflowProgressUpdate) bool {
+		return update.Phase == "upload_plan" && update.Kind == "policy" && update.Label == "Torrent preparation policy" &&
+			update.Status == api.StageStatusCompleted && update.Completed == 0 && update.Total == 1 &&
+			update.Message == "Torrent preparation policy selected no_hash=true tracker_count=1."
+	}) {
+		t.Fatalf("no-hash policy progress = %#v", updates)
 	}
 }
 

--- a/internal/core/workflow_upload_plan_test.go
+++ b/internal/core/workflow_upload_plan_test.go
@@ -344,6 +344,15 @@ func TestWorkflowUploadPlanFingerprintChangesWithReviewedDependency(t *testing.T
 	if authorityFirst == authorityChanged {
 		t.Fatal("upload plan fingerprint ignored tracker authority")
 	}
+	noHash := true
+	options.NoHash = &noHash
+	noHashChanged, err := builder.Fingerprint(context.Background(), projections, dupes, media, descriptions, options)
+	if err != nil {
+		t.Fatalf("fingerprint no-hash upload plan: %v", err)
+	}
+	if authorityChanged == noHashChanged {
+		t.Fatal("upload plan fingerprint ignored no-hash option")
+	}
 }
 
 func TestDryRunClientInjectionReportsAggregateTerminalProgress(t *testing.T) {
@@ -405,6 +414,8 @@ func TestWorkflowUploadPlanPassesSavedClientTorrentForValidation(t *testing.T) {
 	t.Parallel()
 
 	clientTorrent := "C:\\client\\BT_backup\\example.torrent"
+	savedNoHash := false
+	requestedNoHash := true
 	torrents := &workflowTorrentServiceCapture{}
 	builder := workflowUploadPlanBuilder{
 		resolver: workflowUploadResolverFixed{subject: api.UploadSubject{
@@ -430,8 +441,8 @@ func TestWorkflowUploadPlanPassesSavedClientTorrentForValidation(t *testing.T) {
 		api.MediaArtifactSet{},
 		workflowMediaPrivateArtifacts{},
 		api.DescriptionSet{},
-		api.DescriptionInstructions{},
-		releaseworkflow.UploadPlanBuildOptions{},
+		api.DescriptionInstructions{Torrent: api.TorrentOverrides{NoHash: &savedNoHash}},
+		releaseworkflow.UploadPlanBuildOptions{NoHash: &requestedNoHash},
 		time.Now(),
 	)
 	if err != nil {
@@ -440,6 +451,9 @@ func TestWorkflowUploadPlanPassesSavedClientTorrentForValidation(t *testing.T) {
 	defer func() { _ = execution.Release() }()
 	if torrents.subject.ClientTorrentPath != clientTorrent {
 		t.Fatalf("client torrent path=%q, want %q", torrents.subject.ClientTorrentPath, clientTorrent)
+	}
+	if torrents.subject.TorrentOverrides.NoHash == nil || !*torrents.subject.TorrentOverrides.NoHash {
+		t.Fatalf("torrent no-hash override = %#v, want true", torrents.subject.TorrentOverrides.NoHash)
 	}
 }
 

--- a/internal/releaseworkflow/composite_upload.go
+++ b/internal/releaseworkflow/composite_upload.go
@@ -287,6 +287,7 @@ func normalizeCompositeUploadRequest(
 		MediaSelection:         selection,
 		Descriptions:           &descriptions,
 		NoSeed:                 optionalBool(request.Client.NoSeed),
+		NoHash:                 cloneBoolPointer(request.Torrent.NoHash),
 	}
 	fingerprint, err := api.CanonicalWorkflowFingerprint(requestFingerprintPayload(request))
 	if err != nil {
@@ -634,6 +635,13 @@ func cloneBoolPointer(value *bool) *bool {
 	}
 	cloned := *value
 	return &cloned
+}
+
+func boolPointersEqual(left, right *bool) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
 }
 
 func cloneIntPointer(value *int) *int {

--- a/internal/releaseworkflow/contracts.go
+++ b/internal/releaseworkflow/contracts.go
@@ -303,6 +303,7 @@ type RegisteredArtifactAuthority struct {
 type UploadPlanBuildOptions struct {
 	DryRun               bool
 	NoSeed               bool
+	NoHash               *bool
 	TrackerIDs           []api.TrackerID
 	TrackerApproval      *api.TrackerApprovalSnapshotRef
 	AuthorityFingerprint api.WorkflowFingerprint
@@ -922,6 +923,7 @@ type DryRunUploadsCommand struct {
 	WorkflowID       api.WorkflowID
 	ExpectedRevision api.WorkflowRevision
 	NoSeed           bool
+	NoHash           *bool
 	TrackerIDs       []api.TrackerID
 	IdempotencyKey   string
 }
@@ -933,8 +935,9 @@ func (c DryRunUploadsCommand) commandFingerprint() (api.WorkflowFingerprint, err
 	return canonicalCommandFingerprint(struct {
 		ExpectedRevision api.WorkflowRevision
 		NoSeed           bool
+		NoHash           *bool `json:"NoHash,omitempty"`
 		TrackerIDs       []api.TrackerID
-	}{c.ExpectedRevision, c.NoSeed, c.TrackerIDs})
+	}{c.ExpectedRevision, c.NoSeed, c.NoHash, c.TrackerIDs})
 }
 
 // ExecuteUploadsCommand directly prepares and executes eligible trackers.
@@ -942,6 +945,7 @@ type ExecuteUploadsCommand struct {
 	WorkflowID       api.WorkflowID
 	ExpectedRevision api.WorkflowRevision
 	NoSeed           bool
+	NoHash           *bool
 	TrackerIDs       []api.TrackerID
 	Interaction      api.InteractionMode
 	IdempotencyKey   string
@@ -957,15 +961,17 @@ func (c ExecuteUploadsCommand) commandFingerprint() (api.WorkflowFingerprint, er
 		return canonicalCommandFingerprint(struct {
 			ExpectedRevision api.WorkflowRevision
 			NoSeed           bool
+			NoHash           *bool `json:"NoHash,omitempty"`
 			TrackerIDs       []api.TrackerID
 			Interaction      api.InteractionMode
-		}{c.ExpectedRevision, c.NoSeed, c.TrackerIDs, c.Interaction})
+		}{c.ExpectedRevision, c.NoSeed, c.NoHash, c.TrackerIDs, c.Interaction})
 	}
 	return canonicalCommandFingerprint(struct {
 		ExpectedRevision api.WorkflowRevision
 		NoSeed           bool
+		NoHash           *bool `json:"NoHash,omitempty"`
 		TrackerIDs       []api.TrackerID
-	}{c.ExpectedRevision, c.NoSeed, c.TrackerIDs})
+	}{c.ExpectedRevision, c.NoSeed, c.NoHash, c.TrackerIDs})
 }
 
 // RetryFailedUploadsCommand retries only failed trackers from one exact prior result.
@@ -974,6 +980,7 @@ type RetryFailedUploadsCommand struct {
 	ExpectedRevision api.WorkflowRevision
 	Retry            api.FailedTrackerRetryRef
 	NoSeed           bool
+	NoHash           *bool
 	IdempotencyKey   string
 }
 
@@ -987,7 +994,8 @@ func (c RetryFailedUploadsCommand) commandFingerprint() (api.WorkflowFingerprint
 		ExpectedRevision api.WorkflowRevision
 		Retry            api.FailedTrackerRetryRef
 		NoSeed           bool
-	}{c.ExpectedRevision, c.Retry, c.NoSeed})
+		NoHash           *bool `json:"NoHash,omitempty"`
+	}{c.ExpectedRevision, c.Retry, c.NoSeed, c.NoHash})
 }
 
 // RetryClientInjectionsCommand retries retained client effects without

--- a/internal/releaseworkflow/module.go
+++ b/internal/releaseworkflow/module.go
@@ -5246,6 +5246,7 @@ type preparedUploads struct {
 	plan         api.UploadPlan
 	execution    RetainedUploadExecution
 	dryRun       bool
+	noHash       *bool
 }
 
 func (p *preparedUploads) Release() error {
@@ -5348,6 +5349,7 @@ func (m *Module) prepareUploads(
 		plan:         plan,
 		execution:    execution,
 		dryRun:       options.DryRun,
+		noHash:       cloneBoolPointer(options.NoHash),
 	}, nil
 }
 
@@ -5409,6 +5411,7 @@ func (m *Module) dryRunUploads(
 		UploadPlanBuildOptions{
 			DryRun:     true,
 			NoSeed:     command.NoSeed,
+			NoHash:     cloneBoolPointer(command.NoHash),
 			TrackerIDs: command.TrackerIDs,
 		},
 		now,
@@ -5443,6 +5446,7 @@ func (m *Module) dryRunUploads(
 		Descriptions:     api.DescriptionSetRef{ID: prepared.descriptions.ID, Revision: prepared.descriptions.Revision},
 		InputFingerprint: prepared.plan.InputFingerprint,
 		NoSeed:           command.NoSeed,
+		NoHash:           cloneBoolPointer(command.NoHash),
 		TrackerIDs:       append([]api.TrackerID(nil), prepared.trackerIDs...),
 		Reports:          reports,
 		SucceededCount:   succeededCount,
@@ -5779,7 +5783,7 @@ func (m *Module) executeUploads(
 			Recovery:  api.OperationRecoveryConfirm,
 		}, ErrInvalidTransition)
 	}
-	prepared, err := m.preparedUploadsForExecution(ctx, ownerID, state, command.NoSeed, command.TrackerIDs, now)
+	prepared, err := m.preparedUploadsForExecution(ctx, ownerID, state, command.NoSeed, command.NoHash, command.TrackerIDs, now)
 	if err != nil {
 		return CommandResult{}, err
 	}
@@ -5841,11 +5845,16 @@ func (m *Module) preparedUploadsForExecution(
 	ownerID string,
 	state *State,
 	noSeed bool,
+	noHash *bool,
 	trackerIDs []api.TrackerID,
 	now time.Time,
 ) (preparedUploads, error) {
 	if state.Workflow.DryRun == nil {
-		return m.prepareUploads(ctx, ownerID, state, UploadPlanBuildOptions{NoSeed: noSeed, TrackerIDs: trackerIDs}, now)
+		return m.prepareUploads(ctx, ownerID, state, UploadPlanBuildOptions{
+			NoSeed:     noSeed,
+			NoHash:     cloneBoolPointer(noHash),
+			TrackerIDs: trackerIDs,
+		}, now)
 	}
 	value, err := m.private.Consume(
 		ownerID,
@@ -5866,7 +5875,7 @@ func (m *Module) preparedUploadsForExecution(
 		releasePrivateResource(value)
 		return preparedUploads{}, errors.New("release workflow exact upload plan has an invalid private resource type")
 	}
-	if !prepared.dryRun || !prepared.plan.ExpiresAt.After(now) ||
+	if !prepared.dryRun || !boolPointersEqual(prepared.noHash, noHash) || !prepared.plan.ExpiresAt.After(now) ||
 		state.Workflow.TrackerProjections == nil || prepared.plan.ProjectionSet != *state.Workflow.TrackerProjections ||
 		state.Workflow.Dupes == nil || prepared.plan.Dupes != *state.Workflow.Dupes ||
 		!trackerApprovalRefsEqual(prepared.plan.TrackerApproval, state.Workflow.TrackerApproval) ||
@@ -5915,7 +5924,17 @@ func (m *Module) retryFailedUploads(
 	if len(targets) == 0 {
 		return CommandResult{}, fmt.Errorf("%w: failed upload retry targets are required", ErrInvalidTransition)
 	}
-	prepared, err := m.prepareUploads(ctx, ownerID, state, UploadPlanBuildOptions{NoSeed: command.NoSeed, TrackerIDs: targets}, now)
+	prepared, err := m.prepareUploads(
+		ctx,
+		ownerID,
+		state,
+		UploadPlanBuildOptions{
+			NoSeed:     command.NoSeed,
+			NoHash:     cloneBoolPointer(command.NoHash),
+			TrackerIDs: targets,
+		},
+		now,
+	)
 	if err != nil {
 		return CommandResult{}, err
 	}

--- a/internal/releaseworkflow/module_test.go
+++ b/internal/releaseworkflow/module_test.go
@@ -692,8 +692,9 @@ func (f *uploadPlanBuilderFake) Fingerprint(
 		Media        api.MediaArtifactSetID
 		Descriptions api.DescriptionSetID
 		NoSeed       bool
+		NoHash       *bool `json:"NoHash,omitempty"`
 		TrackerIDs   []api.TrackerID
-	}{projections.ID, dupes.ID, media.ID, descriptions.ID, options.NoSeed, options.TrackerIDs})
+	}{projections.ID, dupes.ID, media.ID, descriptions.ID, options.NoSeed, options.NoHash, options.TrackerIDs})
 	if err != nil {
 		return "", fmt.Errorf("upload plan input fingerprint: %w", err)
 	}
@@ -1944,15 +1945,18 @@ func TestModuleDuplicateAssessmentIsRetainedAndDecisionsDoNotRepeatSearch(t *tes
 	if current.Descriptions == nil || current.Descriptions.ID != generated.Descriptions.ID || current.Media == nil || current.Dupes == nil {
 		t.Fatalf("current workflow snapshots = %#v", current)
 	}
+	noHash := true
 	dryRunCommand := DryRunUploadsCommand{
 		WorkflowID:       reused.Workflow.ID,
 		ExpectedRevision: reused.Workflow.Revision,
 		NoSeed:           true,
+		NoHash:           &noHash,
 		IdempotencyKey:   "upload-dry-run",
 	}
 	dryRun := executeCommand(t, module, dryRunCommand)
 	if dryRun.DryRun == nil || dryRun.DryRun.Status != api.StageStatusCompleted || len(dryRun.DryRun.Reports) != 1 ||
-		dryRun.DryRun.Reports[0].ClientInjection.Status != api.StageStatusSkipped || uploadPlans.builds != 1 {
+		dryRun.DryRun.Reports[0].ClientInjection.Status != api.StageStatusSkipped || dryRun.DryRun.NoHash == nil || !*dryRun.DryRun.NoHash ||
+		uploadPlans.builds != 1 || len(uploadPlans.options) != 1 || uploadPlans.options[0].NoHash == nil || !*uploadPlans.options[0].NoHash {
 		t.Fatalf("direct dry run = %#v builds=%d", dryRun.DryRun, uploadPlans.builds)
 	}
 	repeatedDryRun := executeCommand(t, module, dryRunCommand)
@@ -1964,6 +1968,7 @@ func TestModuleDuplicateAssessmentIsRetainedAndDecisionsDoNotRepeatSearch(t *tes
 		WorkflowID:       repeatedDryRun.Workflow.ID,
 		ExpectedRevision: repeatedDryRun.Workflow.Revision,
 		NoSeed:           true,
+		NoHash:           &noHash,
 		IdempotencyKey:   "upload-exact-reviewed-plan",
 	})
 	if reviewedUpload.UploadResult == nil || reviewedUpload.UploadResult.Status != api.StageStatusCompleted ||

--- a/internal/releaseworkflow/planner.go
+++ b/internal/releaseworkflow/planner.go
@@ -515,6 +515,7 @@ func planContinuationCommand(
 		return nil, ""
 	}
 	if current.DryRun == nil || current.DryRun.NoSeed != request.Intent.NoSeed ||
+		!boolPointersEqual(current.DryRun.NoHash, request.Intent.NoHash) ||
 		(len(request.Intent.UploadTrackerIDs) > 0 &&
 			!slices.Equal(
 				normalizeContinuationTrackerIDs(current.DryRun.TrackerIDs),
@@ -524,6 +525,7 @@ func planContinuationCommand(
 			WorkflowID:       workflowID,
 			ExpectedRevision: revision,
 			NoSeed:           request.Intent.NoSeed,
+			NoHash:           cloneBoolPointer(request.Intent.NoHash),
 			TrackerIDs:       append([]api.TrackerID(nil), request.Intent.UploadTrackerIDs...),
 			IdempotencyKey:   key("review-uploads"),
 		}, "review-uploads"
@@ -535,6 +537,7 @@ func planContinuationCommand(
 		WorkflowID:       workflowID,
 		ExpectedRevision: revision,
 		NoSeed:           request.Intent.NoSeed,
+		NoHash:           cloneBoolPointer(request.Intent.NoHash),
 		TrackerIDs:       append([]api.TrackerID(nil), request.Intent.UploadTrackerIDs...),
 		Interaction:      continuationInteractionMode(request.Intent),
 		IdempotencyKey:   key("execute-uploads"),
@@ -788,6 +791,7 @@ func continuationGoalReached(current CommandResult, request api.ContinueReleaseW
 		return descriptionsHaveViableTracker(current.Descriptions)
 	case api.WorkflowGoalUploadReviewed, api.WorkflowGoalDryRun:
 		return current.DryRun != nil && current.DryRun.NoSeed == request.Intent.NoSeed &&
+			boolPointersEqual(current.DryRun.NoHash, request.Intent.NoHash) &&
 			(len(request.Intent.UploadTrackerIDs) == 0 ||
 				slices.Equal(
 					normalizeContinuationTrackerIDs(current.DryRun.TrackerIDs),

--- a/internal/releaseworkflow/planner_test.go
+++ b/internal/releaseworkflow/planner_test.go
@@ -663,6 +663,42 @@ func readyContinuationPlannerResult(t *testing.T, now time.Time) CommandResult {
 	}
 }
 
+func TestContinuationPlannerRebuildsDryRunWhenNoHashChanges(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 23, 1, 2, 3, 0, time.UTC)
+	current := readyContinuationPlannerResult(t, now)
+	current.Media = &api.MediaArtifactSet{Status: api.StageStatusCompleted, ImageRequirementsPrepared: true}
+	current.Descriptions = &api.DescriptionSet{
+		Status: api.StageStatusCompleted,
+		TrackerResults: []api.DescriptionTrackerResult{{
+			TrackerID: "ALPHA",
+			Status:    api.StageStatusCompleted,
+		}},
+	}
+	priorNoHash := true
+	current.DryRun = &api.UploadDryRunResult{NoHash: &priorNoHash}
+	desiredNoHash := false
+	request := api.ContinueReleaseWorkflowRequest{
+		IdempotencyKey: "continue-no-hash-change",
+		Goal:           api.WorkflowGoalDryRun,
+		Intent: api.WorkflowIntent{
+			TrackerIDs:             []api.TrackerID{"ALPHA"},
+			ProjectionInstructions: map[api.TrackerID]api.TrackerProjectionInstructions{},
+			NoHash:                 &desiredNoHash,
+		},
+	}
+
+	if continuationGoalReached(current, request) {
+		t.Fatal("changed no-hash option satisfied the retained dry run")
+	}
+	command, stage := planContinuationCommand(request, current, now)
+	dryRun, ok := command.(DryRunUploadsCommand)
+	if !ok || stage != "review-uploads" || dryRun.NoHash == nil || *dryRun.NoHash {
+		t.Fatalf("changed no-hash plan: stage=%q command=%#v", stage, command)
+	}
+}
+
 func TestContinuationPlannerAdvancesRunnableSiblingPastPendingDupe(t *testing.T) {
 	t.Parallel()
 

--- a/internal/releaseworkflow/request_mapping.go
+++ b/internal/releaseworkflow/request_mapping.go
@@ -177,6 +177,7 @@ func CommandFromRequest(request any) (Command, error) {
 			WorkflowID:       request.WorkflowID,
 			ExpectedRevision: request.ExpectedRevision,
 			NoSeed:           request.NoSeed,
+			NoHash:           cloneBoolPointer(request.NoHash),
 			TrackerIDs:       append([]api.TrackerID(nil), request.TrackerIDs...),
 			IdempotencyKey:   request.IdempotencyKey,
 		}, nil
@@ -185,6 +186,7 @@ func CommandFromRequest(request any) (Command, error) {
 			WorkflowID:       request.WorkflowID,
 			ExpectedRevision: request.ExpectedRevision,
 			NoSeed:           request.NoSeed,
+			NoHash:           cloneBoolPointer(request.NoHash),
 			TrackerIDs:       append([]api.TrackerID(nil), request.TrackerIDs...),
 			IdempotencyKey:   request.IdempotencyKey,
 		}, nil
@@ -194,6 +196,7 @@ func CommandFromRequest(request any) (Command, error) {
 			ExpectedRevision: request.ExpectedRevision,
 			Retry:            request.Retry,
 			NoSeed:           request.NoSeed,
+			NoHash:           cloneBoolPointer(request.NoHash),
 			IdempotencyKey:   request.IdempotencyKey,
 		}, nil
 	case api.RetryReleaseWorkflowClientInjectionRequest:

--- a/internal/releaseworkflow/request_mapping_test.go
+++ b/internal/releaseworkflow/request_mapping_test.go
@@ -23,6 +23,7 @@ func TestCommandFromRequestRejectsInvalidSharedRequest(t *testing.T) {
 func TestCommandFromRequestMapsDirectUploadExactly(t *testing.T) {
 	t.Parallel()
 
+	noHash := true
 	request := api.UploadReleaseWorkflowRequest{
 		ReleaseWorkflowCommandContext: api.ReleaseWorkflowCommandContext{
 			WorkflowID:       api.WorkflowID("workflow-1"),
@@ -30,6 +31,7 @@ func TestCommandFromRequestMapsDirectUploadExactly(t *testing.T) {
 			IdempotencyKey:   "upload-1",
 		},
 		NoSeed:     true,
+		NoHash:     &noHash,
 		TrackerIDs: []api.TrackerID{"ALPHA"},
 	}
 
@@ -43,6 +45,7 @@ func TestCommandFromRequestMapsDirectUploadExactly(t *testing.T) {
 	}
 	if command.WorkflowID != request.WorkflowID || command.ExpectedRevision != request.ExpectedRevision ||
 		command.IdempotencyKey != request.IdempotencyKey || command.NoSeed != request.NoSeed ||
+		!boolPointersEqual(command.NoHash, request.NoHash) ||
 		!slices.Equal(command.TrackerIDs, request.TrackerIDs) {
 		t.Fatalf("command = %#v, request = %#v", command, request)
 	}

--- a/internal/webserver/openapi/release-workflow-v1.json
+++ b/internal/webserver/openapi/release-workflow-v1.json
@@ -6458,6 +6458,16 @@
           "idempotencyKey": {
             "type": "string"
           },
+          "noHash": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "noSeed": {
             "type": "boolean"
           },
@@ -9103,6 +9113,16 @@
           "media": {
             "$ref": "#/components/schemas/MediaArtifactSetRef"
           },
+          "noHash": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "noSeed": {
             "type": "boolean"
           },
@@ -9753,6 +9773,16 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/WorkflowMediaSelection"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "noHash": {
+            "anyOf": [
+              {
+                "type": "boolean"
               },
               {
                 "type": "null"
@@ -12798,6 +12828,16 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "noHash": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
                   "noSeed": {
                     "type": "boolean"
                   },

--- a/pkg/api/workflow_continuation.go
+++ b/pkg/api/workflow_continuation.go
@@ -86,6 +86,8 @@ type WorkflowIntent struct {
 	Descriptions           *DescriptionInstructions                    `json:"descriptions,omitempty"`
 	UploadTrackerIDs       []TrackerID                                 `json:"uploadTrackerIds,omitempty"`
 	NoSeed                 bool                                        `json:"noSeed,omitempty"`
+	// NoHash overrides retained torrent instructions when present. False explicitly permits hashing.
+	NoHash *bool `json:"noHash,omitempty"`
 }
 
 // WorkflowMediaSelection distinguishes default-all selection from an explicit exact selection.

--- a/pkg/api/workflow_intent_contracts.go
+++ b/pkg/api/workflow_intent_contracts.go
@@ -120,6 +120,7 @@ type UploadDryRunResult struct {
 	Descriptions     DescriptionSetRef              `json:"descriptions"`
 	InputFingerprint WorkflowFingerprint            `json:"inputFingerprint"`
 	NoSeed           bool                           `json:"noSeed"`
+	NoHash           *bool                          `json:"noHash,omitempty"`
 	TrackerIDs       []TrackerID                    `json:"trackerIds"`
 	Reports          []TrackerDryRunReport          `json:"reports"`
 	SucceededCount   int                            `json:"succeededCount"`

--- a/pkg/api/workflow_requests.go
+++ b/pkg/api/workflow_requests.go
@@ -444,6 +444,7 @@ func (r ResetReleaseWorkflowDescriptionOverrideRequest) Validate() error {
 type DryRunReleaseWorkflowRequest struct {
 	ReleaseWorkflowCommandContext
 	NoSeed     bool        `json:"noSeed"`
+	NoHash     *bool       `json:"noHash,omitempty"`
 	TrackerIDs []TrackerID `json:"trackerIds,omitempty"`
 }
 
@@ -459,6 +460,7 @@ func (r DryRunReleaseWorkflowRequest) Validate() error {
 type UploadReleaseWorkflowRequest struct {
 	ReleaseWorkflowCommandContext
 	NoSeed     bool        `json:"noSeed"`
+	NoHash     *bool       `json:"noHash,omitempty"`
 	TrackerIDs []TrackerID `json:"trackerIds,omitempty"`
 }
 
@@ -490,6 +492,7 @@ type RetryReleaseWorkflowUploadRequest struct {
 	ReleaseWorkflowCommandContext
 	Retry  FailedTrackerRetryRef `json:"retry"`
 	NoSeed bool                  `json:"noSeed"`
+	NoHash *bool                 `json:"noHash,omitempty"`
 }
 
 // Validate verifies exact workflow authority and explicit failed-tracker targets.

--- a/webui/src/api/generated/release-workflow.ts
+++ b/webui/src/api/generated/release-workflow.ts
@@ -1505,6 +1505,7 @@ export type RetryReleaseWorkflowImageHostRequest = Readonly<{
 export type RetryReleaseWorkflowUploadRequest = Readonly<{
   expectedRevision: WorkflowRevision;
   idempotencyKey: string;
+  noHash?: boolean | null;
   noSeed: boolean;
   retry: FailedTrackerRetryRef;
   workflowId: WorkflowID;
@@ -2200,6 +2201,7 @@ export type UploadDryRunResult = Readonly<{
   id: UploadDryRunResultID;
   inputFingerprint: WorkflowFingerprint;
   media: MediaArtifactSetRef;
+  noHash?: boolean | null;
   noSeed: boolean;
   projectionSet: TrackerReleaseProjectionSetRef;
   reports: readonly TrackerDryRunReport[];
@@ -2371,6 +2373,7 @@ export type WorkflowIntent = Readonly<{
   interaction?: InteractionMode;
   media?: MediaCaptureInstructions | null;
   mediaSelection?: WorkflowMediaSelection | null;
+  noHash?: boolean | null;
   noSeed?: boolean;
   preparation?: PrepareInput | null;
   projectionInstructions?: Readonly<Record<string, TrackerProjectionInstructions>>;

--- a/webui/src/pages/tracker_upload/index.test.tsx
+++ b/webui/src/pages/tracker_upload/index.test.tsx
@@ -18,7 +18,7 @@ const uploadFacet = (
     projections: null,
     ignoredDupesFor: [],
     questionnaireAnswers: {},
-    options: { noSeed: false, runLogLevel: "info" },
+    options: { noSeed: false, noHash: false, runLogLevel: "info" },
     dryRunStatus: "idle",
     uploadStatus: "idle",
     dryRunResult: null,
@@ -51,6 +51,17 @@ describe("TrackerUploadPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Start upload" }));
     expect(runDryRun).toHaveBeenCalledOnce();
     expect(start).toHaveBeenCalledOnce();
+  });
+
+  it("offers reuse-only torrent creation", () => {
+    const changeOptions = vi.fn();
+    renderPage(uploadFacet({}, { changeOptions }));
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Reuse existing torrent (skip hashing)" }),
+    );
+
+    expect(changeOptions).toHaveBeenCalledWith({ noHash: true });
   });
 
   it("collects questionnaire answers from current workflow projections", () => {

--- a/webui/src/pages/tracker_upload/index.tsx
+++ b/webui/src/pages/tracker_upload/index.tsx
@@ -138,6 +138,14 @@ export default function TrackerUploadPage({ facet }: Props) {
             />
             Skip client injection
           </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={view.options.noHash}
+              onChange={(event) => facet.changeOptions({ noHash: event.target.checked })}
+            />
+            Reuse existing torrent (skip hashing)
+          </label>
           <label className="grid gap-1">
             <span className="label">Log level</span>
             <select

--- a/webui/src/releaseSession/index.test.tsx
+++ b/webui/src/releaseSession/index.test.tsx
@@ -157,6 +157,7 @@ type WorkflowStageFixtures = Readonly<{
   dryRunUploads(
     current: ReleaseWorkflowCurrent,
     noSeed: boolean,
+    noHash: boolean | null | undefined,
     trackerIDs: readonly string[],
     idempotencyKey: string,
     signal: AbortSignal,
@@ -164,6 +165,7 @@ type WorkflowStageFixtures = Readonly<{
   executeUploads(
     current: ReleaseWorkflowCurrent,
     noSeed: boolean,
+    noHash: boolean | null | undefined,
     trackerIDs: readonly string[],
     idempotencyKey: string,
     signal: AbortSignal,
@@ -288,6 +290,7 @@ const workflowPorts = (overrides: Partial<TestWorkflowPorts> = {}): TestWorkflow
           next = await activePorts.dryRunUploads(
             current,
             request.intent.noSeed || false,
+            request.intent.noHash,
             request.intent.uploadTrackerIds || [],
             request.idempotencyKey,
             signal,
@@ -311,6 +314,7 @@ const workflowPorts = (overrides: Partial<TestWorkflowPorts> = {}): TestWorkflow
                 descriptions: { id: `${workflowID}-descriptions`, revision: 1 },
                 inputFingerprint: "2".repeat(64),
                 noSeed: request.intent.noSeed || false,
+                noHash: request.intent.noHash,
                 trackerIds: request.intent.uploadTrackerIds || [],
                 reports: [],
                 succeededCount: 0,
@@ -328,6 +332,7 @@ const workflowPorts = (overrides: Partial<TestWorkflowPorts> = {}): TestWorkflow
           next = await activePorts.executeUploads(
             current,
             request.intent.noSeed || false,
+            request.intent.noHash,
             request.intent.uploadTrackerIds || [],
             request.idempotencyKey,
             signal,
@@ -650,7 +655,7 @@ describe("useReleaseSession", () => {
     window.sessionStorage.removeItem("upbrr.activeReleaseWorkflow");
   });
 
-  it("passes the current skip-client option to an explicit workflow dry run", async () => {
+  it("passes current upload options to an explicit workflow dry run", async () => {
     const workflowID = "workflow-dry-run-options";
     window.sessionStorage.setItem("upbrr.activeReleaseWorkflow", workflowID);
     const retained = workflowCurrent(workflowID, 7);
@@ -667,11 +672,12 @@ describe("useReleaseSession", () => {
     });
 
     await waitFor(() => expect(result.current.workflow.view.status).toBe("ready"));
-    act(() => result.current.upload.changeOptions({ noSeed: true }));
+    act(() => result.current.upload.changeOptions({ noSeed: true, noHash: true }));
     await act(() => result.current.upload.runDryRun());
 
     expect(dryRunUploads).toHaveBeenCalledWith(
       expect.objectContaining({ workflow: expect.objectContaining({ id: workflowID }) }),
+      true,
       true,
       [],
       expect.any(String),
@@ -851,6 +857,7 @@ describe("useReleaseSession", () => {
     });
 
     await waitFor(() => expect(result.current.workflow.view.status).toBe("ready"));
+    act(() => result.current.upload.changeOptions({ noHash: true }));
     await act(async () => {
       expect(await result.current.upload.start()).toBe(true);
     });
@@ -858,6 +865,7 @@ describe("useReleaseSession", () => {
     expect(executeUploads).toHaveBeenCalledWith(
       expect.objectContaining({ workflow: expect.objectContaining({ id: workflowID }) }),
       false,
+      true,
       [],
       expect.any(String),
       expect.any(AbortSignal),
@@ -1413,6 +1421,7 @@ describe("useReleaseSession", () => {
         workflow: expect.objectContaining({ id: "workflow-browser-flow" }),
       }),
       false,
+      false,
       [],
       expect.any(String),
       expect.any(AbortSignal),
@@ -1739,18 +1748,22 @@ describe("useReleaseSession", () => {
     const { result } = renderHook(useReleaseSession, { wrapper: wrapperFor(portsFor()) });
     await selectAndPrepare(result, "C:\\media\\Example");
     act(() => result.current.upload.chooseTrackers(["AITHER", "BLU"]));
-    act(() => result.current.upload.changeOptions({ noSeed: true, runLogLevel: "debug" }));
+    act(() =>
+      result.current.upload.changeOptions({ noSeed: true, noHash: true, runLogLevel: "debug" }),
+    );
     act(() => result.current.upload.answerQuestionnaire("AITHER", "season", "1"));
 
     await act(() => result.current.input.prepare());
     expect(result.current.upload.view.selectedTrackers).toEqual(["AITHER", "BLU"]);
     expect(result.current.upload.view.options.noSeed).toBe(true);
+    expect(result.current.upload.view.options.noHash).toBe(true);
     expect(result.current.upload.view.options.runLogLevel).toBe("debug");
     expect(result.current.upload.view.questionnaireAnswers.AITHER).toEqual({ season: "1" });
 
     act(() => result.current.input.selectSource("C:\\media\\Other"));
     expect(result.current.upload.view.selectedTrackers).toEqual([]);
     expect(result.current.upload.view.options.noSeed).toBe(false);
+    expect(result.current.upload.view.options.noHash).toBe(false);
     expect(result.current.upload.view.options.runLogLevel).toBe("info");
     expect(result.current.upload.view.questionnaireAnswers).toEqual({});
   });
@@ -1969,35 +1982,42 @@ describe("useReleaseSession", () => {
   });
 
   it("lets the backend resolve dry-run trackers from current downstream authority", async () => {
-    const dryRunUploads = vi.fn(async (current: ReleaseWorkflowCurrent, noSeed: boolean) => {
-      const revision = current.workflow.revision + 1;
-      return {
-        ...current,
-        workflow: {
-          ...current.workflow,
-          revision,
-          dryRun: { id: "dry-run-1", revision },
-        },
-        dryRun: {
-          id: "dry-run-1",
-          workflowId: current.workflow.id,
-          revision,
-          projectionSet: current.workflow.trackerProjections!,
-          dupes: current.workflow.dupes!,
-          media: { id: "media-1", revision: 1 },
-          descriptions: { id: "descriptions-1", revision: 1 },
-          inputFingerprint: "1".repeat(64),
-          noSeed,
-          trackerIds: ["AITHER"],
-          reports: [],
-          succeededCount: 0,
-          failedCount: 0,
-          skippedCount: 0,
-          status: "skipped" as const,
-          createdAt: "2026-07-22T00:00:00Z",
-        },
-      } as ReleaseWorkflowCurrent;
-    });
+    const dryRunUploads = vi.fn(
+      async (
+        current: ReleaseWorkflowCurrent,
+        noSeed: boolean,
+        noHash: boolean | null | undefined,
+      ) => {
+        const revision = current.workflow.revision + 1;
+        return {
+          ...current,
+          workflow: {
+            ...current.workflow,
+            revision,
+            dryRun: { id: "dry-run-1", revision },
+          },
+          dryRun: {
+            id: "dry-run-1",
+            workflowId: current.workflow.id,
+            revision,
+            projectionSet: current.workflow.trackerProjections!,
+            dupes: current.workflow.dupes!,
+            media: { id: "media-1", revision: 1 },
+            descriptions: { id: "descriptions-1", revision: 1 },
+            inputFingerprint: "1".repeat(64),
+            noSeed,
+            noHash,
+            trackerIds: ["AITHER"],
+            reports: [],
+            succeededCount: 0,
+            failedCount: 0,
+            skippedCount: 0,
+            status: "skipped" as const,
+            createdAt: "2026-07-22T00:00:00Z",
+          },
+        } as ReleaseWorkflowCurrent;
+      },
+    );
     const { result } = renderHook(useReleaseSession, {
       wrapper: wrapperFor(portsFor({ workflow: workflowPorts({ dryRunUploads }) })),
     });
@@ -2022,6 +2042,7 @@ describe("useReleaseSession", () => {
     expect(result.current.upload.view.dryRunStatus).toBe("ready");
     expect(dryRunUploads).toHaveBeenCalledWith(
       expect.anything(),
+      false,
       false,
       [],
       expect.any(String),

--- a/webui/src/releaseSession/index.tsx
+++ b/webui/src/releaseSession/index.tsx
@@ -1307,7 +1307,10 @@ export function ReleaseSessionProvider({
   };
 
   // Selected trackers are pre-dupe UI state; retained backend evidence owns the exact downstream set.
-  const backendResolvedUploadIntent = () => ({ noSeed: state.uploadOptions.noSeed });
+  const backendResolvedUploadIntent = () => ({
+    noSeed: state.uploadOptions.noSeed,
+    noHash: state.uploadOptions.noHash,
+  });
 
   const runDryRun = async (): Promise<boolean> => {
     if (!workflowView.current) return false;
@@ -1563,6 +1566,7 @@ export function ReleaseSessionProvider({
             { id: result.id, revision: result.revision },
             trackerIDs,
             state.uploadOptions.noSeed,
+            state.uploadOptions.noHash,
             commandID,
             signal,
           ),
@@ -2081,6 +2085,7 @@ export function ReleaseSessionProvider({
             { id: result.id, revision: result.revision },
             trackerIDs,
             state.uploadOptions.noSeed,
+            state.uploadOptions.noHash,
             commandID,
             signal,
           ),

--- a/webui/src/releaseSession/ports.ts
+++ b/webui/src/releaseSession/ports.ts
@@ -94,6 +94,7 @@ export type ReleaseWorkflowPorts = Readonly<{
     result: UploadResultRef,
     trackerIDs: readonly string[],
     noSeed: boolean,
+    noHash: boolean,
     idempotencyKey: string,
     signal: AbortSignal,
   ): Promise<ReleaseWorkflowCurrent>;

--- a/webui/src/releaseSession/production.test.ts
+++ b/webui/src/releaseSession/production.test.ts
@@ -98,7 +98,7 @@ describe("productionReleaseSessionPorts", () => {
     ]);
   });
 
-  it("reconciles dry-run and client-injection options through Continue", async () => {
+  it("reconciles upload options through Continue", async () => {
     const requests: Array<{ method: string; body: unknown }> = [];
     const current = {
       workflow: { id: "workflow-1", revision: 7 },
@@ -113,7 +113,7 @@ describe("productionReleaseSessionPorts", () => {
       {
         authority: { workflowId: "workflow-1", expectedRevision: 7 },
         goal: "dry_run",
-        intent: { noSeed: true },
+        intent: { noSeed: true, noHash: true },
         idempotencyKey: "dry-run-1",
       },
       new AbortController().signal,
@@ -125,8 +125,44 @@ describe("productionReleaseSessionPorts", () => {
         body: {
           authority: { workflowId: "workflow-1", expectedRevision: 7 },
           goal: "dry_run",
-          intent: { noSeed: true },
+          intent: { noSeed: true, noHash: true },
           idempotencyKey: "dry-run-1",
+        },
+      },
+    ]);
+  });
+
+  it("forwards no-hash when retrying failed uploads", async () => {
+    const requests: Array<{ method: string; body: unknown }> = [];
+    const current = {
+      workflow: { id: "workflow-1", revision: 7 },
+    } as ReleaseWorkflowCurrent;
+    setAppRequestHandlerForTests(async (method, body) => {
+      requests.push({ method, body });
+      return current;
+    });
+    const ports = productionReleaseSessionPorts();
+
+    await ports.workflow.retryFailedUploads(
+      current,
+      { id: "upload-1", revision: 6 },
+      ["EXAMPLE"],
+      false,
+      true,
+      "retry-1",
+      new AbortController().signal,
+    );
+
+    expect(requests).toEqual([
+      {
+        method: "RetryReleaseWorkflowUpload",
+        body: {
+          workflowId: "workflow-1",
+          expectedRevision: 7,
+          retry: { result: { id: "upload-1", revision: 6 }, trackerIds: ["EXAMPLE"] },
+          noSeed: false,
+          noHash: true,
+          idempotencyKey: "retry-1",
         },
       },
     ]);

--- a/webui/src/releaseSession/production.ts
+++ b/webui/src/releaseSession/production.ts
@@ -173,13 +173,14 @@ export const productionReleaseSessionPorts = (): ReleaseSessionPorts => ({
         signal,
       );
     },
-    retryFailedUploads: (current, result, trackerIDs, noSeed, idempotencyKey, signal) =>
+    retryFailedUploads: (current, result, trackerIDs, noSeed, noHash, idempotencyKey, signal) =>
       releaseWorkflowClient.retryFailedUploads(
         {
           workflowId: current.workflow.id,
           expectedRevision: current.workflow.revision,
           retry: { result, trackerIds: [...trackerIDs] },
           noSeed,
+          noHash,
           idempotencyKey,
         },
         signal,

--- a/webui/src/releaseSession/reducer.ts
+++ b/webui/src/releaseSession/reducer.ts
@@ -279,7 +279,11 @@ const clonePreparationIntent = (intent: PreparationIntent): PreparationIntent =>
   },
 });
 
-const emptyOptions = (): UploadRunOptions => ({ noSeed: false, runLogLevel: "info" });
+const emptyOptions = (): UploadRunOptions => ({
+  noSeed: false,
+  noHash: false,
+  runLogLevel: "info",
+});
 
 const emptyWorkflow = <T>(): WorkflowState<T> => ({
   revision: 0,

--- a/webui/src/releaseSession/types.ts
+++ b/webui/src/releaseSession/types.ts
@@ -75,6 +75,8 @@ export type PreparationIntent = Readonly<{
 
 export type UploadRunOptions = Readonly<{
   noSeed: boolean;
+  /** Require a compatible existing torrent instead of hashing a replacement. */
+  noHash: boolean;
   runLogLevel: string;
 }>;
 


### PR DESCRIPTION
## Summary
- add a tracker-upload toggle that reuses a compatible existing torrent instead of hashing
- carry the explicit no-hash choice through dry-run, upload, and retry contracts
- rebuild stale dry runs when the choice changes and apply it at upload-plan creation

If no compatible torrent exists, preparation fails instead of starting an expensive hash.

## Testing
- `make test-go`
- `make test-frontend`
- `make lint`
- `make workflow-contracts-check`
- `make gofix-check-changed`

Closes #179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Reuse existing torrent (skip hashing)” option to tracker uploads.
  * Preserved the no-hash setting across dry runs, uploads, retries, and workflow continuation.
  * Added API support for explicitly enabling or disabling no-hash behavior.

* **Bug Fixes**
  * Upload plans are now refreshed when the no-hash setting changes.
  * Retry operations correctly retain the selected no-hash option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->