### PR TITLE
fix(metadata): add hardcoded subtitle override

### DIFF
--- a/cmd/upbrr/cli_flag_parity_test.go
+++ b/cmd/upbrr/cli_flag_parity_test.go
@@ -109,6 +109,7 @@ func cliCompositeFlagManifest() map[string]cliCompositeFlagClass {
 		"force-recheck",
 		"foreign",
 		"get-dvd-menus",
+		"hardcoded-subs",
 		"hdb",
 		"imdb",
 		"imghost",

--- a/cmd/upbrr/cli_options.go
+++ b/cmd/upbrr/cli_options.go
@@ -79,6 +79,7 @@ type cliOptions struct {
 	SkipDupeAsActual      bool
 	DoubleDupeCheck       bool
 	Commentary            bool
+	HardcodedSubs         bool
 	PersonalRelease       bool
 	StreamOptimized       bool
 	WebDV                 bool
@@ -285,6 +286,8 @@ func parseCLIOptions(args []string) (cliOptions, map[string]bool, []string, erro
 	fs.BoolVar(&opts.DoubleDupeCheck, "double-dupe-check", false, "Double dupe check")
 	fs.BoolVar(&opts.Commentary, "mc", false, "Mark release as containing commentary")
 	fs.BoolVar(&opts.Commentary, "commentary", false, "Mark release as containing commentary")
+	fs.BoolVar(&opts.HardcodedSubs, "hc", false, "Mark release as containing hardcoded subtitles")
+	fs.BoolVar(&opts.HardcodedSubs, "hardcoded-subs", false, "Mark release as containing hardcoded subtitles")
 	fs.BoolVar(&opts.PersonalRelease, "pr", false, "Mark release as personal")
 	fs.BoolVar(&opts.PersonalRelease, "personalrelease", false, "Mark release as personal")
 	fs.BoolVar(&opts.StreamOptimized, "st", false, "Mark release as stream optimized")
@@ -509,6 +512,7 @@ func cliFlagAliases() map[string]string {
 		"sda":                  "skip-dupe-asking",
 		"ddc":                  "double-dupe-check",
 		"mc":                   "commentary",
+		"hc":                   "hardcoded-subs",
 		"pr":                   "personalrelease",
 		"st":                   "stream",
 		"a":                    "anon",
@@ -830,6 +834,9 @@ func buildMetadataOverrides(opts cliOptions, visited map[string]bool) api.Metada
 	}
 	if visited["commentary"] {
 		overrides.Commentary = boolPtr(opts.Commentary)
+	}
+	if visited["hardcoded-subs"] {
+		overrides.HardcodedSubs = boolPtr(opts.HardcodedSubs)
 	}
 	if visited["personalrelease"] {
 		overrides.PersonalRelease = boolPtr(opts.PersonalRelease)

--- a/cmd/upbrr/cli_options_test.go
+++ b/cmd/upbrr/cli_options_test.go
@@ -939,6 +939,7 @@ func TestBuildCLIRequestMetadataOverrides(t *testing.T) {
 		"--distributor", "Criterion",
 		"--original-language", "ja",
 		"--commentary",
+		"-hc",
 		"--personalrelease",
 		"--stream",
 		"--webdv",
@@ -960,6 +961,9 @@ func TestBuildCLIRequestMetadataOverrides(t *testing.T) {
 	}
 	if req.MetadataOverrides.Commentary == nil || !*req.MetadataOverrides.Commentary {
 		t.Fatalf("expected commentary override, got %#v", req.MetadataOverrides.Commentary)
+	}
+	if req.MetadataOverrides.HardcodedSubs == nil || !*req.MetadataOverrides.HardcodedSubs {
+		t.Fatalf("expected hardcoded subtitle override, got %#v", req.MetadataOverrides.HardcodedSubs)
 	}
 	if req.MetadataOverrides.PersonalRelease == nil || !*req.MetadataOverrides.PersonalRelease {
 		t.Fatalf("expected personal release override, got %#v", req.MetadataOverrides.PersonalRelease)

--- a/cmd/upbrr/cli_options_test.go
+++ b/cmd/upbrr/cli_options_test.go
@@ -977,6 +977,18 @@ func TestBuildCLIRequestMetadataOverrides(t *testing.T) {
 	if req.MetadataOverrides.Anime == nil || *req.MetadataOverrides.Anime {
 		t.Fatalf("expected not-anime to force anime=false, got %#v", req.MetadataOverrides.Anime)
 	}
+
+	falseOpts, falseVisited, falsePaths, err := parseCLIOptions([]string{"--hardcoded-subs=false", "movie.mkv"})
+	if err != nil {
+		t.Fatalf("parse false hardcoded subtitle override: %v", err)
+	}
+	falseReq, err := buildCLIRequest(falseOpts, falseVisited, falsePaths, 4)
+	if err != nil {
+		t.Fatalf("build false hardcoded subtitle override: %v", err)
+	}
+	if falseReq.MetadataOverrides.HardcodedSubs == nil || *falseReq.MetadataOverrides.HardcodedSubs {
+		t.Fatalf("expected hardcoded subtitle override false, got %#v", falseReq.MetadataOverrides.HardcodedSubs)
+	}
 }
 
 func TestBuildCLIRequestOmissionAliases(t *testing.T) {

--- a/cmd/upbrr/composite_upload.go
+++ b/cmd/upbrr/composite_upload.go
@@ -826,6 +826,7 @@ func compositeCLIFacts(instructions api.ReleaseFactInstructions) api.ReleaseWork
 			OriginalLanguage: cloneCLIStringPointer(instructions.Metadata.OriginalLanguage),
 			PersonalRelease:  cloneCLIBoolPointer(instructions.Metadata.PersonalRelease),
 			Commentary:       cloneCLIBoolPointer(instructions.Metadata.Commentary),
+			HardcodedSubs:    cloneCLIBoolPointer(instructions.Metadata.HardcodedSubs),
 			WebDV:            cloneCLIBoolPointer(instructions.Metadata.WebDV),
 			StreamOptimized:  cloneCLIBoolPointer(instructions.Metadata.StreamOptimized),
 			Anime:            cloneCLIBoolPointer(instructions.Metadata.Anime),

--- a/cmd/upbrr/composite_upload_test.go
+++ b/cmd/upbrr/composite_upload_test.go
@@ -51,6 +51,7 @@ func TestMapCLICompositeUploadRequestPreservesPerUploadOptions(t *testing.T) {
 			OriginalLanguage: new("English"),
 			PersonalRelease:  new(true),
 			Commentary:       new(true),
+			HardcodedSubs:    new(true),
 			WebDV:            new(true),
 			StreamOptimized:  new(true),
 			Anime:            new(false),
@@ -176,6 +177,8 @@ func TestMapCLICompositeUploadRequestPreservesPerUploadOptions(t *testing.T) {
 		*mapped.Preparation.Facts.ReleaseName.NoEpisodeTitle ||
 		mapped.Preparation.Facts.ReleaseName.NoDistributor == nil ||
 		*mapped.Preparation.Facts.ReleaseName.NoDistributor ||
+		mapped.Preparation.Facts.Metadata.HardcodedSubs == nil ||
+		!*mapped.Preparation.Facts.Metadata.HardcodedSubs ||
 		mapped.Preparation.Facts.Metadata.Anime == nil ||
 		*mapped.Preparation.Facts.Metadata.Anime {
 		t.Fatalf("fact mapping = %#v", mapped.Preparation.Facts)

--- a/documentation/docs/cli/index.md
+++ b/documentation/docs/cli/index.md
@@ -118,6 +118,7 @@ Process at most five entries from a queue folder:
 | `--service <value>`           | `-service`, `-serv`                               | Override streaming service.                       |
 | `--distributor <value>`       | `-distributor`, `-dist`                           | Override distributor.                             |
 | `--original-language <value>` | `-original-language`, `-ol`                       | Override original language.                       |
+| `--hardcoded-subs`            | `-hardcoded-subs`, `-hc`                          | Force hardcoded-subtitle handling.                |
 | `--edition <value>`           | `-edition`, `-repack`                             | Override edition text.                            |
 | `--season <value>`            | `-season`                                         | Override one season token, such as `5` or `S05`.  |
 | `--episode <value>`           | `-episode`                                        | Override one episode token, such as `5` or `E05`. |

--- a/documentation/docs/web-ui/index.md
+++ b/documentation/docs/web-ui/index.md
@@ -39,6 +39,10 @@ The left navigation follows the release workflow. Some pages appear or unlock on
 
 Navigation guards prevent later operations from silently using missing or stale prerequisites. When a page is unavailable, read the notice and return to the required stage.
 
+### Hardcoded subtitle override
+
+On **Input**, expand **Edit Release Details** and enable **Hardcoded subtitles** when automatic detection misses them. Leave it disabled to keep automatic detection. Trackers that require hardcoded-subtitle languages, including PTP, will then request them before upload.
+
 ## Settings
 
 Use **Settings** to manage:

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -260,7 +260,11 @@ func (s *Service) deriveMediaFacts(ctx context.Context, meta preparationstate.St
 		s.logger.Debugf("metadata: media details service=%q service_longname=%q", meta.Service, meta.ServiceLongName)
 	}
 
+	meta.HardcodedSubs = hardcodedSubsFromMeta(meta)
 	applyMetadataOverrides(&meta)
+	if s.logger != nil {
+		s.logger.Debugf("metadata: media details hardcoded_subs=%t", meta.HardcodedSubs)
+	}
 	meta.Audio = applyAudioLanguagePrefix(meta.Audio, meta)
 	RebuildReleaseName(&meta, s.logger)
 
@@ -352,6 +356,9 @@ func applyMetadataOverrides(meta *preparationstate.State) {
 	}
 	if overrides.Commentary != nil {
 		meta.HasCommentary = *overrides.Commentary
+	}
+	if overrides.HardcodedSubs != nil {
+		meta.HardcodedSubs = *overrides.HardcodedSubs
 	}
 	if overrides.WebDV != nil {
 		meta.WebDV = *overrides.WebDV
@@ -1636,6 +1643,23 @@ func containsExactHybrid(values []string) bool {
 	return slices.ContainsFunc(values, func(value string) bool {
 		return strings.EqualFold(strings.TrimSpace(value), "Hybrid")
 	})
+}
+
+// hardcodedSubsFromMeta centralizes automatic marker detection before explicit metadata overrides.
+func hardcodedSubsFromMeta(meta preparationstate.State) bool {
+	values := make([]string, 0, 5+len(meta.FileList)+len(meta.Release.Edition)+len(meta.Release.Other))
+	values = append(values,
+		pathutil.Base(meta.SourcePath),
+		pathutil.Base(meta.VideoPath),
+		meta.Filename,
+		meta.ReleaseName,
+		meta.ReleaseNameNoTag,
+	)
+	values = append(values, meta.FileList...)
+	values = append(values, meta.Release.Edition...)
+	values = append(values, meta.Release.Other...)
+	value := strings.ToLower(strings.Join(values, " "))
+	return strings.Contains(value, "hardsub") || strings.Contains(value, "hard-sub") || strings.Contains(value, "hardcoded")
 }
 
 // repackFromMeta scans source basenames and parsed release tokens so repack

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -1649,8 +1649,8 @@ func containsExactHybrid(values []string) bool {
 func hardcodedSubsFromMeta(meta preparationstate.State) bool {
 	values := make([]string, 0, 5+len(meta.FileList)+len(meta.Release.Edition)+len(meta.Release.Other))
 	values = append(values,
-		pathutil.Base(meta.SourcePath),
-		pathutil.Base(meta.VideoPath),
+		filepath.Base(meta.SourcePath),
+		filepath.Base(meta.VideoPath),
 		meta.Filename,
 		meta.ReleaseName,
 		meta.ReleaseNameNoTag,

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -800,6 +800,54 @@ func TestDeriveMediaFactsFoldsValueInstructionsIntoFactsAndName(t *testing.T) {
 	}
 }
 
+func TestDeriveMediaFactsResolvesHardcodedSubsOverride(t *testing.T) {
+	t.Parallel()
+
+	force := true
+	suppress := false
+	tests := []struct {
+		name       string
+		sourcePath string
+		override   *bool
+		want       bool
+	}{
+		{
+			name:       "automatic",
+			sourcePath: "Example.Release.2026.HARDSUB.1080p-GRP.mkv",
+			want:       true,
+		},
+		{
+			name:       "manual",
+			sourcePath: "Example.Release.2026.1080p-GRP.mkv",
+			override:   &force,
+			want:       true,
+		},
+		{
+			name:       "suppressed",
+			sourcePath: "Example.Release.2026.HARDSUB.1080p-GRP.mkv",
+			override:   &suppress,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			svc := NewService(&fakeRepo{}, WithConfig(config.Config{}))
+			meta, err := svc.deriveMediaFacts(context.Background(), preparationstate.State{
+				SourcePath: tt.sourcePath,
+				MetadataOverrides: api.MetadataOverrides{
+					HardcodedSubs: tt.override,
+				},
+			})
+			if err != nil {
+				t.Fatalf("derive media facts: %v", err)
+			}
+			if meta.HardcodedSubs != tt.want {
+				t.Fatalf("hardcoded subtitles = %t, want %t", meta.HardcodedSubs, tt.want)
+			}
+		})
+	}
+}
+
 func TestApplyMediaDetailsTreatsUsableMediaInfoWithoutHDRAsSDR(t *testing.T) {
 	miPath := filepath.Join(t.TempDir(), "mediainfo.json")
 	if err := os.WriteFile(miPath, []byte(`{"media":{"track":[{"@type":"General"},{"@type":"Video","Format":"HEVC","Width":"3840","Height":"2160"}]}}`), 0o600); err != nil {

--- a/internal/metadata/tracker_data.go
+++ b/internal/metadata/tracker_data.go
@@ -440,6 +440,7 @@ func trackerLookupSubject(meta preparationstate.State) api.UploadSubject {
 		Audio:                 meta.Audio,
 		Channels:              meta.Channels,
 		HasCommentary:         meta.HasCommentary,
+		HardcodedSubs:         meta.HardcodedSubs,
 		Is3D:                  meta.Is3D,
 		Source:                meta.Source,
 		Type:                  meta.Type,

--- a/internal/preparedrelease/evidence_collector.go
+++ b/internal/preparedrelease/evidence_collector.go
@@ -235,6 +235,7 @@ func mapCollectedFacts(meta preparationstate.State) CollectedFacts {
 			Audio:             meta.Audio,
 			Channels:          meta.Channels,
 			Commentary:        meta.HasCommentary,
+			HardcodedSubs:     meta.HardcodedSubs,
 			ThreeD:            meta.Is3D,
 			Source:            meta.Source,
 			Type:              meta.Type,

--- a/internal/preparedrelease/state/state.go
+++ b/internal/preparedrelease/state/state.go
@@ -168,6 +168,7 @@ type State struct {
 	Audio                          string
 	Channels                       string
 	HasCommentary                  bool
+	HardcodedSubs                  bool
 	Is3D                           string
 	Source                         string
 	Type                           string

--- a/internal/preparedrelease/subjects.go
+++ b/internal/preparedrelease/subjects.go
@@ -80,6 +80,7 @@ func (m *Module) ResolveUploadSubject(ctx context.Context, input api.UploadSubje
 		Audio:                       release.Media.Audio,
 		Channels:                    release.Media.Channels,
 		HasCommentary:               release.Media.Commentary,
+		HardcodedSubs:               release.Media.HardcodedSubs,
 		Is3D:                        release.Media.ThreeD,
 		Source:                      release.Media.Source,
 		Type:                        release.Media.Type,

--- a/internal/releaseworkflow/composite_upload.go
+++ b/internal/releaseworkflow/composite_upload.go
@@ -475,6 +475,7 @@ func compositeUploadFactInstructions(
 			OriginalLanguage: cloneStringPointer(facts.Metadata.OriginalLanguage),
 			PersonalRelease:  cloneBoolPointer(facts.Metadata.PersonalRelease),
 			Commentary:       cloneBoolPointer(facts.Metadata.Commentary),
+			HardcodedSubs:    cloneBoolPointer(facts.Metadata.HardcodedSubs),
 			WebDV:            cloneBoolPointer(facts.Metadata.WebDV),
 			StreamOptimized:  cloneBoolPointer(facts.Metadata.StreamOptimized),
 			Anime:            cloneBoolPointer(facts.Metadata.Anime),

--- a/internal/releaseworkflow/composite_upload_test.go
+++ b/internal/releaseworkflow/composite_upload_test.go
@@ -15,6 +15,25 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+func TestCompositeUploadFactInstructionsPreservesHardcodedSubs(t *testing.T) {
+	t.Parallel()
+
+	enabled := true
+	instructions, err := compositeUploadFactInstructions(api.ReleaseWorkflowUploadFacts{
+		Metadata: api.ReleaseWorkflowUploadMetadata{HardcodedSubs: &enabled},
+	}, nil)
+	if err != nil {
+		t.Fatalf("map composite upload facts: %v", err)
+	}
+	if instructions.Metadata.HardcodedSubs == nil || !*instructions.Metadata.HardcodedSubs {
+		t.Fatalf("hardcoded subtitle override = %#v", instructions.Metadata.HardcodedSubs)
+	}
+	enabled = false
+	if !*instructions.Metadata.HardcodedSubs {
+		t.Fatal("hardcoded subtitle override aliases request state")
+	}
+}
+
 func TestCompositeUploadStrictUnattendedStopsForTrackerApproval(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/impl/standalone/ptp/definition_test.go
+++ b/internal/trackers/impl/standalone/ptp/definition_test.go
@@ -99,6 +99,7 @@ func TestPTPFreshUploadTaxonomy(t *testing.T) {
 		Source:            "Web",
 		VideoCodec:        "HEVC",
 		HasEncodeSettings: true,
+		HardcodedSubs:     true,
 		ReleaseName:       "Example.Release.2026.1440p.WEB-DL.x265.HARDSUB-GRP",
 		FileList:          []string{"Example.Release.2026.1440p.WEB-DL.x265.HARDSUB-GRP.mkv"},
 		Release: api.ReleaseInfo{
@@ -140,12 +141,13 @@ func TestPTPFreshUploadTaxonomy(t *testing.T) {
 	}
 	meta.ReleaseName = "Example.Release.2026.1080p.WEB-DL.x265-GRP"
 	meta.FileList = nil
+	meta.HardcodedSubs = false
 	meta.AudioLanguages = []string{"Japanese"}
 	meta.SubtitleLanguages = []string{"French"}
 	if got := resolveTrumpable(meta); len(got) != 1 || got[0] != 14 {
 		t.Fatalf("no-English trumpable=%#v", got)
 	}
-	meta.ReleaseName = "Example.Release.2026.1080p.WEB-DL.x265.HARDSUB-GRP"
+	meta.HardcodedSubs = true
 	if got := resolveTrumpable(meta); len(got) != 2 || got[0] != 4 || got[1] != 14 {
 		t.Fatalf("hardcoded no-English trumpable=%#v", got)
 	}
@@ -164,7 +166,10 @@ func TestPTPFreshUploadTaxonomy(t *testing.T) {
 func TestPTPHardcodedSubtitleQuestionnaire(t *testing.T) {
 	t.Parallel()
 
-	meta := api.UploadSubject{ReleaseName: "Example.Release.2026.1080p.WEB-DL.x265.HARDSUB-GRP"}
+	meta := api.UploadSubject{
+		HardcodedSubs: true,
+		ReleaseName:   "Example.Release.2026.1080p.WEB-DL.x265-GRP",
+	}
 	questionnaire := buildQuestionnaire(meta, "123")
 	if questionnaire == nil || len(questionnaire.Fields) != 1 || questionnaire.Fields[0].Key != "hardcoded_subtitle_languages" {
 		t.Fatalf("questionnaire=%#v", questionnaire)

--- a/internal/trackers/impl/standalone/ptp/definition_test.go
+++ b/internal/trackers/impl/standalone/ptp/definition_test.go
@@ -139,7 +139,7 @@ func TestPTPFreshUploadTaxonomy(t *testing.T) {
 	if got := resolveTrumpable(meta); len(got) != 1 || got[0] != 4 {
 		t.Fatalf("forced hardcoded trumpable=%#v", got)
 	}
-	meta.ReleaseName = "Example.Release.2026.1080p.WEB-DL.x265-GRP"
+	meta.ReleaseName = "Example.Release.2026.1080p.WEB-DL.x265.HARDSUB-GRP"
 	meta.FileList = nil
 	meta.HardcodedSubs = false
 	meta.AudioLanguages = []string{"Japanese"}

--- a/internal/trackers/impl/standalone/ptp/questionnaire.go
+++ b/internal/trackers/impl/standalone/ptp/questionnaire.go
@@ -56,7 +56,7 @@ func buildQuestionnaire(meta api.UploadSubject, groupID string) *api.TrackerQues
 			Required: false,
 		})
 	}
-	if hasHardcodedSubtitles(meta) {
+	if meta.HardcodedSubs {
 		fields = append(fields, api.TrackerQuestionnaireField{
 			Key:         "hardcoded_subtitle_languages",
 			Label:       "Hardcoded Subtitle Languages",

--- a/internal/trackers/impl/standalone/ptp/taxonomy.go
+++ b/internal/trackers/impl/standalone/ptp/taxonomy.go
@@ -259,7 +259,7 @@ func ptpTag(value string) string {
 
 func resolveTrumpable(meta api.UploadSubject) []int {
 	values := make([]int, 0, 2)
-	if hasHardcodedSubtitles(meta) {
+	if meta.HardcodedSubs {
 		values = append(values, 4)
 	}
 	if len(meta.AudioLanguages) > 0 && !ptpEnglishLanguage(meta.AudioLanguages[0]) && !ptpHasEnglishLanguage(meta.SubtitleLanguages) {
@@ -268,17 +268,8 @@ func resolveTrumpable(meta api.UploadSubject) []int {
 	return values
 }
 
-func hasHardcodedSubtitles(meta api.UploadSubject) bool {
-	name := strings.ToLower(strings.Join(append([]string{
-		meta.ReleaseName,
-		meta.ReleaseNameNoTag,
-		meta.Filename,
-	}, meta.FileList...), " "))
-	return strings.Contains(name, "hardsub") || strings.Contains(name, "hard-sub") || strings.Contains(name, "hardcoded")
-}
-
 func withHardcodedSubtitleLanguages(meta api.UploadSubject, value string) (api.UploadSubject, error) {
-	if !hasHardcodedSubtitles(meta) {
+	if !meta.HardcodedSubs {
 		return meta, nil
 	}
 	if strings.TrimSpace(value) == "" {

--- a/internal/trackers/impl/standalone/validation.go
+++ b/internal/trackers/impl/standalone/validation.go
@@ -51,6 +51,7 @@ func UploadSubjectForValidation(subject api.TrackerValidationSubject) api.Upload
 		Audio:                       subject.Audio,
 		Channels:                    subject.Channels,
 		HasCommentary:               subject.HasCommentary,
+		HardcodedSubs:               subject.HardcodedSubs,
 		Is3D:                        subject.Is3D,
 		Source:                      subject.Source,
 		Type:                        subject.Type,

--- a/internal/trackers/impl/standalone/validation_test.go
+++ b/internal/trackers/impl/standalone/validation_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+func TestUploadSubjectForValidationPreservesHardcodedSubs(t *testing.T) {
+	t.Parallel()
+
+	subject := UploadSubjectForValidation(api.TrackerValidationSubject{HardcodedSubs: true})
+	if !subject.HardcodedSubs {
+		t.Fatal("upload subject lost hardcoded subtitle fact")
+	}
+}
+
 func TestValidatePreparationExecutionPolicy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/rules.go
+++ b/internal/trackers/rules.go
@@ -198,7 +198,7 @@ func evaluateRules(ctx context.Context, registry *Registry, tracker string, meta
 	if rules.BlockExternalSubs && hasReleaseToken(meta, []string{"extsub", "ext-sub", "external subs", "external subtitles"}) {
 		addWaivable("block_external_subs", "external subtitles not allowed")
 	}
-	if rules.BlockHardcodedSubs && hasReleaseToken(meta, []string{"hardsub", "hard-sub", "hardcoded"}) {
+	if rules.BlockHardcodedSubs && meta.HardcodedSubs {
 		addStrict("block_hardcoded_subs", "hardcoded subtitles not allowed")
 	}
 
@@ -291,6 +291,7 @@ func RuleSubjectFromValidation(subject api.TrackerValidationSubject) api.RuleSub
 		ProviderMetadata:   subject.ProviderMetadata,
 		AudioLanguages:     append([]string(nil), subject.AudioLanguages...),
 		SubtitleLanguages:  append([]string(nil), subject.SubtitleLanguages...),
+		HardcodedSubs:      subject.HardcodedSubs,
 		TVPack:             subject.TVPack,
 		Type:               subject.Type,
 		Source:             subject.Source,

--- a/internal/trackers/rules_internal_test.go
+++ b/internal/trackers/rules_internal_test.go
@@ -109,7 +109,7 @@ func TestConfiguredRuleDispositions(t *testing.T) {
 			name:    "hardcoded subtitles",
 			rule:    "block_hardcoded_subs",
 			rules:   RuleSet{BlockHardcodedSubs: true},
-			subject: api.RuleSubject{ReleaseName: "Example.Release.2026.HARDSUB-GRP"},
+			subject: api.RuleSubject{HardcodedSubs: true},
 		},
 		{
 			name:  "single-file folder",

--- a/internal/webserver/openapi/release-workflow-v1.json
+++ b/internal/webserver/openapi/release-workflow-v1.json
@@ -2628,6 +2628,9 @@
           "HDRFacts": {
             "$ref": "#/components/schemas/HDRFacts"
           },
+          "HardcodedSubs": {
+            "type": "boolean"
+          },
           "HasEncodeSettings": {
             "type": "boolean"
           },
@@ -2689,6 +2692,7 @@
           "Edition",
           "HDR",
           "HDRFacts",
+          "HardcodedSubs",
           "HasEncodeSettings",
           "MediaInfoUniqueID",
           "Region",
@@ -2799,6 +2803,16 @@
             "anyOf": [
               {
                 "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "HardcodedSubs": {
+            "anyOf": [
+              {
+                "type": "boolean"
               },
               {
                 "type": "null"
@@ -5299,6 +5313,16 @@
             "anyOf": [
               {
                 "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hardcodedSubs": {
+            "anyOf": [
+              {
+                "type": "boolean"
               },
               {
                 "type": "null"

--- a/pkg/api/prepared_release.go
+++ b/pkg/api/prepared_release.go
@@ -160,7 +160,6 @@ type EpisodeFacts struct {
 }
 
 // MediaFacts contains finalized reusable media characteristics.
-// HardcodedSubs is resolved from automatic detection and then any explicit override.
 type MediaFacts struct {
 	AudioLanguages    []string
 	SubtitleLanguages []string
@@ -168,6 +167,7 @@ type MediaFacts struct {
 	Audio             string
 	Channels          string
 	Commentary        bool
+	// HardcodedSubs is resolved from automatic detection and then any explicit override.
 	HardcodedSubs     bool
 	ThreeD            string
 	Source            string

--- a/pkg/api/prepared_release.go
+++ b/pkg/api/prepared_release.go
@@ -160,6 +160,7 @@ type EpisodeFacts struct {
 }
 
 // MediaFacts contains finalized reusable media characteristics.
+// HardcodedSubs is resolved from automatic detection and then any explicit override.
 type MediaFacts struct {
 	AudioLanguages    []string
 	SubtitleLanguages []string
@@ -167,6 +168,7 @@ type MediaFacts struct {
 	Audio             string
 	Channels          string
 	Commentary        bool
+	HardcodedSubs     bool
 	ThreeD            string
 	Source            string
 	Type              string

--- a/pkg/api/request_mapping.go
+++ b/pkg/api/request_mapping.go
@@ -117,6 +117,7 @@ func cloneMetadataOverrides(value MetadataOverrides) MetadataOverrides {
 		OriginalLanguage: cloneString(value.OriginalLanguage),
 		PersonalRelease:  cloneBool(value.PersonalRelease),
 		Commentary:       cloneBool(value.Commentary),
+		HardcodedSubs:    cloneBool(value.HardcodedSubs),
 		WebDV:            cloneBool(value.WebDV),
 		StreamOptimized:  cloneBool(value.StreamOptimized),
 		Anime:            cloneBool(value.Anime),

--- a/pkg/api/request_mapping_test.go
+++ b/pkg/api/request_mapping_test.go
@@ -19,6 +19,7 @@ func TestMapPreparationRequestPreservesSingleSourceIntent(t *testing.T) {
 	tag := "GRP"
 	distributor := "Example Distributor"
 	personalRelease := false
+	hardcodedSubs := true
 	omitEpisodeTitle := true
 	omitDistributor := true
 	client := "qbit"
@@ -43,6 +44,7 @@ func TestMapPreparationRequestPreservesSingleSourceIntent(t *testing.T) {
 		MetadataOverrides: MetadataOverrides{
 			Distributor:     &distributor,
 			PersonalRelease: &personalRelease,
+			HardcodedSubs:   &hardcodedSubs,
 		},
 		SourceLookupURL:    "  https://example.invalid/source  ",
 		TrackerIDOverrides: map[string]string{"btn": "123"},
@@ -76,7 +78,11 @@ func TestMapPreparationRequestPreservesSingleSourceIntent(t *testing.T) {
 				NoEpisodeTitle: new(true),
 				NoDistributor:  new(true),
 			},
-			Metadata:     MetadataOverrides{Distributor: new("Example Distributor"), PersonalRelease: new(false)},
+			Metadata: MetadataOverrides{
+				Distributor:     new("Example Distributor"),
+				PersonalRelease: new(false),
+				HardcodedSubs:   new(true),
+			},
 			SourceLookup: "https://example.invalid/source",
 			Playlist: PlaylistInstruction{
 				Set:      true,
@@ -106,6 +112,7 @@ func TestMapPreparationRequestPreservesSingleSourceIntent(t *testing.T) {
 	*request.ReleaseNameOverrides.NoEpisodeTitle = false
 	*request.ReleaseNameOverrides.NoDistributor = false
 	*request.MetadataOverrides.Distributor = "CHANGED"
+	*request.MetadataOverrides.HardcodedSubs = false
 	*request.ClientOverrides.Client = "changed"
 	request.TrackerIDOverrides["btn"] = "changed"
 	request.PlaylistInstruction.Selected = append(request.PlaylistInstruction.Selected, "00001.mpls")

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -298,6 +298,7 @@ type UploadSubject struct {
 	Audio                       string
 	Channels                    string
 	HasCommentary               bool
+	HardcodedSubs               bool
 	Is3D                        string
 	Source                      string
 	Type                        string
@@ -354,6 +355,7 @@ type RuleSubject struct {
 	ProviderMetadata     SourceScopedMetadata
 	AudioLanguages       []string
 	SubtitleLanguages    []string
+	HardcodedSubs        bool
 	TVPack               bool
 	Type                 string
 	Source               string
@@ -522,6 +524,7 @@ type TrackerValidationSubject struct {
 	Audio                  string
 	Channels               string
 	HasCommentary          bool
+	HardcodedSubs          bool
 	Is3D                   string
 	BitDepth               string
 	VideoCodec             string
@@ -626,6 +629,7 @@ func NewTrackerValidationSubject(subject UploadSubject, tracker string) TrackerV
 		Audio:                       subject.Audio,
 		Channels:                    subject.Channels,
 		HasCommentary:               subject.HasCommentary,
+		HardcodedSubs:               subject.HardcodedSubs,
 		Is3D:                        subject.Is3D,
 		BitDepth:                    subject.BitDepth,
 		VideoCodec:                  subject.VideoCodec,
@@ -1210,6 +1214,7 @@ func NewTrackerValidationSubjectFromRuleSubject(subject RuleSubject, tracker str
 		ProviderMetadata:     cloneTrackerValidationValue(subject.ProviderMetadata),
 		AudioLanguages:       slices.Clone(subject.AudioLanguages),
 		SubtitleLanguages:    slices.Clone(subject.SubtitleLanguages),
+		HardcodedSubs:        subject.HardcodedSubs,
 		TVPack:               subject.TVPack,
 		Type:                 subject.Type,
 		Source:               subject.Source,
@@ -1256,6 +1261,7 @@ func NewRuleSubject(subject UploadSubject) RuleSubject {
 		ProviderMetadata:     subject.ProviderMetadata,
 		AudioLanguages:       append([]string(nil), subject.AudioLanguages...),
 		SubtitleLanguages:    append([]string(nil), subject.SubtitleLanguages...),
+		HardcodedSubs:        subject.HardcodedSubs,
 		TVPack:               subject.TVPack,
 		Type:                 subject.Type,
 		Source:               subject.Source,
@@ -1362,11 +1368,14 @@ func (s UploadSubject) CanonicalSeasonEpisode() (int, int) {
 	return s.SeasonInt, s.EpisodeInt
 }
 
+// MetadataOverrides contains optional user-authored replacements for derived facts.
+// A nil HardcodedSubs preserves automatic marker detection.
 type MetadataOverrides struct {
 	Distributor      *string
 	OriginalLanguage *string
 	PersonalRelease  *bool
 	Commentary       *bool
+	HardcodedSubs    *bool
 	WebDV            *bool
 	StreamOptimized  *bool
 	Anime            *bool

--- a/pkg/api/services_test.go
+++ b/pkg/api/services_test.go
@@ -9,6 +9,19 @@ import (
 	"testing"
 )
 
+func TestHardcodedSubsProjectsIntoTrackerSubjects(t *testing.T) {
+	t.Parallel()
+
+	rule := NewRuleSubject(UploadSubject{HardcodedSubs: true})
+	if !rule.HardcodedSubs {
+		t.Fatal("rule subject lost hardcoded subtitle fact")
+	}
+	validation := NewTrackerValidationSubjectFromRuleSubject(rule, "EXAMPLE")
+	if !validation.HardcodedSubs {
+		t.Fatal("validation subject lost hardcoded subtitle fact")
+	}
+}
+
 func TestNewDescriptionSubjectDetachesNestedFacts(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/workflow_upload.go
+++ b/pkg/api/workflow_upload.go
@@ -177,11 +177,13 @@ type ReleaseWorkflowUploadReleaseName struct {
 }
 
 // ReleaseWorkflowUploadMetadata contains presence-aware metadata overrides.
+// A nil HardcodedSubs preserves automatic marker detection.
 type ReleaseWorkflowUploadMetadata struct {
 	Distributor      *string `json:"distributor,omitempty"`
 	OriginalLanguage *string `json:"originalLanguage,omitempty"`
 	PersonalRelease  *bool   `json:"personalRelease,omitempty"`
 	Commentary       *bool   `json:"commentary,omitempty"`
+	HardcodedSubs    *bool   `json:"hardcodedSubs,omitempty"`
 	WebDV            *bool   `json:"webDv,omitempty"`
 	StreamOptimized  *bool   `json:"streamOptimized,omitempty"`
 	Anime            *bool   `json:"anime,omitempty"`

--- a/webui/src/api/generated/release-workflow.ts
+++ b/webui/src/api/generated/release-workflow.ts
@@ -679,6 +679,7 @@ export type MediaFacts = Readonly<{
   Edition: string;
   HDR: string;
   HDRFacts: HDRFacts;
+  HardcodedSubs: boolean;
   HasEncodeSettings: boolean;
   MediaInfoUniqueID: string;
   Region: string;
@@ -719,6 +720,7 @@ export type MetadataOverrides = Readonly<{
   Anime?: boolean | null;
   Commentary?: boolean | null;
   Distributor?: string | null;
+  HardcodedSubs?: boolean | null;
   OriginalLanguage?: string | null;
   PersonalRelease?: boolean | null;
   StreamOptimized?: boolean | null;
@@ -1256,6 +1258,7 @@ export type ReleaseWorkflowUploadMetadata = Readonly<{
   anime?: boolean | null;
   commentary?: boolean | null;
   distributor?: string | null;
+  hardcodedSubs?: boolean | null;
   originalLanguage?: string | null;
   personalRelease?: boolean | null;
   streamOptimized?: boolean | null;

--- a/webui/src/pages/input/index.test.tsx
+++ b/webui/src/pages/input/index.test.tsx
@@ -276,7 +276,7 @@ describe("InputPage", () => {
     });
   });
 
-  it("edits distributor and original-language metadata", () => {
+  it("edits metadata overrides", () => {
     const facet = readyInputFacet(1);
     render(
       <InputPage
@@ -304,5 +304,8 @@ describe("InputPage", () => {
       target: { value: "ja" },
     });
     expect(facet.changeMetadata).toHaveBeenLastCalledWith({ OriginalLanguage: "ja" });
+
+    fireEvent.click(screen.getByLabelText("Hardcoded subtitles"));
+    expect(facet.changeMetadata).toHaveBeenLastCalledWith({ HardcodedSubs: true });
   });
 });

--- a/webui/src/pages/input/index.test.tsx
+++ b/webui/src/pages/input/index.test.tsx
@@ -278,19 +278,17 @@ describe("InputPage", () => {
 
   it("edits metadata overrides", () => {
     const facet = readyInputFacet(1);
-    render(
-      <InputPage
-        facet={facet}
-        sourcePathHistory={[]}
-        handleBrowseFile={vi.fn()}
-        handleBrowseFolder={vi.fn()}
-        trackerUploadItems={[]}
-        showExternalIDInputUI={false}
-        setLightboxImage={vi.fn()}
-        setLightboxAlt={vi.fn()}
-        trackerIconSrcByName={{}}
-      />,
-    );
+    const pageProps = {
+      sourcePathHistory: [],
+      handleBrowseFile: vi.fn(),
+      handleBrowseFolder: vi.fn(),
+      trackerUploadItems: [],
+      showExternalIDInputUI: false,
+      setLightboxImage: vi.fn(),
+      setLightboxAlt: vi.fn(),
+      trackerIconSrcByName: {},
+    };
+    const { rerender } = render(<InputPage facet={facet} {...pageProps} />);
 
     fireEvent.click(screen.getByText("Edit Release Details"));
     fireEvent.change(screen.getByLabelText("Distributor"), {
@@ -307,5 +305,17 @@ describe("InputPage", () => {
 
     fireEvent.click(screen.getByLabelText("Hardcoded subtitles"));
     expect(facet.changeMetadata).toHaveBeenLastCalledWith({ HardcodedSubs: true });
+
+    const enabledFacet: InputFacet = {
+      ...facet,
+      view: {
+        ...facet.view,
+        intent: { ...facet.view.intent, metadata: { HardcodedSubs: true } },
+      },
+      changeMetadata: vi.fn(),
+    };
+    rerender(<InputPage facet={enabledFacet} {...pageProps} />);
+    fireEvent.click(screen.getByLabelText("Hardcoded subtitles"));
+    expect(enabledFacet.changeMetadata).toHaveBeenLastCalledWith({});
   });
 });

--- a/webui/src/pages/input/index.tsx
+++ b/webui/src/pages/input/index.tsx
@@ -2035,6 +2035,22 @@ export default function InputPage(props: Props) {
                   <div className="settings-subgroup__title">Flags</div>
                   <div className="settings-grid">
                     <div className="settings-toggle">
+                      <span>Hardcoded subtitles</span>
+                      <Switch
+                        aria-label="Hardcoded subtitles"
+                        checked={Boolean(view.intent.metadata.HardcodedSubs)}
+                        onChange={(event) => {
+                          const metadata = { ...view.intent.metadata };
+                          if (event.target.checked) {
+                            metadata.HardcodedSubs = true;
+                          } else {
+                            delete metadata.HardcodedSubs;
+                          }
+                          facet.changeMetadata(metadata);
+                        }}
+                      />
+                    </div>
+                    <div className="settings-toggle">
                       <span>No season</span>
                       <Switch
                         aria-label="No season"

--- a/webui/src/releaseSession/index.test.tsx
+++ b/webui/src/releaseSession/index.test.tsx
@@ -1103,6 +1103,7 @@ describe("useReleaseSession", () => {
       result.current.input.changeMetadata({
         Distributor: "Example Distributor",
         OriginalLanguage: "ja",
+        HardcodedSubs: true,
       }),
     );
     await act(() => result.current.input.prepare());
@@ -1113,6 +1114,7 @@ describe("useReleaseSession", () => {
         Metadata: {
           Distributor: "Example Distributor",
           OriginalLanguage: "ja",
+          HardcodedSubs: true,
         },
       }),
       expect.any(String),

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -153,6 +153,7 @@ export type MediaFacts = {
   Audio: string;
   Channels: string;
   Commentary: boolean;
+  HardcodedSubs: boolean;
   ThreeD: string;
   Source: string;
   Type: string;
@@ -220,6 +221,7 @@ export type PrepareInput = {
       OriginalLanguage?: string | null;
       PersonalRelease?: boolean | null;
       Commentary?: boolean | null;
+      HardcodedSubs?: boolean | null;
       WebDV?: boolean | null;
       StreamOptimized?: boolean | null;
       Anime?: boolean | null;


### PR DESCRIPTION
## Summary

- restore -hc / --hardcoded-subs as a presence-aware manual metadata override
- centralize automatic hardcoded-subtitle detection into the finalized prepared fact used by tracker rules and PTP
- add the Web UI toggle, generated API contracts, regression tests, and public documentation

## Testing

- make test-go
- make precommit
- make e2e-build
- pnpm --dir documentation run check
- make backend

Closes #165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of hardcoded subtitles from release and media metadata.
  * Added CLI support with `--hardcoded-subs` and `-hc` options.
  * Added a Web UI toggle to enable or disable hardcoded-subtitle handling.
  * Propagated hardcoded-subtitle status through uploads, validation, tracker rules, and release workflows.
* **Documentation**
  * Documented CLI and Web UI configuration, including tracker-specific requirements.
* **Bug Fixes**
  * Ensured explicit overrides consistently take precedence over automatic detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->