### PR TITLE
fix(ptp): avoid duplicate torrent artifacts

### DIFF
--- a/internal/trackers/impl/registry_test.go
+++ b/internal/trackers/impl/registry_test.go
@@ -695,10 +695,14 @@ func TestNewRegistryIncludesHDBPolicies(t *testing.T) {
 	}
 }
 
-func TestNewRegistryIncludesPTPDataPolicy(t *testing.T) {
+func TestNewRegistryIncludesPTPPolicies(t *testing.T) {
 	registry, err := NewRegistry()
 	if err != nil {
 		t.Fatalf("new registry: %v", err)
+	}
+	uploadPolicy, ok := registry.LookupUploadArtifactPolicy("PTP")
+	if !ok || uploadPolicy.Source != "PTP" || !uploadPolicy.RequireAnnounce {
+		t.Fatalf("PTP upload artifact policy = %#v, %t", uploadPolicy, ok)
 	}
 	policy, ok := registry.LookupDataPolicy("PTP")
 	if !ok || policy.Cooldown != time.Minute {

--- a/internal/trackers/impl/standalone/ptp/definition_test.go
+++ b/internal/trackers/impl/standalone/ptp/definition_test.go
@@ -382,10 +382,35 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 	createTestTorrent(t, filepath.Join(tmp, "source.bin"), baseTorrentPath)
 	markTorrentWithPrivateMetadata(t, baseTorrentPath)
 	announceURL := "https://please.passthepopcorn.me/passkey/announce"
-	torrentPath := filepath.Join(tmp, "[ptp].release.torrent")
+	meta := api.UploadSubject{
+		SourcePath:  filepath.Join(tmp, "Movie.mkv"),
+		ReleaseName: "Movie.2026.1080p.BluRay.x264",
+		Source:      "BluRay",
+		VideoCodec:  "AVC",
+		Identity:    api.ExternalIdentity{Category: "MOVIE", IMDBID: 1234567},
+		ProviderMetadata: api.SourceScopedMetadata{
+			TMDB: &api.TMDBMetadata{
+				Title:    "Movie",
+				Year:     2026,
+				Poster:   "https://img.example/poster.jpg",
+				Genres:   "Action",
+				Overview: "Plot",
+			},
+		},
+	}
+	torrentPath, err := trackers.ResolveTrackerTorrentArtifactPath(meta, dbPath, "PTP")
+	if err != nil {
+		t.Fatalf("resolve PTP torrent artifact: %v", err)
+	}
+	meta.TorrentPath = torrentPath
 	if err := trackers.WritePersonalizedTorrent(baseTorrentPath, torrentPath, announceURL, "", "PTP"); err != nil {
 		t.Fatalf("prepare PTP torrent artifact: %v", err)
 	}
+	preparedMeta, err := metainfo.LoadFromFile(torrentPath)
+	if err != nil {
+		t.Fatalf("load prepared PTP torrent: %v", err)
+	}
+	preparedInfoHash := preparedMeta.HashInfoBytes().String()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -475,23 +500,7 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 
 	result, err := (&Definition{baseURL: server.URL}).submit(context.Background(), trackers.PreparationInput{
 		Tracker: "PTP",
-		Meta: api.UploadSubject{
-			SourcePath:  filepath.Join(tmp, "Movie.mkv"),
-			TorrentPath: torrentPath,
-			ReleaseName: "Movie.2026.1080p.BluRay.x264",
-			Source:      "BluRay",
-			VideoCodec:  "AVC",
-			Identity:    api.ExternalIdentity{Category: "MOVIE", IMDBID: 1234567},
-			ProviderMetadata: api.SourceScopedMetadata{
-				TMDB: &api.TMDBMetadata{
-					Title:    "Movie",
-					Year:     2026,
-					Poster:   "https://img.example/poster.jpg",
-					Genres:   "Action",
-					Overview: "Plot",
-				},
-			},
-		},
+		Meta:    meta,
 		TrackerConfig: config.TrackerConfig{
 			Username:    "user",
 			Password:    "pass",
@@ -513,11 +522,34 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 		t.Fatalf("expected torrent id 666, got %q", result.UploadedTorrents[0].TorrentID)
 	}
 	artifactPath := result.UploadedTorrents[0].TorrentPath
-	if strings.TrimSpace(artifactPath) == "" {
-		t.Fatal("expected tracker torrent path")
+	if artifactPath != torrentPath {
+		t.Fatalf("expected finalized prepared artifact %q, got %q", torrentPath, artifactPath)
 	}
-	if _, err := os.Stat(artifactPath); err != nil {
-		t.Fatalf("expected tracker torrent file: %v", err)
+	registeredMeta, err := metainfo.LoadFromFile(artifactPath)
+	if err != nil {
+		t.Fatalf("load registered PTP torrent: %v", err)
+	}
+	if registeredMeta.HashInfoBytes().String() != preparedInfoHash {
+		t.Fatal("expected PTP finalization to preserve infohash")
+	}
+	if registeredMeta.Announce != announceURL || len(registeredMeta.AnnounceList) != 1 ||
+		len(registeredMeta.AnnounceList[0]) != 1 || registeredMeta.AnnounceList[0][0] != announceURL {
+		t.Fatal("expected registered PTP announce and announce-list")
+	}
+	registeredInfo, err := registeredMeta.UnmarshalInfo()
+	if err != nil {
+		t.Fatalf("unmarshal registered PTP torrent: %v", err)
+	}
+	if registeredInfo.Source != "PTP" {
+		t.Fatalf("expected registered PTP source, got %q", registeredInfo.Source)
+	}
+	if registeredMeta.Comment != result.UploadedTorrents[0].TorrentURL {
+		t.Fatalf("expected registered PTP comment %q, got %q", result.UploadedTorrents[0].TorrentURL, registeredMeta.Comment)
+	}
+	legacyBase := strings.TrimSuffix(strings.TrimPrefix(filepath.Base(torrentPath), "[ptp]."), ".torrent")
+	legacyPath := filepath.Join(filepath.Dir(torrentPath), legacyBase+".ptp.torrent")
+	if _, err := os.Stat(legacyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no duplicate PTP torrent at %q, got %v", legacyPath, err)
 	}
 	legacyCookiePath, err := servicedb.CookiePath(dbPath, ptpCookieFile)
 	if err != nil {

--- a/internal/trackers/impl/standalone/ptp/definition_test.go
+++ b/internal/trackers/impl/standalone/ptp/definition_test.go
@@ -15,12 +15,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/autobrr/go-torrent/metainfo"
 	mkbrr "github.com/autobrr/mkbrr/torrent"
 
 	"github.com/autobrr/upbrr/internal/config"
+	cookiepkg "github.com/autobrr/upbrr/internal/cookies"
 	servicedb "github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
@@ -375,6 +377,44 @@ func TestDefinitionBuildUploadDryRunForNewGroupIncludesQuestionnaire(t *testing.
 	}
 }
 
+func TestDefinitionUploadRejectsMissingAnnounceBeforeRequest(t *testing.T) {
+	ctx := context.Background()
+	dbPath := newPTPAuthDB(t)
+	if err := cookiepkg.SaveTrackerCookieMap(ctx, dbPath, "PTP", map[string]string{"session": "existing"}); err != nil {
+		t.Fatalf("save PTP cookies: %v", err)
+	}
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	tmp := t.TempDir()
+	torrentPath := filepath.Join(tmp, "release.torrent")
+	createTestTorrent(t, filepath.Join(tmp, "source.bin"), torrentPath)
+	_, err := (&Definition{baseURL: server.URL}).submit(ctx, trackers.PreparationInput{
+		Tracker: "PTP",
+		Meta: api.UploadSubject{
+			SourcePath:  filepath.Join(tmp, "Movie.mkv"),
+			TorrentPath: torrentPath,
+			ReleaseName: "Movie.2026.1080p.BluRay.x264",
+			Source:      "BluRay",
+			VideoCodec:  "AVC",
+			Identity:    api.ExternalIdentity{Category: "MOVIE", IMDBID: 1234567},
+		},
+		Runtime: trackers.PreparationRuntimeFromConfig(config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}}),
+		Logger:  api.NopLogger{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "required announce URL is missing") {
+		t.Fatalf("missing announce error = %v", err)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("missing announce triggered %d PTP request(s)", got)
+	}
+}
+
 func TestDefinitionUploadSuccess(t *testing.T) {
 	tmp := t.TempDir()
 	dbPath := newPTPAuthDB(t)
@@ -546,8 +586,12 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 	if registeredMeta.Comment != result.UploadedTorrents[0].TorrentURL {
 		t.Fatalf("expected registered PTP comment %q, got %q", result.UploadedTorrents[0].TorrentURL, registeredMeta.Comment)
 	}
-	legacyBase := strings.TrimSuffix(strings.TrimPrefix(filepath.Base(torrentPath), "[ptp]."), ".torrent")
-	legacyPath := filepath.Join(filepath.Dir(torrentPath), legacyBase+".ptp.torrent")
+	expectedBase := filepath.Base(meta.SourcePath)
+	expectedName := "[ptp]." + expectedBase + ".torrent"
+	if got := filepath.Base(torrentPath); got != expectedName {
+		t.Fatalf("expected canonical PTP torrent %q, got %q", expectedName, got)
+	}
+	legacyPath := filepath.Join(filepath.Dir(torrentPath), expectedBase+".ptp.torrent")
 	if _, err := os.Stat(legacyPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected no duplicate PTP torrent at %q, got %v", legacyPath, err)
 	}

--- a/internal/trackers/impl/standalone/ptp/profile.go
+++ b/internal/trackers/impl/standalone/ptp/profile.go
@@ -42,7 +42,7 @@ func Profile() standalone.Profile {
 			AnyOf:       []trackers.MetadataField{trackers.MetadataFieldIMDBIDOnly},
 			Disposition: api.RuleDispositionAdvisory,
 		}}},
-		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: "PTP"},
+		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: "PTP", RequireAnnounce: true},
 		ArtifactPolicy: &trackers.ArtifactPolicy{
 			MaxPieceSizeMiB:     16,
 			PieceSizeProfileURL: ptpBaseURL,

--- a/internal/trackers/impl/standalone/ptp/upload.go
+++ b/internal/trackers/impl/standalone/ptp/upload.go
@@ -204,6 +204,9 @@ func prepareUploadStateAt(ctx context.Context, req trackers.PreparationInput, dr
 		return uploadState{}, nameFailure
 	}
 	announceURL := normalizedAnnounceURL(req.TrackerConfig.AnnounceURL)
+	if !dryRun && announceURL == "" {
+		return uploadState{}, errors.New("trackers: PTP required announce URL is missing")
+	}
 	torrentPath, err := trackers.PreparedUploadTorrentPath(req.Meta)
 	if err != nil {
 		return uploadState{}, fmt.Errorf("trackers: PTP resolve upload torrent: %w", err)

--- a/internal/trackers/impl/standalone/ptp/upload.go
+++ b/internal/trackers/impl/standalone/ptp/upload.go
@@ -83,9 +83,9 @@ func prepareUploadAt(ctx context.Context, req trackers.PreparationInput, baseURL
 	if err != nil {
 		return trackers.PreparedOperation{}, err
 	}
-	trackerTorrentPath, err := resolveTrackerTorrentPath(req.Meta, req.Runtime.DBPath, "PTP")
+	trackerTorrentPath, err := trackers.ResolveTrackerTorrentArtifactPath(req.Meta, req.Runtime.DBPath, "PTP")
 	if err != nil {
-		return trackers.PreparedOperation{}, err
+		return trackers.PreparedOperation{}, fmt.Errorf("trackers: PTP resolve registered torrent path: %w", err)
 	}
 	return trackers.NewPreparedOperation(preview, func(submitCtx context.Context) (api.UploadSummary, error) {
 		return submitPreparedUpload(submitCtx, req, state, body, contentType, trackerTorrentPath)
@@ -456,21 +456,6 @@ func buildMultipartPayload(fields map[string]string, torrentPath string, fileFie
 		return nil, "", fmt.Errorf("trackers: PTP close multipart writer: %w", err)
 	}
 	return body.Bytes(), writer.FormDataContentType(), nil
-}
-
-func resolveTrackerTorrentPath(meta api.UploadSubject, dbPath string, tracker string) (string, error) {
-	if strings.TrimSpace(dbPath) == "" || strings.TrimSpace(meta.SourcePath) == "" {
-		return "", errors.New("trackers: PTP tracker torrent path requires db path and source path")
-	}
-	tmpRoot, err := db.Subdir(dbPath, "tmp")
-	if err != nil {
-		return "", fmt.Errorf("trackers: %w", err)
-	}
-	tmpDir, base, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, meta.Release)
-	if err != nil {
-		return "", fmt.Errorf("trackers: %w", err)
-	}
-	return filepath.Join(tmpDir, base+"."+strings.ToLower(strings.TrimSpace(tracker))+".torrent"), nil
 }
 
 func resolveFailurePath(meta api.UploadSubject, dbPath string) (string, error) {


### PR DESCRIPTION
## Summary

- finalize PTP's canonical `[ptp].<release>.torrent` artifact in place instead of retaining the same-infohash `.ptp.torrent` copy
- require `announce_url` before PTP upload preparation, avoiding uploads that cannot be reconstructed for client injection
- verify source, announce/announce-list, comment, infohash, canonical path, and duplicate absence

## Testing

- `make precommit`
- `make test-go`
- `make backend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PTP upload artifacts now include required tracker announce information and PTP source metadata.
- **Bug Fixes**
  - Improved PTP torrent artifact resolution during uploads.
  - Upload validation now confirms key metadata, including the prepared infohash, announce details, source, and upload URL.
  - Prevented creation of duplicate legacy torrent artifacts.
- **Tests**
  - Expanded coverage to verify PTP policy configuration and finalized upload artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->