### PR TITLE
fix(trackers): fix DigitalCore BDMV upload handling

### DIFF
--- a/internal/trackers/impl/standalone/dc/media.go
+++ b/internal/trackers/impl/standalone/dc/media.go
@@ -14,11 +14,16 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-func resolveMediaInfo(meta api.UploadSubject) (string, error) {
+func resolveMediaInfo(req trackers.PreparationInput, meta api.UploadSubject) (string, error) {
 	if text := metautil.FirstNonEmptyTrimmed(commonhttp.ReadOptionalFile(meta.MediaInfoTextPath), strings.TrimSpace(meta.DVDVOBMediaInfoText)); text != "" {
 		return text, nil
 	}
-	return "", errors.New("trackers: DC missing mediainfo")
+	if strings.EqualFold(strings.TrimSpace(meta.DiscType), "BDMV") {
+		if bdinfo, _ := trackers.ReadBDInfo(req.Runtime.DBPath, meta); strings.TrimSpace(bdinfo) != "" {
+			return strings.TrimSpace(bdinfo), nil
+		}
+	}
+	return "", errors.New("trackers: DC missing mediainfo or BDInfo")
 }
 
 func resolveMedia(req trackers.PreparationInput, meta api.UploadSubject) string {

--- a/internal/trackers/impl/standalone/dc/upload.go
+++ b/internal/trackers/impl/standalone/dc/upload.go
@@ -4,6 +4,7 @@
 package dc
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -85,7 +86,7 @@ func submitPreparedUpload(
 	apiKey string,
 	artifactPath string,
 ) (api.UploadSummary, error) {
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL+"/upload", strings.NewReader(string(body)))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL+"/upload", bytes.NewReader(body))
 	if err != nil {
 		return api.UploadSummary{}, fmt.Errorf("trackers: DC request build: %w", err)
 	}
@@ -189,7 +190,7 @@ func prepareUploadState(_ context.Context, req trackers.PreparationInput) (uploa
 		assets = trackers.DescriptionAssets{}
 	}
 	description := buildDescription(req, assets)
-	mediaInfo, err := resolveMediaInfo(req.Meta)
+	mediaInfo, err := resolveMediaInfo(req, req.Meta)
 	if err != nil {
 		return uploadState{}, err
 	}

--- a/internal/trackers/impl/standalone/dc/upload_test.go
+++ b/internal/trackers/impl/standalone/dc/upload_test.go
@@ -10,12 +10,14 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/autobrr/go-torrent/bencode"
 	"github.com/autobrr/go-torrent/metainfo"
 
+	paths "github.com/autobrr/upbrr/internal/pathing/layout"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -25,6 +27,37 @@ func TestResolveIMDbIDPadsShortID(t *testing.T) {
 
 	if got := resolveIMDbID(api.UploadSubject{Identity: api.ExternalIdentity{IMDBID: 456}}); got != "tt0000456" {
 		t.Fatalf("expected padded IMDb ID, got %q", got)
+	}
+}
+
+func TestResolveMediaInfoUsesBDInfoForBDMV(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "db.sqlite")
+	meta := api.UploadSubject{
+		SourcePath: "Example.Release.2026",
+		DiscType:   "BDMV",
+		SelectedBDMVPlaylists: []api.PlaylistInfo{{
+			File: "00001.MPLS",
+		}},
+	}
+	summaryPath, err := paths.PrimaryBDMVSummaryPathFor(filepath.Join(filepath.Dir(dbPath), "tmp"), meta.SourcePath, meta.Release, meta.SelectedBDMVPlaylists)
+	if err != nil {
+		t.Fatalf("resolve BDInfo summary path: %v", err)
+	}
+	const summary = "DISC INFO:\nDisc Title: Example Release 2026\n"
+	if err := os.WriteFile(summaryPath, []byte(summary), 0o600); err != nil {
+		t.Fatalf("write BDInfo summary: %v", err)
+	}
+
+	got, err := resolveMediaInfo(trackers.PreparationInput{
+		Runtime: trackers.PreparationRuntime{DBPath: dbPath},
+	}, meta)
+	if err != nil {
+		t.Fatalf("resolve DC BDMV media info: %v", err)
+	}
+	if got != strings.TrimSpace(summary) {
+		t.Fatalf("BDInfo media info = %q, want %q", got, strings.TrimSpace(summary))
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes DigitalCore upload preparation for Blu-ray disc uploads and makes the upload POST preserve the captured multipart bytes directly.

DigitalCore accepts BDInfo in its `mediainfo` field, but the DigitalCore tracker module only looked for MediaInfo text during upload preparation. BDMV uploads could therefore fail preparation even when the prepared BDInfo summary existed. The multipart POST also converted the captured payload through a string before sending it; this now uses a byte reader like the other multipart uploaders.

Fixes #

## How has this been tested?

- `go test ./internal/trackers/impl/standalone/dc`

## Screenshots (for UI changes)

No UI changes.

## Checklist

- [x] My PR title follows the conventional commit guidelines, e.g. `fix(module): my fix`.
- [ ] I have read the CONTRIBUTING.md document.
- [ ] I ran `make precommit` and have resolved any issues.
- [ ] For CSS changes, I have run `cd web && pnpm tailwind`.
