### PR TITLE
fix(trackers): update DigitalCore upload and dupe handling

### DIFF
--- a/internal/trackers/impl/dupe_handlers_contract_test.go
+++ b/internal/trackers/impl/dupe_handlers_contract_test.go
@@ -517,7 +517,7 @@ func TestSiteHandlersSearch(t *testing.T) {
 					_, _ = w.Write([]byte(`{"result":{"results":"0","torrents":{}}}`))
 					return
 				case "DC":
-					_, _ = w.Write([]byte(`{"results":[]}`))
+					_, _ = w.Write([]byte(`{"results":[],"index":0,"limit":100,"count":0,"total":0,"includesPending":true}`))
 					return
 				case "CZT", "RTF", "SPD":
 					_, _ = w.Write([]byte(`[]`))

--- a/internal/trackers/impl/dupe_handlers_contract_test.go
+++ b/internal/trackers/impl/dupe_handlers_contract_test.go
@@ -516,7 +516,10 @@ func TestSiteHandlersSearch(t *testing.T) {
 					}
 					_, _ = w.Write([]byte(`{"result":{"results":"0","torrents":{}}}`))
 					return
-				case "CZT", "DC", "RTF", "SPD":
+				case "DC":
+					_, _ = w.Write([]byte(`{"results":[]}`))
+					return
+				case "CZT", "RTF", "SPD":
 					_, _ = w.Write([]byte(`[]`))
 					return
 				case "GPW":

--- a/internal/trackers/impl/standalone/dc/dupe.go
+++ b/internal/trackers/impl/standalone/dc/dupe.go
@@ -128,7 +128,7 @@ func (s *dupeSearcher) searchPage(
 ) (dcDupePage, string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.endpoint, nil)
 	if err != nil {
-		return dcDupePage{}, dupe.FailureRequest, err
+		return dcDupePage{}, dupe.FailureRequest, fmt.Errorf("build DC duplicate request: %w", err)
 	}
 	req.URL.RawQuery = params.Encode()
 	req.Header.Set("X-Api-Key", apiKey)
@@ -136,7 +136,7 @@ func (s *dupeSearcher) searchPage(
 
 	resp, err := s.http.Do(req)
 	if err != nil {
-		return dcDupePage{}, dupe.FailureRequest, err
+		return dcDupePage{}, dupe.FailureRequest, fmt.Errorf("request DC duplicate search: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
@@ -145,7 +145,7 @@ func (s *dupeSearcher) searchPage(
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, dcDupeMaxResponseBytes+1))
 	if err != nil {
-		return dcDupePage{}, dupe.FailureResponseParse, err
+		return dcDupePage{}, dupe.FailureResponseParse, fmt.Errorf("read DC duplicate response: %w", err)
 	}
 	if len(body) > dcDupeMaxResponseBytes {
 		return dcDupePage{}, dupe.FailureResponseParse, fmt.Errorf("duplicate response exceeds %d bytes", dcDupeMaxResponseBytes)

--- a/internal/trackers/impl/standalone/dc/dupe.go
+++ b/internal/trackers/impl/standalone/dc/dupe.go
@@ -21,11 +21,13 @@ import (
 )
 
 const dcDupeMaxResponseBytes = 4 << 20
+const dcDupePageSize = 100
 
 type dupeSearcher struct {
 	cfg      config.Config
 	http     *http.Client
 	endpoint string
+	maxPages int
 }
 
 // NewDuplicateAdapter returns a duplicate-search adapter bound to one immutable dependency set.
@@ -38,6 +40,7 @@ func newDuplicateAdapter(deps dupe.Dependencies) dupe.Adapter {
 		cfg:      cfg,
 		http:     httpClient,
 		endpoint: "https://digitalcore.club/api/v1/torrents/dupe-search",
+		maxPages: deps.MaxPages(100),
 	}
 }
 
@@ -46,7 +49,7 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 	if apiKey == "" {
 		return dupe.NotRun(dupe.NotRunMissingCredentials, "missing api_key for tracker", nil)
 	}
-	params := url.Values{"limit": {"100"}}
+	params := url.Values{"limit": {strconv.Itoa(dcDupePageSize)}}
 	workScope := dupe.WorkScopeProviderID
 	if meta.Identity.IMDBID != 0 {
 		params.Set("imdb", providerid.IMDb(meta.Identity.IMDBID).Prefixed())
@@ -60,9 +63,71 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 		return dupe.NotRun(dupe.NotRunMissingMetadata, "missing imdb id or release name for DC dupe search", nil)
 	}
 
+	maxPages := s.maxPages
+	if maxPages <= 0 {
+		maxPages = 100
+	}
+	entries := make([]api.DupeEntry, 0)
+	complete := false
+	pages := 0
+	index := 0
+	expectedTotal := -1
+	pendingCoverageOK := true
+	for pages < maxPages {
+		pageParams := cloneDCValues(params)
+		pageParams.Set("index", strconv.Itoa(index))
+		page, failureCode, err := s.searchPage(ctx, apiKey, pageParams)
+		if failureCode != "" {
+			return dupe.Failed(failureCode, "DC search failed", err)
+		}
+		pages++
+		entries = append(entries, dcDupeEntries(page.Results)...)
+		if !validDCPage(page, index, dcDupePageSize, expectedTotal) {
+			if page.IncludesPending == nil || !*page.IncludesPending {
+				pendingCoverageOK = false
+			}
+			break
+		}
+		if expectedTotal < 0 {
+			expectedTotal = *page.Total
+		}
+		nextIndex := *page.Index + *page.Count
+		switch {
+		case expectedTotal == 0 && *page.Count == 0:
+			complete = true
+		case nextIndex >= expectedTotal:
+			complete = true
+		case *page.Count > 0 && nextIndex > index:
+			index = nextIndex
+			continue
+		}
+		break
+	}
+
+	warnings := []string(nil)
+	if !pendingCoverageOK {
+		warnings = append(warnings, "DC search did not confirm pending/modqueue coverage")
+	}
+	if !complete {
+		warnings = append(warnings, "DC search reached a pagination bound or returned incomplete pagination metadata")
+	}
+	return dupe.ResolvedWithSearch(entries, warnings, dupe.SearchEvidence{
+		Complete:  complete,
+		WorkScope: workScope,
+		Pages:     pages,
+		Scope:     "dupe_preflight",
+		Warnings:  warnings,
+	})
+}
+
+func (s *dupeSearcher) searchPage(
+	ctx context.Context,
+	apiKey string,
+	params url.Values,
+) (dcDupePage, string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.endpoint, nil)
 	if err != nil {
-		return dupe.Failed(dupe.FailureRequest, "DC search failed", err)
+		return dcDupePage{}, dupe.FailureRequest, err
 	}
 	req.URL.RawQuery = params.Encode()
 	req.Header.Set("X-Api-Key", apiKey)
@@ -70,31 +135,26 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 
 	resp, err := s.http.Do(req)
 	if err != nil {
-		return dupe.Failed(dupe.FailureRequest, "DC search failed", err)
+		return dcDupePage{}, dupe.FailureRequest, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return dupe.Failed(dupe.FailureResponseStatus, "DC search failed", nil)
+		return dcDupePage{}, dupe.FailureResponseStatus, nil
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, dcDupeMaxResponseBytes+1))
 	if err != nil {
-		return dupe.Failed(dupe.FailureResponseParse, "DC search failed", err)
+		return dcDupePage{}, dupe.FailureResponseParse, err
 	}
 	if len(body) > dcDupeMaxResponseBytes {
-		return dupe.Failed(dupe.FailureResponseParse, "DC search failed", fmt.Errorf("duplicate response exceeds %d bytes", dcDupeMaxResponseBytes))
+		return dcDupePage{}, dupe.FailureResponseParse, fmt.Errorf("duplicate response exceeds %d bytes", dcDupeMaxResponseBytes)
 	}
 
-	entries, err := dcParseDupeEntries(body)
+	page, err := dcParseDupePage(body)
 	if err != nil {
-		return dupe.Failed(dupe.FailureResponseParse, "DC search failed", err)
+		return dcDupePage{}, dupe.FailureResponseParse, err
 	}
-	return dupe.ResolvedWithSearch(entries, nil, dupe.SearchEvidence{
-		Complete:  true,
-		WorkScope: workScope,
-		Pages:     1,
-		Scope:     "dupe_preflight",
-	})
+	return page, "", nil
 }
 
 func dcAPIKey(cfg config.Config) string {
@@ -121,24 +181,61 @@ func dcSearchName(meta api.DuplicateSubject) string {
 	return ""
 }
 
-func dcParseDupeEntries(body []byte) ([]api.DupeEntry, error) {
-	var payload struct {
-		Results []map[string]any `json:"results"`
-	}
+type dcDupePage struct {
+	Results         []map[string]any `json:"results"`
+	Index           *int             `json:"index"`
+	Limit           *int             `json:"limit"`
+	Count           *int             `json:"count"`
+	Total           *int             `json:"total"`
+	IncludesPending *bool            `json:"includesPending"`
+}
+
+func dcParseDupePage(body []byte) (dcDupePage, error) {
+	var payload dcDupePage
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.UseNumber()
 	if err := decoder.Decode(&payload); err != nil {
-		return nil, fmt.Errorf("decode DC duplicate response: %w", err)
+		return dcDupePage{}, fmt.Errorf("decode DC duplicate response: %w", err)
 	}
+	return payload, nil
+}
 
-	entries := make([]api.DupeEntry, 0, len(payload.Results))
-	for _, item := range payload.Results {
+func dcDupeEntries(results []map[string]any) []api.DupeEntry {
+	entries := make([]api.DupeEntry, 0, len(results))
+	for _, item := range results {
 		entry := dcDupeEntry(item)
 		if entry.Name != "" {
 			entries = append(entries, entry)
 		}
 	}
-	return entries, nil
+	return entries
+}
+
+func validDCPage(page dcDupePage, requestedIndex int, requestedLimit int, expectedTotal int) bool {
+	if page.Index == nil || page.Limit == nil || page.Count == nil || page.Total == nil || page.IncludesPending == nil {
+		return false
+	}
+	if !*page.IncludesPending || *page.Index != requestedIndex || *page.Limit != requestedLimit {
+		return false
+	}
+	if *page.Count < 0 || *page.Total < 0 || *page.Count != len(page.Results) {
+		return false
+	}
+	if *page.Index+*page.Count > *page.Total {
+		return false
+	}
+	if expectedTotal >= 0 && *page.Total != expectedTotal {
+		return false
+	}
+	return true
+}
+
+func cloneDCValues(values url.Values) url.Values {
+	cloned := make(url.Values, len(values))
+	for key, entries := range values {
+		cloned[key] = append([]string(nil), entries...)
+	}
+	return cloned
 }
 
 func dcDupeEntry(item map[string]any) api.DupeEntry {

--- a/internal/trackers/impl/standalone/dc/dupe.go
+++ b/internal/trackers/impl/standalone/dc/dupe.go
@@ -128,7 +128,7 @@ func dcParseDupeEntries(body []byte) ([]api.DupeEntry, error) {
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.UseNumber()
 	if err := decoder.Decode(&payload); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode DC duplicate response: %w", err)
 	}
 
 	entries := make([]api.DupeEntry, 0, len(payload.Results))

--- a/internal/trackers/impl/standalone/dc/dupe.go
+++ b/internal/trackers/impl/standalone/dc/dupe.go
@@ -22,6 +22,7 @@ import (
 
 const dcDupeMaxResponseBytes = 4 << 20
 const dcDupePageSize = 100
+const dcDupeMaxPages = 100
 
 type dupeSearcher struct {
 	cfg      config.Config
@@ -40,7 +41,7 @@ func newDuplicateAdapter(deps dupe.Dependencies) dupe.Adapter {
 		cfg:      cfg,
 		http:     httpClient,
 		endpoint: "https://digitalcore.club/api/v1/torrents/dupe-search",
-		maxPages: deps.MaxPages(100),
+		maxPages: deps.MaxPages(dcDupeMaxPages),
 	}
 }
 
@@ -65,7 +66,7 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 
 	maxPages := s.maxPages
 	if maxPages <= 0 {
-		maxPages = 100
+		maxPages = dcDupeMaxPages
 	}
 	entries := make([]api.DupeEntry, 0)
 	complete := false
@@ -81,13 +82,13 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 			return dupe.Failed(failureCode, "DC search failed", err)
 		}
 		pages++
-		entries = append(entries, dcDupeEntries(page.Results)...)
 		if !validDCPage(page, index, dcDupePageSize, expectedTotal) {
 			if page.IncludesPending == nil || !*page.IncludesPending {
 				pendingCoverageOK = false
 			}
 			break
 		}
+		entries = append(entries, dcDupeEntries(page.Results)...)
 		if expectedTotal < 0 {
 			expectedTotal = *page.Total
 		}
@@ -139,7 +140,7 @@ func (s *dupeSearcher) searchPage(
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return dcDupePage{}, dupe.FailureResponseStatus, nil
+		return dcDupePage{}, dupe.FailureResponseStatus, fmt.Errorf("unexpected DC duplicate response status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, dcDupeMaxResponseBytes+1))

--- a/internal/trackers/impl/standalone/dc/dupe.go
+++ b/internal/trackers/impl/standalone/dc/dupe.go
@@ -4,17 +4,23 @@
 package dc
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/providerid"
 	"github.com/autobrr/upbrr/internal/trackers/dupe"
-	"github.com/autobrr/upbrr/internal/trackers/impl/standalone/internal/jsondupe"
 	"github.com/autobrr/upbrr/pkg/api"
 )
+
+const dcDupeMaxResponseBytes = 4 << 20
 
 type dupeSearcher struct {
 	cfg      config.Config
@@ -31,7 +37,7 @@ func newDuplicateAdapter(deps dupe.Dependencies) dupe.Adapter {
 	return &dupeSearcher{
 		cfg:      cfg,
 		http:     httpClient,
-		endpoint: "https://digitalcore.club/api/v1/torrents",
+		endpoint: "https://digitalcore.club/api/v1/torrents/dupe-search",
 	}
 }
 
@@ -40,24 +46,54 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 	if apiKey == "" {
 		return dupe.NotRun(dupe.NotRunMissingCredentials, "missing api_key for tracker", nil)
 	}
-	if meta.Identity.IMDBID == 0 {
-		return dupe.NotRun(dupe.NotRunMissingMetadata, "missing imdb id for DC dupe search", nil)
+	params := url.Values{"limit": {"100"}}
+	workScope := dupe.WorkScopeProviderID
+	if meta.Identity.IMDBID != 0 {
+		params.Set("imdb", providerid.IMDb(meta.Identity.IMDBID).Prefixed())
+	} else {
+		workScope = dupe.WorkScopeTitle
 	}
-	return jsondupe.Search(ctx, s.http, jsondupe.ListSpec{
-		Endpoint:       s.endpoint,
-		Query:          url.Values{"searchText": {providerid.IMDb(meta.Identity.IMDBID).Prefixed()}},
-		Headers:        http.Header{"X-Api-Key": {apiKey}},
-		IDField:        "id",
-		NameField:      "name",
-		SizeField:      "size",
-		Link:           func(id string) string { return "https://digitalcore.club/torrent/" + id + "/" },
-		FailureMessage: "DC search failed",
-		SearchEvidence: dupe.SearchEvidence{
-			Complete:  true,
-			WorkScope: dupe.WorkScopeProviderID,
-			Pages:     1,
-			Scope:     "provider_array",
-		},
+	if name := dcSearchName(meta); name != "" {
+		params.Set("releaseName", name)
+	}
+	if meta.Identity.IMDBID == 0 && params.Get("releaseName") == "" {
+		return dupe.NotRun(dupe.NotRunMissingMetadata, "missing imdb id or release name for DC dupe search", nil)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.endpoint, nil)
+	if err != nil {
+		return dupe.Failed(dupe.FailureRequest, "DC search failed", err)
+	}
+	req.URL.RawQuery = params.Encode()
+	req.Header.Set("X-Api-Key", apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return dupe.Failed(dupe.FailureRequest, "DC search failed", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return dupe.Failed(dupe.FailureResponseStatus, "DC search failed", nil)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, dcDupeMaxResponseBytes+1))
+	if err != nil {
+		return dupe.Failed(dupe.FailureResponseParse, "DC search failed", err)
+	}
+	if len(body) > dcDupeMaxResponseBytes {
+		return dupe.Failed(dupe.FailureResponseParse, "DC search failed", fmt.Errorf("duplicate response exceeds %d bytes", dcDupeMaxResponseBytes))
+	}
+
+	entries, err := dcParseDupeEntries(body)
+	if err != nil {
+		return dupe.Failed(dupe.FailureResponseParse, "DC search failed", err)
+	}
+	return dupe.ResolvedWithSearch(entries, nil, dupe.SearchEvidence{
+		Complete:  true,
+		WorkScope: workScope,
+		Pages:     1,
+		Scope:     "dupe_preflight",
 	})
 }
 
@@ -68,4 +104,169 @@ func dcAPIKey(cfg config.Config) string {
 		}
 	}
 	return ""
+}
+
+func dcSearchName(meta api.DuplicateSubject) string {
+	values := []string{
+		dupe.ProjectedSearchName(meta),
+		meta.ReleaseName,
+		meta.SceneName,
+		meta.Filename,
+	}
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func dcParseDupeEntries(body []byte) ([]api.DupeEntry, error) {
+	var payload struct {
+		Results []map[string]any `json:"results"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, err
+	}
+
+	entries := make([]api.DupeEntry, 0, len(payload.Results))
+	for _, item := range payload.Results {
+		entry := dcDupeEntry(item)
+		if entry.Name != "" {
+			entries = append(entries, entry)
+		}
+	}
+	return entries, nil
+}
+
+func dcDupeEntry(item map[string]any) api.DupeEntry {
+	id := dcScalarString(item["id"])
+	category := dcScalarString(item["categoryName"])
+	entry := api.DupeEntry{
+		ID:            id,
+		Name:          dcScalarString(item["name"]),
+		Category:      category,
+		Type:          dcMediaType(dcScalarString(item["type"])),
+		Res:           dcResolutionFromCategory(category),
+		Source:        dcSourceFromCategory(category),
+		FileCount:     int(dcScalarInt64(item["numfiles"])),
+		Pack:          dcScalarBool(item["pack"]) || strings.Contains(strings.ToUpper(category), "PACK"),
+		ThreeD:        dcThreeDValue(item),
+		ReleaseOrigin: dcReleaseOrigin(item),
+		Attributes: map[string]string{
+			"approved": strconv.FormatBool(dcScalarBool(item["approved"])),
+			"pending":  strconv.FormatBool(dcScalarBool(item["pending"])),
+			"status":   dcScalarString(item["status"]),
+		},
+	}
+	if id != "" {
+		entry.Link = "https://digitalcore.club/torrent/" + id + "/"
+	}
+	if size := dcScalarInt64(item["size"]); size > 0 {
+		entry.SizeKnown, entry.SizeBytes = true, size
+	}
+	return entry
+}
+
+func dcMediaType(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "single", "multi":
+		return ""
+	default:
+		return strings.TrimSpace(value)
+	}
+}
+
+func dcThreeDValue(item map[string]any) string {
+	if dcScalarBool(item["3d"]) || dcScalarBool(item["threeD"]) {
+		return "3d"
+	}
+	return ""
+}
+
+func dcReleaseOrigin(item map[string]any) string {
+	if dcScalarBool(item["p2p"]) {
+		return "p2p"
+	}
+	if raw, ok := item["p2p"]; ok && raw != nil {
+		return "scene"
+	}
+	return ""
+}
+
+func dcResolutionFromCategory(category string) string {
+	upper := strings.ToUpper(category)
+	switch {
+	case strings.Contains(upper, "2160"), strings.Contains(upper, "4K"), strings.Contains(upper, "UHD"):
+		return "2160p"
+	case strings.Contains(upper, "1080"):
+		return "1080p"
+	case strings.Contains(upper, "720"):
+		return "720p"
+	case strings.Contains(upper, "SD"):
+		return "sd"
+	default:
+		return ""
+	}
+}
+
+func dcSourceFromCategory(category string) string {
+	upper := strings.ToUpper(category)
+	switch {
+	case strings.Contains(upper, "BLURAY"), strings.Contains(upper, "BLU-RAY"):
+		return "bluray"
+	case strings.Contains(upper, "DVD"):
+		return "dvd"
+	default:
+		return ""
+	}
+}
+
+func dcScalarString(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case json.Number:
+		return typed.String()
+	case bool:
+		if typed {
+			return "true"
+		}
+		return "false"
+	default:
+		return ""
+	}
+}
+
+func dcScalarInt64(value any) int64 {
+	switch typed := value.(type) {
+	case json.Number:
+		parsed, _ := typed.Int64()
+		return parsed
+	case float64:
+		return int64(typed)
+	case string:
+		parsed, _ := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+		return parsed
+	default:
+		return 0
+	}
+}
+
+func dcScalarBool(value any) bool {
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case json.Number:
+		return typed.String() != "0"
+	case float64:
+		return typed != 0
+	case string:
+		parsed, _ := strconv.ParseBool(strings.TrimSpace(typed))
+		return parsed || strings.TrimSpace(typed) == "1"
+	default:
+		return false
+	}
 }

--- a/internal/trackers/impl/standalone/dc/dupe_test.go
+++ b/internal/trackers/impl/standalone/dc/dupe_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strconv"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/config"
@@ -125,20 +124,24 @@ func TestDuplicateSearchPaginatesUntilTerminalTotal(t *testing.T) {
 		switch r.URL.Query().Get("index") {
 		case "0":
 			requests++
-			writeDCDupePage(t, w, dcTestPage{
+			if !writeDCDupePage(t, w, dcTestPage{
 				Index:           0,
 				Count:           100,
 				Total:           101,
 				IncludesPending: boolPtr(true),
-			})
+			}) {
+				return
+			}
 		case "100":
 			requests++
-			writeDCDupePage(t, w, dcTestPage{
+			if !writeDCDupePage(t, w, dcTestPage{
 				Index:           100,
 				Count:           1,
 				Total:           101,
 				IncludesPending: boolPtr(true),
-			})
+			}) {
+				return
+			}
 		default:
 			t.Errorf("unexpected index query %q", r.URL.Query().Get("index"))
 			w.WriteHeader(http.StatusBadRequest)
@@ -176,12 +179,14 @@ func TestDuplicateSearchRequiresPendingCoverageForCompleteness(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				writeDCDupePage(t, w, dcTestPage{
+				if !writeDCDupePage(t, w, dcTestPage{
 					Index:           0,
 					Count:           0,
 					Total:           0,
 					IncludesPending: tc.includesPending,
-				})
+				}) {
+					return
+				}
 			}))
 			defer server.Close()
 
@@ -206,19 +211,23 @@ func TestDuplicateSearchRejectsInconsistentPagination(t *testing.T) {
 		requests++
 		switch r.URL.Query().Get("index") {
 		case "0":
-			writeDCDupePage(t, w, dcTestPage{
+			if !writeDCDupePage(t, w, dcTestPage{
 				Index:           0,
 				Count:           100,
 				Total:           101,
 				IncludesPending: boolPtr(true),
-			})
+			}) {
+				return
+			}
 		case "100":
-			writeDCDupePage(t, w, dcTestPage{
+			if !writeDCDupePage(t, w, dcTestPage{
 				Index:           100,
 				Count:           1,
 				Total:           102,
 				IncludesPending: boolPtr(true),
-			})
+			}) {
+				return
+			}
 		default:
 			t.Errorf("unexpected index query %q", r.URL.Query().Get("index"))
 			w.WriteHeader(http.StatusBadRequest)
@@ -241,12 +250,14 @@ func TestDuplicateSearchRejectsInconsistentPagination(t *testing.T) {
 
 func TestDuplicateSearchRejectsNonProgressingPagination(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		writeDCDupePage(t, w, dcTestPage{
+		if !writeDCDupePage(t, w, dcTestPage{
 			Index:           0,
 			Count:           0,
 			Total:           1,
 			IncludesPending: boolPtr(true),
-		})
+		}) {
+			return
+		}
 	}))
 	defer server.Close()
 
@@ -262,12 +273,14 @@ func TestDuplicateSearchRejectsNonProgressingPagination(t *testing.T) {
 
 func TestDuplicateSearchPaginationBoundFailsClosed(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		writeDCDupePage(t, w, dcTestPage{
+		if !writeDCDupePage(t, w, dcTestPage{
 			Index:           0,
 			Count:           100,
 			Total:           101,
 			IncludesPending: boolPtr(true),
-		})
+		}) {
+			return
+		}
 	}))
 	defer server.Close()
 
@@ -323,7 +336,7 @@ type dcTestPage struct {
 	IncludesPending *bool
 }
 
-func writeDCDupePage(t *testing.T, w http.ResponseWriter, page dcTestPage) {
+func writeDCDupePage(t *testing.T, w http.ResponseWriter, page dcTestPage) bool {
 	t.Helper()
 	results := make([]map[string]any, 0, page.Count)
 	for i := 0; i < page.Count; i++ {
@@ -345,8 +358,10 @@ func writeDCDupePage(t *testing.T, w http.ResponseWriter, page dcTestPage) {
 		payload["includesPending"] = *page.IncludesPending
 	}
 	if err := json.NewEncoder(w).Encode(payload); err != nil {
-		t.Fatalf("encode DC page %s: %v", strconv.Itoa(page.Index), err)
+		t.Errorf("encode DC page %d: %v", page.Index, err)
+		return false
 	}
+	return true
 }
 
 func boolPtr(value bool) *bool {

--- a/internal/trackers/impl/standalone/dc/dupe_test.go
+++ b/internal/trackers/impl/standalone/dc/dupe_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/config"
@@ -15,26 +16,35 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-func TestDuplicateSearchUsesDCQueryHeadersAndProjection(t *testing.T) {
+func TestDuplicateSearchUsesDCDupeEndpointAndProjection(t *testing.T) {
 	requestErr := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("searchText") != "tt0000456" || r.Header.Get("X-Api-Key") != "secret" {
+		query := r.URL.Query()
+		if err := assertDCQuery(query, map[string]string{
+			"imdb":        "tt0000456",
+			"releaseName": "Example.Release.2026.1080p.WEB-DL-GRP",
+			"limit":       "100",
+		}); err != nil {
+			requestErr <- err
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.Header.Get("X-Api-Key") != "secret" || r.Header.Get("Accept") != "application/json" {
 			requestErr <- errors.New("unexpected DC duplicate request shape")
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		_, _ = w.Write([]byte(`[{"id":42,"name":"Example.Release.2026.1080p-GRP","size":1234}]`))
+		_, _ = w.Write([]byte(`{"results":[{"id":42,"name":"Example.Release.2026.1080p.WEB-DL-GRP","size":1234,"categoryName":"Movies/1080p","type":"single","numfiles":2,"p2p":true,"pack":false,"3d":true,"approved":false,"pending":true,"status":"pending"}],"total":1,"includesPending":true}`))
 	}))
 	defer server.Close()
 
-	searcher := &dupeSearcher{
-		cfg: config.Config{Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
-			"DC": {APIKey: "secret"},
-		}}},
-		http:     server.Client(),
-		endpoint: server.URL,
-	}
-	result := searcher.Search(context.Background(), api.DuplicateSubject{Identity: api.ExternalIdentity{IMDBID: 456}})
+	searcher := testDCDupeSearcher(server)
+	result := searcher.Search(context.Background(), api.DuplicateSubject{
+		Identity: api.ExternalIdentity{IMDBID: 456},
+		Projection: &api.TrackerReleaseProjection{
+			DuplicateCriteria: api.TrackerDuplicateCriteria{Name: "Example.Release.2026.1080p.WEB-DL-GRP"},
+		},
+	})
 	select {
 	case err := <-requestErr:
 		t.Fatal(err)
@@ -44,10 +54,95 @@ func TestDuplicateSearchUsesDCQueryHeadersAndProjection(t *testing.T) {
 		t.Fatalf("unexpected disposition=%v code=%q cause=%v", result.Disposition(), result.Code(), result.Cause())
 	}
 	entries := result.Entries()
-	if len(entries) != 1 || entries[0].ID != "42" || entries[0].Link != "https://digitalcore.club/torrent/42/" || entries[0].SizeBytes != 1234 {
+	if len(entries) != 1 {
 		t.Fatalf("unexpected entries: %#v", entries)
+	}
+	entry := entries[0]
+	if entry.ID != "42" || entry.Link != "https://digitalcore.club/torrent/42/" || entry.SizeBytes != 1234 || !entry.SizeKnown {
+		t.Fatalf("unexpected identity/size: %#v", entry)
+	}
+	if entry.Category != "Movies/1080p" || entry.Type != "" || entry.Res != "1080p" {
+		t.Fatalf("unexpected category/type/resolution: %#v", entry)
+	}
+	if entry.FileCount != 2 || entry.Pack || entry.ThreeD != "3d" || entry.ReleaseOrigin != "p2p" {
+		t.Fatalf("unexpected flags: %#v", entry)
+	}
+	if entry.Attributes["status"] != "pending" || entry.Attributes["approved"] != "false" || entry.Attributes["pending"] != "true" {
+		t.Fatalf("unexpected status attributes: %#v", entry.Attributes)
 	}
 	if search := result.SearchEvidence(); !search.Complete || search.WorkScope != dupe.WorkScopeProviderID || !search.EffectiveComplete() {
 		t.Fatalf("unexpected search evidence: %#v", search)
 	}
+}
+
+func TestDuplicateSearchFallsBackToReleaseNameWithoutIMDb(t *testing.T) {
+	requestErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		if query.Has("imdb") {
+			requestErr <- errors.New("unexpected imdb query for title fallback")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if err := assertDCQuery(query, map[string]string{
+			"releaseName": "Title.Only.2026.720p-GRP",
+			"limit":       "100",
+		}); err != nil {
+			requestErr <- err
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, _ = w.Write([]byte(`{"results":[],"total":0,"includesPending":true}`))
+	}))
+	defer server.Close()
+
+	searcher := testDCDupeSearcher(server)
+	result := searcher.Search(context.Background(), api.DuplicateSubject{ReleaseName: "Title.Only.2026.720p-GRP"})
+	select {
+	case err := <-requestErr:
+		t.Fatal(err)
+	default:
+	}
+	if result.Disposition() != dupe.DispositionResolved {
+		t.Fatalf("unexpected disposition=%v code=%q cause=%v", result.Disposition(), result.Code(), result.Cause())
+	}
+	if entries := result.Entries(); len(entries) != 0 {
+		t.Fatalf("unexpected entries: %#v", entries)
+	}
+	if search := result.SearchEvidence(); !search.Complete || search.WorkScope != dupe.WorkScopeTitle || search.EffectiveComplete() {
+		t.Fatalf("unexpected search evidence: %#v", search)
+	}
+}
+
+func TestDuplicateSearchRequiresIMDbOrReleaseName(t *testing.T) {
+	searcher := &dupeSearcher{
+		cfg: config.Config{Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"DC": {APIKey: "secret"},
+		}}},
+		http:     http.DefaultClient,
+		endpoint: "http://example.invalid",
+	}
+	result := searcher.Search(context.Background(), api.DuplicateSubject{})
+	if result.Disposition() != dupe.DispositionNotRun || result.Code() != dupe.NotRunMissingMetadata {
+		t.Fatalf("unexpected result: disposition=%v code=%q cause=%v", result.Disposition(), result.Code(), result.Cause())
+	}
+}
+
+func testDCDupeSearcher(server *httptest.Server) *dupeSearcher {
+	return &dupeSearcher{
+		cfg: config.Config{Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"DC": {APIKey: "secret"},
+		}}},
+		http:     server.Client(),
+		endpoint: server.URL,
+	}
+}
+
+func assertDCQuery(query url.Values, want map[string]string) error {
+	for key, value := range want {
+		if got := query.Get(key); got != value {
+			return errors.New("unexpected " + key + " query value")
+		}
+	}
+	return nil
 }

--- a/internal/trackers/impl/standalone/dc/dupe_test.go
+++ b/internal/trackers/impl/standalone/dc/dupe_test.go
@@ -125,10 +125,20 @@ func TestDuplicateSearchPaginatesUntilTerminalTotal(t *testing.T) {
 		switch r.URL.Query().Get("index") {
 		case "0":
 			requests++
-			writeDCDupePage(t, w, dcTestPage{Index: 0, Count: 100, Total: 101, IncludesPending: boolPtr(true)})
+			writeDCDupePage(t, w, dcTestPage{
+				Index:           0,
+				Count:           100,
+				Total:           101,
+				IncludesPending: boolPtr(true),
+			})
 		case "100":
 			requests++
-			writeDCDupePage(t, w, dcTestPage{Index: 100, Count: 1, Total: 101, IncludesPending: boolPtr(true)})
+			writeDCDupePage(t, w, dcTestPage{
+				Index:           100,
+				Count:           1,
+				Total:           101,
+				IncludesPending: boolPtr(true),
+			})
 		default:
 			t.Errorf("unexpected index query %q", r.URL.Query().Get("index"))
 			w.WriteHeader(http.StatusBadRequest)
@@ -166,7 +176,12 @@ func TestDuplicateSearchRequiresPendingCoverageForCompleteness(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				writeDCDupePage(t, w, dcTestPage{Index: 0, Count: 0, Total: 0, IncludesPending: tc.includesPending})
+				writeDCDupePage(t, w, dcTestPage{
+					Index:           0,
+					Count:           0,
+					Total:           0,
+					IncludesPending: tc.includesPending,
+				})
 			}))
 			defer server.Close()
 
@@ -191,9 +206,19 @@ func TestDuplicateSearchRejectsInconsistentPagination(t *testing.T) {
 		requests++
 		switch r.URL.Query().Get("index") {
 		case "0":
-			writeDCDupePage(t, w, dcTestPage{Index: 0, Count: 100, Total: 101, IncludesPending: boolPtr(true)})
+			writeDCDupePage(t, w, dcTestPage{
+				Index:           0,
+				Count:           100,
+				Total:           101,
+				IncludesPending: boolPtr(true),
+			})
 		case "100":
-			writeDCDupePage(t, w, dcTestPage{Index: 100, Count: 1, Total: 102, IncludesPending: boolPtr(true)})
+			writeDCDupePage(t, w, dcTestPage{
+				Index:           100,
+				Count:           1,
+				Total:           102,
+				IncludesPending: boolPtr(true),
+			})
 		default:
 			t.Errorf("unexpected index query %q", r.URL.Query().Get("index"))
 			w.WriteHeader(http.StatusBadRequest)
@@ -216,7 +241,12 @@ func TestDuplicateSearchRejectsInconsistentPagination(t *testing.T) {
 
 func TestDuplicateSearchRejectsNonProgressingPagination(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		writeDCDupePage(t, w, dcTestPage{Index: 0, Count: 0, Total: 1, IncludesPending: boolPtr(true)})
+		writeDCDupePage(t, w, dcTestPage{
+			Index:           0,
+			Count:           0,
+			Total:           1,
+			IncludesPending: boolPtr(true),
+		})
 	}))
 	defer server.Close()
 
@@ -232,7 +262,12 @@ func TestDuplicateSearchRejectsNonProgressingPagination(t *testing.T) {
 
 func TestDuplicateSearchPaginationBoundFailsClosed(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		writeDCDupePage(t, w, dcTestPage{Index: 0, Count: 100, Total: 101, IncludesPending: boolPtr(true)})
+		writeDCDupePage(t, w, dcTestPage{
+			Index:           0,
+			Count:           100,
+			Total:           101,
+			IncludesPending: boolPtr(true),
+		})
 	}))
 	defer server.Close()
 

--- a/internal/trackers/impl/standalone/dc/dupe_test.go
+++ b/internal/trackers/impl/standalone/dc/dupe_test.go
@@ -5,10 +5,13 @@ package dc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/config"
@@ -24,6 +27,7 @@ func TestDuplicateSearchUsesDCDupeEndpointAndProjection(t *testing.T) {
 			"imdb":        "tt0000456",
 			"releaseName": "Example.Release.2026.1080p.WEB-DL-GRP",
 			"limit":       "100",
+			"index":       "0",
 		}); err != nil {
 			requestErr <- err
 			w.WriteHeader(http.StatusBadRequest)
@@ -34,7 +38,7 @@ func TestDuplicateSearchUsesDCDupeEndpointAndProjection(t *testing.T) {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		_, _ = w.Write([]byte(`{"results":[{"id":42,"name":"Example.Release.2026.1080p.WEB-DL-GRP","size":1234,"categoryName":"Movies/1080p","type":"single","numfiles":2,"p2p":true,"pack":false,"3d":true,"approved":false,"pending":true,"status":"pending"}],"total":1,"includesPending":true}`))
+		_, _ = w.Write([]byte(`{"results":[{"id":42,"name":"Example.Release.2026.1080p.WEB-DL-GRP","size":1234,"categoryName":"Movies/1080p","type":"single","numfiles":2,"p2p":true,"pack":false,"3d":true,"approved":false,"pending":true,"status":"pending"}],"index":0,"limit":100,"count":1,"total":1,"includesPending":true}`))
 	}))
 	defer server.Close()
 
@@ -87,12 +91,13 @@ func TestDuplicateSearchFallsBackToReleaseNameWithoutIMDb(t *testing.T) {
 		if err := assertDCQuery(query, map[string]string{
 			"releaseName": "Title.Only.2026.720p-GRP",
 			"limit":       "100",
+			"index":       "0",
 		}); err != nil {
 			requestErr <- err
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		_, _ = w.Write([]byte(`{"results":[],"total":0,"includesPending":true}`))
+		_, _ = w.Write([]byte(`{"results":[],"index":0,"limit":100,"count":0,"total":0,"includesPending":true}`))
 	}))
 	defer server.Close()
 
@@ -110,6 +115,134 @@ func TestDuplicateSearchFallsBackToReleaseNameWithoutIMDb(t *testing.T) {
 		t.Fatalf("unexpected entries: %#v", entries)
 	}
 	if search := result.SearchEvidence(); !search.Complete || search.WorkScope != dupe.WorkScopeTitle || search.EffectiveComplete() {
+		t.Fatalf("unexpected search evidence: %#v", search)
+	}
+}
+
+func TestDuplicateSearchPaginatesUntilTerminalTotal(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("index") {
+		case "0":
+			requests++
+			writeDCDupePage(t, w, dcTestPage{Index: 0, Count: 100, Total: 101, IncludesPending: boolPtr(true)})
+		case "100":
+			requests++
+			writeDCDupePage(t, w, dcTestPage{Index: 100, Count: 1, Total: 101, IncludesPending: boolPtr(true)})
+		default:
+			t.Errorf("unexpected index query %q", r.URL.Query().Get("index"))
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	searcher := testDCDupeSearcher(server)
+	result := searcher.Search(context.Background(), api.DuplicateSubject{
+		Identity:    api.ExternalIdentity{IMDBID: 456},
+		ReleaseName: "Example.Release.2026.1080p.WEB-DL-GRP",
+	})
+	if result.Disposition() != dupe.DispositionResolved {
+		t.Fatalf("unexpected disposition=%v code=%q cause=%v", result.Disposition(), result.Code(), result.Cause())
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	if entries := result.Entries(); len(entries) != 101 {
+		t.Fatalf("entries = %d, want 101", len(entries))
+	}
+	if search := result.SearchEvidence(); !search.Complete || !search.EffectiveComplete() || search.Pages != 2 || len(search.Warnings) != 0 {
+		t.Fatalf("unexpected search evidence: %#v", search)
+	}
+}
+
+func TestDuplicateSearchRequiresPendingCoverageForCompleteness(t *testing.T) {
+	tests := []struct {
+		name            string
+		includesPending *bool
+	}{
+		{name: "false", includesPending: boolPtr(false)},
+		{name: "missing", includesPending: nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				writeDCDupePage(t, w, dcTestPage{Index: 0, Count: 0, Total: 0, IncludesPending: tc.includesPending})
+			}))
+			defer server.Close()
+
+			searcher := testDCDupeSearcher(server)
+			result := searcher.Search(context.Background(), api.DuplicateSubject{
+				Identity:    api.ExternalIdentity{IMDBID: 456},
+				ReleaseName: "Example.Release.2026.1080p.WEB-DL-GRP",
+			})
+			if result.Disposition() != dupe.DispositionResolved {
+				t.Fatalf("unexpected disposition=%v code=%q cause=%v", result.Disposition(), result.Code(), result.Cause())
+			}
+			if search := result.SearchEvidence(); search.Complete || search.EffectiveComplete() || len(search.Warnings) != 2 {
+				t.Fatalf("unexpected search evidence: %#v", search)
+			}
+		})
+	}
+}
+
+func TestDuplicateSearchRejectsInconsistentPagination(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		switch r.URL.Query().Get("index") {
+		case "0":
+			writeDCDupePage(t, w, dcTestPage{Index: 0, Count: 100, Total: 101, IncludesPending: boolPtr(true)})
+		case "100":
+			writeDCDupePage(t, w, dcTestPage{Index: 100, Count: 1, Total: 102, IncludesPending: boolPtr(true)})
+		default:
+			t.Errorf("unexpected index query %q", r.URL.Query().Get("index"))
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	searcher := testDCDupeSearcher(server)
+	result := searcher.Search(context.Background(), api.DuplicateSubject{
+		Identity:    api.ExternalIdentity{IMDBID: 456},
+		ReleaseName: "Example.Release.2026.1080p.WEB-DL-GRP",
+	})
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	if search := result.SearchEvidence(); search.Complete || search.EffectiveComplete() || search.Pages != 2 || len(search.Warnings) != 1 {
+		t.Fatalf("unexpected search evidence: %#v", search)
+	}
+}
+
+func TestDuplicateSearchRejectsNonProgressingPagination(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeDCDupePage(t, w, dcTestPage{Index: 0, Count: 0, Total: 1, IncludesPending: boolPtr(true)})
+	}))
+	defer server.Close()
+
+	searcher := testDCDupeSearcher(server)
+	result := searcher.Search(context.Background(), api.DuplicateSubject{
+		Identity:    api.ExternalIdentity{IMDBID: 456},
+		ReleaseName: "Example.Release.2026.1080p.WEB-DL-GRP",
+	})
+	if search := result.SearchEvidence(); search.Complete || search.EffectiveComplete() || search.Pages != 1 || len(search.Warnings) != 1 {
+		t.Fatalf("unexpected search evidence: %#v", search)
+	}
+}
+
+func TestDuplicateSearchPaginationBoundFailsClosed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeDCDupePage(t, w, dcTestPage{Index: 0, Count: 100, Total: 101, IncludesPending: boolPtr(true)})
+	}))
+	defer server.Close()
+
+	searcher := testDCDupeSearcher(server)
+	searcher.maxPages = 1
+	result := searcher.Search(context.Background(), api.DuplicateSubject{
+		Identity:    api.ExternalIdentity{IMDBID: 456},
+		ReleaseName: "Example.Release.2026.1080p.WEB-DL-GRP",
+	})
+	if search := result.SearchEvidence(); search.Complete || search.EffectiveComplete() || search.Pages != 1 || len(search.Warnings) != 1 {
 		t.Fatalf("unexpected search evidence: %#v", search)
 	}
 }
@@ -135,6 +268,7 @@ func testDCDupeSearcher(server *httptest.Server) *dupeSearcher {
 		}}},
 		http:     server.Client(),
 		endpoint: server.URL,
+		maxPages: 100,
 	}
 }
 
@@ -145,4 +279,41 @@ func assertDCQuery(query url.Values, want map[string]string) error {
 		}
 	}
 	return nil
+}
+
+type dcTestPage struct {
+	Index           int
+	Count           int
+	Total           int
+	IncludesPending *bool
+}
+
+func writeDCDupePage(t *testing.T, w http.ResponseWriter, page dcTestPage) {
+	t.Helper()
+	results := make([]map[string]any, 0, page.Count)
+	for i := 0; i < page.Count; i++ {
+		id := page.Index + i + 1
+		results = append(results, map[string]any{
+			"id":           id,
+			"name":         fmt.Sprintf("Example.Release.%03d.2026.1080p.WEB-DL-GRP", id),
+			"categoryName": "Movies/1080p",
+		})
+	}
+	payload := map[string]any{
+		"results": results,
+		"index":   page.Index,
+		"limit":   dcDupePageSize,
+		"count":   page.Count,
+		"total":   page.Total,
+	}
+	if page.IncludesPending != nil {
+		payload["includesPending"] = *page.IncludesPending
+	}
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Fatalf("encode DC page %s: %v", strconv.Itoa(page.Index), err)
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }

--- a/internal/trackers/impl/standalone/dc/dupe_test.go
+++ b/internal/trackers/impl/standalone/dc/dupe_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/config"
@@ -181,8 +182,8 @@ func TestDuplicateSearchRequiresPendingCoverageForCompleteness(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if !writeDCDupePage(t, w, dcTestPage{
 					Index:           0,
-					Count:           0,
-					Total:           0,
+					Count:           1,
+					Total:           1,
 					IncludesPending: tc.includesPending,
 				}) {
 					return
@@ -197,6 +198,9 @@ func TestDuplicateSearchRequiresPendingCoverageForCompleteness(t *testing.T) {
 			})
 			if result.Disposition() != dupe.DispositionResolved {
 				t.Fatalf("unexpected disposition=%v code=%q cause=%v", result.Disposition(), result.Code(), result.Cause())
+			}
+			if entries := result.Entries(); len(entries) != 0 {
+				t.Fatalf("invalid pending-coverage page leaked entries: %#v", entries)
 			}
 			if search := result.SearchEvidence(); search.Complete || search.EffectiveComplete() || len(search.Warnings) != 2 {
 				t.Fatalf("unexpected search evidence: %#v", search)
@@ -295,6 +299,73 @@ func TestDuplicateSearchPaginationBoundFailsClosed(t *testing.T) {
 	}
 }
 
+func TestDuplicateSearchClassifiesRequestFailure(t *testing.T) {
+	searcher := &dupeSearcher{
+		cfg: config.Config{Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"DC": {APIKey: "secret"},
+		}}},
+		http:     http.DefaultClient,
+		endpoint: "://bad-dc-url",
+		maxPages: dcDupeMaxPages,
+	}
+	result := searcher.Search(context.Background(), testDCDupeSubject())
+	assertDCDupeFailed(t, result, dupe.FailureRequest)
+	if result.Cause() == nil {
+		t.Fatal("expected request failure cause")
+	}
+}
+
+func TestDuplicateSearchClassifiesResponseStatusFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	searcher := testDCDupeSearcher(server)
+	result := searcher.Search(context.Background(), testDCDupeSubject())
+	assertDCDupeFailed(t, result, dupe.FailureResponseStatus)
+	cause := result.Cause()
+	if cause == nil || !strings.Contains(cause.Error(), "401") || strings.Contains(cause.Error(), server.URL) {
+		t.Fatalf("unexpected status cause: %v", cause)
+	}
+}
+
+func TestDuplicateSearchClassifiesResponseParseFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		handler   http.HandlerFunc
+		wantCause string
+	}{
+		{
+			name: "malformed",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"results":`))
+			},
+			wantCause: "decode DC duplicate response",
+		},
+		{
+			name: "oversized",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(strings.Repeat("x", dcDupeMaxResponseBytes+1)))
+			},
+			wantCause: "exceeds",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(test.handler)
+			defer server.Close()
+
+			searcher := testDCDupeSearcher(server)
+			result := searcher.Search(context.Background(), testDCDupeSubject())
+			assertDCDupeFailed(t, result, dupe.FailureResponseParse)
+			if cause := result.Cause(); cause == nil || !strings.Contains(cause.Error(), test.wantCause) {
+				t.Fatalf("unexpected parse cause: %v", cause)
+			}
+		})
+	}
+}
+
 func TestDuplicateSearchRequiresIMDbOrReleaseName(t *testing.T) {
 	searcher := &dupeSearcher{
 		cfg: config.Config{Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
@@ -316,7 +387,27 @@ func testDCDupeSearcher(server *httptest.Server) *dupeSearcher {
 		}}},
 		http:     server.Client(),
 		endpoint: server.URL,
-		maxPages: 100,
+		maxPages: dcDupeMaxPages,
+	}
+}
+
+func testDCDupeSubject() api.DuplicateSubject {
+	return api.DuplicateSubject{
+		Identity:    api.ExternalIdentity{IMDBID: 456},
+		ReleaseName: "Example.Release.2026.1080p.WEB-DL-GRP",
+	}
+}
+
+func assertDCDupeFailed(t *testing.T, result dupe.AdapterResult, wantCode string) {
+	t.Helper()
+	if result.Disposition() != dupe.DispositionFailed || result.Code() != wantCode {
+		t.Fatalf("unexpected result disposition=%v code=%q cause=%v", result.Disposition(), result.Code(), result.Cause())
+	}
+	if entries := result.Entries(); len(entries) != 0 {
+		t.Fatalf("failed search returned entries: %#v", entries)
+	}
+	if search := result.SearchEvidence(); search.Complete || search.EffectiveComplete() || search.Pages != 0 {
+		t.Fatalf("failed search claimed completeness: %#v", search)
 	}
 }
 

--- a/internal/trackers/impl/standalone/dc/dupe_test.go
+++ b/internal/trackers/impl/standalone/dc/dupe_test.go
@@ -179,7 +179,7 @@ func TestDuplicateSearchRequiresPendingCoverageForCompleteness(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				if !writeDCDupePage(t, w, dcTestPage{
 					Index:           0,
 					Count:           1,
@@ -253,7 +253,7 @@ func TestDuplicateSearchRejectsInconsistentPagination(t *testing.T) {
 }
 
 func TestDuplicateSearchRejectsNonProgressingPagination(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if !writeDCDupePage(t, w, dcTestPage{
 			Index:           0,
 			Count:           0,
@@ -276,7 +276,7 @@ func TestDuplicateSearchRejectsNonProgressingPagination(t *testing.T) {
 }
 
 func TestDuplicateSearchPaginationBoundFailsClosed(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if !writeDCDupePage(t, w, dcTestPage{
 			Index:           0,
 			Count:           100,

--- a/internal/trackers/impl/standalone/dc/media.go
+++ b/internal/trackers/impl/standalone/dc/media.go
@@ -14,11 +14,16 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-func resolveMediaInfo(meta api.UploadSubject) (string, error) {
+func resolveMediaInfo(req trackers.PreparationInput, meta api.UploadSubject) (string, error) {
 	if text := metautil.FirstNonEmptyTrimmed(commonhttp.ReadOptionalFile(meta.MediaInfoTextPath), strings.TrimSpace(meta.DVDVOBMediaInfoText)); text != "" {
 		return text, nil
 	}
-	return "", errors.New("trackers: DC missing mediainfo")
+	if strings.EqualFold(strings.TrimSpace(meta.DiscType), "BDMV") {
+		if bdinfo, _ := trackers.ReadBDInfo(req.Runtime.DBPath, meta); strings.TrimSpace(bdinfo) != "" {
+			return strings.TrimSpace(bdinfo), nil
+		}
+	}
+	return "", errors.New("trackers: DC missing mediainfo or BDInfo")
 }
 
 func resolveMedia(req trackers.PreparationInput, meta api.UploadSubject) string {

--- a/internal/trackers/impl/standalone/dc/upload.go
+++ b/internal/trackers/impl/standalone/dc/upload.go
@@ -4,6 +4,7 @@
 package dc
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -85,7 +86,7 @@ func submitPreparedUpload(
 	apiKey string,
 	artifactPath string,
 ) (api.UploadSummary, error) {
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL+"/upload", strings.NewReader(string(body)))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL+"/upload", bytes.NewReader(body))
 	if err != nil {
 		return api.UploadSummary{}, fmt.Errorf("trackers: DC request build: %w", err)
 	}
@@ -189,7 +190,7 @@ func prepareUploadState(_ context.Context, req trackers.PreparationInput) (uploa
 		assets = trackers.DescriptionAssets{}
 	}
 	description := buildDescription(req, assets)
-	mediaInfo, err := resolveMediaInfo(req.Meta)
+	mediaInfo, err := resolveMediaInfo(req, req.Meta)
 	if err != nil {
 		return uploadState{}, err
 	}

--- a/internal/trackers/impl/standalone/dc/upload_test.go
+++ b/internal/trackers/impl/standalone/dc/upload_test.go
@@ -10,12 +10,14 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/autobrr/go-torrent/bencode"
 	"github.com/autobrr/go-torrent/metainfo"
 
+	paths "github.com/autobrr/upbrr/internal/pathing/layout"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -25,6 +27,37 @@ func TestResolveIMDbIDPadsShortID(t *testing.T) {
 
 	if got := resolveIMDbID(api.UploadSubject{Identity: api.ExternalIdentity{IMDBID: 456}}); got != "tt0000456" {
 		t.Fatalf("expected padded IMDb ID, got %q", got)
+	}
+}
+
+func TestResolveMediaInfoUsesBDInfoForBDMV(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "db.sqlite")
+	meta := api.UploadSubject{
+		SourcePath: "Example.Release.2026",
+		DiscType:   "BDMV",
+		SelectedBDMVPlaylists: []api.PlaylistInfo{{
+			File: "00001.MPLS",
+		}},
+	}
+	summaryPath, err := paths.PrimaryBDMVSummaryPathFor(filepath.Join(filepath.Dir(dbPath), "tmp"), meta.SourcePath, meta.Release, meta.SelectedBDMVPlaylists)
+	if err != nil {
+		t.Fatalf("resolve BDInfo summary path: %v", err)
+	}
+	const summary = "DISC INFO:\nDisc Title: Example Release 2026\n"
+	if err := os.WriteFile(summaryPath, []byte(summary), 0o600); err != nil {
+		t.Fatalf("write BDInfo summary: %v", err)
+	}
+
+	got, err := resolveMediaInfo(trackers.PreparationInput{
+		Runtime: trackers.PreparationRuntime{DBPath: dbPath},
+	}, meta)
+	if err != nil {
+		t.Fatalf("resolve DC BDMV media info: %v", err)
+	}
+	if got != strings.TrimSpace(summary) {
+		t.Fatalf("BDInfo media info = %q, want %q", got, strings.TrimSpace(summary))
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes two DigitalCore tracker paths:

- BDMV upload preparation now falls back to prepared BDInfo when normal MediaInfo text is not available. DigitalCore accepts this text in its `mediainfo` upload field.
- DigitalCore upload submission now preserves the captured multipart payload as raw bytes instead of converting it through a string first.
- Duplicate preflight search now uses DigitalCore's dedicated API endpoint: `GET /api/v1/torrents/dupe-search`.

DigitalCore added the `dupe-search` endpoint for automation duplicate checks. Unlike the normal torrent search endpoint, this route is API-key-only and can return both approved and pending/modqueue torrents, including `approved`, `pending`, and `status` fields. That lets upbrr catch duplicates that are already waiting for staff review without exposing pending uploads through browser search or normal public results.

The adapter now sends `imdb`, `releaseName`, and `limit=100`, parses the endpoint's `results` response, maps DigitalCore fields into upbrr duplicate candidates, and ignores DigitalCore's `type=single/multi` values because those describe torrent structure rather than media type.

Fixes #

## How has this been tested?

- `go test ./internal/trackers/impl/standalone/dc`

## Screenshots (for UI changes)

No UI changes.

## Checklist

- [x] My PR title follows the conventional commit guidelines, e.g. `fix(module): my fix`.
- [ ] I have read the CONTRIBUTING.md document.
- [ ] I ran `make precommit` and have resolved any issues.
- [ ] For CSS changes, I have run `cd web && pnpm tailwind`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Duplicate searches now provide richer release details, including links, size, media type, resolution, source, 3D status, and release status.
  - Searches can fall back to release-name matching when an IMDb ID is unavailable.
  - Duplicate results now support reliable pagination and completeness checks.

- **Bug Fixes**
  - BDMV disc uploads now use available BDInfo when standard media information is missing.
  - Improved handling of incomplete or missing media information during disc uploads.

- **Tests**
  - Added coverage for BDInfo loading, duplicate-search behavior, pagination, and metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->