### PR TITLE
fix(torrent): enforce HDB piece rules

### DIFF
--- a/internal/torrent/policy.go
+++ b/internal/torrent/policy.go
@@ -23,6 +23,7 @@ type trackerTorrentPolicy struct {
 	maxTorrentBytes     int64
 	pieceSizeProfileURL string
 	profileMaxPieceExp  uint
+	hdb                 bool
 	ptp                 bool
 }
 
@@ -44,6 +45,7 @@ func resolveTrackerPolicy(meta api.TorrentSubject, registry *trackers.Registry) 
 		} else {
 			policy.name += "+" + trackerName
 		}
+		policy.hdb = policy.hdb || trackerName == "HDB"
 		policy.ptp = policy.ptp || trackerName == "PTP"
 		maxPieceExp, _ := pieceExpForMiB(artifact.MaxPieceSizeMiB)
 		if maxPieceExp > 0 && (policy.maxPieceExp == 0 || maxPieceExp < policy.maxPieceExp) {
@@ -57,6 +59,9 @@ func resolveTrackerPolicy(meta api.TorrentSubject, registry *trackers.Registry) 
 			continue
 		}
 		profileExp := mkbrr.GetRecommendedPieceLengthExp(profileURL, uint64(max(meta.SourceSize, 0)))
+		if trackerName == "HDB" && meta.SourceSize > 8<<30 {
+			profileExp = 24
+		}
 		if meta.SourceSize <= 0 {
 			profileExp = maxPieceExp
 		}
@@ -83,7 +88,11 @@ func (p *trackerTorrentPolicy) createOptions(meta api.TorrentSubject) mkbrrPiece
 	if p == nil {
 		return applyTorrentOverridePieceOptions(meta, mkbrrPieceOptions{maxPieceExp: 27})
 	}
-	options := mkbrrPieceOptions{maxPieceExp: p.maxPieceExp, profileURL: p.pieceSizeProfileURL}
+	maxPieceExp := p.maxPieceExp
+	if p.hdb && maxPieceExp > 24 {
+		maxPieceExp = 24
+	}
+	options := mkbrrPieceOptions{maxPieceExp: maxPieceExp, profileURL: p.pieceSizeProfileURL}
 	if exp, ok := p.requiredPieceExp(meta); ok {
 		options.pieceExp = &exp
 	}
@@ -94,7 +103,10 @@ func (p *trackerTorrentPolicy) requiredPieceExp(meta api.TorrentSubject) (uint, 
 	if p == nil || p.pieceSizeProfileURL == "" || meta.SourceSize <= 0 {
 		return 0, false
 	}
-	exp := mkbrr.GetRecommendedPieceLengthExp(p.pieceSizeProfileURL, uint64(meta.SourceSize))
+	exp := p.profileMaxPieceExp
+	if exp == 0 {
+		exp = mkbrr.GetRecommendedPieceLengthExp(p.pieceSizeProfileURL, uint64(meta.SourceSize))
+	}
 	if exp == 0 {
 		return 0, false
 	}
@@ -133,10 +145,19 @@ func (p *trackerTorrentPolicy) validateTorrent(path string, meta api.TorrentSubj
 	if err != nil {
 		return fmt.Errorf("decode torrent %q: %w", path, err)
 	}
+	return p.validateTorrentInfo(&info, meta)
+}
+
+func (p *trackerTorrentPolicy) validateTorrentInfo(info *metainfo.Info, meta api.TorrentSubject) error {
 	if p.maxPieceExp > 0 {
 		maxPieceLength := int64(1) << p.maxPieceExp
 		if info.PieceLength > maxPieceLength {
 			return fmt.Errorf("%s piece size %d exceeds max %d", p.name, info.PieceLength, maxPieceLength)
+		}
+	}
+	if p.hdb {
+		if err := validateHDBPieceLayout(info); err != nil {
+			return err
 		}
 	}
 	if !p.ptp {
@@ -152,6 +173,20 @@ func (p *trackerTorrentPolicy) validateTorrent(path string, meta api.TorrentSubj
 		return fmt.Errorf("%s piece size %d is outside PTP range %d-%d", p.name, info.PieceLength, minLength, maxLength)
 	}
 	return nil
+}
+
+func validateHDBPieceLayout(info *metainfo.Info) error {
+	pieceCount := info.NumPieces()
+	switch {
+	case info.PieceLength <= 2<<20 && pieceCount > 4000:
+		return fmt.Errorf("HDB piece size %d allows at most 4000 pieces, got %d", info.PieceLength, pieceCount)
+	case (info.PieceLength == 4<<20 || info.PieceLength == 8<<20) && pieceCount > 30000:
+		return fmt.Errorf("HDB piece size %d allows at most 30000 pieces, got %d", info.PieceLength, pieceCount)
+	case info.PieceLength == 32<<20 && info.TotalLength() <= 1<<40:
+		return fmt.Errorf("HDB 32 MiB pieces require torrent content over 1 TiB, got %d bytes", info.TotalLength())
+	default:
+		return nil
+	}
 }
 
 func ptpPieceExpRange(size int64) (uint, uint) {

--- a/internal/torrent/service.go
+++ b/internal/torrent/service.go
@@ -239,10 +239,14 @@ func (s *Service) Create(ctx context.Context, meta api.TorrentSubject) (api.Torr
 		return api.TorrentResult{}, fmt.Errorf("torrent: validate created torrent %q: %w", info.Path, err)
 	}
 	if policy != nil {
+		trackerCount := len(normalizedTrackerNames(meta.Trackers))
+		s.logger.Infof("torrent: tracker policy validation tracker=%s state=start decision=validate count=%d", policy.name, trackerCount)
 		if err := policy.validateTorrent(info.Path, meta); err != nil {
+			s.logger.Warnf("torrent: tracker policy validation tracker=%s state=completed decision=rejected count=%d", policy.name, trackerCount)
 			emitTorrentProgress(ctx, meta, "failed", "Torrent policy validation failed")
 			return api.TorrentResult{}, fmt.Errorf("torrent: validate created torrent policy %q: %w", info.Path, err)
 		}
+		s.logger.Infof("torrent: tracker policy validation tracker=%s state=completed decision=accepted count=%d", policy.name, trackerCount)
 	}
 	if err := setCreatedBy(info.Path, torrentmeta.MkbrrUploadCreatedBy); err != nil {
 		emitTorrentProgress(ctx, meta, "failed", "Torrent metadata update failed")

--- a/internal/torrent/service.go
+++ b/internal/torrent/service.go
@@ -239,7 +239,7 @@ func (s *Service) Create(ctx context.Context, meta api.TorrentSubject) (api.Torr
 		return api.TorrentResult{}, fmt.Errorf("torrent: validate created torrent %q: %w", info.Path, err)
 	}
 	if policy != nil {
-		if err := validateTorrentFileSize(info.Path, policy); err != nil {
+		if err := policy.validateTorrent(info.Path, meta); err != nil {
 			emitTorrentProgress(ctx, meta, "failed", "Torrent policy validation failed")
 			return api.TorrentResult{}, fmt.Errorf("torrent: validate created torrent policy %q: %w", info.Path, err)
 		}

--- a/internal/torrent/service_test.go
+++ b/internal/torrent/service_test.go
@@ -1042,9 +1042,17 @@ func TestResolveTrackerPieceProfiles(t *testing.T) {
 			name:        "HDB",
 			trackers:    []string{"HDB"},
 			size:        40 << 30,
-			maxExp:      24,
+			maxExp:      25,
 			pieceExp:    24,
 			profileHost: "hdbits.org",
+		},
+		{
+			name:        "HDB and PTP",
+			trackers:    []string{"HDB", "PTP"},
+			size:        10 << 30,
+			maxExp:      24,
+			pieceExp:    23,
+			profileHost: "passthepopcorn.me",
 		},
 	}
 	for _, test := range tests {
@@ -1053,6 +1061,124 @@ func TestResolveTrackerPieceProfiles(t *testing.T) {
 			pieceExp, ok := policy.requiredPieceExp(api.TorrentSubject{SourceSize: test.size})
 			if !ok || policy.maxPieceExp != test.maxExp || pieceExp != test.pieceExp || !strings.Contains(policy.pieceSizeProfileURL, test.profileHost) {
 				t.Fatalf("policy=%#v piece_exp=%d resolved=%t", policy, pieceExp, ok)
+			}
+		})
+	}
+}
+
+func TestHDBPieceRecommendationBoundaries(t *testing.T) {
+	t.Parallel()
+
+	registry := trackers.NewRegistry()
+	if err := registry.Register(hdb.New()); err != nil {
+		t.Fatalf("register HDB: %v", err)
+	}
+	cases := []struct {
+		size int64
+		exp  uint
+	}{
+		{size: 8 << 30, exp: 22},
+		{size: 8<<30 + 1, exp: 24},
+		{size: 1<<40 + 1, exp: 24},
+	}
+	for _, test := range cases {
+		meta := api.TorrentSubject{Trackers: []string{"HDB"}, SourceSize: test.size}
+		policy := resolveTrackerPolicy(meta, registry)
+		options := policy.createOptions(meta)
+		if options.maxPieceExp != 24 || options.pieceExp == nil || *options.pieceExp != test.exp {
+			t.Fatalf("size %d: create options = %#v; want max 24 and piece exponent %d", test.size, options, test.exp)
+		}
+	}
+}
+
+func TestHDBAcceptedPieceLayouts(t *testing.T) {
+	t.Parallel()
+
+	policy := &trackerTorrentPolicy{
+		name:        "HDB",
+		maxPieceExp: 25,
+		hdb:         true,
+	}
+	tests := []struct {
+		name        string
+		pieceLength int64
+		pieces      int
+		totalLength int64
+		wantErr     bool
+	}{
+		{
+			name:        "2 MiB at piece limit",
+			pieceLength: 2 << 20,
+			pieces:      4000,
+		},
+		{
+			name:        "2 MiB over piece limit",
+			pieceLength: 2 << 20,
+			pieces:      4001,
+			wantErr:     true,
+		},
+		{
+			name:        "4 MiB at piece limit",
+			pieceLength: 4 << 20,
+			pieces:      30000,
+		},
+		{
+			name:        "4 MiB over piece limit",
+			pieceLength: 4 << 20,
+			pieces:      30001,
+			wantErr:     true,
+		},
+		{
+			name:        "8 MiB at piece limit",
+			pieceLength: 8 << 20,
+			pieces:      30000,
+		},
+		{
+			name:        "8 MiB over piece limit",
+			pieceLength: 8 << 20,
+			pieces:      30001,
+			wantErr:     true,
+		},
+		{
+			name:        "16 MiB has no stated piece limit",
+			pieceLength: 16 << 20,
+			pieces:      30001,
+		},
+		{
+			name:        "32 MiB at 1 TiB",
+			pieceLength: 32 << 20,
+			pieces:      1,
+			totalLength: 1 << 40,
+			wantErr:     true,
+		},
+		{
+			name:        "32 MiB over 1 TiB",
+			pieceLength: 32 << 20,
+			pieces:      1,
+			totalLength: 1<<40 + 1,
+		},
+		{
+			name:        "64 MiB unsupported",
+			pieceLength: 64 << 20,
+			pieces:      1,
+			totalLength: 1<<40 + 1,
+			wantErr:     true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			totalLength := test.totalLength
+			if totalLength == 0 {
+				totalLength = test.pieceLength * int64(test.pieces)
+			}
+			info := metainfo.Info{
+				PieceLength: test.pieceLength,
+				Pieces:      make([]byte, test.pieces*metainfo.HashSize),
+				Length:      totalLength,
+			}
+			err := policy.validateTorrentInfo(&info, api.TorrentSubject{})
+			if (err != nil) != test.wantErr {
+				t.Fatalf("validateTorrentInfo() error = %v, wantErr %t", err, test.wantErr)
 			}
 		})
 	}

--- a/internal/trackers/impl/registry_test.go
+++ b/internal/trackers/impl/registry_test.go
@@ -680,7 +680,7 @@ func TestNewRegistryIncludesHDBPolicies(t *testing.T) {
 	if policy, ok := registry.LookupUploadArtifactPolicy("HDB"); !ok || policy.Source != "HDBits" {
 		t.Fatalf("HDB upload artifact policy = %#v, %t", policy, ok)
 	}
-	if policy, ok := registry.LookupArtifactPolicy("HDB"); !ok || policy.MaxPieceSizeMiB != 16 {
+	if policy, ok := registry.LookupArtifactPolicy("HDB"); !ok || policy.MaxPieceSizeMiB != 32 {
 		t.Fatalf("HDB artifact policy = %#v, %t", policy, ok)
 	}
 	if _, ok := registry.LookupDataFactory("HDB"); !ok {

--- a/internal/trackers/impl/standalone/hdb/profile.go
+++ b/internal/trackers/impl/standalone/hdb/profile.go
@@ -48,7 +48,7 @@ func Profile() standalone.Profile {
 		},
 		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: "HDBits"},
 		ArtifactPolicy: &trackers.ArtifactPolicy{
-			MaxPieceSizeMiB:     16,
+			MaxPieceSizeMiB:     32,
 			PieceSizeProfileURL: hdbBaseURL,
 		},
 		ImageHostPolicy: &trackers.ImageHostPolicy{


### PR DESCRIPTION
## Summary

- enforce HDB's conditional 4,000/30,000 piece-count limits
- select 16 MiB pieces for HDB torrents over 8 GiB
- allow 32 MiB pieces only for torrent content over 1 TiB
- apply full tracker policy validation to newly created torrents

## Why

HDB's rule is conditional on both piece size and piece count, not a simple 16 MiB maximum. The previous policy rejected HDB's 32 MiB exception and did not validate piece counts.

## Checks

- `go test -race -v -timeout 20m ./internal/torrent ./internal/trackers/impl ./internal/trackers/impl/standalone/hdb`
- `make gofix-check-changed`
- `make lint`
- pre-commit and pre-push hooks, including frontend typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated HDB torrent policies with improved piece-size recommendations and validation for large torrents.
  - Increased the maximum HDB upload artifact piece size from 16 MiB to 32 MiB.
  - Added support for combined HDB/PTP policy validation.

- **Bug Fixes**
  - Improved torrent layout checks, including piece-count limits and large-torrent thresholds.
  - Unsupported piece sizes are now rejected consistently.
  - Torrent creation now applies complete tracker policy validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->