### PR TITLE
feat(cli): manage WebUI auth locally

### DIFF
--- a/cmd/upbrr/auth_cli.go
+++ b/cmd/upbrr/auth_cli.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/pflag"
+
+	"github.com/autobrr/upbrr/internal/webserver"
+)
+
+const authCommandUsage = `Usage: upbrr auth <command> [options]
+
+Commands:
+  password       Change the WebUI password
+  browse-roots  Replace the WebUI browse roots
+
+Run "upbrr auth <command> --help" for command options.
+`
+
+type authPasswordOptions struct {
+	configPath string
+}
+
+type authBrowseRootsOptions struct {
+	configPath        string
+	allowUnrestricted bool
+}
+
+func bindAuthPasswordFlags(fs *pflag.FlagSet, opts *authPasswordOptions) {
+	fs.StringVar(&opts.configPath, "config", "", "Path to config file")
+}
+
+func bindAuthBrowseRootsFlags(fs *pflag.FlagSet, opts *authBrowseRootsOptions) {
+	fs.StringVar(&opts.configPath, "config", "", "Path to config file")
+	fs.BoolVar(&opts.allowUnrestricted, "allow-unrestricted", false, "Allow unrestricted host browsing instead of configured roots")
+}
+
+func runChangeAuthPasswordCommand(ctx context.Context, opts authPasswordOptions, configProvided bool, streams cliIO) error {
+	dbPath, err := resolveExportDBPath(opts.configPath, configProvided)
+	if err != nil {
+		return err
+	}
+	streams = streams.normalized()
+	reader := bufio.NewReader(streams.in)
+	currentPassword, err := promptPassword(streams.in, reader, streams.out, "Current password: ", "change auth password")
+	if err != nil {
+		return err
+	}
+	newPassword, err := promptPassword(streams.in, reader, streams.out, "New password: ", "change auth password")
+	if err != nil {
+		return err
+	}
+	confirmation, err := promptPassword(streams.in, reader, streams.out, "Confirm new password: ", "change auth password")
+	if err != nil {
+		return err
+	}
+	if newPassword != confirmation {
+		return errors.New("change auth password: passwords do not match")
+	}
+	if err := webserver.ChangeAuthPassword(ctx, dbPath, currentPassword, newPassword); err != nil {
+		return fmt.Errorf("change password: %w", err)
+	}
+	if _, err := fmt.Fprintln(streams.out, "Password changed. Retained browser sessions were revoked."); err != nil {
+		return fmt.Errorf("change auth password: write result: %w", err)
+	}
+	return nil
+}
+
+func runUpdateBrowseRootsCommand(
+	ctx context.Context,
+	opts authBrowseRootsOptions,
+	configProvided bool,
+	paths []string,
+	output io.Writer,
+) error {
+	dbPath, err := resolveExportDBPath(opts.configPath, configProvided)
+	if err != nil {
+		return err
+	}
+	count, err := webserver.UpdateBrowseRoots(ctx, dbPath, paths, opts.allowUnrestricted)
+	if err != nil {
+		return fmt.Errorf("replace browse roots: %w", err)
+	}
+	if opts.allowUnrestricted {
+		_, err = fmt.Fprintln(output, "Enabled unrestricted host browsing.")
+	} else {
+		_, err = fmt.Fprintf(output, "Updated %d browse roots.\n", count)
+	}
+	if err != nil {
+		return fmt.Errorf("update browse roots: write result: %w", err)
+	}
+	return nil
+}

--- a/cmd/upbrr/auth_cli.go
+++ b/cmd/upbrr/auth_cli.go
@@ -64,8 +64,12 @@ func runChangeAuthPasswordCommand(ctx context.Context, opts authPasswordOptions,
 	if newPassword != confirmation {
 		return errors.New("change auth password: passwords do not match")
 	}
-	if err := webserver.ChangeAuthPassword(ctx, dbPath, currentPassword, newPassword); err != nil {
-		return fmt.Errorf("change password: %w", err)
+	backupPath, changeErr := webserver.ChangeAuthPassword(ctx, dbPath, currentPassword, newPassword)
+	if changeErr != nil {
+		changeErr = fmt.Errorf("change password: %w", changeErr)
+	}
+	if err := errors.Join(changeErr, writeAuthBackupPath(streams.out, backupPath)); err != nil {
+		return err
 	}
 	if _, err := fmt.Fprintln(streams.out, "Password changed. Retained browser sessions were revoked."); err != nil {
 		return fmt.Errorf("change auth password: write result: %w", err)
@@ -84,9 +88,12 @@ func runUpdateBrowseRootsCommand(
 	if err != nil {
 		return err
 	}
-	count, err := webserver.UpdateBrowseRoots(ctx, dbPath, paths, opts.allowUnrestricted)
-	if err != nil {
-		return fmt.Errorf("replace browse roots: %w", err)
+	count, backupPath, updateErr := webserver.UpdateBrowseRoots(ctx, dbPath, paths, opts.allowUnrestricted)
+	if updateErr != nil {
+		updateErr = fmt.Errorf("replace browse roots: %w", updateErr)
+	}
+	if err := errors.Join(updateErr, writeAuthBackupPath(output, backupPath)); err != nil {
+		return err
 	}
 	if opts.allowUnrestricted {
 		_, err = fmt.Fprintln(output, "Enabled unrestricted host browsing.")
@@ -95,6 +102,21 @@ func runUpdateBrowseRootsCommand(
 	}
 	if err != nil {
 		return fmt.Errorf("update browse roots: write result: %w", err)
+	}
+	return nil
+}
+
+func writeAuthBackupPath(output io.Writer, backupPath string) error {
+	if backupPath == "" {
+		return nil
+	}
+	if _, err := fmt.Fprintf(
+		output,
+		"Web auth backup created: %s\n",
+		//logpolicy:allow the auth backup command must report the exact operator-requested restore path
+		backupPath,
+	); err != nil {
+		return fmt.Errorf("write auth backup result: %w", err)
 	}
 	return nil
 }

--- a/cmd/upbrr/auth_cli_test.go
+++ b/cmd/upbrr/auth_cli_test.go
@@ -29,12 +29,25 @@ func TestAuthCLIChangesPasswordWithoutExposingSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("auth password: %v", err)
 	}
+	backups, err := filepath.Glob(filepath.Join(filepath.Dir(dbPath), authmaterial.WebAuthFileName+".backup-*"))
+	if err != nil {
+		t.Fatalf("glob auth backups: %v", err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("auth backups = %v, want one", backups)
+	}
 	for _, secret := range []string{"very-secure-password", "replacement-secure-password"} {
 		if strings.Contains(stdout.String(), secret) || strings.Contains(stderr.String(), secret) {
 			t.Fatalf("auth password output exposed a password: stdout=%q stderr=%q", stdout.String(), stderr.String())
 		}
 	}
-	for _, want := range []string{"Current password: ", "New password: ", "Confirm new password: ", "Password changed."} {
+	for _, want := range []string{
+		"Current password: ",
+		"New password: ",
+		"Confirm new password: ",
+		"Web auth backup created: " + backups[0],
+		"Password changed.",
+	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("auth password output = %q, want %q", stdout.String(), want)
 		}
@@ -78,6 +91,50 @@ func TestAuthCLIRejectsPasswordMismatch(t *testing.T) {
 	if !authmaterial.VerifyPassword("very-secure-password", record.PasswordHash) {
 		t.Fatal("password changed after mismatched confirmation")
 	}
+	backups, globErr := filepath.Glob(filepath.Join(filepath.Dir(dbPath), authmaterial.WebAuthFileName+".backup-*"))
+	if globErr != nil {
+		t.Fatalf("glob auth backups: %v", globErr)
+	}
+	if len(backups) != 0 {
+		t.Fatalf("password mismatch created backups: %v", backups)
+	}
+}
+
+func TestAuthCLIPrintsBackupWhenPasswordUpdateFailsAfterBackup(t *testing.T) {
+	dbPath, configPath := writeAuthCLIConfig(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	sessionPath := filepath.Join(filepath.Dir(dbPath), "web-sessions.json")
+	if err := os.Mkdir(sessionPath, 0o700); err != nil {
+		t.Fatalf("create session blocker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionPath, "blocker"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write session blocker: %v", err)
+	}
+
+	var output bytes.Buffer
+	err := executeCLI(t.Context(), []string{"auth", "password", "--config", configPath}, cliIO{
+		in:  strings.NewReader("very-secure-password\nreplacement-secure-password\nreplacement-secure-password\n"),
+		out: &output,
+	})
+	if err == nil || !strings.Contains(err.Error(), "revoke retained sessions") {
+		t.Fatalf("auth password error = %v", err)
+	}
+	backups, globErr := filepath.Glob(filepath.Join(filepath.Dir(dbPath), authmaterial.WebAuthFileName+".backup-*"))
+	if globErr != nil {
+		t.Fatalf("glob auth backups: %v", globErr)
+	}
+	if len(backups) != 1 || !strings.Contains(output.String(), "Web auth backup created: "+backups[0]) {
+		t.Fatalf("backup output = %q, backups = %v", output.String(), backups)
+	}
+	record, loadErr := authmaterial.LoadRecordFromDBPath(dbPath)
+	if loadErr != nil {
+		t.Fatalf("LoadRecordFromDBPath: %v", loadErr)
+	}
+	if !authmaterial.VerifyPassword("very-secure-password", record.PasswordHash) {
+		t.Fatal("failed update changed the existing password")
+	}
 }
 
 func TestAuthCLIUpdatesBrowseRoots(t *testing.T) {
@@ -93,7 +150,15 @@ func TestAuthCLIUpdatesBrowseRoots(t *testing.T) {
 	if err != nil {
 		t.Fatalf("auth browse-roots: %v", err)
 	}
-	if output.String() != "Updated 2 browse roots.\n" {
+	backups, err := filepath.Glob(filepath.Join(filepath.Dir(dbPath), authmaterial.WebAuthFileName+".backup-*"))
+	if err != nil {
+		t.Fatalf("glob auth backups: %v", err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("auth backups = %v, want one", backups)
+	}
+	wantOutput := "Web auth backup created: " + backups[0] + "\nUpdated 2 browse roots.\n"
+	if output.String() != wantOutput {
 		t.Fatalf("auth browse-roots output = %q", output.String())
 	}
 	record, err := authmaterial.LoadRecordFromDBPath(dbPath)
@@ -118,7 +183,19 @@ func TestAuthCLIUpdatesBrowseRoots(t *testing.T) {
 	if err != nil {
 		t.Fatalf("auth browse-roots unrestricted: %v", err)
 	}
-	if output.String() != "Enabled unrestricted host browsing.\n" {
+	secondBackups, err := filepath.Glob(filepath.Join(filepath.Dir(dbPath), authmaterial.WebAuthFileName+".backup-*"))
+	if err != nil {
+		t.Fatalf("glob unrestricted auth backups: %v", err)
+	}
+	if len(secondBackups) != 2 {
+		t.Fatalf("auth backups after unrestricted update = %v, want two", secondBackups)
+	}
+	secondBackup := secondBackups[0]
+	if secondBackup == backups[0] {
+		secondBackup = secondBackups[1]
+	}
+	wantOutput = "Web auth backup created: " + secondBackup + "\nEnabled unrestricted host browsing.\n"
+	if output.String() != wantOutput {
 		t.Fatalf("auth browse-roots unrestricted output = %q", output.String())
 	}
 	record, err = authmaterial.LoadRecordFromDBPath(dbPath)

--- a/cmd/upbrr/auth_cli_test.go
+++ b/cmd/upbrr/auth_cli_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/authmaterial"
+)
+
+func TestAuthCLIChangesPasswordWithoutExposingSecrets(t *testing.T) {
+	dbPath, configPath := writeAuthCLIConfig(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := executeCLI(t.Context(), []string{"auth", "password", "--config", configPath}, cliIO{
+		in:     strings.NewReader("very-secure-password\nreplacement-secure-password\nreplacement-secure-password\n"),
+		out:    &stdout,
+		errOut: &stderr,
+	})
+	if err != nil {
+		t.Fatalf("auth password: %v", err)
+	}
+	for _, secret := range []string{"very-secure-password", "replacement-secure-password"} {
+		if strings.Contains(stdout.String(), secret) || strings.Contains(stderr.String(), secret) {
+			t.Fatalf("auth password output exposed a password: stdout=%q stderr=%q", stdout.String(), stderr.String())
+		}
+	}
+	for _, want := range []string{"Current password: ", "New password: ", "Confirm new password: ", "Password changed."} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("auth password output = %q, want %q", stdout.String(), want)
+		}
+	}
+
+	record, err := authmaterial.LoadRecordFromDBPath(dbPath)
+	if err != nil {
+		t.Fatalf("LoadRecordFromDBPath: %v", err)
+	}
+	if !authmaterial.VerifyPassword("replacement-secure-password", record.PasswordHash) {
+		t.Fatal("replacement password does not verify")
+	}
+	if authmaterial.VerifyPassword("very-secure-password", record.PasswordHash) {
+		t.Fatal("previous password still verifies")
+	}
+}
+
+func TestAuthCLIRejectsPasswordMismatch(t *testing.T) {
+	dbPath, configPath := writeAuthCLIConfig(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+
+	var output bytes.Buffer
+	err := executeCLI(t.Context(), []string{"auth", "password", "--config", configPath}, cliIO{
+		in:  strings.NewReader("very-secure-password\nreplacement-secure-password\ndifferent-secure-password\n"),
+		out: &output,
+	})
+	if err == nil || !strings.Contains(err.Error(), "passwords do not match") {
+		t.Fatalf("auth password error = %v", err)
+	}
+	for _, secret := range []string{"very-secure-password", "replacement-secure-password", "different-secure-password"} {
+		if strings.Contains(output.String(), secret) || strings.Contains(err.Error(), secret) {
+			t.Fatalf("auth password mismatch exposed a password: output=%q err=%v", output.String(), err)
+		}
+	}
+	record, loadErr := authmaterial.LoadRecordFromDBPath(dbPath)
+	if loadErr != nil {
+		t.Fatalf("LoadRecordFromDBPath: %v", loadErr)
+	}
+	if !authmaterial.VerifyPassword("very-secure-password", record.PasswordHash) {
+		t.Fatal("password changed after mismatched confirmation")
+	}
+}
+
+func TestAuthCLIUpdatesBrowseRoots(t *testing.T) {
+	dbPath, configPath := writeAuthCLIConfig(t)
+	if err := authmaterial.BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	first := t.TempDir()
+	second := t.TempDir()
+
+	var output bytes.Buffer
+	err := executeCLI(t.Context(), []string{"auth", "browse-roots", "--config", configPath, first, second, first}, cliIO{out: &output})
+	if err != nil {
+		t.Fatalf("auth browse-roots: %v", err)
+	}
+	if output.String() != "Updated 2 browse roots.\n" {
+		t.Fatalf("auth browse-roots output = %q", output.String())
+	}
+	record, err := authmaterial.LoadRecordFromDBPath(dbPath)
+	if err != nil {
+		t.Fatalf("LoadRecordFromDBPath: %v", err)
+	}
+	if !strings.Contains(record.BrowseRoot, first) || !strings.Contains(record.BrowseRoot, second) || record.AllowUnrestrictedBrowse {
+		t.Fatalf(
+			"stored browse policy: has_first=%t has_second=%t unrestricted=%t",
+			strings.Contains(record.BrowseRoot, first),
+			strings.Contains(record.BrowseRoot, second),
+			record.AllowUnrestrictedBrowse,
+		)
+	}
+
+	output.Reset()
+	err = executeCLI(
+		t.Context(),
+		[]string{"auth", "browse-roots", "--config", configPath, "--allow-unrestricted"},
+		cliIO{out: &output},
+	)
+	if err != nil {
+		t.Fatalf("auth browse-roots unrestricted: %v", err)
+	}
+	if output.String() != "Enabled unrestricted host browsing.\n" {
+		t.Fatalf("auth browse-roots unrestricted output = %q", output.String())
+	}
+	record, err = authmaterial.LoadRecordFromDBPath(dbPath)
+	if err != nil {
+		t.Fatalf("LoadRecordFromDBPath unrestricted: %v", err)
+	}
+	if record.BrowseRoot != "" || !record.AllowUnrestrictedBrowse {
+		t.Fatalf(
+			"stored unrestricted browse policy: has_roots=%t unrestricted=%t",
+			record.BrowseRoot != "",
+			record.AllowUnrestrictedBrowse,
+		)
+	}
+}
+
+func writeAuthCLIConfig(t *testing.T) (string, string) {
+	t.Helper()
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "upbrr.db")
+	configPath := filepath.Join(tempDir, "config.yaml")
+	body := "main_settings:\n  db_path: " + filepath.ToSlash(dbPath) + "\nscreenshot_handling:\n  screens: 1\n"
+	if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return dbPath, configPath
+}

--- a/cmd/upbrr/cli_options.go
+++ b/cmd/upbrr/cli_options.go
@@ -631,6 +631,8 @@ func formatFlagUsage(fs *pflag.FlagSet, usage string) string {
 		fmt.Fprint(&builder, "      Options: --addr, --host, --port, --base-url, --persist-web-config, --dev-no-auth\n")
 		fmt.Fprint(&builder, "  api-token <list|revoke> [options]\n")
 		fmt.Fprint(&builder, "      List and revoke persistent API bearer tokens\n")
+		fmt.Fprint(&builder, "  auth <password|browse-roots> [options]\n")
+		fmt.Fprint(&builder, "      Manage the WebUI password and browse policy locally\n")
 	}
 	fmt.Fprint(&builder, "\nOptions:\n")
 	sections := cliHelpSections(fs.Name())

--- a/cmd/upbrr/command.go
+++ b/cmd/upbrr/command.go
@@ -55,6 +55,8 @@ func executeCLI(ctx context.Context, args []string, streams cliIO) error {
 		return executeCobraCommand(ctx, cmd)
 	case "api-token":
 		return executeAPITokenCLI(ctx, args, streams, originalArgs)
+	case "auth":
+		return executeAuthCLI(ctx, args, streams, originalArgs)
 	default:
 		//nolint:contextcheck // Cobra injects ctx through ExecuteContext after command construction.
 		cmd := newUploadRootCommand(streams, originalArgs)
@@ -68,7 +70,7 @@ func executeCLI(ctx context.Context, args []string, streams cliIO) error {
 }
 
 func executeAPITokenCLI(ctx context.Context, args []string, streams cliIO, originalArgs []string) error {
-	if len(args) == 1 || apiTokenHelpToken(args[1]) {
+	if len(args) == 1 || commandHelpToken(args[1]) {
 		//nolint:contextcheck // Cobra injects ctx through ExecuteContext after command construction.
 		cmd := newRootCommand(streams, originalArgs)
 		cmd.SetArgs([]string{"api-token", "--help"})
@@ -99,7 +101,37 @@ func executeCobraCommand(ctx context.Context, cmd *cobra.Command) error {
 	return cmd.ExecuteContext(ctx)
 }
 
-func apiTokenHelpToken(value string) bool {
+func executeAuthCLI(ctx context.Context, args []string, streams cliIO, originalArgs []string) error {
+	if len(args) == 1 || commandHelpToken(args[1]) {
+		//nolint:contextcheck // Cobra injects ctx through ExecuteContext after command construction.
+		cmd := newRootCommand(streams, originalArgs)
+		cmd.SetArgs([]string{"auth", "--help"})
+		return executeCobraCommand(ctx, cmd)
+	}
+
+	childName := args[1]
+	var fs *pflag.FlagSet
+	switch childName {
+	case "password":
+		var opts authPasswordOptions
+		fs = pflag.NewFlagSet("auth "+childName, pflag.ContinueOnError)
+		bindAuthPasswordFlags(fs, &opts)
+	case "browse-roots":
+		var opts authBrowseRootsOptions
+		fs = pflag.NewFlagSet("auth "+childName, pflag.ContinueOnError)
+		bindAuthBrowseRootsFlags(fs, &opts)
+	default:
+		return exitError(2, fmt.Errorf("unknown auth command %q", childName))
+	}
+	normalized := normalizeNonInterspersedArgs(fs, args[2:])
+	commandArgs := append([]string{"auth", childName}, normalized...)
+	//nolint:contextcheck // Cobra injects ctx through ExecuteContext after command construction.
+	cmd := newRootCommand(streams, originalArgs)
+	cmd.SetArgs(commandArgs)
+	return executeCobraCommand(ctx, cmd)
+}
+
+func commandHelpToken(value string) bool {
 	switch value {
 	case "help", "-h", "--h", "-help", "--help":
 		return true
@@ -110,7 +142,7 @@ func apiTokenHelpToken(value string) bool {
 
 func newRootCommand(streams cliIO, originalArgs []string) *cobra.Command {
 	cmd := newUploadRootCommand(streams, originalArgs)
-	cmd.AddCommand(newServeCommand(streams), newAPITokenCommand(streams))
+	cmd.AddCommand(newServeCommand(streams), newAPITokenCommand(streams), newAuthCommand(streams))
 	return cmd
 }
 
@@ -224,6 +256,80 @@ func newAPITokenRevokeCommand(streams cliIO) *cobra.Command {
 		return formatFlagUsage(cmd.Flags(), "upbrr api-token revoke [options] <token-id>")
 	})
 	bindConfigAPITokenFlags(cmd.Flags(), &opts)
+	addExplicitHelpFlag(cmd)
+	cmd.Flags().SetInterspersed(false)
+	return cmd
+}
+
+func newAuthCommand(streams cliIO) *cobra.Command {
+	streams = streams.normalized()
+	cmd := &cobra.Command{
+		Use:  "auth <command> [options]",
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	configureCommand(cmd, streams, 2, "parse auth options", func(*cobra.Command) string {
+		return authCommandUsage
+	})
+	addExplicitHelpFlag(cmd)
+	cmd.Flags().SetInterspersed(false)
+	cmd.AddCommand(
+		newAuthPasswordCommand(streams),
+		newAuthBrowseRootsCommand(streams),
+	)
+	return cmd
+}
+
+func newAuthPasswordCommand(streams cliIO) *cobra.Command {
+	var opts authPasswordOptions
+	cmd := &cobra.Command{
+		Use: "password [options]",
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return exitError(2, errors.New("auth password does not accept positional arguments"))
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runChangeAuthPasswordCommand(cmd.Context(), opts, cmd.Flags().Changed("config"), cliIO{
+				in:     cmd.InOrStdin(),
+				out:    cmd.OutOrStdout(),
+				errOut: cmd.ErrOrStderr(),
+			})
+		},
+	}
+	configureCommand(cmd, streams, 2, "parse auth password options", func(cmd *cobra.Command) string {
+		return formatFlagUsage(cmd.Flags(), "upbrr auth password [options]")
+	})
+	bindAuthPasswordFlags(cmd.Flags(), &opts)
+	addExplicitHelpFlag(cmd)
+	cmd.Flags().SetInterspersed(false)
+	return cmd
+}
+
+func newAuthBrowseRootsCommand(streams cliIO) *cobra.Command {
+	var opts authBrowseRootsOptions
+	cmd := &cobra.Command{
+		Use: "browse-roots [options] <path>...",
+		Args: func(_ *cobra.Command, args []string) error {
+			if opts.allowUnrestricted && len(args) != 0 {
+				return exitError(2, errors.New("auth browse-roots cannot combine paths with --allow-unrestricted"))
+			}
+			if !opts.allowUnrestricted && len(args) == 0 {
+				return exitError(2, errors.New("auth browse-roots requires at least one path or --allow-unrestricted"))
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runUpdateBrowseRootsCommand(cmd.Context(), opts, cmd.Flags().Changed("config"), args, cmd.OutOrStdout())
+		},
+	}
+	configureCommand(cmd, streams, 2, "parse auth browse-roots options", func(cmd *cobra.Command) string {
+		return formatFlagUsage(cmd.Flags(), "upbrr auth browse-roots [options] <path>...")
+	})
+	bindAuthBrowseRootsFlags(cmd.Flags(), &opts)
 	addExplicitHelpFlag(cmd)
 	cmd.Flags().SetInterspersed(false)
 	return cmd

--- a/cmd/upbrr/command.go
+++ b/cmd/upbrr/command.go
@@ -327,7 +327,10 @@ func newAuthBrowseRootsCommand(streams cliIO) *cobra.Command {
 		},
 	}
 	configureCommand(cmd, streams, 2, "parse auth browse-roots options", func(cmd *cobra.Command) string {
-		return formatFlagUsage(cmd.Flags(), "upbrr auth browse-roots [options] <path>...")
+		return formatFlagUsage(
+			cmd.Flags(),
+			"upbrr auth browse-roots [options] <path>...\n       upbrr auth browse-roots --allow-unrestricted",
+		)
 	})
 	bindAuthBrowseRootsFlags(cmd.Flags(), &opts)
 	addExplicitHelpFlag(cmd)

--- a/cmd/upbrr/command_test.go
+++ b/cmd/upbrr/command_test.go
@@ -79,6 +79,21 @@ func TestCommandHelpGoldens(t *testing.T) {
 			args:   []string{"api-token", "revoke", "--help"},
 			golden: "api-token-revoke.txt",
 		},
+		{
+			name:   "auth",
+			args:   []string{"auth", "--help"},
+			golden: "auth.txt",
+		},
+		{
+			name:   "auth password",
+			args:   []string{"auth", "password", "--help"},
+			golden: "auth-password.txt",
+		},
+		{
+			name:   "auth browse roots",
+			args:   []string{"auth", "browse-roots", "--help"},
+			golden: "auth-browse-roots.txt",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -143,6 +158,26 @@ func TestAPITokenFirstTokenDispatch(t *testing.T) {
 	}
 }
 
+func TestAuthFirstTokenDispatch(t *testing.T) {
+	wantHelp := readHelpGolden(t, "auth.txt")
+	for _, args := range [][]string{
+		{"auth"},
+		{"auth", "help", "password"},
+		{"auth", "-h", "password"},
+		{"auth", "--help", "password"},
+	} {
+		result := executeCLIForTest(t.Context(), t, args)
+		if result.code != 0 || result.stdout != wantHelp || result.stderr != "" {
+			t.Fatalf("args %v: code=%d stdout_match=%t stderr=%q err=%v", args, result.code, result.stdout == wantHelp, result.stderr, result.err)
+		}
+	}
+
+	result := executeCLIForTest(t.Context(), t, []string{"auth", "bad", "--help"})
+	if result.code != 2 || result.stdout != "" || !strings.Contains(result.stderr, `unknown auth command "bad"`) {
+		t.Fatalf("unknown auth command result: %#v", result)
+	}
+}
+
 func TestCommandExitCodesAndRouting(t *testing.T) {
 	missingConfig := filepath.Join(t.TempDir(), "missing.yaml")
 	tests := []struct {
@@ -198,6 +233,30 @@ func TestCommandExitCodesAndRouting(t *testing.T) {
 			args:      []string{"api-token", "revoke", "TOKEN_ID", "--config", "path"},
 			wantCode:  2,
 			wantError: "api-token revoke requires exactly one token ID",
+		},
+		{
+			name:      "auth password positional",
+			args:      []string{"auth", "password", "extra"},
+			wantCode:  2,
+			wantError: "auth password does not accept positional arguments",
+		},
+		{
+			name:      "auth password rejects unattended mode",
+			args:      []string{"auth", "password", "--unattended"},
+			wantCode:  2,
+			wantError: "parse auth password options: flag provided but not defined: -unattended",
+		},
+		{
+			name:      "auth browse roots requires policy",
+			args:      []string{"auth", "browse-roots"},
+			wantCode:  2,
+			wantError: "auth browse-roots requires at least one path or --allow-unrestricted",
+		},
+		{
+			name:      "auth browse roots rejects mixed policy",
+			args:      []string{"auth", "browse-roots", "--allow-unrestricted", "path"},
+			wantCode:  2,
+			wantError: "auth browse-roots cannot combine paths with --allow-unrestricted",
 		},
 		{
 			name:      "leading flag keeps root route",

--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -433,11 +433,11 @@ func createCLIAuthFile(stdin io.Reader, stdout io.Writer, dbPath string) error {
 	if err != nil {
 		return err
 	}
-	password, err := promptAuthPassword(stdin, reader, stdout, "Password: ")
+	password, err := promptPassword(stdin, reader, stdout, "Password: ", "create auth")
 	if err != nil {
 		return err
 	}
-	confirm, err := promptAuthPassword(stdin, reader, stdout, "Confirm password: ")
+	confirm, err := promptPassword(stdin, reader, stdout, "Confirm password: ", "create auth")
 	if err != nil {
 		return err
 	}
@@ -468,23 +468,23 @@ func promptAuthValue(reader *bufio.Reader, stdout io.Writer, label string) (stri
 	return value, nil
 }
 
-func promptAuthPassword(stdin io.Reader, reader *bufio.Reader, stdout io.Writer, label string) (string, error) {
+func promptPassword(stdin io.Reader, reader *bufio.Reader, stdout io.Writer, label string, operation string) (string, error) {
 	if _, err := fmt.Fprint(stdout, label); err != nil {
-		return "", fmt.Errorf("create auth: write password prompt: %w", err)
+		return "", fmt.Errorf("%s: write password prompt: %w", operation, err)
 	}
 	if file, ok := stdin.(*os.File); ok {
 		fd, ok := terminalFileDescriptor(file)
 		if ok && term.IsTerminal(fd) {
 			raw, err := term.ReadPassword(fd)
 			if err != nil {
-				return "", fmt.Errorf("create auth: read password: %w", err)
+				return "", fmt.Errorf("%s: read password: %w", operation, err)
 			}
 			if _, err := fmt.Fprintln(stdout); err != nil {
-				return "", fmt.Errorf("create auth: finish password prompt: %w", err)
+				return "", fmt.Errorf("%s: finish password prompt: %w", operation, err)
 			}
 			value := strings.TrimSpace(string(raw))
 			if value == "" {
-				return "", errors.New("create auth: password cannot be empty")
+				return "", fmt.Errorf("%s: password cannot be empty", operation)
 			}
 			return value, nil
 		}
@@ -492,11 +492,11 @@ func promptAuthPassword(stdin io.Reader, reader *bufio.Reader, stdout io.Writer,
 
 	line, err := reader.ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
-		return "", fmt.Errorf("create auth: read password: %w", err)
+		return "", fmt.Errorf("%s: read password: %w", operation, err)
 	}
 	value := strings.TrimSpace(line)
 	if value == "" {
-		return "", errors.New("create auth: password cannot be empty")
+		return "", fmt.Errorf("%s: password cannot be empty", operation)
 	}
 	return value, nil
 }

--- a/cmd/upbrr/testdata/help/auth-browse-roots.txt
+++ b/cmd/upbrr/testdata/help/auth-browse-roots.txt
@@ -1,0 +1,11 @@
+Usage: upbrr auth browse-roots [options] <path>...
+
+Options:
+
+Config:
+  -config, --config string
+      Path to config file
+
+Other:
+  -allow-unrestricted, --allow-unrestricted
+      Allow unrestricted host browsing instead of configured roots

--- a/cmd/upbrr/testdata/help/auth-browse-roots.txt
+++ b/cmd/upbrr/testdata/help/auth-browse-roots.txt
@@ -1,4 +1,5 @@
 Usage: upbrr auth browse-roots [options] <path>...
+       upbrr auth browse-roots --allow-unrestricted
 
 Options:
 

--- a/cmd/upbrr/testdata/help/auth-password.txt
+++ b/cmd/upbrr/testdata/help/auth-password.txt
@@ -1,0 +1,7 @@
+Usage: upbrr auth password [options]
+
+Options:
+
+Config:
+  -config, --config string
+      Path to config file

--- a/cmd/upbrr/testdata/help/auth.txt
+++ b/cmd/upbrr/testdata/help/auth.txt
@@ -1,0 +1,7 @@
+Usage: upbrr auth <command> [options]
+
+Commands:
+  password       Change the WebUI password
+  browse-roots  Replace the WebUI browse roots
+
+Run "upbrr auth <command> --help" for command options.

--- a/cmd/upbrr/testdata/help/root.txt
+++ b/cmd/upbrr/testdata/help/root.txt
@@ -6,6 +6,8 @@ Commands:
       Options: --addr, --host, --port, --base-url, --persist-web-config, --dev-no-auth
   api-token <list|revoke> [options]
       List and revoke persistent API bearer tokens
+  auth <password|browse-roots> [options]
+      Manage the WebUI password and browse policy locally
 
 Options:
 

--- a/documentation/docs/cli/index.md
+++ b/documentation/docs/cli/index.md
@@ -224,7 +224,7 @@ See [Web server and reverse proxy](../configuration/web-server.md) for precedenc
 
 ## `auth`
 
-Password and browse-policy changes are available only through the local binary. Stop `upbrr serve` before running either command, then restart it when the command completes.
+Password changes and browse-policy changes after initial setup are available only through the local binary. The first authenticated Web UI setup may establish the initial browse policy. Stop `upbrr serve` before running either command, then restart it when the command completes.
 
 Change the Web UI password interactively:
 
@@ -232,7 +232,7 @@ Change the Web UI password interactively:
 .\upbrr.exe auth password
 ```
 
-The command prompts for the current password, the replacement, and confirmation without accepting password flags. A successful change revokes retained browser sessions.
+The command prompts for the current password, the replacement, and confirmation without accepting password flags. Retained browser sessions are revoked immediately after the current password is verified. If a later update step fails, sign in again with the existing password before retrying.
 
 Replace all browse roots by passing each existing directory as a separate argument:
 

--- a/documentation/docs/cli/index.md
+++ b/documentation/docs/cli/index.md
@@ -226,6 +226,8 @@ See [Web server and reverse proxy](../configuration/web-server.md) for precedenc
 
 Password changes and browse-policy changes after initial setup are available only through the local binary. The first authenticated Web UI setup may establish the initial browse policy. Stop `upbrr serve` before running either command, then restart it when the command completes.
 
+After validation, each command creates a unique `web-auth.json.backup-*` beside the active auth file and prints its exact path. The path is still printed if a later update step fails. Backups contain sensitive authentication and encryption material; protect them like `web-auth.json` and remove obsolete copies manually.
+
 Change the Web UI password interactively:
 
 ```powershell

--- a/documentation/docs/cli/index.md
+++ b/documentation/docs/cli/index.md
@@ -9,6 +9,7 @@ description: Commands, interaction modes, aliases, and upload preparation flags 
 upbrr [options] <input path>...
 upbrr serve [options]
 upbrr api-token <list|revoke> [options]
+upbrr auth <password|browse-roots> [options]
 ```
 
 On Windows, examples use `upbrr.exe`. Put options before input paths.
@@ -19,6 +20,7 @@ Use executable help as the exact reference for your installed version:
 .\upbrr.exe --help
 .\upbrr.exe serve --help
 .\upbrr.exe api-token list --help
+.\upbrr.exe auth password --help
 ```
 
 ## Common operations
@@ -219,6 +221,32 @@ upbrr serve [options]
 | `--dev-no-auth`            | Disable Web auth for local development on loopback only. |
 
 See [Web server and reverse proxy](../configuration/web-server.md) for precedence and proxy examples.
+
+## `auth`
+
+Password and browse-policy changes are available only through the local binary. Stop `upbrr serve` before running either command, then restart it when the command completes.
+
+Change the Web UI password interactively:
+
+```powershell
+.\upbrr.exe auth password
+```
+
+The command prompts for the current password, the replacement, and confirmation without accepting password flags. A successful change revokes retained browser sessions.
+
+Replace all browse roots by passing each existing directory as a separate argument:
+
+```powershell
+.\upbrr.exe auth browse-roots "D:\Media" "E:\Downloads"
+```
+
+To remove the roots and explicitly allow unrestricted host browsing:
+
+```powershell
+.\upbrr.exe auth browse-roots --allow-unrestricted
+```
+
+Both subcommands accept `--config` when the active database is selected through a non-default config file. For containers, run the command in the same environment as upbrr and use paths visible inside the container.
 
 ## `api-token`
 

--- a/documentation/docs/configuration/web-server.md
+++ b/documentation/docs/configuration/web-server.md
@@ -48,9 +48,17 @@ Use `--persist-web-config` to save supplied `serve` settings. Add `--persist-lis
 
 ## First-run authentication and browse policy
 
-The first browser connection creates an administrator account. The same setup asks for one or more browse roots or explicit unrestricted browsing.
+The first browser connection creates an administrator account. Browse-policy and password changes are intentionally unavailable through the Web UI.
 
 Browse roots restrict browser-driven folder selection and file import. They do not restrict a direct CLI input path. Store them in `web-auth.json`, separate from imported application configuration.
+
+After creating the account, stop the server and set one or more existing directories with the local binary:
+
+```powershell
+.\upbrr.exe auth browse-roots "D:\Media" "E:\Downloads"
+```
+
+Restart `upbrr serve` after the command completes. Use `auth password` with the server stopped when the administrator password must change. See the [`auth` CLI reference](../cli/index.md#auth) for unrestricted browsing, custom config paths, and session behavior.
 
 `--dev-no-auth` disables browser authentication only on loopback hosts and is intended for local development. Do not use it for a network-accessible deployment.
 

--- a/documentation/docs/configuration/web-server.md
+++ b/documentation/docs/configuration/web-server.md
@@ -48,11 +48,11 @@ Use `--persist-web-config` to save supplied `serve` settings. Add `--persist-lis
 
 ## First-run authentication and browse policy
 
-The first browser connection creates an administrator account. Browse-policy and password changes are intentionally unavailable through the Web UI.
+The first browser connection creates an administrator account and establishes the initial browse policy. After that setup, browse-policy and password changes are intentionally unavailable through the Web UI.
 
 Browse roots restrict browser-driven folder selection and file import. They do not restrict a direct CLI input path. Store them in `web-auth.json`, separate from imported application configuration.
 
-After creating the account, stop the server and set one or more existing directories with the local binary:
+To replace the initial policy later, stop the server and set one or more existing directories with the local binary:
 
 ```powershell
 .\upbrr.exe auth browse-roots "D:\Media" "E:\Downloads"

--- a/documentation/docs/getting-started/migrate-from-upload-assistant.md
+++ b/documentation/docs/getting-started/migrate-from-upload-assistant.md
@@ -49,7 +49,7 @@ Verify tracker authentication from **Settings** before preparing a live upload.
 
 Browse roots are not part of imported application config. They are stored in `web-auth.json` beside the database because they control which host paths the browser may access.
 
-After import, stop the Web UI server and replace the policy through the local binary:
+If no browse policy exists, the first authenticated Web UI setup can establish it. To replace a policy after setup, stop the Web UI server and use the local binary:
 
 ```powershell
 .\upbrr.exe auth browse-roots "D:\Media" "E:\Downloads"

--- a/documentation/docs/getting-started/migrate-from-upload-assistant.md
+++ b/documentation/docs/getting-started/migrate-from-upload-assistant.md
@@ -49,7 +49,13 @@ Verify tracker authentication from **Settings** before preparing a live upload.
 
 Browse roots are not part of imported application config. They are stored in `web-auth.json` beside the database because they control which host paths the browser may access.
 
-After import, complete first-run Web UI setup or update the browse policy. Existing browse roots remain unchanged when application config is imported.
+After import, stop the Web UI server and replace the policy through the local binary:
+
+```powershell
+.\upbrr.exe auth browse-roots "D:\Media" "E:\Downloads"
+```
+
+Existing browse roots remain unchanged when application config is imported.
 
 ## Validate the migration
 

--- a/documentation/docs/getting-started/quick-start.md
+++ b/documentation/docs/getting-started/quick-start.md
@@ -37,9 +37,16 @@ For Linux or macOS, run the equivalent executable:
 
 ## 2. Secure browser access
 
-The first-run screen creates the administrator account. Choose a unique password.
+The first-run screen creates the administrator account. Choose a unique password. The browser then reports that browse access requires the local binary.
 
-Then set one or more browse roots. These roots limit which host folders the browser can select. Use the narrowest folders containing your releases, such as `D:\Media` and `E:\Downloads`. Unrestricted host browsing is available but broadens access.
+Stop the server with <kbd>Ctrl</kbd>+<kbd>C</kbd>, set the narrowest folders containing your releases, then restart it:
+
+```powershell
+.\upbrr.exe auth browse-roots "D:\Media" "E:\Downloads"
+.\upbrr.exe serve
+```
+
+These roots limit which host folders the browser can select. Unrestricted host browsing is available through `auth browse-roots --allow-unrestricted`, but broadens access.
 
 :::caution Network exposure
 

--- a/documentation/docs/getting-started/quick-start.md
+++ b/documentation/docs/getting-started/quick-start.md
@@ -37,16 +37,9 @@ For Linux or macOS, run the equivalent executable:
 
 ## 2. Secure browser access
 
-The first-run screen creates the administrator account. Choose a unique password. The browser then reports that browse access requires the local binary.
+The first-run screens create the administrator account and initial browse policy. Choose a unique password, then set the narrowest folders containing your releases, such as `D:\releases` and `E:\Downloads`.
 
-Stop the server with <kbd>Ctrl</kbd>+<kbd>C</kbd>, set the narrowest folders containing your releases, then restart it:
-
-```powershell
-.\upbrr.exe auth browse-roots "D:\Media" "E:\Downloads"
-.\upbrr.exe serve
-```
-
-These roots limit which host folders the browser can select. Unrestricted host browsing is available through `auth browse-roots --allow-unrestricted`, but broadens access.
+These roots limit which host folders the browser can select. Initial setup can explicitly allow unrestricted host browsing, but this broadens access. Later password or browse-policy changes require the local `upbrr auth` commands while the server is stopped.
 
 :::caution Network exposure
 

--- a/documentation/docs/web-ui/index.md
+++ b/documentation/docs/web-ui/index.md
@@ -17,7 +17,7 @@ The default address is [http://localhost:7480](http://localhost:7480).
 
 ## First-run setup
 
-Create the administrator account, then choose one or more host browse roots. Browse roots control which folders the browser can open for release selection and file import.
+Create the administrator account in the browser. Then stop the server, configure one or more host browse roots with `upbrr auth browse-roots <path>...`, and restart it. Browse roots control which folders the browser can open for release selection and file import.
 
 Use a dedicated account password. Do not expose an unconfigured instance to an untrusted network.
 
@@ -73,10 +73,10 @@ The host browser lists only configured roots unless unrestricted browsing was ex
 
 1. verify the upbrr process or container can read it;
 2. verify the path is mounted into the container when using Docker;
-3. update browse roots through the Web UI auth/browse policy;
+3. stop the server and replace the roots with `upbrr auth browse-roots <path>...`;
 4. use the path as visible inside the container, not the host-only path.
 
-Imported application config does not change browse roots.
+Imported application config does not change browse roots. Password and browse-policy mutations are not exposed through Web UI routes.
 
 ## Safe first use
 

--- a/documentation/docs/web-ui/index.md
+++ b/documentation/docs/web-ui/index.md
@@ -17,7 +17,7 @@ The default address is [http://localhost:7480](http://localhost:7480).
 
 ## First-run setup
 
-Create the administrator account in the browser. Then stop the server, configure one or more host browse roots with `upbrr auth browse-roots <path>...`, and restart it. Browse roots control which folders the browser can open for release selection and file import.
+Create the administrator account in the browser, then configure one or more host browse roots in the initial setup screen. Browse roots control which folders the browser can open for release selection and file import.
 
 Use a dedicated account password. Do not expose an unconfigured instance to an untrusted network.
 
@@ -76,7 +76,7 @@ The host browser lists only configured roots unless unrestricted browsing was ex
 3. stop the server and replace the roots with `upbrr auth browse-roots <path>...`;
 4. use the path as visible inside the container, not the host-only path.
 
-Imported application config does not change browse roots. Password and browse-policy mutations are not exposed through Web UI routes.
+Imported application config does not change browse roots. The Web UI route accepts only the initial browse policy; later password and browse-policy changes require the local CLI.
 
 ## Safe first use
 

--- a/internal/authmaterial/store.go
+++ b/internal/authmaterial/store.go
@@ -138,6 +138,46 @@ func (s *Store) Load() (Record, error) {
 	return s.loadLocked()
 }
 
+// CreateBackup copies the current auth file bytes to a unique secure file
+// beside it. Completed backups are never overwritten or removed.
+func (s *Store) CreateBackup() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	raw, err := os.ReadFile(s.path)
+	if err != nil {
+		return "", fmt.Errorf("web auth: read auth file for backup: %w", err)
+	}
+
+	backupFile, err := os.CreateTemp(filepath.Dir(s.path), filepath.Base(s.path)+".backup-*")
+	if err != nil {
+		return "", fmt.Errorf("web auth: create backup file: %w", err)
+	}
+	backupPath := backupFile.Name()
+
+	if err := backupFile.Chmod(0o600); err != nil {
+		_ = backupFile.Close()
+		_ = os.Remove(backupPath)
+		return "", fmt.Errorf("web auth: chmod backup file: %w", err)
+	}
+	if _, err := backupFile.Write(raw); err != nil {
+		_ = backupFile.Close()
+		_ = os.Remove(backupPath)
+		return "", fmt.Errorf("web auth: write backup file: %w", err)
+	}
+	if err := backupFile.Sync(); err != nil {
+		_ = backupFile.Close()
+		_ = os.Remove(backupPath)
+		return "", fmt.Errorf("web auth: sync backup file: %w", err)
+	}
+	if err := backupFile.Close(); err != nil {
+		_ = os.Remove(backupPath)
+		return "", fmt.Errorf("web auth: close backup file: %w", err)
+	}
+
+	return backupPath, nil
+}
+
 // loadLocked is intentionally separate so read-modify-write operations hold
 // one store lock across both the read and atomic replacement.
 func (s *Store) loadLocked() (Record, error) {

--- a/internal/authmaterial/store.go
+++ b/internal/authmaterial/store.go
@@ -180,12 +180,15 @@ func (s *Store) Bootstrap(username string, password string) error {
 	return s.saveLocked(record)
 }
 
-// UpdatePasswordHash replaces only the hash when username matches the active
-// record.
-func (s *Store) UpdatePasswordHash(username string, passwordHash string) error {
+// UpdatePasswordHash replaces only the hash when username and current hash
+// still match the active record.
+func (s *Store) UpdatePasswordHash(username string, currentPasswordHash string, passwordHash string) error {
 	return s.updateRecordLocked(func(record *Record) error {
 		if record.Username != strings.TrimSpace(username) {
 			return errors.New("web auth: user mismatch")
+		}
+		if strings.TrimSpace(record.PasswordHash) != strings.TrimSpace(currentPasswordHash) {
+			return errors.New("web auth: password changed during update")
 		}
 		record.PasswordHash = strings.TrimSpace(passwordHash)
 		return nil

--- a/internal/authmaterial/store.go
+++ b/internal/authmaterial/store.go
@@ -195,6 +195,38 @@ func (s *Store) UpdatePasswordHash(username string, currentPasswordHash string, 
 	})
 }
 
+// InitializeBrowsePolicy atomically persists the first WebUI browse policy. It
+// returns false without modifying a policy that was already configured.
+func (s *Store) InitializeBrowsePolicy(username string, browseRoot string, allowUnrestricted bool) (bool, error) {
+	browseRoot = strings.TrimSpace(browseRoot)
+	if allowUnrestricted && browseRoot != "" {
+		return false, errors.New("web auth: unrestricted browsing cannot be combined with browse roots")
+	}
+	if !allowUnrestricted && browseRoot == "" {
+		return false, errors.New("web auth: at least one browse root is required")
+	}
+
+	initialized := false
+	err := s.updateRecordLocked(func(record *Record) error {
+		if record.Username != strings.TrimSpace(username) {
+			return errors.New("web auth: user mismatch")
+		}
+		if strings.TrimSpace(record.BrowseRoot) != "" || record.AllowUnrestrictedBrowse {
+			return nil
+		}
+
+		record.BrowseRoot = browseRoot
+		record.AllowUnrestrictedBrowse = allowUnrestricted
+		if record.PendingUpgrade != nil {
+			record.PendingUpgrade.Target.BrowseRoot = record.BrowseRoot
+			record.PendingUpgrade.Target.AllowUnrestrictedBrowse = allowUnrestricted
+		}
+		initialized = true
+		return nil
+	})
+	return initialized, err
+}
+
 // UpdateRecord replaces mutable auth, export, browse, and upgrade fields while
 // preserving the active username and creation time.
 func (s *Store) UpdateRecord(updated Record) error {

--- a/internal/authmaterial/store_test.go
+++ b/internal/authmaterial/store_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package authmaterial
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestStoreCreateBackupPreservesExactBytesInUniqueSecureFiles(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
+	if err := BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	store, err := NewStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	authPath := AuthFilePath(dbPath)
+	original, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatalf("read original auth file: %v", err)
+	}
+
+	firstPath, err := store.CreateBackup()
+	if err != nil {
+		t.Fatalf("CreateBackup: %v", err)
+	}
+	if !strings.HasPrefix(filepath.Base(firstPath), WebAuthFileName+".backup-") {
+		t.Fatalf("unexpected backup name %q", filepath.Base(firstPath))
+	}
+	first, err := os.ReadFile(firstPath)
+	if err != nil {
+		t.Fatalf("read first backup: %v", err)
+	}
+	if !bytes.Equal(first, original) {
+		t.Fatal("first backup does not preserve exact auth file bytes")
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(firstPath)
+		if err != nil {
+			t.Fatalf("stat first backup: %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("backup permissions = %o, want 600", got)
+		}
+	}
+
+	record, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	record.BrowseRoot = t.TempDir()
+	if err := store.UpdateRecord(record); err != nil {
+		t.Fatalf("UpdateRecord: %v", err)
+	}
+	updated, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatalf("read updated auth file: %v", err)
+	}
+	secondPath, err := store.CreateBackup()
+	if err != nil {
+		t.Fatalf("CreateBackup after update: %v", err)
+	}
+	if secondPath == firstPath {
+		t.Fatal("successive backups reused one path")
+	}
+	second, err := os.ReadFile(secondPath)
+	if err != nil {
+		t.Fatalf("read second backup: %v", err)
+	}
+	if !bytes.Equal(second, updated) {
+		t.Fatal("second backup does not preserve updated auth file bytes")
+	}
+	first, err = os.ReadFile(firstPath)
+	if err != nil {
+		t.Fatalf("reread first backup: %v", err)
+	}
+	if !bytes.Equal(first, original) {
+		t.Fatal("later backup changed the first backup")
+	}
+}

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -611,7 +611,7 @@ func lineColumnForOffset(content []byte, offset int) (int, int) {
 // checkCLISensitiveOutputFile flags raw dry-run endpoint and payload printing in
 // cmd/upbrr, where stdout becomes user-shareable debug log material.
 func checkCLISensitiveOutputFile(fset *token.FileSet, root string, path string) ([]Violation, error) {
-	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments|parser.SkipObjectResolution)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
@@ -625,7 +625,8 @@ func checkCLISensitiveOutputFile(fset *token.FileSet, root string, path string) 
 
 	dryRunFileVars := collectDryRunFileVars(file)
 	localPathVars := collectLocalPathVars(file, aliases)
-	violations := make([]Violation, 0)
+	allows, allowViolations := collectLogpolicyAllows(fset, relPath, file)
+	violations := append([]Violation(nil), allowViolations...)
 	ast.Inspect(file, func(node ast.Node) bool {
 		call, ok := node.(*ast.CallExpr)
 		if !ok {
@@ -657,9 +658,13 @@ func checkCLISensitiveOutputFile(fset *token.FileSet, root string, path string) 
 				)
 			}
 			if containsLocalPathOutputExpr(arg, localPathVars, aliases) && !isSafeLocalPathOutputExpr(arg) {
-				violations = append(
-					violations,
-					violationAt(fset, relPath, arg.Pos(), "local filesystem path output must be reduced to a stable path label before printing"),
+				appendLogpolicyViolation(
+					fset,
+					relPath,
+					allows,
+					&violations,
+					arg.Pos(),
+					"local filesystem path output must be reduced to a stable path label before printing",
 				)
 			}
 		}
@@ -672,6 +677,7 @@ func checkCLISensitiveOutputFile(fset *token.FileSet, root string, path string) 
 		}
 		return true
 	})
+	violations = append(violations, unusedLogpolicyAllowViolations(fset, relPath, allows)...)
 	return violations, nil
 }
 

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -1738,7 +1738,7 @@ func shouldSuppressLogpolicyPosition(fset *token.FileSet, allows map[int]*logpol
 	line := fset.Position(pos).Line
 	for _, candidateLine := range []int{line, line - 1} {
 		allow := allows[candidateLine]
-		if allow == nil || allow.reason == "" {
+		if allow == nil || allow.reason == "" || allow.used {
 			continue
 		}
 		allow.used = true

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -1105,6 +1105,41 @@ func printReleaseDetails(p preview, sourcePath string) {
 	}
 }
 
+func TestCheckRepositoryAllowsReasonedExactLocalPathCLIOutput(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal"), 0o755); err != nil {
+		t.Fatalf("mkdir internal: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "cmd", "upbrr"), 0o755); err != nil {
+		t.Fatalf("mkdir cmd upbrr: %v", err)
+	}
+
+	content := `package main
+
+import "fmt"
+
+func printBackup(backupPath string) {
+	fmt.Printf(
+		"Backup: %s\n",
+		//logpolicy:allow exact operator-requested backup location is required for recovery
+		backupPath,
+	)
+}
+`
+
+	if err := os.WriteFile(filepath.Join(root, "cmd", "upbrr", "auth.go"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations, got %#v", violations)
+	}
+}
+
 func TestCheckRepositoryAllowsGenericCLIOutputNamesWithoutPathSource(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "internal"), 0o755); err != nil {

--- a/internal/logpolicy/checker_test.go
+++ b/internal/logpolicy/checker_test.go
@@ -1140,6 +1140,38 @@ func printBackup(backupPath string) {
 	}
 }
 
+func TestCheckRepositoryReasonedCLIPathAllowSuppressesOnlyOneViolation(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal"), 0o755); err != nil {
+		t.Fatalf("mkdir internal: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "cmd", "upbrr"), 0o755); err != nil {
+		t.Fatalf("mkdir cmd upbrr: %v", err)
+	}
+
+	content := `package main
+
+import "fmt"
+
+func printBackup(backupPath string, unrelatedPath string) {
+	//logpolicy:allow exact operator-requested backup location is required for recovery
+	fmt.Printf("Backup: %s; unrelated: %s\n", backupPath, unrelatedPath)
+}
+`
+
+	if err := os.WriteFile(filepath.Join(root, "cmd", "upbrr", "auth.go"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write sample file: %v", err)
+	}
+
+	violations, err := CheckRepository(root)
+	if err != nil {
+		t.Fatalf("CheckRepository returned error: %v", err)
+	}
+	if len(violations) != 1 || !strings.Contains(violations[0].Message, "local filesystem path output") {
+		t.Fatalf("expected one local path violation, got %#v", violations)
+	}
+}
+
 func TestCheckRepositoryAllowsGenericCLIOutputNamesWithoutPathSource(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "internal"), 0o755); err != nil {

--- a/internal/webserver/auth_management.go
+++ b/internal/webserver/auth_management.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package webserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/autobrr/upbrr/internal/authmaterial"
+	"github.com/autobrr/upbrr/internal/services/db"
+)
+
+// ChangeAuthPassword verifies and replaces the persisted WebUI password. The
+// caller must stop the WebUI server first so in-memory sessions cannot survive.
+// It revokes retained sessions and preserves protected data during legacy key upgrades.
+func ChangeAuthPassword(ctx context.Context, dbPath string, currentPassword string, newPassword string) error {
+	if ctx == nil {
+		return errors.New("change auth password: context is required")
+	}
+	if strings.TrimSpace(dbPath) == "" {
+		return errors.New("change auth password: database path is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("change auth password: %w", err)
+	}
+
+	store, err := authmaterial.NewStore(dbPath)
+	if err != nil {
+		return fmt.Errorf("change auth password: open auth store: %w", err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		return fmt.Errorf("change auth password: load auth record: %w", err)
+	}
+	if !record.AuthMaterial().IsUsable() {
+		return errors.New("change auth password: web-auth.json is incomplete")
+	}
+	if !authmaterial.VerifyPassword(currentPassword, record.PasswordHash) {
+		return errors.New("change auth password: current password is incorrect")
+	}
+
+	newHash, err := authmaterial.HashPassword(newPassword)
+	if err != nil {
+		return fmt.Errorf("change auth password: %w", err)
+	}
+	if err := clearPersistedAuthSessions(dbPath); err != nil {
+		return err
+	}
+
+	var repo *db.SQLiteRepository
+	openRepo := func() (*db.SQLiteRepository, error) {
+		if repo != nil {
+			return repo, nil
+		}
+		opened, err := db.OpenContext(ctx, dbPath)
+		if err != nil {
+			return nil, fmt.Errorf("change auth password: open database: %w", err)
+		}
+		if err := opened.MigrateContext(ctx); err != nil {
+			_ = opened.Close()
+			return nil, fmt.Errorf("change auth password: migrate database: %w", err)
+		}
+		repo = opened
+		return repo, nil
+	}
+	defer func() {
+		if repo != nil {
+			_ = repo.Close()
+		}
+	}()
+
+	if record.PendingUpgrade != nil {
+		currentRepo, err := openRepo()
+		if err != nil {
+			return err
+		}
+		if err := rewrapProtectedDataForAuthChange(ctx, store, currentRepo, record, record.PendingUpgrade.Target); err != nil {
+			return fmt.Errorf("change auth password: resume pending auth update: %w", err)
+		}
+		record, err = store.FinalizePendingUpgrade(record.Username)
+		if err != nil {
+			return fmt.Errorf("change auth password: finalize pending auth update: %w", err)
+		}
+	}
+
+	target := record
+	target.PasswordHash = newHash
+	target.PendingUpgrade = nil
+	if strings.TrimSpace(target.EncryptionKeySeed) == "" {
+		target.EncryptionKeySeed, err = authmaterial.GenerateSeed()
+		if err != nil {
+			return fmt.Errorf("change auth password: generate encryption seed: %w", err)
+		}
+	}
+
+	_, oldFingerprint, err := record.AuthMaterial().PrimaryHelper()
+	if err != nil {
+		return fmt.Errorf("change auth password: derive current encryption helper: %w", err)
+	}
+	_, newFingerprint, err := target.AuthMaterial().PrimaryHelper()
+	if err != nil {
+		return fmt.Errorf("change auth password: derive replacement encryption helper: %w", err)
+	}
+	if oldFingerprint == newFingerprint {
+		if err := store.UpdatePasswordHash(record.Username, record.PasswordHash, newHash); err != nil {
+			return fmt.Errorf("change auth password: persist password: %w", err)
+		}
+		return nil
+	}
+
+	currentRepo, err := openRepo()
+	if err != nil {
+		return err
+	}
+	if err := rewrapProtectedDataForAuthChange(ctx, store, currentRepo, record, target); err != nil {
+		return fmt.Errorf("change auth password: rewrap protected data: %w", err)
+	}
+	if _, err := store.FinalizePendingUpgrade(record.Username); err != nil {
+		return fmt.Errorf("change auth password: finalize password: %w", err)
+	}
+	return nil
+}
+
+// UpdateBrowseRoots replaces the persisted WebUI browse policy. Paths must be
+// existing directories; unrestricted access cannot be combined with roots.
+// The caller must stop the WebUI server first to avoid concurrent auth writes.
+func UpdateBrowseRoots(ctx context.Context, dbPath string, values []string, allowUnrestricted bool) (int, error) {
+	if ctx == nil {
+		return 0, errors.New("update browse roots: context is required")
+	}
+	if strings.TrimSpace(dbPath) == "" {
+		return 0, errors.New("update browse roots: database path is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, fmt.Errorf("update browse roots: %w", err)
+	}
+	if allowUnrestricted && len(values) != 0 {
+		return 0, errors.New("update browse roots: unrestricted browsing cannot be combined with browse roots")
+	}
+
+	roots, err := normalizeBrowsePolicyRoots(values)
+	if err != nil {
+		return 0, fmt.Errorf("update browse roots: %w", err)
+	}
+	if !allowUnrestricted && len(roots) == 0 {
+		return 0, errors.New("update browse roots: at least one browse root is required unless unrestricted browsing is explicitly allowed")
+	}
+
+	store, err := authmaterial.NewStore(dbPath)
+	if err != nil {
+		return 0, fmt.Errorf("update browse roots: open auth store: %w", err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		return 0, fmt.Errorf("update browse roots: load auth record: %w", err)
+	}
+	if !record.AuthMaterial().IsUsable() {
+		return 0, errors.New("update browse roots: web-auth.json is incomplete")
+	}
+	record.BrowseRoot = joinBrowsePolicyRoots(roots)
+	record.AllowUnrestrictedBrowse = allowUnrestricted
+	if record.PendingUpgrade != nil {
+		record.PendingUpgrade.Target.BrowseRoot = record.BrowseRoot
+		record.PendingUpgrade.Target.AllowUnrestrictedBrowse = allowUnrestricted
+	}
+	if err := store.UpdateRecord(record); err != nil {
+		return 0, fmt.Errorf("update browse roots: persist policy: %w", err)
+	}
+	return len(roots), nil
+}
+
+func clearPersistedAuthSessions(dbPath string) error {
+	path := filepath.Join(filepath.Dir(strings.TrimSpace(dbPath)), sessionFileName)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("change auth password: revoke retained sessions: %w", err)
+	}
+	return nil
+}

--- a/internal/webserver/auth_management.go
+++ b/internal/webserver/auth_management.go
@@ -17,39 +17,45 @@ import (
 
 // ChangeAuthPassword verifies and replaces the persisted WebUI password. The
 // caller must stop the WebUI server first so in-memory sessions cannot survive.
-// It revokes retained sessions and preserves protected data during legacy key upgrades.
-func ChangeAuthPassword(ctx context.Context, dbPath string, currentPassword string, newPassword string) error {
+// It creates one pre-change backup, revokes retained sessions, and preserves
+// protected data during legacy key upgrades. A returned backup path remains
+// valid when a later update step fails.
+func ChangeAuthPassword(ctx context.Context, dbPath string, currentPassword string, newPassword string) (string, error) {
 	if ctx == nil {
-		return errors.New("change auth password: context is required")
+		return "", errors.New("change auth password: context is required")
 	}
 	if strings.TrimSpace(dbPath) == "" {
-		return errors.New("change auth password: database path is required")
+		return "", errors.New("change auth password: database path is required")
 	}
 	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("change auth password: %w", err)
+		return "", fmt.Errorf("change auth password: %w", err)
 	}
 
 	store, err := authmaterial.NewStore(dbPath)
 	if err != nil {
-		return fmt.Errorf("change auth password: open auth store: %w", err)
+		return "", fmt.Errorf("change auth password: open auth store: %w", err)
 	}
 	record, err := store.Load()
 	if err != nil {
-		return fmt.Errorf("change auth password: load auth record: %w", err)
+		return "", fmt.Errorf("change auth password: load auth record: %w", err)
 	}
 	if !record.AuthMaterial().IsUsable() {
-		return errors.New("change auth password: web-auth.json is incomplete")
+		return "", errors.New("change auth password: web-auth.json is incomplete")
 	}
 	if !authmaterial.VerifyPassword(currentPassword, record.PasswordHash) {
-		return errors.New("change auth password: current password is incorrect")
+		return "", errors.New("change auth password: current password is incorrect")
 	}
 
 	newHash, err := authmaterial.HashPassword(newPassword)
 	if err != nil {
-		return fmt.Errorf("change auth password: %w", err)
+		return "", fmt.Errorf("change auth password: %w", err)
+	}
+	backupPath, err := store.CreateBackup()
+	if err != nil {
+		return "", fmt.Errorf("change auth password: create auth backup: %w", err)
 	}
 	if err := clearPersistedAuthSessions(dbPath); err != nil {
-		return err
+		return backupPath, err
 	}
 
 	var repo *db.SQLiteRepository
@@ -77,14 +83,14 @@ func ChangeAuthPassword(ctx context.Context, dbPath string, currentPassword stri
 	if record.PendingUpgrade != nil {
 		currentRepo, err := openRepo()
 		if err != nil {
-			return err
+			return backupPath, err
 		}
 		if err := rewrapProtectedDataForAuthChange(ctx, store, currentRepo, record, record.PendingUpgrade.Target); err != nil {
-			return fmt.Errorf("change auth password: resume pending auth update: %w", err)
+			return backupPath, fmt.Errorf("change auth password: resume pending auth update: %w", err)
 		}
 		record, err = store.FinalizePendingUpgrade(record.Username)
 		if err != nil {
-			return fmt.Errorf("change auth password: finalize pending auth update: %w", err)
+			return backupPath, fmt.Errorf("change auth password: finalize pending auth update: %w", err)
 		}
 	}
 
@@ -94,73 +100,78 @@ func ChangeAuthPassword(ctx context.Context, dbPath string, currentPassword stri
 	if strings.TrimSpace(target.EncryptionKeySeed) == "" {
 		target.EncryptionKeySeed, err = authmaterial.GenerateSeed()
 		if err != nil {
-			return fmt.Errorf("change auth password: generate encryption seed: %w", err)
+			return backupPath, fmt.Errorf("change auth password: generate encryption seed: %w", err)
 		}
 	}
 
 	_, oldFingerprint, err := record.AuthMaterial().PrimaryHelper()
 	if err != nil {
-		return fmt.Errorf("change auth password: derive current encryption helper: %w", err)
+		return backupPath, fmt.Errorf("change auth password: derive current encryption helper: %w", err)
 	}
 	_, newFingerprint, err := target.AuthMaterial().PrimaryHelper()
 	if err != nil {
-		return fmt.Errorf("change auth password: derive replacement encryption helper: %w", err)
+		return backupPath, fmt.Errorf("change auth password: derive replacement encryption helper: %w", err)
 	}
 	if oldFingerprint == newFingerprint {
 		if err := store.UpdatePasswordHash(record.Username, record.PasswordHash, newHash); err != nil {
-			return fmt.Errorf("change auth password: persist password: %w", err)
+			return backupPath, fmt.Errorf("change auth password: persist password: %w", err)
 		}
-		return nil
+		return backupPath, nil
 	}
 
 	currentRepo, err := openRepo()
 	if err != nil {
-		return err
+		return backupPath, err
 	}
 	if err := rewrapProtectedDataForAuthChange(ctx, store, currentRepo, record, target); err != nil {
-		return fmt.Errorf("change auth password: rewrap protected data: %w", err)
+		return backupPath, fmt.Errorf("change auth password: rewrap protected data: %w", err)
 	}
 	if _, err := store.FinalizePendingUpgrade(record.Username); err != nil {
-		return fmt.Errorf("change auth password: finalize password: %w", err)
+		return backupPath, fmt.Errorf("change auth password: finalize password: %w", err)
 	}
-	return nil
+	return backupPath, nil
 }
 
 // UpdateBrowseRoots replaces the persisted WebUI browse policy. Paths must be
 // existing directories; unrestricted access cannot be combined with roots.
 // The caller must stop the WebUI server first to avoid concurrent auth writes.
-func UpdateBrowseRoots(ctx context.Context, dbPath string, values []string, allowUnrestricted bool) (int, error) {
+// A returned backup path remains valid when persistence later fails.
+func UpdateBrowseRoots(ctx context.Context, dbPath string, values []string, allowUnrestricted bool) (int, string, error) {
 	if ctx == nil {
-		return 0, errors.New("update browse roots: context is required")
+		return 0, "", errors.New("update browse roots: context is required")
 	}
 	if strings.TrimSpace(dbPath) == "" {
-		return 0, errors.New("update browse roots: database path is required")
+		return 0, "", errors.New("update browse roots: database path is required")
 	}
 	if err := ctx.Err(); err != nil {
-		return 0, fmt.Errorf("update browse roots: %w", err)
+		return 0, "", fmt.Errorf("update browse roots: %w", err)
 	}
 	if allowUnrestricted && len(values) != 0 {
-		return 0, errors.New("update browse roots: unrestricted browsing cannot be combined with browse roots")
+		return 0, "", errors.New("update browse roots: unrestricted browsing cannot be combined with browse roots")
 	}
 
 	roots, err := normalizeBrowsePolicyRoots(values)
 	if err != nil {
-		return 0, fmt.Errorf("update browse roots: %w", err)
+		return 0, "", fmt.Errorf("update browse roots: %w", err)
 	}
 	if !allowUnrestricted && len(roots) == 0 {
-		return 0, errors.New("update browse roots: at least one browse root is required unless unrestricted browsing is explicitly allowed")
+		return 0, "", errors.New("update browse roots: at least one browse root is required unless unrestricted browsing is explicitly allowed")
 	}
 
 	store, err := authmaterial.NewStore(dbPath)
 	if err != nil {
-		return 0, fmt.Errorf("update browse roots: open auth store: %w", err)
+		return 0, "", fmt.Errorf("update browse roots: open auth store: %w", err)
 	}
 	record, err := store.Load()
 	if err != nil {
-		return 0, fmt.Errorf("update browse roots: load auth record: %w", err)
+		return 0, "", fmt.Errorf("update browse roots: load auth record: %w", err)
 	}
 	if !record.AuthMaterial().IsUsable() {
-		return 0, errors.New("update browse roots: web-auth.json is incomplete")
+		return 0, "", errors.New("update browse roots: web-auth.json is incomplete")
+	}
+	backupPath, err := store.CreateBackup()
+	if err != nil {
+		return 0, "", fmt.Errorf("update browse roots: create auth backup: %w", err)
 	}
 	record.BrowseRoot = joinBrowsePolicyRoots(roots)
 	record.AllowUnrestrictedBrowse = allowUnrestricted
@@ -169,9 +180,9 @@ func UpdateBrowseRoots(ctx context.Context, dbPath string, values []string, allo
 		record.PendingUpgrade.Target.AllowUnrestrictedBrowse = allowUnrestricted
 	}
 	if err := store.UpdateRecord(record); err != nil {
-		return 0, fmt.Errorf("update browse roots: persist policy: %w", err)
+		return 0, backupPath, fmt.Errorf("update browse roots: persist policy: %w", err)
 	}
-	return len(roots), nil
+	return len(roots), backupPath, nil
 }
 
 func clearPersistedAuthSessions(dbPath string) error {

--- a/internal/webserver/auth_management_test.go
+++ b/internal/webserver/auth_management_test.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package webserver
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/authmaterial"
+	"github.com/autobrr/upbrr/internal/cookies"
+	"github.com/autobrr/upbrr/internal/services/db"
+)
+
+func TestChangeAuthPasswordUpdatesHashAndRevokesRetainedSessions(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
+	if err := BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	store, err := newAuthStore(dbPath)
+	if err != nil {
+		t.Fatalf("newAuthStore: %v", err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	record.BrowseRoot = filepath.Join(t.TempDir(), "media")
+	if err := store.UpdateRecord(record); err != nil {
+		t.Fatalf("UpdateRecord: %v", err)
+	}
+
+	sessionStore, err := newSessionStore(dbPath)
+	if err != nil {
+		t.Fatalf("newSessionStore: %v", err)
+	}
+	if err := sessionStore.Save([]session{{
+		ID:        "retained-session",
+		Username:  "tester",
+		CSRFToken: "synthetic-csrf",
+		ExpiresAt: time.Now().UTC().Add(time.Hour),
+		Retain:    true,
+	}}); err != nil {
+		t.Fatalf("Save session: %v", err)
+	}
+
+	if err := ChangeAuthPassword(t.Context(), dbPath, "very-secure-password", "replacement-secure-password"); err != nil {
+		t.Fatalf("ChangeAuthPassword: %v", err)
+	}
+	updated, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load updated record: %v", err)
+	}
+	if !verifyPassword("replacement-secure-password", updated.PasswordHash) {
+		t.Fatal("replacement password does not verify")
+	}
+	if verifyPassword("very-secure-password", updated.PasswordHash) {
+		t.Fatal("previous password still verifies")
+	}
+	if updated.BrowseRoot != record.BrowseRoot {
+		t.Fatalf("browse root = %q, want %q", updated.BrowseRoot, record.BrowseRoot)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(dbPath), sessionFileName)); !os.IsNotExist(err) {
+		t.Fatalf("retained session file still exists: %v", err)
+	}
+}
+
+func TestChangeAuthPasswordRejectsWrongCurrentPasswordWithoutRevokingSessions(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
+	if err := BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	sessionPath := filepath.Join(filepath.Dir(dbPath), sessionFileName)
+	if err := os.WriteFile(sessionPath, []byte("[]"), 0o600); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+
+	err := ChangeAuthPassword(t.Context(), dbPath, "incorrect-password", "replacement-secure-password")
+	if err == nil || !strings.Contains(err.Error(), "current password is incorrect") {
+		t.Fatalf("ChangeAuthPassword error = %v", err)
+	}
+	if _, err := os.Stat(sessionPath); err != nil {
+		t.Fatalf("session file changed after rejected password: %v", err)
+	}
+	record, err := authmaterial.LoadRecordFromDBPath(dbPath)
+	if err != nil {
+		t.Fatalf("LoadRecordFromDBPath: %v", err)
+	}
+	if !verifyPassword("very-secure-password", record.PasswordHash) {
+		t.Fatal("current password changed after rejected attempt")
+	}
+}
+
+func TestChangeAuthPasswordRewrapsLegacyCookies(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
+	ensureMigratedTestDB(t, dbPath)
+	legacy := authRecord{
+		Username:     "tester",
+		PasswordHash: makeLegacyHash(),
+		CreatedAt:    time.Now().UTC(),
+	}
+	raw, err := json.MarshalIndent(legacy, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent: %v", err)
+	}
+	if err := os.WriteFile(AuthFilePath(dbPath), raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	repo, err := db.OpenContext(t.Context(), dbPath)
+	if err != nil {
+		t.Fatalf("OpenContext: %v", err)
+	}
+	oldKey, err := cookies.NewKeyManager(repo.RawDB()).InitializeEncryptionKey(t.Context(), dbPath)
+	if err != nil {
+		_ = repo.Close()
+		t.Fatalf("InitializeEncryptionKey: %v", err)
+	}
+	cookieStore, err := cookies.NewCookieStore(repo.RawDB())
+	if err != nil {
+		_ = repo.Close()
+		t.Fatalf("NewCookieStore: %v", err)
+	}
+	if err := cookieStore.SaveCookie(t.Context(), "tracker", "session", "cookie-value", oldKey); err != nil {
+		_ = repo.Close()
+		t.Fatalf("SaveCookie: %v", err)
+	}
+	if err := repo.Close(); err != nil {
+		t.Fatalf("Close seed repository: %v", err)
+	}
+
+	if err := ChangeAuthPassword(t.Context(), dbPath, "very-secure-password", "replacement-secure-password"); err != nil {
+		t.Fatalf("ChangeAuthPassword: %v", err)
+	}
+	updated, err := authmaterial.LoadRecordFromDBPath(dbPath)
+	if err != nil {
+		t.Fatalf("LoadRecordFromDBPath: %v", err)
+	}
+	if updated.PendingUpgrade != nil || strings.TrimSpace(updated.EncryptionKeySeed) == "" {
+		t.Fatalf(
+			"legacy auth update incomplete: pending=%t seed_present=%t",
+			updated.PendingUpgrade != nil,
+			strings.TrimSpace(updated.EncryptionKeySeed) != "",
+		)
+	}
+	if !verifyPassword("replacement-secure-password", updated.PasswordHash) {
+		t.Fatal("replacement password does not verify")
+	}
+
+	repo, err = db.OpenContext(t.Context(), dbPath)
+	if err != nil {
+		t.Fatalf("reopen repository: %v", err)
+	}
+	defer repo.Close()
+	newHelper, _, err := updated.AuthMaterial().PrimaryHelper()
+	if err != nil {
+		t.Fatalf("PrimaryHelper: %v", err)
+	}
+	salt, err := loadCookieEncryptionSalt(t.Context(), repo.RawDB())
+	if err != nil {
+		t.Fatalf("loadCookieEncryptionSalt: %v", err)
+	}
+	newKey, err := cookies.DeriveEncryptionKey(newHelper, salt)
+	if err != nil {
+		t.Fatalf("DeriveEncryptionKey: %v", err)
+	}
+	cookieStore, err = cookies.NewCookieStore(repo.RawDB())
+	if err != nil {
+		t.Fatalf("NewCookieStore: %v", err)
+	}
+	value, err := cookieStore.GetCookie(t.Context(), "tracker", "session", newKey)
+	if err != nil {
+		t.Fatalf("GetCookie: %v", err)
+	}
+	if value != "cookie-value" {
+		t.Fatalf("cookie value = %q, want %q", value, "cookie-value")
+	}
+}
+
+func TestUpdateBrowseRootsReplacesPolicy(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
+	if err := BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	first := t.TempDir()
+	second := t.TempDir()
+
+	count, err := UpdateBrowseRoots(t.Context(), dbPath, []string{first, second, first}, false)
+	if err != nil {
+		t.Fatalf("UpdateBrowseRoots: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("root count = %d, want 2", count)
+	}
+	record, err := authmaterial.LoadRecordFromDBPath(dbPath)
+	if err != nil {
+		t.Fatalf("LoadRecordFromDBPath: %v", err)
+	}
+	roots := splitBrowsePolicyRoots(record.BrowseRoot)
+	if len(roots) != 2 || !sameFilesystemPath(roots[0], first) || !sameFilesystemPath(roots[1], second) {
+		t.Fatalf("stored roots = %#v", roots)
+	}
+	if record.AllowUnrestrictedBrowse {
+		t.Fatal("restricted policy unexpectedly allows unrestricted browsing")
+	}
+
+	count, err = UpdateBrowseRoots(t.Context(), dbPath, nil, true)
+	if err != nil {
+		t.Fatalf("UpdateBrowseRoots unrestricted: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("unrestricted root count = %d, want 0", count)
+	}
+	record, err = authmaterial.LoadRecordFromDBPath(dbPath)
+	if err != nil {
+		t.Fatalf("LoadRecordFromDBPath unrestricted: %v", err)
+	}
+	if record.BrowseRoot != "" || !record.AllowUnrestrictedBrowse {
+		t.Fatalf("unrestricted policy: has_roots=%t unrestricted=%t", record.BrowseRoot != "", record.AllowUnrestrictedBrowse)
+	}
+}
+
+func TestUpdateBrowseRootsRejectsMissingDirectoryWithoutChangingPolicy(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
+	if err := BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	existing := t.TempDir()
+	if _, err := UpdateBrowseRoots(t.Context(), dbPath, []string{existing}, false); err != nil {
+		t.Fatalf("seed browse roots: %v", err)
+	}
+
+	missing := filepath.Join(t.TempDir(), "missing")
+	if _, err := UpdateBrowseRoots(t.Context(), dbPath, []string{missing}, false); err == nil {
+		t.Fatal("expected missing browse root to fail")
+	}
+	record, err := authmaterial.LoadRecordFromDBPath(dbPath)
+	if err != nil {
+		t.Fatalf("LoadRecordFromDBPath: %v", err)
+	}
+	roots := splitBrowsePolicyRoots(record.BrowseRoot)
+	if len(roots) != 1 || !sameFilesystemPath(roots[0], existing) {
+		t.Fatalf("browse roots changed after rejected update: %#v", roots)
+	}
+}
+
+func TestUpdateBrowseRootsKeepsPendingPasswordUpdateInSync(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
+	if err := BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+	store, err := newAuthStore(dbPath)
+	if err != nil {
+		t.Fatalf("newAuthStore: %v", err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	target := record
+	target.PasswordHash = "pending-password-hash"
+	if err := store.BeginPendingUpgrade(record, target); err != nil {
+		t.Fatalf("BeginPendingUpgrade: %v", err)
+	}
+
+	root := t.TempDir()
+	if _, err := UpdateBrowseRoots(t.Context(), dbPath, []string{root}, false); err != nil {
+		t.Fatalf("UpdateBrowseRoots: %v", err)
+	}
+	updated, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load updated record: %v", err)
+	}
+	if updated.PendingUpgrade == nil {
+		t.Fatal("pending password update was cleared")
+	}
+	if !sameFilesystemPath(updated.BrowseRoot, root) || !sameFilesystemPath(updated.PendingUpgrade.Target.BrowseRoot, root) {
+		t.Fatalf("active and pending browse roots differ: active=%q pending=%q", updated.BrowseRoot, updated.PendingUpgrade.Target.BrowseRoot)
+	}
+}

--- a/internal/webserver/auth_management_test.go
+++ b/internal/webserver/auth_management_test.go
@@ -48,8 +48,16 @@ func TestChangeAuthPasswordUpdatesHashAndRevokesRetainedSessions(t *testing.T) {
 		t.Fatalf("Save session: %v", err)
 	}
 
-	if err := ChangeAuthPassword(t.Context(), dbPath, "very-secure-password", "replacement-secure-password"); err != nil {
+	backupPath, err := ChangeAuthPassword(t.Context(), dbPath, "very-secure-password", "replacement-secure-password")
+	if err != nil {
 		t.Fatalf("ChangeAuthPassword: %v", err)
+	}
+	backup := readAuthBackup(t, backupPath)
+	if !verifyPassword("very-secure-password", backup.PasswordHash) {
+		t.Fatal("backup does not preserve the previous password")
+	}
+	if backup.BrowseRoot != record.BrowseRoot {
+		t.Fatalf("backup browse root = %q, want %q", backup.BrowseRoot, record.BrowseRoot)
 	}
 	updated, err := store.Load()
 	if err != nil {
@@ -79,9 +87,12 @@ func TestChangeAuthPasswordRejectsWrongCurrentPasswordWithoutRevokingSessions(t 
 		t.Fatalf("write session file: %v", err)
 	}
 
-	err := ChangeAuthPassword(t.Context(), dbPath, "incorrect-password", "replacement-secure-password")
+	backupPath, err := ChangeAuthPassword(t.Context(), dbPath, "incorrect-password", "replacement-secure-password")
 	if err == nil || !strings.Contains(err.Error(), "current password is incorrect") {
 		t.Fatalf("ChangeAuthPassword error = %v", err)
+	}
+	if backupPath != "" {
+		t.Fatalf("rejected password created backup %q", backupPath)
 	}
 	if _, err := os.Stat(sessionPath); err != nil {
 		t.Fatalf("session file changed after rejected password: %v", err)
@@ -133,8 +144,13 @@ func TestChangeAuthPasswordRewrapsLegacyCookies(t *testing.T) {
 		t.Fatalf("Close seed repository: %v", err)
 	}
 
-	if err := ChangeAuthPassword(t.Context(), dbPath, "very-secure-password", "replacement-secure-password"); err != nil {
+	backupPath, err := ChangeAuthPassword(t.Context(), dbPath, "very-secure-password", "replacement-secure-password")
+	if err != nil {
 		t.Fatalf("ChangeAuthPassword: %v", err)
+	}
+	backup := readAuthBackup(t, backupPath)
+	if strings.TrimSpace(backup.EncryptionKeySeed) != "" || !verifyPassword("very-secure-password", backup.PasswordHash) {
+		t.Fatal("backup does not preserve the legacy auth record")
 	}
 	updated, err := authmaterial.LoadRecordFromDBPath(dbPath)
 	if err != nil {
@@ -189,7 +205,7 @@ func TestUpdateBrowseRootsReplacesPolicy(t *testing.T) {
 	first := t.TempDir()
 	second := t.TempDir()
 
-	count, err := UpdateBrowseRoots(t.Context(), dbPath, []string{first, second, first}, false)
+	count, backupPath, err := UpdateBrowseRoots(t.Context(), dbPath, []string{first, second, first}, false)
 	if err != nil {
 		t.Fatalf("UpdateBrowseRoots: %v", err)
 	}
@@ -207,8 +223,12 @@ func TestUpdateBrowseRootsReplacesPolicy(t *testing.T) {
 	if record.AllowUnrestrictedBrowse {
 		t.Fatal("restricted policy unexpectedly allows unrestricted browsing")
 	}
+	backup := readAuthBackup(t, backupPath)
+	if backup.BrowseRoot != "" || backup.AllowUnrestrictedBrowse {
+		t.Fatal("first backup contains the updated browse policy")
+	}
 
-	count, err = UpdateBrowseRoots(t.Context(), dbPath, nil, true)
+	count, secondBackupPath, err := UpdateBrowseRoots(t.Context(), dbPath, nil, true)
 	if err != nil {
 		t.Fatalf("UpdateBrowseRoots unrestricted: %v", err)
 	}
@@ -222,6 +242,14 @@ func TestUpdateBrowseRootsReplacesPolicy(t *testing.T) {
 	if record.BrowseRoot != "" || !record.AllowUnrestrictedBrowse {
 		t.Fatalf("unrestricted policy: has_roots=%t unrestricted=%t", record.BrowseRoot != "", record.AllowUnrestrictedBrowse)
 	}
+	if secondBackupPath == backupPath {
+		t.Fatal("successive browse updates reused one backup path")
+	}
+	secondBackup := readAuthBackup(t, secondBackupPath)
+	secondBackupRoots := splitBrowsePolicyRoots(secondBackup.BrowseRoot)
+	if len(secondBackupRoots) != 2 || secondBackup.AllowUnrestrictedBrowse {
+		t.Fatalf("second backup does not preserve the restricted policy: %#v", secondBackup)
+	}
 }
 
 func TestUpdateBrowseRootsRejectsRootsWithUnrestrictedAccess(t *testing.T) {
@@ -230,7 +258,7 @@ func TestUpdateBrowseRootsRejectsRootsWithUnrestrictedAccess(t *testing.T) {
 		t.Fatalf("BootstrapAuthFile: %v", err)
 	}
 
-	if _, err := UpdateBrowseRoots(t.Context(), dbPath, []string{t.TempDir()}, true); err == nil ||
+	if _, _, err := UpdateBrowseRoots(t.Context(), dbPath, []string{t.TempDir()}, true); err == nil ||
 		!strings.Contains(err.Error(), "cannot be combined") {
 		t.Fatalf("UpdateBrowseRoots mixed policy error = %v", err)
 	}
@@ -249,12 +277,12 @@ func TestUpdateBrowseRootsRejectsMissingDirectoryWithoutChangingPolicy(t *testin
 		t.Fatalf("BootstrapAuthFile: %v", err)
 	}
 	existing := t.TempDir()
-	if _, err := UpdateBrowseRoots(t.Context(), dbPath, []string{existing}, false); err != nil {
+	if _, _, err := UpdateBrowseRoots(t.Context(), dbPath, []string{existing}, false); err != nil {
 		t.Fatalf("seed browse roots: %v", err)
 	}
 
 	missing := filepath.Join(t.TempDir(), "missing")
-	if _, err := UpdateBrowseRoots(t.Context(), dbPath, []string{missing}, false); err == nil {
+	if _, _, err := UpdateBrowseRoots(t.Context(), dbPath, []string{missing}, false); err == nil {
 		t.Fatal("expected missing browse root to fail")
 	}
 	record, err := authmaterial.LoadRecordFromDBPath(dbPath)
@@ -287,7 +315,7 @@ func TestUpdateBrowseRootsKeepsPendingPasswordUpdateInSync(t *testing.T) {
 	}
 
 	root := t.TempDir()
-	if _, err := UpdateBrowseRoots(t.Context(), dbPath, []string{root}, false); err != nil {
+	if _, _, err := UpdateBrowseRoots(t.Context(), dbPath, []string{root}, false); err != nil {
 		t.Fatalf("UpdateBrowseRoots: %v", err)
 	}
 	updated, err := store.Load()
@@ -300,4 +328,17 @@ func TestUpdateBrowseRootsKeepsPendingPasswordUpdateInSync(t *testing.T) {
 	if !sameFilesystemPath(updated.BrowseRoot, root) || !sameFilesystemPath(updated.PendingUpgrade.Target.BrowseRoot, root) {
 		t.Fatalf("active and pending browse roots differ: active=%q pending=%q", updated.BrowseRoot, updated.PendingUpgrade.Target.BrowseRoot)
 	}
+}
+
+func readAuthBackup(t *testing.T, path string) authRecord {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read auth backup: %v", err)
+	}
+	var record authRecord
+	if err := json.Unmarshal(raw, &record); err != nil {
+		t.Fatalf("unmarshal auth backup: %v", err)
+	}
+	return record
 }

--- a/internal/webserver/auth_management_test.go
+++ b/internal/webserver/auth_management_test.go
@@ -224,6 +224,25 @@ func TestUpdateBrowseRootsReplacesPolicy(t *testing.T) {
 	}
 }
 
+func TestUpdateBrowseRootsRejectsRootsWithUnrestrictedAccess(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
+	if err := BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {
+		t.Fatalf("BootstrapAuthFile: %v", err)
+	}
+
+	if _, err := UpdateBrowseRoots(t.Context(), dbPath, []string{t.TempDir()}, true); err == nil ||
+		!strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("UpdateBrowseRoots mixed policy error = %v", err)
+	}
+	record, err := authmaterial.LoadRecordFromDBPath(dbPath)
+	if err != nil {
+		t.Fatalf("LoadRecordFromDBPath: %v", err)
+	}
+	if record.BrowseRoot != "" || record.AllowUnrestrictedBrowse {
+		t.Fatal("rejected mixed policy changed the auth record")
+	}
+}
+
 func TestUpdateBrowseRootsRejectsMissingDirectoryWithoutChangingPolicy(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
 	if err := BootstrapAuthFile(dbPath, "tester", "very-secure-password"); err != nil {

--- a/internal/webserver/auth_rewrap.go
+++ b/internal/webserver/auth_rewrap.go
@@ -16,6 +16,7 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/redaction"
+	"github.com/autobrr/upbrr/internal/services/db"
 )
 
 func generateStableEncryptionSeed() (string, error) {
@@ -31,9 +32,22 @@ func (s *Server) rewrapProtectedDataForAuthChange(ctx context.Context, oldRecord
 	if s == nil || s.backend == nil || s.backend.repo == nil {
 		return errors.New("auth_rewrap: missing server/backend/repo configuration (s.backend.repo unavailable)")
 	}
+	return rewrapProtectedDataForAuthChange(ctx, s.auth, s.backend.repo, oldRecord, newRecord)
+}
+
+func rewrapProtectedDataForAuthChange(
+	ctx context.Context,
+	store *authmaterial.Store,
+	repo *db.SQLiteRepository,
+	oldRecord authRecord,
+	newRecord authRecord,
+) error {
+	if store == nil || repo == nil {
+		return errors.New("auth rewrap: missing auth store or database repository")
+	}
 
 	if oldRecord.PendingUpgrade == nil {
-		if err := s.auth.BeginPendingUpgrade(oldRecord, newRecord); err != nil {
+		if err := store.BeginPendingUpgrade(oldRecord, newRecord); err != nil {
 			return fmt.Errorf("auth rewrap: persist pending upgrade: %w", err)
 		}
 		oldRecord.PendingUpgrade = &authmaterial.PendingUpgrade{
@@ -56,10 +70,10 @@ func (s *Server) rewrapProtectedDataForAuthChange(ctx context.Context, oldRecord
 	}
 
 	if pending.Stage == authmaterial.UpgradeStagePrepared {
-		if err := rewrapCookiesForAuthChange(ctx, s.backend.repo.RawDB(), oldMaterial, newMaterial); err != nil {
+		if err := rewrapCookiesForAuthChange(ctx, repo.RawDB(), oldMaterial, newMaterial); err != nil {
 			return fmt.Errorf("web: %w", err)
 		}
-		if err := s.auth.AdvancePendingUpgrade(oldRecord.Username, authmaterial.UpgradeStageCookiesRewrapped); err != nil {
+		if err := store.AdvancePendingUpgrade(oldRecord.Username, authmaterial.UpgradeStageCookiesRewrapped); err != nil {
 			return fmt.Errorf("auth rewrap: persist cookie phase: %w", err)
 		}
 		pending.Stage = authmaterial.UpgradeStageCookiesRewrapped
@@ -67,10 +81,10 @@ func (s *Server) rewrapProtectedDataForAuthChange(ctx context.Context, oldRecord
 
 	if pending.Stage == authmaterial.UpgradeStageCookiesRewrapped {
 		sourceMaterials := []authmaterial.Material{oldMaterial, newMaterial}
-		if err := config.RewrapSecretsInDatabaseWithFallback(ctx, s.backend.repo, sourceMaterials, newMaterial); err != nil {
+		if err := config.RewrapSecretsInDatabaseWithFallback(ctx, repo, sourceMaterials, newMaterial); err != nil {
 			return fmt.Errorf("web: %w", err)
 		}
-		if err := s.auth.AdvancePendingUpgrade(oldRecord.Username, authmaterial.UpgradeStageDataRewrapped); err != nil {
+		if err := store.AdvancePendingUpgrade(oldRecord.Username, authmaterial.UpgradeStageDataRewrapped); err != nil {
 			return fmt.Errorf("auth rewrap: persist data phase: %w", err)
 		}
 		pending.Stage = authmaterial.UpgradeStageDataRewrapped

--- a/internal/webserver/auth_test.go
+++ b/internal/webserver/auth_test.go
@@ -154,7 +154,11 @@ func TestAuthStoreUpdatePasswordHashReappliesSecurePermissions(t *testing.T) {
 	if err := os.Chmod(authPath, 0o644); err != nil {
 		t.Fatalf("Chmod before update: %v", err)
 	}
-	if err := store.UpdatePasswordHash("tester", "updated-test-password-hash"); err != nil {
+	current, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load before update: %v", err)
+	}
+	if err := store.UpdatePasswordHash("tester", current.PasswordHash, "updated-test-password-hash"); err != nil {
 		t.Fatalf("UpdatePasswordHash: %v", err)
 	}
 

--- a/internal/webserver/routes.go
+++ b/internal/webserver/routes.go
@@ -100,6 +100,7 @@ func (s *Server) registerRootRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/auth/bootstrap", func(w http.ResponseWriter, r *http.Request) { s.handleBootstrap(w, r, session{}) })
 	mux.HandleFunc("/api/auth/login", func(w http.ResponseWriter, r *http.Request) { s.handleLogin(w, r, session{}) })
 	mux.HandleFunc("/api/auth/logout", s.requireSession(s.handleLogout))
+	mux.HandleFunc("/api/auth/browse-policy", s.requireSession(s.handleBrowsePolicy))
 	mux.HandleFunc("/api/events", s.requireSession(s.handleEvents))
 	mux.HandleFunc("/api/app/TrackerIcon", s.requireSession(s.handleTrackerIcon))
 
@@ -293,14 +294,15 @@ func isRootAbsoluteAssetPath(value string) bool {
 func (s *Server) handleAuthStatus(w http.ResponseWriter, r *http.Request, _ session) {
 	if current, ok := s.developmentCurrentSession(r); ok {
 		writeJSON(w, http.StatusOK, map[string]any{
-			"authenticated":           true,
-			"needsSetup":              false,
-			"username":                current.Username,
-			"csrfToken":               current.CSRFToken,
-			"caseInsensitivePaths":    runtime.GOOS == "windows",
-			"browseRoot":              "",
-			"allowUnrestrictedBrowse": true,
-			"needsBrowsePolicy":       false,
+			"authenticated":             true,
+			"needsSetup":                false,
+			"username":                  current.Username,
+			"csrfToken":                 current.CSRFToken,
+			"caseInsensitivePaths":      runtime.GOOS == "windows",
+			"browseRoot":                "",
+			"allowUnrestrictedBrowse":   true,
+			"needsBrowsePolicy":         false,
+			"canInitializeBrowsePolicy": false,
 		})
 		return
 	}
@@ -312,14 +314,15 @@ func (s *Server) handleAuthStatus(w http.ResponseWriter, r *http.Request, _ sess
 	}
 	current, ok := s.currentSession(r)
 	payload := map[string]any{
-		"authenticated":           ok,
-		"needsSetup":              !exists,
-		"username":                "",
-		"csrfToken":               "",
-		"caseInsensitivePaths":    runtime.GOOS == "windows",
-		"browseRoot":              "",
-		"allowUnrestrictedBrowse": false,
-		"needsBrowsePolicy":       false,
+		"authenticated":             ok,
+		"needsSetup":                !exists,
+		"username":                  "",
+		"csrfToken":                 "",
+		"caseInsensitivePaths":      runtime.GOOS == "windows",
+		"browseRoot":                "",
+		"allowUnrestrictedBrowse":   false,
+		"needsBrowsePolicy":         false,
+		"canInitializeBrowsePolicy": false,
 	}
 	if exists {
 		record, err := s.auth.Load()
@@ -332,6 +335,7 @@ func (s *Server) handleAuthStatus(w http.ResponseWriter, r *http.Request, _ sess
 			payload["browseRoot"] = joinBrowsePolicyRoots(browseRoots)
 			payload["allowUnrestrictedBrowse"] = record.AllowUnrestrictedBrowse
 			payload["needsBrowsePolicy"] = !record.AllowUnrestrictedBrowse && len(browseRoots) == 0
+			payload["canInitializeBrowsePolicy"] = canInitializeBrowsePolicy(record)
 		}
 	}
 	if ok {
@@ -374,14 +378,15 @@ func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request, _ sessi
 	}
 	s.writeSessionCookie(w, r, current)
 	writeJSON(w, http.StatusOK, map[string]any{
-		"authenticated":           true,
-		"needsSetup":              false,
-		"username":                current.Username,
-		"csrfToken":               current.CSRFToken,
-		"caseInsensitivePaths":    runtime.GOOS == "windows",
-		"browseRoot":              "",
-		"allowUnrestrictedBrowse": false,
-		"needsBrowsePolicy":       true,
+		"authenticated":             true,
+		"needsSetup":                false,
+		"username":                  current.Username,
+		"csrfToken":                 current.CSRFToken,
+		"caseInsensitivePaths":      runtime.GOOS == "windows",
+		"browseRoot":                "",
+		"allowUnrestrictedBrowse":   false,
+		"needsBrowsePolicy":         true,
+		"canInitializeBrowsePolicy": true,
 	})
 }
 
@@ -484,14 +489,15 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request, _ session) 
 	s.writeSessionCookie(w, r, current)
 	browseRoots := recordBrowseRoots(record)
 	writeJSON(w, http.StatusOK, map[string]any{
-		"authenticated":           true,
-		"needsSetup":              false,
-		"username":                current.Username,
-		"csrfToken":               current.CSRFToken,
-		"caseInsensitivePaths":    runtime.GOOS == "windows",
-		"browseRoot":              joinBrowsePolicyRoots(browseRoots),
-		"allowUnrestrictedBrowse": record.AllowUnrestrictedBrowse,
-		"needsBrowsePolicy":       !record.AllowUnrestrictedBrowse && len(browseRoots) == 0,
+		"authenticated":             true,
+		"needsSetup":                false,
+		"username":                  current.Username,
+		"csrfToken":                 current.CSRFToken,
+		"caseInsensitivePaths":      runtime.GOOS == "windows",
+		"browseRoot":                joinBrowsePolicyRoots(browseRoots),
+		"allowUnrestrictedBrowse":   record.AllowUnrestrictedBrowse,
+		"needsBrowsePolicy":         !record.AllowUnrestrictedBrowse && len(browseRoots) == 0,
+		"canInitializeBrowsePolicy": canInitializeBrowsePolicy(record),
 	})
 }
 
@@ -521,6 +527,75 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request, current se
 		})
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (s *Server) handleBrowsePolicy(w http.ResponseWriter, r *http.Request, current session) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	var req struct {
+		BrowseRoot              string `json:"browseRoot"`
+		AllowUnrestrictedBrowse bool   `json:"allowUnrestrictedBrowse"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	record, err := s.auth.Load()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if strings.TrimSpace(record.Username) != strings.TrimSpace(current.Username) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "session user does not match auth record"})
+		return
+	}
+	if !canInitializeBrowsePolicy(record) {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "browse policy is already configured; use the local CLI to change it"})
+		return
+	}
+
+	roots, err := normalizeBrowsePolicyRoots(splitBrowsePolicyRoots(req.BrowseRoot))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if req.AllowUnrestrictedBrowse && len(roots) != 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unrestricted browsing cannot be combined with browse roots"})
+		return
+	}
+	if !req.AllowUnrestrictedBrowse && len(roots) == 0 {
+		writeJSON(
+			w,
+			http.StatusBadRequest,
+			map[string]string{"error": "at least one browse root is required unless unrestricted browsing is explicitly allowed"},
+		)
+		return
+	}
+
+	initialized, err := s.auth.InitializeBrowsePolicy(current.Username, joinBrowsePolicyRoots(roots), req.AllowUnrestrictedBrowse)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if !initialized {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "browse policy is already configured; use the local CLI to change it"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"authenticated":             true,
+		"needsSetup":                false,
+		"username":                  current.Username,
+		"csrfToken":                 current.CSRFToken,
+		"caseInsensitivePaths":      runtime.GOOS == "windows",
+		"browseRoot":                joinBrowsePolicyRoots(roots),
+		"allowUnrestrictedBrowse":   req.AllowUnrestrictedBrowse,
+		"needsBrowsePolicy":         false,
+		"canInitializeBrowsePolicy": false,
+	})
 }
 
 // splitBrowsePolicyRoots decodes stored or submitted browse roots. A single
@@ -602,6 +677,10 @@ func recordBrowseRoots(record authmaterial.Record) []string {
 		return roots
 	}
 	return normalized
+}
+
+func canInitializeBrowsePolicy(record authmaterial.Record) bool {
+	return strings.TrimSpace(record.BrowseRoot) == "" && !record.AllowUnrestrictedBrowse
 }
 
 // joinBrowsePolicyRoots encodes browse roots as one CSV record so commas in

--- a/internal/webserver/routes.go
+++ b/internal/webserver/routes.go
@@ -100,7 +100,6 @@ func (s *Server) registerRootRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/auth/bootstrap", func(w http.ResponseWriter, r *http.Request) { s.handleBootstrap(w, r, session{}) })
 	mux.HandleFunc("/api/auth/login", func(w http.ResponseWriter, r *http.Request) { s.handleLogin(w, r, session{}) })
 	mux.HandleFunc("/api/auth/logout", s.requireSession(s.handleLogout))
-	mux.HandleFunc("/api/auth/browse-policy", s.requireSession(s.handleBrowsePolicy))
 	mux.HandleFunc("/api/events", s.requireSession(s.handleEvents))
 	mux.HandleFunc("/api/app/TrackerIcon", s.requireSession(s.handleTrackerIcon))
 
@@ -522,62 +521,6 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request, current se
 		})
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
-}
-
-func (s *Server) handleBrowsePolicy(w http.ResponseWriter, r *http.Request, current session) {
-	if r.Method != http.MethodPost {
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
-		return
-	}
-	var req struct {
-		BrowseRoot              string `json:"browseRoot"`
-		AllowUnrestrictedBrowse bool   `json:"allowUnrestrictedBrowse"`
-	}
-	if err := decodeJSON(r, &req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		return
-	}
-
-	roots, err := normalizeBrowsePolicyRoots(splitBrowsePolicyRoots(req.BrowseRoot))
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		return
-	}
-	if !req.AllowUnrestrictedBrowse && len(roots) == 0 {
-		writeJSON(
-			w,
-			http.StatusBadRequest,
-			map[string]string{"error": "at least one browse root is required unless unrestricted browsing is explicitly allowed"},
-		)
-		return
-	}
-
-	record, err := s.auth.Load()
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
-	if strings.TrimSpace(record.Username) != strings.TrimSpace(current.Username) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "session user does not match auth record"})
-		return
-	}
-	record.BrowseRoot = joinBrowsePolicyRoots(roots)
-	record.AllowUnrestrictedBrowse = req.AllowUnrestrictedBrowse
-	if err := s.auth.UpdateRecord(record); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
-
-	writeJSON(w, http.StatusOK, map[string]any{
-		"authenticated":           true,
-		"needsSetup":              false,
-		"username":                current.Username,
-		"csrfToken":               current.CSRFToken,
-		"caseInsensitivePaths":    runtime.GOOS == "windows",
-		"browseRoot":              joinBrowsePolicyRoots(roots),
-		"allowUnrestrictedBrowse": req.AllowUnrestrictedBrowse,
-		"needsBrowsePolicy":       false,
-	})
 }
 
 // splitBrowsePolicyRoots decodes stored or submitted browse roots. A single

--- a/internal/webserver/routes_auth_test.go
+++ b/internal/webserver/routes_auth_test.go
@@ -581,6 +581,53 @@ func TestBrowsePolicyCanOnlyCompleteInitialSetup(t *testing.T) {
 	}
 }
 
+func TestBrowsePolicyCanOnlyInitializeUnrestrictedAccessOnce(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
+	server := newAuthTestServer(t, dbPath)
+	if err := server.auth.Bootstrap("admin", "very-secure-password"); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	current := session{Username: "admin", CSRFToken: "synthetic-csrf"}
+
+	body, err := json.Marshal(map[string]any{"browseRoot": "", "allowUnrestrictedBrowse": true})
+	if err != nil {
+		t.Fatalf("marshal unrestricted browse policy: %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/auth/browse-policy", strings.NewReader(string(body)))
+	recorder := httptest.NewRecorder()
+	server.handleBrowsePolicy(recorder, req, current)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("initial unrestricted browse policy returned %d: %s", recorder.Code, recorder.Body.String())
+	}
+
+	record, err := server.auth.Load()
+	if err != nil {
+		t.Fatalf("load unrestricted browse policy: %v", err)
+	}
+	if record.BrowseRoot != "" || !record.AllowUnrestrictedBrowse {
+		t.Fatal("unrestricted browse policy was not stored")
+	}
+
+	replacementRoot := t.TempDir()
+	body, err = json.Marshal(map[string]any{"browseRoot": replacementRoot, "allowUnrestrictedBrowse": false})
+	if err != nil {
+		t.Fatalf("marshal replacement browse policy: %v", err)
+	}
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/auth/browse-policy", strings.NewReader(string(body)))
+	recorder = httptest.NewRecorder()
+	server.handleBrowsePolicy(recorder, req, current)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("replacement browse policy returned %d, want 409: %s", recorder.Code, recorder.Body.String())
+	}
+	record, err = server.auth.Load()
+	if err != nil {
+		t.Fatalf("load rejected replacement: %v", err)
+	}
+	if record.BrowseRoot != "" || !record.AllowUnrestrictedBrowse {
+		t.Fatal("WebUI replaced an unrestricted browse policy")
+	}
+}
+
 func TestDevelopmentNoAuthStatusBypassesMissingAuthOnLoopback(t *testing.T) {
 	server := &Server{
 		developmentNoAuth: true,

--- a/internal/webserver/routes_auth_test.go
+++ b/internal/webserver/routes_auth_test.go
@@ -514,6 +514,73 @@ func TestAuthStatusMasksBrowseRootUntilAuthenticated(t *testing.T) {
 	}
 }
 
+func TestBrowsePolicyCanOnlyCompleteInitialSetup(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "state", "db.sqlite")
+	server := newAuthTestServer(t, dbPath)
+	if err := server.auth.Bootstrap("admin", "very-secure-password"); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	current := session{Username: "admin", CSRFToken: "synthetic-csrf"}
+	firstRoot := t.TempDir()
+
+	mixedBody, err := json.Marshal(map[string]any{"browseRoot": firstRoot, "allowUnrestrictedBrowse": true})
+	if err != nil {
+		t.Fatalf("marshal mixed browse policy: %v", err)
+	}
+	mixedReq := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/api/auth/browse-policy",
+		strings.NewReader(string(mixedBody)),
+	)
+	mixedRecorder := httptest.NewRecorder()
+	server.handleBrowsePolicy(mixedRecorder, mixedReq, current)
+	if mixedRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("mixed initial browse policy returned %d, want 400: %s", mixedRecorder.Code, mixedRecorder.Body.String())
+	}
+
+	body, err := json.Marshal(map[string]any{"browseRoot": firstRoot, "allowUnrestrictedBrowse": false})
+	if err != nil {
+		t.Fatalf("marshal initial browse policy: %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/auth/browse-policy", strings.NewReader(string(body)))
+	recorder := httptest.NewRecorder()
+	server.handleBrowsePolicy(recorder, req, current)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("initial browse policy returned %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), `"canInitializeBrowsePolicy":false`) {
+		t.Fatalf("initial browse policy response did not close setup: %s", recorder.Body.String())
+	}
+
+	record, err := server.auth.Load()
+	if err != nil {
+		t.Fatalf("load initial browse policy: %v", err)
+	}
+	if !sameFilesystemPath(record.BrowseRoot, firstRoot) || record.AllowUnrestrictedBrowse {
+		t.Fatalf("initial browse policy was not stored")
+	}
+
+	secondRoot := t.TempDir()
+	body, err = json.Marshal(map[string]any{"browseRoot": secondRoot, "allowUnrestrictedBrowse": false})
+	if err != nil {
+		t.Fatalf("marshal replacement browse policy: %v", err)
+	}
+	req = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/auth/browse-policy", strings.NewReader(string(body)))
+	recorder = httptest.NewRecorder()
+	server.handleBrowsePolicy(recorder, req, current)
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("replacement browse policy returned %d, want 409: %s", recorder.Code, recorder.Body.String())
+	}
+	record, err = server.auth.Load()
+	if err != nil {
+		t.Fatalf("load rejected replacement: %v", err)
+	}
+	if !sameFilesystemPath(record.BrowseRoot, firstRoot) {
+		t.Fatalf("WebUI replaced an existing browse policy")
+	}
+}
+
 func TestDevelopmentNoAuthStatusBypassesMissingAuthOnLoopback(t *testing.T) {
 	server := &Server{
 		developmentNoAuth: true,

--- a/internal/webserver/routes_base_path_test.go
+++ b/internal/webserver/routes_base_path_test.go
@@ -52,6 +52,17 @@ func TestRegisterRoutesMountsConfiguredBasePath(t *testing.T) {
 	if !strings.Contains(status.Body.String(), `"authenticated":true`) {
 		t.Fatalf("expected development auth status, got %s", status.Body.String())
 	}
+	browsePolicyReq := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/upbrr/api/auth/browse-policy",
+		strings.NewReader(`{"browseRoot":"local-path"}`),
+	)
+	browsePolicy := httptest.NewRecorder()
+	mux.ServeHTTP(browsePolicy, browsePolicyReq)
+	if browsePolicy.Code != http.StatusNotFound {
+		t.Fatalf("WebUI browse-policy mutation returned %d, want 404", browsePolicy.Code)
+	}
 
 	docs := serveBasePathTestRequest(t, mux, "/upbrr/api/v1/docs")
 	if docs.Code != http.StatusOK {

--- a/internal/webserver/routes_base_path_test.go
+++ b/internal/webserver/routes_base_path_test.go
@@ -54,14 +54,14 @@ func TestRegisterRoutesMountsConfiguredBasePath(t *testing.T) {
 	}
 	browsePolicyReq := httptest.NewRequestWithContext(
 		context.Background(),
-		http.MethodPost,
+		http.MethodGet,
 		"/upbrr/api/auth/browse-policy",
-		strings.NewReader(`{"browseRoot":"local-path"}`),
+		nil,
 	)
 	browsePolicy := httptest.NewRecorder()
 	mux.ServeHTTP(browsePolicy, browsePolicyReq)
-	if browsePolicy.Code != http.StatusNotFound {
-		t.Fatalf("WebUI browse-policy mutation returned %d, want 404", browsePolicy.Code)
+	if browsePolicy.Code != http.StatusUnauthorized {
+		t.Fatalf("prefixed initial browse-policy route returned %d, want 401", browsePolicy.Code)
 	}
 
 	docs := serveBasePathTestRequest(t, mux, "/upbrr/api/v1/docs")

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -318,7 +318,5 @@ export const authClient = {
     postJSON("/api/auth/bootstrap", { username, password, retainLogin }),
   login: (username: string, password: string, retainLogin: boolean) =>
     postJSON("/api/auth/login", { username, password, retainLogin }),
-  saveBrowsePolicy: (browseRoot: string, allowUnrestrictedBrowse: boolean) =>
-    postJSON("/api/auth/browse-policy", { browseRoot, allowUnrestrictedBrowse }),
   logout: () => postJSON("/api/auth/logout"),
 };

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -318,5 +318,8 @@ export const authClient = {
     postJSON("/api/auth/bootstrap", { username, password, retainLogin }),
   login: (username: string, password: string, retainLogin: boolean) =>
     postJSON("/api/auth/login", { username, password, retainLogin }),
+  /** Saves the first browse policy; the server rejects later mutations. */
+  saveInitialBrowsePolicy: (browseRoot: string, allowUnrestrictedBrowse: boolean) =>
+    postJSON("/api/auth/browse-policy", { browseRoot, allowUnrestrictedBrowse }),
   logout: () => postJSON("/api/auth/logout"),
 };

--- a/webui/src/webRoot.tsx
+++ b/webui/src/webRoot.tsx
@@ -13,7 +13,10 @@ type AuthStatus = {
   username: string;
   csrfToken: string;
   caseInsensitivePaths: boolean;
+  browseRoot: string;
+  allowUnrestrictedBrowse: boolean;
   needsBrowsePolicy: boolean;
+  canInitializeBrowsePolicy: boolean;
 };
 
 const initialStatus: AuthStatus = {
@@ -22,15 +25,20 @@ const initialStatus: AuthStatus = {
   username: "",
   csrfToken: "",
   caseInsensitivePaths: false,
+  browseRoot: "",
+  allowUnrestrictedBrowse: false,
   needsBrowsePolicy: false,
+  canInitializeBrowsePolicy: false,
 };
 
-/** Gates the embedded app on Web authentication and CLI-managed browse policy. */
+/** Gates the embedded app on Web authentication and initial browse setup. */
 export default function WebRoot() {
   const [status, setStatus] = useState<AuthStatus | null>(null);
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [retainLogin, setRetainLogin] = useState(false);
+  const [browseRoot, setBrowseRoot] = useState("");
+  const [allowUnrestrictedBrowse, setAllowUnrestrictedBrowse] = useState(false);
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
@@ -40,6 +48,8 @@ export default function WebRoot() {
       .then((payload) => {
         const next = { ...initialStatus, ...payload };
         setStatus(next);
+        setBrowseRoot(next.browseRoot || "");
+        setAllowUnrestrictedBrowse(!!next.allowUnrestrictedBrowse);
         initializeWebClient(next.csrfToken || "", !!next.caseInsensitivePaths);
       })
       .catch((err) => {
@@ -58,7 +68,75 @@ export default function WebRoot() {
   }
 
   if (status.authenticated) {
+    const submitInitialBrowsePolicy = async (event?: FormEvent<HTMLFormElement>) => {
+      event?.preventDefault();
+      if (submitting || (!allowUnrestrictedBrowse && !browseRoot.trim())) {
+        return;
+      }
+      setSubmitting(true);
+      setError("");
+      try {
+        const payload = await authClient.saveInitialBrowsePolicy(
+          allowUnrestrictedBrowse ? "" : browseRoot,
+          allowUnrestrictedBrowse,
+        );
+        const next = { ...initialStatus, ...(payload as Partial<AuthStatus>) };
+        setStatus(next);
+        setBrowseRoot(next.browseRoot || "");
+        setAllowUnrestrictedBrowse(!!next.allowUnrestrictedBrowse);
+        updateWebCSRFToken(next.csrfToken || "", !!next.caseInsensitivePaths);
+      } catch (err) {
+        setError(String(err));
+      } finally {
+        setSubmitting(false);
+      }
+    };
+
     if (status.needsBrowsePolicy) {
+      if (status.canInitializeBrowsePolicy) {
+        return (
+          <div className="web-auth-shell">
+            <div className="web-auth-card">
+              <p className="web-auth-card__eyebrow">upbrr Web</p>
+              <h1>Set Browse Access</h1>
+              <p className="web-auth-card__copy">
+                Choose the host directories this web UI can browse, or explicitly allow unrestricted
+                host browsing. Later changes require the local upbrr binary. Separate multiple paths
+                with commas.
+              </p>
+              <form onSubmit={submitInitialBrowsePolicy}>
+                <label>
+                  <span>Browse root</span>
+                  <input
+                    value={browseRoot}
+                    onChange={(event) => setBrowseRoot(event.target.value)}
+                    disabled={allowUnrestrictedBrowse}
+                    placeholder="D:\\Media, E:\\Downloads"
+                  />
+                </label>
+                <div className="web-auth-card__checkbox">
+                  <Checkbox
+                    id="allow-unrestricted-browse"
+                    checked={allowUnrestrictedBrowse}
+                    onCheckedChange={setAllowUnrestrictedBrowse}
+                  />
+                  <label htmlFor="allow-unrestricted-browse">
+                    Allow unrestricted host browsing
+                  </label>
+                </div>
+                {error ? <p className="web-auth-card__error">{error}</p> : null}
+                <button
+                  type="submit"
+                  disabled={submitting || (!allowUnrestrictedBrowse && !browseRoot.trim())}
+                >
+                  {submitting ? "Saving..." : "Continue"}
+                </button>
+              </form>
+            </div>
+          </div>
+        );
+      }
+
       return (
         <div className="web-auth-shell">
           <div className="web-auth-card">
@@ -108,6 +186,8 @@ export default function WebRoot() {
         : await authClient.login(username, password, retainLogin);
       const next = { ...initialStatus, ...(payload as Partial<AuthStatus>) };
       setStatus(next);
+      setBrowseRoot(next.browseRoot || "");
+      setAllowUnrestrictedBrowse(!!next.allowUnrestrictedBrowse);
       updateWebCSRFToken(next.csrfToken || "", !!next.caseInsensitivePaths);
     } catch (err) {
       setError(String(err));

--- a/webui/src/webRoot.tsx
+++ b/webui/src/webRoot.tsx
@@ -13,8 +13,6 @@ type AuthStatus = {
   username: string;
   csrfToken: string;
   caseInsensitivePaths: boolean;
-  browseRoot: string;
-  allowUnrestrictedBrowse: boolean;
   needsBrowsePolicy: boolean;
 };
 
@@ -24,18 +22,15 @@ const initialStatus: AuthStatus = {
   username: "",
   csrfToken: "",
   caseInsensitivePaths: false,
-  browseRoot: "",
-  allowUnrestrictedBrowse: false,
   needsBrowsePolicy: false,
 };
 
+/** Gates the embedded app on Web authentication and CLI-managed browse policy. */
 export default function WebRoot() {
   const [status, setStatus] = useState<AuthStatus | null>(null);
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [retainLogin, setRetainLogin] = useState(false);
-  const [browseRoot, setBrowseRoot] = useState("");
-  const [allowUnrestrictedBrowse, setAllowUnrestrictedBrowse] = useState(false);
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
@@ -45,8 +40,6 @@ export default function WebRoot() {
       .then((payload) => {
         const next = { ...initialStatus, ...payload };
         setStatus(next);
-        setBrowseRoot(next.browseRoot || "");
-        setAllowUnrestrictedBrowse(!!next.allowUnrestrictedBrowse);
         initializeWebClient(next.csrfToken || "", !!next.caseInsensitivePaths);
       })
       .catch((err) => {
@@ -65,63 +58,17 @@ export default function WebRoot() {
   }
 
   if (status.authenticated) {
-    const submitBrowsePolicy = async (event?: FormEvent<HTMLFormElement>) => {
-      event?.preventDefault();
-      if (submitting || (!allowUnrestrictedBrowse && !browseRoot.trim())) {
-        return;
-      }
-      setSubmitting(true);
-      setError("");
-      try {
-        const payload = await authClient.saveBrowsePolicy(browseRoot, allowUnrestrictedBrowse);
-        const next = { ...initialStatus, ...(payload as Partial<AuthStatus>) };
-        setStatus(next);
-        setBrowseRoot(next.browseRoot || "");
-        setAllowUnrestrictedBrowse(!!next.allowUnrestrictedBrowse);
-        updateWebCSRFToken(next.csrfToken || "", !!next.caseInsensitivePaths);
-      } catch (err) {
-        setError(String(err));
-      } finally {
-        setSubmitting(false);
-      }
-    };
-
     if (status.needsBrowsePolicy) {
       return (
         <div className="web-auth-shell">
           <div className="web-auth-card">
             <p className="web-auth-card__eyebrow">upbrr Web</p>
-            <h1>Set Browse Access</h1>
+            <h1>Browse Access Required</h1>
             <p className="web-auth-card__copy">
-              Choose the host directories this web UI can browse, or explicitly allow unrestricted
-              host browsing. Separate multiple paths with commas.
+              Browse access can only be changed from the local upbrr binary. Stop the server, run
+              the command below, then restart it.
             </p>
-            <form onSubmit={submitBrowsePolicy}>
-              <label>
-                <span>Browse root</span>
-                <input
-                  value={browseRoot}
-                  onChange={(event) => setBrowseRoot(event.target.value)}
-                  disabled={allowUnrestrictedBrowse}
-                  placeholder="D:\\Media, E:\\Downloads"
-                />
-              </label>
-              <div className="web-auth-card__checkbox">
-                <Checkbox
-                  id="allow-unrestricted-browse"
-                  checked={allowUnrestrictedBrowse}
-                  onCheckedChange={setAllowUnrestrictedBrowse}
-                />
-                <label htmlFor="allow-unrestricted-browse">Allow unrestricted host browsing</label>
-              </div>
-              {error ? <p className="web-auth-card__error">{error}</p> : null}
-              <button
-                type="submit"
-                disabled={submitting || (!allowUnrestrictedBrowse && !browseRoot.trim())}
-              >
-                {submitting ? "Saving..." : "Continue"}
-              </button>
-            </form>
+            <code>upbrr auth browse-roots &lt;path&gt;...</code>
           </div>
         </div>
       );
@@ -161,8 +108,6 @@ export default function WebRoot() {
         : await authClient.login(username, password, retainLogin);
       const next = { ...initialStatus, ...(payload as Partial<AuthStatus>) };
       setStatus(next);
-      setBrowseRoot(next.browseRoot || "");
-      setAllowUnrestrictedBrowse(!!next.allowUnrestrictedBrowse);
       updateWebCSRFToken(next.csrfToken || "", !!next.caseInsensitivePaths);
     } catch (err) {
       setError(String(err));


### PR DESCRIPTION
## Summary

- add local `upbrr auth password` and `upbrr auth browse-roots` commands
- verify the current password, revoke retained sessions, and preserve encrypted data across legacy auth upgrades
- keep initial browse-policy setup in the WebUI, then atomically reject later WebUI mutations
- add CLI, auth migration, route, frontend, and documentation coverage

## Impact

First login still creates the administrator account and sets browse roots in the WebUI. Later password and browse-policy changes require local binary access while `upbrr serve` is stopped.

## Checks

- `make test-go`
- focused Go race tests
- `make lint`
- `make test-frontend`
- `pnpm --dir webui run build`
- `pnpm --dir documentation run check`
- `make backend`
- embedded Playwright `web-smoke` and `web-base-path-smoke`

`make e2e-web` completed 12/14 tests; two unrelated full-upload duplicate-evidence assertions still expect older UI text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CLI commands to change the WebUI password and configure browse roots or unrestricted browsing.
  - Password changes verify the current password, revoke existing sessions, and create a secure backup.
  - Browse-root settings are validated, normalized, and safely applied.

- **Changes**
  - Browse-policy setup is available in the Web UI only during initial configuration; later changes use the local CLI while the server is stopped.
  - First-run and migration guidance now explains the updated setup process.

- **Documentation**
  - Added CLI help and reference documentation for authentication management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->