### PR TITLE
feat(metadata): add multi-disc source and media foundation

### DIFF
--- a/cmd/upbrr/release_workflow.go
+++ b/cmd/upbrr/release_workflow.go
@@ -857,21 +857,10 @@ func cliWorkflowContinuationError(current releaseworkflow.CommandResult, interac
 
 func cliWorkflowMediaInstructions(request api.Request) api.MediaCaptureInstructions {
 	count := max(request.Options.Screens, 0)
-	var selections []api.ScreenshotSelection
-	if len(request.ScreenshotOverrides.ManualFrames) > 0 {
-		selections = make([]api.ScreenshotSelection, 0, len(request.ScreenshotOverrides.ManualFrames))
-	}
-	for index, frame := range request.ScreenshotOverrides.ManualFrames {
-		selections = append(selections, api.ScreenshotSelection{
-			Index:  index,
-			Frame:  frame,
-			Source: "manual",
-		})
-	}
 	return api.MediaCaptureInstructions{
 		ScreenshotCount: count,
 		Purpose:         api.ScreenshotPurposeFinal,
-		Selections:      selections,
+		ManualFrames:    append([]int(nil), request.ScreenshotOverrides.ManualFrames...),
 		CaptureDVDMenus: request.Options.CaptureDVDMenus,
 	}
 }

--- a/cmd/upbrr/release_workflow_test.go
+++ b/cmd/upbrr/release_workflow_test.go
@@ -1033,8 +1033,8 @@ func TestCLIWorkflowMediaInstructionsPreserveExplicitFrames(t *testing.T) {
 		Options:             api.UploadOptions{Screens: 0, CaptureDVDMenus: true},
 		ScreenshotOverrides: api.ScreenshotOverrides{ManualFrames: []int{0, 42}},
 	})
-	if instructions.ScreenshotCount != 0 || !instructions.CaptureDVDMenus || len(instructions.Selections) != 2 ||
-		instructions.Selections[0].Frame != 0 || instructions.Selections[1].Frame != 42 {
+	if instructions.ScreenshotCount != 0 || !instructions.CaptureDVDMenus || instructions.Selections != nil ||
+		!slices.Equal(instructions.ManualFrames, []int{0, 42}) {
 		t.Fatalf("media instructions = %#v", instructions)
 	}
 }

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -609,36 +609,41 @@ func (c *Core) DiscoverPlaylists(ctx context.Context, sourcePath string) ([]api.
 	if err != nil {
 		return nil, classifyOperationError(api.OperationKindPreparation, fmt.Errorf("core: resolve playlist source: %w", err))
 	}
-	if strings.TrimSpace(layout.BDMVRoot) == "" {
+	if layout.DiscType != "BDMV" || len(layout.Discs) == 0 {
 		return nil, classifyOperationError(api.OperationKindPreparation, &api.InvalidPlaylistSelectionError{
 			SourcePath: layout.SourcePath,
 			Reason:     "source is not a Blu-ray disc",
 		})
 	}
 
-	playlists, err := filesystem.DiscoverPlaylists(ctx, layout.BDMVRoot)
-	if err != nil {
-		c.logger.Warnf("core: discover playlists failed: %v", err)
-		return nil, classifyOperationError(api.OperationKindPreparation, fmt.Errorf("core: discover playlists: %w", err))
-	}
-
-	// Convert filesystem types to API types.
 	var result []api.PlaylistInfo
-	for _, p := range playlists {
-		var items []api.PlaylistItem
-		for _, item := range p.Items {
-			items = append(items, api.PlaylistItem{
-				File: item.File,
-				Size: item.Size,
+	for _, disc := range layout.Discs {
+		playlists, err := filesystem.DiscoverPlaylists(ctx, disc.Root)
+		if err != nil {
+			c.logger.Warnf("core: discover playlists failed: %v", err)
+			return nil, classifyOperationError(api.OperationKindPreparation, fmt.Errorf("core: discover playlists: %w", err))
+		}
+		for _, playlist := range playlists {
+			items := make([]api.PlaylistItem, 0, len(playlist.Items))
+			for _, item := range playlist.Items {
+				items = append(items, api.PlaylistItem{File: item.File, Size: item.Size})
+			}
+			file := strings.ToUpper(filepath.Base(strings.TrimSpace(playlist.File)))
+			id := file
+			if len(layout.Discs) > 1 {
+				id = disc.ID + ":" + file
+			}
+			result = append(result, api.PlaylistInfo{
+				ID:       id,
+				DiscID:   disc.ID,
+				DiscName: disc.Name,
+				File:     file,
+				Duration: playlist.Duration,
+				Items:    items,
+				Score:    playlist.Score,
+				Edition:  playlist.Edition,
 			})
 		}
-		result = append(result, api.PlaylistInfo{
-			File:     p.File,
-			Duration: p.Duration,
-			Items:    items,
-			Score:    p.Score,
-			Edition:  p.Edition,
-		})
 	}
 
 	c.logger.Infof("core: discovered %d playlists", len(result))

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -498,9 +498,10 @@ func (c *Core) PreviewReleaseWorkflowFrame(
 	ownerID string,
 	workflowID api.WorkflowID,
 	expectedRevision api.WorkflowRevision,
+	discID string,
 	timestampSeconds float64,
 ) (api.FramePreview, error) {
-	preview, err := c.workflow.PreviewFrame(ctx, ownerID, workflowID, expectedRevision, timestampSeconds)
+	preview, err := c.workflow.PreviewFrame(ctx, ownerID, workflowID, expectedRevision, discID, timestampSeconds)
 	if err != nil {
 		return api.FramePreview{}, classifyOperationError(api.OperationKindMedia, err)
 	}

--- a/internal/core/e2e_enabled.go
+++ b/internal/core/e2e_enabled.go
@@ -1254,7 +1254,7 @@ type e2eImageService struct {
 	shotPath string
 	tmpRoot  string
 	repo     interface {
-		SaveUploadedImages(context.Context, string, string, []api.UploadedImageLink) error
+		SaveUploadedImages(context.Context, api.PreparedMediaBinding, string, []api.UploadedImageLink) error
 	}
 }
 
@@ -1283,6 +1283,7 @@ func (s e2eImageService) Upload(
 		}
 		base := fmt.Sprintf("%s/image/%d", strings.TrimRight(s.endpoint, "/"), idx+1)
 		links = append(links, api.UploadedImageLink{
+			DiscID:     image.DiscID,
 			ImagePath:  image.Path,
 			Host:       strings.ToLower(strings.TrimSpace(host)),
 			ImgURL:     base + ".jpg",
@@ -1293,7 +1294,7 @@ func (s e2eImageService) Upload(
 		})
 	}
 	if s.repo != nil && len(links) > 0 {
-		if err := s.repo.SaveUploadedImages(ctx, meta.SourcePath, strings.ToLower(strings.TrimSpace(host)), links); err != nil {
+		if err := s.repo.SaveUploadedImages(ctx, meta.MediaBinding, strings.ToLower(strings.TrimSpace(host)), links); err != nil {
 			return nil, fmt.Errorf("e2e image: save uploads: %w", err)
 		}
 	}
@@ -1356,6 +1357,7 @@ func (s e2eScreenshotService) Plan(_ context.Context, meta api.ScreenshotSubject
 		})
 	}
 	return api.ScreenshotPlan{
+		MediaBinding:        meta.MediaBinding,
 		SourcePath:          meta.SourcePath,
 		DurationSeconds:     120,
 		FrameRate:           24,
@@ -1387,7 +1389,12 @@ func (s e2eScreenshotService) Capture(
 	}, nil
 }
 
-func (s e2eScreenshotService) PreviewFrame(_ context.Context, meta api.ScreenshotSubject, timestampSeconds float64) (api.ScreenshotPreview, error) {
+func (s e2eScreenshotService) PreviewFrame(
+	_ context.Context,
+	meta api.ScreenshotSubject,
+	discID string,
+	timestampSeconds float64,
+) (api.ScreenshotPreview, error) {
 	shot, err := s.image(meta)
 	if err != nil {
 		return api.ScreenshotPreview{}, err
@@ -1397,6 +1404,7 @@ func (s e2eScreenshotService) PreviewFrame(_ context.Context, meta api.Screensho
 		return api.ScreenshotPreview{}, fmt.Errorf("e2e screenshots: read preview: %w", err)
 	}
 	return api.ScreenshotPreview{
+		DiscID:           discID,
 		TimestampSeconds: timestampSeconds,
 		ImageBytes:       payload,
 		Width:            shot.Width,
@@ -1433,14 +1441,14 @@ func (s e2eScreenshotService) SaveFinalSelections(ctx context.Context, meta api.
 	selections := make([]api.ScreenshotFinalSelection, 0, len(images))
 	for idx, image := range images {
 		selections = append(selections, api.ScreenshotFinalSelection{
-			SourcePath: meta.SourcePath,
+			DiscID:     image.DiscID,
 			ImagePath:  image.Path,
 			Order:      idx,
 			Source:     string(api.ScreenshotPurposeFinal),
 			SelectedAt: time.Now().UTC(),
 		})
 	}
-	return s.repo.ReplaceNormalFinalSelections(ctx, meta.SourcePath, selections)
+	return s.repo.ReplaceNormalFinalSelections(ctx, meta.MediaBinding, selections)
 }
 
 func (s e2eScreenshotService) image(meta api.ScreenshotSubject) (api.ScreenshotImage, error) {

--- a/internal/core/media.go
+++ b/internal/core/media.go
@@ -28,8 +28,8 @@ type mediaRepository interface {
 	api.ScreenshotLifecycleRepository
 	ListTrackerMetadataByPath(ctx context.Context, path string) ([]api.TrackerMetadata, error)
 	SaveTrackerMetadata(ctx context.Context, metadata api.TrackerMetadata) error
-	ListUploadedImagesByPath(ctx context.Context, path string) ([]api.UploadedImageLink, error)
-	DeleteUploadedImage(ctx context.Context, path string, imagePath string, host string) error
+	ListUploadedImagesByPath(ctx context.Context, binding api.PreparedMediaBinding) ([]api.UploadedImageLink, error)
+	DeleteUploadedImage(ctx context.Context, binding api.PreparedMediaBinding, imagePath string, host string) error
 }
 
 type mediaScreenshotService interface {
@@ -40,7 +40,7 @@ type mediaScreenshotService interface {
 		selections []api.ScreenshotSelection,
 		purpose api.ScreenshotPurpose,
 	) (api.ScreenshotResult, error)
-	PreviewFrame(ctx context.Context, subject api.ScreenshotSubject, timestampSeconds float64) (api.ScreenshotPreview, error)
+	PreviewFrame(ctx context.Context, subject api.ScreenshotSubject, discID string, timestampSeconds float64) (api.ScreenshotPreview, error)
 	Delete(ctx context.Context, subject api.ScreenshotSubject, imagePath string) error
 	SaveFinalSelections(ctx context.Context, subject api.ScreenshotSubject, images []api.ScreenshotImage) error
 }
@@ -108,7 +108,16 @@ func imageHostingSubject(meta api.UploadSubject) api.ImageHostingSubject {
 			break
 		}
 	}
-	return api.ImageHostingSubject{SourcePath: meta.SourcePath, GalleryName: galleryName}
+	discs := make([]api.ImageHostingDiscSubject, 0, len(meta.Discs))
+	for _, disc := range meta.Discs {
+		discs = append(discs, api.ImageHostingDiscSubject{ID: disc.ID, Name: disc.Name})
+	}
+	return api.ImageHostingSubject{
+		MediaBinding: meta.MediaBinding,
+		SourcePath:   meta.SourcePath,
+		GalleryName:  galleryName,
+		Discs:        discs,
+	}
 }
 
 func (m *mediaModule) dvdMenuCapability(ctx context.Context) (api.DVDMenuEngineInfo, error) {
@@ -121,6 +130,7 @@ func (m *mediaModule) dvdMenuCapability(ctx context.Context) (api.DVDMenuEngineI
 type menuImageContent struct {
 	contentType string
 	bytes       []byte
+	discID      string
 }
 
 // importAcceptedMenuImageContents persists browser/API-uploaded image bytes in
@@ -164,7 +174,12 @@ func (m *mediaModule) importAcceptedMenuImageContents(
 			removeMenuImportFiles(created)
 			return api.DVDMenuSubject{}, nil, internalerrors.ErrInvalidInput
 		}
-		destPath, wasCreated, writeErr := writeManagedMenuImage(tmpDir, content.bytes, extension)
+		discID, discName, discErr := resolveMenuImageDisc(subject.Discs, content.discID)
+		if discErr != nil {
+			removeMenuImportFiles(created)
+			return api.DVDMenuSubject{}, nil, discErr
+		}
+		destPath, wasCreated, writeErr := writeManagedMenuImage(tmpDir, content.bytes, extension, discID)
 		if writeErr != nil {
 			removeMenuImportFiles(created)
 			return api.DVDMenuSubject{}, nil, writeErr
@@ -177,6 +192,8 @@ func (m *mediaModule) importAcceptedMenuImageContents(
 			created = append(created, destPath)
 		}
 		image := api.ScreenshotImage{
+			DiscID:    discID,
+			DiscName:  discName,
 			Index:     len(images),
 			Path:      destPath,
 			Purpose:   api.ScreenshotPurposeMenu,
@@ -184,20 +201,20 @@ func (m *mediaModule) importAcceptedMenuImageContents(
 		}
 		images = append(images, image)
 		records = append(records, api.Screenshot{
-			SourcePath: subject.SourcePath,
+			DiscID:     discID,
 			ImagePath:  destPath,
 			Purpose:    api.ScreenshotPurposeMenu,
 			CapturedAt: now,
 		})
 		selections = append(selections, api.ScreenshotFinalSelection{
-			SourcePath: subject.SourcePath,
+			DiscID:     discID,
 			ImagePath:  destPath,
 			Order:      len(selections),
 			Source:     api.ScreenshotSelectionSourceMenu,
 			SelectedAt: now,
 		})
 	}
-	if err := m.repo.AppendManualMenuScreenshots(ctx, subject.SourcePath, records, selections); err != nil {
+	if err := m.repo.AppendManualMenuScreenshots(ctx, subject.MediaBinding, records, selections); err != nil {
 		removeMenuImportFiles(created)
 		return api.DVDMenuSubject{}, nil, fmt.Errorf("core: save staged menu selections: %w", err)
 	}
@@ -217,9 +234,20 @@ func stagedMenuImageExtension(contentType string) (string, error) {
 	}
 }
 
-func writeManagedMenuImage(tmpDir string, data []byte, extension string) (string, bool, error) {
+func writeManagedMenuImage(tmpDir string, data []byte, extension string, discID string) (string, bool, error) {
 	sum := sha256.Sum256(data)
-	destPath := filepath.Join(tmpDir, fmt.Sprintf("manual-dvd-menu-%x%s", sum[:8], extension))
+	discSegment := strings.Map(func(char rune) rune {
+		switch {
+		case char >= 'a' && char <= 'z', char >= 'A' && char <= 'Z', char >= '0' && char <= '9', char == '-', char == '_':
+			return char
+		default:
+			return '_'
+		}
+	}, strings.TrimSpace(discID))
+	if discSegment == "" {
+		discSegment = "single"
+	}
+	destPath := filepath.Join(tmpDir, fmt.Sprintf("manual-disc-%s-dvd-menu-%x%s", discSegment, sum[:8], extension))
 	if info, err := os.Stat(destPath); err == nil {
 		if info.IsDir() {
 			return "", false, internalerrors.ErrInvalidInput
@@ -254,6 +282,25 @@ func writeManagedMenuImage(tmpDir string, data []byte, extension string) (string
 	}
 	cleanup = false
 	return destPath, true, nil
+}
+
+func resolveMenuImageDisc(discs []api.DVDMenuDiscSubject, requested string) (string, string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		if len(discs) == 1 {
+			return discs[0].ID, discs[0].Name, nil
+		}
+		if len(discs) == 0 {
+			return "", "", nil
+		}
+		return "", "", internalerrors.ErrInvalidInput
+	}
+	for _, disc := range discs {
+		if disc.ID == requested {
+			return disc.ID, disc.Name, nil
+		}
+	}
+	return "", "", internalerrors.ErrInvalidInput
 }
 
 func removeMenuImportFiles(paths []string) {
@@ -644,7 +691,7 @@ func (m *mediaModule) uploadImagesToTarget(
 		return wrapCoreResult(uploaded, err)
 	}
 
-	existing, err := m.repo.ListUploadedImagesByPath(ctx, meta.SourcePath)
+	existing, err := m.repo.ListUploadedImagesByPath(ctx, meta.MediaBinding)
 	if err != nil {
 		emitCoreImageUploadProgress(progressCtx, progressTarget, api.ImageUploadProgressFailed, 0, 0, 0, "Existing uploads could not be checked.")
 		return nil, fmt.Errorf("core: %w", err)

--- a/internal/core/media_test.go
+++ b/internal/core/media_test.go
@@ -372,7 +372,7 @@ type reusableImageRepository struct {
 	links []api.UploadedImageLink
 }
 
-func (r *reusableImageRepository) ListUploadedImagesByPath(context.Context, string) ([]api.UploadedImageLink, error) {
+func (r *reusableImageRepository) ListUploadedImagesByPath(context.Context, api.PreparedMediaBinding) ([]api.UploadedImageLink, error) {
 	return slices.Clone(r.links), nil
 }
 

--- a/internal/core/workflow_media.go
+++ b/internal/core/workflow_media.go
@@ -74,11 +74,22 @@ func (b workflowMediaBuilder) Plan(
 			Purpose:         api.ScreenshotPurposeFinal,
 		})
 	}
+	discs := make([]api.MediaDiscPlan, 0, len(plan.Discs))
+	for _, disc := range plan.Discs {
+		discs = append(discs, api.MediaDiscPlan{
+			DiscID:              disc.DiscID,
+			DiscName:            disc.DiscName,
+			DurationSeconds:     disc.DurationSeconds,
+			FrameRate:           disc.FrameRate,
+			SuggestedSelections: append([]api.ScreenshotSelection(nil), disc.SuggestedSelections...),
+		})
+	}
 	return api.MediaPlan{
 		DurationSeconds:     plan.DurationSeconds,
 		FrameRate:           plan.FrameRate,
 		DiscType:            plan.DiscType,
 		SuggestedSelections: append([]api.ScreenshotSelection(nil), plan.SuggestedSelections...),
+		Discs:               discs,
 		Requirements:        requirements,
 	}, nil
 }
@@ -86,6 +97,7 @@ func (b workflowMediaBuilder) Plan(
 func (b workflowMediaBuilder) PreviewFrame(
 	ctx context.Context,
 	release api.ReleaseRef,
+	discID string,
 	timestampSeconds float64,
 ) (releaseworkflow.MediaPreviewContent, error) {
 	if b.resolver == nil || b.screenshots == nil {
@@ -98,7 +110,7 @@ func (b workflowMediaBuilder) PreviewFrame(
 	if err != nil {
 		return releaseworkflow.MediaPreviewContent{}, fmt.Errorf("workflow media resolve preview subject: %w", err)
 	}
-	preview, err := b.screenshots.PreviewFrame(ctx, subject, timestampSeconds)
+	preview, err := b.screenshots.PreviewFrame(ctx, subject, discID, timestampSeconds)
 	if err != nil {
 		return releaseworkflow.MediaPreviewContent{}, fmt.Errorf("workflow media preview frame: %w", err)
 	}
@@ -107,6 +119,8 @@ func (b workflowMediaBuilder) PreviewFrame(
 		contentType = "application/octet-stream"
 	}
 	return releaseworkflow.MediaPreviewContent{
+		DiscID:      preview.DiscID,
+		DiscName:    preview.DiscName,
 		Bytes:       append([]byte(nil), preview.ImageBytes...),
 		ContentType: contentType,
 		Width:       preview.Width,
@@ -130,10 +144,10 @@ type workflowMediaPrivateArtifacts struct {
 }
 
 type workflowMediaPendingDelete struct {
-	kind       api.MediaArtifactKind
-	path       string
-	sourcePath string
-	host       string
+	kind    api.MediaArtifactKind
+	path    string
+	binding api.PreparedMediaBinding
+	host    string
 }
 
 type workflowMediaCommitState struct {
@@ -269,7 +283,7 @@ func (a workflowMediaPrivateArtifacts) Commit(ctx context.Context) error {
 			if a.hostedRepository == nil {
 				return errors.New("workflow hosted-image repository is unavailable")
 			}
-			err = a.hostedRepository.DeleteUploadedImage(ctx, deletion.sourcePath, deletion.path, deletion.host)
+			err = a.hostedRepository.DeleteUploadedImage(ctx, deletion.binding, deletion.path, deletion.host)
 		}
 		if err != nil {
 			return fmt.Errorf("workflow media delete artifact: %w", err)
@@ -421,11 +435,9 @@ func (b workflowMediaBuilder) Build(
 	switch instructions.Purpose {
 	case api.ScreenshotPurposeMenu:
 	case api.ScreenshotPurposeFinal:
-		if instructions.Selections != nil {
-			screenshotCount = len(instructions.Selections)
-		} else {
-			screenshotCount = max(projectedScreenshots, instructions.ScreenshotCount)
-		}
+		screenshotCount = max(projectedScreenshots, instructions.ScreenshotCount)
+		screenshotCount = max(screenshotCount, len(instructions.Selections))
+		screenshotCount = max(screenshotCount, len(instructions.ManualFrames))
 	case api.ScreenshotPurposePreview:
 		screenshotCount = max(projectedScreenshots, instructions.ScreenshotCount)
 	default:
@@ -486,6 +498,7 @@ func (b workflowMediaBuilder) Build(
 			Release: release,
 			Count:   screenshotCount,
 			Purpose: purpose,
+			Options: api.ScreenshotOverrides{ManualFrames: append([]int(nil), instructions.ManualFrames...)},
 		}
 		subject, err := b.resolver.ResolveScreenshotSubject(ctx, input)
 		if err != nil {
@@ -494,20 +507,24 @@ func (b workflowMediaBuilder) Build(
 		privateArtifacts.screenshotSubject = subject
 		selections := append([]api.ScreenshotSelection(nil), instructions.Selections...)
 		var existingScreenshots []api.ScreenshotImage
-		if len(selections) == 0 {
-			plan, err := b.screenshots.Plan(ctx, subject, screenshotCount)
-			if err != nil {
-				if ctx.Err() != nil {
-					return api.MediaArtifactSet{}, nil, fmt.Errorf("workflow media screenshot plan: %w", ctx.Err())
-				}
-				return failedMediaSnapshot(snapshot, "Screenshot planning failed. Retry media capture."), privateArtifacts, nil
+		plan, err := b.screenshots.Plan(ctx, subject, screenshotCount)
+		if err != nil {
+			if ctx.Err() != nil {
+				return api.MediaArtifactSet{}, nil, fmt.Errorf("workflow media screenshot plan: %w", ctx.Err())
 			}
+			return failedMediaSnapshot(snapshot, "Screenshot planning failed. Retry media capture."), privateArtifacts, nil
+		}
+		if len(selections) == 0 {
 			selections = append(selections, plan.SuggestedSelections...)
 			existingScreenshots = append(existingScreenshots, plan.ExistingScreenshots...)
+		} else {
+			var mergeErr error
+			selections, existingScreenshots, mergeErr = mergeManualSelectionsWithDiscPlan(selections, plan)
+			if mergeErr != nil {
+				return failedMediaSnapshot(snapshot, "Screenshot selections must identify a prepared disc."), privateArtifacts, nil
+			}
 		}
-		if len(selections) > screenshotCount {
-			selections = selections[:screenshotCount]
-		}
+		captureTotal := max(screenshotCount, len(selections)+len(existingScreenshots))
 		if len(selections) == 0 && len(existingScreenshots) == 0 {
 			snapshot.Status = api.StageStatusBlocked
 			snapshot.RequiredActions = []api.RequiredAction{{
@@ -538,7 +555,7 @@ func (b workflowMediaBuilder) Build(
 				return failedMediaSnapshot(snapshot, "Screenshot capture failed. Retry media capture."), privateArtifacts, nil
 			}
 		}
-		images := mergeWorkflowScreenshotImages(existingScreenshots, capture.Images, screenshotCount)
+		images := mergeWorkflowScreenshotImages(existingScreenshots, capture.Images, plan.Discs, captureTotal)
 		privateArtifacts.Screenshots = append(privateArtifacts.Screenshots, images...)
 		api.EmitWorkflowProgress(ctx, api.WorkflowProgressUpdate{
 			Phase:     "screenshots",
@@ -547,7 +564,7 @@ func (b workflowMediaBuilder) Build(
 			Label:     "Screenshots",
 			Status:    api.StageStatusCompleted,
 			Completed: len(images),
-			Total:     screenshotCount,
+			Total:     captureTotal,
 			Message:   "Screenshot capture complete.",
 		})
 		for index, image := range images {
@@ -667,23 +684,43 @@ func applyWorkflowMediaMinimums(snapshot *api.MediaArtifactSet, requiredScreensh
 	})
 }
 
-func mergeWorkflowScreenshotImages(existing, captured []api.ScreenshotImage, limit int) []api.ScreenshotImage {
+func mergeWorkflowScreenshotImages(
+	existing []api.ScreenshotImage,
+	captured []api.ScreenshotImage,
+	discs []api.ScreenshotDiscPlan,
+	limit int,
+) []api.ScreenshotImage {
 	images := make([]api.ScreenshotImage, 0, len(existing)+len(captured))
-	byIndex := make(map[int]int, cap(images))
+	byIndex := make(map[string]int, cap(images))
 	appendImages := func(values []api.ScreenshotImage) {
 		for _, image := range values {
-			if existingIndex, ok := byIndex[image.Index]; ok {
+			key := fmt.Sprintf("%s\x00%d", image.DiscID, image.Index)
+			if existingIndex, ok := byIndex[key]; ok {
 				images[existingIndex] = image
 				continue
 			}
-			byIndex[image.Index] = len(images)
+			byIndex[key] = len(images)
 			images = append(images, image)
 		}
 	}
 	appendImages(existing)
 	appendImages(captured)
+	discOrder := make(map[string]int, len(discs))
+	for index, disc := range discs {
+		discOrder[disc.DiscID] = index
+	}
 	slices.SortStableFunc(images, func(left, right api.ScreenshotImage) int {
+		leftDisc, leftFound := discOrder[left.DiscID]
+		rightDisc, rightFound := discOrder[right.DiscID]
 		switch {
+		case leftFound && !rightFound:
+			return -1
+		case !leftFound && rightFound:
+			return 1
+		case leftDisc < rightDisc:
+			return -1
+		case leftDisc > rightDisc:
+			return 1
 		case left.Index < right.Index:
 			return -1
 		case left.Index > right.Index:
@@ -696,6 +733,44 @@ func mergeWorkflowScreenshotImages(existing, captured []api.ScreenshotImage, lim
 		images = images[:limit]
 	}
 	return images
+}
+
+func mergeManualSelectionsWithDiscPlan(
+	selections []api.ScreenshotSelection,
+	plan api.ScreenshotPlan,
+) ([]api.ScreenshotSelection, []api.ScreenshotImage, error) {
+	if len(plan.Discs) == 0 {
+		return selections, nil, nil
+	}
+	discIDs := make(map[string]struct{}, len(plan.Discs))
+	for _, disc := range plan.Discs {
+		discIDs[disc.DiscID] = struct{}{}
+	}
+	provided := make(map[string]struct{}, len(selections))
+	for index := range selections {
+		discID := strings.TrimSpace(selections[index].DiscID)
+		if discID == "" && len(plan.Discs) == 1 {
+			discID = plan.Discs[0].DiscID
+			selections[index].DiscID = discID
+		}
+		if _, ok := discIDs[discID]; !ok {
+			return nil, nil, internalerrors.ErrInvalidInput
+		}
+		provided[discID] = struct{}{}
+	}
+	for _, disc := range plan.Discs {
+		if _, ok := provided[disc.DiscID]; ok {
+			continue
+		}
+		selections = append(selections, disc.SuggestedSelections...)
+	}
+	existing := make([]api.ScreenshotImage, 0, len(plan.ExistingScreenshots))
+	for _, image := range plan.ExistingScreenshots {
+		if _, ok := provided[image.DiscID]; !ok {
+			existing = append(existing, image)
+		}
+	}
+	return selections, existing, nil
 }
 
 func (b workflowMediaBuilder) BuildIncremental(
@@ -717,20 +792,32 @@ func (b workflowMediaBuilder) BuildIncremental(
 		retained = cloneWorkflowMediaPrivateArtifacts(retained)
 	}
 	if instructions.Purpose == api.ScreenshotPurposeFinal && len(instructions.Selections) > 0 && existing != nil {
-		indexes := make(map[int]struct{})
+		requestedScreenshotCount := max(instructions.ScreenshotCount, len(instructions.Selections))
+		indexes := make(map[string]struct{})
 		for _, artifact := range existing.Artifacts {
 			if artifact.Kind == api.MediaArtifactScreenshot {
-				indexes[artifact.Index] = struct{}{}
+				indexes[fmt.Sprintf("%s\x00%d", artifact.DiscID, artifact.Index)] = struct{}{}
 			}
 		}
 		filtered := make([]api.ScreenshotSelection, 0, len(instructions.Selections))
 		for _, selection := range instructions.Selections {
-			if _, exists := indexes[selection.Index]; !exists {
+			key := fmt.Sprintf("%s\x00%d", selection.DiscID, selection.Index)
+			if _, exists := indexes[key]; !exists {
 				filtered = append(filtered, selection)
 			}
 		}
 		instructions.Selections = filtered
 		instructions.ScreenshotCount = len(filtered)
+		projectedScreenshots, projectedDVDMenus := projectedMediaRequirements(projections.Projections)
+		if len(filtered) == 0 && !instructions.CaptureDVDMenus &&
+			countMediaArtifacts(existing.Artifacts, api.MediaArtifactScreenshot) >= max(projectedScreenshots, requestedScreenshotCount) &&
+			countMediaArtifacts(existing.Artifacts, api.MediaArtifactDVDMenu) >= projectedDVDMenus {
+			snapshot, cloneErr := existing.Clone()
+			if cloneErr != nil {
+				return api.MediaArtifactSet{}, nil, fmt.Errorf("workflow media clone existing capture: %w", cloneErr)
+			}
+			return snapshot, retained, nil
+		}
 	}
 	captured, privateCaptured, err := b.Build(ctx, release, projections, instructions, now)
 	if err != nil {
@@ -893,6 +980,7 @@ func (b workflowMediaBuilder) Attach(
 		contents = append(contents, menuImageContent{
 			contentType: attachment.Content.ContentType,
 			bytes:       append([]byte(nil), attachment.Content.Bytes...),
+			discID:      attachment.Attachment.DiscID,
 		})
 	}
 	subject, images, err := b.media.importAcceptedMenuImageContents(ctx, api.MediaPlanInput{Release: release}, contents)
@@ -1193,7 +1281,7 @@ func imageHostingEffectScope(host string, projections api.TrackerReleaseProjecti
 
 func (b workflowMediaBuilder) RemoveHostedImages(
 	ctx context.Context,
-	release api.ReleaseRef,
+	_ api.ReleaseRef,
 	snapshot api.MediaArtifactSet,
 	privateExisting any,
 	artifactIDs []api.PublicResourceID,
@@ -1213,15 +1301,22 @@ func (b workflowMediaBuilder) RemoveHostedImages(
 		if !exists {
 			return api.MediaArtifactSet{}, nil, errors.New("workflow hosted image is unavailable")
 		}
-		sourcePath := link.SourcePath
-		if strings.TrimSpace(sourcePath) == "" {
-			sourcePath = release.SourcePath
+		binding := api.PreparedMediaBinding{
+			SourcePath:               link.SourcePath,
+			PreparedMediaFingerprint: link.PreparedMediaFingerprint,
+			PreparedGeneration:       link.PreparedGeneration,
+		}
+		if !binding.Valid() {
+			binding = retained.screenshotSubject.MediaBinding
+		}
+		if !binding.Valid() {
+			return api.MediaArtifactSet{}, nil, errors.New("workflow hosted image binding is unavailable")
 		}
 		retained.commitState.pending = append(retained.commitState.pending, workflowMediaPendingDelete{
-			kind:       api.MediaArtifactHostedImage,
-			path:       link.ImagePath,
-			sourcePath: sourcePath,
-			host:       link.Host,
+			kind:    api.MediaArtifactHostedImage,
+			path:    link.ImagePath,
+			binding: binding,
+			host:    link.Host,
 		})
 		delete(retained.HostedImages, artifactID)
 		delete(retained.HostedSources, artifactID)
@@ -1365,6 +1460,8 @@ func publicMediaArtifact(
 	idFingerprint := hex.EncodeToString(sum[:])
 	return api.MediaArtifact{
 		ID:               api.PublicResourceID("media_" + idFingerprint[:24]),
+		DiscID:           image.DiscID,
+		DiscName:         image.DiscName,
 		Kind:             kind,
 		Purpose:          purpose,
 		Selected:         true,

--- a/internal/core/workflow_media_test.go
+++ b/internal/core/workflow_media_test.go
@@ -21,13 +21,24 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-type workflowMediaResolverFake struct{}
+type workflowMediaResolverFake struct {
+	screenshotSubject *api.ScreenshotSubject
+}
 
-func (workflowMediaResolverFake) ResolveScreenshotSubject(
+func (f workflowMediaResolverFake) ResolveScreenshotSubject(
 	_ context.Context,
 	input api.MediaPlanInput,
 ) (api.ScreenshotSubject, error) {
-	return api.ScreenshotSubject{SourcePath: input.Release.SourcePath, DiscType: "DVD"}, nil
+	if f.screenshotSubject != nil {
+		subject := *f.screenshotSubject
+		subject.ManualFrames = append([]int(nil), input.Options.ManualFrames...)
+		return subject, nil
+	}
+	return api.ScreenshotSubject{
+		SourcePath:   input.Release.SourcePath,
+		DiscType:     "DVD",
+		ManualFrames: append([]int(nil), input.Options.ManualFrames...),
+	}, nil
 }
 
 func (workflowMediaResolverFake) ResolveDVDMenuSubject(
@@ -38,12 +49,13 @@ func (workflowMediaResolverFake) ResolveDVDMenuSubject(
 }
 
 type workflowScreenshotFake struct {
-	root     string
-	plan     *api.ScreenshotPlan
-	plans    int
-	captures int
-	deleted  []string
-	err      error
+	root       string
+	plan       *api.ScreenshotPlan
+	plans      int
+	captures   int
+	selections []api.ScreenshotSelection
+	deleted    []string
+	err        error
 }
 
 func (f *workflowScreenshotFake) Plan(
@@ -60,18 +72,29 @@ func (f *workflowScreenshotFake) Plan(
 
 func (f *workflowScreenshotFake) Capture(
 	_ context.Context,
-	_ api.ScreenshotSubject,
+	subject api.ScreenshotSubject,
 	selections []api.ScreenshotSelection,
 	purpose api.ScreenshotPurpose,
 ) (api.ScreenshotResult, error) {
 	f.captures++
+	f.selections = append(f.selections, selections...)
 	if f.err != nil {
 		return api.ScreenshotResult{}, f.err
 	}
 	images := make([]api.ScreenshotImage, len(selections))
+	discNames := make(map[string]string, len(subject.Discs))
+	for _, disc := range subject.Discs {
+		discNames[disc.ID] = disc.Name
+	}
 	for index, selection := range selections {
+		name := fmt.Sprintf("screen-%d.png", selection.Index)
+		if selection.DiscID != "" {
+			name = fmt.Sprintf("%s-screen-%d.png", selection.DiscID, selection.Index)
+		}
 		images[index] = api.ScreenshotImage{
-			Path:             filepath.Join(f.root, fmt.Sprintf("screen-%d.png", selection.Index)),
+			DiscID:           selection.DiscID,
+			DiscName:         discNames[selection.DiscID],
+			Path:             filepath.Join(f.root, name),
 			Purpose:          purpose,
 			Index:            selection.Index,
 			TimestampSeconds: selection.TimestampSeconds,
@@ -83,9 +106,134 @@ func (f *workflowScreenshotFake) Capture(
 	return api.ScreenshotResult{Purpose: purpose, Images: images}, nil
 }
 
+func TestWorkflowMediaBuilderKeepsAutomaticSuggestionsForOmittedDiscs(t *testing.T) {
+	t.Parallel()
+
+	subject := api.ScreenshotSubject{SourcePath: "C:\\releases\\Example.Release.2026", Discs: []api.ScreenshotDiscSubject{
+		{ID: "disc-a", Name: "Disc 1"},
+		{ID: "disc-b", Name: "Disc 2"},
+	}}
+	screenshots := &workflowScreenshotFake{root: t.TempDir(), plan: &api.ScreenshotPlan{
+		Discs: []api.ScreenshotDiscPlan{
+			{
+				DiscID:   "disc-a",
+				DiscName: "Disc 1",
+				SuggestedSelections: []api.ScreenshotSelection{{
+					DiscID:           "disc-a",
+					Index:            0,
+					TimestampSeconds: 10,
+				}},
+			},
+			{
+				DiscID:   "disc-b",
+				DiscName: "Disc 2",
+				SuggestedSelections: []api.ScreenshotSelection{{
+					DiscID:           "disc-b",
+					Index:            0,
+					TimestampSeconds: 20,
+				}},
+			},
+		},
+	}}
+	builder := workflowMediaBuilder{
+		resolver:    workflowMediaResolverFake{screenshotSubject: &subject},
+		screenshots: screenshots,
+	}
+	projections := api.TrackerReleaseProjectionSet{Projections: []api.TrackerReleaseProjection{{
+		TrackerID: "ALPHA", Artifacts: api.TrackerArtifactRequirements{ScreenshotCount: 2},
+	}}}
+
+	result, _, err := builder.Build(context.Background(), api.ReleaseRef{SourcePath: subject.SourcePath, Generation: 1}, projections,
+		api.MediaCaptureInstructions{Purpose: api.ScreenshotPurposeFinal, Selections: []api.ScreenshotSelection{{
+			DiscID:           "disc-a",
+			Index:            4,
+			TimestampSeconds: 40,
+		}}}, time.Now())
+	if err != nil {
+		t.Fatalf("build media: %v", err)
+	}
+	if len(result.Artifacts) != 2 || len(screenshots.selections) != 2 || screenshots.selections[0].DiscID != "disc-a" ||
+		screenshots.selections[1].DiscID != "disc-b" {
+		t.Fatalf("artifacts=%#v selections=%#v", result.Artifacts, screenshots.selections)
+	}
+}
+
+func TestWorkflowMediaBuilderRetainsExpandedRawFramesAcrossDiscs(t *testing.T) {
+	t.Parallel()
+
+	subject := api.ScreenshotSubject{SourcePath: "C:\\releases\\Example.Release.2026", Discs: []api.ScreenshotDiscSubject{
+		{ID: "disc-a", Name: "Disc 1"},
+		{ID: "disc-b", Name: "Disc 2"},
+	}}
+	expanded := []api.ScreenshotSelection{
+		{
+			DiscID:           "disc-a",
+			Index:            0,
+			Frame:            24,
+			TimestampSeconds: 1,
+			Source:           "manual",
+		},
+		{
+			DiscID:           "disc-a",
+			Index:            1,
+			Frame:            48,
+			TimestampSeconds: 2,
+			Source:           "manual",
+		},
+		{
+			DiscID:           "disc-b",
+			Index:            0,
+			Frame:            24,
+			TimestampSeconds: 1,
+			Source:           "manual",
+		},
+		{
+			DiscID:           "disc-b",
+			Index:            1,
+			Frame:            48,
+			TimestampSeconds: 2,
+			Source:           "manual",
+		},
+	}
+	screenshots := &workflowScreenshotFake{root: t.TempDir(), plan: &api.ScreenshotPlan{
+		SuggestedSelections: expanded,
+		Discs: []api.ScreenshotDiscPlan{
+			{
+				DiscID:              "disc-a",
+				DiscName:            "Disc 1",
+				SuggestedSelections: expanded[:2],
+			},
+			{
+				DiscID:              "disc-b",
+				DiscName:            "Disc 2",
+				SuggestedSelections: expanded[2:],
+			},
+		},
+	}}
+	builder := workflowMediaBuilder{
+		resolver:    workflowMediaResolverFake{screenshotSubject: &subject},
+		screenshots: screenshots,
+	}
+
+	result, _, err := builder.Build(context.Background(), api.ReleaseRef{SourcePath: subject.SourcePath, Generation: 1}, api.TrackerReleaseProjectionSet{},
+		api.MediaCaptureInstructions{Purpose: api.ScreenshotPurposeFinal, ManualFrames: []int{24, 48}}, time.Now())
+	if err != nil {
+		t.Fatalf("build media: %v", err)
+	}
+	if len(result.Artifacts) != 4 || len(screenshots.selections) != 4 {
+		t.Fatalf("artifacts=%#v selections=%#v", result.Artifacts, screenshots.selections)
+	}
+	for index, artifact := range result.Artifacts {
+		if artifact.DiscID != expanded[index].DiscID || artifact.Index != expanded[index].Index {
+			t.Fatalf("artifact[%d] = %#v", index, artifact)
+		}
+	}
+}
+
 func (*workflowScreenshotFake) PreviewFrame(
 	context.Context,
 	api.ScreenshotSubject,
+	string,
 	float64,
 ) (api.ScreenshotPreview, error) {
 	return api.ScreenshotPreview{}, nil

--- a/internal/core/workflow_private_resources.go
+++ b/internal/core/workflow_private_resources.go
@@ -68,10 +68,12 @@ type persistedWorkflowMediaArtifacts struct {
 }
 
 type persistedWorkflowMediaPendingDelete struct {
-	Kind       api.MediaArtifactKind `json:"kind"`
-	Path       string                `json:"path"`
-	SourcePath string                `json:"sourcePath,omitempty"`
-	Host       string                `json:"host,omitempty"`
+	Kind                     api.MediaArtifactKind  `json:"kind"`
+	Path                     string                 `json:"path"`
+	SourcePath               string                 `json:"sourcePath,omitempty"`
+	PreparedMediaFingerprint string                 `json:"preparedMediaFingerprint,omitempty"`
+	PreparedGeneration       api.PreparedGeneration `json:"preparedGeneration,omitempty"`
+	Host                     string                 `json:"host,omitempty"`
 }
 
 func (a workflowMediaPrivateArtifacts) MarshalPrivateResource() (string, []byte, error) {
@@ -79,10 +81,12 @@ func (a workflowMediaPrivateArtifacts) MarshalPrivateResource() (string, []byte,
 	persistedPending := make([]persistedWorkflowMediaPendingDelete, 0, len(pending))
 	for _, deletion := range pending {
 		persistedPending = append(persistedPending, persistedWorkflowMediaPendingDelete{
-			Kind:       deletion.kind,
-			Path:       deletion.path,
-			SourcePath: deletion.sourcePath,
-			Host:       deletion.host,
+			Kind:                     deletion.kind,
+			Path:                     deletion.path,
+			SourcePath:               deletion.binding.SourcePath,
+			PreparedMediaFingerprint: deletion.binding.PreparedMediaFingerprint,
+			PreparedGeneration:       deletion.binding.PreparedGeneration,
+			Host:                     deletion.host,
 		})
 	}
 	payload, err := json.Marshal(persistedWorkflowMediaArtifacts{
@@ -112,10 +116,14 @@ func decodeWorkflowMediaPrivateArtifacts(builder workflowMediaBuilder, payload [
 			return nil, errors.New("workflow private media contains invalid pending deletion")
 		}
 		pending = append(pending, workflowMediaPendingDelete{
-			kind:       deletion.Kind,
-			path:       deletion.Path,
-			sourcePath: deletion.SourcePath,
-			host:       deletion.Host,
+			kind: deletion.Kind,
+			path: deletion.Path,
+			binding: api.PreparedMediaBinding{
+				SourcePath:               deletion.SourcePath,
+				PreparedMediaFingerprint: deletion.PreparedMediaFingerprint,
+				PreparedGeneration:       deletion.PreparedGeneration,
+			},
+			host: deletion.Host,
 		})
 	}
 	var commitState *workflowMediaCommitState

--- a/internal/imagehosting/service.go
+++ b/internal/imagehosting/service.go
@@ -36,13 +36,13 @@ type Service struct {
 }
 
 type repository interface {
-	ListFinalSelections(context.Context, string) ([]api.ScreenshotFinalSelection, error)
-	ListScreenshotsByPath(context.Context, string) ([]api.Screenshot, error)
-	ListUploadedImagesByPath(context.Context, string) ([]api.UploadedImageLink, error)
-	SaveUploadedImages(context.Context, string, string, []api.UploadedImageLink) error
-	ListScreenshotSlotsByPath(context.Context, string) ([]api.ScreenshotSlot, error)
-	ReplaceScreenshotSlots(context.Context, string, []api.ScreenshotSlot) error
-	UpsertScreenshotSlotVariants(context.Context, string, []api.ScreenshotSlotVariant) error
+	ListFinalSelections(context.Context, api.PreparedMediaBinding) ([]api.ScreenshotFinalSelection, error)
+	ListScreenshotsByPath(context.Context, api.PreparedMediaBinding) ([]api.Screenshot, error)
+	ListUploadedImagesByPath(context.Context, api.PreparedMediaBinding) ([]api.UploadedImageLink, error)
+	SaveUploadedImages(context.Context, api.PreparedMediaBinding, string, []api.UploadedImageLink) error
+	ListScreenshotSlotsByPath(context.Context, api.PreparedMediaBinding) ([]api.ScreenshotSlot, error)
+	ReplaceScreenshotSlots(context.Context, api.PreparedMediaBinding, []api.ScreenshotSlot) error
+	UpsertScreenshotSlotVariants(context.Context, api.PreparedMediaBinding, []api.ScreenshotSlotVariant) error
 }
 
 // NewServiceWithRegistry returns an image-hosting service with tracker-owned host scope metadata.
@@ -75,29 +75,37 @@ func (s *Service) ListCandidates(ctx context.Context, meta api.ImageHostingSubje
 	if s == nil || s.repo == nil {
 		return nil, errors.New("image hosting: repository not configured")
 	}
-	if strings.TrimSpace(meta.SourcePath) == "" {
+	if !meta.MediaBinding.Valid() {
 		return nil, internalerrors.ErrInvalidInput
 	}
 
 	// First, get all screenshots from the database
-	screens, err := s.repo.ListScreenshotsByPath(ctx, meta.SourcePath)
+	screens, err := s.repo.ListScreenshotsByPath(ctx, meta.MediaBinding)
 	if err != nil {
 		return nil, fmt.Errorf("image hosting: %w", err)
 	}
 
 	// Then, get all previously uploaded images
-	uploaded, err := s.repo.ListUploadedImagesByPath(ctx, meta.SourcePath)
+	uploaded, err := s.repo.ListUploadedImagesByPath(ctx, meta.MediaBinding)
 	if err != nil {
 		return nil, fmt.Errorf("image hosting: %w", err)
 	}
-	selections, err := s.repo.ListFinalSelections(ctx, meta.SourcePath)
+	selections, err := s.repo.ListFinalSelections(ctx, meta.MediaBinding)
 	if err != nil {
 		s.logger.Debugf("image hosting: final selections unavailable: %v", err)
 		selections = nil
 	}
 	selectionSourceByPath := make(map[string]string, len(selections))
+	selectionDiscByPath := make(map[string]string, len(selections))
 	for _, selection := range selections {
 		selectionSourceByPath[strings.TrimSpace(selection.ImagePath)] = strings.TrimSpace(selection.Source)
+		selectionDiscByPath[strings.TrimSpace(selection.ImagePath)] = strings.TrimSpace(selection.DiscID)
+	}
+	discNames := make(map[string]string, len(meta.Discs))
+	discOrder := make(map[string]int, len(meta.Discs))
+	for index, disc := range meta.Discs {
+		discNames[disc.ID] = disc.Name
+		discOrder[disc.ID] = index
 	}
 
 	// Build a map of uploaded images by path for quick lookup
@@ -119,6 +127,8 @@ func (s *Service) ListCandidates(ctx context.Context, meta api.ImageHostingSubje
 		}
 
 		img := api.ScreenshotImage{
+			DiscID:           shot.DiscID,
+			DiscName:         discNames[shot.DiscID],
 			Path:             pathValue,
 			TimestampSeconds: shot.Timestamp,
 			Purpose:          shot.Purpose,
@@ -169,6 +179,8 @@ func (s *Service) ListCandidates(ctx context.Context, meta api.ImageHostingSubje
 		}
 
 		img := api.ScreenshotImage{
+			DiscID:           sel.DiscID,
+			DiscName:         discNames[sel.DiscID],
 			Path:             pathValue,
 			TimestampSeconds: 0, // Fallback since it wasn't a generated frame
 			Purpose:          api.ScreenshotPurposeFinal,
@@ -214,7 +226,13 @@ func (s *Service) ListCandidates(ctx context.Context, meta api.ImageHostingSubje
 		if api.IsDiscMenuSelectionSource(selectionSourceByPath[pathValue]) {
 			purpose = api.ScreenshotPurposeMenu
 		}
+		discID := strings.TrimSpace(upload.DiscID)
+		if discID == "" {
+			discID = selectionDiscByPath[pathValue]
+		}
 		images = append(images, api.ScreenshotImage{
+			DiscID:     discID,
+			DiscName:   discNames[discID],
 			Path:       pathValue,
 			Purpose:    purpose,
 			SizeBytes:  info.Size(),
@@ -233,8 +251,19 @@ func (s *Service) ListCandidates(ctx context.Context, meta api.ImageHostingSubje
 		)
 	}
 
-	sort.Slice(images, func(i, j int) bool {
-		return images[i].TimestampSeconds < images[j].TimestampSeconds
+	sort.SliceStable(images, func(i, j int) bool {
+		leftRank, leftFound := discOrder[images[i].DiscID]
+		rightRank, rightFound := discOrder[images[j].DiscID]
+		if leftFound != rightFound {
+			return leftFound
+		}
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		if images[i].TimestampSeconds != images[j].TimestampSeconds {
+			return images[i].TimestampSeconds < images[j].TimestampSeconds
+		}
+		return images[i].Path < images[j].Path
 	})
 
 	s.logger.Debugf("image hosting: returning candidate images count=%d uploaded=%d", len(images), len(uploadedByPath))
@@ -285,7 +314,7 @@ func (s *Service) Upload(
 	if uploader == nil {
 		return nil, fmt.Errorf("image hosting: unsupported host %q", normalizedHost)
 	}
-	if strings.TrimSpace(meta.SourcePath) == "" {
+	if !meta.MediaBinding.Valid() {
 		return nil, internalerrors.ErrInvalidInput
 	}
 	if err := ctx.Err(); err != nil {
@@ -323,6 +352,7 @@ func (s *Service) Upload(
 		}
 		seen[absPath] = struct{}{}
 		unique = append(unique, imageCandidate{
+			DiscID:    image.DiscID,
 			Path:      absPath,
 			Purpose:   image.Purpose,
 			SizeBytes: info.Size(),
@@ -427,7 +457,7 @@ func (s *Service) Upload(
 				uploaded.WebURL = uploaded.RawURL
 			}
 			results[idx] = api.UploadedImageLink{
-				SourcePath: meta.SourcePath,
+				DiscID:     candidate.DiscID,
 				ImagePath:  candidate.Path,
 				Host:       normalizedHost,
 				UsageScope: normalizedScope,
@@ -440,7 +470,7 @@ func (s *Service) Upload(
 		}
 		if s.repo != nil {
 			s.logger.Tracef("image hosting: persisting upload records count=%d host=%s tracker=%s", len(results), normalizedHost, logTracker)
-			if err := s.repo.SaveUploadedImages(ctx, meta.SourcePath, normalizedHost, results); err != nil {
+			if err := s.repo.SaveUploadedImages(ctx, meta.MediaBinding, normalizedHost, results); err != nil {
 				s.logger.Errorf(
 					"image hosting: failed to save upload records host=%s tracker=%s err=%s",
 					normalizedHost,
@@ -458,7 +488,7 @@ func (s *Service) Upload(
 				)
 				return nil, fmt.Errorf("image hosting: %w", err)
 			}
-			summary, err := syncScreenshotSlotVariants(ctx, s.repo, meta.SourcePath, results)
+			summary, err := syncScreenshotSlotVariants(ctx, s.repo, meta.MediaBinding, results)
 			if err != nil {
 				s.logger.Warnf(
 					"image hosting: failed to sync screenshot slot variants host=%s tracker=%s err=%s",
@@ -614,7 +644,7 @@ dispatchLoop:
 			results = append(results, indexedUploadResult{
 				index: idx,
 				link: api.UploadedImageLink{
-					SourcePath: meta.SourcePath,
+					DiscID:     candidate.DiscID,
 					ImagePath:  candidate.Path,
 					Host:       normalizedHost,
 					UsageScope: normalizedScope,
@@ -652,7 +682,7 @@ dispatchLoop:
 
 	if s.repo != nil && len(orderedResults) > 0 {
 		s.logger.Tracef("image hosting: persisting upload records count=%d host=%s tracker=%s", len(orderedResults), normalizedHost, logTracker)
-		if err := s.repo.SaveUploadedImages(ctx, meta.SourcePath, normalizedHost, orderedResults); err != nil {
+		if err := s.repo.SaveUploadedImages(ctx, meta.MediaBinding, normalizedHost, orderedResults); err != nil {
 			s.logger.Errorf(
 				"image hosting: failed to save upload records host=%s tracker=%s err=%s",
 				normalizedHost,
@@ -670,7 +700,7 @@ dispatchLoop:
 			)
 			return nil, fmt.Errorf("image hosting: %w", err)
 		}
-		summary, err := syncScreenshotSlotVariants(ctx, s.repo, meta.SourcePath, orderedResults)
+		summary, err := syncScreenshotSlotVariants(ctx, s.repo, meta.MediaBinding, orderedResults)
 		if err != nil {
 			s.logger.Warnf(
 				"image hosting: failed to sync screenshot slot variants host=%s tracker=%s err=%s",
@@ -882,6 +912,7 @@ func imagePurposeCounts(images []imageCandidate) (normal int, menus int) {
 }
 
 type imageCandidate struct {
+	DiscID    string
 	Path      string
 	Purpose   api.ScreenshotPurpose
 	SizeBytes int64
@@ -916,13 +947,13 @@ func isAllowedImageExt(path string) bool {
 func syncScreenshotSlotVariants(
 	ctx context.Context,
 	repo repository,
-	sourcePath string,
+	binding api.PreparedMediaBinding,
 	uploaded []api.UploadedImageLink,
 ) (trackers.SlotUploadAttachmentResult, error) {
-	if repo == nil || len(uploaded) == 0 || strings.TrimSpace(sourcePath) == "" {
+	if repo == nil || len(uploaded) == 0 || !binding.Valid() {
 		return trackers.SlotUploadAttachmentResult{}, nil
 	}
-	slots, err := repo.ListScreenshotSlotsByPath(ctx, sourcePath)
+	slots, err := repo.ListScreenshotSlotsByPath(ctx, binding)
 	if err != nil {
 		return trackers.SlotUploadAttachmentResult{}, fmt.Errorf("image hosting: %w", err)
 	}
@@ -931,7 +962,7 @@ func syncScreenshotSlotVariants(
 	}
 	summary := trackers.ApplyUploadedVariantsToSlots(slots, uploaded)
 	if summary.FallbackMatched > 0 {
-		if err := repo.ReplaceScreenshotSlots(ctx, sourcePath, slots); err != nil {
+		if err := repo.ReplaceScreenshotSlots(ctx, binding, slots); err != nil {
 			return summary, fmt.Errorf("image hosting: %w", err)
 		}
 	}
@@ -948,7 +979,7 @@ func syncScreenshotSlotVariants(
 			continue
 		}
 		variants = append(variants, api.ScreenshotSlotVariant{
-			SourcePath: sourcePath,
+			DiscID:     image.DiscID,
 			SlotOrder:  slotOrder,
 			Host:       strings.TrimSpace(image.Host),
 			UsageScope: strings.TrimSpace(image.UsageScope),
@@ -959,7 +990,7 @@ func syncScreenshotSlotVariants(
 			UploadedAt: image.UploadedAt,
 		})
 	}
-	if err := repo.UpsertScreenshotSlotVariants(ctx, sourcePath, variants); err != nil {
+	if err := repo.UpsertScreenshotSlotVariants(ctx, binding, variants); err != nil {
 		return summary, fmt.Errorf("image hosting: upsert screenshot slot variants: %w", err)
 	}
 	return summary, nil

--- a/internal/imagehosting/service_test.go
+++ b/internal/imagehosting/service_test.go
@@ -40,9 +40,14 @@ func imageHostingTestRegistry(t *testing.T) *trackers.Registry {
 	return registry
 }
 
-func (r *recordingRepo) SaveUploadedImages(_ context.Context, path string, host string, images []api.UploadedImageLink) error {
+func (r *recordingRepo) SaveUploadedImages(
+	_ context.Context,
+	binding api.PreparedMediaBinding,
+	host string,
+	images []api.UploadedImageLink,
+) error {
 	r.savedHost = host
-	r.savedPath = path
+	r.savedPath = binding.SourcePath
 	r.savedImages = images
 	return nil
 }
@@ -100,27 +105,27 @@ func (r *recordingRepo) ListTrackerMetadataByPath(context.Context, string) ([]ap
 	return nil, nil
 }
 func (r *recordingRepo) SaveScreenshot(context.Context, api.Screenshot) error { return nil }
-func (r *recordingRepo) ListScreenshotsByPath(context.Context, string) ([]api.Screenshot, error) {
+func (r *recordingRepo) ListScreenshotsByPath(context.Context, api.PreparedMediaBinding) ([]api.Screenshot, error) {
 	return append([]api.Screenshot(nil), r.screens...), nil
 }
 func (r *recordingRepo) DeleteScreenshot(context.Context, string) error { return nil }
-func (r *recordingRepo) SaveFinalSelections(context.Context, string, []api.ScreenshotFinalSelection) error {
+func (r *recordingRepo) SaveFinalSelections(context.Context, api.PreparedMediaBinding, []api.ScreenshotFinalSelection) error {
 	return nil
 }
-func (r *recordingRepo) ListFinalSelections(context.Context, string) ([]api.ScreenshotFinalSelection, error) {
+func (r *recordingRepo) ListFinalSelections(context.Context, api.PreparedMediaBinding) ([]api.ScreenshotFinalSelection, error) {
 	return append([]api.ScreenshotFinalSelection(nil), r.selections...), nil
 }
 func (r *recordingRepo) DeleteFinalSelection(context.Context, string) error { return nil }
-func (r *recordingRepo) ReplaceScreenshotSlots(context.Context, string, []api.ScreenshotSlot) error {
+func (r *recordingRepo) ReplaceScreenshotSlots(context.Context, api.PreparedMediaBinding, []api.ScreenshotSlot) error {
 	return nil
 }
-func (r *recordingRepo) ListScreenshotSlotsByPath(context.Context, string) ([]api.ScreenshotSlot, error) {
+func (r *recordingRepo) ListScreenshotSlotsByPath(context.Context, api.PreparedMediaBinding) ([]api.ScreenshotSlot, error) {
 	return nil, nil
 }
-func (r *recordingRepo) UpsertScreenshotSlotVariants(context.Context, string, []api.ScreenshotSlotVariant) error {
+func (r *recordingRepo) UpsertScreenshotSlotVariants(context.Context, api.PreparedMediaBinding, []api.ScreenshotSlotVariant) error {
 	return nil
 }
-func (r *recordingRepo) ListUploadedImagesByPath(context.Context, string) ([]api.UploadedImageLink, error) {
+func (r *recordingRepo) ListUploadedImagesByPath(context.Context, api.PreparedMediaBinding) ([]api.UploadedImageLink, error) {
 	return append([]api.UploadedImageLink(nil), r.uploads...), nil
 }
 func (r *recordingRepo) DeleteUploadedImage(context.Context, string, string, string) error {
@@ -330,7 +335,7 @@ func TestUploadImagesSuccess(t *testing.T) {
 		uploaders: map[string]uploader{"test": uploaderStub},
 	}
 
-	meta := api.ImageHostingSubject{SourcePath: "source"}
+	meta := imageHostingTestSubject("source")
 	images := []api.ScreenshotImage{{Path: imagePath}}
 	result, err := service.Upload(context.Background(), meta, "test", "tracker:HDB", images)
 	if err != nil {
@@ -399,7 +404,7 @@ func TestListCandidatesIncludesUploadedOnlyImages(t *testing.T) {
 	}
 	service := &Service{logger: api.NopLogger{}, repo: repo}
 
-	images, err := service.ListCandidates(context.Background(), api.ImageHostingSubject{SourcePath: "/tmp/source"})
+	images, err := service.ListCandidates(context.Background(), imageHostingTestSubject("/tmp/source"))
 	if err != nil {
 		t.Fatalf("ListCandidates returned error: %v", err)
 	}
@@ -448,7 +453,7 @@ func TestListCandidatesPopulatesGeneratedAndManualMenuPurpose(t *testing.T) {
 	}
 	service := &Service{logger: api.NopLogger{}, repo: repo}
 
-	images, err := service.ListCandidates(context.Background(), api.ImageHostingSubject{SourcePath: "/tmp/source"})
+	images, err := service.ListCandidates(context.Background(), imageHostingTestSubject("/tmp/source"))
 	if err != nil {
 		t.Fatalf("list candidates: %v", err)
 	}
@@ -462,9 +467,59 @@ func TestListCandidatesPopulatesGeneratedAndManualMenuPurpose(t *testing.T) {
 	}
 }
 
+func TestListCandidatesKeepsPreparedDiscOrder(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	paths := []string{
+		filepath.Join(root, "disc-b.png"),
+		filepath.Join(root, "disc-a-late.png"),
+		filepath.Join(root, "disc-a-early.png"),
+	}
+	for _, imagePath := range paths {
+		if err := os.WriteFile(imagePath, []byte("synthetic image"), 0o600); err != nil {
+			t.Fatalf("write image: %v", err)
+		}
+	}
+	repo := &recordingRepo{screens: []api.Screenshot{
+		{
+			DiscID:    "disc-b",
+			ImagePath: paths[0],
+			Timestamp: 20,
+		},
+		{
+			DiscID:    "disc-a",
+			ImagePath: paths[1],
+			Timestamp: 30,
+		},
+		{
+			DiscID:    "disc-a",
+			ImagePath: paths[2],
+			Timestamp: 10,
+		},
+	}}
+	service := &Service{logger: api.NopLogger{}, repo: repo}
+	subject := imageHostingTestSubject(root)
+	subject.Discs = []api.ImageHostingDiscSubject{
+		{ID: "disc-a", Name: "Disc 1"},
+		{ID: "disc-b", Name: "Disc 2"},
+	}
+
+	images, err := service.ListCandidates(context.Background(), subject)
+	if err != nil {
+		t.Fatalf("list candidates: %v", err)
+	}
+	if len(images) != 3 || images[0].Path != paths[2] || images[1].Path != paths[1] || images[2].Path != paths[0] {
+		t.Fatalf("ordered images = %#v", images)
+	}
+	if images[0].DiscName != "Disc 1" || images[2].DiscName != "Disc 2" {
+		t.Fatalf("disc labels = %#v", images)
+	}
+}
+
 func TestUploadImagesUnsupportedHost(t *testing.T) {
 	service := &Service{logger: api.NopLogger{}, uploaders: map[string]uploader{}}
-	meta := api.ImageHostingSubject{SourcePath: "source"}
+	meta := imageHostingTestSubject("source")
 	_, err := service.Upload(context.Background(), meta, "missing", "global", []api.ScreenshotImage{{Path: "x.png"}})
 	if err == nil {
 		t.Fatal("expected error for unsupported host")
@@ -485,7 +540,7 @@ func TestUploadImagesRejectsTrackerOwnedHostOutsideOwnerScope(t *testing.T) {
 	if err := tmp.Close(); err != nil {
 		t.Fatalf("close temp file: %v", err)
 	}
-	meta := api.ImageHostingSubject{SourcePath: "source"}
+	meta := imageHostingTestSubject("source")
 	_, err = service.Upload(context.Background(), meta, "hdb", "global", []api.ScreenshotImage{{Path: tmpPath}})
 	if err == nil {
 		t.Fatal("expected tracker-owned host outside owner scope to fail")
@@ -502,7 +557,7 @@ func TestUploadImagesMissingFile(t *testing.T) {
 		WebURL: "https://web",
 	}}
 	service := &Service{logger: api.NopLogger{}, uploaders: map[string]uploader{"test": uploaderStub}}
-	meta := api.ImageHostingSubject{SourcePath: "source"}
+	meta := imageHostingTestSubject("source")
 	_, err := service.Upload(context.Background(), meta, "test", "global", []api.ScreenshotImage{{Path: "missing.png"}})
 	if err == nil {
 		t.Fatal("expected error for missing file")
@@ -560,8 +615,9 @@ func TestUploadImagesUsesBatchUploader(t *testing.T) {
 	}
 
 	_, err := service.Upload(context.Background(), api.ImageHostingSubject{
-		SourcePath:  "source",
-		GalleryName: "Movie.2026.2160p.WEB-DL",
+		MediaBinding: imageHostingTestBinding("source"),
+		SourcePath:   "source",
+		GalleryName:  "Movie.2026.2160p.WEB-DL",
 	}, "hdb", "tracker:HDB", []api.ScreenshotImage{
 		{Path: firstPath},
 		{Path: secondPath},
@@ -611,9 +667,11 @@ func TestUploadImagesBatchFailureUsesDebugDiagnosticsAndStableProgress(t *testin
 		Total:      1,
 	})
 
+	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
 	_, err := service.Upload(ctx, api.ImageHostingSubject{
-		SourcePath:  filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv"),
-		GalleryName: "Example.Release.2026.1080p-GRP",
+		MediaBinding: imageHostingTestBinding(sourcePath),
+		SourcePath:   sourcePath,
+		GalleryName:  "Example.Release.2026.1080p-GRP",
 	}, "hdb", "tracker:HDB", []api.ScreenshotImage{{Path: imagePath}})
 	if err == nil {
 		t.Fatal("expected batch upload failure")
@@ -656,9 +714,11 @@ func TestUploadImagesSeparatesHDBMenuGalleryWithoutDuplicates(t *testing.T) {
 		registry:  imageHostingTestRegistry(t),
 	}
 
+	sourcePath := filepath.Join(tmpDir, "Example.Release.2026.2160p.WEB-DL-GRP.mkv")
 	result, err := service.Upload(context.Background(), api.ImageHostingSubject{
-		SourcePath:  filepath.Join(tmpDir, "Example.Release.2026.2160p.WEB-DL-GRP.mkv"),
-		GalleryName: "Example.Release.2026.2160p.WEB-DL-GRP",
+		MediaBinding: imageHostingTestBinding(sourcePath),
+		SourcePath:   sourcePath,
+		GalleryName:  "Example.Release.2026.2160p.WEB-DL-GRP",
 	}, "hdb", "tracker:HDB", []api.ScreenshotImage{
 		{Path: firstPath, Purpose: api.ScreenshotPurposeFinal},
 		{Path: menuPath, Purpose: api.ScreenshotPurposeMenu},
@@ -747,7 +807,7 @@ func TestUploadImagesPersistsSuccessfulConcurrentUploadsOnPartialFailure(t *test
 		uploaders: map[string]uploader{"test": uploaderStub},
 	}
 
-	result, err := service.Upload(context.Background(), api.ImageHostingSubject{SourcePath: "source"}, "test", "global", []api.ScreenshotImage{
+	result, err := service.Upload(context.Background(), imageHostingTestSubject("source"), "test", "global", []api.ScreenshotImage{
 		{Path: firstPath},
 		{Path: secondPath},
 	})
@@ -802,7 +862,7 @@ func TestUploadImagesReportsAbsoluteConcurrentProgress(t *testing.T) {
 		Total:      2,
 	})
 
-	_, err := service.Upload(ctx, api.ImageHostingSubject{SourcePath: "synthetic-source"}, "example", "global", []api.ScreenshotImage{
+	_, err := service.Upload(ctx, imageHostingTestSubject("synthetic-source"), "example", "global", []api.ScreenshotImage{
 		{Path: firstPath},
 		{Path: secondPath},
 	})
@@ -848,7 +908,7 @@ func TestUploadImagesStopsDispatchingWhenContextCanceled(t *testing.T) {
 	firstCallCh := uploaderStub.firstCallCh
 	done := make(chan error, 1)
 	go func() {
-		_, err := service.Upload(ctx, api.ImageHostingSubject{SourcePath: "source"}, "test", "global", []api.ScreenshotImage{
+		_, err := service.Upload(ctx, imageHostingTestSubject("source"), "test", "global", []api.ScreenshotImage{
 			{Path: firstPath},
 			{Path: secondPath},
 		})
@@ -877,4 +937,16 @@ func TestUploadImagesStopsDispatchingWhenContextCanceled(t *testing.T) {
 	if len(uploaderStub.calls) != 1 {
 		t.Fatalf("expected only first upload to start, got %d calls", len(uploaderStub.calls))
 	}
+}
+
+func imageHostingTestBinding(sourcePath string) api.PreparedMediaBinding {
+	return api.PreparedMediaBinding{
+		SourcePath:               sourcePath,
+		PreparedMediaFingerprint: "test-prepared-media",
+		PreparedGeneration:       1,
+	}
+}
+
+func imageHostingTestSubject(sourcePath string) api.ImageHostingSubject {
+	return api.ImageHostingSubject{MediaBinding: imageHostingTestBinding(sourcePath), SourcePath: sourcePath}
 }

--- a/internal/imagehosting/service_test.go
+++ b/internal/imagehosting/service_test.go
@@ -139,7 +139,7 @@ func (r *recordingRepo) DeleteDescriptionOverride(context.Context, string, strin
 func (r *recordingRepo) GetPlaylistSelection(context.Context, string) (api.PlaylistSelection, error) {
 	return api.PlaylistSelection{}, nil
 }
-func (r *recordingRepo) SavePlaylistSelection(context.Context, string, []string, bool) error {
+func (r *recordingRepo) SavePlaylistSelection(context.Context, string, string, []string, bool) error {
 	return nil
 }
 func (r *recordingRepo) DeletePlaylistSelection(context.Context, string) error { return nil }

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -256,7 +256,7 @@ func (f *fakeRepo) GetPlaylistSelection(_ context.Context, _ string) (api.Playli
 	return api.PlaylistSelection{}, internalerrors.ErrNotFound
 }
 
-func (f *fakeRepo) SavePlaylistSelection(_ context.Context, _ string, _ []string, _ bool) error {
+func (f *fakeRepo) SavePlaylistSelection(_ context.Context, _ string, _ string, _ []string, _ bool) error {
 	return nil
 }
 
@@ -395,26 +395,26 @@ func (s *stubIMDB) GetEpisodeInfo(_ context.Context, _ string, _ bool) (imdb.Epi
 }
 
 type stubTVDB struct {
-	id                int
-	name              string
-	calls             int
-	tvMovieCalls      []bool
-	idWhenTVMovie     int
-	nameWhenTVMovie   string
-	episodes          tvdb.EpisodesData
-	specificAlias     string
-	episodeErr        error
-	episodeTranslate  tvdb.EpisodeTranslation
-	episodeTransErr   error
-	seriesMetadata    tvdb.SeriesMetadata
-	nameDisambiguation tvdb.NameDisambiguation
-	episodeCalls      int
-	seriesMetadataCalls int
-	seriesLangCalls   []string
+	id                       int
+	name                     string
+	calls                    int
+	tvMovieCalls             []bool
+	idWhenTVMovie            int
+	nameWhenTVMovie          string
+	episodes                 tvdb.EpisodesData
+	specificAlias            string
+	episodeErr               error
+	episodeTranslate         tvdb.EpisodeTranslation
+	episodeTransErr          error
+	seriesMetadata           tvdb.SeriesMetadata
+	nameDisambiguation       tvdb.NameDisambiguation
+	episodeCalls             int
+	seriesMetadataCalls      int
+	seriesLangCalls          []string
 	nameDisambiguationInputs []tvdb.NameDisambiguationInput
-	episodeLangCalls  []string
-	episodeTransCalls []int
-	lastEpisodeQuery  tvdb.EpisodeQuery
+	episodeLangCalls         []string
+	episodeTransCalls        []int
+	lastEpisodeQuery         tvdb.EpisodeQuery
 }
 
 func (s *stubTVDB) GetByExternalID(_ context.Context, _, _ string, tvMovie bool) (int, string, error) {
@@ -3130,7 +3130,7 @@ func TestTVDBMetadataAndDisambiguationReuseAreIndependent(t *testing.T) {
 	t.Parallel()
 
 	for _, test := range []struct {
-		status api.MetadataEvidenceStatus
+		status             api.MetadataEvidenceStatus
 		wantDisambiguation bool
 	}{
 		{status: api.MetadataEvidenceStatusComplete, wantDisambiguation: true},

--- a/internal/metadata/media_details_test.go
+++ b/internal/metadata/media_details_test.go
@@ -183,6 +183,66 @@ func TestEditionFromMetaMultiPlaylistDeduplicatesMatches(t *testing.T) {
 	}
 }
 
+func TestEditionFromMetaMultiDiscAggregatesProviderBackedEditions(t *testing.T) {
+	meta := preparationstate.State{
+		DiscType: "BDMV",
+		SelectedBDMVPlaylists: []api.PlaylistInfo{
+			{
+ID: "disc-a:00001.MPLS",
+ DiscID: "disc-a",
+ File: "00001.MPLS",
+ Duration: 7200,
+},
+			{
+ID: "disc-b:00001.MPLS",
+ DiscID: "disc-b",
+ File: "00001.MPLS",
+ Duration: 7500,
+},
+		},
+		ProviderMetadata: api.SourceScopedMetadata{IMDB: &api.IMDBMetadata{EditionDetails: map[string]api.IMDBEditionDetail{
+			"120": {Seconds: 7200, Minutes: 120},
+			"125": {
+Seconds: 7500,
+ Minutes: 125,
+ Attributes: []string{"Extended"},
+},
+		}}},
+	}
+	if edition, _ := editionFromMeta(meta, mediaInfoDoc{}); edition != "2in1 Theatrical / Extended" {
+		t.Fatalf("multi-disc edition = %q", edition)
+	}
+}
+
+func TestEditionFromMetaDoesNotPromoteSplitOrExtrasDurations(t *testing.T) {
+	meta := preparationstate.State{
+		DiscType: "BDMV",
+		SelectedBDMVPlaylists: []api.PlaylistInfo{
+			{
+ID: "disc-a:00001.MPLS",
+ DiscID: "disc-a",
+ Duration: 3600,
+},
+			{
+ID: "disc-b:00001.MPLS",
+ DiscID: "disc-b",
+ Duration: 1800,
+},
+		},
+		ProviderMetadata: api.SourceScopedMetadata{IMDB: &api.IMDBMetadata{EditionDetails: map[string]api.IMDBEditionDetail{
+			"120": {Seconds: 7200, Minutes: 120},
+			"125": {
+Seconds: 7500,
+ Minutes: 125,
+ Attributes: []string{"Extended"},
+},
+		}}},
+	}
+	if edition, _ := editionFromMeta(meta, mediaInfoDoc{}); edition != "" {
+		t.Fatalf("split/extras durations invented edition %q", edition)
+	}
+}
+
 func TestEditionFromMetaMultiPlaylistTieBreaksEqualRuntimeMatches(t *testing.T) {
 	meta := preparationstate.State{
 		DiscType: "BDMV",

--- a/internal/metadata/mediainfo/service.go
+++ b/internal/metadata/mediainfo/service.go
@@ -16,6 +16,7 @@ import (
 	gomediainfo "github.com/autobrr/go-mediainfo"
 
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	pathutil "github.com/autobrr/upbrr/internal/pathing"
 	paths "github.com/autobrr/upbrr/internal/pathing/layout"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -32,7 +33,9 @@ type Request struct {
 	DiscType   string
 	VideoPath  string
 	TempRoot   string
-	Release    api.ReleaseInfo
+	// ArtifactDir optionally selects a namespaced directory within TempRoot.
+	ArtifactDir string
+	Release     api.ReleaseInfo
 }
 
 // Result identifies persisted MediaInfo artifacts and optional DVD evidence.
@@ -99,9 +102,20 @@ func (s *Service) Export(ctx context.Context, req Request) (Result, error) {
 		return Result{}, errors.New("mediainfo: empty target")
 	}
 
-	tmpDir, _, err := paths.ReleaseTempDir(req.TempRoot, preparationstate.State{Release: req.Release}, req.SourcePath)
-	if err != nil {
-		return Result{}, fmt.Errorf("metadata: %w", err)
+	tmpDir := strings.TrimSpace(req.ArtifactDir)
+	if tmpDir == "" {
+		tmpDir, _, err = paths.ReleaseTempDir(req.TempRoot, preparationstate.State{Release: req.Release}, req.SourcePath)
+		if err != nil {
+			return Result{}, fmt.Errorf("metadata: %w", err)
+		}
+	} else {
+		tmpDir = filepath.Clean(tmpDir)
+		if !pathutil.IsWithinRoot(req.TempRoot, tmpDir) {
+			return Result{}, errors.New("mediainfo: artifact directory escapes temporary root")
+		}
+		if err := os.MkdirAll(tmpDir, 0o700); err != nil {
+			return Result{}, fmt.Errorf("mediainfo: create artifact directory: %w", err)
+		}
 	}
 	textPath := filepath.Join(tmpDir, "mediainfo.txt")
 	jsonPath := filepath.Join(tmpDir, "MediaInfo.json")

--- a/internal/metadata/playlist_selection.go
+++ b/internal/metadata/playlist_selection.go
@@ -10,96 +10,165 @@ import (
 	"path/filepath"
 	"strings"
 
-	preparationstate "github.com/autobrr/upbrr/internal/preparedrelease/state"
-
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
 	"github.com/autobrr/upbrr/internal/filesystem"
 	"github.com/autobrr/upbrr/internal/metadata/discparse"
+	preparationstate "github.com/autobrr/upbrr/internal/preparedrelease/state"
+	"github.com/autobrr/upbrr/internal/sourcelayout"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-// resolveBDMVPlaylistSelection resolves a direct or remembered selection only
-// against playlists discovered from the current BDMV resource root.
+// resolveBDMVPlaylistSelection resolves one complete selection against every
+// discovered BDMV and persists it only after all discs validate.
 func (s *Service) resolveBDMVPlaylistSelection(ctx context.Context, request preparationstate.Request) ([]api.PlaylistInfo, error) {
-	bdmvRoot := strings.TrimSpace(request.Layout.BDMVRoot)
-	if bdmvRoot == "" {
-		return nil, fmt.Errorf("metadata: BDMV resource root is unavailable: %w", internalerrors.ErrInvalidInput)
+	discs := request.Layout.Discs
+	if len(discs) == 0 {
+		return nil, fmt.Errorf("metadata: BDMV resources are unavailable: %w", internalerrors.ErrInvalidInput)
 	}
-	discovered, err := discoverBDMVPlaylists(ctx, bdmvRoot)
-	if err != nil {
-		return nil, fmt.Errorf("metadata: discover BDMV playlists: %w", err)
+	candidates := make([]api.PlaylistInfo, 0)
+	for _, disc := range discs {
+		if disc.Type != "BDMV" {
+			return nil, fmt.Errorf("metadata: invalid BDMV resource set: %w", internalerrors.ErrInvalidInput)
+		}
+		discovered, err := discoverBDMVPlaylists(ctx, disc.Root)
+		if err != nil {
+			return nil, fmt.Errorf("metadata: discover BDMV playlists: %w", err)
+		}
+		if len(discovered) == 0 {
+			return nil, playlistSelectionRequired(request, candidates)
+		}
+		for _, playlist := range discovered {
+			candidates = append(candidates, apiPlaylistForDisc(playlist, disc, len(discs) == 1))
+		}
 	}
 
 	instruction := request.Input.Instructions.Playlist
 	selected := append([]string(nil), instruction.Selected...)
 	useAll := instruction.UseAll
 	if !instruction.Set {
-		stored, lookupErr := s.repo.GetPlaylistSelection(ctx, playlistSelectionKey(request.Layout.SourcePath))
-		if lookupErr != nil {
-			if errors.Is(lookupErr, internalerrors.ErrNotFound) {
-				return nil, &api.PlaylistSelectionRequiredError{
-					SourcePath: request.Layout.SourcePath,
-					Candidates: apiPlaylists(discovered),
-				}
+		stored, err := s.repo.GetPlaylistSelection(ctx, playlistSelectionKey(request.Layout.SourcePath))
+		if err != nil {
+			if errors.Is(err, internalerrors.ErrNotFound) {
+				return nil, playlistSelectionRequired(request, candidates)
 			}
-			return nil, fmt.Errorf("metadata: load remembered playlist selection: %w", lookupErr)
+			return nil, fmt.Errorf("metadata: load remembered playlist selection: %w", err)
+		}
+		storedFingerprint := strings.TrimSpace(stored.SourceFingerprint)
+		currentFingerprint := strings.TrimSpace(request.SourceFingerprint)
+		if storedFingerprint != currentFingerprint && (storedFingerprint != "" || len(discs) != 1) {
+			return nil, playlistSelectionRequired(request, candidates)
 		}
 		selected = append([]string(nil), stored.SelectedPlaylists...)
 		useAll = stored.UseAll
 	}
 
+	resolved, err := resolvePlaylistIDs(request, candidates, selected, useAll)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(resolved))
+	for i := range resolved {
+		ids[i] = resolved[i].ID
+	}
+	if err := s.repo.SavePlaylistSelection(
+		ctx,
+		playlistSelectionKey(request.Layout.SourcePath),
+		strings.TrimSpace(request.SourceFingerprint),
+		ids,
+		useAll,
+	); err != nil {
+		return nil, fmt.Errorf("metadata: save playlist selection: %w", err)
+	}
+	return resolved, nil
+}
+
+func resolvePlaylistIDs(
+	request preparationstate.Request,
+	candidates []api.PlaylistInfo,
+	selected []string,
+	useAll bool,
+) ([]api.PlaylistInfo, error) {
 	if useAll {
-		return apiPlaylists(discovered), nil
+		return append([]api.PlaylistInfo(nil), candidates...), nil
 	}
 	if len(selected) == 0 {
-		return nil, &api.PlaylistSelectionRequiredError{
-			SourcePath: request.Layout.SourcePath,
-			Candidates: apiPlaylists(discovered),
-		}
+		return nil, playlistSelectionRequired(request, candidates)
 	}
 
-	byName := make(map[string]filesystem.PlaylistInfo, len(discovered))
-	for _, playlist := range discovered {
-		byName[discparse.NormalizePlaylistName(playlist.File)] = playlist
+	byID := make(map[string]api.PlaylistInfo, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.ID == "" {
+			return nil, fmt.Errorf("metadata: discovered playlist has no ID: %w", internalerrors.ErrInvalidInput)
+		}
+		if _, exists := byID[candidate.ID]; exists {
+			return nil, fmt.Errorf("metadata: duplicate playlist ID: %w", internalerrors.ErrInvalidInput)
+		}
+		byID[candidate.ID] = candidate
 	}
-	seen := make(map[string]struct{}, len(selected))
-	result := make([]api.PlaylistInfo, 0, len(selected))
+
+	selectedIDs := make(map[string]struct{}, len(selected))
+	selectedDiscs := make(map[string]struct{}, len(request.Layout.Discs))
 	for _, raw := range selected {
-		normalized, validationErr := validatePlaylistName(raw)
-		if validationErr != nil {
+		id, err := decodePlaylistSelectionID(raw, candidates, len(request.Layout.Discs) == 1)
+		if err != nil {
 			return nil, &api.InvalidPlaylistSelectionError{
 				SourcePath: request.Layout.SourcePath,
 				Playlist:   strings.TrimSpace(raw),
-				Reason:     validationErr.Error(),
+				Reason:     err.Error(),
 			}
 		}
-		if _, exists := seen[normalized]; exists {
-			return nil, &api.InvalidPlaylistSelectionError{
-				SourcePath: request.Layout.SourcePath,
-				Playlist:   normalized,
-				Reason:     "duplicate playlist",
-			}
+		if _, exists := selectedIDs[id]; exists {
+			continue
 		}
-		playlist, exists := byName[normalized]
-		if !exists {
-			return nil, &api.InvalidPlaylistSelectionError{
-				SourcePath: request.Layout.SourcePath,
-				Playlist:   normalized,
-				Reason:     "playlist was not found in the current source",
-			}
+		selectedIDs[id] = struct{}{}
+		selectedDiscs[byID[id].DiscID] = struct{}{}
+	}
+	if len(selectedDiscs) != len(request.Layout.Discs) {
+		return nil, &api.InvalidPlaylistSelectionError{
+			SourcePath: request.Layout.SourcePath,
+			Reason:     "at least one playlist must be selected for every disc",
 		}
-		seen[normalized] = struct{}{}
-		result = append(result, apiPlaylist(playlist))
+	}
+
+	result := make([]api.PlaylistInfo, 0, len(selectedIDs))
+	for _, candidate := range candidates {
+		if _, selected := selectedIDs[candidate.ID]; selected {
+			result = append(result, candidate)
+		}
 	}
 	return result, nil
 }
 
-// validatePlaylistName accepts one local MPLS filename and rejects paths or traversal.
-func validatePlaylistName(value string) (string, error) {
-	trimmed := strings.TrimSpace(value)
+func decodePlaylistSelectionID(raw string, candidates []api.PlaylistInfo, singleDisc bool) (string, error) {
+	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
-		return "", errors.New("playlist name is empty")
+		return "", errors.New("playlist ID is empty")
 	}
+	if !singleDisc {
+		for _, candidate := range candidates {
+			if candidate.ID == trimmed {
+				return candidate.ID, nil
+			}
+		}
+		return "", errors.New("playlist ID was not found in the current source")
+	}
+
+	normalized, err := validateLegacyPlaylistName(trimmed)
+	if err != nil {
+		return "", err
+	}
+	for _, candidate := range candidates {
+		if strings.EqualFold(candidate.ID, normalized) {
+			return candidate.ID, nil
+		}
+	}
+	return "", errors.New("playlist was not found in the current source")
+}
+
+// validateLegacyPlaylistName is the only compatibility decoder that treats a
+// selection as a one-disc MPLS basename.
+func validateLegacyPlaylistName(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
 	if filepath.IsAbs(trimmed) || filepath.VolumeName(trimmed) != "" || strings.ContainsAny(trimmed, `/\\`) || trimmed == "." || trimmed == ".." {
 		return "", errors.New("playlist name must be a local filename")
 	}
@@ -110,28 +179,33 @@ func validatePlaylistName(value string) (string, error) {
 	return normalized, nil
 }
 
+func playlistSelectionRequired(request preparationstate.Request, candidates []api.PlaylistInfo) error {
+	return &api.PlaylistSelectionRequiredError{
+		SourcePath: request.Layout.SourcePath,
+		Candidates: append([]api.PlaylistInfo(nil), candidates...),
+	}
+}
+
 // playlistSelectionKey preserves the repository's slash-normalized source key.
 func playlistSelectionKey(sourcePath string) string {
 	return filepath.ToSlash(filepath.Clean(sourcePath))
 }
 
-// apiPlaylists projects discovered filesystem playlists into detached API values.
-func apiPlaylists(values []filesystem.PlaylistInfo) []api.PlaylistInfo {
-	result := make([]api.PlaylistInfo, 0, len(values))
-	for _, value := range values {
-		result = append(result, apiPlaylist(value))
-	}
-	return result
-}
-
-// apiPlaylist projects one filesystem playlist and detaches its item list.
-func apiPlaylist(value filesystem.PlaylistInfo) api.PlaylistInfo {
+func apiPlaylistForDisc(value filesystem.PlaylistInfo, disc sourcelayout.DiscResource, singleDisc bool) api.PlaylistInfo {
 	items := make([]api.PlaylistItem, 0, len(value.Items))
 	for _, item := range value.Items {
 		items = append(items, api.PlaylistItem{File: item.File, Size: item.Size})
 	}
+	file := discparse.NormalizePlaylistName(value.File)
+	id := file
+	if !singleDisc {
+		id = disc.ID + ":" + file
+	}
 	return api.PlaylistInfo{
-		File:     value.File,
+		ID:       id,
+		DiscID:   disc.ID,
+		DiscName: disc.Name,
+		File:     file,
 		Duration: value.Duration,
 		Items:    items,
 		Score:    value.Score,

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -69,6 +69,7 @@ type repository interface {
 	GetReleaseNameOverrides(context.Context, string) (api.ReleaseNameOverrides, error)
 	SaveReleaseNameOverrides(context.Context, string, api.ReleaseNameOverrides) error
 	GetPlaylistSelection(context.Context, string) (api.PlaylistSelection, error)
+	SavePlaylistSelection(context.Context, string, string, []string, bool) error
 	GetTrackerTimestamp(context.Context, string) (time.Time, error)
 	SaveTrackerTimestamp(context.Context, api.TrackerTimestamp) error
 	SaveTrackerMetadata(context.Context, api.TrackerMetadata) error
@@ -425,78 +426,24 @@ func (s *Service) collectSourceEvidence(ctx context.Context, request preparation
 		s.logger.Debugf("metadata: detected disc type %s", discType)
 	}
 
-	// For BDMV discs, check if a playlist was selected
-	if discType == "BDMV" {
-		s.logger.Debugf("metadata: checking playlist selection, bdinfo=%v", s.bdinfo != nil)
-		selectedPlaylists, derr := s.resolveBDMVPlaylistSelection(ctx, request)
-		if derr != nil {
+	if discType != "" {
+		if discType == "BDMV" && s.bdinfo != nil {
+			bdinfoActive = true
+			reportBDInfo(api.PreparationProgressRunning, "Analyzing selected Blu-ray playlists.")
+		}
+		if derr := s.collectDiscEvidence(ctx, request, &meta, reportBDInfo); derr != nil {
+			if discType == "BDMV" && s.bdinfo != nil {
+				bdinfoTerminal = true
+				reportBDInfo(api.PreparationProgressFailed, "Blu-ray analysis failed.")
+			}
 			return preparationstate.State{}, derr
 		}
-		meta.SelectedBDMVPlaylists = selectedPlaylists
-		if len(selectedPlaylists) > 0 {
-			playlistPath := request.Layout.BDMVRoot
-			s.logger.Debugf("metadata: resolved playlist selection playlists=%d", len(selectedPlaylists))
-			selectedPlaylistNames := playlistNames(meta.SelectedBDMVPlaylists)
-
-			// Execute BDInfo on selected playlists
-			if s.bdinfo != nil {
-				bdinfoActive = true
-				reportBDInfo(api.PreparationProgressRunning, "Analyzing selected Blu-ray playlists.")
-				tmpRoot, rerr := db.Subdir(s.cfg.MainSettings.DBPath, "tmp")
-				if rerr != nil {
-					bdinfoTerminal = true
-					reportBDInfo(api.PreparationProgressFailed, "Blu-ray analysis failed.")
-					return preparationstate.State{}, fmt.Errorf("metadata: resolve tmp root: %w", rerr)
-				}
-				tmpDir, _, rerr := paths.ReleaseTempDir(tmpRoot, meta, primary)
-				if rerr != nil {
-					return preparationstate.State{}, fmt.Errorf("metadata: resolve bdinfo temp dir: %w", rerr)
-				}
-				s.logger.Debugf("metadata: bdinfo temp dir: %s", tmpDir)
-				if err := os.MkdirAll(tmpDir, 0755); err != nil {
-					return preparationstate.State{}, fmt.Errorf("metadata: create bdinfo temp dir: %w", err)
-				}
-
-				analysisCtx := bdinfo.WithProgressReporter(ctx, func(message string) {
-					reportBDInfo(api.PreparationProgressRunning, message)
-				})
-				outputPath, needScan, berr := s.resolveOrCreateBDMVSummaries(analysisCtx, input, tmpDir, playlistPath, selectedPlaylistNames)
-				if berr != nil {
-					bdinfoTerminal = true
-					reportBDInfo(api.PreparationProgressFailed, "Blu-ray analysis failed.")
-					return preparationstate.State{}, berr
-				}
-				if strings.TrimSpace(outputPath) != "" {
-					s.logger.Debugf("metadata: parsing canonical bdinfo output from %s", outputPath)
-					bdinfoParsed, perr := parseBDInfoOutput(s.bdinfo, outputPath)
-					if perr != nil {
-						return preparationstate.State{}, fmt.Errorf("metadata: bdinfo parse failed: %w", perr)
-					}
-					meta.BDInfo = bdinfoParsed
-					s.logger.Debugf("metadata: bdinfo data collected with %d fields", len(bdinfoParsed))
-				}
-				if needScan {
-					s.logger.Debugf("metadata: bdinfo scan completed for %d selected playlists", len(selectedPlaylistNames))
-					reportBDInfo(api.PreparationProgressCompleted, "Blu-ray analysis complete.")
-					bdinfoTerminal = true
-				} else {
-					reportBDInfo(api.PreparationProgressSkipped, "Reused cached Blu-ray analysis.")
-					bdinfoTerminal = true
-				}
-			} else {
-				s.logger.Debugf("metadata: bdinfo service is nil, skipping disc analysis")
+		if discType == "BDMV" {
+			bdinfoTerminal = true
+			if s.bdinfo == nil {
 				api.SkipPreparationProgress(ctx, api.PreparationPhaseBDInfo, "Blu-ray analysis is unavailable.")
-			}
-
-			// Extract m2ts files from selected playlist(s)
-			m2tsFiles, mainFile, err := s.extractM2TSFromPlaylist(playlistPath, selectedPlaylistNames)
-			if err != nil {
-				s.logger.Debugf("metadata: failed to extract m2ts from playlist: %v", err)
-				// Fall back to regular disc handling
-			} else if mainFile != "" && len(m2tsFiles) > 0 {
-				meta.VideoPath = mainFile
-				meta.FileList = m2tsFiles
-				s.logger.Debugf("metadata: extracted m2ts files count=%d main=%s", len(m2tsFiles), filepath.Base(mainFile))
+			} else {
+				reportBDInfo(api.PreparationProgressCompleted, "Blu-ray analysis complete.")
 			}
 		}
 	}
@@ -620,7 +567,7 @@ func (s *Service) collectSourceEvidence(ctx context.Context, request preparation
 	default:
 	}
 
-	if s.mi != nil {
+	if s.mi != nil && discType == "" {
 		tmpRoot, err := db.Subdir(s.cfg.MainSettings.DBPath, "tmp")
 		if err != nil {
 			return preparationstate.State{}, fmt.Errorf("metadata: tmp dir: %w", err)
@@ -730,6 +677,228 @@ func (s *Service) collectSourceEvidence(ctx context.Context, request preparation
 	s.logger.Debugf("metadata: persisted metadata for %s", primary)
 
 	return meta, nil
+}
+
+func (s *Service) collectDiscEvidence(
+	ctx context.Context,
+	request preparationstate.Request,
+	meta *preparationstate.State,
+	reportBDInfo func(api.PreparationProgressStatus, string),
+) error {
+	if meta == nil || len(request.Layout.Discs) == 0 {
+		return fmt.Errorf("metadata: disc resources are unavailable: %w", internalerrors.ErrInvalidInput)
+	}
+
+	selectedByDisc := map[string][]api.PlaylistInfo{}
+	if request.Layout.DiscType == "BDMV" {
+		selected, err := s.resolveBDMVPlaylistSelection(ctx, request)
+		if err != nil {
+			return err
+		}
+		meta.SelectedBDMVPlaylists = selected
+		for _, playlist := range selected {
+			selectedByDisc[playlist.DiscID] = append(selectedByDisc[playlist.DiscID], playlist)
+		}
+	}
+
+	var tmpRoot string
+	var releaseTemp string
+	if s.bdinfo != nil || s.mi != nil {
+		var err error
+		tmpRoot, err = db.Subdir(s.cfg.MainSettings.DBPath, "tmp")
+		if err != nil {
+			return fmt.Errorf("metadata: resolve tmp root: %w", err)
+		}
+		releaseTemp, _, err = paths.ReleaseTempDir(tmpRoot, *meta, meta.SourcePath)
+		if err != nil {
+			return fmt.Errorf("metadata: resolve release temp dir: %w", err)
+		}
+	}
+
+	resources := make([]preparationstate.DiscResource, 0, len(request.Layout.Discs))
+	for _, disc := range request.Layout.Discs {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("metadata: disc analysis canceled: %w", err)
+		}
+		resource := preparationstate.DiscResource{
+			ID:   disc.ID,
+			Name: disc.Name,
+			Type: disc.Type,
+			Root: disc.Root,
+		}
+		artifactDir := ""
+		if releaseTemp != "" {
+			var err error
+			artifactDir, err = paths.DiscTempDir(releaseTemp, disc.ID)
+			if err != nil {
+				return fmt.Errorf("metadata: resolve disc artifact directory: %w", err)
+			}
+			if err := os.MkdirAll(artifactDir, 0o700); err != nil {
+				return fmt.Errorf("metadata: create disc artifact directory: %w", err)
+			}
+		}
+
+		if disc.Type == "BDMV" {
+			resource.SelectedPlaylists = append([]api.PlaylistInfo(nil), selectedByDisc[disc.ID]...)
+			if len(resource.SelectedPlaylists) == 0 {
+				return &api.InvalidPlaylistSelectionError{Reason: "at least one playlist must be selected for every disc"}
+			}
+			playlistFiles := playlistNames(resource.SelectedPlaylists)
+			files, video, err := s.extractM2TSFromPlaylist(disc.Root, playlistFiles)
+			if err != nil {
+				s.logger.Debugf("metadata: failed to extract selected streams disc=%s err=%s", disc.Name, redaction.RedactValue(err.Error(), nil))
+			} else {
+				resource.FileList = files
+				resource.VideoPath = video
+			}
+
+			if s.bdinfo != nil {
+				analysisCtx := bdinfo.WithProgressReporter(ctx, func(message string) {
+					reportBDInfo(api.PreparationProgressRunning, message)
+				})
+				outputPath, _, err := s.resolveOrCreateBDMVSummaries(analysisCtx, request.Input, artifactDir, disc.Root, playlistFiles)
+				if err != nil {
+					return fmt.Errorf("metadata: analyze BDMV disc %s: %w", disc.Name, err)
+				}
+				resource.Reports, err = loadBDMVDiscReports(artifactDir, resource.SelectedPlaylists)
+				if err != nil {
+					return err
+				}
+				if meta.BDInfo == nil && strings.TrimSpace(outputPath) != "" {
+					parsed, err := parseBDInfoOutput(s.bdinfo, outputPath)
+					if err != nil {
+						return fmt.Errorf("metadata: parse BDInfo: %w", err)
+					}
+					meta.BDInfo = parsed
+				}
+			}
+		}
+
+		if s.mi != nil {
+			result, err := s.mi.Export(ctx, mediainfo.Request{
+				SourcePath:  disc.Root,
+				DiscType:    disc.Type,
+				VideoPath:   resource.VideoPath,
+				TempRoot:    tmpRoot,
+				ArtifactDir: artifactDir,
+				Release:     meta.Release,
+			})
+			if err != nil {
+				return fmt.Errorf("metadata: disc MediaInfo: %w", err)
+			}
+			resource.MediaInfoJSONPath = result.JSONPath
+			resource.MediaInfoTextPath = result.TextPath
+			resource.DVDIFOPath = result.IFOPath
+			resource.DVDVOBPath = result.VOBPath
+			resource.DVDVOBSet = result.VOBSet
+			resource.DVDVOBMediaInfoJSON = result.VOBJSON
+			resource.DVDVOBMediaInfoText = result.VOBText
+			if disc.Type == "DVD" {
+				doc, err := loadMediaInfoDocFromJSONPayload(result.VOBJSON)
+				if err != nil {
+					return fmt.Errorf("metadata: parse DVD title MediaInfo: %w", err)
+				}
+				resource.DurationSeconds = mediaDurationSeconds(doc)
+				if err := s.persistDiscDVDMediaInfo(ctx, *meta, resource, len(request.Layout.Discs) == 1); err != nil {
+					return err
+				}
+			}
+		}
+		resources = append(resources, resource)
+	}
+
+	meta.Discs = resources
+	applyPrimaryDiscCompatibility(meta)
+	return nil
+}
+
+func loadBDMVDiscReports(dir string, playlists []api.PlaylistInfo) ([]preparationstate.DiscReportResource, error) {
+	reports := make([]preparationstate.DiscReportResource, 0, len(playlists))
+	for _, playlist := range playlists {
+		summaryPath := paths.BDMVSummaryPath(dir, playlist.File)
+		extPath := paths.BDMVExtSummaryPath(dir, playlist.File)
+		fullPath := paths.BDMVFullSummaryPath(dir, playlist.File)
+		summary, err := os.ReadFile(summaryPath)
+		if err != nil {
+			return nil, fmt.Errorf("metadata: read selected BDInfo summary: %w", err)
+		}
+		extended, err := os.ReadFile(extPath)
+		if err != nil {
+			return nil, fmt.Errorf("metadata: read selected extended BDInfo summary: %w", err)
+		}
+		full, err := os.ReadFile(fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("metadata: read selected full BDInfo summary: %w", err)
+		}
+		reports = append(reports, preparationstate.DiscReportResource{
+			Playlist:        playlist,
+			Summary:         strings.TrimSpace(string(summary)),
+			ExtSummary:      strings.TrimSpace(string(extended)),
+			FullSummary:     strings.TrimSpace(string(full)),
+			SummaryPath:     summaryPath,
+			ExtSummaryPath:  extPath,
+			FullSummaryPath: fullPath,
+		})
+	}
+	return reports, nil
+}
+
+func (s *Service) persistDiscDVDMediaInfo(
+	ctx context.Context,
+	meta preparationstate.State,
+	disc preparationstate.DiscResource,
+	singleDisc bool,
+) error {
+	meta.SourcePath = disc.Root
+	meta.MediaInfoJSONPath = disc.MediaInfoJSONPath
+	meta.MediaInfoTextPath = disc.MediaInfoTextPath
+	meta.DVDIFOPath = disc.DVDIFOPath
+	meta.DVDVOBPath = disc.DVDVOBPath
+	meta.DVDVOBSet = disc.DVDVOBSet
+	meta.DVDVOBMediaInfoJSON = disc.DVDVOBMediaInfoJSON
+	meta.DVDVOBMediaInfoText = disc.DVDVOBMediaInfoText
+	details := extractDVDMediaInfo(meta)
+	if singleDisc {
+		details.SourcePath = meta.Paths[0]
+	} else {
+		details.SourcePath = disc.Root
+	}
+	details.IFOPath = disc.DVDIFOPath
+	details.VOBPath = disc.DVDVOBPath
+	details.VOBSet = disc.DVDVOBSet
+	details.MediaInfoJSON = disc.MediaInfoJSONPath
+	details.MediaInfoText = disc.MediaInfoTextPath
+	details.VOBMediaInfoRaw = metautil.FirstNonEmptyTrimmed(disc.DVDVOBMediaInfoText, disc.DVDVOBMediaInfoJSON)
+	details.UpdatedAt = time.Now().UTC()
+	if err := s.repo.SaveDVDMediaInfo(ctx, details); err != nil {
+		return fmt.Errorf("metadata: persist DVD MediaInfo: %w", err)
+	}
+	return nil
+}
+
+func applyPrimaryDiscCompatibility(meta *preparationstate.State) {
+	if meta == nil {
+		return
+	}
+	meta.FileList = nil
+	for _, disc := range meta.Discs {
+		meta.FileList = append(meta.FileList, disc.FileList...)
+	}
+	for _, disc := range meta.Discs {
+		if len(disc.SelectedPlaylists) == 0 && strings.TrimSpace(disc.DVDVOBSet) == "" &&
+			strings.TrimSpace(disc.VideoPath) == "" && strings.TrimSpace(disc.DVDIFOPath) == "" && strings.TrimSpace(disc.MediaInfoJSONPath) == "" {
+			continue
+		}
+		meta.VideoPath = disc.VideoPath
+		meta.MediaInfoJSONPath = disc.MediaInfoJSONPath
+		meta.MediaInfoTextPath = disc.MediaInfoTextPath
+		meta.DVDIFOPath = disc.DVDIFOPath
+		meta.DVDVOBPath = disc.DVDVOBPath
+		meta.DVDVOBSet = disc.DVDVOBSet
+		meta.DVDVOBMediaInfoJSON = disc.DVDVOBMediaInfoJSON
+		meta.DVDVOBMediaInfoText = disc.DVDVOBMediaInfoText
+		return
+	}
 }
 
 // sceneResultHasData reports whether a scene detector returned metadata worth

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -660,7 +660,7 @@ func TestPrepareBDMVMultiPlaylistUsesFullScanAndDerivesSummaries(t *testing.T) {
 	if !reflect.DeepEqual(sortedStrings(meta.FileList), sortedStrings(wantFiles)) {
 		t.Fatalf("unexpected file list: %#v", meta.FileList)
 	}
-	if len(meta.SelectedBDMVPlaylists) != 2 || meta.SelectedBDMVPlaylists[0].File != "00002.MPLS" || meta.SelectedBDMVPlaylists[1].File != "00001.MPLS" {
+	if len(meta.SelectedBDMVPlaylists) != 2 || meta.SelectedBDMVPlaylists[0].File != "00001.MPLS" || meta.SelectedBDMVPlaylists[1].File != "00002.MPLS" {
 		t.Fatalf("unexpected selected playlists: %#v", meta.SelectedBDMVPlaylists)
 	}
 
@@ -668,10 +668,7 @@ func TestPrepareBDMVMultiPlaylistUsesFullScanAndDerivesSummaries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tmp root: %v", err)
 	}
-	tmpDir, _, err := paths.ReleaseTempDir(tmpRoot, meta, sourcePath)
-	if err != nil {
-		t.Fatalf("tmp dir: %v", err)
-	}
+	tmpDir := firstDiscTempDir(t, tmpRoot, sourcePath)
 
 	assertFileContains(t, paths.BDMVSummaryPath(tmpDir, "00002.MPLS"), "Playlist: 00002.MPLS")
 	assertFileContains(t, paths.BDMVSummaryPath(tmpDir, "00001.MPLS"), "Playlist: 00001.MPLS")
@@ -697,7 +694,16 @@ func TestResolveBDMVPlaylistSelectionRejectsUnknownDirectPlaylist(t *testing.T) 
 			Set:      true,
 			Selected: []string{"00001.MPLS", "00002.MPLS"},
 		}}},
-		Layout: sourcelayout.Layout{SourcePath: `D:\Disc`, BDMVRoot: `D:\Disc\BDMV`},
+		Layout: sourcelayout.Layout{
+			SourcePath: "Disc",
+			DiscType:   "BDMV",
+			Discs: []sourcelayout.DiscResource{{
+				ID:   "disc-test",
+				Name: "Disc 1",
+				Type: "BDMV",
+				Root: filepath.Join("Disc", "BDMV"),
+			}},
+		},
 	})
 	var invalid *api.InvalidPlaylistSelectionError
 	if !errors.As(err, &invalid) || invalid.Playlist != "00002.MPLS" {
@@ -721,12 +727,245 @@ func TestResolveBDMVPlaylistSelectionRequiredIncludesCandidates(t *testing.T) {
 	}
 
 	_, err := (&Service{repo: &fakeRepo{}}).resolveBDMVPlaylistSelection(context.Background(), preparationstate.Request{
-		Layout: sourcelayout.Layout{SourcePath: `D:\Disc`, BDMVRoot: `D:\Disc\BDMV`},
+		Layout: sourcelayout.Layout{
+			SourcePath: "Disc",
+			DiscType:   "BDMV",
+			Discs: []sourcelayout.DiscResource{{
+				ID:   "disc-test",
+				Name: "Disc 1",
+				Type: "BDMV",
+				Root: filepath.Join("Disc", "BDMV"),
+			}},
+		},
 	})
 	var required *api.PlaylistSelectionRequiredError
 	if !errors.As(err, &required) || len(required.Candidates) != 1 || required.Candidates[0].File != "00001.MPLS" ||
 		required.Candidates[0].Duration != 5400 || len(required.Candidates[0].Items) != 1 {
 		t.Fatalf("playlist selection error candidates = %#v", required)
+	}
+}
+
+func TestResolveBDMVPlaylistSelectionKeepsDuplicateBasenamesDiscScoped(t *testing.T) {
+	originalDiscover := discoverBDMVPlaylists
+	t.Cleanup(func() { discoverBDMVPlaylists = originalDiscover })
+	discoverBDMVPlaylists = func(_ context.Context, _ string) ([]filesystem.PlaylistInfo, error) {
+		return []filesystem.PlaylistInfo{{
+File: "00001.MPLS",
+ Duration: 5400,
+ Score: 100,
+}}, nil
+	}
+
+	repo := &stubRepo{}
+	request := preparationstate.Request{
+		Input: api.PrepareInput{Instructions: api.ReleaseFactInstructions{Playlist: api.PlaylistInstruction{
+			Set:      true,
+			Selected: []string{"disc-a:00001.MPLS", "disc-b:00001.MPLS"},
+		}}},
+		Layout: sourcelayout.Layout{
+			SourcePath: "Collection",
+			DiscType:   "BDMV",
+			Discs: []sourcelayout.DiscResource{
+				{
+ID: "disc-a",
+ Name: "Disc 1",
+ Type: "BDMV",
+ Root: filepath.Join("Collection", "Disc 1", "BDMV"),
+},
+				{
+ID: "disc-b",
+ Name: "Disc 2",
+ Type: "BDMV",
+ Root: filepath.Join("Collection", "Disc 2", "BDMV"),
+},
+			},
+		},
+		SourceFingerprint: "inventory-fingerprint",
+	}
+	selected, err := (&Service{repo: repo}).resolveBDMVPlaylistSelection(context.Background(), request)
+	if err != nil {
+		t.Fatalf("resolve selection: %v", err)
+	}
+	want := []string{"disc-a:00001.MPLS", "disc-b:00001.MPLS"}
+	got := []string{selected[0].ID, selected[1].ID}
+	if !slices.Equal(got, want) || !slices.Equal(repo.playlistSelection.SelectedPlaylists, want) ||
+		repo.playlistSelection.SourceFingerprint != request.SourceFingerprint {
+		t.Fatalf("resolved=%#v stored=%#v", selected, repo.playlistSelection)
+	}
+}
+
+func TestCollectDiscEvidenceNamespacesDuplicatePlaylists(t *testing.T) {
+	originalDiscover := discoverBDMVPlaylists
+	originalParse := parseBDMVPlaylist
+	t.Cleanup(func() {
+		discoverBDMVPlaylists = originalDiscover
+		parseBDMVPlaylist = originalParse
+	})
+
+	base := t.TempDir()
+	sourcePath := filepath.Join(base, "Example.Release.2026.COMPLETE.BLURAY-GRP")
+	for _, name := range []string{"Disc 1", "Disc 2"} {
+		if err := os.MkdirAll(filepath.Join(sourcePath, name, "BDMV", "PLAYLIST"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(sourcePath, name, "BDMV", "STREAM"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	layout, err := sourcelayout.Resolve(context.Background(), sourcePath)
+	if err != nil {
+		t.Fatalf("resolve layout: %v", err)
+	}
+	discoverBDMVPlaylists = func(_ context.Context, _ string) ([]filesystem.PlaylistInfo, error) {
+		return []filesystem.PlaylistInfo{{
+File: "00001.MPLS",
+ Duration: 5400,
+ Score: 100,
+}}, nil
+	}
+	parseBDMVPlaylist = func(_ string) (float64, []filesystem.PlaylistItem, error) {
+		return 5400, []filesystem.PlaylistItem{{File: "00001.m2ts", Size: 100}}, nil
+	}
+
+	dbPath := filepath.Join(base, "upbrr.db")
+	tmpRoot, err := db.Subdir(dbPath, "tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseDir, _, err := paths.ReleaseTempDirFor(tmpRoot, sourcePath, api.ReleaseInfo{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index, disc := range layout.Discs {
+		discDir, err := paths.DiscTempDir(releaseDir, disc.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(discDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		writeBDMVSummaryFixture(t, discDir, "00001.MPLS", fmt.Sprintf("extended summary %d", index+1))
+	}
+
+	selected := make([]string, 0, len(layout.Discs))
+	for _, disc := range layout.Discs {
+		selected = append(selected, disc.ID+":00001.MPLS")
+	}
+	service := NewService(
+		&stubRepo{},
+		WithConfig(config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}}),
+		WithBDInfoService(bdinfo.New(api.NopLogger{})),
+		WithMediaInfoExporter(&stubMediaInfo{}),
+	)
+	meta := preparationstate.State{
+SourcePath: sourcePath,
+ Paths: []string{sourcePath},
+ DiscType: "BDMV",
+}
+	err = service.collectDiscEvidence(context.Background(), preparationstate.Request{
+		Input: api.PrepareInput{SourcePath: sourcePath, Instructions: api.ReleaseFactInstructions{Playlist: api.PlaylistInstruction{
+			Set: true, Selected: selected,
+		}}},
+		Layout:            layout,
+		SourceFingerprint: "inventory-fingerprint",
+	}, &meta, func(api.PreparationProgressStatus, string) {})
+	if err != nil {
+		t.Fatalf("collect disc evidence: %v", err)
+	}
+	if len(meta.Discs) != 2 || len(meta.SelectedBDMVPlaylists) != 2 || len(meta.FileList) != 2 {
+		t.Fatalf("disc evidence = discs:%d playlists:%d files:%d", len(meta.Discs), len(meta.SelectedBDMVPlaylists), len(meta.FileList))
+	}
+	firstPath := meta.Discs[0].Reports[0].SummaryPath
+	secondPath := meta.Discs[1].Reports[0].SummaryPath
+	if firstPath == secondPath || !strings.Contains(firstPath, meta.Discs[0].ID) || !strings.Contains(secondPath, meta.Discs[1].ID) {
+		t.Fatalf("report paths are not disc-scoped: %q %q", firstPath, secondPath)
+	}
+	if meta.Discs[0].Reports[0].Playlist.ID == meta.Discs[1].Reports[0].Playlist.ID {
+		t.Fatal("duplicate playlist basenames shared an ID")
+	}
+}
+
+func TestResolveBDMVPlaylistSelectionRejectsIncompleteMultiDiscAtomically(t *testing.T) {
+	originalDiscover := discoverBDMVPlaylists
+	t.Cleanup(func() { discoverBDMVPlaylists = originalDiscover })
+	discoverBDMVPlaylists = func(_ context.Context, _ string) ([]filesystem.PlaylistInfo, error) {
+		return []filesystem.PlaylistInfo{{File: "00001.MPLS", Duration: 5400}}, nil
+	}
+
+	repo := &stubRepo{}
+	_, err := (&Service{repo: repo}).resolveBDMVPlaylistSelection(context.Background(), preparationstate.Request{
+		Input: api.PrepareInput{Instructions: api.ReleaseFactInstructions{Playlist: api.PlaylistInstruction{
+			Set:      true,
+			Selected: []string{"disc-a:00001.MPLS"},
+		}}},
+		Layout: sourcelayout.Layout{
+SourcePath: "Collection",
+ DiscType: "BDMV",
+ Discs: []sourcelayout.DiscResource{
+			{
+ID: "disc-a",
+ Name: "Disc 1",
+ Type: "BDMV",
+ Root: filepath.Join("Collection", "Disc 1", "BDMV"),
+},
+			{
+ID: "disc-b",
+ Name: "Disc 2",
+ Type: "BDMV",
+ Root: filepath.Join("Collection", "Disc 2", "BDMV"),
+},
+		},
+},
+		SourceFingerprint: "inventory-fingerprint",
+	})
+	var invalid *api.InvalidPlaylistSelectionError
+	if !errors.As(err, &invalid) || !strings.Contains(invalid.Error(), "every disc") {
+		t.Fatalf("selection error = %v", err)
+	}
+	if repo.playlistSelectionSaveCalls != 0 {
+		t.Fatalf("partial selection was saved %d time(s)", repo.playlistSelectionSaveCalls)
+	}
+}
+
+func TestResolveBDMVPlaylistSelectionRejectsStaleAndMultiDiscLegacyState(t *testing.T) {
+	originalDiscover := discoverBDMVPlaylists
+	t.Cleanup(func() { discoverBDMVPlaylists = originalDiscover })
+	discoverBDMVPlaylists = func(_ context.Context, _ string) ([]filesystem.PlaylistInfo, error) {
+		return []filesystem.PlaylistInfo{{File: "00001.MPLS", Duration: 5400}}, nil
+	}
+
+	for _, storedFingerprint := range []string{"old-inventory", ""} {
+		t.Run("fingerprint="+storedFingerprint, func(t *testing.T) {
+			repo := &stubRepo{playlistSelection: db.PlaylistSelection{
+				SourceFingerprint: storedFingerprint,
+				SelectedPlaylists: []string{"disc-a:00001.MPLS", "disc-b:00001.MPLS"},
+			}}
+			_, err := (&Service{repo: repo}).resolveBDMVPlaylistSelection(context.Background(), preparationstate.Request{
+				Layout: sourcelayout.Layout{
+SourcePath: "Collection",
+ DiscType: "BDMV",
+ Discs: []sourcelayout.DiscResource{
+					{
+ID: "disc-a",
+ Name: "Disc 1",
+ Type: "BDMV",
+ Root: filepath.Join("Collection", "Disc 1", "BDMV"),
+},
+					{
+ID: "disc-b",
+ Name: "Disc 2",
+ Type: "BDMV",
+ Root: filepath.Join("Collection", "Disc 2", "BDMV"),
+},
+				},
+},
+				SourceFingerprint: "current-inventory",
+			})
+			var required *api.PlaylistSelectionRequiredError
+			if !errors.As(err, &required) {
+				t.Fatalf("selection error = %v", err)
+			}
+		})
 	}
 }
 
@@ -860,10 +1099,7 @@ func TestPrepareBDMVUsesCachedSummariesWithoutRescan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tmp root: %v", err)
 	}
-	tmpDir, _, err := paths.ReleaseTempDir(tmpRoot, preparationstate.State{}, sourcePath)
-	if err != nil {
-		t.Fatalf("tmp dir: %v", err)
-	}
+	tmpDir := firstDiscTempDir(t, tmpRoot, sourcePath)
 	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
 		t.Fatalf("mkdir tmp dir: %v", err)
 	}
@@ -890,7 +1126,7 @@ func TestPrepareBDMVUsesCachedSummariesWithoutRescan(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected BDInfo summary string, got %T", meta.BDInfo["summary"])
 	}
-	if !strings.Contains(got, "Playlist: 00002.MPLS") {
+	if !strings.Contains(got, "Playlist: 00001.MPLS") {
 		t.Fatalf("expected cached canonical summary for first selected playlist, got %#v", meta.BDInfo)
 	}
 }
@@ -1000,10 +1236,7 @@ func TestPrepareBDMVDirectPlaylistInvokesBDInfoForParentAndRoot(t *testing.T) {
 		if err != nil {
 			t.Fatalf("tmp root: %v", err)
 		}
-		tmpDir, _, err := paths.ReleaseTempDir(tmpRoot, meta, requestedSource)
-		if err != nil {
-			t.Fatalf("tmp dir: %v", err)
-		}
+		tmpDir := firstDiscTempDir(t, tmpRoot, requestedSource)
 		assertFileContains(t, paths.BDMVSummaryPath(tmpDir, "00001.MPLS"), "Playlist: 00001.MPLS")
 		assertFileContains(t, paths.BDMVExtSummaryPath(tmpDir, "00001.MPLS"), "extended summary one")
 		assertFileContains(t, paths.BDMVFullSummaryPath(tmpDir, "00001.MPLS"), "QUICK SUMMARY:")
@@ -1065,10 +1298,7 @@ func TestPrepareBDMVPartialCacheRequiresConfirmation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tmp root: %v", err)
 	}
-	tmpDir, _, err := paths.ReleaseTempDir(tmpRoot, preparationstate.State{}, sourcePath)
-	if err != nil {
-		t.Fatalf("tmp dir: %v", err)
-	}
+	tmpDir := firstDiscTempDir(t, tmpRoot, sourcePath)
 	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
 		t.Fatalf("mkdir tmp dir: %v", err)
 	}
@@ -1186,10 +1416,7 @@ func TestPrepareBDMVPartialCacheRescansWhenConfirmed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tmp root: %v", err)
 	}
-	tmpDir, _, err := paths.ReleaseTempDir(tmpRoot, preparationstate.State{}, sourcePath)
-	if err != nil {
-		t.Fatalf("tmp dir: %v", err)
-	}
+	tmpDir := firstDiscTempDir(t, tmpRoot, sourcePath)
 	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
 		t.Fatalf("mkdir tmp dir: %v", err)
 	}
@@ -1210,12 +1437,13 @@ func TestPrepareBDMVPartialCacheRescansWhenConfirmed(t *testing.T) {
 }
 
 type stubRepo struct {
-	saved                   db.FileMetadata
-	existing                db.FileMetadata
-	releaseNameOverrides    db.ReleaseNameOverrides
-	releaseNameOverridesErr error
-	playlistSelection       db.PlaylistSelection
-	playlistSelectionPath   string
+	saved                      db.FileMetadata
+	existing                   db.FileMetadata
+	releaseNameOverrides       db.ReleaseNameOverrides
+	releaseNameOverridesErr    error
+	playlistSelection          db.PlaylistSelection
+	playlistSelectionPath      string
+	playlistSelectionSaveCalls int
 }
 
 type stubMediaInfo struct{}
@@ -1420,11 +1648,19 @@ func (s *stubRepo) GetPlaylistSelection(_ context.Context, path string) (db.Play
 	if len(s.playlistSelection.SelectedPlaylists) > 0 && (s.playlistSelectionPath == "" || s.playlistSelectionPath == path) {
 		return s.playlistSelection, nil
 	}
-	return db.PlaylistSelection{}, internalerrors.ErrNotImplemented
+	return db.PlaylistSelection{}, internalerrors.ErrNotFound
 }
 
-func (s *stubRepo) SavePlaylistSelection(context.Context, string, []string, bool) error {
-	return internalerrors.ErrNotImplemented
+func (s *stubRepo) SavePlaylistSelection(_ context.Context, path string, fingerprint string, playlists []string, useAll bool) error {
+	s.playlistSelectionSaveCalls++
+	s.playlistSelectionPath = path
+	s.playlistSelection = db.PlaylistSelection{
+		SourcePath:        path,
+		SourceFingerprint: fingerprint,
+		SelectedPlaylists: append([]string(nil), playlists...),
+		UseAll:            useAll,
+	}
+	return nil
 }
 
 func (s *stubRepo) DeletePlaylistSelection(context.Context, string) error {
@@ -1485,6 +1721,29 @@ func TestSafeWriteFileRejectsCrossPlatformTraversal(t *testing.T) {
 			}
 		})
 	}
+}
+
+func firstDiscTempDir(t *testing.T, tmpRoot string, sourcePath string) string {
+	t.Helper()
+	layout, err := sourcelayout.Resolve(context.Background(), sourcePath)
+	if err != nil {
+		t.Fatalf("resolve test disc layout: %v", err)
+	}
+	if len(layout.Discs) == 0 {
+		t.Fatal("test source has no disc")
+	}
+	releaseDir, _, err := paths.ReleaseTempDirFor(tmpRoot, sourcePath, api.ReleaseInfo{})
+	if err != nil {
+		t.Fatalf("resolve test release temp dir: %v", err)
+	}
+	discDir, err := paths.DiscTempDir(releaseDir, layout.Discs[0].ID)
+	if err != nil {
+		t.Fatalf("resolve test disc temp dir: %v", err)
+	}
+	if err := os.MkdirAll(discDir, 0o700); err != nil {
+		t.Fatalf("create test disc temp dir: %v", err)
+	}
+	return discDir
 }
 
 func writeBDMVSummaryFixture(t *testing.T, tmpDir string, playlist string, extSummary string) {

--- a/internal/pathing/layout/bdinfo.go
+++ b/internal/pathing/layout/bdinfo.go
@@ -4,6 +4,7 @@
 package layout
 
 import (
+	"encoding/hex"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -11,8 +12,28 @@ import (
 	preparationstate "github.com/autobrr/upbrr/internal/preparedrelease/state"
 
 	"github.com/autobrr/upbrr/internal/metadata/discparse"
+	pathutil "github.com/autobrr/upbrr/internal/pathing"
 	"github.com/autobrr/upbrr/pkg/api"
 )
+
+// DiscTempDir returns the namespaced artifact directory for one backend-owned
+// lowercase SHA-256 disc ID, rejecting malformed IDs and paths outside releaseTempDir.
+func DiscTempDir(releaseTempDir string, discID string) (string, error) {
+	id := strings.TrimSpace(discID)
+	if len(id) != len("disc-")+sha256HexLength || !strings.HasPrefix(id, "disc-") {
+		return "", errors.New("paths: invalid disc ID")
+	}
+	if _, err := hex.DecodeString(strings.TrimPrefix(id, "disc-")); err != nil || strings.ToLower(id) != id {
+		return "", errors.New("paths: invalid disc ID")
+	}
+	dir := filepath.Join(filepath.Clean(releaseTempDir), "discs", id)
+	if !pathutil.IsWithinRoot(releaseTempDir, dir) {
+		return "", errors.New("paths: disc artifact directory escapes release root")
+	}
+	return dir, nil
+}
+
+const sha256HexLength = 64
 
 // BDMVPlaylistKey returns the normalized playlist identifier used in BDInfo artifact names.
 func BDMVPlaylistKey(playlist string) string {

--- a/internal/preparedrelease/evidence_collector.go
+++ b/internal/preparedrelease/evidence_collector.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -256,13 +255,7 @@ func mapCollectedFacts(meta preparationstate.State) CollectedFacts {
 			MediaInfoUniqueID: meta.MediaInfoUniqueID,
 			Anime:             meta.Anime,
 		},
-		Disc: api.DiscFacts{
-			Type:            meta.DiscType,
-			Summary:         collectedBDInfoSummary(meta.BDInfo),
-			DurationSeconds: collectedBDInfoDurationSeconds(meta.BDInfo),
-			PlaylistCount:   len(meta.SelectedBDMVPlaylists),
-			DVDVOBSet:       meta.DVDVOBSet,
-		},
+		Disc:        collectedDiscFacts(meta),
 		Assessments: assessments,
 		Identity: externalidentity.ResolutionIntent{
 			Title:   meta.Release.Title,
@@ -289,6 +282,7 @@ func collectedResources(meta preparationstate.State) CollectedResources {
 		SceneNFOPath:          meta.SceneNFOPath,
 		DescriptionTemplate:   meta.DescriptionTemplate,
 		SelectedBDMVPlaylists: clonePlaylists(meta.SelectedBDMVPlaylists),
+		Discs:                 cloneDiscResources(meta.Discs),
 		ClientEvidence:        preparationstate.CloneClientEvidenceSnapshot(meta.ClientEvidence),
 	}
 }
@@ -302,27 +296,42 @@ func firstCollectedSourcePath(paths []string) string {
 	return ""
 }
 
-func collectedBDInfoSummary(value map[string]any) string {
-	summary, _ := value["summary"].(string)
-	return strings.TrimSpace(summary)
-}
-
-func collectedBDInfoDurationSeconds(value map[string]any) float64 {
-	text := strings.TrimSpace(fmt.Sprint(value["length"]))
-	if text == "" || text == "<nil>" {
-		return 0
+func collectedDiscFacts(meta preparationstate.State) api.DiscFacts {
+	facts := api.DiscFacts{Type: meta.DiscType}
+	for _, resource := range meta.Discs {
+		item := api.DiscItemFacts{
+			ID:              resource.ID,
+			Name:            resource.Name,
+			Type:            resource.Type,
+			DurationSeconds: resource.DurationSeconds,
+			DVDVOBSet:       resource.DVDVOBSet,
+		}
+		reportsByID := make(map[string]preparationstate.DiscReportResource, len(resource.Reports))
+		for _, report := range resource.Reports {
+			reportsByID[report.Playlist.ID] = report
+		}
+		for _, playlist := range resource.SelectedPlaylists {
+			report := reportsByID[playlist.ID]
+			item.Reports = append(item.Reports, api.DiscReportFacts{
+				Playlist: playlist,
+				Summary:  strings.TrimSpace(report.Summary),
+			})
+			facts.PlaylistCount++
+		}
+		if len(item.Reports) > 0 {
+			primary := 0
+			for i := 1; i < len(item.Reports); i++ {
+				if item.Reports[i].Playlist.Score > item.Reports[primary].Playlist.Score {
+					primary = i
+				}
+			}
+			item.DurationSeconds = item.Reports[primary].Playlist.Duration
+		}
+		facts.Items = append(facts.Items, item)
 	}
-	parts := strings.Split(text, ":")
-	if len(parts) != 3 {
-		return 0
-	}
-	hours, hoursErr := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-	minutes, minutesErr := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-	seconds, secondsErr := strconv.ParseFloat(strings.TrimSpace(parts[2]), 64)
-	if hoursErr != nil || minutesErr != nil || secondsErr != nil || hours < 0 || minutes < 0 || seconds < 0 {
-		return 0
-	}
-	return hours*3600 + minutes*60 + seconds
+	facts.PrimaryDiscID, facts.PrimaryReportID, facts.DurationSeconds, facts.DVDVOBSet = facts.CanonicalPrimary()
+	facts.Summary = facts.AggregateSummary()
+	return facts
 }
 
 func cloneCollectedIdentity(value api.ExternalIdentity) api.ExternalIdentity {
@@ -346,6 +355,14 @@ func cloneCollectedCandidates(value []api.ExternalIdentityCandidate) []api.Exter
 }
 
 func clonePlaylists(value []api.PlaylistInfo) []api.PlaylistInfo {
+	cloned, err := cloneWithJSON(value)
+	if err != nil {
+		panic(err)
+	}
+	return cloned
+}
+
+func cloneDiscResources(value []preparationstate.DiscResource) []preparationstate.DiscResource {
 	cloned, err := cloneWithJSON(value)
 	if err != nil {
 		panic(err)

--- a/internal/preparedrelease/fingerprint.go
+++ b/internal/preparedrelease/fingerprint.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	pathutil "github.com/autobrr/upbrr/internal/pathing"
 	"github.com/autobrr/upbrr/internal/sourcelayout"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -97,18 +98,14 @@ func normalizePlaylistSelection(values []string) []string {
 	result := make([]string, 0, len(values))
 	seen := make(map[string]struct{}, len(values))
 	for _, value := range values {
-		value = filepath.ToSlash(filepath.Clean(strings.TrimSpace(value)))
-		if value == "." || value == "" {
+		value = strings.TrimSpace(value)
+		if value == "" {
 			continue
 		}
-		key := value
-		if runtime.GOOS == "windows" {
-			key = strings.ToLower(key)
-		}
-		if _, ok := seen[key]; ok {
+		if _, ok := seen[value]; ok {
 			continue
 		}
-		seen[key] = struct{}{}
+		seen[value] = struct{}{}
 		result = append(result, value)
 	}
 	sort.Strings(result)
@@ -137,7 +134,7 @@ func inspectSource(ctx context.Context, input api.PrepareInput, layout sourcelay
 			return api.SourceManifest{}, "", fmt.Errorf("prepared release: inspect source %s: %w", root, err)
 		}
 		if !info.IsDir() {
-			entry := manifestEntry(root, info)
+			entry := manifestEntry(root, info, layout)
 			entries = append(entries, entry)
 			total += entry.Size
 			continue
@@ -153,7 +150,7 @@ func inspectSource(ctx context.Context, input api.PrepareInput, layout sourcelay
 			if infoErr != nil {
 				return fmt.Errorf("prepared release: inspect inventory entry %q: %w", path, infoErr)
 			}
-			item := manifestEntry(path, info)
+			item := manifestEntry(path, info, layout)
 			entries = append(entries, item)
 			if item.Type == api.SourceEntryTypeFile || item.Type == api.SourceEntryTypePlaylist {
 				total += item.Size
@@ -170,24 +167,19 @@ func inspectSource(ctx context.Context, input api.PrepareInput, layout sourcelay
 		return left < right
 	})
 
-	selected := make([]api.PlaylistInfo, 0, len(input.Instructions.Playlist.Selected))
-	for _, value := range input.Instructions.Playlist.Selected {
-		selected = append(selected, api.PlaylistInfo{File: value})
-	}
 	manifest := api.SourceManifest{
-		SourcePath:        input.SourcePath,
-		Size:              total,
-		Entries:           entries,
-		SelectedPlaylists: selected,
-		Classification:    classifyManifest(entries),
+		SourcePath:     input.SourcePath,
+		Size:           total,
+		Entries:        entries,
+		Classification: classifyManifest(entries),
 	}
 	if manifest.Classification.DiscType == "" {
 		manifest.Classification.DiscType = layout.DiscType
 	}
+	manifest.Classification.DiscCount = len(layout.Discs)
 	fingerprint, err := fingerprintJSON(sourceFingerprintPayload{
 		SourcePath: canonicalSourceKey(input.SourcePath),
 		Entries:    canonicalFingerprintEntries(entries),
-		Playlists:  input.Instructions.Playlist,
 	})
 	if err != nil {
 		return api.SourceManifest{}, "", fmt.Errorf("prepared release: fingerprint source: %w", err)
@@ -195,7 +187,7 @@ func inspectSource(ctx context.Context, input api.PrepareInput, layout sourcelay
 	return manifest, fingerprint, nil
 }
 
-func manifestEntry(path string, info fs.FileInfo) api.SourceManifestEntry {
+func manifestEntry(path string, info fs.FileInfo, layout sourcelayout.Layout) api.SourceManifestEntry {
 	entryType := api.SourceEntryTypeUnknown
 	switch {
 	case info.IsDir():
@@ -208,12 +200,13 @@ func manifestEntry(path string, info fs.FileInfo) api.SourceManifestEntry {
 		entryType = api.SourceEntryTypePlaylist
 	}
 	disc := ""
-	upper := strings.ToUpper(filepath.ToSlash(path))
-	switch {
-	case strings.Contains(upper, "/BDMV/") || strings.HasSuffix(upper, "/BDMV"):
-		disc = "BDMV"
-	case strings.Contains(upper, "/VIDEO_TS/") || strings.HasSuffix(upper, "/VIDEO_TS"):
-		disc = "DVD"
+	discID := ""
+	for _, resource := range layout.Discs {
+		if pathutil.IsWithinRoot(resource.Root, path) {
+			disc = resource.Type
+			discID = resource.ID
+			break
+		}
 	}
 	playlist := ""
 	if entryType == api.SourceEntryTypePlaylist {
@@ -225,6 +218,7 @@ func manifestEntry(path string, info fs.FileInfo) api.SourceManifestEntry {
 		Size:       info.Size(),
 		ModifiedAt: info.ModTime().UTC(),
 		Disc:       disc,
+		DiscID:     discID,
 		Playlist:   playlist,
 	}
 }
@@ -245,7 +239,6 @@ func classifyManifest(entries []api.SourceManifestEntry) api.SourceClassificatio
 type sourceFingerprintPayload struct {
 	SourcePath string
 	Entries    []sourceFingerprintEntry
-	Playlists  api.PlaylistInstruction
 }
 
 type sourceFingerprintEntry struct {
@@ -254,6 +247,7 @@ type sourceFingerprintEntry struct {
 	Size         int64
 	ModifiedNano int64
 	Disc         string
+	DiscID       string
 	Playlist     string
 }
 
@@ -270,6 +264,7 @@ func canonicalFingerprintEntries(entries []api.SourceManifestEntry) []sourceFing
 			Size:         entry.Size,
 			ModifiedNano: modifiedNano,
 			Disc:         entry.Disc,
+			DiscID:       entry.DiscID,
 			Playlist:     filepath.ToSlash(entry.Playlist),
 		})
 	}
@@ -305,4 +300,30 @@ func fingerprintJSON(value any) (string, error) {
 	}
 	digest := sha256.Sum256(payload)
 	return hex.EncodeToString(digest[:]), nil
+}
+
+func preparedMediaBinding(release api.PreparedRelease) (api.PreparedMediaBinding, error) {
+	fingerprint, err := api.CanonicalWorkflowFingerprint(struct {
+		ContractVersion            string
+		SourceFingerprint          string
+		FactInstructionFingerprint string
+		Generation                 api.PreparedGeneration
+		Discs                      []api.DiscItemFacts
+		SelectedPlaylists          []api.PlaylistInfo
+	}{
+		ContractVersion:            ContractVersion,
+		SourceFingerprint:          release.Compatibility.SourceFingerprint,
+		FactInstructionFingerprint: release.Compatibility.FactInstructionFingerprint,
+		Generation:                 release.Generation,
+		Discs:                      release.Disc.Items,
+		SelectedPlaylists:          release.Disc.SelectedPlaylists(),
+	})
+	if err != nil {
+		return api.PreparedMediaBinding{}, fmt.Errorf("prepared release: fingerprint prepared media: %w", err)
+	}
+	return api.PreparedMediaBinding{
+		SourcePath:               release.Source.SourcePath,
+		PreparedMediaFingerprint: string(fingerprint),
+		PreparedGeneration:       release.Generation,
+	}, nil
 }

--- a/internal/preparedrelease/fingerprint.go
+++ b/internal/preparedrelease/fingerprint.go
@@ -303,27 +303,9 @@ func fingerprintJSON(value any) (string, error) {
 }
 
 func preparedMediaBinding(release api.PreparedRelease) (api.PreparedMediaBinding, error) {
-	fingerprint, err := api.CanonicalWorkflowFingerprint(struct {
-		ContractVersion            string
-		SourceFingerprint          string
-		FactInstructionFingerprint string
-		Generation                 api.PreparedGeneration
-		Discs                      []api.DiscItemFacts
-		SelectedPlaylists          []api.PlaylistInfo
-	}{
-		ContractVersion:            ContractVersion,
-		SourceFingerprint:          release.Compatibility.SourceFingerprint,
-		FactInstructionFingerprint: release.Compatibility.FactInstructionFingerprint,
-		Generation:                 release.Generation,
-		Discs:                      release.Disc.Items,
-		SelectedPlaylists:          release.Disc.SelectedPlaylists(),
-	})
+	fingerprint, err := release.MediaBinding()
 	if err != nil {
-		return api.PreparedMediaBinding{}, fmt.Errorf("prepared release: fingerprint prepared media: %w", err)
+		return api.PreparedMediaBinding{}, fmt.Errorf("prepared release: derive media binding: %w", err)
 	}
-	return api.PreparedMediaBinding{
-		SourcePath:               release.Source.SourcePath,
-		PreparedMediaFingerprint: string(fingerprint),
-		PreparedGeneration:       release.Generation,
-	}, nil
+	return fingerprint, nil
 }

--- a/internal/preparedrelease/module.go
+++ b/internal/preparedrelease/module.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -23,7 +24,7 @@ import (
 
 // ContractVersion changes whenever prepared fact semantics or the private seed
 // contract become incompatible, forcing persisted generations to be recomputed.
-const ContractVersion = "prepared-release-v4"
+const ContractVersion = "prepared-release-v5"
 
 // Store is the prepared-release persistence port. Implementations must commit
 // facts, identity, and provider metadata as one generation transaction.
@@ -75,6 +76,7 @@ type CollectedResources struct {
 	SceneNFOPath          string
 	DescriptionTemplate   string
 	SelectedBDMVPlaylists []api.PlaylistInfo
+	Discs                 []preparationstate.DiscResource
 	ClientEvidence        preparationstate.ClientEvidenceSnapshot
 }
 
@@ -201,9 +203,10 @@ func (m *Module) Prepare(ctx context.Context, input api.PrepareInput) (api.Prepa
 			}
 			finish := api.BeginPreparationProgress(ctx, api.PreparationPhaseClientDiscovery, "Hydrating private prepared resources.")
 			resources, hydrateErr := hydrator.HydratePrivateResources(ctx, preparationstate.Request{
-				Input:    input,
-				Manifest: current.Source,
-				Layout:   layout,
+				Input:             input,
+				Manifest:          current.Source,
+				Layout:            layout,
+				SourceFingerprint: sourceFingerprint,
 			})
 			finish(hydrateErr)
 			if hydrateErr != nil {
@@ -244,14 +247,15 @@ func (m *Module) Prepare(ctx context.Context, input api.PrepareInput) (api.Prepa
 		}
 	}
 	collected, err := m.collector.Collect(ctx, preparationstate.Request{
-		Input:    input,
-		Manifest: manifest,
-		Layout:   layout,
+		Input:             input,
+		Manifest:          manifest,
+		Layout:            layout,
+		SourceFingerprint: sourceFingerprint,
 	})
 	if err != nil {
 		return api.PrepareResult{}, fmt.Errorf("prepared release: collect facts: %w", err)
 	}
-	manifest.SelectedPlaylists = clonePreparedPlaylists(collected.Resources.SelectedBDMVPlaylists)
+	manifest.SelectedPlaylists = clonePreparedPlaylists(collected.Disc.SelectedPlaylists())
 	identityIntent := collected.Identity
 	mergeFactInstructions(&identityIntent, input.Instructions)
 	identityFinish := api.BeginPreparationProgress(ctx, api.PreparationPhaseCanonicalIdentity, "Resolving canonical identity.")
@@ -524,7 +528,66 @@ func validateGeneration(release api.PreparedRelease) error {
 	if reason := providerIdentityMismatch(release); reason != "" {
 		return &IncompatiblePreparationError{SourcePath: release.Source.SourcePath, Reason: reason}
 	}
+	if reason := discProjectionMismatch(release); reason != "" {
+		return &IncompatiblePreparationError{SourcePath: release.Source.SourcePath, Reason: reason}
+	}
 	return nil
+}
+
+func discProjectionMismatch(release api.PreparedRelease) string {
+	disc := release.Disc
+	if release.Source.Classification.DiscCount != len(disc.Items) {
+		return "disc inventory count differs from canonical facts"
+	}
+	if release.Source.Classification.DiscType != disc.Type {
+		return "disc type differs from source classification"
+	}
+	selected := disc.SelectedPlaylists()
+	if !reflect.DeepEqual(selected, release.Source.SelectedPlaylists) {
+		return "selected playlist projection differs from canonical disc facts"
+	}
+	if disc.PlaylistCount != len(selected) || disc.Summary != disc.AggregateSummary() {
+		return "disc scalar projection differs from canonical disc facts"
+	}
+	itemByID := make(map[string]api.DiscItemFacts, len(disc.Items))
+	for _, item := range disc.Items {
+		if strings.TrimSpace(item.ID) == "" || strings.TrimSpace(item.Name) == "" || item.Type != disc.Type {
+			return "canonical disc item is invalid"
+		}
+		if _, exists := itemByID[item.ID]; exists {
+			return "canonical disc IDs are not unique"
+		}
+		itemByID[item.ID] = item
+		primaryReport := -1
+		for index, report := range item.Reports {
+			if strings.TrimSpace(report.Playlist.ID) == "" || report.Playlist.DiscID != item.ID || report.Playlist.DiscName != item.Name {
+				return "canonical disc report identity is invalid"
+			}
+			if item.Type != "BDMV" {
+				return "non-BDMV disc contains canonical reports"
+			}
+			if primaryReport < 0 || report.Playlist.Score > item.Reports[primaryReport].Playlist.Score {
+				primaryReport = index
+			}
+		}
+		if primaryReport >= 0 && item.DurationSeconds != item.Reports[primaryReport].Playlist.Duration {
+			return "disc duration differs from canonical primary report"
+		}
+	}
+	for _, entry := range release.Source.Entries {
+		if entry.DiscID == "" {
+			continue
+		}
+		if _, exists := itemByID[entry.DiscID]; !exists {
+			return "source manifest references an unknown disc"
+		}
+	}
+	expectedDiscID, expectedReportID, expectedDuration, expectedVOBSet := disc.CanonicalPrimary()
+	if disc.PrimaryDiscID != expectedDiscID || disc.PrimaryReportID != expectedReportID ||
+		disc.DurationSeconds != expectedDuration || disc.DVDVOBSet != expectedVOBSet {
+		return "disc primary projection differs from canonical disc items"
+	}
+	return ""
 }
 
 func providerIdentityMismatch(release api.PreparedRelease) string {
@@ -655,6 +718,7 @@ type preparationResources struct {
 	sceneNFOPath          string
 	descriptionTemplate   string
 	selectedBDMVPlaylists []api.PlaylistInfo
+	discs                 []preparationstate.DiscResource
 	clientEvidence        preparationstate.ClientEvidenceSnapshot
 }
 
@@ -689,6 +753,7 @@ func mergePreparationResources(base preparationResources, collected preparationR
 	base.sceneNFOPath = collected.sceneNFOPath
 	base.descriptionTemplate = collected.descriptionTemplate
 	base.selectedBDMVPlaylists = collected.selectedBDMVPlaylists
+	base.discs = clonePreparedDiscResources(collected.discs)
 	base.clientEvidence = preparationstate.CloneClientEvidenceSnapshot(collected.clientEvidence)
 	return base
 }
@@ -707,6 +772,7 @@ func resourcesFromCollected(collected CollectedResources) preparationResources {
 		sceneNFOPath:          collected.SceneNFOPath,
 		descriptionTemplate:   collected.DescriptionTemplate,
 		selectedBDMVPlaylists: clonePreparedPlaylists(collected.SelectedBDMVPlaylists),
+		discs:                 clonePreparedDiscResources(collected.Discs),
 		clientEvidence:        preparationstate.CloneClientEvidenceSnapshot(collected.ClientEvidence),
 	}
 }
@@ -736,6 +802,7 @@ func cloneEnvelope(value envelope) (envelope, error) {
 				UseAll:   value.resources.playlist.UseAll,
 			},
 			selectedBDMVPlaylists: clonePreparedPlaylists(value.resources.selectedBDMVPlaylists),
+			discs:                 clonePreparedDiscResources(value.resources.discs),
 			clientEvidence:        preparationstate.CloneClientEvidenceSnapshot(value.resources.clientEvidence),
 		},
 	}
@@ -746,6 +813,14 @@ func clonePreparedPlaylists(value []api.PlaylistInfo) []api.PlaylistInfo {
 	cloned, err := cloneWithJSON(value)
 	if err != nil {
 		panic(fmt.Sprintf("prepared release: clone playlists: %v", err))
+	}
+	return cloned
+}
+
+func clonePreparedDiscResources(value []preparationstate.DiscResource) []preparationstate.DiscResource {
+	cloned, err := cloneWithJSON(value)
+	if err != nil {
+		panic(fmt.Sprintf("prepared release: clone disc resources: %v", err))
 	}
 	return cloned
 }

--- a/internal/preparedrelease/module_test.go
+++ b/internal/preparedrelease/module_test.go
@@ -54,6 +54,210 @@ func TestCanonicalFingerprintEntriesIgnoreDirectoryModificationTime(t *testing.T
 	}
 }
 
+func TestSourceFingerprintExcludesPlaylistInstruction(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "Example.Release.2026.COMPLETE.BLURAY-GRP")
+	if err := os.MkdirAll(filepath.Join(root, "BDMV", "PLAYLIST"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "BDMV", "PLAYLIST", "00001.mpls"), []byte("playlist"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	layout, err := sourcelayout.Resolve(context.Background(), root)
+	if err != nil {
+		t.Fatalf("resolve layout: %v", err)
+	}
+	absent := api.PrepareInput{SourcePath: root}
+	explicit := absent
+	explicit.Instructions.Playlist = api.PlaylistInstruction{Set: true, Selected: []string{"00001.MPLS"}}
+	_, absentFingerprint, err := inspectSource(context.Background(), absent, layout)
+	if err != nil {
+		t.Fatalf("inspect absent selection: %v", err)
+	}
+	_, explicitFingerprint, err := inspectSource(context.Background(), explicit, layout)
+	if err != nil {
+		t.Fatalf("inspect explicit selection: %v", err)
+	}
+	if absentFingerprint != explicitFingerprint {
+		t.Fatalf("source fingerprints differ: %q != %q", absentFingerprint, explicitFingerprint)
+	}
+	absentCompatibility, err := preparationCompatibility(absent, absentFingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	explicitCompatibility, err := preparationCompatibility(explicit, explicitFingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if absentCompatibility.FactInstructionFingerprint == explicitCompatibility.FactInstructionFingerprint {
+		t.Fatal("fact-instruction fingerprint ignored playlist intent")
+	}
+}
+
+func TestDiscInventoryFingerprintTracksInsertionAndRename(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "Example.Release.2026.COMPLETE.BLURAY-GRP")
+	writeDisc := func(name string) {
+		dir := filepath.Join(root, name, "BDMV", "PLAYLIST")
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "00001.mpls"), []byte(name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	inspect := func() (sourcelayout.Layout, string) {
+		layout, err := sourcelayout.Resolve(context.Background(), root)
+		if err != nil {
+			t.Fatalf("resolve layout: %v", err)
+		}
+		_, fingerprint, err := inspectSource(context.Background(), api.PrepareInput{SourcePath: root}, layout)
+		if err != nil {
+			t.Fatalf("inspect source: %v", err)
+		}
+		return layout, fingerprint
+	}
+
+	writeDisc("Disc 2")
+	before, beforeFingerprint := inspect()
+	beforeID := before.Discs[0].ID
+	writeDisc("Disc 1")
+	afterInsertion, insertionFingerprint := inspect()
+	if beforeFingerprint == insertionFingerprint {
+		t.Fatal("sibling insertion retained inventory fingerprint")
+	}
+	var retainedID string
+	for _, disc := range afterInsertion.Discs {
+		if disc.Name == "Disc 2" {
+			retainedID = disc.ID
+		}
+	}
+	if retainedID != beforeID {
+		t.Fatalf("sibling insertion changed existing disc ID: %q != %q", retainedID, beforeID)
+	}
+	if err := os.Rename(filepath.Join(root, "Disc 2"), filepath.Join(root, "Disc 3")); err != nil {
+		t.Fatal(err)
+	}
+	afterRename, renameFingerprint := inspect()
+	if insertionFingerprint == renameFingerprint {
+		t.Fatal("disc rename retained inventory fingerprint")
+	}
+	for _, disc := range afterRename.Discs {
+		if disc.Name == "Disc 3" && disc.ID == beforeID {
+			t.Fatal("disc rename retained canonical disc ID")
+		}
+	}
+}
+
+func TestPreparedMediaBindingIsStableAndSelectionScoped(t *testing.T) {
+	t.Parallel()
+
+	release := api.PreparedRelease{
+		Generation: 4,
+		Compatibility: api.PreparationCompatibility{
+			SourceFingerprint:          "source-fingerprint",
+			FactInstructionFingerprint: "instruction-fingerprint",
+		},
+		Source: api.SourceManifest{SourcePath: filepath.Join(t.TempDir(), "Example.Release.2026")},
+		Disc: api.DiscFacts{
+			Items: []api.DiscItemFacts{
+				{
+					ID:   "disc-one",
+					Name: "Disc 1",
+					Type: "BDMV",
+					Reports: []api.DiscReportFacts{
+						{
+							Playlist: api.PlaylistInfo{
+ID: "00001.MPLS",
+ DiscID: "disc-one",
+ DiscName: "Disc 1",
+ File: "00001.MPLS",
+},
+							Summary:  "BDINFO",
+						},
+					},
+				},
+			},
+		},
+	}
+	first, err := preparedMediaBinding(release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := cloneWithJSON(release)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := preparedMediaBinding(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.Equal(second) || !first.Valid() {
+		t.Fatalf("round-trip bindings differ: %#v != %#v", first, second)
+	}
+
+	changed := release
+	changed.Disc.Items = append([]api.DiscItemFacts(nil), release.Disc.Items...)
+	changed.Disc.Items[0].Reports = append([]api.DiscReportFacts(nil), release.Disc.Items[0].Reports...)
+	changed.Disc.Items[0].Reports[0].Playlist.ID = "00002.MPLS"
+	changedBinding, err := preparedMediaBinding(changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Equal(changedBinding) {
+		t.Fatal("playlist change retained prepared-media binding")
+	}
+	changed = release
+	changed.Generation++
+	changedBinding, err = preparedMediaBinding(changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Equal(changedBinding) {
+		t.Fatal("generation change retained prepared-media binding")
+	}
+}
+
+func TestDiscProjectionRequiresCanonicalPrimaryPair(t *testing.T) {
+	t.Parallel()
+
+	playlist := api.PlaylistInfo{
+		ID:       "disc-one:00001.MPLS",
+		DiscID:   "disc-one",
+		DiscName: "Disc 1",
+		File:     "00001.MPLS",
+		Duration: 5400,
+		Score:    100,
+	}
+	release := api.PreparedRelease{
+		Source: api.SourceManifest{
+			Classification:    api.SourceClassification{DiscType: "BDMV", DiscCount: 1},
+			SelectedPlaylists: []api.PlaylistInfo{playlist},
+		},
+		Disc: api.DiscFacts{
+			Type:          "BDMV",
+			PlaylistCount: 1,
+			Items: []api.DiscItemFacts{{
+				ID:              "disc-one",
+				Name:            "Disc 1",
+				Type:            "BDMV",
+				DurationSeconds: 5400,
+				Reports:         []api.DiscReportFacts{{Playlist: playlist, Summary: "BDINFO"}},
+			}},
+		},
+	}
+	release.Disc.Summary = release.Disc.AggregateSummary()
+	if reason := discProjectionMismatch(release); !strings.Contains(reason, "primary projection") {
+		t.Fatalf("missing primary reason = %q", reason)
+	}
+	release.Disc.PrimaryDiscID, release.Disc.PrimaryReportID, release.Disc.DurationSeconds, release.Disc.DVDVOBSet = release.Disc.CanonicalPrimary()
+	if reason := discProjectionMismatch(release); reason != "" {
+		t.Fatalf("canonical projection mismatch = %q", reason)
+	}
+}
+
 func TestPrepareUsesExactCompatibilityAndPublishesConcreteAssessments(t *testing.T) {
 	t.Parallel()
 	path := writePreparedTestFile(t, "source.mkv", "first")
@@ -835,7 +1039,7 @@ func (c *recordingCollector) Collect(_ context.Context, request preparationstate
 	c.mu.Lock()
 	c.calls = append(c.calls, request.Input.Instructions.SourceLookup)
 	c.mu.Unlock()
-	return CollectedFacts{
+	facts := CollectedFacts{
 		Naming: api.NamingFacts{
 			Filename:    filepath.Base(request.Manifest.SourcePath),
 			ReleaseName: "Example.Release.2026.1080p-GRP",
@@ -855,7 +1059,32 @@ func (c *recordingCollector) Collect(_ context.Context, request preparationstate
 				Status: api.NamingStatusComplete,
 			},
 		},
-	}, nil
+	}
+	if len(request.Layout.Discs) > 0 {
+		facts.Disc.Type = request.Layout.DiscType
+		for _, disc := range request.Layout.Discs {
+			facts.Disc.Items = append(facts.Disc.Items, api.DiscItemFacts{
+ID: disc.ID,
+ Name: disc.Name,
+ Type: disc.Type,
+})
+		}
+		if len(request.Layout.Discs) == 1 {
+			for _, selected := range request.Input.Instructions.Playlist.Selected {
+				playlist := api.PlaylistInfo{
+					ID:       selected,
+					DiscID:   request.Layout.Discs[0].ID,
+					DiscName: request.Layout.Discs[0].Name,
+					File:     selected,
+				}
+				facts.Disc.Items[0].Reports = append(facts.Disc.Items[0].Reports, api.DiscReportFacts{Playlist: playlist})
+				facts.Disc.PlaylistCount++
+			}
+		}
+		facts.Disc.PrimaryDiscID, facts.Disc.PrimaryReportID, facts.Disc.DurationSeconds, facts.Disc.DVDVOBSet = facts.Disc.CanonicalPrimary()
+		facts.Disc.Summary = facts.Disc.AggregateSummary()
+	}
+	return facts, nil
 }
 
 func (c *recordingCollector) callCount() int {

--- a/internal/preparedrelease/state/state.go
+++ b/internal/preparedrelease/state/state.go
@@ -24,6 +24,39 @@ type Request struct {
 	Manifest api.SourceManifest
 	// Layout exposes preparation-only derived resource roots for the same source.
 	Layout sourcelayout.Layout
+	// SourceFingerprint binds repository-backed selection to the inspected inventory.
+	SourceFingerprint string
+}
+
+// DiscReportResource contains private paths and text for one selected BDMV report.
+type DiscReportResource struct {
+	Playlist        api.PlaylistInfo
+	Summary         string
+	ExtSummary      string
+	FullSummary     string
+	SummaryPath     string
+	ExtSummaryPath  string
+	FullSummaryPath string
+}
+
+// DiscResource contains all preparation-private evidence for one source disc.
+type DiscResource struct {
+	ID                  string
+	Name                string
+	Type                string
+	Root                string
+	SelectedPlaylists   []api.PlaylistInfo
+	VideoPath           string
+	FileList            []string
+	Reports             []DiscReportResource
+	MediaInfoJSONPath   string
+	MediaInfoTextPath   string
+	DVDIFOPath          string
+	DVDVOBPath          string
+	DVDVOBSet           string
+	DurationSeconds     float64
+	DVDVOBMediaInfoJSON string
+	DVDVOBMediaInfoText string
 }
 
 // ReleaseAssessments projects concrete source-derived validation facts from
@@ -79,6 +112,7 @@ type State struct {
 	LookupWarnings          []string
 	Paths                   []string
 	DiscType                string
+	Discs                   []DiscResource
 	VideoPath               string
 	FileList                []string
 	SourceSize              int64

--- a/internal/preparedrelease/subjects.go
+++ b/internal/preparedrelease/subjects.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	preparationstate "github.com/autobrr/upbrr/internal/preparedrelease/state"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -23,6 +24,10 @@ func (m *Module) ResolveUploadSubject(ctx context.Context, input api.UploadSubje
 	}
 	release := owned.result.Release
 	resources := owned.resources
+	binding, err := preparedMediaBinding(release)
+	if err != nil {
+		return api.UploadSubject{}, err
+	}
 	discType := firstNonEmpty(release.Disc.Type, release.Source.Classification.DiscType)
 	fileList := append([]string(nil), resources.fileList...)
 	if len(fileList) == 0 {
@@ -33,6 +38,7 @@ func (m *Module) ResolveUploadSubject(ctx context.Context, input api.UploadSubje
 		selectedPlaylists = clonePreparedPlaylists(release.Source.SelectedPlaylists)
 	}
 	subject := api.UploadSubject{
+		MediaBinding:                binding,
 		SourcePath:                  release.Source.SourcePath,
 		Paths:                       []string{resources.sourcePath},
 		DiscType:                    discType,
@@ -74,6 +80,7 @@ func (m *Module) ResolveUploadSubject(ctx context.Context, input api.UploadSubje
 		Identity:                    release.Identity,
 		ProviderMetadata:            release.ProviderMetadata,
 		Disc:                        release.Disc,
+		Discs:                       projectDiscResources(resources.discs),
 		AudioLanguages:              append([]string(nil), release.Media.AudioLanguages...),
 		SubtitleLanguages:           append([]string(nil), release.Media.SubtitleLanguages...),
 		Container:                   release.Media.Container,
@@ -142,6 +149,7 @@ func (m *Module) ResolveDuplicateSubject(ctx context.Context, input api.Duplicat
 		Identity:          release.Identity,
 		ProviderMetadata:  release.ProviderMetadata,
 		DiscType:          firstNonEmpty(release.Disc.Type, release.Source.Classification.DiscType),
+		Disc:              release.Disc,
 		Type:              release.Media.Type,
 		Source:            release.Media.Source,
 		Tag:               release.Naming.Tag,
@@ -176,9 +184,25 @@ func (m *Module) ResolveDVDMenuSubject(ctx context.Context, input api.MediaPlanI
 		return api.DVDMenuSubject{}, err
 	}
 	release := owned.result.Release
+	binding, err := preparedMediaBinding(release)
+	if err != nil {
+		return api.DVDMenuSubject{}, err
+	}
+	discs := make([]api.DVDMenuDiscSubject, 0, len(owned.resources.discs))
+	for _, disc := range owned.resources.discs {
+		if disc.Type == "DVD" {
+			discs = append(discs, api.DVDMenuDiscSubject{
+				ID:   disc.ID,
+				Name: disc.Name,
+				Root: disc.Root,
+			})
+		}
+	}
 	return api.DVDMenuSubject{
-		SourcePath: release.Source.SourcePath,
-		DiscType:   firstNonEmpty(release.Disc.Type, release.Source.Classification.DiscType),
+		MediaBinding: binding,
+		SourcePath:   release.Source.SourcePath,
+		DiscType:     firstNonEmpty(release.Disc.Type, release.Source.Classification.DiscType),
+		Discs:        discs,
 	}, nil
 }
 
@@ -191,11 +215,27 @@ func (m *Module) ResolveScreenshotSubject(ctx context.Context, input api.MediaPl
 	}
 	release := owned.result.Release
 	resources := owned.resources
+	binding, err := preparedMediaBinding(release)
+	if err != nil {
+		return api.ScreenshotSubject{}, err
+	}
 	selectedPlaylists := clonePreparedPlaylists(resources.selectedBDMVPlaylists)
 	if len(selectedPlaylists) == 0 {
 		selectedPlaylists = clonePreparedPlaylists(release.Source.SelectedPlaylists)
 	}
+	discs := make([]api.ScreenshotDiscSubject, 0, len(resources.discs))
+	for _, disc := range resources.discs {
+		discs = append(discs, api.ScreenshotDiscSubject{
+			ID:                    disc.ID,
+			Name:                  disc.Name,
+			Type:                  disc.Type,
+			VideoPath:             disc.VideoPath,
+			MediaInfoJSONPath:     disc.MediaInfoJSONPath,
+			SelectedBDMVPlaylists: clonePreparedPlaylists(disc.SelectedPlaylists),
+		})
+	}
 	return api.ScreenshotSubject{
+		MediaBinding:          binding,
 		SourcePath:            release.Source.SourcePath,
 		DiscType:              firstNonEmpty(release.Disc.Type, release.Source.Classification.DiscType),
 		VideoPath:             resources.videoPath,
@@ -208,6 +248,7 @@ func (m *Module) ResolveScreenshotSubject(ctx context.Context, input api.MediaPl
 		SelectedBDMVPlaylists: selectedPlaylists,
 		DefaultCount:          input.Count,
 		ManualFrames:          append([]int(nil), input.Options.ManualFrames...),
+		Discs:                 discs,
 	}, nil
 }
 
@@ -219,6 +260,10 @@ func (m *Module) ResolveImageHostingSubject(ctx context.Context, input api.Image
 		return api.ImageHostingSubject{}, err
 	}
 	release := owned.result.Release
+	binding, err := preparedMediaBinding(release)
+	if err != nil {
+		return api.ImageHostingSubject{}, err
+	}
 	galleryName := firstNonEmpty(
 		release.Naming.ReleaseName,
 		release.Naming.NameWithoutTag,
@@ -226,7 +271,11 @@ func (m *Module) ResolveImageHostingSubject(ctx context.Context, input api.Image
 		release.Naming.Filename,
 		filepath.Base(release.Source.SourcePath),
 	)
-	return api.ImageHostingSubject{SourcePath: release.Source.SourcePath, GalleryName: galleryName}, nil
+	return api.ImageHostingSubject{
+		MediaBinding: binding,
+		SourcePath:   release.Source.SourcePath,
+		GalleryName:  galleryName,
+	}, nil
 }
 
 // ResolveDescriptionSubject validates and projects one exact prepared
@@ -238,11 +287,16 @@ func (m *Module) ResolveDescriptionSubject(ctx context.Context, input api.Descri
 	}
 	release := owned.result.Release
 	resources := owned.resources
+	binding, err := preparedMediaBinding(release)
+	if err != nil {
+		return api.DescriptionSubject{}, err
+	}
 	selectedPlaylists := clonePreparedPlaylists(resources.selectedBDMVPlaylists)
 	if len(selectedPlaylists) == 0 {
 		selectedPlaylists = clonePreparedPlaylists(release.Source.SelectedPlaylists)
 	}
 	return api.DescriptionSubject{
+		MediaBinding:          binding,
 		SourcePath:            release.Source.SourcePath,
 		DiscType:              firstNonEmpty(release.Disc.Type, release.Source.Classification.DiscType),
 		MediaInfoTextPath:     resources.mediaInfoTextPath,
@@ -252,6 +306,8 @@ func (m *Module) ResolveDescriptionSubject(ctx context.Context, input api.Descri
 		Options:               input.Options,
 		Release:               releaseInfo(release),
 		SelectedBDMVPlaylists: selectedPlaylists,
+		Disc:                  release.Disc,
+		Discs:                 projectDiscResources(resources.discs),
 		Tag:                   release.Naming.Tag,
 		Identity:              release.Identity,
 		ProviderMetadata:      release.ProviderMetadata,
@@ -265,6 +321,43 @@ func (m *Module) ResolveDescriptionSubject(ctx context.Context, input api.Descri
 		HDR:                   release.Media.HDR,
 		ArrReleaseGroup:       release.Naming.Group,
 	}, nil
+}
+
+func projectDiscResources(resources []preparationstate.DiscResource) []api.DiscEvidenceResource {
+	result := make([]api.DiscEvidenceResource, 0, len(resources))
+	for _, resource := range resources {
+		reports := make([]api.DiscReportResource, 0, len(resource.Reports))
+		for _, report := range resource.Reports {
+			reports = append(reports, api.DiscReportResource{
+				Playlist:        report.Playlist,
+				Summary:         report.Summary,
+				ExtSummary:      report.ExtSummary,
+				FullSummary:     report.FullSummary,
+				SummaryPath:     report.SummaryPath,
+				ExtSummaryPath:  report.ExtSummaryPath,
+				FullSummaryPath: report.FullSummaryPath,
+			})
+		}
+		result = append(result, api.DiscEvidenceResource{
+			ID:                  resource.ID,
+			Name:                resource.Name,
+			Type:                resource.Type,
+			Root:                resource.Root,
+			SelectedPlaylists:   clonePreparedPlaylists(resource.SelectedPlaylists),
+			VideoPath:           resource.VideoPath,
+			FileList:            append([]string(nil), resource.FileList...),
+			Reports:             reports,
+			MediaInfoJSONPath:   resource.MediaInfoJSONPath,
+			MediaInfoTextPath:   resource.MediaInfoTextPath,
+			DVDIFOPath:          resource.DVDIFOPath,
+			DVDVOBPath:          resource.DVDVOBPath,
+			DVDVOBSet:           resource.DVDVOBSet,
+			DurationSeconds:     resource.DurationSeconds,
+			DVDVOBMediaInfoJSON: resource.DVDVOBMediaInfoJSON,
+			DVDVOBMediaInfoText: resource.DVDVOBMediaInfoText,
+		})
+	}
+	return result
 }
 
 func (m *Module) resolveEnvelope(ctx context.Context, ref api.ReleaseRef) (envelope, error) {

--- a/internal/preparedrelease/subjects.go
+++ b/internal/preparedrelease/subjects.go
@@ -229,6 +229,7 @@ func (m *Module) ResolveScreenshotSubject(ctx context.Context, input api.MediaPl
 			ID:                    disc.ID,
 			Name:                  disc.Name,
 			Type:                  disc.Type,
+			Root:                  disc.Root,
 			VideoPath:             disc.VideoPath,
 			MediaInfoJSONPath:     disc.MediaInfoJSONPath,
 			SelectedBDMVPlaylists: clonePreparedPlaylists(disc.SelectedPlaylists),
@@ -271,10 +272,15 @@ func (m *Module) ResolveImageHostingSubject(ctx context.Context, input api.Image
 		release.Naming.Filename,
 		filepath.Base(release.Source.SourcePath),
 	)
+	discs := make([]api.ImageHostingDiscSubject, 0, len(release.Disc.Items))
+	for _, disc := range release.Disc.Items {
+		discs = append(discs, api.ImageHostingDiscSubject{ID: disc.ID, Name: disc.Name})
+	}
 	return api.ImageHostingSubject{
 		MediaBinding: binding,
 		SourcePath:   release.Source.SourcePath,
 		GalleryName:  galleryName,
+		Discs:        discs,
 	}, nil
 }
 

--- a/internal/releaseworkflow/composite_upload.go
+++ b/internal/releaseworkflow/composite_upload.go
@@ -536,18 +536,10 @@ func compositeUploadMediaIntent(
 	if input.Screenshots.Count != nil {
 		count = *input.Screenshots.Count
 	}
-	selections := make([]api.ScreenshotSelection, 0, len(input.Screenshots.Frames))
-	for index, frame := range input.Screenshots.Frames {
-		selections = append(selections, api.ScreenshotSelection{
-			Index:  index,
-			Frame:  frame,
-			Source: "manual",
-		})
-	}
 	media := api.MediaCaptureInstructions{
 		ScreenshotCount: count,
 		Purpose:         api.ScreenshotPurposeFinal,
-		Selections:      selections,
+		ManualFrames:    append([]int(nil), input.Screenshots.Frames...),
 		CaptureDVDMenus: optionalBool(input.DVDMenus.Capture),
 	}
 	if input.DVDMenus.MaxItems != nil {

--- a/internal/releaseworkflow/contracts.go
+++ b/internal/releaseworkflow/contracts.go
@@ -31,6 +31,10 @@ type MediaArtifactContent struct {
 // MediaPreviewContent retains one non-authoritative frame preview without
 // exposing image bytes or filesystem identity in workflow snapshots.
 type MediaPreviewContent struct {
+	// DiscID identifies the prepared disc used for this preview.
+	DiscID string
+	// DiscName is the safe page-facing label for DiscID.
+	DiscName    string
 	Bytes       []byte
 	ContentType string
 	Width       int
@@ -256,7 +260,7 @@ type MediaArtifactMutator interface {
 // for one exact prepared release.
 type MediaPlanner interface {
 	Plan(context.Context, api.ReleaseRef, api.TrackerReleaseProjectionSet, time.Time) (api.MediaPlan, error)
-	PreviewFrame(context.Context, api.ReleaseRef, float64) (MediaPreviewContent, error)
+	PreviewFrame(context.Context, api.ReleaseRef, string, float64) (MediaPreviewContent, error)
 }
 
 // DescriptionBuilder generates projection- and media-bound descriptions.
@@ -398,7 +402,7 @@ type Application interface {
 	Operation(context.Context, string, api.WorkflowID, api.WorkflowOperationID) (api.WorkflowOperationStatus, error)
 	CancelOperation(context.Context, string, api.WorkflowID, api.WorkflowOperationID) (api.WorkflowOperationStatus, error)
 	MediaPlan(context.Context, string, api.WorkflowID) (api.MediaPlan, error)
-	PreviewFrame(context.Context, string, api.WorkflowID, api.WorkflowRevision, float64) (api.FramePreview, error)
+	PreviewFrame(context.Context, string, api.WorkflowID, api.WorkflowRevision, string, float64) (api.FramePreview, error)
 	PreviewArtifact(context.Context, string, api.WorkflowID, api.PublicResourceID) (MediaArtifactContent, error)
 	StageMediaResource(context.Context, string, api.WorkflowID, api.WorkflowRevision, StagedMediaContent) (api.WorkflowResourceRef, error)
 	MediaArtifact(context.Context, string, api.WorkflowID, api.MediaArtifactSetRef, api.PublicResourceID) (MediaArtifactContent, error)

--- a/internal/releaseworkflow/module.go
+++ b/internal/releaseworkflow/module.go
@@ -1899,6 +1899,7 @@ func (m *Module) PreviewFrame(
 	ownerID string,
 	workflowID api.WorkflowID,
 	expectedRevision api.WorkflowRevision,
+	discID string,
 	timestampSeconds float64,
 ) (api.FramePreview, error) {
 	if err := ctx.Err(); err != nil {
@@ -1935,7 +1936,7 @@ func (m *Module) PreviewFrame(
 	content, err := planner.PreviewFrame(ctx, api.ReleaseRef{
 		SourcePath: release.Release.Source.SourcePath,
 		Generation: release.Release.Generation,
-	}, timestampSeconds)
+	}, discID, timestampSeconds)
 	if err != nil {
 		return api.FramePreview{}, fmt.Errorf("release workflow preview frame: %w", err)
 	}
@@ -1953,6 +1954,8 @@ func (m *Module) PreviewFrame(
 		WorkflowID:       workflowID,
 		WorkflowRevision: expectedRevision,
 		Release:          *state.Workflow.Release,
+		DiscID:           content.DiscID,
+		DiscName:         content.DiscName,
 		TimestampSeconds: timestampSeconds,
 		ExpiresAt:        expiresAt,
 	}, nil

--- a/internal/services/db/history_capability.go
+++ b/internal/services/db/history_capability.go
@@ -55,14 +55,20 @@ func (r *SQLiteRepository) LoadHistoryRecord(ctx context.Context, sourcePath str
 	if record.TrackerRuleFailures, err = r.ListTrackerRuleFailuresByPath(ctx, sourcePath); err != nil {
 		return api.HistoryRecord{}, fmt.Errorf("db history record tracker failures: %w", err)
 	}
-	if record.Screenshots, err = r.ListScreenshotsByPath(ctx, sourcePath); err != nil {
-		return api.HistoryRecord{}, fmt.Errorf("db history record screenshots: %w", err)
-	}
-	if record.FinalSelections, err = r.ListFinalSelections(ctx, sourcePath); err != nil {
-		return api.HistoryRecord{}, fmt.Errorf("db history record final selections: %w", err)
-	}
-	if record.UploadedImages, err = r.ListUploadedImagesByPath(ctx, sourcePath); err != nil {
-		return api.HistoryRecord{}, fmt.Errorf("db history record uploaded images: %w", err)
+	if record.PreparedRelease != nil {
+		binding, bindingErr := record.PreparedRelease.MediaBinding()
+		if bindingErr != nil {
+			return api.HistoryRecord{}, fmt.Errorf("db history record media binding: %w", bindingErr)
+		}
+		if record.Screenshots, err = r.ListScreenshotsByPath(ctx, binding); err != nil {
+			return api.HistoryRecord{}, fmt.Errorf("db history record screenshots: %w", err)
+		}
+		if record.FinalSelections, err = r.ListFinalSelections(ctx, binding); err != nil {
+			return api.HistoryRecord{}, fmt.Errorf("db history record final selections: %w", err)
+		}
+		if record.UploadedImages, err = r.ListUploadedImagesByPath(ctx, binding); err != nil {
+			return api.HistoryRecord{}, fmt.Errorf("db history record uploaded images: %w", err)
+		}
 	}
 	if record.UploadHistory, err = r.ListUploadHistoryByPath(ctx, sourcePath); err != nil {
 		return api.HistoryRecord{}, fmt.Errorf("db history record upload history: %w", err)
@@ -78,40 +84,40 @@ func (r *SQLiteRepository) LoadHistoryRecord(ctx context.Context, sourcePath str
 // optional metadata needed to derive the managed release directory.
 func (r *SQLiteRepository) LoadHistoryCleanupSnapshot(ctx context.Context, sourcePath string) (api.HistoryCleanupSnapshot, error) {
 	snapshot := api.HistoryCleanupSnapshot{}
-	shots, err := r.ListScreenshotsByPath(ctx, sourcePath)
+	trimmed := strings.TrimSpace(sourcePath)
+	if trimmed == "" {
+		return api.HistoryCleanupSnapshot{}, internalerrors.ErrInvalidInput
+	}
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT image_path FROM screenshots WHERE source_path = ?
+		UNION
+		SELECT image_path FROM uploaded_images WHERE source_path = ?
+		UNION
+		SELECT image_path FROM screenshot_final_selections WHERE source_path = ?
+		UNION
+		SELECT image_path FROM screenshot_slots WHERE source_path = ?
+		UNION
+		SELECT image_path FROM screenshot_slot_variants WHERE source_path = ?
+	`, trimmed, trimmed, trimmed, trimmed, trimmed)
 	if err != nil {
-		return api.HistoryCleanupSnapshot{}, fmt.Errorf("db history cleanup screenshots: %w", err)
+		return api.HistoryCleanupSnapshot{}, fmt.Errorf("db history cleanup artifact paths: %w", err)
 	}
-	for _, shot := range shots {
-		snapshot.ArtifactPaths = append(snapshot.ArtifactPaths, shot.ImagePath)
-	}
-	uploaded, err := r.ListUploadedImagesByPath(ctx, sourcePath)
-	if err != nil {
-		return api.HistoryCleanupSnapshot{}, fmt.Errorf("db history cleanup uploaded images: %w", err)
-	}
-	for _, image := range uploaded {
-		snapshot.ArtifactPaths = append(snapshot.ArtifactPaths, image.ImagePath)
-	}
-	finals, err := r.ListFinalSelections(ctx, sourcePath)
-	if err != nil {
-		return api.HistoryCleanupSnapshot{}, fmt.Errorf("db history cleanup final selections: %w", err)
-	}
-	for _, image := range finals {
-		snapshot.ArtifactPaths = append(snapshot.ArtifactPaths, image.ImagePath)
-	}
-	slots, err := r.ListScreenshotSlotsByPath(ctx, sourcePath)
-	if err != nil {
-		return api.HistoryCleanupSnapshot{}, fmt.Errorf("db history cleanup screenshot slots: %w", err)
-	}
-	for _, slot := range slots {
-		snapshot.ArtifactPaths = append(snapshot.ArtifactPaths, slot.ImagePath)
-		for _, variant := range slot.Variants {
-			snapshot.ArtifactPaths = append(snapshot.ArtifactPaths, variant.ImagePath)
+	defer rows.Close()
+	for rows.Next() {
+		var artifactPath string
+		if err := rows.Scan(&artifactPath); err != nil {
+			return api.HistoryCleanupSnapshot{}, fmt.Errorf("db history cleanup scan artifact path: %w", err)
 		}
+		if artifactPath = strings.TrimSpace(artifactPath); artifactPath != "" {
+			snapshot.ArtifactPaths = append(snapshot.ArtifactPaths, artifactPath)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return api.HistoryCleanupSnapshot{}, fmt.Errorf("db history cleanup iterate artifact paths: %w", err)
 	}
 	// Metadata only refines the derived temp directory. Preserve cleanup of
 	// known artifact paths when the optional release row cannot be read.
-	if metadata, metadataErr := r.GetByPath(ctx, sourcePath); metadataErr == nil {
+	if metadata, metadataErr := r.GetByPath(ctx, trimmed); metadataErr == nil {
 		snapshot.Metadata = &metadata
 	}
 	return snapshot, nil

--- a/internal/services/db/media_binding_test.go
+++ b/internal/services/db/media_binding_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMediaAssetsRequireExactPreparedBinding(t *testing.T) {
+	t.Parallel()
+
+	repo, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	first := testPreparedMediaBinding("C:\\releases\\Example.Release.2026")
+	second := first
+	second.PreparedMediaFingerprint = "replacement-prepared-media"
+	second.PreparedGeneration = 2
+	imagePath := "C:\\screens\\disc-a.png"
+	stamp := time.Date(2026, time.August, 18, 1, 2, 3, 0, time.UTC)
+
+	writeMediaAssetsForBinding(t, repo, first, "disc-a", imagePath, stamp)
+	assertMediaAssetsForBinding(t, repo, first, "disc-a", 1)
+	assertMediaAssetsForBinding(t, repo, second, "", 0)
+
+	writeMediaAssetsForBinding(t, repo, second, "disc-b", imagePath, stamp.Add(time.Minute))
+	assertMediaAssetsForBinding(t, repo, first, "", 0)
+	assertMediaAssetsForBinding(t, repo, second, "disc-b", 1)
+}
+
+func writeMediaAssetsForBinding(
+	t *testing.T,
+	repo *SQLiteRepository,
+	binding PreparedMediaBinding,
+	discID string,
+	imagePath string,
+	stamp time.Time,
+) {
+	t.Helper()
+	ctx := context.Background()
+	if err := repo.SaveScreenshot(ctx, binding, Screenshot{
+		DiscID:     discID,
+		ImagePath:  imagePath,
+		Timestamp:  42,
+		Purpose:    "final",
+		CapturedAt: stamp,
+	}); err != nil {
+		t.Fatalf("save screenshot: %v", err)
+	}
+	if err := repo.SaveFinalSelections(ctx, binding, []ScreenshotFinalSelection{{
+		DiscID:     discID,
+		ImagePath:  imagePath,
+		Source:     "final",
+		SelectedAt: stamp,
+	}}); err != nil {
+		t.Fatalf("save final selections: %v", err)
+	}
+	if err := repo.SaveUploadedImages(ctx, binding, "imgbox", []UploadedImageLink{{
+		DiscID:     discID,
+		ImagePath:  imagePath,
+		UsageScope: "global",
+		RawURL:     "https://example.invalid/image.png",
+		UploadedAt: stamp,
+	}}); err != nil {
+		t.Fatalf("save uploaded images: %v", err)
+	}
+	if err := repo.ReplaceScreenshotSlots(ctx, binding, []ScreenshotSlot{{
+		DiscID:    discID,
+		SlotOrder: 0,
+		ImagePath: imagePath,
+		Variants: []ScreenshotSlotVariant{{
+			DiscID:     discID,
+			SlotOrder:  0,
+			Host:       "imgbox",
+			UsageScope: "global",
+			ImagePath:  imagePath,
+			RawURL:     "https://example.invalid/image.png",
+			UploadedAt: stamp,
+		}},
+	}}); err != nil {
+		t.Fatalf("replace screenshot slots: %v", err)
+	}
+}
+
+func assertMediaAssetsForBinding(
+	t *testing.T,
+	repo *SQLiteRepository,
+	binding PreparedMediaBinding,
+	discID string,
+	want int,
+) {
+	t.Helper()
+	ctx := context.Background()
+	screenshots, err := repo.ListScreenshotsByPath(ctx, binding)
+	if err != nil {
+		t.Fatalf("list screenshots: %v", err)
+	}
+	selections, err := repo.ListFinalSelections(ctx, binding)
+	if err != nil {
+		t.Fatalf("list final selections: %v", err)
+	}
+	uploads, err := repo.ListUploadedImagesByPath(ctx, binding)
+	if err != nil {
+		t.Fatalf("list uploaded images: %v", err)
+	}
+	slots, err := repo.ListScreenshotSlotsByPath(ctx, binding)
+	if err != nil {
+		t.Fatalf("list screenshot slots: %v", err)
+	}
+	if len(screenshots) != want || len(selections) != want || len(uploads) != want || len(slots) != want {
+		t.Fatalf("asset counts = screenshots:%d selections:%d uploads:%d slots:%d, want %d", len(screenshots), len(selections), len(uploads), len(slots), want)
+	}
+	if want == 0 {
+		return
+	}
+	if screenshots[0].DiscID != discID || selections[0].DiscID != discID || uploads[0].DiscID != discID ||
+		slots[0].DiscID != discID || len(slots[0].Variants) != 1 || slots[0].Variants[0].DiscID != discID {
+		t.Fatalf("disc binding was not retained: screenshots=%#v selections=%#v uploads=%#v slots=%#v", screenshots, selections, uploads, slots)
+	}
+	if screenshots[0].PreparedMediaFingerprint != binding.PreparedMediaFingerprint || screenshots[0].PreparedGeneration != binding.PreparedGeneration ||
+		selections[0].PreparedMediaFingerprint != binding.PreparedMediaFingerprint || uploads[0].PreparedGeneration != binding.PreparedGeneration ||
+		slots[0].PreparedMediaFingerprint != binding.PreparedMediaFingerprint || slots[0].Variants[0].PreparedGeneration != binding.PreparedGeneration {
+		t.Fatalf("prepared binding was not retained: screenshots=%#v selections=%#v uploads=%#v slots=%#v", screenshots, selections, uploads, slots)
+	}
+}

--- a/internal/services/db/media_capability.go
+++ b/internal/services/db/media_capability.go
@@ -13,22 +13,22 @@ import (
 // LoadMediaAssetSnapshot assembles the ordered media records for one release.
 // Each query already returns caller-owned values; nested slot variants are
 // cloned so callers cannot share mutable slice backing storage.
-func (r *SQLiteRepository) LoadMediaAssetSnapshot(ctx context.Context, path string) (api.MediaAssetSnapshot, error) {
+func (r *SQLiteRepository) LoadMediaAssetSnapshot(ctx context.Context, binding api.PreparedMediaBinding) (api.MediaAssetSnapshot, error) {
 	snapshot := api.MediaAssetSnapshot{}
 	var err error
-	if snapshot.Screenshots, err = r.ListScreenshotsByPath(ctx, path); err != nil {
+	if snapshot.Screenshots, err = r.ListScreenshotsByPath(ctx, binding); err != nil {
 		return api.MediaAssetSnapshot{}, fmt.Errorf("db media snapshot screenshots: %w", err)
 	}
-	if snapshot.FinalSelections, err = r.ListFinalSelections(ctx, path); err != nil {
+	if snapshot.FinalSelections, err = r.ListFinalSelections(ctx, binding); err != nil {
 		return api.MediaAssetSnapshot{}, fmt.Errorf("db media snapshot final selections: %w", err)
 	}
-	if snapshot.ScreenshotSlots, err = r.ListScreenshotSlotsByPath(ctx, path); err != nil {
+	if snapshot.ScreenshotSlots, err = r.ListScreenshotSlotsByPath(ctx, binding); err != nil {
 		return api.MediaAssetSnapshot{}, fmt.Errorf("db media snapshot screenshot slots: %w", err)
 	}
 	for index := range snapshot.ScreenshotSlots {
 		snapshot.ScreenshotSlots[index].Variants = append([]api.ScreenshotSlotVariant(nil), snapshot.ScreenshotSlots[index].Variants...)
 	}
-	if snapshot.UploadedImages, err = r.ListUploadedImagesByPath(ctx, path); err != nil {
+	if snapshot.UploadedImages, err = r.ListUploadedImagesByPath(ctx, binding); err != nil {
 		return api.MediaAssetSnapshot{}, fmt.Errorf("db media snapshot uploaded images: %w", err)
 	}
 	return snapshot, nil

--- a/internal/services/db/migrations.go
+++ b/internal/services/db/migrations.go
@@ -160,6 +160,32 @@ var migrationRegistry = []migrationStep{
 		dependsOn: []string{baselineMigrationID},
 		apply:     migrateAddReleaseOmissionControls,
 	},
+	{
+		id:        "2026_08_add_multi_disc_media_binding",
+		dependsOn: []string{baselineMigrationID},
+		apply:     migrateAddMultiDiscMediaBinding,
+	},
+}
+
+func migrateAddMultiDiscMediaBinding(ctx context.Context, exec migrationExecutor) error {
+	if _, err := exec.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS playlist_selections (
+		source_path TEXT PRIMARY KEY,
+		selected_playlists TEXT NOT NULL DEFAULT "[]",
+		use_all INTEGER NOT NULL DEFAULT 0,
+		updated_at TEXT NOT NULL
+	)`); err != nil {
+		return fmt.Errorf("db: ensure playlist selections: %w", err)
+	}
+	exists, err := tableColumnExists(ctx, exec, "playlist_selections", "source_fingerprint")
+	if err != nil {
+		return fmt.Errorf("db: inspect playlist selection fingerprint: %w", err)
+	}
+	if !exists {
+		if _, err := exec.ExecContext(ctx, `ALTER TABLE playlist_selections ADD COLUMN source_fingerprint TEXT NOT NULL DEFAULT ""`); err != nil {
+			return fmt.Errorf("db: add playlist selection fingerprint: %w", err)
+		}
+	}
+	return nil
 }
 
 func migrateAddReleaseWorkflowStates(ctx context.Context, exec migrationExecutor) error {

--- a/internal/services/db/migrations.go
+++ b/internal/services/db/migrations.go
@@ -165,6 +165,11 @@ var migrationRegistry = []migrationStep{
 		dependsOn: []string{baselineMigrationID},
 		apply:     migrateAddMultiDiscMediaBinding,
 	},
+	{
+		id:        "2026_08_bind_prepared_media_assets",
+		dependsOn: []string{"2026_08_add_multi_disc_media_binding", "2026_04_add_screenshot_slot_tables"},
+		apply:     migrateBindPreparedMediaAssets,
+	},
 }
 
 func migrateAddMultiDiscMediaBinding(ctx context.Context, exec migrationExecutor) error {
@@ -183,6 +188,38 @@ func migrateAddMultiDiscMediaBinding(ctx context.Context, exec migrationExecutor
 	if !exists {
 		if _, err := exec.ExecContext(ctx, `ALTER TABLE playlist_selections ADD COLUMN source_fingerprint TEXT NOT NULL DEFAULT ""`); err != nil {
 			return fmt.Errorf("db: add playlist selection fingerprint: %w", err)
+		}
+	}
+	return nil
+}
+
+func migrateBindPreparedMediaAssets(ctx context.Context, exec migrationExecutor) error {
+	for _, table := range []string{"screenshots", "screenshot_final_selections", "uploaded_images", "screenshot_slots", "screenshot_slot_variants"} {
+		tablePresent, err := tableExists(ctx, exec, table)
+		if err != nil {
+			return fmt.Errorf("db: inspect media table %s: %w", table, err)
+		}
+		if !tablePresent {
+			continue
+		}
+		for _, column := range []struct {
+			name       string
+			definition string
+		}{
+			{name: "prepared_media_fingerprint", definition: `TEXT NOT NULL DEFAULT ""`},
+			{name: "prepared_generation", definition: `INTEGER NOT NULL DEFAULT 0`},
+			{name: "disc_id", definition: `TEXT NOT NULL DEFAULT ""`},
+		} {
+			exists, err := tableColumnExists(ctx, exec, table, column.name)
+			if err != nil {
+				return fmt.Errorf("db: inspect %s.%s: %w", table, column.name, err)
+			}
+			if exists {
+				continue
+			}
+			if _, err := exec.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s ADD COLUMN %s %s`, table, column.name, column.definition)); err != nil {
+				return fmt.Errorf("db: add %s.%s: %w", table, column.name, err)
+			}
 		}
 	}
 	return nil

--- a/internal/services/db/repository.go
+++ b/internal/services/db/repository.go
@@ -27,6 +27,7 @@ type ScreenshotFinalSelection = api.ScreenshotFinalSelection
 type ScreenshotSlot = api.ScreenshotSlot
 type ScreenshotSlotVariant = api.ScreenshotSlotVariant
 type UploadedImageLink = api.UploadedImageLink
+type PreparedMediaBinding = api.PreparedMediaBinding
 type PlaylistSelection = api.PlaylistSelection
 type PlaylistInfo = api.PlaylistInfo
 type PlaylistItem = api.PlaylistItem

--- a/internal/services/db/screenshot_final_selections_test.go
+++ b/internal/services/db/screenshot_final_selections_test.go
@@ -48,11 +48,12 @@ func TestScreenshotFinalSelectionsCRUD(t *testing.T) {
 		},
 	}
 
-	if err := repo.SaveFinalSelections(ctx, sourcePath, selections); err != nil {
+	binding := testPreparedMediaBinding(sourcePath)
+	if err := repo.SaveFinalSelections(ctx, binding, selections); err != nil {
 		t.Fatalf("save final selections: %v", err)
 	}
 
-	loaded, err := repo.ListFinalSelections(ctx, sourcePath)
+	loaded, err := repo.ListFinalSelections(ctx, binding)
 	if err != nil {
 		t.Fatalf("list final selections: %v", err)
 	}
@@ -66,11 +67,11 @@ func TestScreenshotFinalSelectionsCRUD(t *testing.T) {
 		t.Fatalf("unexpected second selection: %#v", loaded[1])
 	}
 
-	if err := repo.DeleteFinalSelection(ctx, selections[0].ImagePath); err != nil {
+	if err := repo.DeleteFinalSelection(ctx, binding, selections[0].ImagePath); err != nil {
 		t.Fatalf("delete final selection: %v", err)
 	}
 
-	loaded, err = repo.ListFinalSelections(ctx, sourcePath)
+	loaded, err = repo.ListFinalSelections(ctx, binding)
 	if err != nil {
 		t.Fatalf("list final selections: %v", err)
 	}
@@ -99,15 +100,23 @@ func TestScreenshotFinalSelectionsInvalidInput(t *testing.T) {
 
 	ctx := context.Background()
 
-	if err := repo.SaveFinalSelections(ctx, "", nil); !errors.Is(err, internalerrors.ErrInvalidInput) {
+	if err := repo.SaveFinalSelections(ctx, PreparedMediaBinding{}, nil); !errors.Is(err, internalerrors.ErrInvalidInput) {
 		t.Fatalf("expected invalid input, got %v", err)
 	}
 
-	if _, err := repo.ListFinalSelections(ctx, ""); !errors.Is(err, internalerrors.ErrInvalidInput) {
+	if _, err := repo.ListFinalSelections(ctx, PreparedMediaBinding{}); !errors.Is(err, internalerrors.ErrInvalidInput) {
 		t.Fatalf("expected invalid input, got %v", err)
 	}
 
-	if err := repo.DeleteFinalSelection(ctx, ""); !errors.Is(err, internalerrors.ErrInvalidInput) {
+	if err := repo.DeleteFinalSelection(ctx, PreparedMediaBinding{}, ""); !errors.Is(err, internalerrors.ErrInvalidInput) {
 		t.Fatalf("expected invalid input, got %v", err)
+	}
+}
+
+func testPreparedMediaBinding(sourcePath string) PreparedMediaBinding {
+	return PreparedMediaBinding{
+		SourcePath:               sourcePath,
+		PreparedMediaFingerprint: "test-prepared-media",
+		PreparedGeneration:       1,
 	}
 }

--- a/internal/services/db/screenshot_lifecycle_test.go
+++ b/internal/services/db/screenshot_lifecycle_test.go
@@ -29,13 +29,14 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 	ctx := context.Background()
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "Example.Release.2026.DVD-GRP")
+	binding := testPreparedMediaBinding(sourcePath)
 	autoOld := filepath.Join(root, "auto-old.png")
 	manualOld := filepath.Join(root, "manual-old.png")
 	normalOld := filepath.Join(root, "normal-old.png")
 	normalNew := filepath.Join(root, "normal-new.png")
 	now := time.Now().UTC()
 
-	if err := repo.SaveScreenshot(ctx, api.Screenshot{
+	if err := repo.SaveScreenshot(ctx, binding, api.Screenshot{
 		SourcePath: sourcePath,
 		ImagePath:  autoOld,
 		Purpose:    api.ScreenshotPurposeMenu,
@@ -43,7 +44,7 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 	}); err != nil {
 		t.Fatalf("save old auto screenshot: %v", err)
 	}
-	if err := repo.SaveScreenshot(ctx, api.Screenshot{
+	if err := repo.SaveScreenshot(ctx, binding, api.Screenshot{
 		SourcePath: sourcePath,
 		ImagePath:  manualOld,
 		Purpose:    api.ScreenshotPurposeMenu,
@@ -51,7 +52,7 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 	}); err != nil {
 		t.Fatalf("save old manual screenshot: %v", err)
 	}
-	if err := repo.SaveFinalSelections(ctx, sourcePath, []api.ScreenshotFinalSelection{
+	if err := repo.SaveFinalSelections(ctx, binding, []api.ScreenshotFinalSelection{
 		{
 			SourcePath: sourcePath,
 			ImagePath:  normalOld,
@@ -77,7 +78,7 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 		t.Fatalf("seed final selections: %v", err)
 	}
 
-	if err := repo.ReplaceNormalFinalSelections(ctx, sourcePath, []api.ScreenshotFinalSelection{
+	if err := repo.ReplaceNormalFinalSelections(ctx, binding, []api.ScreenshotFinalSelection{
 		{
 			SourcePath: sourcePath,
 			ImagePath:  normalNew,
@@ -91,7 +92,7 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 	assertFinalSelectionPaths(t, repo, sourcePath, []string{autoOld, manualOld, normalNew})
 
 	manualNew := filepath.Join(root, "manual-new.png")
-	if err := repo.AppendManualMenuScreenshots(ctx, sourcePath,
+	if err := repo.AppendManualMenuScreenshots(ctx, binding,
 		[]api.Screenshot{{
 			SourcePath: sourcePath,
 			ImagePath:  manualNew,
@@ -109,7 +110,7 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 	}
 	assertFinalSelectionPaths(t, repo, sourcePath, []string{autoOld, manualOld, manualNew, normalNew})
 
-	if err := repo.SaveUploadedImages(ctx, sourcePath, "example-host", []api.UploadedImageLink{{
+	if err := repo.SaveUploadedImages(ctx, binding, "example-host", []api.UploadedImageLink{{
 		SourcePath: sourcePath,
 		ImagePath:  autoOld,
 		Host:       "example-host",
@@ -119,7 +120,7 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 	}}); err != nil {
 		t.Fatalf("save old auto upload: %v", err)
 	}
-	if err := repo.ReplaceScreenshotSlots(ctx, sourcePath, []api.ScreenshotSlot{{
+	if err := repo.ReplaceScreenshotSlots(ctx, binding, []api.ScreenshotSlot{{
 		SourcePath: sourcePath,
 		SlotOrder:  0,
 		ImagePath:  autoOld,
@@ -135,7 +136,7 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 	}
 
 	autoNew := filepath.Join(root, "auto-new.png")
-	replaced, err := repo.ReplaceDVDMenuScreenshots(ctx, sourcePath,
+	replaced, err := repo.ReplaceDVDMenuScreenshots(ctx, binding,
 		[]api.Screenshot{{
 			SourcePath: sourcePath,
 			ImagePath:  autoNew,
@@ -158,7 +159,7 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 	assertFinalSelectionPaths(t, repo, sourcePath, []string{autoNew, manualOld, manualNew, normalNew})
 	assertNoScreenshotReferences(t, repo, sourcePath, autoOld)
 
-	if err := repo.SaveUploadedImages(ctx, sourcePath, "example-host", []api.UploadedImageLink{{
+	if err := repo.SaveUploadedImages(ctx, binding, "example-host", []api.UploadedImageLink{{
 		SourcePath: sourcePath,
 		ImagePath:  manualNew,
 		Host:       "example-host",
@@ -168,7 +169,7 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 	}}); err != nil {
 		t.Fatalf("save manual upload: %v", err)
 	}
-	if err := repo.ReplaceScreenshotSlots(ctx, sourcePath, []api.ScreenshotSlot{{
+	if err := repo.ReplaceScreenshotSlots(ctx, binding, []api.ScreenshotSlot{{
 		SourcePath: sourcePath,
 		SlotOrder:  0,
 		ImagePath:  manualNew,
@@ -184,7 +185,7 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 	}}); err != nil {
 		t.Fatalf("save manual screenshot slot: %v", err)
 	}
-	deleted, err := repo.DeleteDiscMenuScreenshot(ctx, sourcePath, manualNew)
+	deleted, err := repo.DeleteDiscMenuScreenshot(ctx, binding, manualNew)
 	if err != nil {
 		t.Fatalf("delete manual screenshot: %v", err)
 	}
@@ -197,15 +198,15 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 	assertFinalSelectionPaths(t, repo, sourcePath, []string{autoNew, manualOld, normalNew})
 	assertNoScreenshotReferences(t, repo, sourcePath, manualNew)
 
-	if err := repo.RestoreDiscMenuScreenshot(ctx, sourcePath, deleted); err != nil {
+	if err := repo.RestoreDiscMenuScreenshot(ctx, binding, deleted); err != nil {
 		t.Fatal("restore deleted menu screenshot records failed")
 	}
 	assertFinalSelectionPaths(t, repo, sourcePath, []string{autoNew, manualOld, manualNew, normalNew})
-	restoredScreenshots, err := repo.ListScreenshotsByPath(ctx, sourcePath)
+	restoredScreenshots, err := repo.ListScreenshotsByPath(ctx, binding)
 	if err != nil {
 		t.Fatal("list restored screenshots failed")
 	}
-	restoredUploads, err := repo.ListUploadedImagesByPath(ctx, sourcePath)
+	restoredUploads, err := repo.ListUploadedImagesByPath(ctx, binding)
 	if err != nil {
 		t.Fatal("list restored uploads failed")
 	}
@@ -226,7 +227,7 @@ func TestScreenshotLifecyclePreservesCategoriesAndCleansReferences(t *testing.T)
 	if !restoredScreenshot || !restoredUpload {
 		t.Fatal("restored menu screenshot references are incomplete")
 	}
-	restoredSlots, err := repo.ListScreenshotSlotsByPath(ctx, sourcePath)
+	restoredSlots, err := repo.ListScreenshotSlotsByPath(ctx, binding)
 	if err != nil {
 		t.Fatal("list restored screenshot slots failed")
 	}
@@ -252,7 +253,9 @@ func TestAppendManualMenuScreenshotsRollsBackCrossSourceImageConflict(t *testing
 	firstSource := filepath.Join(root, "first")
 	secondSource := filepath.Join(root, "second")
 	imagePath := filepath.Join(root, "shared.png")
-	if err := repo.SaveScreenshot(ctx, api.Screenshot{
+	firstBinding := testPreparedMediaBinding(firstSource)
+	secondBinding := testPreparedMediaBinding(secondSource)
+	if err := repo.SaveScreenshot(ctx, firstBinding, api.Screenshot{
 		SourcePath: firstSource,
 		ImagePath:  imagePath,
 		Purpose:    api.ScreenshotPurposeFinal,
@@ -261,7 +264,7 @@ func TestAppendManualMenuScreenshotsRollsBackCrossSourceImageConflict(t *testing
 		t.Fatalf("seed screenshot: %v", err)
 	}
 
-	err = repo.AppendManualMenuScreenshots(ctx, secondSource,
+	err = repo.AppendManualMenuScreenshots(ctx, secondBinding,
 		[]api.Screenshot{{
 			SourcePath: secondSource,
 			ImagePath:  imagePath,
@@ -276,14 +279,14 @@ func TestAppendManualMenuScreenshotsRollsBackCrossSourceImageConflict(t *testing
 	if !errors.Is(err, internalerrors.ErrInvalidInput) {
 		t.Fatalf("append error = %v, want invalid input", err)
 	}
-	selections, err := repo.ListFinalSelections(ctx, secondSource)
+	selections, err := repo.ListFinalSelections(ctx, secondBinding)
 	if err != nil {
 		t.Fatalf("list rolled-back selections: %v", err)
 	}
 	if len(selections) != 0 {
 		t.Fatalf("rolled-back selections = %#v", selections)
 	}
-	records, err := repo.ListScreenshotsByPath(ctx, firstSource)
+	records, err := repo.ListScreenshotsByPath(ctx, firstBinding)
 	if err != nil {
 		t.Fatalf("list original screenshots: %v", err)
 	}
@@ -307,8 +310,9 @@ func TestDeleteUploadedImageConvergesAfterRecordIsGone(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "Example.Release.2026.1080p-GRP.mkv")
+	binding := testPreparedMediaBinding(sourcePath)
 	imagePath := filepath.Join(root, "capture.png")
-	if err := repo.SaveUploadedImages(ctx, sourcePath, "example-host", []api.UploadedImageLink{{
+	if err := repo.SaveUploadedImages(ctx, binding, "example-host", []api.UploadedImageLink{{
 		SourcePath: sourcePath,
 		ImagePath:  imagePath,
 		Host:       "example-host",
@@ -320,11 +324,11 @@ func TestDeleteUploadedImageConvergesAfterRecordIsGone(t *testing.T) {
 	}
 
 	for range 2 {
-		if err := repo.DeleteUploadedImage(ctx, sourcePath, imagePath, "example-host"); err != nil {
+		if err := repo.DeleteUploadedImage(ctx, binding, imagePath, "example-host"); err != nil {
 			t.Fatalf("delete uploaded image: %v", err)
 		}
 	}
-	stored, err := repo.ListUploadedImagesByPath(ctx, sourcePath)
+	stored, err := repo.ListUploadedImagesByPath(ctx, binding)
 	if err != nil {
 		t.Fatalf("list uploaded images: %v", err)
 	}
@@ -335,7 +339,7 @@ func TestDeleteUploadedImageConvergesAfterRecordIsGone(t *testing.T) {
 
 func assertFinalSelectionPaths(t *testing.T, repo *SQLiteRepository, sourcePath string, expected []string) {
 	t.Helper()
-	selections, err := repo.ListFinalSelections(context.Background(), sourcePath)
+	selections, err := repo.ListFinalSelections(context.Background(), testPreparedMediaBinding(sourcePath))
 	if err != nil {
 		t.Fatalf("list final selections: %v", err)
 	}
@@ -351,7 +355,8 @@ func assertFinalSelectionPaths(t *testing.T, repo *SQLiteRepository, sourcePath 
 
 func assertNoScreenshotReferences(t *testing.T, repo *SQLiteRepository, sourcePath string, imagePath string) {
 	t.Helper()
-	records, err := repo.ListScreenshotsByPath(context.Background(), sourcePath)
+	binding := testPreparedMediaBinding(sourcePath)
+	records, err := repo.ListScreenshotsByPath(context.Background(), binding)
 	if err != nil {
 		t.Fatalf("list screenshots: %v", err)
 	}
@@ -360,7 +365,7 @@ func assertNoScreenshotReferences(t *testing.T, repo *SQLiteRepository, sourcePa
 			t.Fatalf("screenshot record retained for %q", imagePath)
 		}
 	}
-	uploads, err := repo.ListUploadedImagesByPath(context.Background(), sourcePath)
+	uploads, err := repo.ListUploadedImagesByPath(context.Background(), binding)
 	if err != nil {
 		t.Fatalf("list uploads: %v", err)
 	}
@@ -369,7 +374,7 @@ func assertNoScreenshotReferences(t *testing.T, repo *SQLiteRepository, sourcePa
 			t.Fatalf("upload retained for %q", imagePath)
 		}
 	}
-	slots, err := repo.ListScreenshotSlotsByPath(context.Background(), sourcePath)
+	slots, err := repo.ListScreenshotSlotsByPath(context.Background(), binding)
 	if err != nil {
 		t.Fatalf("list slots: %v", err)
 	}

--- a/internal/services/db/sqlite.go
+++ b/internal/services/db/sqlite.go
@@ -1126,15 +1126,16 @@ func (r *SQLiteRepository) GetPlaylistSelection(ctx context.Context, sourcePath 
 	}
 
 	row := r.db.QueryRowContext(ctx, `
-		SELECT selected_playlists, use_all
+		SELECT source_fingerprint, selected_playlists, use_all
 		FROM playlist_selections
 		WHERE source_path = ?
 	`, sourcePath)
 
 	var playlistsJSON string
+	var sourceFingerprint string
 	var useAll bool
 
-	if err := row.Scan(&playlistsJSON, &useAll); err != nil {
+	if err := row.Scan(&sourceFingerprint, &playlistsJSON, &useAll); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return PlaylistSelection{}, internalerrors.ErrNotFound
 		}
@@ -1150,12 +1151,19 @@ func (r *SQLiteRepository) GetPlaylistSelection(ctx context.Context, sourcePath 
 
 	return PlaylistSelection{
 		SourcePath:        sourcePath,
+		SourceFingerprint: sourceFingerprint,
 		SelectedPlaylists: playlists,
 		UseAll:            useAll,
 	}, nil
 }
 
-func (r *SQLiteRepository) SavePlaylistSelection(ctx context.Context, sourcePath string, playlists []string, useAll bool) error {
+func (r *SQLiteRepository) SavePlaylistSelection(
+	ctx context.Context,
+	sourcePath string,
+	sourceFingerprint string,
+	playlists []string,
+	useAll bool,
+) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
 	}
@@ -1176,13 +1184,14 @@ func (r *SQLiteRepository) SavePlaylistSelection(ctx context.Context, sourcePath
 	}
 
 	_, err := r.execWrite(ctx, "save playlist selection", `
-		INSERT INTO playlist_selections (source_path, selected_playlists, use_all, updated_at)
-		VALUES (?, ?, ?, ?)
+		INSERT INTO playlist_selections (source_path, source_fingerprint, selected_playlists, use_all, updated_at)
+		VALUES (?, ?, ?, ?, ?)
 		ON CONFLICT(source_path) DO UPDATE SET
+			source_fingerprint = excluded.source_fingerprint,
 			selected_playlists = excluded.selected_playlists,
 			use_all = excluded.use_all,
 			updated_at = excluded.updated_at
-	`, sourcePath, playlistsJSON, useAll, timestamp)
+	`, sourcePath, strings.TrimSpace(sourceFingerprint), playlistsJSON, useAll, timestamp)
 
 	if err != nil {
 		return fmt.Errorf("db save playlist selection: %w", err)

--- a/internal/services/db/sqlite.go
+++ b/internal/services/db/sqlite.go
@@ -2020,18 +2020,30 @@ func (r *SQLiteRepository) ListTrackerMetadataByPath(ctx context.Context, path s
 	return records, nil
 }
 
-func (r *SQLiteRepository) SaveScreenshot(ctx context.Context, screenshot Screenshot) error {
+func normalizePreparedMediaBinding(binding PreparedMediaBinding) (PreparedMediaBinding, error) {
+	binding.SourcePath = strings.TrimSpace(binding.SourcePath)
+	binding.PreparedMediaFingerprint = strings.TrimSpace(binding.PreparedMediaFingerprint)
+	if !binding.Valid() {
+		return PreparedMediaBinding{}, internalerrors.ErrInvalidInput
+	}
+	return binding, nil
+}
+
+func (r *SQLiteRepository) SaveScreenshot(ctx context.Context, binding PreparedMediaBinding, screenshot Screenshot) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
 	}
-	if strings.TrimSpace(screenshot.SourcePath) == "" || strings.TrimSpace(screenshot.ImagePath) == "" {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil || strings.TrimSpace(screenshot.ImagePath) == "" {
 		return internalerrors.ErrInvalidInput
 	}
-	_, err := r.execWrite(ctx, "save screenshot", `
+	_, err = r.execWrite(ctx, "save screenshot", `
 		INSERT OR REPLACE INTO screenshots (
-			source_path, image_path, timestamp, frame_number, width, height, purpose, captured_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`, screenshot.SourcePath, screenshot.ImagePath, screenshot.Timestamp, screenshot.FrameNumber,
+			source_path, prepared_media_fingerprint, prepared_generation, disc_id,
+			image_path, timestamp, frame_number, width, height, purpose, captured_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, bound.SourcePath, bound.PreparedMediaFingerprint, bound.PreparedGeneration, strings.TrimSpace(screenshot.DiscID),
+		screenshot.ImagePath, screenshot.Timestamp, screenshot.FrameNumber,
 		screenshot.Width, screenshot.Height, screenshot.Purpose, screenshot.CapturedAt.UTC().Format(time.RFC3339Nano))
 	if err != nil {
 		return fmt.Errorf("db save screenshot: %w", err)
@@ -2039,20 +2051,20 @@ func (r *SQLiteRepository) SaveScreenshot(ctx context.Context, screenshot Screen
 	return nil
 }
 
-func (r *SQLiteRepository) ListScreenshotsByPath(ctx context.Context, path string) ([]Screenshot, error) {
+func (r *SQLiteRepository) ListScreenshotsByPath(ctx context.Context, binding PreparedMediaBinding) ([]Screenshot, error) {
 	if r == nil || r.db == nil {
 		return nil, errors.New("db: repository not initialized")
 	}
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil {
 		return nil, internalerrors.ErrInvalidInput
 	}
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT image_path, timestamp, frame_number, width, height, purpose, captured_at
+		SELECT disc_id, image_path, timestamp, frame_number, width, height, purpose, captured_at
 		FROM screenshots
-		WHERE source_path = ?
-		ORDER BY timestamp ASC
-	`, trimmed)
+		WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ?
+		ORDER BY disc_id ASC, timestamp ASC, image_path ASC
+	`, bound.SourcePath, bound.PreparedMediaFingerprint, bound.PreparedGeneration)
 	if err != nil {
 		return nil, fmt.Errorf("db list screenshots: %w", err)
 	}
@@ -2064,6 +2076,7 @@ func (r *SQLiteRepository) ListScreenshotsByPath(ctx context.Context, path strin
 		var purpose string
 		var capturedAt string
 		if err := rows.Scan(
+			&shot.DiscID,
 			&shot.ImagePath,
 			&shot.Timestamp,
 			&shot.FrameNumber,
@@ -2074,7 +2087,9 @@ func (r *SQLiteRepository) ListScreenshotsByPath(ctx context.Context, path strin
 		); err != nil {
 			return nil, fmt.Errorf("db list screenshots: %w", err)
 		}
-		shot.SourcePath = trimmed
+		shot.SourcePath = bound.SourcePath
+		shot.PreparedMediaFingerprint = bound.PreparedMediaFingerprint
+		shot.PreparedGeneration = bound.PreparedGeneration
 		shot.Purpose = ScreenshotPurpose(purpose)
 		if capturedAt != "" {
 			if parsed, err := time.Parse(time.RFC3339Nano, capturedAt); err == nil {
@@ -2091,18 +2106,25 @@ func (r *SQLiteRepository) ListScreenshotsByPath(ctx context.Context, path strin
 
 // DeleteScreenshot atomically removes the screenshot record and every local
 // uploaded-image record keyed by imagePath. Final selections are not removed.
-func (r *SQLiteRepository) DeleteScreenshot(ctx context.Context, imagePath string) error {
+func (r *SQLiteRepository) DeleteScreenshot(ctx context.Context, binding PreparedMediaBinding, imagePath string) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
 	}
-	if strings.TrimSpace(imagePath) == "" {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil || strings.TrimSpace(imagePath) == "" {
 		return internalerrors.ErrInvalidInput
 	}
 	if err := r.withWriteTx(ctx, "delete screenshot", func(tx *sql.Tx) error {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM uploaded_images WHERE image_path = ?`, imagePath); err != nil {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM uploaded_images
+			WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND image_path = ?
+		`, bound.SourcePath, bound.PreparedMediaFingerprint, bound.PreparedGeneration, imagePath); err != nil {
 			return fmt.Errorf("db delete screenshot: delete uploaded images: %w", err)
 		}
-		if _, err := tx.ExecContext(ctx, `DELETE FROM screenshots WHERE image_path = ?`, imagePath); err != nil {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM screenshots
+			WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND image_path = ?
+		`, bound.SourcePath, bound.PreparedMediaFingerprint, bound.PreparedGeneration, imagePath); err != nil {
 			return fmt.Errorf("db delete screenshot: %w", err)
 		}
 		return nil
@@ -2115,12 +2137,12 @@ func (r *SQLiteRepository) DeleteScreenshot(ctx context.Context, imagePath strin
 // SaveFinalSelections atomically replaces every final selection for path.
 // Callers that must preserve menu selections should use
 // [SQLiteRepository.ReplaceNormalFinalSelections].
-func (r *SQLiteRepository) SaveFinalSelections(ctx context.Context, path string, selections []ScreenshotFinalSelection) error {
+func (r *SQLiteRepository) SaveFinalSelections(ctx context.Context, binding PreparedMediaBinding, selections []ScreenshotFinalSelection) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
 	}
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil {
 		return internalerrors.ErrInvalidInput
 	}
 	if err := ctx.Err(); err != nil {
@@ -2128,14 +2150,15 @@ func (r *SQLiteRepository) SaveFinalSelections(ctx context.Context, path string,
 	}
 
 	if err := r.withWriteTx(ctx, "save final selections", func(tx *sql.Tx) error {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM screenshot_final_selections WHERE source_path = ?`, trimmed); err != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM screenshot_final_selections WHERE source_path = ?`, bound.SourcePath); err != nil {
 			return fmt.Errorf("db save final selections: clear: %w", err)
 		}
 
 		stmt, err := tx.PrepareContext(ctx, `
 			INSERT INTO screenshot_final_selections (
-				source_path, image_path, sort_order, source, selected_at
-			) VALUES (?, ?, ?, ?, ?)
+				source_path, prepared_media_fingerprint, prepared_generation, disc_id,
+				image_path, sort_order, source, selected_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		`)
 		if err != nil {
 			return fmt.Errorf("db save final selections: prepare: %w", err)
@@ -2156,7 +2179,10 @@ func (r *SQLiteRepository) SaveFinalSelections(ctx context.Context, path string,
 			}
 			if _, err := stmt.ExecContext(
 				ctx,
-				trimmed,
+				bound.SourcePath,
+				bound.PreparedMediaFingerprint,
+				bound.PreparedGeneration,
+				strings.TrimSpace(selection.DiscID),
 				selection.ImagePath,
 				selection.Order,
 				source,
@@ -2172,20 +2198,20 @@ func (r *SQLiteRepository) SaveFinalSelections(ctx context.Context, path string,
 	return nil
 }
 
-func (r *SQLiteRepository) ListFinalSelections(ctx context.Context, path string) ([]ScreenshotFinalSelection, error) {
+func (r *SQLiteRepository) ListFinalSelections(ctx context.Context, binding PreparedMediaBinding) ([]ScreenshotFinalSelection, error) {
 	if r == nil || r.db == nil {
 		return nil, errors.New("db: repository not initialized")
 	}
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil {
 		return nil, internalerrors.ErrInvalidInput
 	}
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT image_path, sort_order, source, selected_at
+		SELECT disc_id, image_path, sort_order, source, selected_at
 		FROM screenshot_final_selections
-		WHERE source_path = ?
+		WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ?
 		ORDER BY sort_order ASC
-	`, trimmed)
+	`, bound.SourcePath, bound.PreparedMediaFingerprint, bound.PreparedGeneration)
 	if err != nil {
 		return nil, fmt.Errorf("db list final selections: %w", err)
 	}
@@ -2195,10 +2221,12 @@ func (r *SQLiteRepository) ListFinalSelections(ctx context.Context, path string)
 	for rows.Next() {
 		var selection ScreenshotFinalSelection
 		var selectedAt string
-		if err := rows.Scan(&selection.ImagePath, &selection.Order, &selection.Source, &selectedAt); err != nil {
+		if err := rows.Scan(&selection.DiscID, &selection.ImagePath, &selection.Order, &selection.Source, &selectedAt); err != nil {
 			return nil, fmt.Errorf("db list final selections: %w", err)
 		}
-		selection.SourcePath = trimmed
+		selection.SourcePath = bound.SourcePath
+		selection.PreparedMediaFingerprint = bound.PreparedMediaFingerprint
+		selection.PreparedGeneration = bound.PreparedGeneration
 		if selectedAt != "" {
 			if parsed, err := time.Parse(time.RFC3339Nano, selectedAt); err == nil {
 				selection.SelectedAt = parsed
@@ -2212,14 +2240,18 @@ func (r *SQLiteRepository) ListFinalSelections(ctx context.Context, path string)
 	return selections, nil
 }
 
-func (r *SQLiteRepository) DeleteFinalSelection(ctx context.Context, imagePath string) error {
+func (r *SQLiteRepository) DeleteFinalSelection(ctx context.Context, binding PreparedMediaBinding, imagePath string) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
 	}
-	if strings.TrimSpace(imagePath) == "" {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil || strings.TrimSpace(imagePath) == "" {
 		return internalerrors.ErrInvalidInput
 	}
-	_, err := r.execWrite(ctx, "delete final selection", `DELETE FROM screenshot_final_selections WHERE image_path = ?`, imagePath)
+	_, err = r.execWrite(ctx, "delete final selection", `
+		DELETE FROM screenshot_final_selections
+		WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND image_path = ?
+	`, bound.SourcePath, bound.PreparedMediaFingerprint, bound.PreparedGeneration, imagePath)
 	if err != nil {
 		return fmt.Errorf("db delete final selection: %w", err)
 	}
@@ -2228,23 +2260,27 @@ func (r *SQLiteRepository) DeleteFinalSelection(ctx context.Context, imagePath s
 
 // ReplaceNormalFinalSelections atomically replaces non-menu final selections
 // for path while preserving manual and automatic disc-menu selections.
-func (r *SQLiteRepository) ReplaceNormalFinalSelections(ctx context.Context, path string, selections []ScreenshotFinalSelection) error {
+func (r *SQLiteRepository) ReplaceNormalFinalSelections(
+	ctx context.Context,
+	binding PreparedMediaBinding,
+	selections []ScreenshotFinalSelection,
+) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
 	}
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil {
 		return internalerrors.ErrInvalidInput
 	}
 	for _, selection := range selections {
-		if strings.TrimSpace(selection.SourcePath) != trimmed || strings.TrimSpace(selection.ImagePath) == "" ||
+		if strings.TrimSpace(selection.ImagePath) == "" ||
 			api.IsDiscMenuSelectionSource(strings.TrimSpace(selection.Source)) {
 			return internalerrors.ErrInvalidInput
 		}
 	}
 
 	return r.withWriteTx(ctx, "replace normal final selections", func(tx *sql.Tx) error {
-		existing, err := listFinalSelectionsTx(ctx, tx, trimmed)
+		existing, err := listFinalSelectionsTx(ctx, tx, bound)
 		if err != nil {
 			return err
 		}
@@ -2255,7 +2291,7 @@ func (r *SQLiteRepository) ReplaceNormalFinalSelections(ctx context.Context, pat
 			}
 		}
 		merged = append(merged, selections...)
-		return rewriteFinalSelectionsTx(ctx, tx, trimmed, merged)
+		return rewriteFinalSelectionsTx(ctx, tx, bound, merged)
 	})
 }
 
@@ -2263,23 +2299,23 @@ func (r *SQLiteRepository) ReplaceNormalFinalSelections(ctx context.Context, pat
 // and appends their selections after existing manual-menu order values.
 func (r *SQLiteRepository) AppendManualMenuScreenshots(
 	ctx context.Context,
-	path string,
+	binding PreparedMediaBinding,
 	screenshots []Screenshot,
 	selections []ScreenshotFinalSelection,
 ) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
 	}
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" || !validMenuScreenshotBatch(trimmed, screenshots, selections, api.ScreenshotSelectionSourceMenu) {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil || !validMenuScreenshotBatch(screenshots, selections, api.ScreenshotSelectionSourceMenu) {
 		return internalerrors.ErrInvalidInput
 	}
 
 	return r.withWriteTx(ctx, "append manual menu screenshots", func(tx *sql.Tx) error {
-		if err := upsertMenuScreenshotsTx(ctx, tx, trimmed, screenshots); err != nil {
+		if err := upsertMenuScreenshotsTx(ctx, tx, bound, screenshots); err != nil {
 			return err
 		}
-		existing, err := listFinalSelectionsTx(ctx, tx, trimmed)
+		existing, err := listFinalSelectionsTx(ctx, tx, bound)
 		if err != nil {
 			return err
 		}
@@ -2292,7 +2328,7 @@ func (r *SQLiteRepository) AppendManualMenuScreenshots(
 		for index := range selections {
 			selections[index].Order = maxManualOrder + 1 + index
 		}
-		return rewriteFinalSelectionsTx(ctx, tx, trimmed, append(existing, selections...))
+		return rewriteFinalSelectionsTx(ctx, tx, bound, append(existing, selections...))
 	})
 }
 
@@ -2301,21 +2337,21 @@ func (r *SQLiteRepository) AppendManualMenuScreenshots(
 // replaced local image paths for caller-owned filesystem cleanup.
 func (r *SQLiteRepository) ReplaceDVDMenuScreenshots(
 	ctx context.Context,
-	path string,
+	binding PreparedMediaBinding,
 	screenshots []Screenshot,
 	selections []ScreenshotFinalSelection,
 ) ([]string, error) {
 	if r == nil || r.db == nil {
 		return nil, errors.New("db: repository not initialized")
 	}
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" || !validMenuScreenshotBatch(trimmed, screenshots, selections, api.ScreenshotSelectionSourceDVDMenu) {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil || !validMenuScreenshotBatch(screenshots, selections, api.ScreenshotSelectionSourceDVDMenu) {
 		return nil, internalerrors.ErrInvalidInput
 	}
 
 	var replaced []string
-	err := r.withWriteTx(ctx, "replace DVD menu screenshots", func(tx *sql.Tx) error {
-		existing, err := listFinalSelectionsTx(ctx, tx, trimmed)
+	err = r.withWriteTx(ctx, "replace DVD menu screenshots", func(tx *sql.Tx) error {
+		existing, err := listFinalSelectionsTx(ctx, tx, bound)
 		if err != nil {
 			return err
 		}
@@ -2323,18 +2359,18 @@ func (r *SQLiteRepository) ReplaceDVDMenuScreenshots(
 		for _, selection := range existing {
 			if strings.TrimSpace(selection.Source) == api.ScreenshotSelectionSourceDVDMenu {
 				replaced = append(replaced, selection.ImagePath)
-				if err := deleteScreenshotReferencesTx(ctx, tx, trimmed, selection.ImagePath); err != nil {
+				if err := deleteScreenshotReferencesTx(ctx, tx, bound, selection.ImagePath); err != nil {
 					return err
 				}
 				continue
 			}
 			preserved = append(preserved, selection)
 		}
-		if err := upsertMenuScreenshotsTx(ctx, tx, trimmed, screenshots); err != nil {
+		if err := upsertMenuScreenshotsTx(ctx, tx, bound, screenshots); err != nil {
 			return err
 		}
 		preserved = append(preserved, selections...)
-		return rewriteFinalSelectionsTx(ctx, tx, trimmed, preserved)
+		return rewriteFinalSelectionsTx(ctx, tx, bound, preserved)
 	})
 	if err != nil {
 		return nil, err
@@ -2346,13 +2382,17 @@ func (r *SQLiteRepository) ReplaceDVDMenuScreenshots(
 // selection and all local records tied to it. It rejects normal final
 // selections and returns a complete snapshot suitable for compensation with
 // [SQLiteRepository.RestoreDiscMenuScreenshot]. Remote assets are unchanged.
-func (r *SQLiteRepository) DeleteDiscMenuScreenshot(ctx context.Context, path string, imagePath string) (api.DiscMenuDeleteResult, error) {
+func (r *SQLiteRepository) DeleteDiscMenuScreenshot(
+	ctx context.Context,
+	binding PreparedMediaBinding,
+	imagePath string,
+) (api.DiscMenuDeleteResult, error) {
 	if r == nil || r.db == nil {
 		return api.DiscMenuDeleteResult{}, errors.New("db: repository not initialized")
 	}
-	trimmedPath := strings.TrimSpace(path)
+	bound, bindingErr := normalizePreparedMediaBinding(binding)
 	trimmedImage := strings.TrimSpace(imagePath)
-	if trimmedPath == "" || trimmedImage == "" {
+	if bindingErr != nil || trimmedImage == "" {
 		return api.DiscMenuDeleteResult{}, internalerrors.ErrInvalidInput
 	}
 
@@ -2360,10 +2400,15 @@ func (r *SQLiteRepository) DeleteDiscMenuScreenshot(ctx context.Context, path st
 	err := r.withWriteTx(ctx, "delete disc menu screenshot", func(tx *sql.Tx) error {
 		var selectedAt string
 		err := tx.QueryRowContext(ctx, `
-			SELECT sort_order, source, selected_at
+			SELECT disc_id, sort_order, source, selected_at
 			FROM screenshot_final_selections
-			WHERE source_path = ? AND image_path = ?
-		`, trimmedPath, trimmedImage).Scan(&deleted.Selection.Order, &deleted.Selection.Source, &selectedAt)
+			WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND image_path = ?
+		`, bound.SourcePath, bound.PreparedMediaFingerprint, bound.PreparedGeneration, trimmedImage).Scan(
+			&deleted.Selection.DiscID,
+			&deleted.Selection.Order,
+			&deleted.Selection.Source,
+			&selectedAt,
+		)
 		if errors.Is(err, sql.ErrNoRows) {
 			return internalerrors.ErrNotFound
 		}
@@ -2373,7 +2418,9 @@ func (r *SQLiteRepository) DeleteDiscMenuScreenshot(ctx context.Context, path st
 		if !api.IsDiscMenuSelectionSource(strings.TrimSpace(deleted.Selection.Source)) {
 			return internalerrors.ErrInvalidInput
 		}
-		deleted.Selection.SourcePath = trimmedPath
+		deleted.Selection.SourcePath = bound.SourcePath
+		deleted.Selection.PreparedMediaFingerprint = bound.PreparedMediaFingerprint
+		deleted.Selection.PreparedGeneration = bound.PreparedGeneration
 		deleted.Selection.ImagePath = trimmedImage
 		if selectedAt != "" {
 			if parsed, parseErr := time.Parse(time.RFC3339Nano, selectedAt); parseErr == nil {
@@ -2384,10 +2431,11 @@ func (r *SQLiteRepository) DeleteDiscMenuScreenshot(ctx context.Context, path st
 		var purpose string
 		var capturedAt string
 		err = tx.QueryRowContext(ctx, `
-			SELECT timestamp, frame_number, width, height, purpose, captured_at
+			SELECT disc_id, timestamp, frame_number, width, height, purpose, captured_at
 			FROM screenshots
-			WHERE source_path = ? AND image_path = ?
-		`, trimmedPath, trimmedImage).Scan(
+			WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND image_path = ?
+		`, bound.SourcePath, bound.PreparedMediaFingerprint, bound.PreparedGeneration, trimmedImage).Scan(
+			&screenshot.DiscID,
 			&screenshot.Timestamp,
 			&screenshot.FrameNumber,
 			&screenshot.Width,
@@ -2399,7 +2447,9 @@ func (r *SQLiteRepository) DeleteDiscMenuScreenshot(ctx context.Context, path st
 			return fmt.Errorf("db delete disc menu screenshot: load screenshot: %w", err)
 		}
 		if err == nil {
-			screenshot.SourcePath = trimmedPath
+			screenshot.SourcePath = bound.SourcePath
+			screenshot.PreparedMediaFingerprint = bound.PreparedMediaFingerprint
+			screenshot.PreparedGeneration = bound.PreparedGeneration
 			screenshot.ImagePath = trimmedImage
 			screenshot.Purpose = ScreenshotPurpose(purpose)
 			if capturedAt != "" {
@@ -2409,19 +2459,19 @@ func (r *SQLiteRepository) DeleteDiscMenuScreenshot(ctx context.Context, path st
 			}
 			deleted.Screenshot = &screenshot
 		}
-		deleted.UploadedImages, err = listUploadedImagesForImageTx(ctx, tx, trimmedPath, trimmedImage)
+		deleted.UploadedImages, err = listUploadedImagesForImageTx(ctx, tx, bound, trimmedImage)
 		if err != nil {
 			return err
 		}
 		deleted.UploadedLinks = len(deleted.UploadedImages)
-		deleted.ScreenshotSlots, deleted.ScreenshotSlotVariants, err = listDeletedScreenshotSlotsTx(ctx, tx, trimmedPath, trimmedImage)
+		deleted.ScreenshotSlots, deleted.ScreenshotSlotVariants, err = listDeletedScreenshotSlotsTx(ctx, tx, bound, trimmedImage)
 		if err != nil {
 			return err
 		}
-		if err := deleteScreenshotReferencesTx(ctx, tx, trimmedPath, trimmedImage); err != nil {
+		if err := deleteScreenshotReferencesTx(ctx, tx, bound, trimmedImage); err != nil {
 			return err
 		}
-		remaining, err := listFinalSelectionsTx(ctx, tx, trimmedPath)
+		remaining, err := listFinalSelectionsTx(ctx, tx, bound)
 		if err != nil {
 			return err
 		}
@@ -2431,7 +2481,7 @@ func (r *SQLiteRepository) DeleteDiscMenuScreenshot(ctx context.Context, path st
 				filtered = append(filtered, selection)
 			}
 		}
-		return rewriteFinalSelectionsTx(ctx, tx, trimmedPath, filtered)
+		return rewriteFinalSelectionsTx(ctx, tx, bound, filtered)
 	})
 	if err != nil {
 		return api.DiscMenuDeleteResult{}, err
@@ -2443,48 +2493,54 @@ func (r *SQLiteRepository) DeleteDiscMenuScreenshot(ctx context.Context, path st
 // deletion when the corresponding filesystem deletion could not be finalized.
 // It rejects snapshots whose source, image, menu purpose, or host data do not
 // match path and the deleted selection.
-func (r *SQLiteRepository) RestoreDiscMenuScreenshot(ctx context.Context, path string, deleted api.DiscMenuDeleteResult) error {
+func (r *SQLiteRepository) RestoreDiscMenuScreenshot(
+	ctx context.Context,
+	binding PreparedMediaBinding,
+	deleted api.DiscMenuDeleteResult,
+) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
 	}
-	trimmedPath := strings.TrimSpace(path)
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil {
+		return internalerrors.ErrInvalidInput
+	}
 	selection := deleted.Selection
-	selection.SourcePath = strings.TrimSpace(selection.SourcePath)
 	selection.ImagePath = strings.TrimSpace(selection.ImagePath)
-	if trimmedPath == "" || selection.SourcePath != trimmedPath || selection.ImagePath == "" ||
+	if selection.ImagePath == "" ||
 		!api.IsDiscMenuSelectionSource(strings.TrimSpace(selection.Source)) {
 		return internalerrors.ErrInvalidInput
 	}
 	if deleted.Screenshot != nil {
-		if strings.TrimSpace(deleted.Screenshot.SourcePath) != trimmedPath || strings.TrimSpace(deleted.Screenshot.ImagePath) != selection.ImagePath ||
+		if strings.TrimSpace(deleted.Screenshot.ImagePath) != selection.ImagePath ||
 			deleted.Screenshot.Purpose != api.ScreenshotPurposeMenu {
 			return internalerrors.ErrInvalidInput
 		}
 	}
 	for _, uploaded := range deleted.UploadedImages {
-		if strings.TrimSpace(uploaded.SourcePath) != trimmedPath || strings.TrimSpace(uploaded.ImagePath) != selection.ImagePath ||
+		if strings.TrimSpace(uploaded.ImagePath) != selection.ImagePath ||
 			strings.TrimSpace(uploaded.Host) == "" {
 			return internalerrors.ErrInvalidInput
 		}
 	}
 	for _, slot := range deleted.ScreenshotSlots {
-		if strings.TrimSpace(slot.SourcePath) != trimmedPath || strings.TrimSpace(slot.ImagePath) != selection.ImagePath {
+		if strings.TrimSpace(slot.ImagePath) != selection.ImagePath {
 			return internalerrors.ErrInvalidInput
 		}
 	}
 	for _, variant := range deleted.ScreenshotSlotVariants {
-		if strings.TrimSpace(variant.SourcePath) != trimmedPath || strings.TrimSpace(variant.Host) == "" {
+		if strings.TrimSpace(variant.Host) == "" {
 			return internalerrors.ErrInvalidInput
 		}
 	}
 
 	return r.withWriteTx(ctx, "restore disc menu screenshot", func(tx *sql.Tx) error {
 		if deleted.Screenshot != nil {
-			if err := upsertMenuScreenshotsTx(ctx, tx, trimmedPath, []Screenshot{*deleted.Screenshot}); err != nil {
+			if err := upsertMenuScreenshotsTx(ctx, tx, bound, []Screenshot{*deleted.Screenshot}); err != nil {
 				return err
 			}
 		}
-		selections, err := listFinalSelectionsTx(ctx, tx, trimmedPath)
+		selections, err := listFinalSelectionsTx(ctx, tx, bound)
 		if err != nil {
 			return err
 		}
@@ -2495,26 +2551,31 @@ func (r *SQLiteRepository) RestoreDiscMenuScreenshot(ctx context.Context, path s
 			}
 		}
 		filtered = append(filtered, selection)
-		if err := rewriteFinalSelectionsTx(ctx, tx, trimmedPath, filtered); err != nil {
+		if err := rewriteFinalSelectionsTx(ctx, tx, bound, filtered); err != nil {
 			return err
 		}
-		if err := restoreScreenshotSlotsTx(ctx, tx, trimmedPath, deleted.ScreenshotSlots, deleted.ScreenshotSlotVariants); err != nil {
+		if err := restoreScreenshotSlotsTx(ctx, tx, bound, deleted.ScreenshotSlots, deleted.ScreenshotSlotVariants); err != nil {
 			return err
 		}
-		return upsertUploadedImagesTx(ctx, tx, trimmedPath, deleted.UploadedImages)
+		return upsertUploadedImagesTx(ctx, tx, bound, deleted.UploadedImages)
 	})
 }
 
 // listDeletedScreenshotSlotsTx snapshots slots selected by imagePath and every
 // variant that deletion would remove with those slots or the image itself.
-func listDeletedScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, imagePath string) ([]ScreenshotSlot, []ScreenshotSlotVariant, error) {
+func listDeletedScreenshotSlotsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	binding PreparedMediaBinding,
+	imagePath string,
+) ([]ScreenshotSlot, []ScreenshotSlotVariant, error) {
 	slotRows, err := tx.QueryContext(ctx, `
-		SELECT slot_order, source_kind, original_key, original_url, original_host, image_path,
+		SELECT disc_id, slot_order, source_kind, original_key, original_url, original_host, image_path,
 			from_description, tracker, section_kind, render_in_screenshots
 		FROM screenshot_slots
-		WHERE source_path = ? AND image_path = ?
+		WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND image_path = ?
 		ORDER BY slot_order ASC
-	`, path, imagePath)
+	`, binding.SourcePath, binding.PreparedMediaFingerprint, binding.PreparedGeneration, imagePath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("db delete disc menu screenshot: list slots: %w", err)
 	}
@@ -2526,6 +2587,7 @@ func listDeletedScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, 
 		var fromDescription int
 		var renderInScreenshots int
 		if err := slotRows.Scan(
+			&slot.DiscID,
 			&slot.SlotOrder,
 			&slot.SourceKind,
 			&slot.OriginalKey,
@@ -2539,7 +2601,9 @@ func listDeletedScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, 
 		); err != nil {
 			return nil, nil, fmt.Errorf("db delete disc menu screenshot: scan slot: %w", err)
 		}
-		slot.SourcePath = path
+		slot.SourcePath = binding.SourcePath
+		slot.PreparedMediaFingerprint = binding.PreparedMediaFingerprint
+		slot.PreparedGeneration = binding.PreparedGeneration
 		slot.FromDescription = fromDescription != 0
 		slot.RenderInScreenshots = renderInScreenshots != 0
 		slots = append(slots, slot)
@@ -2549,15 +2613,17 @@ func listDeletedScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, 
 	}
 
 	variantRows, err := tx.QueryContext(ctx, `
-		SELECT slot_order, host, usage_scope, image_path, img_url, raw_url, web_url, uploaded_at
+		SELECT disc_id, slot_order, host, usage_scope, image_path, img_url, raw_url, web_url, uploaded_at
 		FROM screenshot_slot_variants
-		WHERE source_path = ? AND (
+		WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND (
 			image_path = ? OR slot_order IN (
-				SELECT slot_order FROM screenshot_slots WHERE source_path = ? AND image_path = ?
+				SELECT slot_order FROM screenshot_slots
+				WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND image_path = ?
 			)
 		)
 		ORDER BY slot_order ASC
-	`, path, imagePath, path, imagePath)
+	`, binding.SourcePath, binding.PreparedMediaFingerprint, binding.PreparedGeneration, imagePath,
+		binding.SourcePath, binding.PreparedMediaFingerprint, binding.PreparedGeneration, imagePath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("db delete disc menu screenshot: list slot variants: %w", err)
 	}
@@ -2568,6 +2634,7 @@ func listDeletedScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, 
 		var variant ScreenshotSlotVariant
 		var uploadedAt string
 		if err := variantRows.Scan(
+			&variant.DiscID,
 			&variant.SlotOrder,
 			&variant.Host,
 			&variant.UsageScope,
@@ -2579,7 +2646,9 @@ func listDeletedScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, 
 		); err != nil {
 			return nil, nil, fmt.Errorf("db delete disc menu screenshot: scan slot variant: %w", err)
 		}
-		variant.SourcePath = path
+		variant.SourcePath = binding.SourcePath
+		variant.PreparedMediaFingerprint = binding.PreparedMediaFingerprint
+		variant.PreparedGeneration = binding.PreparedGeneration
 		if uploadedAt != "" {
 			if parsed, parseErr := time.Parse(time.RFC3339Nano, uploadedAt); parseErr == nil {
 				variant.UploadedAt = parsed
@@ -2595,14 +2664,24 @@ func listDeletedScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, 
 
 // restoreScreenshotSlotsTx upserts a compensation snapshot into the caller's
 // transaction, replacing conflicting slot and variant state for path.
-func restoreScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, slots []ScreenshotSlot, variants []ScreenshotSlotVariant) error {
+func restoreScreenshotSlotsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	binding PreparedMediaBinding,
+	slots []ScreenshotSlot,
+	variants []ScreenshotSlotVariant,
+) error {
 	if len(slots) > 0 {
 		slotStmt, err := tx.PrepareContext(ctx, `
 			INSERT INTO screenshot_slots (
-				source_path, slot_order, source_kind, original_key, original_url, original_host,
+				source_path, prepared_media_fingerprint, prepared_generation, disc_id,
+				slot_order, source_kind, original_key, original_url, original_host,
 				image_path, from_description, tracker, section_kind, render_in_screenshots
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(source_path, slot_order) DO UPDATE SET
+				prepared_media_fingerprint = excluded.prepared_media_fingerprint,
+				prepared_generation = excluded.prepared_generation,
+				disc_id = excluded.disc_id,
 				source_kind = excluded.source_kind,
 				original_key = excluded.original_key,
 				original_url = excluded.original_url,
@@ -2620,7 +2699,10 @@ func restoreScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, slot
 		for _, slot := range slots {
 			if _, err := slotStmt.ExecContext(
 				ctx,
-				path,
+				binding.SourcePath,
+				binding.PreparedMediaFingerprint,
+				binding.PreparedGeneration,
+				strings.TrimSpace(slot.DiscID),
 				slot.SlotOrder,
 				strings.TrimSpace(slot.SourceKind),
 				strings.TrimSpace(slot.OriginalKey),
@@ -2641,9 +2723,13 @@ func restoreScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, slot
 	}
 	variantStmt, err := tx.PrepareContext(ctx, `
 		INSERT INTO screenshot_slot_variants (
-			source_path, slot_order, host, usage_scope, image_path, img_url, raw_url, web_url, uploaded_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			source_path, prepared_media_fingerprint, prepared_generation, disc_id,
+			slot_order, host, usage_scope, image_path, img_url, raw_url, web_url, uploaded_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(source_path, slot_order, host, usage_scope) DO UPDATE SET
+			prepared_media_fingerprint = excluded.prepared_media_fingerprint,
+			prepared_generation = excluded.prepared_generation,
+			disc_id = excluded.disc_id,
 			image_path = excluded.image_path,
 			img_url = excluded.img_url,
 			raw_url = excluded.raw_url,
@@ -2661,7 +2747,10 @@ func restoreScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, slot
 		}
 		if _, err := variantStmt.ExecContext(
 			ctx,
-			path,
+			binding.SourcePath,
+			binding.PreparedMediaFingerprint,
+			binding.PreparedGeneration,
+			strings.TrimSpace(variant.DiscID),
 			variant.SlotOrder,
 			strings.TrimSpace(variant.Host),
 			strings.TrimSpace(variant.UsageScope),
@@ -2679,13 +2768,18 @@ func restoreScreenshotSlotsTx(ctx context.Context, tx *sql.Tx, path string, slot
 
 // listUploadedImagesForImageTx snapshots every local upload record associated
 // with one source image. It does not inspect or mutate remote assets.
-func listUploadedImagesForImageTx(ctx context.Context, tx *sql.Tx, path string, imagePath string) ([]UploadedImageLink, error) {
+func listUploadedImagesForImageTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	binding PreparedMediaBinding,
+	imagePath string,
+) ([]UploadedImageLink, error) {
 	rows, err := tx.QueryContext(ctx, `
-		SELECT host, usage_scope, img_url, raw_url, web_url, size_bytes, uploaded_at
+		SELECT disc_id, host, usage_scope, img_url, raw_url, web_url, size_bytes, uploaded_at
 		FROM uploaded_images
-		WHERE source_path = ? AND image_path = ?
+		WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND image_path = ?
 		ORDER BY id ASC
-	`, path, imagePath)
+	`, binding.SourcePath, binding.PreparedMediaFingerprint, binding.PreparedGeneration, imagePath)
 	if err != nil {
 		return nil, fmt.Errorf("db delete disc menu screenshot: list uploaded images: %w", err)
 	}
@@ -2695,10 +2789,21 @@ func listUploadedImagesForImageTx(ctx context.Context, tx *sql.Tx, path string, 
 	for rows.Next() {
 		var image UploadedImageLink
 		var uploadedAt string
-		if err := rows.Scan(&image.Host, &image.UsageScope, &image.ImgURL, &image.RawURL, &image.WebURL, &image.SizeBytes, &uploadedAt); err != nil {
+		if err := rows.Scan(
+			&image.DiscID,
+			&image.Host,
+			&image.UsageScope,
+			&image.ImgURL,
+			&image.RawURL,
+			&image.WebURL,
+			&image.SizeBytes,
+			&uploadedAt,
+		); err != nil {
 			return nil, fmt.Errorf("db delete disc menu screenshot: scan uploaded image: %w", err)
 		}
-		image.SourcePath = path
+		image.SourcePath = binding.SourcePath
+		image.PreparedMediaFingerprint = binding.PreparedMediaFingerprint
+		image.PreparedGeneration = binding.PreparedGeneration
 		image.ImagePath = imagePath
 		if uploadedAt != "" {
 			if parsed, parseErr := time.Parse(time.RFC3339Nano, uploadedAt); parseErr == nil {
@@ -2713,28 +2818,28 @@ func listUploadedImagesForImageTx(ctx context.Context, tx *sql.Tx, path string, 
 	return images, nil
 }
 
-func validMenuScreenshotBatch(path string, screenshots []Screenshot, selections []ScreenshotFinalSelection, source string) bool {
+func validMenuScreenshotBatch(screenshots []Screenshot, selections []ScreenshotFinalSelection, source string) bool {
 	if len(screenshots) != len(selections) {
 		return false
 	}
-	paths := make(map[string]struct{}, len(screenshots))
+	paths := make(map[string]string, len(screenshots))
 	for _, screenshot := range screenshots {
-		if strings.TrimSpace(screenshot.SourcePath) != path || strings.TrimSpace(screenshot.ImagePath) == "" ||
-			screenshot.Purpose != api.ScreenshotPurposeMenu {
+		if strings.TrimSpace(screenshot.ImagePath) == "" || screenshot.Purpose != api.ScreenshotPurposeMenu {
 			return false
 		}
 		imagePath := strings.TrimSpace(screenshot.ImagePath)
 		if _, exists := paths[imagePath]; exists {
 			return false
 		}
-		paths[imagePath] = struct{}{}
+		paths[imagePath] = strings.TrimSpace(screenshot.DiscID)
 	}
 	for _, selection := range selections {
-		if strings.TrimSpace(selection.SourcePath) != path || strings.TrimSpace(selection.ImagePath) == "" || strings.TrimSpace(selection.Source) != source {
+		if strings.TrimSpace(selection.ImagePath) == "" || strings.TrimSpace(selection.Source) != source {
 			return false
 		}
 		imagePath := strings.TrimSpace(selection.ImagePath)
-		if _, exists := paths[imagePath]; !exists {
+		discID, exists := paths[imagePath]
+		if !exists || discID != strings.TrimSpace(selection.DiscID) {
 			return false
 		}
 		delete(paths, imagePath)
@@ -2742,12 +2847,17 @@ func validMenuScreenshotBatch(path string, screenshots []Screenshot, selections 
 	return len(paths) == 0
 }
 
-func upsertMenuScreenshotsTx(ctx context.Context, tx *sql.Tx, path string, screenshots []Screenshot) error {
+func upsertMenuScreenshotsTx(ctx context.Context, tx *sql.Tx, binding PreparedMediaBinding, screenshots []Screenshot) error {
 	stmt, err := tx.PrepareContext(ctx, `
 		INSERT INTO screenshots (
-			source_path, image_path, timestamp, frame_number, width, height, purpose, captured_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			source_path, prepared_media_fingerprint, prepared_generation, disc_id,
+			image_path, timestamp, frame_number, width, height, purpose, captured_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(image_path) DO UPDATE SET
+			source_path = excluded.source_path,
+			prepared_media_fingerprint = excluded.prepared_media_fingerprint,
+			prepared_generation = excluded.prepared_generation,
+			disc_id = excluded.disc_id,
 			timestamp = excluded.timestamp,
 			frame_number = excluded.frame_number,
 			width = excluded.width,
@@ -2768,7 +2878,10 @@ func upsertMenuScreenshotsTx(ctx context.Context, tx *sql.Tx, path string, scree
 		}
 		result, err := stmt.ExecContext(
 			ctx,
-			path,
+			binding.SourcePath,
+			binding.PreparedMediaFingerprint,
+			binding.PreparedGeneration,
+			strings.TrimSpace(screenshot.DiscID),
 			screenshot.ImagePath,
 			screenshot.Timestamp,
 			screenshot.FrameNumber,
@@ -2791,13 +2904,13 @@ func upsertMenuScreenshotsTx(ctx context.Context, tx *sql.Tx, path string, scree
 	return nil
 }
 
-func listFinalSelectionsTx(ctx context.Context, tx *sql.Tx, path string) ([]ScreenshotFinalSelection, error) {
+func listFinalSelectionsTx(ctx context.Context, tx *sql.Tx, binding PreparedMediaBinding) ([]ScreenshotFinalSelection, error) {
 	rows, err := tx.QueryContext(ctx, `
-		SELECT image_path, sort_order, source, selected_at
+		SELECT disc_id, image_path, sort_order, source, selected_at
 		FROM screenshot_final_selections
-		WHERE source_path = ?
+		WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ?
 		ORDER BY sort_order ASC
-	`, path)
+	`, binding.SourcePath, binding.PreparedMediaFingerprint, binding.PreparedGeneration)
 	if err != nil {
 		return nil, fmt.Errorf("db list final selections in transaction: %w", err)
 	}
@@ -2807,10 +2920,12 @@ func listFinalSelectionsTx(ctx context.Context, tx *sql.Tx, path string) ([]Scre
 	for rows.Next() {
 		var selection ScreenshotFinalSelection
 		var selectedAt string
-		if err := rows.Scan(&selection.ImagePath, &selection.Order, &selection.Source, &selectedAt); err != nil {
+		if err := rows.Scan(&selection.DiscID, &selection.ImagePath, &selection.Order, &selection.Source, &selectedAt); err != nil {
 			return nil, fmt.Errorf("db list final selections in transaction: scan: %w", err)
 		}
-		selection.SourcePath = path
+		selection.SourcePath = binding.SourcePath
+		selection.PreparedMediaFingerprint = binding.PreparedMediaFingerprint
+		selection.PreparedGeneration = binding.PreparedGeneration
 		if selectedAt != "" {
 			if parsed, parseErr := time.Parse(time.RFC3339Nano, selectedAt); parseErr == nil {
 				selection.SelectedAt = parsed
@@ -2824,15 +2939,16 @@ func listFinalSelectionsTx(ctx context.Context, tx *sql.Tx, path string) ([]Scre
 	return selections, nil
 }
 
-func rewriteFinalSelectionsTx(ctx context.Context, tx *sql.Tx, path string, selections []ScreenshotFinalSelection) error {
-	if _, err := tx.ExecContext(ctx, `DELETE FROM screenshot_final_selections WHERE source_path = ?`, path); err != nil {
+func rewriteFinalSelectionsTx(ctx context.Context, tx *sql.Tx, binding PreparedMediaBinding, selections []ScreenshotFinalSelection) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM screenshot_final_selections WHERE source_path = ?`, binding.SourcePath); err != nil {
 		return fmt.Errorf("db rewrite final selections: clear: %w", err)
 	}
-	ordered := orderFinalSelections(path, selections)
+	ordered := orderFinalSelections(binding, selections)
 	stmt, err := tx.PrepareContext(ctx, `
 		INSERT INTO screenshot_final_selections (
-			source_path, image_path, sort_order, source, selected_at
-		) VALUES (?, ?, ?, ?, ?)
+			source_path, prepared_media_fingerprint, prepared_generation, disc_id,
+			image_path, sort_order, source, selected_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return fmt.Errorf("db rewrite final selections: prepare: %w", err)
@@ -2841,7 +2957,10 @@ func rewriteFinalSelectionsTx(ctx context.Context, tx *sql.Tx, path string, sele
 	for _, selection := range ordered {
 		if _, err := stmt.ExecContext(
 			ctx,
-			path,
+			binding.SourcePath,
+			binding.PreparedMediaFingerprint,
+			binding.PreparedGeneration,
+			strings.TrimSpace(selection.DiscID),
 			selection.ImagePath,
 			selection.Order,
 			selection.Source,
@@ -2853,7 +2972,7 @@ func rewriteFinalSelectionsTx(ctx context.Context, tx *sql.Tx, path string, sele
 	return nil
 }
 
-func orderFinalSelections(path string, selections []ScreenshotFinalSelection) []ScreenshotFinalSelection {
+func orderFinalSelections(binding PreparedMediaBinding, selections []ScreenshotFinalSelection) []ScreenshotFinalSelection {
 	groups := [3][]ScreenshotFinalSelection{}
 	for _, selection := range selections {
 		selection.ImagePath = strings.TrimSpace(selection.ImagePath)
@@ -2887,7 +3006,9 @@ func orderFinalSelections(path string, selections []ScreenshotFinalSelection) []
 				continue
 			}
 			seen[selection.ImagePath] = struct{}{}
-			selection.SourcePath = path
+			selection.SourcePath = binding.SourcePath
+			selection.PreparedMediaFingerprint = binding.PreparedMediaFingerprint
+			selection.PreparedGeneration = binding.PreparedGeneration
 			selection.Order = len(ordered)
 			if selection.SelectedAt.IsZero() {
 				selection.SelectedAt = time.Now().UTC()
@@ -2898,27 +3019,34 @@ func orderFinalSelections(path string, selections []ScreenshotFinalSelection) []
 	return ordered
 }
 
-func deleteScreenshotReferencesTx(ctx context.Context, tx *sql.Tx, path string, imagePath string) error {
+func deleteScreenshotReferencesTx(ctx context.Context, tx *sql.Tx, binding PreparedMediaBinding, imagePath string) error {
 	queries := []string{
 		`DELETE FROM screenshot_slot_variants
-		 WHERE source_path = ? AND (
+		 WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND (
 			image_path = ? OR slot_order IN (
-				SELECT slot_order FROM screenshot_slots WHERE source_path = ? AND image_path = ?
+				SELECT slot_order FROM screenshot_slots
+				WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND image_path = ?
 			)
 		)`,
-		`DELETE FROM screenshot_slots WHERE source_path = ? AND image_path = ?`,
-		`DELETE FROM uploaded_images WHERE source_path = ? AND image_path = ?`,
-		`DELETE FROM screenshots WHERE source_path = ? AND image_path = ? AND purpose = ?`,
+		`DELETE FROM screenshot_slots
+		 WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND image_path = ?`,
+		`DELETE FROM uploaded_images
+		 WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND image_path = ?`,
+		`DELETE FROM screenshots
+		 WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND image_path = ? AND purpose = ?`,
 	}
 	for index, query := range queries {
 		var args []any
 		switch index {
 		case 0:
-			args = []any{path, imagePath, path, imagePath}
+			args = []any{
+				binding.SourcePath, binding.PreparedMediaFingerprint, binding.PreparedGeneration, imagePath,
+				binding.SourcePath, binding.PreparedMediaFingerprint, binding.PreparedGeneration, imagePath,
+			}
 		case 1, 2:
-			args = []any{path, imagePath}
+			args = []any{binding.SourcePath, binding.PreparedMediaFingerprint, binding.PreparedGeneration, imagePath}
 		case 3:
-			args = []any{path, imagePath, api.ScreenshotPurposeMenu}
+			args = []any{binding.SourcePath, binding.PreparedMediaFingerprint, binding.PreparedGeneration, imagePath, api.ScreenshotPurposeMenu}
 		}
 		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 			return fmt.Errorf("db delete screenshot references: %w", err)
@@ -2929,12 +3057,12 @@ func deleteScreenshotReferencesTx(ctx context.Context, tx *sql.Tx, path string, 
 
 // ReplaceScreenshotSlots atomically replaces all slots and variants for path;
 // variants absent from slots are deleted.
-func (r *SQLiteRepository) ReplaceScreenshotSlots(ctx context.Context, path string, slots []ScreenshotSlot) error {
+func (r *SQLiteRepository) ReplaceScreenshotSlots(ctx context.Context, binding PreparedMediaBinding, slots []ScreenshotSlot) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
 	}
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil {
 		return internalerrors.ErrInvalidInput
 	}
 	if err := ctx.Err(); err != nil {
@@ -2942,18 +3070,19 @@ func (r *SQLiteRepository) ReplaceScreenshotSlots(ctx context.Context, path stri
 	}
 
 	if err := r.withWriteTx(ctx, "replace screenshot slots", func(tx *sql.Tx) error {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM screenshot_slot_variants WHERE source_path = ?`, trimmed); err != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM screenshot_slot_variants WHERE source_path = ?`, bound.SourcePath); err != nil {
 			return fmt.Errorf("db replace screenshot slots: clear variants: %w", err)
 		}
-		if _, err := tx.ExecContext(ctx, `DELETE FROM screenshot_slots WHERE source_path = ?`, trimmed); err != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM screenshot_slots WHERE source_path = ?`, bound.SourcePath); err != nil {
 			return fmt.Errorf("db replace screenshot slots: clear slots: %w", err)
 		}
 
 		slotStmt, err := tx.PrepareContext(ctx, `
 			INSERT INTO screenshot_slots (
-				source_path, slot_order, source_kind, original_key, original_url, original_host,
+				source_path, prepared_media_fingerprint, prepared_generation, disc_id,
+				slot_order, source_kind, original_key, original_url, original_host,
 				image_path, from_description, tracker, section_kind, render_in_screenshots
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`)
 		if err != nil {
 			return fmt.Errorf("db replace screenshot slots: prepare slots: %w", err)
@@ -2962,8 +3091,9 @@ func (r *SQLiteRepository) ReplaceScreenshotSlots(ctx context.Context, path stri
 
 		variantStmt, err := tx.PrepareContext(ctx, `
 			INSERT INTO screenshot_slot_variants (
-				source_path, slot_order, host, usage_scope, image_path, img_url, raw_url, web_url, uploaded_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+				source_path, prepared_media_fingerprint, prepared_generation, disc_id,
+				slot_order, host, usage_scope, image_path, img_url, raw_url, web_url, uploaded_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`)
 		if err != nil {
 			return fmt.Errorf("db replace screenshot slots: prepare variants: %w", err)
@@ -2973,7 +3103,10 @@ func (r *SQLiteRepository) ReplaceScreenshotSlots(ctx context.Context, path stri
 		for _, slot := range slots {
 			if _, err := slotStmt.ExecContext(
 				ctx,
-				trimmed,
+				bound.SourcePath,
+				bound.PreparedMediaFingerprint,
+				bound.PreparedGeneration,
+				strings.TrimSpace(slot.DiscID),
 				slot.SlotOrder,
 				strings.TrimSpace(slot.SourceKind),
 				strings.TrimSpace(slot.OriginalKey),
@@ -2994,7 +3127,10 @@ func (r *SQLiteRepository) ReplaceScreenshotSlots(ctx context.Context, path stri
 				}
 				if _, err := variantStmt.ExecContext(
 					ctx,
-					trimmed,
+					bound.SourcePath,
+					bound.PreparedMediaFingerprint,
+					bound.PreparedGeneration,
+					strings.TrimSpace(variant.DiscID),
 					slot.SlotOrder,
 					strings.TrimSpace(variant.Host),
 					strings.TrimSpace(variant.UsageScope),
@@ -3015,22 +3151,22 @@ func (r *SQLiteRepository) ReplaceScreenshotSlots(ctx context.Context, path stri
 	return nil
 }
 
-func (r *SQLiteRepository) ListScreenshotSlotsByPath(ctx context.Context, path string) ([]ScreenshotSlot, error) {
+func (r *SQLiteRepository) ListScreenshotSlotsByPath(ctx context.Context, binding PreparedMediaBinding) ([]ScreenshotSlot, error) {
 	if r == nil || r.db == nil {
 		return nil, errors.New("db: repository not initialized")
 	}
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil {
 		return nil, internalerrors.ErrInvalidInput
 	}
 
 	slotRows, err := r.db.QueryContext(ctx, `
-		SELECT slot_order, source_kind, original_key, original_url, original_host, image_path,
+		SELECT disc_id, slot_order, source_kind, original_key, original_url, original_host, image_path,
 			from_description, tracker, section_kind, render_in_screenshots
 		FROM screenshot_slots
-		WHERE source_path = ?
+		WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ?
 		ORDER BY slot_order ASC
-	`, trimmed)
+	`, bound.SourcePath, bound.PreparedMediaFingerprint, bound.PreparedGeneration)
 	if err != nil {
 		return nil, fmt.Errorf("db list screenshot slots: %w", err)
 	}
@@ -3043,6 +3179,7 @@ func (r *SQLiteRepository) ListScreenshotSlotsByPath(ctx context.Context, path s
 		var fromDescription int
 		var renderInScreenshots int
 		if err := slotRows.Scan(
+			&slot.DiscID,
 			&slot.SlotOrder,
 			&slot.SourceKind,
 			&slot.OriginalKey,
@@ -3056,7 +3193,9 @@ func (r *SQLiteRepository) ListScreenshotSlotsByPath(ctx context.Context, path s
 		); err != nil {
 			return nil, fmt.Errorf("db list screenshot slots: %w", err)
 		}
-		slot.SourcePath = trimmed
+		slot.SourcePath = bound.SourcePath
+		slot.PreparedMediaFingerprint = bound.PreparedMediaFingerprint
+		slot.PreparedGeneration = bound.PreparedGeneration
 		slot.FromDescription = fromDescription != 0
 		slot.RenderInScreenshots = renderInScreenshots != 0
 		slots = append(slots, slot)
@@ -3070,11 +3209,11 @@ func (r *SQLiteRepository) ListScreenshotSlotsByPath(ctx context.Context, path s
 	}
 
 	variantRows, err := r.db.QueryContext(ctx, `
-		SELECT slot_order, host, usage_scope, image_path, img_url, raw_url, web_url, uploaded_at
+		SELECT disc_id, slot_order, host, usage_scope, image_path, img_url, raw_url, web_url, uploaded_at
 		FROM screenshot_slot_variants
-		WHERE source_path = ?
+		WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ?
 		ORDER BY slot_order ASC
-	`, trimmed)
+	`, bound.SourcePath, bound.PreparedMediaFingerprint, bound.PreparedGeneration)
 	if err != nil {
 		return nil, fmt.Errorf("db list screenshot slot variants: %w", err)
 	}
@@ -3084,6 +3223,7 @@ func (r *SQLiteRepository) ListScreenshotSlotsByPath(ctx context.Context, path s
 		var variant ScreenshotSlotVariant
 		var uploadedAt string
 		if err := variantRows.Scan(
+			&variant.DiscID,
 			&variant.SlotOrder,
 			&variant.Host,
 			&variant.UsageScope,
@@ -3095,7 +3235,9 @@ func (r *SQLiteRepository) ListScreenshotSlotsByPath(ctx context.Context, path s
 		); err != nil {
 			return nil, fmt.Errorf("db list screenshot slot variants: %w", err)
 		}
-		variant.SourcePath = trimmed
+		variant.SourcePath = bound.SourcePath
+		variant.PreparedMediaFingerprint = bound.PreparedMediaFingerprint
+		variant.PreparedGeneration = bound.PreparedGeneration
 		if uploadedAt != "" {
 			if parsed, parseErr := time.Parse(time.RFC3339Nano, uploadedAt); parseErr == nil {
 				variant.UploadedAt = parsed
@@ -3112,12 +3254,16 @@ func (r *SQLiteRepository) ListScreenshotSlotsByPath(ctx context.Context, path s
 	return slots, nil
 }
 
-func (r *SQLiteRepository) UpsertScreenshotSlotVariants(ctx context.Context, path string, variants []ScreenshotSlotVariant) error {
+func (r *SQLiteRepository) UpsertScreenshotSlotVariants(
+	ctx context.Context,
+	binding PreparedMediaBinding,
+	variants []ScreenshotSlotVariant,
+) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
 	}
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil {
 		return internalerrors.ErrInvalidInput
 	}
 	if len(variants) == 0 {
@@ -3127,10 +3273,14 @@ func (r *SQLiteRepository) UpsertScreenshotSlotVariants(ctx context.Context, pat
 	if err := r.withWriteTx(ctx, "upsert screenshot slot variants", func(tx *sql.Tx) error {
 		stmt, err := tx.PrepareContext(ctx, `
 			INSERT INTO screenshot_slot_variants (
-				source_path, slot_order, host, usage_scope, image_path, img_url, raw_url, web_url, uploaded_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+				source_path, prepared_media_fingerprint, prepared_generation, disc_id,
+				slot_order, host, usage_scope, image_path, img_url, raw_url, web_url, uploaded_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(source_path, slot_order, usage_scope, host)
 			DO UPDATE SET
+				prepared_media_fingerprint = excluded.prepared_media_fingerprint,
+				prepared_generation = excluded.prepared_generation,
+				disc_id = excluded.disc_id,
 				image_path = excluded.image_path,
 				img_url = excluded.img_url,
 				raw_url = excluded.raw_url,
@@ -3149,7 +3299,10 @@ func (r *SQLiteRepository) UpsertScreenshotSlotVariants(ctx context.Context, pat
 			}
 			if _, err := stmt.ExecContext(
 				ctx,
-				trimmed,
+				bound.SourcePath,
+				bound.PreparedMediaFingerprint,
+				bound.PreparedGeneration,
+				strings.TrimSpace(variant.DiscID),
 				variant.SlotOrder,
 				strings.TrimSpace(variant.Host),
 				strings.TrimSpace(variant.UsageScope),
@@ -3172,12 +3325,17 @@ func (r *SQLiteRepository) UpsertScreenshotSlotVariants(ctx context.Context, pat
 // SaveUploadedImages upserts upload records without deleting omitted images.
 // path and host override their per-image fields; empty usage scopes default to
 // "global" and zero upload times default to the current UTC time.
-func (r *SQLiteRepository) SaveUploadedImages(ctx context.Context, path string, host string, images []UploadedImageLink) error {
+func (r *SQLiteRepository) SaveUploadedImages(
+	ctx context.Context,
+	binding PreparedMediaBinding,
+	host string,
+	images []UploadedImageLink,
+) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
 	}
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil {
 		return internalerrors.ErrInvalidInput
 	}
 	trimmedHost := strings.TrimSpace(host)
@@ -3190,11 +3348,13 @@ func (r *SQLiteRepository) SaveUploadedImages(ctx context.Context, path string, 
 
 	normalized := slices.Clone(images)
 	for idx := range normalized {
-		normalized[idx].SourcePath = trimmed
+		normalized[idx].SourcePath = bound.SourcePath
+		normalized[idx].PreparedMediaFingerprint = bound.PreparedMediaFingerprint
+		normalized[idx].PreparedGeneration = bound.PreparedGeneration
 		normalized[idx].Host = trimmedHost
 	}
 	if err := r.withWriteTx(ctx, "save uploaded images", func(tx *sql.Tx) error {
-		return upsertUploadedImagesTx(ctx, tx, trimmed, normalized)
+		return upsertUploadedImagesTx(ctx, tx, bound, normalized)
 	}); err != nil {
 		return err
 	}
@@ -3204,16 +3364,20 @@ func (r *SQLiteRepository) SaveUploadedImages(ctx context.Context, path string, 
 // upsertUploadedImagesTx stores normalized upload records in the caller's
 // transaction. Each record must match path and name a local image and host;
 // empty usage scopes and upload times receive their persistence defaults.
-func upsertUploadedImagesTx(ctx context.Context, tx *sql.Tx, path string, images []UploadedImageLink) error {
+func upsertUploadedImagesTx(ctx context.Context, tx *sql.Tx, binding PreparedMediaBinding, images []UploadedImageLink) error {
 	if len(images) == 0 {
 		return nil
 	}
 	stmt, err := tx.PrepareContext(ctx, `
 		INSERT INTO uploaded_images (
-			source_path, image_path, host, usage_scope, img_url, raw_url, web_url, size_bytes, uploaded_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			source_path, prepared_media_fingerprint, prepared_generation, disc_id,
+			image_path, host, usage_scope, img_url, raw_url, web_url, size_bytes, uploaded_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(source_path, usage_scope, host, image_path)
 		DO UPDATE SET
+			prepared_media_fingerprint = excluded.prepared_media_fingerprint,
+			prepared_generation = excluded.prepared_generation,
+			disc_id = excluded.disc_id,
 			img_url = excluded.img_url,
 			raw_url = excluded.raw_url,
 			web_url = excluded.web_url,
@@ -3226,7 +3390,7 @@ func upsertUploadedImagesTx(ctx context.Context, tx *sql.Tx, path string, images
 	defer stmt.Close()
 
 	for _, image := range images {
-		if strings.TrimSpace(image.SourcePath) != path || strings.TrimSpace(image.ImagePath) == "" || strings.TrimSpace(image.Host) == "" {
+		if strings.TrimSpace(image.ImagePath) == "" || strings.TrimSpace(image.Host) == "" {
 			return internalerrors.ErrInvalidInput
 		}
 		usageScope := strings.TrimSpace(image.UsageScope)
@@ -3239,7 +3403,10 @@ func upsertUploadedImagesTx(ctx context.Context, tx *sql.Tx, path string, images
 		}
 		if _, err := stmt.ExecContext(
 			ctx,
-			path,
+			binding.SourcePath,
+			binding.PreparedMediaFingerprint,
+			binding.PreparedGeneration,
+			strings.TrimSpace(image.DiscID),
 			image.ImagePath,
 			strings.TrimSpace(image.Host),
 			usageScope,
@@ -3255,21 +3422,21 @@ func upsertUploadedImagesTx(ctx context.Context, tx *sql.Tx, path string, images
 	return nil
 }
 
-func (r *SQLiteRepository) ListUploadedImagesByPath(ctx context.Context, path string) ([]UploadedImageLink, error) {
+func (r *SQLiteRepository) ListUploadedImagesByPath(ctx context.Context, binding PreparedMediaBinding) ([]UploadedImageLink, error) {
 	if r == nil || r.db == nil {
 		return nil, errors.New("db: repository not initialized")
 	}
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil {
 		return nil, internalerrors.ErrInvalidInput
 	}
 
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT image_path, host, usage_scope, img_url, raw_url, web_url, size_bytes, uploaded_at
+		SELECT disc_id, image_path, host, usage_scope, img_url, raw_url, web_url, size_bytes, uploaded_at
 		FROM uploaded_images
-		WHERE source_path = ?
+		WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ?
 		ORDER BY id ASC
-	`, trimmed)
+	`, bound.SourcePath, bound.PreparedMediaFingerprint, bound.PreparedGeneration)
 	if err != nil {
 		return nil, fmt.Errorf("db list uploaded images: %w", err)
 	}
@@ -3280,6 +3447,7 @@ func (r *SQLiteRepository) ListUploadedImagesByPath(ctx context.Context, path st
 		var image UploadedImageLink
 		var uploadedAt string
 		if err := rows.Scan(
+			&image.DiscID,
 			&image.ImagePath,
 			&image.Host,
 			&image.UsageScope,
@@ -3291,7 +3459,9 @@ func (r *SQLiteRepository) ListUploadedImagesByPath(ctx context.Context, path st
 		); err != nil {
 			return nil, fmt.Errorf("db list uploaded images: %w", err)
 		}
-		image.SourcePath = trimmed
+		image.SourcePath = bound.SourcePath
+		image.PreparedMediaFingerprint = bound.PreparedMediaFingerprint
+		image.PreparedGeneration = bound.PreparedGeneration
 		if strings.TrimSpace(image.UsageScope) == "" {
 			image.UsageScope = "global"
 		}
@@ -3311,12 +3481,17 @@ func (r *SQLiteRepository) ListUploadedImagesByPath(ctx context.Context, path st
 // DeleteUploadedImage deletes every usage-scope record matching path,
 // imagePath, and host. Repeated deletion succeeds once no matching record
 // remains so retained workflow cleanup can safely replay after restart.
-func (r *SQLiteRepository) DeleteUploadedImage(ctx context.Context, path string, imagePath string, host string) error {
+func (r *SQLiteRepository) DeleteUploadedImage(
+	ctx context.Context,
+	binding PreparedMediaBinding,
+	imagePath string,
+	host string,
+) error {
 	if r == nil || r.db == nil {
 		return errors.New("db: repository not initialized")
 	}
-	trimmedPath := strings.TrimSpace(path)
-	if trimmedPath == "" {
+	bound, err := normalizePreparedMediaBinding(binding)
+	if err != nil {
 		return internalerrors.ErrInvalidInput
 	}
 	trimmedImagePath := strings.TrimSpace(imagePath)
@@ -3327,10 +3502,10 @@ func (r *SQLiteRepository) DeleteUploadedImage(ctx context.Context, path string,
 	if trimmedHost == "" {
 		return internalerrors.ErrInvalidInput
 	}
-	_, err := r.execWrite(ctx, "delete uploaded image", `
+	_, err = r.execWrite(ctx, "delete uploaded image", `
 		DELETE FROM uploaded_images
-		WHERE source_path = ? AND host = ? AND image_path = ?
-	`, trimmedPath, trimmedHost, trimmedImagePath)
+		WHERE source_path = ? AND prepared_media_fingerprint = ? AND prepared_generation = ? AND host = ? AND image_path = ?
+	`, bound.SourcePath, bound.PreparedMediaFingerprint, bound.PreparedGeneration, trimmedHost, trimmedImagePath)
 	if err != nil {
 		return fmt.Errorf("db delete uploaded image: %w", err)
 	}

--- a/internal/services/db/sqlite_test.go
+++ b/internal/services/db/sqlite_test.go
@@ -658,7 +658,7 @@ func TestSQLiteRepositoryConcurrentDistinctPathWritesOnDisk(t *testing.T) {
 					errCh <- fmt.Errorf("repo %d save rule failures %d: %w", repoIdx, item, err)
 					return
 				}
-				if err := repo.SaveFinalSelections(ctx, sourcePath, []ScreenshotFinalSelection{{
+				if err := repo.SaveFinalSelections(ctx, testPreparedMediaBinding(sourcePath), []ScreenshotFinalSelection{{
 					ImagePath:  imagePath,
 					Order:      1,
 					Source:     "test",
@@ -667,7 +667,7 @@ func TestSQLiteRepositoryConcurrentDistinctPathWritesOnDisk(t *testing.T) {
 					errCh <- fmt.Errorf("repo %d save final selections %d: %w", repoIdx, item, err)
 					return
 				}
-				if err := repo.SaveUploadedImages(ctx, sourcePath, "imgbb", []UploadedImageLink{{
+				if err := repo.SaveUploadedImages(ctx, testPreparedMediaBinding(sourcePath), "imgbb", []UploadedImageLink{{
 					ImagePath:  imagePath,
 					UsageScope: "global",
 					ImgURL:     fmt.Sprintf("https://img.example/%d/%d.jpg", repoIdx, item),
@@ -722,14 +722,14 @@ func TestSQLiteRepositoryConcurrentDistinctPathWritesOnDisk(t *testing.T) {
 			if len(failures) != 1 {
 				t.Fatalf("expected 1 rule failure for %s, got %d", sourcePath, len(failures))
 			}
-			selections, err := migratorRepo.ListFinalSelections(ctx, sourcePath)
+			selections, err := migratorRepo.ListFinalSelections(ctx, testPreparedMediaBinding(sourcePath))
 			if err != nil {
 				t.Fatalf("list final selections %s: %v", sourcePath, err)
 			}
 			if len(selections) != 1 {
 				t.Fatalf("expected 1 final selection for %s, got %d", sourcePath, len(selections))
 			}
-			images, err := migratorRepo.ListUploadedImagesByPath(ctx, sourcePath)
+			images, err := migratorRepo.ListUploadedImagesByPath(ctx, testPreparedMediaBinding(sourcePath))
 			if err != nil {
 				t.Fatalf("list uploaded images %s: %v", sourcePath, err)
 			}
@@ -1654,7 +1654,7 @@ func TestSQLitePurgeContentData(t *testing.T) {
 	}}); err != nil {
 		t.Fatalf("save rule failures: %v", err)
 	}
-	if err := repo.SaveScreenshot(ctx, Screenshot{
+	if err := repo.SaveScreenshot(ctx, testPreparedMediaBinding(targetPath), Screenshot{
 		SourcePath: targetPath,
 		ImagePath:  "/tmp/target-01.png",
 		Purpose:    ScreenshotPurpose("final"),
@@ -1662,7 +1662,7 @@ func TestSQLitePurgeContentData(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save screenshot: %v", err)
 	}
-	if err := repo.SaveFinalSelections(ctx, targetPath, []ScreenshotFinalSelection{{
+	if err := repo.SaveFinalSelections(ctx, testPreparedMediaBinding(targetPath), []ScreenshotFinalSelection{{
 		ImagePath:  "/tmp/target-01.png",
 		Order:      0,
 		Source:     "existing",
@@ -1670,7 +1670,7 @@ func TestSQLitePurgeContentData(t *testing.T) {
 	}}); err != nil {
 		t.Fatalf("save final selection: %v", err)
 	}
-	if err := repo.SaveUploadedImages(ctx, targetPath, "imgbox", []UploadedImageLink{{
+	if err := repo.SaveUploadedImages(ctx, testPreparedMediaBinding(targetPath), "imgbox", []UploadedImageLink{{
 		SourcePath: targetPath,
 		ImagePath:  "/tmp/target-01.png",
 		Host:       "imgbox",
@@ -1679,7 +1679,7 @@ func TestSQLitePurgeContentData(t *testing.T) {
 	}}); err != nil {
 		t.Fatalf("save uploaded image: %v", err)
 	}
-	if err := repo.ReplaceScreenshotSlots(ctx, targetPath, []ScreenshotSlot{{
+	if err := repo.ReplaceScreenshotSlots(ctx, testPreparedMediaBinding(targetPath), []ScreenshotSlot{{
 		SourcePath:          targetPath,
 		SlotOrder:           0,
 		SourceKind:          "tracker_metadata",
@@ -1698,7 +1698,7 @@ func TestSQLitePurgeContentData(t *testing.T) {
 	}}); err != nil {
 		t.Fatalf("save screenshot slots target: %v", err)
 	}
-	if err := repo.ReplaceScreenshotSlots(ctx, otherPath, []ScreenshotSlot{{
+	if err := repo.ReplaceScreenshotSlots(ctx, testPreparedMediaBinding(otherPath), []ScreenshotSlot{{
 		SourcePath:          otherPath,
 		SlotOrder:           0,
 		SourceKind:          "tracker_metadata",
@@ -1749,16 +1749,16 @@ func TestSQLitePurgeContentData(t *testing.T) {
 	if ruleFailures, err := repo.ListTrackerRuleFailuresByPath(ctx, targetPath); err != nil || len(ruleFailures) != 0 {
 		t.Fatalf("expected tracker rule failures removed, got len=%d err=%v", len(ruleFailures), err)
 	}
-	if screenshots, err := repo.ListScreenshotsByPath(ctx, targetPath); err != nil || len(screenshots) != 0 {
+	if screenshots, err := repo.ListScreenshotsByPath(ctx, testPreparedMediaBinding(targetPath)); err != nil || len(screenshots) != 0 {
 		t.Fatalf("expected screenshots removed, got len=%d err=%v", len(screenshots), err)
 	}
-	if finals, err := repo.ListFinalSelections(ctx, targetPath); err != nil || len(finals) != 0 {
+	if finals, err := repo.ListFinalSelections(ctx, testPreparedMediaBinding(targetPath)); err != nil || len(finals) != 0 {
 		t.Fatalf("expected final selections removed, got len=%d err=%v", len(finals), err)
 	}
-	if uploaded, err := repo.ListUploadedImagesByPath(ctx, targetPath); err != nil || len(uploaded) != 0 {
+	if uploaded, err := repo.ListUploadedImagesByPath(ctx, testPreparedMediaBinding(targetPath)); err != nil || len(uploaded) != 0 {
 		t.Fatalf("expected uploaded images removed, got len=%d err=%v", len(uploaded), err)
 	}
-	if slots, err := repo.ListScreenshotSlotsByPath(ctx, targetPath); err != nil || len(slots) != 0 {
+	if slots, err := repo.ListScreenshotSlotsByPath(ctx, testPreparedMediaBinding(targetPath)); err != nil || len(slots) != 0 {
 		t.Fatalf("expected screenshot slots removed, got len=%d err=%v", len(slots), err)
 	}
 	var legacyRows int
@@ -1772,7 +1772,7 @@ func TestSQLitePurgeContentData(t *testing.T) {
 	if _, err := repo.GetByPath(ctx, otherPath); err != nil {
 		t.Fatalf("expected other path untouched, got %v", err)
 	}
-	if slots, err := repo.ListScreenshotSlotsByPath(ctx, otherPath); err != nil || len(slots) != 1 {
+	if slots, err := repo.ListScreenshotSlotsByPath(ctx, testPreparedMediaBinding(otherPath)); err != nil || len(slots) != 1 {
 		t.Fatalf("expected other screenshot slots untouched, got len=%d err=%v", len(slots), err)
 	}
 	pending, err := repo.ListPendingUploads(ctx)
@@ -1885,7 +1885,7 @@ func TestSQLiteRepositoryListStoredReleasePathsIncludesOrphans(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("create upload record: %v", err)
 	}
-	if err := repo.SaveScreenshot(ctx, Screenshot{
+	if err := repo.SaveScreenshot(ctx, testPreparedMediaBinding("/media/orphan-shot.mkv"), Screenshot{
 		SourcePath: "/media/orphan-shot.mkv",
 		ImagePath:  "/tmp/orphan-shot.png",
 		Purpose:    ScreenshotPurpose("final"),
@@ -1893,7 +1893,7 @@ func TestSQLiteRepositoryListStoredReleasePathsIncludesOrphans(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save screenshot: %v", err)
 	}
-	if err := repo.ReplaceScreenshotSlots(ctx, "/media/orphan-slot.mkv", []ScreenshotSlot{{
+	if err := repo.ReplaceScreenshotSlots(ctx, testPreparedMediaBinding("/media/orphan-slot.mkv"), []ScreenshotSlot{{
 		SourcePath:          "/media/orphan-slot.mkv",
 		SlotOrder:           0,
 		SourceKind:          "tracker_metadata",
@@ -1902,7 +1902,7 @@ func TestSQLiteRepositoryListStoredReleasePathsIncludesOrphans(t *testing.T) {
 	}}); err != nil {
 		t.Fatalf("save screenshot slot: %v", err)
 	}
-	if err := repo.UpsertScreenshotSlotVariants(ctx, "/media/orphan-variant.mkv", []ScreenshotSlotVariant{{
+	if err := repo.UpsertScreenshotSlotVariants(ctx, testPreparedMediaBinding("/media/orphan-variant.mkv"), []ScreenshotSlotVariant{{
 		SourcePath: "/media/orphan-variant.mkv",
 		SlotOrder:  0,
 		Host:       "imgbox",
@@ -1992,7 +1992,7 @@ func TestSQLiteUploadedImagesPersistUsageScope(t *testing.T) {
 
 	ctx := context.Background()
 	now := time.Now().UTC().Truncate(time.Second)
-	if err := repo.SaveUploadedImages(ctx, "/tmp/source", "hdb", []UploadedImageLink{{
+	if err := repo.SaveUploadedImages(ctx, testPreparedMediaBinding("/tmp/source"), "hdb", []UploadedImageLink{{
 		SourcePath: "/tmp/source",
 		ImagePath:  "/tmp/a.png",
 		Host:       "hdb",
@@ -2005,7 +2005,7 @@ func TestSQLiteUploadedImagesPersistUsageScope(t *testing.T) {
 		t.Fatalf("save uploaded image: %v", err)
 	}
 
-	images, err := repo.ListUploadedImagesByPath(ctx, "/tmp/source")
+	images, err := repo.ListUploadedImagesByPath(ctx, testPreparedMediaBinding("/tmp/source"))
 	if err != nil {
 		t.Fatalf("list uploaded images: %v", err)
 	}
@@ -2056,15 +2056,19 @@ func TestSQLiteMigrationBackfillsUploadedImageUsageScope(t *testing.T) {
 	}
 
 	repo := &SQLiteRepository{db: rawDB}
-	images, err := repo.ListUploadedImagesByPath(context.Background(), "/tmp/source")
+	images, err := repo.ListUploadedImagesByPath(context.Background(), testPreparedMediaBinding("/tmp/source"))
 	if err != nil {
 		t.Fatalf("list uploaded images: %v", err)
 	}
-	if len(images) != 1 {
-		t.Fatalf("expected 1 uploaded image, got %d", len(images))
+	if len(images) != 0 {
+		t.Fatalf("legacy uploaded images must remain hidden, got %d", len(images))
 	}
-	if images[0].UsageScope != "global" {
-		t.Fatalf("expected global usage scope after migration, got %q", images[0].UsageScope)
+	var usageScope string
+	if err := rawDB.QueryRowContext(context.Background(), `SELECT usage_scope FROM uploaded_images WHERE source_path = "/tmp/source"`).Scan(&usageScope); err != nil {
+		t.Fatalf("load migrated usage scope: %v", err)
+	}
+	if usageScope != "global" {
+		t.Fatalf("expected global usage scope after migration, got %q", usageScope)
 	}
 }
 
@@ -2194,10 +2198,10 @@ func TestSQLiteRepositoryScreenshotSlotsRoundTrip(t *testing.T) {
 		},
 	}
 
-	if err := repo.ReplaceScreenshotSlots(ctx, "/tmp/source", slots); err != nil {
+	if err := repo.ReplaceScreenshotSlots(ctx, testPreparedMediaBinding("/tmp/source"), slots); err != nil {
 		t.Fatalf("replace screenshot slots: %v", err)
 	}
-	if err := repo.UpsertScreenshotSlotVariants(ctx, "/tmp/source", []ScreenshotSlotVariant{{
+	if err := repo.UpsertScreenshotSlotVariants(ctx, testPreparedMediaBinding("/tmp/source"), []ScreenshotSlotVariant{{
 		SourcePath: "/tmp/source",
 		SlotOrder:  1,
 		Host:       "hdb",
@@ -2210,7 +2214,7 @@ func TestSQLiteRepositoryScreenshotSlotsRoundTrip(t *testing.T) {
 		t.Fatalf("upsert screenshot slot variants: %v", err)
 	}
 
-	loaded, err := repo.ListScreenshotSlotsByPath(ctx, "/tmp/source")
+	loaded, err := repo.ListScreenshotSlotsByPath(ctx, testPreparedMediaBinding("/tmp/source"))
 	if err != nil {
 		t.Fatalf("list screenshot slots: %v", err)
 	}

--- a/internal/services/db/sqlite_test.go
+++ b/internal/services/db/sqlite_test.go
@@ -1634,7 +1634,7 @@ func TestSQLitePurgeContentData(t *testing.T) {
 	if err := repo.SaveDescriptionOverride(ctx, DescriptionOverride{SourcePath: targetPath, Description: "desc"}); err != nil {
 		t.Fatalf("save description override: %v", err)
 	}
-	if err := repo.SavePlaylistSelection(ctx, targetPath, []string{"00001.mpls"}, false); err != nil {
+	if err := repo.SavePlaylistSelection(ctx, targetPath, "source-fingerprint", []string{"00001.mpls"}, false); err != nil {
 		t.Fatalf("save playlist selection: %v", err)
 	}
 	if err := repo.SaveTrackerMetadata(ctx, TrackerMetadata{

--- a/internal/services/dvdmenus/service.go
+++ b/internal/services/dvdmenus/service.go
@@ -72,7 +72,7 @@ type Service struct {
 
 type repository interface {
 	api.ScreenshotLifecycleRepository
-	LoadMediaAssetSnapshot(context.Context, string) (api.MediaAssetSnapshot, error)
+	LoadMediaAssetSnapshot(context.Context, api.PreparedMediaBinding) (api.MediaAssetSnapshot, error)
 }
 
 // NewService returns a DVD menu service that shares the screenshot FFmpeg
@@ -113,13 +113,22 @@ func newService(
 	}
 }
 
-// Capture renders and persists up to maxItems automatic menu images for one
-// prepared DVD. It atomically replaces earlier automatic captures, preserves
-// manual menus and normal screenshots, and reports partial coverage in result.
+// Capture renders and persists up to maxItems automatic menu images across all
+// prepared DVDs. It preserves collection-wide coverage before adding another
+// image from any disc.
 func (s *Service) Capture(ctx context.Context, meta api.DVDMenuSubject, maxItems int) (api.DVDMenuCaptureResult, error) {
-	result := api.DVDMenuCaptureResult{SourcePath: meta.SourcePath, MaxItems: maxItems}
+	result := api.DVDMenuCaptureResult{
+		SourcePath:       meta.SourcePath,
+		SelectedLanguage: defaultLanguage,
+		MaxItems:         maxItems,
+	}
 	if s != nil && s.logger != nil {
-		s.logger.Debugf("DVD menus: capture requested disc_type=%s max_items=%d", strings.ToUpper(strings.TrimSpace(meta.DiscType)), maxItems)
+		s.logger.Debugf(
+			"DVD menus: capture requested disc_type=%s discs=%d max_items=%d",
+			strings.ToUpper(strings.TrimSpace(meta.DiscType)),
+			len(dvdMenuDiscs(meta)),
+			maxItems,
+		)
 	}
 	api.ReportDVDMenuProgress(ctx, api.DVDMenuProgressUpdate{Phase: "preflight", Message: "Checking DVD menu capture support."})
 	if err := ctx.Err(); err != nil {
@@ -131,42 +140,48 @@ func (s *Service) Capture(ctx context.Context, meta api.DVDMenuSubject, maxItems
 	if !strings.EqualFold(strings.TrimSpace(meta.DiscType), "DVD") {
 		return result, errors.New("DVD menus: source is not a DVD")
 	}
-	if strings.TrimSpace(meta.SourcePath) == "" || maxItems < 1 || maxItems > graph.MaxMenuItems {
+	discs := dvdMenuDiscs(meta)
+	if !meta.MediaBinding.Valid() || len(discs) == 0 || maxItems < 1 || maxItems > graph.MaxMenuItems {
 		return result, internalerrors.ErrInvalidInput
 	}
-
-	videoTS, err := resolveVideoTSDirectory(meta.SourcePath)
-	if err != nil {
-		return result, err
-	}
-	s.logger.Debugf("DVD menus: source ready input=extracted_video_ts")
 	executable, capability, info, err := s.resolveCapability(ctx)
 	result.Engine = info
 	if err != nil {
-		s.logger.Warnf("DVD menus: capture failed stage=capability missing_options=%d", len(info.MissingFFmpegOptions))
 		return result, err
 	}
 
 	s.logger.Infof(
-		"DVD menus: capture started language=%s region=%d max_items=%d engine_version=%s ffmpeg_dvdvideo=%t",
+		"DVD menus: capture started discs=%d language=%s region=%d max_items=%d engine_version=%s ffmpeg_dvdvideo=%t",
+		len(discs),
 		defaultLanguage,
 		0,
 		maxItems,
 		info.EngineVersion,
 		info.FFmpegDVDVideo,
 	)
-	lastProgress := engine.Progress{}
-	hasProgress := false
-	engineResult, err := s.captureDirectory(ctx, videoTS, s.runner, executable, engine.Options{
-		Traversal:      graph.Options{Language: defaultLanguage, MaxItems: maxItems},
-		ProcessTimeout: engine.DefaultProcessTimeout,
-		Deinterlace:    true,
-		Capability:     &capability,
-		Logger:         s.logger,
-		Progress: func(update engine.Progress) {
-			if !hasProgress || update != lastProgress {
+	capturedDiscs := make([]dvdMenuDiscResult, 0, len(discs))
+	for _, disc := range discs {
+		if err := ctx.Err(); err != nil {
+			return result, fmt.Errorf("DVD menus: capture canceled: %w", err)
+		}
+		videoTS, resolveErr := resolveVideoTSDirectory(disc.Root)
+		if resolveErr != nil {
+			result.Partial = true
+			result.Warnings = appendWarning(result.Warnings, uncoveredDVDMenuWarning(disc, "disc_source_unavailable"))
+			s.logger.Warnf("DVD menus: disc unavailable disc_id=%s", disc.ID)
+			continue
+		}
+		s.logger.Debugf("DVD menus: disc capture started disc_id=%s", disc.ID)
+		engineResult, captureErr := s.captureDirectory(ctx, videoTS, s.runner, executable, engine.Options{
+			Traversal:      graph.Options{Language: defaultLanguage, MaxItems: maxItems},
+			ProcessTimeout: engine.DefaultProcessTimeout,
+			Deinterlace:    true,
+			Capability:     &capability,
+			Logger:         s.logger,
+			Progress: func(update engine.Progress) {
 				s.logger.Debugf(
-					"DVD menus: progress phase=%s inventoried=%d states=%d buttons=%d captured=%d warnings=%d",
+					"DVD menus: progress disc_id=%s phase=%s inventoried=%d states=%d buttons=%d captured=%d warnings=%d",
+					disc.ID,
 					update.Phase,
 					update.Inventoried,
 					update.VisitedStates,
@@ -174,56 +189,82 @@ func (s *Service) Capture(ctx context.Context, meta api.DVDMenuSubject, maxItems
 					update.Captured,
 					update.Warnings,
 				)
-				lastProgress = update
-				hasProgress = true
-			}
-			api.ReportDVDMenuProgress(ctx, api.DVDMenuProgressUpdate{
-				Phase:           update.Phase,
-				Message:         dvdMenuProgressMessage(update.Phase),
-				DiscoveredMenus: update.Inventoried,
-				VisitedStates:   update.VisitedStates,
-				VisitedButtons:  update.VisitedButtons,
-				CapturedCount:   update.Captured,
-				WarningCount:    update.Warnings,
+				api.ReportDVDMenuProgress(ctx, api.DVDMenuProgressUpdate{
+					Phase:           update.Phase,
+					Message:         dvdMenuProgressMessage(update.Phase),
+					DiscoveredMenus: result.DiscoveredMenus + update.Inventoried,
+					VisitedStates:   result.VisitedStates + update.VisitedStates,
+					VisitedButtons:  result.VisitedButtons + update.VisitedButtons,
+					CapturedCount:   update.Captured,
+					WarningCount:    len(result.Warnings) + update.Warnings,
+				})
+			},
+		})
+		result.DiscoveredMenus += engineResult.Inventoried
+		result.VisitedStates += engineResult.VisitedStates
+		result.VisitedButtons += engineResult.VisitedButtons
+		result.Truncated = result.Truncated || engineResult.Truncated
+		result.Partial = result.Partial || engineResult.Partial
+		for _, warning := range engineResult.Warnings {
+			result.Warnings = appendWarning(result.Warnings, api.DVDMenuCaptureWarning{
+				DiscID:   disc.ID,
+				DiscName: disc.Name,
+				Code:     warning.Code,
+				Message:  warning.Message,
 			})
-		},
-	})
-	result = mapEngineResult(meta.SourcePath, maxItems, engineResult, info)
-	if err != nil {
-		s.logger.Warnf(
-			"DVD menus: capture failed stage=engine captured=%d discovered=%d warnings=%d",
-			len(engineResult.Captures),
-			engineResult.Inventoried,
-			len(engineResult.Warnings),
-		)
-		return result, fmt.Errorf("DVD menus: %w", err)
+			s.logger.Debugf("DVD menus: warning recorded disc_id=%s code=%s", disc.ID, warning.Code)
+		}
+		if hasStructuralDVDMenuCapture(engineResult.Captures) {
+			result.Warnings = appendWarning(result.Warnings, api.DVDMenuCaptureWarning{
+				DiscID:   disc.ID,
+				DiscName: disc.Name,
+				Code:     "structural_discovery",
+				Message:  "Some menu screens were found through structural inventory rather than reachable navigation.",
+			})
+		}
+		if captureErr != nil {
+			result.Partial = true
+			result.Warnings = appendWarning(result.Warnings, uncoveredDVDMenuWarning(disc, "disc_capture_failed"))
+		}
+		if len(engineResult.Captures) == 0 {
+			result.Partial = true
+			result.Warnings = appendWarning(result.Warnings, uncoveredDVDMenuWarning(disc, "disc_no_menus"))
+			continue
+		}
+		capturedDiscs = append(capturedDiscs, dvdMenuDiscResult{disc: disc, result: engineResult})
+		s.logger.Debugf("DVD menus: disc capture complete disc_id=%s captured=%d", disc.ID, len(engineResult.Captures))
 	}
-	if len(engineResult.Captures) == 0 {
-		s.logger.Warnf("DVD menus: capture failed stage=render reason=no_frames")
+
+	selected := allocateDVDMenuCaptures(capturedDiscs, maxItems)
+	if len(selected) == 0 {
 		return result, errors.New("DVD menus: no menu images captured")
 	}
-	s.logger.Debugf(
-		"DVD menus: engine complete discovered=%d states=%d buttons=%d selected=%d captured=%d partial=%t truncated=%t warnings=%d",
-		result.DiscoveredMenus,
-		result.VisitedStates,
-		result.VisitedButtons,
-		engineResult.Selected,
-		len(engineResult.Captures),
-		result.Partial,
-		result.Truncated,
-		len(result.Warnings),
-	)
-	for _, warning := range result.Warnings {
-		s.logger.Debugf("DVD menus: warning recorded code=%s detail=%q", warning.Code, dvdMenuWarningDetail(warning.Code))
+	covered := make(map[string]struct{}, len(capturedDiscs))
+	for _, capture := range selected {
+		covered[capture.disc.ID] = struct{}{}
 	}
-	s.logger.Debugf("DVD menus: persistence started images=%d", len(engineResult.Captures))
+	for _, disc := range discs {
+		if _, ok := covered[disc.ID]; ok {
+			continue
+		}
+		result.Partial = true
+		result.Warnings = appendWarning(result.Warnings, uncoveredDVDMenuWarning(disc, "disc_uncovered"))
+	}
+	totalAvailable := 0
+	for _, disc := range capturedDiscs {
+		totalAvailable += len(disc.result.Captures)
+	}
+	result.Truncated = result.Truncated || totalAvailable > len(selected)
+	result.Complete = !result.Partial && !result.Truncated
+	s.logger.Debugf("DVD menus: persistence started images=%d", len(selected))
+
 	api.ReportDVDMenuProgress(ctx, api.DVDMenuProgressUpdate{
 		Phase:           "persisting",
 		Message:         "Saving captured DVD menu images.",
 		DiscoveredMenus: result.DiscoveredMenus,
 		VisitedStates:   result.VisitedStates,
 		VisitedButtons:  result.VisitedButtons,
-		CapturedCount:   len(engineResult.Captures),
+		CapturedCount:   len(selected),
 		WarningCount:    len(result.Warnings),
 	})
 
@@ -231,14 +272,14 @@ func (s *Service) Capture(ctx context.Context, meta api.DVDMenuSubject, maxItems
 	if err != nil {
 		return result, fmt.Errorf("DVD menus: %w", err)
 	}
-	images, records, selections, created, err := writeCaptureImages(ctx, tmpDir, base, meta.SourcePath, engineResult.Captures)
+	images, records, selections, created, err := writeCaptureImages(ctx, tmpDir, base, selected)
 	if err != nil {
 		removeCreatedFiles(created)
 		s.logger.Warnf("DVD menus: persistence failed stage=write created=%d", len(created))
 		return result, err
 	}
 	s.logger.Debugf("DVD menus: persistence files ready created=%d", len(created))
-	replaced, err := s.repo.ReplaceDVDMenuScreenshots(ctx, meta.SourcePath, records, selections)
+	replaced, err := s.repo.ReplaceDVDMenuScreenshots(ctx, meta.MediaBinding, records, selections)
 	if err != nil {
 		removeCreatedFiles(created)
 		s.logger.Warnf("DVD menus: persistence failed stage=database created=%d", len(created))
@@ -301,6 +342,65 @@ func (s *Service) Capture(ctx context.Context, meta api.DVDMenuSubject, maxItems
 	return result, nil
 }
 
+func hasStructuralDVDMenuCapture(captures []engine.Capture) bool {
+	for _, capture := range captures {
+		if capture.Discovery == graph.DiscoveryStructural {
+			return true
+		}
+	}
+	return false
+}
+
+type dvdMenuDiscResult struct {
+	disc   api.DVDMenuDiscSubject
+	result engine.Result
+}
+
+type dvdMenuSelectedCapture struct {
+	disc    api.DVDMenuDiscSubject
+	capture engine.Capture
+}
+
+func dvdMenuDiscs(meta api.DVDMenuSubject) []api.DVDMenuDiscSubject {
+	if len(meta.Discs) > 0 {
+		return append([]api.DVDMenuDiscSubject(nil), meta.Discs...)
+	}
+	if strings.TrimSpace(meta.SourcePath) == "" {
+		return nil
+	}
+	return []api.DVDMenuDiscSubject{{Root: meta.SourcePath}}
+}
+
+func allocateDVDMenuCaptures(discs []dvdMenuDiscResult, maxItems int) []dvdMenuSelectedCapture {
+	selected := make([]dvdMenuSelectedCapture, 0, maxItems)
+	for captureIndex := 0; len(selected) < maxItems; captureIndex++ {
+		added := false
+		for _, disc := range discs {
+			if captureIndex >= len(disc.result.Captures) {
+				continue
+			}
+			selected = append(selected, dvdMenuSelectedCapture{disc: disc.disc, capture: disc.result.Captures[captureIndex]})
+			added = true
+			if len(selected) == maxItems {
+				break
+			}
+		}
+		if !added {
+			break
+		}
+	}
+	return selected
+}
+
+func uncoveredDVDMenuWarning(disc api.DVDMenuDiscSubject, code string) api.DVDMenuCaptureWarning {
+	return api.DVDMenuCaptureWarning{
+		DiscID:   disc.ID,
+		DiscName: disc.Name,
+		Code:     code,
+		Message:  "DVD menu coverage is unavailable for this disc.",
+	}
+}
+
 func dvdMenuProgressMessage(phase string) string {
 	switch phase {
 	case "discovering":
@@ -327,7 +427,10 @@ func (s *Service) List(ctx context.Context, meta api.DVDMenuSubject) ([]api.Scre
 		return nil, internalerrors.ErrInvalidInput
 	}
 
-	snapshot, err := s.repo.LoadMediaAssetSnapshot(ctx, meta.SourcePath)
+	if !meta.MediaBinding.Valid() {
+		return nil, internalerrors.ErrInvalidInput
+	}
+	snapshot, err := s.repo.LoadMediaAssetSnapshot(ctx, meta.MediaBinding)
 	if err != nil {
 		return nil, fmt.Errorf("DVD menus: load media assets: %w", err)
 	}
@@ -344,6 +447,10 @@ func (s *Service) List(ctx context.Context, meta api.DVDMenuSubject) ([]api.Scre
 	}
 
 	images := make([]api.ScreenshotImage, 0)
+	discNames := make(map[string]string, len(meta.Discs))
+	for _, disc := range meta.Discs {
+		discNames[disc.ID] = disc.Name
+	}
 	for _, selection := range snapshot.FinalSelections {
 		if !api.IsDiscMenuSelectionSource(selection.Source) {
 			continue
@@ -354,6 +461,8 @@ func (s *Service) List(ctx context.Context, meta api.DVDMenuSubject) ([]api.Scre
 		}
 		imageValue, ok := screenshotImage(pathValue, len(images), recordByPath[pathValue], uploadByPath[pathValue])
 		if ok {
+			imageValue.DiscID = selection.DiscID
+			imageValue.DiscName = discNames[selection.DiscID]
 			images = append(images, imageValue)
 		}
 	}
@@ -375,7 +484,7 @@ func (s *Service) Delete(ctx context.Context, meta api.DVDMenuSubject, imagePath
 		return errors.New("DVD menus: screenshot lifecycle repository not configured")
 	}
 	trimmedPath := strings.TrimSpace(imagePath)
-	if strings.TrimSpace(meta.SourcePath) == "" || trimmedPath == "" {
+	if !meta.MediaBinding.Valid() || trimmedPath == "" {
 		return internalerrors.ErrInvalidInput
 	}
 	tmpDir, _, err := paths.ReleaseTempDirFor(s.tmpRoot, meta.SourcePath, api.ReleaseInfo{})
@@ -401,7 +510,7 @@ func (s *Service) Delete(ctx context.Context, meta api.DVDMenuSubject, imagePath
 		return fmt.Errorf("DVD menus: inspect local image: %w", statErr)
 	}
 
-	deleted, err := s.repo.DeleteDiscMenuScreenshot(ctx, meta.SourcePath, trimmedPath)
+	deleted, err := s.repo.DeleteDiscMenuScreenshot(ctx, meta.MediaBinding, trimmedPath)
 	if err != nil {
 		if renamed {
 			if restoreErr := os.Rename(pendingPath, trimmedPath); restoreErr != nil {
@@ -425,7 +534,7 @@ func (s *Service) Delete(ctx context.Context, meta api.DVDMenuSubject, imagePath
 			if restoreErr := os.Rename(pendingPath, trimmedPath); restoreErr != nil {
 				return fmt.Errorf("DVD menus: remove staged local image and restore file: %w", errors.Join(removeErr, restoreErr))
 			}
-			if restoreErr := s.repo.RestoreDiscMenuScreenshot(context.WithoutCancel(ctx), meta.SourcePath, deleted); restoreErr != nil {
+			if restoreErr := s.repo.RestoreDiscMenuScreenshot(context.WithoutCancel(ctx), meta.MediaBinding, deleted); restoreErr != nil {
 				return fmt.Errorf("DVD menus: remove staged local image and restore records: %w", errors.Join(removeErr, restoreErr))
 			}
 			return fmt.Errorf("DVD menus: remove staged local image; deletion rolled back: %w", removeErr)
@@ -496,50 +605,6 @@ func (s *Service) resolveCapability(ctx context.Context) (string, render.Capabil
 	return executable, capability, engineInfo(capability), nil
 }
 
-func dvdMenuWarningDetail(code string) string {
-	switch code {
-	case "depth_limit":
-		return "menu branch depth limit reached"
-	case "state_limit":
-		return "menu state limit reached"
-	case "pre_command":
-		return "menu pre-command failed"
-	case "unsupported_pre_link":
-		return "menu pre-command target was not resolved"
-	case "live_state":
-		return "menu NAV/SPU state could not be resolved"
-	case "button_limit":
-		return "menu button limit reached"
-	case "button_command":
-		return "menu button command failed"
-	case "unsupported_button_link":
-		return "menu button target was not resolved"
-	case "post_command":
-		return "menu post-command failed"
-	case "unsupported_post_link":
-		return "menu post-command target was not resolved"
-	case "structural_only":
-		return "visible menu was not reached through navigation"
-	case "structural_state":
-		return "structural menu candidate could not be classified"
-	case "nav_scan_limit":
-		return "menu NAV/SPU sector scan limit reached"
-	case "frame_decode":
-		return "inventory-selected menu frame could not be decoded"
-	case "spu_unavailable":
-		return "menu subpicture state was not available"
-	case "highlight_unavailable":
-		return "default menu highlight state was not available"
-	case "black_frame":
-		return "decoded menu frame was black"
-	case "structural_discovery":
-		return "some menu screens were found through structural inventory rather than reachable navigation"
-	case "cleanup_failed":
-		return "some replaced local DVD menu files could not be removed"
-	}
-	return "DVD menu coverage warning"
-}
-
 func inspectExecutable(executable string) (executableIdentity, error) {
 	absPath, err := filepath.Abs(strings.TrimSpace(executable))
 	if err != nil {
@@ -594,40 +659,9 @@ func missingFFmpegOptions(err error) []string {
 	return missing
 }
 
-func mapEngineResult(sourcePath string, maxItems int, source engine.Result, info api.DVDMenuEngineInfo) api.DVDMenuCaptureResult {
-	result := api.DVDMenuCaptureResult{
-		SourcePath:       sourcePath,
-		SelectedLanguage: defaultLanguage,
-		DiscoveredMenus:  source.Inventoried,
-		VisitedStates:    source.VisitedStates,
-		VisitedButtons:   source.VisitedButtons,
-		MaxItems:         maxItems,
-		Complete:         source.Complete,
-		Partial:          source.Partial,
-		Truncated:        source.Truncated,
-		Engine:           info,
-	}
-	structural := false
-	for _, capture := range source.Captures {
-		if capture.Discovery == graph.DiscoveryStructural {
-			structural = true
-		}
-	}
-	for _, warning := range source.Warnings {
-		result.Warnings = appendWarning(result.Warnings, api.DVDMenuCaptureWarning{Code: warning.Code, Message: warning.Message})
-	}
-	if structural {
-		result.Warnings = appendWarning(result.Warnings, api.DVDMenuCaptureWarning{
-			Code:    "structural_discovery",
-			Message: "Some menu screens were found through structural inventory rather than reachable navigation.",
-		})
-	}
-	return result
-}
-
 func appendWarning(warnings []api.DVDMenuCaptureWarning, warning api.DVDMenuCaptureWarning) []api.DVDMenuCaptureWarning {
 	for _, existing := range warnings {
-		if existing.Code == warning.Code {
+		if existing.Code == warning.Code && existing.DiscID == warning.DiscID {
 			return warnings
 		}
 	}
@@ -640,22 +674,29 @@ func writeCaptureImages(
 	ctx context.Context,
 	tmpDir string,
 	base string,
-	sourcePath string,
-	captures []engine.Capture,
+	captures []dvdMenuSelectedCapture,
 ) ([]api.DVDMenuCaptureImage, []api.Screenshot, []api.ScreenshotFinalSelection, []string, error) {
 	stamp := time.Now().UTC()
 	images := make([]api.DVDMenuCaptureImage, 0, len(captures))
 	records := make([]api.Screenshot, 0, len(captures))
 	selections := make([]api.ScreenshotFinalSelection, 0, len(captures))
 	created := make([]string, 0, len(captures))
-	for index, capture := range captures {
+	for index, selected := range captures {
+		capture := selected.capture
 		if err := ctx.Err(); err != nil {
 			return nil, nil, nil, created, fmt.Errorf("DVD menus: write capture canceled: %w", err)
 		}
 		if capture.Image == nil || capture.Image.Bounds().Empty() {
 			return nil, nil, nil, created, errors.New("DVD menus: capture image is empty")
 		}
-		finalPath := filepath.Join(tmpDir, fmt.Sprintf("%s-dvd-menu-%02d-%d.png", base, index+1, stamp.UnixNano()))
+		discID := strings.TrimSpace(selected.disc.ID)
+		if discID == "" {
+			discID = "single"
+		}
+		finalPath := filepath.Join(
+			tmpDir,
+			fmt.Sprintf("%s-disc-%s-dvd-menu-%02d-%d.png", base, safeDVDMenuFilenameSegment(discID), index+1, stamp.UnixNano()),
+		)
 		partialPath := finalPath + ".partial"
 		file, err := os.OpenFile(partialPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 		if err != nil {
@@ -684,6 +725,8 @@ func writeCaptureImages(
 		discovery := api.DVDMenuDiscovery(capture.Discovery)
 		images = append(images, api.DVDMenuCaptureImage{
 			ScreenshotImage: api.ScreenshotImage{
+				DiscID:    selected.disc.ID,
+				DiscName:  selected.disc.Name,
 				Index:     index,
 				Path:      finalPath,
 				Purpose:   api.ScreenshotPurposeMenu,
@@ -694,7 +737,7 @@ func writeCaptureImages(
 			Discovery: discovery,
 		})
 		records = append(records, api.Screenshot{
-			SourcePath:  sourcePath,
+			DiscID:      selected.disc.ID,
 			ImagePath:   finalPath,
 			FrameNumber: index,
 			Width:       bounds.Dx(),
@@ -703,7 +746,7 @@ func writeCaptureImages(
 			CapturedAt:  stamp,
 		})
 		selections = append(selections, api.ScreenshotFinalSelection{
-			SourcePath: sourcePath,
+			DiscID:     selected.disc.ID,
 			ImagePath:  finalPath,
 			Order:      index,
 			Source:     api.ScreenshotSelectionSourceDVDMenu,
@@ -711,6 +754,17 @@ func writeCaptureImages(
 		})
 	}
 	return images, records, selections, created, nil
+}
+
+func safeDVDMenuFilenameSegment(value string) string {
+	return strings.Map(func(char rune) rune {
+		switch {
+		case char >= 'a' && char <= 'z', char >= 'A' && char <= 'Z', char >= '0' && char <= '9', char == '-', char == '_':
+			return char
+		default:
+			return '_'
+		}
+	}, value)
 }
 
 func removeCreatedFiles(paths []string) {

--- a/internal/services/dvdmenus/service_test.go
+++ b/internal/services/dvdmenus/service_test.go
@@ -105,7 +105,7 @@ func TestCaptureRerunListAndDeletePreserveManualMenus(t *testing.T) {
 		t.Fatalf("write FFmpeg identity: %v", err)
 	}
 
-	meta := api.DVDMenuSubject{SourcePath: discRoot, DiscType: "DVD"}
+	meta := dvdMenuTestSubject(discRoot)
 	managedDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, api.ReleaseInfo{})
 	if err != nil {
 		t.Fatalf("managed dir: %v", err)
@@ -118,7 +118,7 @@ func TestCaptureRerunListAndDeletePreserveManualMenus(t *testing.T) {
 		A: 255,
 	})
 	now := time.Now().UTC()
-	if err := repo.AppendManualMenuScreenshots(context.Background(), meta.SourcePath,
+	if err := repo.AppendManualMenuScreenshots(context.Background(), meta.MediaBinding,
 		[]api.Screenshot{{
 			SourcePath: meta.SourcePath,
 			ImagePath:  manualPath,
@@ -211,11 +211,11 @@ func TestCaptureRerunListAndDeletePreserveManualMenus(t *testing.T) {
 		t.Fatalf("missing structural warning: %#v", first.Warnings)
 	}
 	for _, expected := range []string{
-		"DEBUG DVD menus: capture requested disc_type=DVD max_items=6",
+		"DEBUG DVD menus: capture requested disc_type=DVD discs=1 max_items=6",
 		"DEBUG DVD menus: FFmpeg capability probe complete dvdvideo=true options=5",
-		"INFO DVD menus: capture started language=en region=0",
-		"DEBUG DVD menus: progress phase=capturing",
-		`DEBUG DVD menus: warning recorded code=unsupported_pre_link detail="menu pre-command target was not resolved"`,
+		"INFO DVD menus: capture started discs=1 language=en region=0",
+		"DEBUG DVD menus: progress disc_id= phase=capturing",
+		"DEBUG DVD menus: warning recorded disc_id= code=unsupported_pre_link",
 		"DEBUG DVD menus: persistence started images=2",
 		"DEBUG DVD menus: persistence complete stored=2",
 		"WARN DVD menus: capture incomplete captured=2",
@@ -233,7 +233,7 @@ func TestCaptureRerunListAndDeletePreserveManualMenus(t *testing.T) {
 	}
 	assertProgressPhases(t, progressUpdates, []string{"preflight", "capturing", "persisting", "complete"})
 	firstAutoPaths := []string{first.Images[0].Path, first.Images[1].Path}
-	assertSelectionSources(t, repo, meta.SourcePath, []string{
+	assertSelectionSources(t, repo, meta.MediaBinding, []string{
 		api.ScreenshotSelectionSourceDVDMenu,
 		api.ScreenshotSelectionSourceDVDMenu,
 		api.ScreenshotSelectionSourceMenu,
@@ -269,7 +269,7 @@ func TestCaptureRerunListAndDeletePreserveManualMenus(t *testing.T) {
 		}
 	}
 
-	if err := repo.SaveUploadedImages(context.Background(), meta.SourcePath, "example-host", []api.UploadedImageLink{{
+	if err := repo.SaveUploadedImages(context.Background(), meta.MediaBinding, "example-host", []api.UploadedImageLink{{
 		SourcePath: meta.SourcePath,
 		ImagePath:  second.Images[0].Path,
 		Host:       "example-host",
@@ -285,7 +285,140 @@ func TestCaptureRerunListAndDeletePreserveManualMenus(t *testing.T) {
 	if _, err := os.Stat(second.Images[0].Path); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("deleted image stat = %v", err)
 	}
-	assertSelectionSources(t, repo, meta.SourcePath, []string{api.ScreenshotSelectionSourceMenu})
+	assertSelectionSources(t, repo, meta.MediaBinding, []string{api.ScreenshotSelectionSourceMenu})
+}
+
+func TestCaptureDistributesCollectionCapAcrossDVDs(t *testing.T) {
+	t.Parallel()
+
+	repo := openTestRepository(t)
+	collectionRoot := t.TempDir()
+	discARoot := filepath.Join(collectionRoot, "Disc 1")
+	discBRoot := filepath.Join(collectionRoot, "Disc 2")
+	videoTSA := filepath.Join(discARoot, "VIDEO_TS")
+	videoTSB := filepath.Join(discBRoot, "VIDEO_TS")
+	for _, root := range []string{videoTSA, videoTSB} {
+		if err := os.MkdirAll(root, 0o700); err != nil {
+			t.Fatalf("create VIDEO_TS: %v", err)
+		}
+	}
+	executable := filepath.Join(t.TempDir(), "ffmpeg-example")
+	if err := os.WriteFile(executable, []byte("example"), 0o600); err != nil {
+		t.Fatalf("write FFmpeg identity: %v", err)
+	}
+
+	service := newService(api.NopLogger{}, t.TempDir(), repo, &capabilityRunner{}, func() (string, error) { return executable, nil },
+		func(_ context.Context, root string, _ render.Runner, _ string, _ engine.Options) (engine.Result, error) {
+			if root != videoTSA && root != videoTSB {
+				t.Fatalf("capture root = %q", root)
+			}
+			return engine.Result{
+				Complete:    true,
+				Inventoried: 2,
+				Captures: []engine.Capture{
+					{Image: solidImage(color.NRGBA{R: 40, A: 255}), Discovery: graph.DiscoveryReachable},
+					{Image: solidImage(color.NRGBA{G: 40, A: 255}), Discovery: graph.DiscoveryReachable},
+				},
+			}, nil
+		})
+	subject := dvdMenuTestSubject(collectionRoot)
+	subject.Discs = []api.DVDMenuDiscSubject{
+		{
+			ID:   "disc-a",
+			Name: "Disc 1",
+			Root: discARoot,
+		},
+		{
+			ID:   "disc-b",
+			Name: "Disc 2",
+			Root: discBRoot,
+		},
+	}
+
+	result, err := service.Capture(context.Background(), subject, 3)
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if len(result.Images) != 3 || !result.Truncated || result.Partial || result.Complete {
+		t.Fatalf("capture result = %#v", result)
+	}
+	for index, wantDiscID := range []string{"disc-a", "disc-b", "disc-a"} {
+		if result.Images[index].DiscID != wantDiscID || !strings.Contains(filepath.Base(result.Images[index].Path), "disc-"+wantDiscID+"-") {
+			t.Fatalf("image[%d] = %#v, want disc %q", index, result.Images[index], wantDiscID)
+		}
+	}
+}
+
+func TestCaptureRedistributesQuotaPastEmptyDVD(t *testing.T) {
+	t.Parallel()
+
+	repo := openTestRepository(t)
+	collectionRoot := t.TempDir()
+	discARoot := filepath.Join(collectionRoot, "Disc 1")
+	discBRoot := filepath.Join(collectionRoot, "Disc 2")
+	videoTSA := filepath.Join(discARoot, "VIDEO_TS")
+	videoTSB := filepath.Join(discBRoot, "VIDEO_TS")
+	for _, root := range []string{videoTSA, videoTSB} {
+		if err := os.MkdirAll(root, 0o700); err != nil {
+			t.Fatalf("create VIDEO_TS: %v", err)
+		}
+	}
+	executable := filepath.Join(t.TempDir(), "ffmpeg-example")
+	if err := os.WriteFile(executable, []byte("example"), 0o600); err != nil {
+		t.Fatalf("write FFmpeg identity: %v", err)
+	}
+
+	service := newService(api.NopLogger{}, t.TempDir(), repo, &capabilityRunner{}, func() (string, error) { return executable, nil },
+		func(_ context.Context, root string, _ render.Runner, _ string, _ engine.Options) (engine.Result, error) {
+			if root == videoTSA {
+				return engine.Result{}, nil
+			}
+			if root != videoTSB {
+				t.Fatalf("capture root = %q", root)
+			}
+			return engine.Result{Captures: []engine.Capture{
+				{Image: solidImage(color.NRGBA{B: 40, A: 255}), Discovery: graph.DiscoveryReachable},
+				{Image: solidImage(color.NRGBA{
+					R: 40,
+					B: 40,
+					A: 255,
+				}), Discovery: graph.DiscoveryReachable},
+				{Image: solidImage(color.NRGBA{
+					G: 40,
+					B: 40,
+					A: 255,
+				}), Discovery: graph.DiscoveryReachable},
+			}}, nil
+		})
+	subject := dvdMenuTestSubject(collectionRoot)
+	subject.Discs = []api.DVDMenuDiscSubject{
+		{
+			ID:   "disc-a",
+			Name: "Disc 1",
+			Root: discARoot,
+		},
+		{
+			ID:   "disc-b",
+			Name: "Disc 2",
+			Root: discBRoot,
+		},
+	}
+
+	result, err := service.Capture(context.Background(), subject, 2)
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if len(result.Images) != 2 || !result.Partial || !result.Truncated {
+		t.Fatalf("capture result = %#v", result)
+	}
+	for index, image := range result.Images {
+		if image.DiscID != "disc-b" {
+			t.Fatalf("image[%d] = %#v", index, image)
+		}
+	}
+	if !hasDiscWarning(result.Warnings, "disc-a") {
+		t.Fatalf("missing uncovered warning for disc-a: %#v", result.Warnings)
+	}
 }
 
 func assertProgressPhases(t *testing.T, updates []api.DVDMenuProgressUpdate, want []string) {
@@ -318,7 +451,7 @@ func TestCaptureRollsBackCreatedFilesWhenPersistenceFails(t *testing.T) {
 			return engine.Result{Captures: []engine.Capture{{Image: solidImage(color.NRGBA{R: 50, A: 255}), Discovery: graph.DiscoveryReachable}}}, nil
 		})
 
-	_, err := service.Capture(context.Background(), api.DVDMenuSubject{SourcePath: discRoot, DiscType: "DVD"}, 1)
+	_, err := service.Capture(context.Background(), dvdMenuTestSubject(discRoot), 1)
 	if err == nil || !strings.Contains(err.Error(), "persist capture") {
 		t.Fatalf("capture error = %v", err)
 	}
@@ -343,7 +476,8 @@ func TestDeleteRejectsOriginalOutsideManagedDirectory(t *testing.T) {
 	discRoot := t.TempDir()
 	original := filepath.Join(t.TempDir(), "original-menu.png")
 	writePNG(t, original, color.NRGBA{B: 200, A: 255})
-	if err := repo.SaveFinalSelections(context.Background(), discRoot, []api.ScreenshotFinalSelection{{
+	meta := dvdMenuTestSubject(discRoot)
+	if err := repo.SaveFinalSelections(context.Background(), meta.MediaBinding, []api.ScreenshotFinalSelection{{
 		SourcePath: discRoot,
 		ImagePath:  original,
 		Source:     api.ScreenshotSelectionSourceMenu,
@@ -352,7 +486,7 @@ func TestDeleteRejectsOriginalOutsideManagedDirectory(t *testing.T) {
 		t.Fatalf("save original selection: %v", err)
 	}
 	service := NewService(api.NopLogger{}, tmpRoot, repo)
-	err := service.Delete(context.Background(), api.DVDMenuSubject{SourcePath: discRoot, DiscType: "DVD"}, original)
+	err := service.Delete(context.Background(), meta, original)
 	if err == nil || !strings.Contains(err.Error(), "outside the managed release directory") {
 		t.Fatalf("delete error = %v", err)
 	}
@@ -367,7 +501,7 @@ func TestDeleteRestoresFileAndRecordsWhenFinalRemoveFails(t *testing.T) {
 	repo := openTestRepository(t)
 	tmpRoot := t.TempDir()
 	discRoot := t.TempDir()
-	meta := api.DVDMenuSubject{SourcePath: discRoot, DiscType: "DVD"}
+	meta := dvdMenuTestSubject(discRoot)
 	managedDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, api.ReleaseInfo{})
 	if err != nil {
 		t.Fatal("create managed directory failed")
@@ -380,7 +514,7 @@ func TestDeleteRestoresFileAndRecordsWhenFinalRemoveFails(t *testing.T) {
 		A: 255,
 	})
 	now := time.Now().UTC()
-	if err := repo.AppendManualMenuScreenshots(context.Background(), meta.SourcePath,
+	if err := repo.AppendManualMenuScreenshots(context.Background(), meta.MediaBinding,
 		[]api.Screenshot{{
 			SourcePath: meta.SourcePath,
 			ImagePath:  imagePath,
@@ -398,7 +532,7 @@ func TestDeleteRestoresFileAndRecordsWhenFinalRemoveFails(t *testing.T) {
 	); err != nil {
 		t.Fatal("seed menu screenshot failed")
 	}
-	if err := repo.SaveUploadedImages(context.Background(), meta.SourcePath, "example-host", []api.UploadedImageLink{{
+	if err := repo.SaveUploadedImages(context.Background(), meta.MediaBinding, "example-host", []api.UploadedImageLink{{
 		SourcePath: meta.SourcePath,
 		ImagePath:  imagePath,
 		Host:       "example-host",
@@ -408,7 +542,7 @@ func TestDeleteRestoresFileAndRecordsWhenFinalRemoveFails(t *testing.T) {
 	}}); err != nil {
 		t.Fatal("seed menu upload record failed")
 	}
-	if err := repo.ReplaceScreenshotSlots(context.Background(), meta.SourcePath, []api.ScreenshotSlot{{
+	if err := repo.ReplaceScreenshotSlots(context.Background(), meta.MediaBinding, []api.ScreenshotSlot{{
 		SourcePath: meta.SourcePath,
 		SlotOrder:  0,
 		ImagePath:  imagePath,
@@ -441,7 +575,7 @@ func TestDeleteRestoresFileAndRecordsWhenFinalRemoveFails(t *testing.T) {
 	if len(listed) != 1 || listed[0].Path != imagePath {
 		t.Fatal("rolled-back image is not recoverable through the menu list")
 	}
-	uploads, err := repo.ListUploadedImagesByPath(context.Background(), meta.SourcePath)
+	uploads, err := repo.ListUploadedImagesByPath(context.Background(), meta.MediaBinding)
 	if err != nil {
 		t.Fatal("list rolled-back upload association failed")
 	}
@@ -455,7 +589,7 @@ func TestDeleteRestoresFileAndRecordsWhenFinalRemoveFails(t *testing.T) {
 	if !restoredUpload {
 		t.Fatal("rolled-back upload association was not restored")
 	}
-	slots, err := repo.ListScreenshotSlotsByPath(context.Background(), meta.SourcePath)
+	slots, err := repo.ListScreenshotSlotsByPath(context.Background(), meta.MediaBinding)
 	if err != nil || len(slots) != 1 || slots[0].ImagePath != imagePath || len(slots[0].Variants) != 1 {
 		t.Fatal("rolled-back screenshot slot associations were not restored")
 	}
@@ -474,7 +608,7 @@ func TestDeleteConvergesOnlyWhenFileAndRecordAreBothGone(t *testing.T) {
 
 	tmpRoot := t.TempDir()
 	discRoot := t.TempDir()
-	meta := api.DVDMenuSubject{SourcePath: discRoot, DiscType: "DVD"}
+	meta := dvdMenuTestSubject(discRoot)
 	managedDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, api.ReleaseInfo{})
 	if err != nil {
 		t.Fatal("create managed directory failed")
@@ -515,7 +649,7 @@ func TestDeleteFailsWhenMissingRecordAlsoFailsRestore(t *testing.T) {
 
 	tmpRoot := t.TempDir()
 	discRoot := t.TempDir()
-	meta := api.DVDMenuSubject{SourcePath: discRoot, DiscType: "DVD"}
+	meta := dvdMenuTestSubject(discRoot)
 	managedDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, api.ReleaseInfo{})
 	if err != nil {
 		t.Fatal("create managed directory failed")
@@ -595,7 +729,7 @@ type restoreBlockingRepository struct {
 
 func (*restoreBlockingRepository) DeleteDiscMenuScreenshot(
 	_ context.Context,
-	_ string,
+	_ api.PreparedMediaBinding,
 	imagePath string,
 ) (api.DiscMenuDeleteResult, error) {
 	if err := os.MkdirAll(imagePath, 0o700); err != nil {
@@ -604,7 +738,12 @@ func (*restoreBlockingRepository) DeleteDiscMenuScreenshot(
 	return api.DiscMenuDeleteResult{}, internalerrors.ErrNotFound
 }
 
-func (r *failingCaptureRepository) ReplaceDVDMenuScreenshots(context.Context, string, []api.Screenshot, []api.ScreenshotFinalSelection) ([]string, error) {
+func (r *failingCaptureRepository) ReplaceDVDMenuScreenshots(
+	context.Context,
+	api.PreparedMediaBinding,
+	[]api.Screenshot,
+	[]api.ScreenshotFinalSelection,
+) ([]string, error) {
 	return nil, errors.New("synthetic persistence failure")
 }
 
@@ -646,9 +785,9 @@ func writePNG(t *testing.T, path string, fill color.NRGBA) {
 	}
 }
 
-func assertSelectionSources(t *testing.T, repo *db.SQLiteRepository, sourcePath string, expected []string) {
+func assertSelectionSources(t *testing.T, repo *db.SQLiteRepository, binding api.PreparedMediaBinding, expected []string) {
 	t.Helper()
-	selections, err := repo.ListFinalSelections(context.Background(), sourcePath)
+	selections, err := repo.ListFinalSelections(context.Background(), binding)
 	if err != nil {
 		t.Fatalf("list final selections: %v", err)
 	}
@@ -662,9 +801,30 @@ func assertSelectionSources(t *testing.T, repo *db.SQLiteRepository, sourcePath 
 	}
 }
 
+func dvdMenuTestSubject(sourcePath string) api.DVDMenuSubject {
+	return api.DVDMenuSubject{
+		MediaBinding: api.PreparedMediaBinding{
+			SourcePath:               sourcePath,
+			PreparedMediaFingerprint: "test-prepared-media",
+			PreparedGeneration:       1,
+		},
+		SourcePath: sourcePath,
+		DiscType:   "DVD",
+	}
+}
+
 func hasWarning(warnings []api.DVDMenuCaptureWarning, code string) bool {
 	for _, warning := range warnings {
 		if warning.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDiscWarning(warnings []api.DVDMenuCaptureWarning, discID string) bool {
+	for _, warning := range warnings {
+		if warning.DiscID == discID {
 			return true
 		}
 	}

--- a/internal/services/screenshots/helpers.go
+++ b/internal/services/screenshots/helpers.go
@@ -75,7 +75,7 @@ func resolveVideoInfo(ctx context.Context, meta api.ScreenshotSubject, tmpRoot s
 
 	basePath := strings.TrimSpace(meta.VideoPath)
 	if basePath == "" {
-		basePath = strings.TrimSpace(meta.SourcePath)
+		basePath = screenshotCaptureRoot(meta)
 	}
 	if basePath == "" {
 		return info, errors.New("screenshots: source path required")
@@ -136,7 +136,7 @@ func resolveVideoInfo(ctx context.Context, meta api.ScreenshotSubject, tmpRoot s
 				info.FrameRate = parseFPS(bdinfo)
 			}
 			if info.SourcePath == "" {
-				filePath, err := selectBDMVFile(ctx, meta.SourcePath, bdinfo)
+				filePath, err := selectBDMVFile(ctx, screenshotCaptureRoot(meta), bdinfo)
 				if err == nil {
 					info.SourcePath = filePath
 					logger.Tracef("screenshots: BDMV source selected method=bdinfo path=%s", filePath)
@@ -156,8 +156,9 @@ func resolveVideoInfo(ctx context.Context, meta api.ScreenshotSubject, tmpRoot s
 	}
 
 	if strings.EqualFold(strings.TrimSpace(meta.DiscType), "DVD") {
-		logger.Tracef("screenshots: DVD source selection root=%s", meta.SourcePath)
-		vobs, err := selectDVDVOBs(ctx, meta.SourcePath)
+		captureRoot := screenshotCaptureRoot(meta)
+		logger.Tracef("screenshots: DVD source selection root=%s", captureRoot)
+		vobs, err := selectDVDVOBs(ctx, captureRoot)
 		if err != nil {
 			return info, err
 		}
@@ -281,7 +282,7 @@ func resolveVideoSource(ctx context.Context, meta api.ScreenshotSubject, tmpRoot
 	logger = screenshotLogger(logger)
 	basePath := strings.TrimSpace(meta.VideoPath)
 	if basePath == "" {
-		basePath = strings.TrimSpace(meta.SourcePath)
+		basePath = screenshotCaptureRoot(meta)
 	}
 	if basePath == "" {
 		return "", errors.New("screenshots: source path required")
@@ -313,7 +314,7 @@ func resolveVideoSource(ctx context.Context, meta api.ScreenshotSubject, tmpRoot
 			return "", err
 		}
 		if bdinfo != nil {
-			filePath, err := selectBDMVFile(ctx, meta.SourcePath, bdinfo)
+			filePath, err := selectBDMVFile(ctx, screenshotCaptureRoot(meta), bdinfo)
 			if err != nil {
 				return "", err
 			}
@@ -323,8 +324,9 @@ func resolveVideoSource(ctx context.Context, meta api.ScreenshotSubject, tmpRoot
 	}
 
 	if strings.EqualFold(strings.TrimSpace(meta.DiscType), "DVD") {
-		logger.Tracef("screenshots: video source DVD selection root=%s", meta.SourcePath)
-		vob, err := selectDVDVOB(ctx, meta.SourcePath)
+		captureRoot := screenshotCaptureRoot(meta)
+		logger.Tracef("screenshots: video source DVD selection root=%s", captureRoot)
+		vob, err := selectDVDVOB(ctx, captureRoot)
 		if err != nil {
 			return "", err
 		}
@@ -344,7 +346,7 @@ func selectBDMVFileFromMetadata(ctx context.Context, meta api.ScreenshotSubject)
 			return videoPath, true, nil
 		}
 
-		filePath, err := findBDMVFile(ctx, meta.SourcePath, fileName)
+		filePath, err := findBDMVFile(ctx, screenshotCaptureRoot(meta), fileName)
 		if err != nil {
 			return "", false, err
 		}
@@ -658,7 +660,14 @@ func loadBDInfo(tmpRoot string, meta api.ScreenshotSubject) (*discparse.BDInfo, 
 		return nil, fmt.Errorf("screenshots: read BDMV summary: %w", err)
 	}
 	summary, files, _ := discparse.SplitBDInfoReport(string(payload))
-	return discparse.ParseBDInfoSummary(summary, files, meta.SourcePath), nil
+	return discparse.ParseBDInfoSummary(summary, files, screenshotCaptureRoot(meta)), nil
+}
+
+func screenshotCaptureRoot(meta api.ScreenshotSubject) string {
+	if root := strings.TrimSpace(meta.DiscRoot); root != "" {
+		return root
+	}
+	return strings.TrimSpace(meta.SourcePath)
 }
 
 func parseFPS(info *discparse.BDInfo) float64 {

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -50,11 +50,11 @@ type Service struct {
 
 type repository interface {
 	api.ScreenshotLifecycleRepository
-	SaveScreenshot(context.Context, api.Screenshot) error
-	ListScreenshotsByPath(context.Context, string) ([]api.Screenshot, error)
-	DeleteScreenshot(context.Context, string) error
-	ListFinalSelections(context.Context, string) ([]api.ScreenshotFinalSelection, error)
-	DeleteFinalSelection(context.Context, string) error
+	SaveScreenshot(context.Context, api.PreparedMediaBinding, api.Screenshot) error
+	ListScreenshotsByPath(context.Context, api.PreparedMediaBinding) ([]api.Screenshot, error)
+	DeleteScreenshot(context.Context, api.PreparedMediaBinding, string) error
+	ListFinalSelections(context.Context, api.PreparedMediaBinding) ([]api.ScreenshotFinalSelection, error)
+	DeleteFinalSelection(context.Context, api.PreparedMediaBinding, string) error
 	ListTrackerMetadataByPath(context.Context, string) ([]api.TrackerMetadata, error)
 	SaveTrackerMetadata(context.Context, api.TrackerMetadata) error
 }
@@ -99,7 +99,76 @@ func NewServiceWithRepo(cfg config.Config, logger api.Logger, tmpRoot string, ru
 // A non-positive count falls back to the subject default and then config. When
 // timing is unavailable, the returned plan requests manual frames instead of
 // failing; stored tracker images are merged into final selections.
-func (s *Service) Plan(ctx context.Context, meta api.ScreenshotSubject, count int) (plan api.ScreenshotPlan, err error) {
+func (s *Service) Plan(ctx context.Context, meta api.ScreenshotSubject, count int) (api.ScreenshotPlan, error) {
+	if s.repo != nil && !meta.MediaBinding.Valid() {
+		return api.ScreenshotPlan{}, internalerrors.ErrInvalidInput
+	}
+	discs := screenshotDiscs(meta)
+	if len(discs) == 0 {
+		return api.ScreenshotPlan{}, internalerrors.ErrInvalidInput
+	}
+	if count <= 0 {
+		count = meta.DefaultCount
+	}
+	if count <= 0 {
+		count = s.cfg.ScreenshotHandling.Screens
+	}
+	if count <= 0 {
+		return api.ScreenshotPlan{}, internalerrors.ErrInvalidInput
+	}
+	total := max(count, len(discs))
+	baseCount := total / len(discs)
+	remainder := total % len(discs)
+
+	plan := api.ScreenshotPlan{
+		MediaBinding:      meta.MediaBinding,
+		SourcePath:        meta.SourcePath,
+		DiscType:          meta.DiscType,
+		MetadataTimestamp: time.Now().UTC().Format(time.RFC3339),
+		Discs:             make([]api.ScreenshotDiscPlan, 0, len(discs)),
+	}
+	for index, disc := range discs {
+		discCount := baseCount
+		if index < remainder {
+			discCount++
+		}
+		discPlan, err := s.planDisc(ctx, screenshotSubjectForDisc(meta, disc), discCount)
+		if err != nil {
+			return api.ScreenshotPlan{}, err
+		}
+		if index == 0 {
+			plan.DurationSeconds = discPlan.DurationSeconds
+			plan.FrameRate = discPlan.FrameRate
+		}
+		plan.SuggestedSelections = append(plan.SuggestedSelections, discPlan.SuggestedSelections...)
+		plan.ExistingScreenshots = append(plan.ExistingScreenshots, discPlan.ExistingScreenshots...)
+		plan.ExistingTrackerScreenshots = append(plan.ExistingTrackerScreenshots, discPlan.ExistingTrackerScreenshots...)
+		plan.FinalSelections = append(plan.FinalSelections, discPlan.FinalSelections...)
+		plan.TrackerImageLinks = append(plan.TrackerImageLinks, discPlan.TrackerImageLinks...)
+		plan.PreviewImages = append(plan.PreviewImages, discPlan.PreviewImages...)
+		plan.RequiresManualFrames = plan.RequiresManualFrames || discPlan.RequiresManualFrames
+		plan.Discs = append(plan.Discs, api.ScreenshotDiscPlan{
+			DiscID:              disc.ID,
+			DiscName:            disc.Name,
+			DurationSeconds:     discPlan.DurationSeconds,
+			FrameRate:           discPlan.FrameRate,
+			SuggestedSelections: append([]api.ScreenshotSelection(nil), discPlan.SuggestedSelections...),
+		})
+	}
+	if tmpDir, _, err := paths.ReleaseTempDirFor(s.tmpRoot, meta.SourcePath, meta.Release); err == nil {
+		trackerLinks := buildTrackerImageLinks(s.loadTrackerMetadata(ctx, meta.SourcePath), tmpDir)
+		plan.TrackerImageLinks = trackerLinks
+		plan.ExistingTrackerScreenshots = filterUnlinkedTrackerScreens(
+			listTrackerScreens(tmpDir, screenshotBaseName(meta)),
+			trackerLinks,
+		)
+		plan.FinalSelections = mergeTrackerImagesIntoFinalSelections(plan.FinalSelections, trackerLinks)
+	}
+	plan.FinalSelections = orderScreenshotImagesByDisc(plan.FinalSelections, discs)
+	return plan, nil
+}
+
+func (s *Service) planDisc(ctx context.Context, meta api.ScreenshotSubject, count int) (plan api.ScreenshotPlan, err error) {
 	defer func() {
 		if err != nil {
 			s.logger.Warnf("screenshots: planning blocked err=%s", redaction.RedactValue(err.Error(), nil))
@@ -113,16 +182,11 @@ func (s *Service) Plan(ctx context.Context, meta api.ScreenshotSubject, count in
 	}
 
 	plan = api.ScreenshotPlan{
-		SourcePath: meta.SourcePath,
-		DiscType:   meta.DiscType,
+		MediaBinding: meta.MediaBinding,
+		SourcePath:   meta.SourcePath,
+		DiscType:     meta.DiscType,
 	}
 
-	if count <= 0 {
-		count = meta.DefaultCount
-	}
-	if count <= 0 {
-		count = s.cfg.ScreenshotHandling.Screens
-	}
 	if count <= 0 {
 		return api.ScreenshotPlan{}, internalerrors.ErrInvalidInput
 	}
@@ -146,6 +210,7 @@ func (s *Service) Plan(ctx context.Context, meta api.ScreenshotSubject, count in
 	)
 
 	manualSelections := buildManualFrameSelections(meta.ManualFrames, plan.FrameRate)
+	stampScreenshotSelections(manualSelections, meta.DiscID)
 	if len(manualSelections) == 0 && plan.DurationSeconds <= 0 && len(info.Segments) == 0 {
 		if cmd, resolveErr := resolveFFmpeg(); resolveErr != nil {
 			s.logger.Debugf(
@@ -186,6 +251,7 @@ func (s *Service) Plan(ctx context.Context, meta api.ScreenshotSubject, count in
 	if len(baselineSelections) == 0 {
 		baselineSelections = buildScreenshotSelections(total, plan.DurationSeconds, plan.FrameRate, meta)
 	}
+	stampScreenshotSelections(baselineSelections, meta.DiscID)
 	base := screenshotBaseName(meta)
 	baselineByIndex := screenshotSelectionsByIndex(baselineSelections)
 
@@ -193,13 +259,16 @@ func (s *Service) Plan(ctx context.Context, meta api.ScreenshotSubject, count in
 	var missingIndexTimestamps []float64
 	var existingIndices map[int]struct{}
 	if s.repo != nil {
-		dbScreenshots, err := s.repo.ListScreenshotsByPath(ctx, meta.SourcePath)
+		dbScreenshots, err := s.repo.ListScreenshotsByPath(ctx, meta.MediaBinding)
 		if err != nil {
 			s.logger.Debugf("screenshots: failed to load existing screenshots: %v", err)
 		} else {
 			existingIndices = make(map[int]struct{}, len(dbScreenshots))
 			kept := 0
 			for _, shot := range dbScreenshots {
+				if shot.DiscID != meta.DiscID {
+					continue
+				}
 				pathValue := strings.TrimSpace(shot.ImagePath)
 				if pathValue == "" || !isAllowedImageExt(pathValue) || !isPathWithinDir(tmpDir, pathValue) {
 					continue
@@ -264,11 +333,15 @@ func (s *Service) Plan(ctx context.Context, meta api.ScreenshotSubject, count in
 	plan.SuggestedSelections = suggestions
 
 	plan.ExistingScreenshots = filterScreenshotsMatchingSelections(listExistingScreens(tmpDir, base), baselineSelections, plan.FrameRate)
-	plan.TrackerImageLinks = buildTrackerImageLinks(s.loadTrackerMetadata(ctx, meta.SourcePath), tmpDir)
+	stampScreenshotImages(plan.ExistingScreenshots, meta.DiscID, meta.DiscName)
+	if meta.DiscID == "" {
+		plan.TrackerImageLinks = buildTrackerImageLinks(s.loadTrackerMetadata(ctx, meta.SourcePath), tmpDir)
+	}
 	plan.ExistingTrackerScreenshots = filterUnlinkedTrackerScreens(
 		listTrackerScreens(tmpDir, base),
 		plan.TrackerImageLinks,
 	)
+	stampScreenshotImages(plan.ExistingTrackerScreenshots, meta.DiscID, meta.DiscName)
 	plan.FinalSelections = filterScreenshotsMatchingSelections(s.loadFinalSelections(ctx, meta, tmpDir), baselineSelections, plan.FrameRate)
 
 	// Automatically include tracker images in final selections
@@ -290,6 +363,44 @@ func (s *Service) Plan(ctx context.Context, meta api.ScreenshotSubject, count in
 // directory and records each image with purpose. It returns successful images
 // plus per-selection failures and honors context cancellation.
 func (s *Service) Capture(
+	ctx context.Context,
+	meta api.ScreenshotSubject,
+	selections []api.ScreenshotSelection,
+	purpose api.ScreenshotPurpose,
+) (api.ScreenshotResult, error) {
+	if len(selections) == 0 || (s.repo != nil && purpose != api.ScreenshotPurposePreview && !meta.MediaBinding.Valid()) {
+		return api.ScreenshotResult{}, internalerrors.ErrInvalidInput
+	}
+	discs := screenshotDiscs(meta)
+	grouped := make(map[string][]api.ScreenshotSelection, len(discs))
+	for _, selection := range selections {
+		disc, ok := selectScreenshotDisc(discs, selection.DiscID)
+		if !ok {
+			return api.ScreenshotResult{}, internalerrors.ErrInvalidInput
+		}
+		selection.DiscID = disc.ID
+		grouped[disc.ID] = append(grouped[disc.ID], selection)
+	}
+
+	result := api.ScreenshotResult{SourcePath: meta.SourcePath, Purpose: purpose}
+	for _, disc := range discs {
+		discSelections := grouped[disc.ID]
+		if len(discSelections) == 0 {
+			continue
+		}
+		discResult, err := s.captureDisc(ctx, screenshotSubjectForDisc(meta, disc), discSelections, purpose)
+		if err != nil {
+			return result, err
+		}
+		result.Images = append(result.Images, discResult.Images...)
+		result.Errors = append(result.Errors, discResult.Errors...)
+		result.Tonemapped = result.Tonemapped || discResult.Tonemapped
+		result.UsedLibplacebo = result.UsedLibplacebo || discResult.UsedLibplacebo
+	}
+	return result, nil
+}
+
+func (s *Service) captureDisc(
 	ctx context.Context,
 	meta api.ScreenshotSubject,
 	selections []api.ScreenshotSelection,
@@ -368,7 +479,11 @@ func (s *Service) Capture(
 	for _, selection := range selections {
 		ts := selectionTimestamp(selection, info.FrameRate)
 		if ts <= 0 {
-			captureErrors = append(captureErrors, api.ScreenshotError{Index: selection.Index, Message: "invalid timestamp"})
+			captureErrors = append(captureErrors, api.ScreenshotError{
+				DiscID:  meta.DiscID,
+				Index:   selection.Index,
+				Message: "invalid timestamp",
+			})
 			continue
 		}
 		jobs = append(jobs, captureJob{selection: selection, timestamp: ts})
@@ -488,7 +603,11 @@ func (s *Service) Capture(
 				}
 				s.logger.Warnf("screenshots: capture frame failed index=%d err=%s", selection.Index, redaction.RedactValue(captureErr.Error(), nil))
 				mu.Lock()
-				captureErrors = append(captureErrors, api.ScreenshotError{Index: selection.Index, Message: logging.SanitizeMessage(captureErr.Error())})
+				captureErrors = append(captureErrors, api.ScreenshotError{
+					DiscID:  meta.DiscID,
+					Index:   selection.Index,
+					Message: logging.SanitizeMessage(captureErr.Error()),
+				})
 				mu.Unlock()
 				continue
 			}
@@ -498,6 +617,8 @@ func (s *Service) Capture(
 			}
 
 			img := api.ScreenshotImage{
+				DiscID:           meta.DiscID,
+				DiscName:         meta.DiscName,
 				Index:            selection.Index,
 				TimestampSeconds: ts,
 				Path:             output,
@@ -565,7 +686,7 @@ func (s *Service) Capture(
 	if s.repo != nil && len(images) > 0 && purpose != api.ScreenshotPurposePreview {
 		for _, img := range images {
 			screenshot := api.Screenshot{
-				SourcePath:  meta.SourcePath,
+				DiscID:      meta.DiscID,
 				ImagePath:   img.Path,
 				Timestamp:   img.TimestampSeconds,
 				FrameNumber: int(img.TimestampSeconds * info.FrameRate),
@@ -574,7 +695,7 @@ func (s *Service) Capture(
 				Purpose:     purpose,
 				CapturedAt:  time.Now().UTC(),
 			}
-			if err := s.repo.SaveScreenshot(ctx, screenshot); err != nil {
+			if err := s.repo.SaveScreenshot(ctx, meta.MediaBinding, screenshot); err != nil {
 				s.logger.Debugf("screenshots: failed to persist screenshot: %v", err)
 			}
 		}
@@ -586,7 +707,24 @@ func (s *Service) Capture(
 // persisting it. DVD inputs try the selected VOB segment followed by later
 // segments when a candidate yields no usable frame. When enabled for HDR/DV
 // inputs, it applies configured software tone mapping before returning.
-func (s *Service) PreviewFrame(ctx context.Context, meta api.ScreenshotSubject, timestampSeconds float64) (preview api.ScreenshotPreview, err error) {
+func (s *Service) PreviewFrame(
+	ctx context.Context,
+	meta api.ScreenshotSubject,
+	discID string,
+	timestampSeconds float64,
+) (api.ScreenshotPreview, error) {
+	disc, ok := selectScreenshotDisc(screenshotDiscs(meta), discID)
+	if !ok {
+		return api.ScreenshotPreview{}, internalerrors.ErrInvalidInput
+	}
+	return s.previewDisc(ctx, screenshotSubjectForDisc(meta, disc), timestampSeconds)
+}
+
+func (s *Service) previewDisc(
+	ctx context.Context,
+	meta api.ScreenshotSubject,
+	timestampSeconds float64,
+) (preview api.ScreenshotPreview, err error) {
 	defer func() {
 		if err != nil {
 			s.logger.Warnf("screenshots: preview blocked err=%s", redaction.RedactValue(err.Error(), nil))
@@ -661,6 +799,8 @@ func (s *Service) PreviewFrame(ctx context.Context, meta api.ScreenshotSubject, 
 	}
 
 	preview = api.ScreenshotPreview{
+		DiscID:           meta.DiscID,
+		DiscName:         meta.DiscName,
 		TimestampSeconds: timestampSeconds,
 		ImageBytes:       payload,
 		SizeBytes:        int64(len(payload)),
@@ -686,6 +826,9 @@ func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imageP
 	case <-ctx.Done():
 		return fmt.Errorf("context canceled: %w", ctx.Err())
 	default:
+	}
+	if s.repo != nil && !meta.MediaBinding.Valid() {
+		return internalerrors.ErrInvalidInput
 	}
 
 	trimmed := strings.TrimSpace(imagePath)
@@ -720,7 +863,7 @@ func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imageP
 		return internalerrors.ErrInvalidInput
 	}
 
-	deleteTargets, cleanupErr := s.storedDeleteTargets(ctx, meta.SourcePath, absTarget)
+	deleteTargets, cleanupErr := s.storedDeleteTargets(ctx, meta.MediaBinding, absTarget)
 	cleanupErrs := make([]error, 0, 1)
 	if cleanupErr != nil {
 		cleanupErrs = append(cleanupErrs, cleanupErr)
@@ -756,7 +899,7 @@ func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imageP
 				s.logger.Tracef("screenshots: deleting db records for %s", target)
 			}
 			if err := retrySQLiteBusy(ctx, func() error {
-				return s.repo.DeleteScreenshot(ctx, target)
+				return s.repo.DeleteScreenshot(ctx, meta.MediaBinding, target)
 			}); err != nil {
 				s.logger.Warnf(
 					"screenshots: failed to delete screenshot record target=%s err=%s",
@@ -768,7 +911,7 @@ func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imageP
 				s.logger.Tracef("screenshots: deleted screenshot record for %s", target)
 			}
 			if err := retrySQLiteBusy(ctx, func() error {
-				return s.repo.DeleteFinalSelection(ctx, target)
+				return s.repo.DeleteFinalSelection(ctx, meta.MediaBinding, target)
 			}); err != nil {
 				s.logger.Warnf(
 					"screenshots: failed to delete final selection target=%s err=%s",
@@ -798,9 +941,13 @@ func (s *Service) Delete(ctx context.Context, meta api.ScreenshotSubject, imageP
 // remove the file and leave its screenshot, upload, and selection rows behind.
 // A failed lookup returns the targets resolved so far plus an error: cleanup can
 // still run, but it can no longer be claimed complete.
-func (s *Service) storedDeleteTargets(ctx context.Context, sourcePath string, absTarget string) ([]string, error) {
+func (s *Service) storedDeleteTargets(
+	ctx context.Context,
+	binding api.PreparedMediaBinding,
+	absTarget string,
+) ([]string, error) {
 	targets := []string{absTarget}
-	if s.repo == nil || strings.TrimSpace(sourcePath) == "" {
+	if s.repo == nil || !binding.Valid() {
 		return targets, nil
 	}
 	targetInfo, targetStatErr := os.Stat(absTarget)
@@ -825,7 +972,7 @@ func (s *Service) storedDeleteTargets(ctx context.Context, sourcePath string, ab
 	lookupErrs := make([]error, 0, 2)
 	var screenshots []api.Screenshot
 	if err := retrySQLiteBusy(ctx, func() error {
-		stored, err := s.repo.ListScreenshotsByPath(ctx, sourcePath)
+		stored, err := s.repo.ListScreenshotsByPath(ctx, binding)
 		if err != nil {
 			return fmt.Errorf("load screenshot records: %w", err)
 		}
@@ -840,7 +987,7 @@ func (s *Service) storedDeleteTargets(ctx context.Context, sourcePath string, ab
 	}
 	var selections []api.ScreenshotFinalSelection
 	if err := retrySQLiteBusy(ctx, func() error {
-		stored, err := s.repo.ListFinalSelections(ctx, sourcePath)
+		stored, err := s.repo.ListFinalSelections(ctx, binding)
 		if err != nil {
 			return fmt.Errorf("load final selections: %w", err)
 		}
@@ -1007,6 +1154,9 @@ func (s *Service) SaveFinalSelections(ctx context.Context, meta api.ScreenshotSu
 	if s.repo == nil {
 		return nil
 	}
+	if !meta.MediaBinding.Valid() {
+		return internalerrors.ErrInvalidInput
+	}
 	select {
 	case <-ctx.Done():
 		return fmt.Errorf("context canceled: %w", ctx.Err())
@@ -1034,15 +1184,30 @@ func (s *Service) SaveFinalSelections(ctx context.Context, meta api.ScreenshotSu
 			return internalerrors.ErrInvalidInput
 		}
 		selections = append(selections, api.ScreenshotFinalSelection{
-			SourcePath: meta.SourcePath,
+			DiscID:     img.DiscID,
 			ImagePath:  pathValue,
 			Order:      index,
 			Source:     selectionSourceLabel(img),
 			SelectedAt: time.Now().UTC(),
 		})
 	}
+	discOrder := screenshotDiscOrder(screenshotDiscs(meta))
+	sort.SliceStable(selections, func(left, right int) bool {
+		leftRank, leftFound := discOrder[selections[left].DiscID]
+		rightRank, rightFound := discOrder[selections[right].DiscID]
+		if leftFound != rightFound {
+			return leftFound
+		}
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		return selections[left].Order < selections[right].Order
+	})
+	for index := range selections {
+		selections[index].Order = index
+	}
 
-	if err := s.repo.ReplaceNormalFinalSelections(ctx, meta.SourcePath, selections); err != nil {
+	if err := s.repo.ReplaceNormalFinalSelections(ctx, meta.MediaBinding, selections); err != nil {
 		return fmt.Errorf("screenshots: replace normal final selections: %w", err)
 	}
 	return nil
@@ -1050,7 +1215,104 @@ func (s *Service) SaveFinalSelections(ctx context.Context, meta api.ScreenshotSu
 
 func screenshotBaseName(meta api.ScreenshotSubject) string {
 	base := paths.ReleaseTempBaseFor(meta.SourcePath, meta.Release)
-	return sanitizeFilename(base)
+	base = sanitizeFilename(base)
+	if discID := strings.TrimSpace(meta.DiscID); discID != "" {
+		return base + "-disc-" + sanitizeFilename(discID)
+	}
+	return base
+}
+
+func screenshotDiscs(meta api.ScreenshotSubject) []api.ScreenshotDiscSubject {
+	if len(meta.Discs) > 0 {
+		return append([]api.ScreenshotDiscSubject(nil), meta.Discs...)
+	}
+	return []api.ScreenshotDiscSubject{{
+		ID:                    strings.TrimSpace(meta.DiscID),
+		Name:                  strings.TrimSpace(meta.DiscName),
+		Type:                  strings.TrimSpace(meta.DiscType),
+		Root:                  firstScreenshotValue(meta.DiscRoot, meta.SourcePath),
+		VideoPath:             meta.VideoPath,
+		MediaInfoJSONPath:     meta.MediaInfoJSONPath,
+		SelectedBDMVPlaylists: append([]api.PlaylistInfo(nil), meta.SelectedBDMVPlaylists...),
+	}}
+}
+
+func screenshotSubjectForDisc(meta api.ScreenshotSubject, disc api.ScreenshotDiscSubject) api.ScreenshotSubject {
+	meta.DiscID = strings.TrimSpace(disc.ID)
+	meta.DiscName = strings.TrimSpace(disc.Name)
+	meta.DiscRoot = strings.TrimSpace(disc.Root)
+	meta.DiscType = firstScreenshotValue(disc.Type, meta.DiscType)
+	meta.VideoPath = strings.TrimSpace(disc.VideoPath)
+	meta.MediaInfoJSONPath = strings.TrimSpace(disc.MediaInfoJSONPath)
+	meta.SelectedBDMVPlaylists = append([]api.PlaylistInfo(nil), disc.SelectedBDMVPlaylists...)
+	meta.Discs = nil
+	return meta
+}
+
+func selectScreenshotDisc(discs []api.ScreenshotDiscSubject, discID string) (api.ScreenshotDiscSubject, bool) {
+	trimmed := strings.TrimSpace(discID)
+	if trimmed == "" {
+		if len(discs) == 1 {
+			return discs[0], true
+		}
+		return api.ScreenshotDiscSubject{}, false
+	}
+	for _, disc := range discs {
+		if disc.ID == trimmed {
+			return disc, true
+		}
+	}
+	return api.ScreenshotDiscSubject{}, false
+}
+
+func stampScreenshotSelections(selections []api.ScreenshotSelection, discID string) {
+	for index := range selections {
+		selections[index].DiscID = discID
+	}
+}
+
+func stampScreenshotImages(images []api.ScreenshotImage, discID string, discName string) {
+	for index := range images {
+		images[index].DiscID = discID
+		images[index].DiscName = discName
+	}
+}
+
+func screenshotDiscOrder(discs []api.ScreenshotDiscSubject) map[string]int {
+	order := make(map[string]int, len(discs))
+	for index, disc := range discs {
+		order[disc.ID] = index
+	}
+	return order
+}
+
+func orderScreenshotImagesByDisc(images []api.ScreenshotImage, discs []api.ScreenshotDiscSubject) []api.ScreenshotImage {
+	ordered := append([]api.ScreenshotImage(nil), images...)
+	discOrder := screenshotDiscOrder(discs)
+	sort.SliceStable(ordered, func(left, right int) bool {
+		leftRank, leftFound := discOrder[ordered[left].DiscID]
+		rightRank, rightFound := discOrder[ordered[right].DiscID]
+		if leftFound != rightFound {
+			return leftFound
+		}
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		if ordered[left].Index != ordered[right].Index {
+			return ordered[left].Index < ordered[right].Index
+		}
+		return ordered[left].Path < ordered[right].Path
+	})
+	return ordered
+}
+
+func firstScreenshotValue(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func selectionTimestamp(selection api.ScreenshotSelection, frameRate float64) float64 {
@@ -1184,7 +1446,7 @@ func (s *Service) loadFinalSelections(ctx context.Context, meta api.ScreenshotSu
 	if s.repo == nil {
 		return nil
 	}
-	selections, err := s.repo.ListFinalSelections(ctx, meta.SourcePath)
+	selections, err := s.repo.ListFinalSelections(ctx, meta.MediaBinding)
 	if err != nil {
 		s.logger.Debugf("screenshots: failed to load final selections: %v", err)
 		return nil
@@ -1194,6 +1456,9 @@ func (s *Service) loadFinalSelections(ctx context.Context, meta api.ScreenshotSu
 	}
 	images := make([]api.ScreenshotImage, 0, len(selections))
 	for _, selection := range selections {
+		if selection.DiscID != meta.DiscID {
+			continue
+		}
 		pathValue := strings.TrimSpace(selection.ImagePath)
 		if pathValue == "" {
 			continue
@@ -1213,6 +1478,8 @@ func (s *Service) loadFinalSelections(ctx context.Context, meta api.ScreenshotSu
 		} else {
 			img.Purpose = api.ScreenshotPurposeFinal
 		}
+		img.DiscID = selection.DiscID
+		img.DiscName = meta.DiscName
 		images = append(images, img)
 	}
 	sort.Slice(images, func(i, j int) bool { return images[i].Index < images[j].Index })

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -224,6 +224,113 @@ func TestPlanUsesRequestedNormalScreenshotCountForEverySourceKind(t *testing.T) 
 	}
 }
 
+func TestPlanAllocatesScreenshotsAcrossEveryDisc(t *testing.T) {
+	t.Parallel()
+
+	subject, _, _ := multiDiscScreenshotSubject(t)
+	service := NewService(config.Config{}, api.NopLogger{}, t.TempDir(), nil)
+	plan, err := service.Plan(context.Background(), subject, 5)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if len(plan.Discs) != 2 || len(plan.Discs[0].SuggestedSelections) != 3 || len(plan.Discs[1].SuggestedSelections) != 2 {
+		t.Fatalf("disc plans = %#v", plan.Discs)
+	}
+	wantDiscIDs := []string{"disc-a", "disc-a", "disc-a", "disc-b", "disc-b"}
+	if len(plan.SuggestedSelections) != len(wantDiscIDs) {
+		t.Fatalf("suggestions = %#v", plan.SuggestedSelections)
+	}
+	for index, wantDiscID := range wantDiscIDs {
+		if plan.SuggestedSelections[index].DiscID != wantDiscID {
+			t.Fatalf("suggestion[%d] = %#v, want disc %q", index, plan.SuggestedSelections[index], wantDiscID)
+		}
+	}
+}
+
+func TestPlanExpandsRawManualFramesAcrossEveryDisc(t *testing.T) {
+	t.Parallel()
+
+	subject, _, _ := multiDiscScreenshotSubject(t)
+	subject.ManualFrames = []int{24, 48}
+	service := NewService(config.Config{}, api.NopLogger{}, t.TempDir(), nil)
+	plan, err := service.Plan(context.Background(), subject, 2)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	wantDiscIDs := []string{"disc-a", "disc-a", "disc-b", "disc-b"}
+	wantFrames := []int{24, 48, 24, 48}
+	if len(plan.SuggestedSelections) != len(wantDiscIDs) {
+		t.Fatalf("suggestions = %#v", plan.SuggestedSelections)
+	}
+	for index := range wantDiscIDs {
+		selection := plan.SuggestedSelections[index]
+		if selection.DiscID != wantDiscIDs[index] || selection.Frame != wantFrames[index] || selection.Source != "manual" {
+			t.Fatalf("suggestion[%d] = %#v", index, selection)
+		}
+	}
+}
+
+func TestMultiDiscPreviewRequiresDiscAndCaptureNamesDoNotCollide(t *testing.T) {
+	subject, videoA, videoB := multiDiscScreenshotSubject(t)
+	ffmpegRoot := t.TempDir()
+	if err := writeTestBundledFFmpeg(ffmpegRoot); err != nil {
+		t.Fatalf("write bundled ffmpeg: %v", err)
+	}
+	t.Chdir(ffmpegRoot)
+
+	payload := testPNGBytes(t, color.RGBA{
+		R: 16,
+		G: 16,
+		B: 16,
+		A: 255,
+	})
+	previewRunner := &scriptedRunner{results: []CommandResult{{Stdout: payload, ExitCode: 0}}}
+	previewService := NewService(config.Config{}, api.NopLogger{}, t.TempDir(), previewRunner)
+	if _, err := previewService.PreviewFrame(context.Background(), subject, "", 10); !errors.Is(err, internalerrors.ErrInvalidInput) {
+		t.Fatalf("preview without disc error = %v", err)
+	}
+	if _, err := previewService.PreviewFrame(context.Background(), subject, "missing-disc", 10); !errors.Is(err, internalerrors.ErrInvalidInput) {
+		t.Fatalf("preview with unknown disc error = %v", err)
+	}
+	preview, err := previewService.PreviewFrame(context.Background(), subject, "disc-b", 10)
+	if err != nil {
+		t.Fatalf("preview disc-b: %v", err)
+	}
+	if preview.DiscID != "disc-b" || preview.DiscName != "Disc 2" || len(previewRunner.calls) != 1 ||
+		ffmpegInputArg(previewRunner.calls[0].args) != videoB {
+		t.Fatalf("preview = %#v calls=%#v", preview, previewRunner.calls)
+	}
+
+	captureRunner := &writingScreenshotRunner{payload: payload}
+	captureService := NewService(config.Config{}, api.NopLogger{}, t.TempDir(), captureRunner)
+	result, err := captureService.Capture(context.Background(), subject, []api.ScreenshotSelection{
+		{
+			DiscID:           "disc-a",
+			Index:            0,
+			TimestampSeconds: 10,
+		},
+		{
+			DiscID:           "disc-b",
+			Index:            0,
+			TimestampSeconds: 10,
+		},
+	}, api.ScreenshotPurposeFinal)
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if len(result.Images) != 2 || result.Images[0].Path == result.Images[1].Path {
+		t.Fatalf("capture images = %#v", result.Images)
+	}
+	if result.Images[0].DiscID != "disc-a" || result.Images[1].DiscID != "disc-b" ||
+		!strings.Contains(filepath.Base(result.Images[0].Path), "disc-disc-a-") ||
+		!strings.Contains(filepath.Base(result.Images[1].Path), "disc-disc-b-") {
+		t.Fatalf("disc-scoped capture images = %#v", result.Images)
+	}
+	if len(captureRunner.calls) != 2 || ffmpegInputArg(captureRunner.calls[0].args) != videoA || ffmpegInputArg(captureRunner.calls[1].args) != videoB {
+		t.Fatalf("capture calls = %#v", captureRunner.calls)
+	}
+}
+
 func TestPreviewFrameExcludesDVDMenuVOB(t *testing.T) {
 	root := t.TempDir()
 	videoTS := filepath.Join(root, "VIDEO_TS")
@@ -262,7 +369,7 @@ func TestPreviewFrameExcludesDVDMenuVOB(t *testing.T) {
 		SourcePath:        root,
 		DiscType:          "DVD",
 		MediaInfoJSONPath: mediaInfoPath,
-	}, 0.5)
+	}, "", 0.5)
 	if err != nil {
 		t.Fatalf("preview frame: %v", err)
 	}
@@ -304,7 +411,7 @@ func TestPreviewFrameTonemapsHDR(t *testing.T) {
 	_, err := service.PreviewFrame(context.Background(), api.ScreenshotSubject{
 		SourcePath: "Example.Release.2026.1080p-GRP.mkv",
 		HDR:        "HDR10",
-	}, 1)
+	}, "", 1)
 	if err != nil {
 		t.Fatalf("preview frame: %v", err)
 	}
@@ -361,6 +468,11 @@ type scriptedRunner struct {
 	calls   []runnerCall
 }
 
+type writingScreenshotRunner struct {
+	payload []byte
+	calls   []runnerCall
+}
+
 type corruptionCancelRunner struct {
 	started    atomic.Int32
 	canceled   atomic.Int32
@@ -393,6 +505,48 @@ func (r *scriptedRunner) Run(_ context.Context, _ string, args []string, _ strin
 	result := r.results[0]
 	r.results = r.results[1:]
 	return result, nil
+}
+
+func (r *writingScreenshotRunner) Run(_ context.Context, _ string, args []string, _ string) (CommandResult, error) {
+	r.calls = append(r.calls, runnerCall{args: append([]string(nil), args...)})
+	if len(args) == 0 {
+		return CommandResult{ExitCode: 1}, errors.New("missing screenshot output")
+	}
+	if err := os.WriteFile(args[len(args)-1], r.payload, 0o600); err != nil {
+		return CommandResult{ExitCode: 1}, fmt.Errorf("write screenshot output: %w", err)
+	}
+	return CommandResult{ExitCode: 0}, nil
+}
+
+func multiDiscScreenshotSubject(t *testing.T) (api.ScreenshotSubject, string, string) {
+	t.Helper()
+	collectionRoot := t.TempDir()
+	mediaInfoPayload := []byte(`{"media":{"track":[{"@type":"General","Duration":"600"},{"@type":"Video","FrameRate":"24.000"}]}}`)
+	discs := make([]api.ScreenshotDiscSubject, 0, 2)
+	videos := make([]string, 0, 2)
+	for index, discID := range []string{"disc-a", "disc-b"} {
+		root := filepath.Join(collectionRoot, fmt.Sprintf("Disc %d", index+1))
+		if err := os.MkdirAll(root, 0o700); err != nil {
+			t.Fatalf("create disc root: %v", err)
+		}
+		videoPath := filepath.Join(root, fmt.Sprintf("video-%d.mkv", index+1))
+		if err := os.WriteFile(videoPath, []byte("synthetic video"), 0o600); err != nil {
+			t.Fatalf("write video: %v", err)
+		}
+		mediaInfoPath := filepath.Join(root, "mediainfo.json")
+		if err := os.WriteFile(mediaInfoPath, mediaInfoPayload, 0o600); err != nil {
+			t.Fatalf("write mediainfo: %v", err)
+		}
+		discs = append(discs, api.ScreenshotDiscSubject{
+			ID:                discID,
+			Name:              fmt.Sprintf("Disc %d", index+1),
+			Root:              root,
+			VideoPath:         videoPath,
+			MediaInfoJSONPath: mediaInfoPath,
+		})
+		videos = append(videos, videoPath)
+	}
+	return api.ScreenshotSubject{SourcePath: collectionRoot, Discs: discs}, videos[0], videos[1]
 }
 
 func writeTestBundledFFmpeg(root string) error {
@@ -440,7 +594,11 @@ func TestPlanResuggestsDeletedAndStaleScreenshotSlots(t *testing.T) {
 	repo := openScreenshotTestRepository(t)
 	tmpRoot := t.TempDir()
 	service := NewServiceWithRepo(config.Config{}, api.NopLogger{}, tmpRoot, nil, repo)
-	meta := api.ScreenshotSubject{SourcePath: sourcePath, MediaInfoJSONPath: mediaInfoPath}
+	meta := api.ScreenshotSubject{
+		MediaBinding:      screenshotTestBinding(sourcePath),
+		SourcePath:        sourcePath,
+		MediaInfoJSONPath: mediaInfoPath,
+	}
 
 	tmpDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, meta.Release)
 	if err != nil {
@@ -459,7 +617,7 @@ func TestPlanResuggestsDeletedAndStaleScreenshotSlots(t *testing.T) {
 	if err := os.WriteFile(capturePath, []byte("synthetic image"), 0o600); err != nil {
 		t.Fatalf("write capture: %v", err)
 	}
-	if err := repo.SaveScreenshot(context.Background(), api.Screenshot{
+	if err := repo.SaveScreenshot(context.Background(), meta.MediaBinding, api.Screenshot{
 		SourcePath: meta.SourcePath,
 		ImagePath:  capturePath,
 		Timestamp:  30,
@@ -491,7 +649,7 @@ func TestPlanResuggestsDeletedAndStaleScreenshotSlots(t *testing.T) {
 	}
 
 	stalePath := filepath.Join(tmpDir, buildScreenshotFilename(base, 1, 157.5, api.ScreenshotPurposeFinal))
-	if err := repo.SaveScreenshot(context.Background(), api.Screenshot{
+	if err := repo.SaveScreenshot(context.Background(), meta.MediaBinding, api.Screenshot{
 		SourcePath: meta.SourcePath,
 		ImagePath:  stalePath,
 		Timestamp:  157.5,
@@ -513,7 +671,7 @@ func TestDeleteRejectsPathsOutsideManagedTempDir(t *testing.T) {
 	tmpRoot := t.TempDir()
 	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
 	service := NewService(config.Config{}, api.NopLogger{}, tmpRoot, nil)
-	meta := api.ScreenshotSubject{SourcePath: sourcePath}
+	meta := api.ScreenshotSubject{MediaBinding: screenshotTestBinding(sourcePath), SourcePath: sourcePath}
 	tmpDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, meta.Release)
 	if err != nil {
 		t.Fatalf("resolve temp dir: %v", err)
@@ -563,7 +721,7 @@ func TestDeleteAcceptsWindowsCaseAndSeparatorVariants(t *testing.T) {
 	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
 	repo := openScreenshotTestRepository(t)
 	service := NewServiceWithRepo(config.Config{}, api.NopLogger{}, tmpRoot, nil, repo)
-	meta := api.ScreenshotSubject{SourcePath: sourcePath}
+	meta := api.ScreenshotSubject{MediaBinding: screenshotTestBinding(sourcePath), SourcePath: sourcePath}
 	tmpDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, meta.Release)
 	if err != nil {
 		t.Fatalf("resolve temp dir: %v", err)
@@ -599,7 +757,7 @@ func TestDeleteAcceptsDarwinCaseVariant(t *testing.T) {
 	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
 	repo := openScreenshotTestRepository(t)
 	service := NewServiceWithRepo(config.Config{}, api.NopLogger{}, tmpRoot, nil, repo)
-	meta := api.ScreenshotSubject{SourcePath: sourcePath}
+	meta := api.ScreenshotSubject{MediaBinding: screenshotTestBinding(sourcePath), SourcePath: sourcePath}
 	tmpDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, meta.Release)
 	if err != nil {
 		t.Fatalf("resolve temp dir: %v", err)
@@ -634,10 +792,11 @@ func seedStoredCaptures(t *testing.T, repo *db.SQLiteRepository, sourcePath stri
 	t.Helper()
 
 	now := time.Now().UTC()
+	binding := screenshotTestBinding(sourcePath)
 	selections := make([]api.ScreenshotFinalSelection, 0, len(imagePaths))
 	uploads := make([]api.UploadedImageLink, 0, len(imagePaths))
 	for order, imagePath := range imagePaths {
-		if err := repo.SaveScreenshot(context.Background(), api.Screenshot{
+		if err := repo.SaveScreenshot(context.Background(), binding, api.Screenshot{
 			SourcePath: sourcePath,
 			ImagePath:  imagePath,
 			Timestamp:  float64(30 * (order + 1)),
@@ -662,10 +821,10 @@ func seedStoredCaptures(t *testing.T, repo *db.SQLiteRepository, sourcePath stri
 			SelectedAt: now,
 		})
 	}
-	if err := repo.SaveUploadedImages(context.Background(), sourcePath, "example-host", uploads); err != nil {
+	if err := repo.SaveUploadedImages(context.Background(), binding, "example-host", uploads); err != nil {
 		t.Fatalf("seed uploaded image records: %v", err)
 	}
-	if err := repo.SaveFinalSelections(context.Background(), sourcePath, selections); err != nil {
+	if err := repo.SaveFinalSelections(context.Background(), binding, selections); err != nil {
 		t.Fatalf("seed final selections: %v", err)
 	}
 }
@@ -693,15 +852,16 @@ func requireStoredCaptureRows(t *testing.T, repo *db.SQLiteRepository, sourcePat
 func storedCaptureRows(t *testing.T, repo *db.SQLiteRepository, sourcePath string) []string {
 	t.Helper()
 
-	screenshots, err := repo.ListScreenshotsByPath(context.Background(), sourcePath)
+	binding := screenshotTestBinding(sourcePath)
+	screenshots, err := repo.ListScreenshotsByPath(context.Background(), binding)
 	if err != nil {
 		t.Fatalf("list screenshot records: %v", err)
 	}
-	uploads, err := repo.ListUploadedImagesByPath(context.Background(), sourcePath)
+	uploads, err := repo.ListUploadedImagesByPath(context.Background(), binding)
 	if err != nil {
 		t.Fatalf("list uploaded image records: %v", err)
 	}
-	selections, err := repo.ListFinalSelections(context.Background(), sourcePath)
+	selections, err := repo.ListFinalSelections(context.Background(), binding)
 	if err != nil {
 		t.Fatalf("list final selections: %v", err)
 	}
@@ -725,11 +885,11 @@ type flakyDeleteRepository struct {
 	healthy bool
 }
 
-func (r *flakyDeleteRepository) DeleteScreenshot(ctx context.Context, imagePath string) error {
+func (r *flakyDeleteRepository) DeleteScreenshot(ctx context.Context, binding api.PreparedMediaBinding, imagePath string) error {
 	if !r.healthy {
 		return errors.New("synthetic screenshot record delete failure")
 	}
-	if err := r.SQLiteRepository.DeleteScreenshot(ctx, imagePath); err != nil {
+	if err := r.SQLiteRepository.DeleteScreenshot(ctx, binding, imagePath); err != nil {
 		return fmt.Errorf("delete screenshot: %w", err)
 	}
 	return nil
@@ -745,7 +905,7 @@ func TestDeleteReportsIncompleteCleanupAndConvergesOnRetry(t *testing.T) {
 	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
 	repo := &flakyDeleteRepository{SQLiteRepository: openScreenshotTestRepository(t)}
 	service := NewServiceWithRepo(config.Config{}, api.NopLogger{}, tmpRoot, nil, repo)
-	meta := api.ScreenshotSubject{SourcePath: sourcePath}
+	meta := api.ScreenshotSubject{MediaBinding: screenshotTestBinding(sourcePath), SourcePath: sourcePath}
 	tmpDir, _, err := paths.ReleaseTempDirFor(tmpRoot, meta.SourcePath, meta.Release)
 	if err != nil {
 		t.Fatalf("resolve temp dir: %v", err)
@@ -788,4 +948,12 @@ func openScreenshotTestRepository(t *testing.T) *db.SQLiteRepository {
 		t.Fatalf("migrate repository: %v", err)
 	}
 	return repo
+}
+
+func screenshotTestBinding(sourcePath string) api.PreparedMediaBinding {
+	return api.PreparedMediaBinding{
+		SourcePath:               sourcePath,
+		PreparedMediaFingerprint: "test-prepared-media",
+		PreparedGeneration:       1,
+	}
 }

--- a/internal/sourcelayout/layout.go
+++ b/internal/sourcelayout/layout.go
@@ -6,11 +6,16 @@
 package sourcelayout
 
 import (
+	"cmp"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
@@ -25,38 +30,54 @@ const (
 	KindFile Kind = "file"
 	// KindDirectory identifies a non-disc directory source.
 	KindDirectory Kind = "directory"
-	// KindDiscParent identifies a directory containing a recognized disc root.
+	// KindDiscParent identifies a directory containing one or more recognized disc roots.
 	KindDiscParent Kind = "disc_parent"
 	// KindDiscRoot identifies a recognized disc root selected directly.
 	KindDiscRoot Kind = "disc_root"
 )
+
+// DiscResource is one preparation-private disc root within a selected source.
+type DiscResource struct {
+	ID   string
+	Name string
+	Type string
+	Root string
+}
 
 // Layout preserves requested-source identity while exposing derived local
 // resource roots only to preparation internals.
 type Layout struct {
 	// SourcePath is the absolute, cleaned path originally selected by the caller.
 	SourcePath string
-	// Kind describes how SourcePath relates to ContentRoot.
+	// Kind describes how SourcePath relates to its discovered resources.
 	Kind Kind
-	// DiscType is BDMV, DVD, or HDDVD for recognized disc layouts; otherwise empty.
+	// DiscType is BDMV, DVD, or HDDVD for a homogeneous recognized disc layout.
 	DiscType string
-	// ContentRoot is the local file or directory used to collect source facts.
-	ContentRoot string
-	// BDMVRoot is the selected or discovered BDMV directory; otherwise empty.
-	BDMVRoot string
-	// DVDRoot is the selected or discovered VIDEO_TS or HVDVD_TS directory; otherwise empty.
-	DVDRoot string
+	// Discs contains every recognized disc root in deterministic display order.
+	Discs []DiscResource
 }
 
-// ErrSourceNotFound identifies a requested preparation source that does not
-// exist without exposing its local path through public failures. Test it with
-// [errors.Is].
-var ErrSourceNotFound = errors.New("source layout: source not found")
+var (
+	// ErrSourceNotFound identifies a requested source that does not exist.
+	ErrSourceNotFound = errors.New("source layout: source not found")
+	// ErrDirectorySymlink identifies a selected or nested directory symlink.
+	ErrDirectorySymlink = errors.New("source layout: directory symlinks are not supported")
+	// ErrMixedDiscCollection identifies a collection containing different disc formats.
+	ErrMixedDiscCollection = errors.New("source layout: mixed disc collections are not supported")
+	// ErrUnsupportedHDDVDCollection identifies nested or multiple HD DVD roots.
+	ErrUnsupportedHDDVDCollection = errors.New("source layout: HD DVD collections are not supported")
+	// ErrConflictingDiscLayout identifies ambiguous or colliding disc marker identities.
+	ErrConflictingDiscLayout = errors.New("source layout: conflicting disc layout")
+)
 
-// Resolve normalizes and validates sourcePath and derives any disc resource
-// root without changing the source's canonical identity. Disc markers are
-// matched case-insensitively at the source root or among its immediate children;
-// deeper descendants are not scanned.
+type discoveredDisc struct {
+	resource       DiscResource
+	relativeMarker string
+	relativeParent string
+}
+
+// Resolve normalizes and validates sourcePath and discovers every disc root
+// without dereferencing directory symlinks or changing source identity.
 func Resolve(ctx context.Context, sourcePath string) (Layout, error) {
 	if ctx == nil {
 		return Layout{}, errors.New("source layout: context is required")
@@ -73,76 +94,177 @@ func Resolve(ctx context.Context, sourcePath string) (Layout, error) {
 	if err := ctx.Err(); err != nil {
 		return Layout{}, fmt.Errorf("source layout: resolve canceled: %w", err)
 	}
-	info, err := os.Stat(abs)
+	info, err := os.Lstat(abs)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return Layout{}, ErrSourceNotFound
 		}
 		return Layout{}, fmt.Errorf("source layout: inspect source: %w", err)
 	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, statErr := os.Stat(abs)
+		if statErr != nil {
+			return Layout{}, fmt.Errorf("source layout: inspect source link: %w", statErr)
+		}
+		if target.IsDir() {
+			return Layout{}, ErrDirectorySymlink
+		}
+		return Layout{SourcePath: abs, Kind: KindFile}, nil
+	}
 	if !info.IsDir() {
-		return Layout{
-			SourcePath:  abs,
-			Kind:        KindFile,
-			ContentRoot: abs,
-		}, nil
+		return Layout{SourcePath: abs, Kind: KindFile}, nil
 	}
 
-	markerPath, discType, err := findDiscMarker(ctx, abs)
+	discs, err := discoverDiscs(ctx, abs)
 	if err != nil {
 		return Layout{}, err
 	}
-	if markerPath == "" {
-		return Layout{
-			SourcePath:  abs,
-			Kind:        KindDirectory,
-			ContentRoot: abs,
-		}, nil
+	if len(discs) == 0 {
+		return Layout{SourcePath: abs, Kind: KindDirectory}, nil
+	}
+	if err := validateDiscSet(abs, discs); err != nil {
+		return Layout{}, err
+	}
+
+	slices.SortFunc(discs, func(left, right discoveredDisc) int {
+		return cmp.Or(
+			cmp.Compare(strings.ToLower(filepath.ToSlash(left.relativeParent)), strings.ToLower(filepath.ToSlash(right.relativeParent))),
+			cmp.Compare(filepath.ToSlash(left.relativeParent), filepath.ToSlash(right.relativeParent)),
+			cmp.Compare(left.relativeMarker, right.relativeMarker),
+		)
+	})
+	resources := make([]DiscResource, len(discs))
+	for i := range discs {
+		resources[i] = discs[i].resource
+		if !usefulDiscLabel(discs[i].relativeParent) {
+			resources[i].Name = fmt.Sprintf("Disc %d", i+1)
+		}
 	}
 
 	kind := KindDiscParent
-	if pathutil.SamePath(abs, markerPath) {
+	if len(discs) == 1 && pathutil.SamePath(abs, discs[0].resource.Root) {
 		kind = KindDiscRoot
 	}
-	layout := Layout{
-		SourcePath:  abs,
-		Kind:        kind,
-		DiscType:    discType,
-		ContentRoot: markerPath,
-	}
-	switch discType {
-	case "BDMV":
-		layout.BDMVRoot = markerPath
-	case "DVD", "HDDVD":
-		layout.DVDRoot = markerPath
-	}
-	return layout, nil
+	return Layout{
+		SourcePath: abs,
+		Kind:       kind,
+		DiscType:   discs[0].resource.Type,
+		Discs:      resources,
+	}, nil
 }
 
-// findDiscMarker checks root and its immediate children for a recognized disc directory.
-func findDiscMarker(ctx context.Context, root string) (string, string, error) {
-	if err := ctx.Err(); err != nil {
-		return "", "", fmt.Errorf("source layout: scan canceled: %w", err)
-	}
-	if discType := markerDiscType(filepath.Base(root)); discType != "" {
-		return filepath.Clean(root), discType, nil
-	}
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return "", "", fmt.Errorf("source layout: read source: %w", err)
-	}
-	for _, entry := range entries {
+func discoverDiscs(ctx context.Context, root string) ([]discoveredDisc, error) {
+	discs := make([]discoveredDisc, 0, 1)
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
 		if err := ctx.Err(); err != nil {
-			return "", "", fmt.Errorf("source layout: scan canceled: %w", err)
+			return fmt.Errorf("source layout: scan canceled: %w", err)
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			return fmt.Errorf("source layout: inspect candidate: %w", err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, statErr := os.Stat(path)
+			if statErr == nil && target.IsDir() {
+				return ErrDirectorySymlink
+			}
+			return nil
 		}
 		if !entry.IsDir() {
-			continue
+			return nil
 		}
-		if discType := markerDiscType(entry.Name()); discType != "" {
-			return filepath.Join(root, entry.Name()), discType, nil
+		discType := markerDiscType(entry.Name())
+		if discType == "" {
+			return nil
+		}
+		disc, err := newDiscoveredDisc(root, path, discType)
+		if err != nil {
+			return err
+		}
+		discs = append(discs, disc)
+		return filepath.SkipDir
+	})
+	if err != nil {
+		return nil, fmt.Errorf("source layout: scan source: %w", err)
+	}
+	return discs, nil
+}
+
+func newDiscoveredDisc(sourceRoot string, markerRoot string, discType string) (discoveredDisc, error) {
+	relativeMarker, err := filepath.Rel(sourceRoot, markerRoot)
+	if err != nil {
+		return discoveredDisc{}, fmt.Errorf("source layout: resolve disc identity: %w", err)
+	}
+	if relativeMarker == "." {
+		relativeMarker = filepath.Base(markerRoot)
+	}
+	relativeMarker = filepath.Clean(relativeMarker)
+	if !validRelativePath(relativeMarker) {
+		return discoveredDisc{}, ErrConflictingDiscLayout
+	}
+	relativeParent := filepath.Clean(filepath.Dir(relativeMarker))
+	canonicalMarker := strings.ToLower(filepath.ToSlash(relativeMarker))
+	identity := strings.ToUpper(discType) + "\x00" + canonicalMarker
+	digest := sha256.Sum256([]byte(identity))
+	name := filepath.ToSlash(relativeParent)
+	return discoveredDisc{
+		resource: DiscResource{
+			ID:   "disc-" + hex.EncodeToString(digest[:]),
+			Name: name,
+			Type: discType,
+			Root: filepath.Clean(markerRoot),
+		},
+		relativeMarker: filepath.ToSlash(relativeMarker),
+		relativeParent: name,
+	}, nil
+}
+
+func validateDiscSet(sourceRoot string, discs []discoveredDisc) error {
+	types := make(map[string]struct{}, len(discs))
+	identities := make(map[string]struct{}, len(discs))
+	for _, disc := range discs {
+		if !pathutil.IsWithinRoot(sourceRoot, disc.resource.Root) {
+			return ErrConflictingDiscLayout
+		}
+		types[disc.resource.Type] = struct{}{}
+		if _, exists := identities[disc.resource.ID]; exists {
+			return ErrConflictingDiscLayout
+		}
+		identities[disc.resource.ID] = struct{}{}
+	}
+	if _, hasHDDVD := types["HDDVD"]; hasHDDVD {
+		if len(discs) != 1 || len(types) != 1 || !directOrImmediateMarker(sourceRoot, discs[0].resource.Root) {
+			return ErrUnsupportedHDDVDCollection
 		}
 	}
-	return "", "", nil
+	if len(types) != 1 {
+		return ErrMixedDiscCollection
+	}
+	return nil
+}
+
+func validRelativePath(value string) bool {
+	if value == "" || value == "." || filepath.IsAbs(value) || filepath.VolumeName(value) != "" {
+		return false
+	}
+	for _, part := range strings.FieldsFunc(filepath.ToSlash(value), func(r rune) bool { return r == '/' }) {
+		if part == ".." || part == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func usefulDiscLabel(value string) bool {
+	value = strings.TrimSpace(filepath.ToSlash(value))
+	return value != "" && value != "."
+}
+
+func directOrImmediateMarker(sourceRoot string, markerRoot string) bool {
+	return pathutil.SamePath(sourceRoot, markerRoot) || pathutil.SamePath(sourceRoot, filepath.Dir(markerRoot))
 }
 
 // markerDiscType maps a case-insensitive disc directory name to its canonical type.

--- a/internal/sourcelayout/layout_test.go
+++ b/internal/sourcelayout/layout_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
+	"strings"
 	"testing"
 
 	pathutil "github.com/autobrr/upbrr/internal/pathing"
@@ -19,77 +21,60 @@ func TestResolveSourceKinds(t *testing.T) {
 
 	root := t.TempDir()
 	filePath := filepath.Join(root, "Example.Release.2026.mkv")
-	if err := os.WriteFile(filePath, []byte("example"), 0o600); err != nil {
-		t.Fatalf("write source file: %v", err)
-	}
+	writeTestFile(t, filePath)
 	ordinary := filepath.Join(root, "ordinary")
-	nestedBDMV := filepath.Join(ordinary, "nested", "BDMV")
-	if err := os.MkdirAll(nestedBDMV, 0o700); err != nil {
-		t.Fatalf("create ordinary source: %v", err)
-	}
+	mkdirTest(t, filepath.Join(ordinary, "nested"))
 	discParent := filepath.Join(root, "disc-parent")
 	bdmvRoot := filepath.Join(discParent, "BDMV")
-	if err := os.MkdirAll(bdmvRoot, 0o700); err != nil {
-		t.Fatalf("create BDMV source: %v", err)
-	}
+	mkdirTest(t, bdmvRoot)
 	dvdParent := filepath.Join(root, "dvd-parent")
 	dvdRoot := filepath.Join(dvdParent, "VIDEO_TS")
-	if err := os.MkdirAll(dvdRoot, 0o700); err != nil {
-		t.Fatalf("create DVD source: %v", err)
-	}
+	mkdirTest(t, dvdRoot)
 
 	tests := []struct {
-		name        string
-		path        string
-		kind        Kind
-		discType    string
-		contentRoot string
-		bdmvRoot    string
-		dvdRoot     string
+		name     string
+		path     string
+		kind     Kind
+		discType string
+		discRoot string
 	}{
 		{
 name: "file",
  path: filePath,
  kind: KindFile,
- contentRoot: filePath,
 },
 		{
 name: "ordinary directory",
  path: ordinary,
  kind: KindDirectory,
- contentRoot: ordinary,
 },
 		{
 name: "disc parent",
  path: discParent + string(filepath.Separator),
  kind: KindDiscParent,
  discType: "BDMV",
- contentRoot: bdmvRoot,
- bdmvRoot: bdmvRoot,
+ discRoot: bdmvRoot,
 },
 		{
 name: "direct BDMV root",
  path: bdmvRoot,
  kind: KindDiscRoot,
  discType: "BDMV",
- contentRoot: bdmvRoot,
- bdmvRoot: bdmvRoot,
+ discRoot: bdmvRoot,
 },
 		{
 name: "DVD parent",
  path: dvdParent,
  kind: KindDiscParent,
  discType: "DVD",
- contentRoot: dvdRoot,
- dvdRoot: dvdRoot,
+ discRoot: dvdRoot,
 },
 		{
 name: "direct DVD root",
  path: dvdRoot,
  kind: KindDiscRoot,
  discType: "DVD",
- contentRoot: dvdRoot,
- dvdRoot: dvdRoot,
+ discRoot: dvdRoot,
 },
 	}
 	for _, test := range tests {
@@ -102,11 +87,178 @@ name: "direct DVD root",
 			if layout.Kind != test.kind || layout.DiscType != test.discType {
 				t.Fatalf("layout kind/disc = %s/%s, want %s/%s", layout.Kind, layout.DiscType, test.kind, test.discType)
 			}
-			assertSamePath(t, layout.ContentRoot, test.contentRoot)
-			assertSamePath(t, layout.BDMVRoot, test.bdmvRoot)
-			assertSamePath(t, layout.DVDRoot, test.dvdRoot)
 			assertSamePath(t, layout.SourcePath, filepath.Clean(test.path))
+			if test.discRoot == "" {
+				if len(layout.Discs) != 0 {
+					t.Fatalf("discs = %#v, want none", layout.Discs)
+				}
+				return
+			}
+			if len(layout.Discs) != 1 {
+				t.Fatalf("disc count = %d, want 1", len(layout.Discs))
+			}
+			assertSamePath(t, layout.Discs[0].Root, test.discRoot)
+			if layout.Discs[0].ID == "" || layout.Discs[0].Name != "Disc 1" || layout.Discs[0].Type != test.discType {
+				t.Fatalf("disc = %#v", layout.Discs[0])
+			}
 		})
+	}
+}
+
+func TestResolveNestedHomogeneousCollections(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	second := filepath.Join(root, "Feature", "Disc 2", "VIDEO_TS")
+	first := filepath.Join(root, "Disc 1", "VIDEO_TS")
+	mkdirTest(t, second)
+	mkdirTest(t, first)
+	writeTestFile(t, filepath.Join(first, "VIDEO_TS.IFO"))
+	writeTestFile(t, filepath.Join(second, "VIDEO_TS.IFO"))
+
+	layout, err := Resolve(context.Background(), root)
+	if err != nil {
+		t.Fatalf("resolve collection: %v", err)
+	}
+	if layout.Kind != KindDiscParent || layout.DiscType != "DVD" || len(layout.Discs) != 2 {
+		t.Fatalf("layout = %#v", layout)
+	}
+	if got := []string{layout.Discs[0].Name, layout.Discs[1].Name}; !slices.Equal(got, []string{"Disc 1", "Feature/Disc 2"}) {
+		t.Fatalf("disc names = %#v", got)
+	}
+	assertSamePath(t, layout.Discs[0].Root, first)
+	assertSamePath(t, layout.Discs[1].Root, second)
+	if layout.Discs[0].ID == layout.Discs[1].ID {
+		t.Fatal("disc IDs collided")
+	}
+}
+
+func TestResolveDiscIDsIgnoreDiscoveryOrderAndSiblingInsertion(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	discTwo := filepath.Join(root, "Disc 2", "BDMV")
+	discThree := filepath.Join(root, "Disc 3", "BDMV")
+	mkdirTest(t, discThree)
+	mkdirTest(t, discTwo)
+	before, err := Resolve(context.Background(), root)
+	if err != nil {
+		t.Fatalf("resolve before insertion: %v", err)
+	}
+	beforeIDs := discIDsByName(before.Discs)
+
+	mkdirTest(t, filepath.Join(root, "Disc 1", "BDMV"))
+	after, err := Resolve(context.Background(), root)
+	if err != nil {
+		t.Fatalf("resolve after insertion: %v", err)
+	}
+	afterIDs := discIDsByName(after.Discs)
+	for _, name := range []string{"Disc 2", "Disc 3"} {
+		if beforeIDs[name] != afterIDs[name] {
+			t.Fatalf("%s ID changed: %q != %q", name, beforeIDs[name], afterIDs[name])
+		}
+	}
+
+	if err := os.Rename(filepath.Join(root, "Disc 2"), filepath.Join(root, "Disc 4")); err != nil {
+		t.Fatalf("rename disc: %v", err)
+	}
+	renamed, err := Resolve(context.Background(), root)
+	if err != nil {
+		t.Fatalf("resolve after rename: %v", err)
+	}
+	if discIDsByName(renamed.Discs)["Disc 4"] == beforeIDs["Disc 2"] {
+		t.Fatal("renamed disc retained its old ID")
+	}
+}
+
+func TestResolveRejectsMixedAndUnsupportedDiscCollections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		markers []string
+		want    error
+	}{
+		{
+name: "mixed BDMV and DVD",
+ markers: []string{"Disc 1/BDMV", "Disc 2/VIDEO_TS"},
+ want: ErrMixedDiscCollection,
+},
+		{
+name: "nested HD DVD",
+ markers: []string{"Disc 1/HVDVD_TS"},
+ want: ErrUnsupportedHDDVDCollection,
+},
+		{
+name: "multiple HD DVD",
+ markers: []string{"HVDVD_TS", "Disc 2/HVDVD_TS"},
+ want: ErrUnsupportedHDDVDCollection,
+},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			for _, marker := range test.markers {
+				mkdirTest(t, filepath.Join(root, filepath.FromSlash(marker)))
+			}
+			_, err := Resolve(context.Background(), root)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("error = %v, want %v", err, test.want)
+			}
+			if strings.Contains(err.Error(), root) {
+				t.Fatalf("error exposes source path: %v", err)
+			}
+		})
+	}
+
+	directParent := t.TempDir()
+	directRoot := filepath.Join(directParent, "HVDVD_TS")
+	mkdirTest(t, directRoot)
+	for _, source := range []string{directRoot, directParent} {
+		layout, err := Resolve(context.Background(), source)
+		if err != nil {
+			t.Fatalf("resolve legacy HD DVD %q: %v", source, err)
+		}
+		if layout.DiscType != "HDDVD" || len(layout.Discs) != 1 {
+			t.Fatalf("legacy HD DVD layout = %#v", layout)
+		}
+	}
+}
+
+func TestResolveRejectsDirectorySymlinksWithoutTraversal(t *testing.T) {
+	t.Parallel()
+
+	target := t.TempDir()
+	mkdirTest(t, filepath.Join(target, "BDMV"))
+	root := t.TempDir()
+	selectedLink := filepath.Join(root, "selected")
+	if err := os.Symlink(target, selectedLink); err != nil {
+		t.Skipf("directory symlinks unavailable: %v", err)
+	}
+	if _, err := Resolve(context.Background(), selectedLink); !errors.Is(err, ErrDirectorySymlink) {
+		t.Fatalf("selected symlink error = %v", err)
+	}
+
+	collection := filepath.Join(root, "collection")
+	mkdirTest(t, collection)
+	if err := os.Symlink(target, filepath.Join(collection, "Disc 1")); err != nil {
+		t.Fatalf("create nested symlink: %v", err)
+	}
+	if _, err := Resolve(context.Background(), collection); !errors.Is(err, ErrDirectorySymlink) {
+		t.Fatalf("nested symlink error = %v", err)
+	}
+}
+
+func TestResolveRejectsCanonicalIdentityCollisions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("case-insensitive filesystem cannot create colliding marker paths")
+	}
+	root := t.TempDir()
+	mkdirTest(t, filepath.Join(root, "Disc", "BDMV"))
+	mkdirTest(t, filepath.Join(root, "disc", "bdmv"))
+	if _, err := Resolve(context.Background(), root); !errors.Is(err, ErrConflictingDiscLayout) {
+		t.Fatalf("collision error = %v", err)
 	}
 }
 
@@ -116,9 +268,7 @@ func TestResolveWindowsPathCasing(t *testing.T) {
 	}
 	root := t.TempDir()
 	bdmvRoot := filepath.Join(root, "BDMV")
-	if err := os.MkdirAll(bdmvRoot, 0o700); err != nil {
-		t.Fatalf("create BDMV source: %v", err)
-	}
+	mkdirTest(t, bdmvRoot)
 	layout, err := Resolve(context.Background(), filepath.Join(root, "bdmv"))
 	if err != nil {
 		t.Fatalf("resolve differently cased source: %v", err)
@@ -141,12 +291,40 @@ func TestResolveRejectsMissingAndCanceledSources(t *testing.T) {
 	}
 }
 
+func discIDsByName(discs []DiscResource) map[string]string {
+	result := make(map[string]string, len(discs))
+	for _, disc := range discs {
+		result[disc.Name] = disc.ID
+	}
+	return result
+}
+
+func mkdirTest(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+}
+
+func writeTestFile(t *testing.T, path string) {
+	t.Helper()
+	mkdirTest(t, filepath.Dir(path))
+	if err := os.WriteFile(path, []byte("example"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
 func assertSamePath(t *testing.T, got string, want string) {
 	t.Helper()
 	if got == "" || want == "" {
 		if got != want {
 			t.Fatalf("path = %q, want %q", got, want)
 		}
+		return
+	}
+	gotInfo, gotErr := os.Stat(got)
+	wantInfo, wantErr := os.Stat(want)
+	if gotErr == nil && wantErr == nil && os.SameFile(gotInfo, wantInfo) {
 		return
 	}
 	if !pathutil.SamePath(got, want) {

--- a/internal/torrent/service_test.go
+++ b/internal/torrent/service_test.go
@@ -333,6 +333,39 @@ func TestCreateDiscFolderIgnoresWantedFileList(t *testing.T) {
 	})
 }
 
+func TestCreateMultiDiscCollectionIncludesEveryTree(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := filepath.Join(t.TempDir(), "Example.Release.2026.COMPLETE.BLURAY-GRP")
+	firstStream := filepath.Join(sourceDir, "Disc 1", "BDMV", "STREAM", "00001.m2ts")
+	secondStream := filepath.Join(sourceDir, "Disc 2", "BDMV", "STREAM", "00001.m2ts")
+	writeTestFile(t, firstStream, "first stream")
+	writeTestFile(t, filepath.Join(sourceDir, "Disc 1", "BDMV", "PLAYLIST", "00001.mpls"), "first playlist")
+	writeTestFile(t, secondStream, "second stream")
+	writeTestFile(t, filepath.Join(sourceDir, "Disc 2", "BDMV", "PLAYLIST", "00001.mpls"), "second playlist")
+
+	service := NewService(api.NopLogger{}, t.TempDir())
+	result, err := service.Create(context.Background(), api.TorrentSubject{
+		SourcePath: sourceDir,
+		DiscType:   "BDMV",
+		FileList:   []string{firstStream},
+	})
+	if err != nil {
+		t.Fatalf("create collection torrent: %v", err)
+	}
+
+	name, files := loadTorrentShape(t, result.Path)
+	if name != filepath.Base(sourceDir) {
+		t.Fatalf("torrent name = %q, want %q", name, filepath.Base(sourceDir))
+	}
+	assertStringSliceEqual(t, files, []string{
+		"Disc 1/BDMV/PLAYLIST/00001.mpls",
+		"Disc 1/BDMV/STREAM/00001.m2ts",
+		"Disc 2/BDMV/PLAYLIST/00001.mpls",
+		"Disc 2/BDMV/STREAM/00001.m2ts",
+	})
+}
+
 func TestCreateDiscMarkerFolderUsesSelectedRoot(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/description_assets.go
+++ b/internal/trackers/description_assets.go
@@ -875,13 +875,13 @@ func preloadUploadAssetData(
 		return preloaded, nil
 	}
 
-	selections, err := repo.ListFinalSelections(ctx, meta.SourcePath)
+	selections, err := repo.ListFinalSelections(ctx, meta.MediaBinding)
 	if err != nil {
 		return nil, fmt.Errorf("trackers: %w", err)
 	}
 	preloaded.selections = selections
 
-	uploads, err := repo.ListUploadedImagesByPath(ctx, meta.SourcePath)
+	uploads, err := repo.ListUploadedImagesByPath(ctx, meta.MediaBinding)
 	if err != nil {
 		return nil, fmt.Errorf("trackers: %w", err)
 	}
@@ -980,7 +980,7 @@ func finalSelectionsFromSource(
 	if preloaded != nil {
 		return preloaded.selections, nil
 	}
-	return wrapTrackerResult(repo.ListFinalSelections(ctx, meta.SourcePath))
+	return wrapTrackerResult(repo.ListFinalSelections(ctx, meta.MediaBinding))
 }
 
 func uploadedImagesFromSource(
@@ -995,7 +995,7 @@ func uploadedImagesFromSource(
 	if preloaded != nil {
 		return preloaded.uploads, nil
 	}
-	return wrapTrackerResult(repo.ListUploadedImagesByPath(ctx, meta.SourcePath))
+	return wrapTrackerResult(repo.ListUploadedImagesByPath(ctx, meta.MediaBinding))
 }
 
 func resolveTrackerImageURLs(

--- a/internal/trackers/description_assets_test.go
+++ b/internal/trackers/description_assets_test.go
@@ -227,14 +227,14 @@ func (s *stubRepo) ListTrackerMetadataByPath(context.Context, string) ([]api.Tra
 	return cloneTrackerMetadata(s.trackerRecords), nil
 }
 func (s *stubRepo) SaveScreenshot(context.Context, api.Screenshot) error { return nil }
-func (s *stubRepo) ListScreenshotsByPath(context.Context, string) ([]api.Screenshot, error) {
+func (s *stubRepo) ListScreenshotsByPath(context.Context, api.PreparedMediaBinding) ([]api.Screenshot, error) {
 	return nil, nil
 }
 func (s *stubRepo) DeleteScreenshot(context.Context, string) error { return nil }
-func (s *stubRepo) SaveFinalSelections(context.Context, string, []api.ScreenshotFinalSelection) error {
+func (s *stubRepo) SaveFinalSelections(context.Context, api.PreparedMediaBinding, []api.ScreenshotFinalSelection) error {
 	return nil
 }
-func (s *stubRepo) ListFinalSelections(context.Context, string) ([]api.ScreenshotFinalSelection, error) {
+func (s *stubRepo) ListFinalSelections(context.Context, api.PreparedMediaBinding) ([]api.ScreenshotFinalSelection, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.selectionsCalls++
@@ -244,13 +244,13 @@ func (s *stubRepo) ListFinalSelections(context.Context, string) ([]api.Screensho
 	return append([]api.ScreenshotFinalSelection(nil), s.selections...), nil
 }
 func (s *stubRepo) DeleteFinalSelection(context.Context, string) error { return nil }
-func (s *stubRepo) ReplaceScreenshotSlots(_ context.Context, _ string, slots []api.ScreenshotSlot) error {
+func (s *stubRepo) ReplaceScreenshotSlots(_ context.Context, _ api.PreparedMediaBinding, slots []api.ScreenshotSlot) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.screenshotSlots = cloneScreenshotSlots(slots)
 	return nil
 }
-func (s *stubRepo) ListScreenshotSlotsByPath(context.Context, string) ([]api.ScreenshotSlot, error) {
+func (s *stubRepo) ListScreenshotSlotsByPath(context.Context, api.PreparedMediaBinding) ([]api.ScreenshotSlot, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.screenshotSlotCalls++
@@ -259,7 +259,7 @@ func (s *stubRepo) ListScreenshotSlotsByPath(context.Context, string) ([]api.Scr
 	}
 	return cloneScreenshotSlots(s.screenshotSlots), nil
 }
-func (s *stubRepo) UpsertScreenshotSlotVariants(_ context.Context, _ string, variants []api.ScreenshotSlotVariant) error {
+func (s *stubRepo) UpsertScreenshotSlotVariants(_ context.Context, _ api.PreparedMediaBinding, variants []api.ScreenshotSlotVariant) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, variant := range variants {
@@ -272,13 +272,13 @@ func (s *stubRepo) UpsertScreenshotSlotVariants(_ context.Context, _ string, var
 	}
 	return nil
 }
-func (s *stubRepo) SaveUploadedImages(_ context.Context, _ string, _ string, images []api.UploadedImageLink) error {
+func (s *stubRepo) SaveUploadedImages(_ context.Context, _ api.PreparedMediaBinding, _ string, images []api.UploadedImageLink) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.uploads = append(s.uploads, images...)
 	return nil
 }
-func (s *stubRepo) ListUploadedImagesByPath(context.Context, string) ([]api.UploadedImageLink, error) {
+func (s *stubRepo) ListUploadedImagesByPath(context.Context, api.PreparedMediaBinding) ([]api.UploadedImageLink, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.uploadsCalls++
@@ -287,7 +287,7 @@ func (s *stubRepo) ListUploadedImagesByPath(context.Context, string) ([]api.Uplo
 	}
 	return append([]api.UploadedImageLink(nil), s.uploads...), nil
 }
-func (s *stubRepo) DeleteUploadedImage(_ context.Context, _ string, imagePath string, host string) error {
+func (s *stubRepo) DeleteUploadedImage(_ context.Context, _ api.PreparedMediaBinding, imagePath string, host string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.deletedUploads = append(s.deletedUploads, host+":"+imagePath)
@@ -400,7 +400,7 @@ func TestResolveDescriptionAssetsDedupesAfterSanitizingBotSignatures(t *testing.
 			{Tracker: "AITHER", Description: "Body"},
 		},
 	}
-	meta := api.UploadSubject{SourcePath: "/tmp/source"}
+	meta := api.UploadSubject{MediaBinding: trackerTestMediaBinding("/tmp/source"), SourcePath: "/tmp/source"}
 
 	assets, err := ResolveDescriptionAssets(context.Background(), "AITHER", meta, repo, api.NopLogger{}, descriptionAssetsTestRegistry(t))
 	if err != nil {
@@ -464,6 +464,7 @@ func TestDescriptionAssetsPreserveMenuClassificationAcrossRehost(t *testing.T) {
 
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "Example.Release.2026.DVD-GRP")
+	binding := trackerTestMediaBinding(sourcePath)
 	paths := []string{
 		filepath.Join(root, "auto-menu.png"),
 		filepath.Join(root, "manual-menu.png"),
@@ -490,7 +491,7 @@ func TestDescriptionAssetsPreserveMenuClassificationAcrossRehost(t *testing.T) {
 		},
 	}}
 	images := &stubImageService{repo: repo}
-	meta := api.UploadSubject{SourcePath: sourcePath}
+	meta := api.UploadSubject{MediaBinding: binding, SourcePath: sourcePath}
 
 	resolution, err := ensureDescriptionImageHostWithRegistry(
 		context.Background(),
@@ -537,6 +538,7 @@ func TestPartialMenuRemovalUpdatesResolvedAndRenderedDescription(t *testing.T) {
 
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "Example.Release.2026.DVD-GRP")
+	binding := trackerTestMediaBinding(sourcePath)
 	autoFirst := filepath.Join(root, "auto-menu-01.png")
 	autoSecond := filepath.Join(root, "auto-menu-02.png")
 	normal := filepath.Join(root, "normal-screen-01.png")
@@ -560,7 +562,7 @@ func TestPartialMenuRemovalUpdatesResolvedAndRenderedDescription(t *testing.T) {
 			Source:     string(api.ScreenshotPurposeFinal),
 		},
 	}
-	if err := repo.SaveFinalSelections(context.Background(), sourcePath, selections); err != nil {
+	if err := repo.SaveFinalSelections(context.Background(), binding, selections); err != nil {
 		t.Fatalf("save selections: %v", err)
 	}
 	uploads := make([]api.UploadedImageLink, 0, len(selections))
@@ -596,20 +598,20 @@ func TestPartialMenuRemovalUpdatesResolvedAndRenderedDescription(t *testing.T) {
 			}},
 		})
 	}
-	if err := repo.SaveUploadedImages(context.Background(), sourcePath, "imgbb", uploads); err != nil {
+	if err := repo.SaveUploadedImages(context.Background(), binding, "imgbb", uploads); err != nil {
 		t.Fatalf("save uploads: %v", err)
 	}
-	if err := repo.ReplaceScreenshotSlots(context.Background(), sourcePath, slots); err != nil {
+	if err := repo.ReplaceScreenshotSlots(context.Background(), binding, slots); err != nil {
 		t.Fatalf("save slots: %v", err)
 	}
 
-	meta := api.UploadSubject{SourcePath: sourcePath}
+	meta := api.UploadSubject{MediaBinding: binding, SourcePath: sourcePath}
 	before := resolveAssetsForTest(t, meta, repo)
 	if len(before.MenuImages) != 2 || len(before.Screenshots) != 1 {
 		t.Fatalf("assets before removal = %#v", before)
 	}
 
-	if _, err := repo.DeleteDiscMenuScreenshot(context.Background(), sourcePath, autoFirst); err != nil {
+	if _, err := repo.DeleteDiscMenuScreenshot(context.Background(), binding, autoFirst); err != nil {
 		t.Fatalf("delete first menu: %v", err)
 	}
 	after := resolveAssetsForTest(t, meta, repo)
@@ -636,6 +638,14 @@ func TestPartialMenuRemovalUpdatesResolvedAndRenderedDescription(t *testing.T) {
 	assertDescriptionTokensInOrder(t, description, "Body token", "Disc menu token", "1.png", "Screenshots token", "2.png")
 	if strings.Contains(description, "0.png") {
 		t.Fatalf("removed menu remained in description: %q", description)
+	}
+}
+
+func trackerTestMediaBinding(sourcePath string) api.PreparedMediaBinding {
+	return api.PreparedMediaBinding{
+		SourcePath:               sourcePath,
+		PreparedMediaFingerprint: "test-prepared-media",
+		PreparedGeneration:       1,
 	}
 }
 
@@ -3219,7 +3229,7 @@ func TestEnsureDescriptionImageHostRollsBackUploadedImagesOnSelectionError(t *te
 			},
 		},
 	}
-	meta := api.UploadSubject{SourcePath: "/tmp/source"}
+	meta := api.UploadSubject{MediaBinding: trackerTestMediaBinding("/tmp/source"), SourcePath: "/tmp/source"}
 	images := &stubImageService{
 		uploads: map[string][]api.UploadedImageLink{
 			"pixhost": {

--- a/internal/trackers/description_assets_test.go
+++ b/internal/trackers/description_assets_test.go
@@ -296,10 +296,12 @@ func (s *stubRepo) DeleteUploadedImage(_ context.Context, _ string, imagePath st
 func (s *stubRepo) GetPlaylistSelection(context.Context, string) (api.PlaylistSelection, error) {
 	return api.PlaylistSelection{}, nil
 }
-func (s *stubRepo) SavePlaylistSelection(context.Context, string, []string, bool) error { return nil }
-func (s *stubRepo) DeletePlaylistSelection(context.Context, string) error               { return nil }
-func (s *stubRepo) ListStoredReleasePaths(context.Context) ([]string, error)            { return nil, nil }
-func (s *stubRepo) PurgeContentData(context.Context, string) error                      { return nil }
+func (s *stubRepo) SavePlaylistSelection(context.Context, string, string, []string, bool) error {
+	return nil
+}
+func (s *stubRepo) DeletePlaylistSelection(context.Context, string) error    { return nil }
+func (s *stubRepo) ListStoredReleasePaths(context.Context) ([]string, error) { return nil, nil }
+func (s *stubRepo) PurgeContentData(context.Context, string) error           { return nil }
 
 type stubImageService struct {
 	uploads map[string][]api.UploadedImageLink

--- a/internal/trackers/image_host_resolution.go
+++ b/internal/trackers/image_host_resolution.go
@@ -103,7 +103,7 @@ func ensureDescriptionImageHostWithDataAndRegistry(
 	if !skipUpload {
 		localTrackerImages = resolveLocalTrackerScreenshots(meta, appCfg, tracker, logger)
 		if detachComparisonSourceImagesFromSlots(slots, localTrackerImages) {
-			if err := repo.ReplaceScreenshotSlots(ctx, meta.SourcePath, slots); err != nil {
+			if err := repo.ReplaceScreenshotSlots(ctx, meta.MediaBinding, slots); err != nil {
 				return descriptionImageHostResolution{}, fmt.Errorf("trackers: %w", err)
 			}
 			syncSlotsToPreloaded(preloaded, slots)
@@ -172,7 +172,7 @@ func ensureDescriptionImageHostWithDataAndRegistry(
 	if len(sourceImages) == 0 {
 		sourceImages = localTrackerImages
 		if len(sourceImages) > 0 && !slotsContainComparison(slots) && alignRenderableSlotsToSourceImages(slots, sourceImages) {
-			if err := repo.ReplaceScreenshotSlots(ctx, meta.SourcePath, slots); err != nil {
+			if err := repo.ReplaceScreenshotSlots(ctx, meta.MediaBinding, slots); err != nil {
 				return descriptionImageHostResolution{}, fmt.Errorf("trackers: %w", err)
 			}
 			syncSlotsToPreloaded(preloaded, slots)
@@ -195,7 +195,7 @@ func ensureDescriptionImageHostWithDataAndRegistry(
 			changed = changed || materializeChanged
 		}
 		if changed {
-			if err := repo.ReplaceScreenshotSlots(ctx, meta.SourcePath, slots); err != nil {
+			if err := repo.ReplaceScreenshotSlots(ctx, meta.MediaBinding, slots); err != nil {
 				return descriptionImageHostResolution{}, fmt.Errorf("trackers: %w", err)
 			}
 			syncSlotsToPreloaded(preloaded, slots)
@@ -282,7 +282,7 @@ func ensureDescriptionImageHostWithDataAndRegistry(
 		if err != nil {
 			lastErr = err
 			if len(uploaded) > 0 {
-				cleanupUploadedImages(ctx, repo, meta.SourcePath, uploaded, logger)
+				cleanupUploadedImages(ctx, repo, meta.MediaBinding, uploaded, logger)
 			}
 			feedback.Warnings = append(feedback.Warnings, api.ImageHostWarning{
 				Host:    host,
@@ -300,7 +300,7 @@ func ensureDescriptionImageHostWithDataAndRegistry(
 		}
 		screenshots, _, _, err := selectScreenshotsFromSlots(tracker, candidateSlots, selectionPolicy)
 		if err != nil {
-			cleanupUploadedImages(ctx, repo, meta.SourcePath, uploaded, logger)
+			cleanupUploadedImages(ctx, repo, meta.MediaBinding, uploaded, logger)
 			lastErr = err
 			feedback.Warnings = append(feedback.Warnings, api.ImageHostWarning{
 				Host:    host,
@@ -312,7 +312,7 @@ func ensureDescriptionImageHostWithDataAndRegistry(
 			continue
 		}
 		if len(screenshots) == 0 {
-			cleanupUploadedImages(ctx, repo, meta.SourcePath, uploaded, logger)
+			cleanupUploadedImages(ctx, repo, meta.MediaBinding, uploaded, logger)
 			message := "upload did not produce usable screenshots"
 			feedback.Warnings = append(feedback.Warnings, api.ImageHostWarning{
 				Host:    host,
@@ -323,8 +323,8 @@ func ensureDescriptionImageHostWithDataAndRegistry(
 			}
 			continue
 		}
-		if err := upsertScreenshotVariantsFromUploads(ctx, repo, meta.SourcePath, slots, uploaded); err != nil {
-			cleanupUploadedImages(ctx, repo, meta.SourcePath, uploaded, logger)
+		if err := upsertScreenshotVariantsFromUploads(ctx, repo, meta.MediaBinding, slots, uploaded); err != nil {
+			cleanupUploadedImages(ctx, repo, meta.MediaBinding, uploaded, logger)
 			return descriptionImageHostResolution{}, err
 		}
 		applyUploadedVariantsToSlots(slots, uploaded)
@@ -371,7 +371,16 @@ func imageHostingSubject(meta api.UploadSubject) api.ImageHostingSubject {
 			break
 		}
 	}
-	return api.ImageHostingSubject{SourcePath: meta.SourcePath, GalleryName: galleryName}
+	discs := make([]api.ImageHostingDiscSubject, 0, len(meta.Discs))
+	for _, disc := range meta.Discs {
+		discs = append(discs, api.ImageHostingDiscSubject{ID: disc.ID, Name: disc.Name})
+	}
+	return api.ImageHostingSubject{
+		MediaBinding: meta.MediaBinding,
+		SourcePath:   meta.SourcePath,
+		GalleryName:  galleryName,
+		Discs:        discs,
+	}
 }
 
 func firstPreferredDescriptionImageHost(hosts []string) string {
@@ -469,7 +478,7 @@ func screenshotSlotsFromSourceWithoutPersist(
 		return cloneScreenshotSlots(preloaded.screenshotSlots), nil
 	}
 
-	slots, err := repo.ListScreenshotSlotsByPath(ctx, meta.SourcePath)
+	slots, err := repo.ListScreenshotSlotsByPath(ctx, meta.MediaBinding)
 	if err != nil {
 		return nil, fmt.Errorf("trackers: %w", err)
 	}
@@ -560,8 +569,14 @@ func reusableUploadedScreenshotsForHost(
 	return screenshots, nil
 }
 
-func cleanupUploadedImages(ctx context.Context, repo UploadPersistence, sourcePath string, uploaded []api.UploadedImageLink, logger api.Logger) {
-	if repo == nil || len(uploaded) == 0 || strings.TrimSpace(sourcePath) == "" {
+func cleanupUploadedImages(
+	ctx context.Context,
+	repo UploadPersistence,
+	binding api.PreparedMediaBinding,
+	uploaded []api.UploadedImageLink,
+	logger api.Logger,
+) {
+	if repo == nil || len(uploaded) == 0 || !binding.Valid() {
 		return
 	}
 	seen := make(map[string]struct{}, len(uploaded))
@@ -576,10 +591,10 @@ func cleanupUploadedImages(ctx context.Context, repo UploadPersistence, sourcePa
 			continue
 		}
 		seen[key] = struct{}{}
-		if err := repo.DeleteUploadedImage(ctx, sourcePath, pathValue, hostValue); err != nil && logger != nil {
+		if err := repo.DeleteUploadedImage(ctx, binding, pathValue, hostValue); err != nil && logger != nil {
 			logger.Warnf(
 				"trackers: failed to roll back uploaded image tracker=%s host=%s path=%s: %v",
-				strings.TrimSpace(sourcePath),
+				strings.TrimSpace(binding.SourcePath),
 				hostValue,
 				pathValue,
 				err,

--- a/internal/trackers/image_host_resolution_test.go
+++ b/internal/trackers/image_host_resolution_test.go
@@ -30,9 +30,13 @@ type imageHostResolutionRepo struct {
 	replaceCalls int
 }
 
-func (r *imageHostResolutionRepo) ReplaceScreenshotSlots(ctx context.Context, sourcePath string, slots []api.ScreenshotSlot) error {
+func (r *imageHostResolutionRepo) ReplaceScreenshotSlots(
+	ctx context.Context,
+	binding api.PreparedMediaBinding,
+	slots []api.ScreenshotSlot,
+) error {
 	r.replaceCalls++
-	return r.stubRepo.ReplaceScreenshotSlots(ctx, sourcePath, slots)
+	return r.stubRepo.ReplaceScreenshotSlots(ctx, binding, slots)
 }
 
 func TestEnsureDescriptionImageHostSkipUploadDoesNotMaterializeURLOnlySlots(t *testing.T) {
@@ -53,6 +57,7 @@ func TestEnsureDescriptionImageHostSkipUploadDoesNotMaterializeURLOnlySlots(t *t
 	sourcePath := filepath.Join(t.TempDir(), "source.mkv")
 	repo := &imageHostResolutionRepo{stubRepo: &stubRepo{}}
 	meta := api.UploadSubject{
+		MediaBinding:        trackerTestMediaBinding(sourcePath),
 		SourcePath:          sourcePath,
 		DescriptionOverride: "[center][img]http://8.8.8.8/image.gif[/img][/center]",
 		ImageHostOverrides: api.ImageHostOverrides{

--- a/internal/trackers/persistence.go
+++ b/internal/trackers/persistence.go
@@ -16,13 +16,13 @@ import (
 type UploadPersistence interface {
 	GetDescriptionOverride(context.Context, string, string) (api.DescriptionOverride, error)
 	ListDescriptionOverridesByPath(context.Context, string) ([]api.DescriptionOverride, error)
-	ListFinalSelections(context.Context, string) ([]api.ScreenshotFinalSelection, error)
+	ListFinalSelections(context.Context, api.PreparedMediaBinding) ([]api.ScreenshotFinalSelection, error)
 	ListTrackerMetadataByPath(context.Context, string) ([]api.TrackerMetadata, error)
-	ListUploadedImagesByPath(context.Context, string) ([]api.UploadedImageLink, error)
-	ListScreenshotSlotsByPath(context.Context, string) ([]api.ScreenshotSlot, error)
-	ReplaceScreenshotSlots(context.Context, string, []api.ScreenshotSlot) error
-	UpsertScreenshotSlotVariants(context.Context, string, []api.ScreenshotSlotVariant) error
-	DeleteUploadedImage(context.Context, string, string, string) error
+	ListUploadedImagesByPath(context.Context, api.PreparedMediaBinding) ([]api.UploadedImageLink, error)
+	ListScreenshotSlotsByPath(context.Context, api.PreparedMediaBinding) ([]api.ScreenshotSlot, error)
+	ReplaceScreenshotSlots(context.Context, api.PreparedMediaBinding, []api.ScreenshotSlot) error
+	UpsertScreenshotSlotVariants(context.Context, api.PreparedMediaBinding, []api.ScreenshotSlotVariant) error
+	DeleteUploadedImage(context.Context, api.PreparedMediaBinding, string, string) error
 	SaveTrackerRuleFailures(context.Context, string, string, []api.TrackerRuleFailure) error
 	CreateUploadRecord(context.Context, api.UploadRecord) error
 	UpdateLatestUploadRecordStatus(context.Context, string, string, string) error

--- a/internal/trackers/screenshot_slots.go
+++ b/internal/trackers/screenshot_slots.go
@@ -69,7 +69,7 @@ func screenshotSlotsFromSource(
 		return nil, nil
 	}
 
-	slots, err := repo.ListScreenshotSlotsByPath(ctx, meta.SourcePath)
+	slots, err := repo.ListScreenshotSlotsByPath(ctx, meta.MediaBinding)
 	if err != nil {
 		return nil, fmt.Errorf("trackers: %w", err)
 	}
@@ -98,7 +98,7 @@ func screenshotSlotsFromSource(
 	if len(slots) == 0 {
 		return nil, nil
 	}
-	if err := repo.ReplaceScreenshotSlots(ctx, meta.SourcePath, slots); err != nil {
+	if err := repo.ReplaceScreenshotSlots(ctx, meta.MediaBinding, slots); err != nil {
 		return nil, fmt.Errorf("trackers: %w", err)
 	}
 	return cloneScreenshotSlots(slots), nil
@@ -392,6 +392,7 @@ func attachSelectionPathsToSlots(slots []api.ScreenshotSlot, selections []api.Sc
 			continue
 		}
 		slots[idx].ImagePath = strings.TrimSpace(selections[idx].ImagePath)
+		slots[idx].DiscID = selections[idx].DiscID
 		if strings.TrimSpace(slots[idx].OriginalKey) == "" {
 			slots[idx].OriginalKey = slots[idx].ImagePath
 		}
@@ -451,6 +452,7 @@ func alignRenderableSlotsToSourceImages(slots []api.ScreenshotSlot, sourceImages
 			pathValue := strings.TrimSpace(source.Path)
 			if pathValue != "" && strings.TrimSpace(slots[idx].ImagePath) == "" {
 				slots[idx].ImagePath = pathValue
+				slots[idx].DiscID = source.DiscID
 				if strings.TrimSpace(slots[idx].OriginalKey) == "" {
 					slots[idx].OriginalKey = pathValue
 				}
@@ -495,6 +497,7 @@ func attachMatchingSourceImagesToSlots(slots []api.ScreenshotSlot, sourceImages 
 			continue
 		}
 		slots[idx].ImagePath = pathValue
+		slots[idx].DiscID = source.DiscID
 		if strings.TrimSpace(slots[idx].OriginalKey) == "" {
 			slots[idx].OriginalKey = pathValue
 		}
@@ -572,6 +575,7 @@ func appendSourceImageSlots(slots *[]api.ScreenshotSlot, sourcePath string, sour
 		}
 		*slots = append(*slots, api.ScreenshotSlot{
 			SourcePath:          sourcePath,
+			DiscID:              image.DiscID,
 			SourceKind:          screenshotSlotSourceTracker,
 			OriginalKey:         pathValue,
 			ImagePath:           pathValue,
@@ -605,6 +609,7 @@ func alignRenderableSlotsToSourceImagesByOrder(slots []api.ScreenshotSlot, sourc
 			continue
 		}
 		slots[idx].ImagePath = pathValue
+		slots[idx].DiscID = sourceImages[sourceIdx-1].DiscID
 		if strings.TrimSpace(slots[idx].OriginalKey) == "" {
 			slots[idx].OriginalKey = pathValue
 		}
@@ -655,6 +660,7 @@ func appendSelectionOnlySlots(slots *[]api.ScreenshotSlot, selections []api.Scre
 		}
 		*slots = append(*slots, api.ScreenshotSlot{
 			SourcePath:          selection.SourcePath,
+			DiscID:              selection.DiscID,
 			SourceKind:          screenshotSlotSourceSelection,
 			OriginalKey:         pathValue,
 			ImagePath:           pathValue,
@@ -673,6 +679,7 @@ func buildSelectionSlots(sourcePath string, selections []api.ScreenshotFinalSele
 		}
 		slots = append(slots, api.ScreenshotSlot{
 			SourcePath:          sourcePath,
+			DiscID:              selection.DiscID,
 			SourceKind:          screenshotSlotSourceSelection,
 			OriginalKey:         pathValue,
 			ImagePath:           pathValue,
@@ -715,6 +722,7 @@ func normalizeSlotOrders(slots []api.ScreenshotSlot) []api.ScreenshotSlot {
 		}
 		for variantIdx := range slots[idx].Variants {
 			slots[idx].Variants[variantIdx].SourcePath = slots[idx].SourcePath
+			slots[idx].Variants[variantIdx].DiscID = slots[idx].DiscID
 			slots[idx].Variants[variantIdx].SlotOrder = idx
 			if strings.TrimSpace(slots[idx].Variants[variantIdx].UsageScope) == "" {
 				slots[idx].Variants[variantIdx].UsageScope = globalImageUsageScope
@@ -790,6 +798,7 @@ func ApplyUploadedVariantsToSlots(slots []api.ScreenshotSlot, uploads []api.Uplo
 			directlyMatchedSlots[slotIndexByPointer[slot]] = struct{}{}
 			slot.Variants = upsertVariant(slot.Variants, api.ScreenshotSlotVariant{
 				SourcePath: slot.SourcePath,
+				DiscID:     firstNonEmptyScreenshotValue(upload.DiscID, slot.DiscID),
 				SlotOrder:  slot.SlotOrder,
 				Host:       strings.TrimSpace(upload.Host),
 				UsageScope: normalizeUsageScope(upload.UsageScope),
@@ -831,12 +840,14 @@ func ApplyUploadedVariantsToSlots(slots []api.ScreenshotSlot, uploads []api.Uplo
 		slot := &slots[fallbackSlotIndexes[idx]]
 		if strings.TrimSpace(slot.ImagePath) == "" {
 			slot.ImagePath = strings.TrimSpace(upload.ImagePath)
+			slot.DiscID = upload.DiscID
 			if strings.TrimSpace(slot.OriginalKey) == "" {
 				slot.OriginalKey = slot.ImagePath
 			}
 		}
 		slot.Variants = upsertVariant(slot.Variants, api.ScreenshotSlotVariant{
 			SourcePath: slot.SourcePath,
+			DiscID:     firstNonEmptyScreenshotValue(upload.DiscID, slot.DiscID),
 			SlotOrder:  slot.SlotOrder,
 			Host:       strings.TrimSpace(upload.Host),
 			UsageScope: normalizeUsageScope(upload.UsageScope),
@@ -937,6 +948,7 @@ func selectSlotImageForTracker(slot api.ScreenshotSlot, tracker string, policy i
 				host = strings.TrimSpace(imagehost.ExtractHost(originalURL))
 			}
 			return api.ScreenshotImage{
+				DiscID: slot.DiscID,
 				Path:   strings.TrimSpace(slot.ImagePath),
 				Host:   host,
 				ImgURL: originalURL,
@@ -985,6 +997,7 @@ func selectVariantForSlot(slot api.ScreenshotSlot, tracker string, policy imageH
 		})
 		chosen := candidates[0]
 		return api.ScreenshotImage{
+			DiscID:     firstNonEmptyScreenshotValue(chosen.DiscID, slot.DiscID),
 			Path:       strings.TrimSpace(chosen.ImagePath),
 			Host:       strings.TrimSpace(chosen.Host),
 			ImgURL:     strings.TrimSpace(chosen.ImgURL),
@@ -1061,7 +1074,7 @@ func slotIdentity(slot api.ScreenshotSlot) string {
 func upsertScreenshotVariantsFromUploads(
 	ctx context.Context,
 	repo UploadPersistence,
-	sourcePath string,
+	binding api.PreparedMediaBinding,
 	slots []api.ScreenshotSlot,
 	uploads []api.UploadedImageLink,
 ) error {
@@ -1082,7 +1095,7 @@ func upsertScreenshotVariantsFromUploads(
 		}
 		for _, slotOrder := range slotOrders {
 			variants = append(variants, api.ScreenshotSlotVariant{
-				SourcePath: sourcePath,
+				DiscID:     upload.DiscID,
 				SlotOrder:  slotOrder,
 				Host:       strings.TrimSpace(upload.Host),
 				UsageScope: normalizeUsageScope(upload.UsageScope),
@@ -1094,7 +1107,7 @@ func upsertScreenshotVariantsFromUploads(
 			})
 		}
 	}
-	return wrapTrackerError(repo.UpsertScreenshotSlotVariants(ctx, sourcePath, variants))
+	return wrapTrackerError(repo.UpsertScreenshotSlotVariants(ctx, binding, variants))
 }
 
 func slotSourceImagesForRehost(slots []api.ScreenshotSlot) []api.ScreenshotImage {
@@ -1106,8 +1119,9 @@ func slotSourceImagesForRehost(slots []api.ScreenshotSlot) []api.ScreenshotImage
 			continue
 		}
 		results = append(results, api.ScreenshotImage{
-			Index: preservedScreenshotImageIndex(slot.SlotOrder),
-			Path:  pathValue,
+			DiscID: slot.DiscID,
+			Index:  preservedScreenshotImageIndex(slot.SlotOrder),
+			Path:   pathValue,
 		})
 	}
 	return results
@@ -1115,6 +1129,15 @@ func slotSourceImagesForRehost(slots []api.ScreenshotSlot) []api.ScreenshotImage
 
 func errorsIsNotFound(err error) bool {
 	return errors.Is(err, internalerrors.ErrNotFound)
+}
+
+func firstNonEmptyScreenshotValue(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func syncSlotVariantsToPreloaded(preloaded *preloadedDescriptionAssetData, uploads []api.UploadedImageLink) {

--- a/internal/trackers/service_test.go
+++ b/internal/trackers/service_test.go
@@ -2037,7 +2037,10 @@ func TestUploadReportsCancellationAfterCompletedTrackerUpload(t *testing.T) {
 	cfg := config.Config{Trackers: config.TrackersConfig{DefaultTrackers: config.CSVList{"AITHER"}}}
 	svc := NewServiceWithRegistry(cfg, nil, nil, registry)
 
-	summary, err := svc.Upload(ctx, api.UploadSubject{SourcePath: "/tmp/file"})
+	summary, err := svc.Upload(ctx, api.UploadSubject{
+		MediaBinding: trackerTestMediaBinding("/tmp/file"),
+		SourcePath:   "/tmp/file",
+	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context cancellation after upload, got %v", err)
 	}
@@ -2383,7 +2386,10 @@ func TestUploadRetriesTransientUploadedStatusFailure(t *testing.T) {
 	svc := NewServiceWithRegistry(cfg, nil, repo, registry)
 
 	ctx := context.Background()
-	summary, err := svc.Upload(ctx, api.UploadSubject{SourcePath: "/tmp/file"})
+	summary, err := svc.Upload(ctx, api.UploadSubject{
+		MediaBinding: trackerTestMediaBinding("/tmp/file"),
+		SourcePath:   "/tmp/file",
+	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/webserver/api_v1_routes.go
+++ b/internal/webserver/api_v1_routes.go
@@ -329,6 +329,7 @@ func (s *Server) handleAPIV1WorkflowResource(w http.ResponseWriter, r *http.Requ
 			principal.OwnerID,
 			workflowID,
 			revision,
+			request.DiscID,
 			request.TimestampSeconds,
 		)
 		if err != nil {

--- a/internal/webserver/capabilities.go
+++ b/internal/webserver/capabilities.go
@@ -31,7 +31,7 @@ type ReleaseWorkflowCapability interface {
 	ReleaseWorkflowOperation(context.Context, string, api.WorkflowID, api.WorkflowOperationID) (api.WorkflowOperationStatus, error)
 	CancelReleaseWorkflowOperation(context.Context, string, api.WorkflowID, api.WorkflowOperationID) (api.WorkflowOperationStatus, error)
 	ReleaseWorkflowMediaPlan(context.Context, string, api.WorkflowID) (api.MediaPlan, error)
-	PreviewReleaseWorkflowFrame(context.Context, string, api.WorkflowID, api.WorkflowRevision, float64) (api.FramePreview, error)
+	PreviewReleaseWorkflowFrame(context.Context, string, api.WorkflowID, api.WorkflowRevision, string, float64) (api.FramePreview, error)
 	OpenReleaseWorkflowPreview(context.Context, string, api.WorkflowID, api.PublicResourceID) (releaseworkflow.MediaArtifactContent, error)
 	StageReleaseWorkflowMediaResource(
 		context.Context,

--- a/internal/webserver/openapi/release-workflow-v1.json
+++ b/internal/webserver/openapi/release-workflow-v1.json
@@ -1179,8 +1179,20 @@
           "DurationSeconds": {
             "type": "number"
           },
+          "Items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiscItemFacts"
+            }
+          },
           "PlaylistCount": {
             "type": "integer"
+          },
+          "PrimaryDiscID": {
+            "type": "string"
+          },
+          "PrimaryReportID": {
+            "type": "string"
           },
           "Summary": {
             "type": "string"
@@ -1192,9 +1204,61 @@
         "required": [
           "DVDVOBSet",
           "DurationSeconds",
+          "Items",
           "PlaylistCount",
+          "PrimaryDiscID",
+          "PrimaryReportID",
           "Summary",
           "Type"
+        ]
+      },
+      "DiscItemFacts": {
+        "type": "object",
+        "properties": {
+          "DVDVOBSet": {
+            "type": "string"
+          },
+          "DurationSeconds": {
+            "type": "number"
+          },
+          "ID": {
+            "type": "string"
+          },
+          "Name": {
+            "type": "string"
+          },
+          "Reports": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiscReportFacts"
+            }
+          },
+          "Type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "DVDVOBSet",
+          "DurationSeconds",
+          "ID",
+          "Name",
+          "Reports",
+          "Type"
+        ]
+      },
+      "DiscReportFacts": {
+        "type": "object",
+        "properties": {
+          "Playlist": {
+            "$ref": "#/components/schemas/PlaylistInfo"
+          },
+          "Summary": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "Playlist",
+          "Summary"
         ]
       },
       "DupeAssessment": {
@@ -1704,6 +1768,12 @@
         "type": "object",
         "properties": {
           "contentUrl": {
+            "type": "string"
+          },
+          "discId": {
+            "type": "string"
+          },
+          "discName": {
             "type": "string"
           },
           "expiresAt": {
@@ -2356,6 +2426,12 @@
       "MediaArtifact": {
         "type": "object",
         "properties": {
+          "discId": {
+            "type": "string"
+          },
+          "discName": {
+            "type": "string"
+          },
           "height": {
             "type": "integer"
           },
@@ -2519,6 +2595,9 @@
       "MediaAttachment": {
         "type": "object",
         "properties": {
+          "discId": {
+            "type": "string"
+          },
           "kind": {
             "$ref": "#/components/schemas/MediaArtifactKind"
           },
@@ -2543,6 +2622,12 @@
         "properties": {
           "captureDvdMenus": {
             "type": "boolean"
+          },
+          "manualFrames": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
           },
           "maxDvdMenuItems": {
             "type": "integer"
@@ -2587,6 +2672,35 @@
           "purpose",
           "screenshotCount",
           "trackerId"
+        ]
+      },
+      "MediaDiscPlan": {
+        "type": "object",
+        "properties": {
+          "discId": {
+            "type": "string"
+          },
+          "discName": {
+            "type": "string"
+          },
+          "durationSeconds": {
+            "type": "number"
+          },
+          "frameRate": {
+            "type": "number"
+          },
+          "suggestedSelections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScreenshotSelection"
+            }
+          }
+        },
+        "required": [
+          "discId",
+          "discName",
+          "durationSeconds",
+          "frameRate"
         ]
       },
       "MediaFacts": {
@@ -2714,6 +2828,12 @@
           },
           "discType": {
             "type": "string"
+          },
+          "discs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaDiscPlan"
+            }
           },
           "durationSeconds": {
             "type": "number"
@@ -3168,6 +3288,12 @@
       "PlaylistInfo": {
         "type": "object",
         "properties": {
+          "discId": {
+            "type": "string"
+          },
+          "discName": {
+            "type": "string"
+          },
           "duration": {
             "type": "number"
           },
@@ -3175,6 +3301,9 @@
             "type": "string"
           },
           "file": {
+            "type": "string"
+          },
+          "id": {
             "type": "string"
           },
           "items": {
@@ -3188,9 +3317,12 @@
           }
         },
         "required": [
+          "discId",
+          "discName",
           "duration",
           "edition",
           "file",
+          "id",
           "items",
           "score"
         ]
@@ -3449,6 +3581,9 @@
       "PreviewReleaseWorkflowFrameRequest": {
         "type": "object",
         "properties": {
+          "discId": {
+            "type": "string"
+          },
           "expectedRevision": {
             "$ref": "#/components/schemas/WorkflowRevision"
           },
@@ -6508,6 +6643,9 @@
       "ScreenshotSelection": {
         "type": "object",
         "properties": {
+          "DiscID": {
+            "type": "string"
+          },
           "Frame": {
             "type": "integer"
           },
@@ -6522,6 +6660,7 @@
           }
         },
         "required": [
+          "DiscID",
           "Frame",
           "Index",
           "Source",
@@ -6568,6 +6707,9 @@
           "Container": {
             "type": "string"
           },
+          "DiscCount": {
+            "type": "integer"
+          },
           "DiscType": {
             "type": "string"
           },
@@ -6577,6 +6719,7 @@
         },
         "required": [
           "Container",
+          "DiscCount",
           "DiscType",
           "MediaType"
         ]
@@ -6623,6 +6766,9 @@
           "Disc": {
             "type": "string"
           },
+          "DiscID": {
+            "type": "string"
+          },
           "ModifiedAt": {
             "type": "string"
           },
@@ -6641,6 +6787,7 @@
         },
         "required": [
           "Disc",
+          "DiscID",
           "ModifiedAt",
           "Path",
           "Playlist",
@@ -11227,6 +11374,9 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "discId": {
+                    "type": "string"
+                  },
                   "timestampSeconds": {
                     "type": "number"
                   }

--- a/internal/webserver/release_workflow.go
+++ b/internal/webserver/release_workflow.go
@@ -250,6 +250,7 @@ func (b *Backend) previewReleaseWorkflowFrame(
 	ownerID string,
 	workflowID api.WorkflowID,
 	expectedRevision api.WorkflowRevision,
+	discID string,
 	timestampSeconds float64,
 ) (api.FramePreview, error) {
 	runtime, err := b.requireRuntime()
@@ -260,7 +261,7 @@ func (b *Backend) previewReleaseWorkflowFrame(
 	if err != nil {
 		return api.FramePreview{}, err
 	}
-	preview, err := workflowCore.PreviewReleaseWorkflowFrame(ctx, ownerID, workflowID, expectedRevision, timestampSeconds)
+	preview, err := workflowCore.PreviewReleaseWorkflowFrame(ctx, ownerID, workflowID, expectedRevision, discID, timestampSeconds)
 	if err != nil {
 		return api.FramePreview{}, classifyReleaseWorkflowError(err)
 	}

--- a/internal/webserver/release_workflow_routes.go
+++ b/internal/webserver/release_workflow_routes.go
@@ -202,6 +202,7 @@ func (s *Server) registerReleaseWorkflowAppRoutes(mux *http.ServeMux) {
 			current.ID,
 			request.WorkflowID,
 			request.ExpectedRevision,
+			request.DiscID,
 			request.TimestampSeconds,
 		)
 		if err != nil {

--- a/pkg/api/dvd_menus.go
+++ b/pkg/api/dvd_menus.go
@@ -56,6 +56,10 @@ type DVDMenuCaptureImage struct {
 
 // DVDMenuCaptureWarning is a stable, redacted partial-capture diagnostic.
 type DVDMenuCaptureWarning struct {
+	// DiscID identifies the uncovered prepared disc when applicable.
+	DiscID string
+	// DiscName is the safe page-facing label for the uncovered disc.
+	DiscName string
 	// Code is a stable machine-readable warning identifier.
 	Code string
 	// Message is a redacted user-facing description of the incomplete coverage.

--- a/pkg/api/media_binding.go
+++ b/pkg/api/media_binding.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package api
+
+import "strings"
+
+// PreparedMediaBinding identifies repository media for one exact prepared generation.
+type PreparedMediaBinding struct {
+	SourcePath               string
+	PreparedMediaFingerprint string
+	PreparedGeneration       PreparedGeneration
+}
+
+// Valid reports whether every binding component is present.
+func (b PreparedMediaBinding) Valid() bool {
+	return strings.TrimSpace(b.SourcePath) != "" &&
+		strings.TrimSpace(b.PreparedMediaFingerprint) != "" &&
+		b.PreparedGeneration > 0
+}
+
+// Equal reports exact equality across all binding components.
+func (b PreparedMediaBinding) Equal(other PreparedMediaBinding) bool {
+	return b.SourcePath == other.SourcePath &&
+		b.PreparedMediaFingerprint == other.PreparedMediaFingerprint &&
+		b.PreparedGeneration == other.PreparedGeneration
+}

--- a/pkg/api/media_binding.go
+++ b/pkg/api/media_binding.go
@@ -3,7 +3,11 @@
 
 package api
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
 
 // PreparedMediaBinding identifies repository media for one exact prepared generation.
 type PreparedMediaBinding struct {
@@ -24,4 +28,35 @@ func (b PreparedMediaBinding) Equal(other PreparedMediaBinding) bool {
 	return b.SourcePath == other.SourcePath &&
 		b.PreparedMediaFingerprint == other.PreparedMediaFingerprint &&
 		b.PreparedGeneration == other.PreparedGeneration
+}
+
+// MediaBinding identifies media derived from this exact prepared generation.
+func (r PreparedRelease) MediaBinding() (PreparedMediaBinding, error) {
+	fingerprint, err := CanonicalWorkflowFingerprint(struct {
+		ContractVersion            string
+		SourceFingerprint          string
+		FactInstructionFingerprint string
+		Generation                 PreparedGeneration
+		Discs                      []DiscItemFacts
+		SelectedPlaylists          []PlaylistInfo
+	}{
+		ContractVersion:            r.Compatibility.ContractVersion,
+		SourceFingerprint:          r.Compatibility.SourceFingerprint,
+		FactInstructionFingerprint: r.Compatibility.FactInstructionFingerprint,
+		Generation:                 r.Generation,
+		Discs:                      r.Disc.Items,
+		SelectedPlaylists:          r.Disc.SelectedPlaylists(),
+	})
+	if err != nil {
+		return PreparedMediaBinding{}, fmt.Errorf("prepared release: fingerprint prepared media: %w", err)
+	}
+	binding := PreparedMediaBinding{
+		SourcePath:               r.Source.SourcePath,
+		PreparedMediaFingerprint: string(fingerprint),
+		PreparedGeneration:       r.Generation,
+	}
+	if !binding.Valid() {
+		return PreparedMediaBinding{}, errors.New("prepared release: incomplete media binding")
+	}
+	return binding, nil
 }

--- a/pkg/api/playlists.go
+++ b/pkg/api/playlists.go
@@ -3,8 +3,12 @@
 
 package api
 
-// PlaylistInfo represents a discovered playlist file with its metrics and scoring.
+// PlaylistInfo represents a discovered playlist with an opaque backend ID.
+// DiscID scopes duplicate filenames; File and DiscName are display evidence only.
 type PlaylistInfo struct {
+	ID       string         `json:"id"`
+	DiscID   string         `json:"discId"`
+	DiscName string         `json:"discName"`
 	File     string         `json:"file"`
 	Duration float64        `json:"duration"`
 	Items    []PlaylistItem `json:"items"`

--- a/pkg/api/prepared_release.go
+++ b/pkg/api/prepared_release.go
@@ -87,6 +87,7 @@ type SourceManifestEntry struct {
 	Size       int64
 	ModifiedAt time.Time `ts_type:"string"`
 	Disc       string
+	DiscID     string
 	Playlist   string
 }
 
@@ -94,6 +95,7 @@ type SourceManifestEntry struct {
 // preparation-resource paths.
 type SourceClassification struct {
 	DiscType  string
+	DiscCount int
 	Container string
 	MediaType string
 }
@@ -197,6 +199,108 @@ type DiscFacts struct {
 	DurationSeconds float64
 	PlaylistCount   int
 	DVDVOBSet       string
+	PrimaryDiscID   string
+	PrimaryReportID string
+	Items           []DiscItemFacts
+}
+
+// DiscItemFacts contains canonical public facts for one ordered source disc.
+type DiscItemFacts struct {
+	ID              string
+	Name            string
+	Type            string
+	Reports         []DiscReportFacts
+	DurationSeconds float64
+	DVDVOBSet       string
+}
+
+// DiscReportFacts contains canonical facts for one selected BDMV report.
+type DiscReportFacts struct {
+	Playlist PlaylistInfo
+	Summary  string
+}
+
+// SelectedPlaylists returns all canonical selected playlists in disc/report order.
+func (d DiscFacts) SelectedPlaylists() []PlaylistInfo {
+	playlists := make([]PlaylistInfo, 0, d.PlaylistCount)
+	for _, disc := range d.Items {
+		for _, report := range disc.Reports {
+			playlists = append(playlists, report.Playlist)
+		}
+	}
+	if len(playlists) == 0 {
+		return nil
+	}
+	return playlists
+}
+
+// AggregateSummary returns deterministic plain-text BDMV evidence in disc and report order.
+// One disc with one report remains unchanged after trimming; larger sets receive safe headings.
+func (d DiscFacts) AggregateSummary() string {
+	reportCount := 0
+	for _, disc := range d.Items {
+		reportCount += len(disc.Reports)
+	}
+	if len(d.Items) == 1 && reportCount == 1 {
+		return strings.TrimSpace(d.Items[0].Reports[0].Summary)
+	}
+
+	blocks := make([]string, 0, reportCount)
+	for _, disc := range d.Items {
+		for _, report := range disc.Reports {
+			heading := safeDiscHeading(disc.Name)
+			file := safeDiscHeading(report.Playlist.File)
+			if file != "" {
+				heading = strings.TrimSpace(heading + " — " + file)
+			}
+			if summary := strings.TrimSpace(report.Summary); summary != "" {
+				blocks = append(blocks, strings.TrimSpace(heading+"\n"+summary))
+			}
+		}
+	}
+	return strings.Join(blocks, "\n\n")
+}
+
+// PrimaryReport returns the canonical primary BDMV report when one exists.
+func (d DiscFacts) PrimaryReport() (DiscItemFacts, DiscReportFacts, bool) {
+	for _, item := range d.Items {
+		if item.ID != d.PrimaryDiscID {
+			continue
+		}
+		for _, report := range item.Reports {
+			if report.Playlist.ID == d.PrimaryReportID {
+				return item, report, true
+			}
+		}
+		return DiscItemFacts{}, DiscReportFacts{}, false
+	}
+	return DiscItemFacts{}, DiscReportFacts{}, false
+}
+
+// CanonicalPrimary returns the first disc with a usable title. BDMV reports use
+// highest score with report-order ties; DVD titles use the selected VOB set.
+func (d DiscFacts) CanonicalPrimary() (discID string, reportID string, durationSeconds float64, dvdVOBSet string) {
+	for _, item := range d.Items {
+		if len(item.Reports) > 0 {
+			primary := 0
+			for index := 1; index < len(item.Reports); index++ {
+				if item.Reports[index].Playlist.Score > item.Reports[primary].Playlist.Score {
+					primary = index
+				}
+			}
+			return item.ID, item.Reports[primary].Playlist.ID, item.Reports[primary].Playlist.Duration, ""
+		}
+		if item.Type == "DVD" && strings.TrimSpace(item.DVDVOBSet) != "" {
+			return item.ID, "", item.DurationSeconds, item.DVDVOBSet
+		}
+	}
+	return "", "", 0, ""
+}
+
+func safeDiscHeading(value string) string {
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	return strings.Join(strings.Fields(value), " ")
 }
 
 // UniqueIDStatus records the concrete MediaInfo unique-ID assessment.

--- a/pkg/api/prepared_release_test.go
+++ b/pkg/api/prepared_release_test.go
@@ -8,6 +8,83 @@ import (
 	"testing"
 )
 
+func TestDiscFactsAggregateSummaryPreservesSingleReport(t *testing.T) {
+	t.Parallel()
+
+	facts := DiscFacts{Items: []DiscItemFacts{{
+		ID:   "disc-one",
+		Name: "Disc 1",
+		Reports: []DiscReportFacts{{
+			Playlist: PlaylistInfo{ID: "00001.MPLS", File: "00001.MPLS"},
+			Summary:  "\nBDINFO ONE\n",
+		}},
+	}}}
+	if got := facts.AggregateSummary(); got != "BDINFO ONE" {
+		t.Fatalf("aggregate summary = %q", got)
+	}
+}
+
+func TestDiscFactsAggregateSummaryUsesStableSafeHeadings(t *testing.T) {
+	t.Parallel()
+
+	facts := DiscFacts{Items: []DiscItemFacts{
+		{
+			ID:   "disc-one",
+			Name: "Disc\n1",
+			Reports: []DiscReportFacts{
+				{Playlist: PlaylistInfo{ID: "one", File: "00001.MPLS"}, Summary: "BDINFO ONE"},
+				{Playlist: PlaylistInfo{ID: "two", File: "00002.MPLS"}, Summary: "BDINFO TWO"},
+			},
+		},
+		{
+			ID:   "disc-two",
+			Name: "Disc 2",
+			Reports: []DiscReportFacts{{
+				Playlist: PlaylistInfo{ID: "three", File: "00001.MPLS\r\n"},
+				Summary:  "BDINFO THREE",
+			}},
+		},
+	}}
+	want := "Disc 1 — 00001.MPLS\nBDINFO ONE\n\n" +
+		"Disc 1 — 00002.MPLS\nBDINFO TWO\n\n" +
+		"Disc 2 — 00001.MPLS\nBDINFO THREE"
+	if got := facts.AggregateSummary(); got != want {
+		t.Fatalf("aggregate summary = %q, want %q", got, want)
+	}
+}
+
+func TestDiscFactsCanonicalPrimaryUsesFirstDiscAndHighestScore(t *testing.T) {
+	t.Parallel()
+
+	facts := DiscFacts{Items: []DiscItemFacts{
+		{
+			ID: "disc-one",
+			Reports: []DiscReportFacts{
+				{Playlist: PlaylistInfo{
+ID: "lower",
+ Duration: 100,
+ Score: 10,
+}},
+				{Playlist: PlaylistInfo{
+ID: "higher",
+ Duration: 200,
+ Score: 20,
+}},
+				{Playlist: PlaylistInfo{
+ID: "equal-later",
+ Duration: 300,
+ Score: 20,
+}},
+			},
+		},
+		{ID: "disc-two", Reports: []DiscReportFacts{{Playlist: PlaylistInfo{ID: "later", Score: 100}}}},
+	}}
+	discID, reportID, duration, vobSet := facts.CanonicalPrimary()
+	if discID != "disc-one" || reportID != "higher" || duration != 200 || vobSet != "" {
+		t.Fatalf("canonical primary = %q/%q/%.0f/%q", discID, reportID, duration, vobSet)
+	}
+}
+
 func TestPreparedReleaseCloneDetachesCollections(t *testing.T) {
 	source := PreparedRelease{
 		Source: SourceManifest{

--- a/pkg/api/repository.go
+++ b/pkg/api/repository.go
@@ -187,20 +187,24 @@ type DescriptionOverride struct {
 
 type PlaylistSelection struct {
 	SourcePath        string
+	SourceFingerprint string
 	SelectedPlaylists []string
 	UseAll            bool
 	UpdatedAt         time.Time `ts_type:"string"`
 }
 
 type Screenshot struct {
-	SourcePath  string
-	ImagePath   string
-	Timestamp   float64
-	FrameNumber int
-	Width       int
-	Height      int
-	Purpose     ScreenshotPurpose
-	CapturedAt  time.Time `ts_type:"string"`
+	SourcePath               string
+	PreparedMediaFingerprint string
+	PreparedGeneration       PreparedGeneration
+	DiscID                   string
+	ImagePath                string
+	Timestamp                float64
+	FrameNumber              int
+	Width                    int
+	Height                   int
+	Purpose                  ScreenshotPurpose
+	CapturedAt               time.Time `ts_type:"string"`
 }
 
 // DiscMenuDeleteResult describes local references removed by one atomic menu
@@ -287,7 +291,7 @@ type ReleaseSelectionRepository interface {
 	SaveDescriptionOverride(ctx context.Context, override DescriptionOverride) error
 	DeleteDescriptionOverride(ctx context.Context, path string, groupKey string) error
 	GetPlaylistSelection(ctx context.Context, sourcePath string) (PlaylistSelection, error)
-	SavePlaylistSelection(ctx context.Context, sourcePath string, playlists []string, useAll bool) error
+	SavePlaylistSelection(ctx context.Context, sourcePath string, sourceFingerprint string, playlists []string, useAll bool) error
 }
 
 // HistoryCleanupSnapshot contains persisted local paths needed by Core's

--- a/pkg/api/repository.go
+++ b/pkg/api/repository.go
@@ -229,17 +229,22 @@ type DiscMenuDeleteResult struct {
 // must stay atomic without expanding the general metadata repository contract.
 type ScreenshotLifecycleRepository interface {
 	// ReplaceNormalFinalSelections replaces non-menu selections while preserving disc menus.
-	ReplaceNormalFinalSelections(ctx context.Context, path string, selections []ScreenshotFinalSelection) error
+	ReplaceNormalFinalSelections(ctx context.Context, binding PreparedMediaBinding, selections []ScreenshotFinalSelection) error
 	// AppendManualMenuScreenshots atomically appends manual menu records and selections.
-	AppendManualMenuScreenshots(ctx context.Context, path string, screenshots []Screenshot, selections []ScreenshotFinalSelection) error
+	AppendManualMenuScreenshots(ctx context.Context, binding PreparedMediaBinding, screenshots []Screenshot, selections []ScreenshotFinalSelection) error
 	// ReplaceDVDMenuScreenshots atomically replaces automatic captures and returns their old local paths.
-	ReplaceDVDMenuScreenshots(ctx context.Context, path string, screenshots []Screenshot, selections []ScreenshotFinalSelection) ([]string, error)
+	ReplaceDVDMenuScreenshots(
+		ctx context.Context,
+		binding PreparedMediaBinding,
+		screenshots []Screenshot,
+		selections []ScreenshotFinalSelection,
+	) ([]string, error)
 	// DeleteDiscMenuScreenshot atomically removes one manual or automatic menu
 	// selection and returns the local records needed to compensate the deletion.
-	DeleteDiscMenuScreenshot(ctx context.Context, path string, imagePath string) (DiscMenuDeleteResult, error)
+	DeleteDiscMenuScreenshot(ctx context.Context, binding PreparedMediaBinding, imagePath string) (DiscMenuDeleteResult, error)
 	// RestoreDiscMenuScreenshot atomically restores a result returned by
 	// DeleteDiscMenuScreenshot for the same source path.
-	RestoreDiscMenuScreenshot(ctx context.Context, path string, deleted DiscMenuDeleteResult) error
+	RestoreDiscMenuScreenshot(ctx context.Context, binding PreparedMediaBinding, deleted DiscMenuDeleteResult) error
 }
 
 type DVDMediaInfo struct {
@@ -344,19 +349,19 @@ type MediaAssetSnapshot struct {
 // uploaded-image records. Screenshot lifecycle mutations are atomic.
 type MediaAssetRepository interface {
 	ScreenshotLifecycleRepository
-	LoadMediaAssetSnapshot(ctx context.Context, path string) (MediaAssetSnapshot, error)
-	SaveScreenshot(ctx context.Context, screenshot Screenshot) error
-	ListScreenshotsByPath(ctx context.Context, path string) ([]Screenshot, error)
-	DeleteScreenshot(ctx context.Context, imagePath string) error
-	SaveFinalSelections(ctx context.Context, path string, selections []ScreenshotFinalSelection) error
-	ListFinalSelections(ctx context.Context, path string) ([]ScreenshotFinalSelection, error)
-	DeleteFinalSelection(ctx context.Context, imagePath string) error
-	ReplaceScreenshotSlots(ctx context.Context, path string, slots []ScreenshotSlot) error
-	ListScreenshotSlotsByPath(ctx context.Context, path string) ([]ScreenshotSlot, error)
-	UpsertScreenshotSlotVariants(ctx context.Context, path string, variants []ScreenshotSlotVariant) error
-	SaveUploadedImages(ctx context.Context, path string, host string, images []UploadedImageLink) error
-	ListUploadedImagesByPath(ctx context.Context, path string) ([]UploadedImageLink, error)
-	DeleteUploadedImage(ctx context.Context, path string, imagePath string, host string) error
+	LoadMediaAssetSnapshot(ctx context.Context, binding PreparedMediaBinding) (MediaAssetSnapshot, error)
+	SaveScreenshot(ctx context.Context, binding PreparedMediaBinding, screenshot Screenshot) error
+	ListScreenshotsByPath(ctx context.Context, binding PreparedMediaBinding) ([]Screenshot, error)
+	DeleteScreenshot(ctx context.Context, binding PreparedMediaBinding, imagePath string) error
+	SaveFinalSelections(ctx context.Context, binding PreparedMediaBinding, selections []ScreenshotFinalSelection) error
+	ListFinalSelections(ctx context.Context, binding PreparedMediaBinding) ([]ScreenshotFinalSelection, error)
+	DeleteFinalSelection(ctx context.Context, binding PreparedMediaBinding, imagePath string) error
+	ReplaceScreenshotSlots(ctx context.Context, binding PreparedMediaBinding, slots []ScreenshotSlot) error
+	ListScreenshotSlotsByPath(ctx context.Context, binding PreparedMediaBinding) ([]ScreenshotSlot, error)
+	UpsertScreenshotSlotVariants(ctx context.Context, binding PreparedMediaBinding, variants []ScreenshotSlotVariant) error
+	SaveUploadedImages(ctx context.Context, binding PreparedMediaBinding, host string, images []UploadedImageLink) error
+	ListUploadedImagesByPath(ctx context.Context, binding PreparedMediaBinding) ([]UploadedImageLink, error)
+	DeleteUploadedImage(ctx context.Context, binding PreparedMediaBinding, imagePath string, host string) error
 }
 
 // ReleaseWorkflowStateRecord is one owner-scoped durable public workflow

--- a/pkg/api/screenshot_slots.go
+++ b/pkg/api/screenshot_slots.go
@@ -6,28 +6,34 @@ package api
 import "time"
 
 type ScreenshotSlot struct {
-	SourcePath          string
-	SlotOrder           int
-	SourceKind          string
-	OriginalKey         string
-	OriginalURL         string
-	OriginalHost        string
-	ImagePath           string
-	FromDescription     bool
-	Tracker             string
-	SectionKind         string
-	RenderInScreenshots bool
-	Variants            []ScreenshotSlotVariant
+	SourcePath               string
+	PreparedMediaFingerprint string
+	PreparedGeneration       PreparedGeneration
+	DiscID                   string
+	SlotOrder                int
+	SourceKind               string
+	OriginalKey              string
+	OriginalURL              string
+	OriginalHost             string
+	ImagePath                string
+	FromDescription          bool
+	Tracker                  string
+	SectionKind              string
+	RenderInScreenshots      bool
+	Variants                 []ScreenshotSlotVariant
 }
 
 type ScreenshotSlotVariant struct {
-	SourcePath string
-	SlotOrder  int
-	Host       string
-	UsageScope string
-	ImagePath  string
-	ImgURL     string
-	RawURL     string
-	WebURL     string
-	UploadedAt time.Time `ts_type:"string"`
+	SourcePath               string
+	PreparedMediaFingerprint string
+	PreparedGeneration       PreparedGeneration
+	DiscID                   string
+	SlotOrder                int
+	Host                     string
+	UsageScope               string
+	ImagePath                string
+	ImgURL                   string
+	RawURL                   string
+	WebURL                   string
+	UploadedAt               time.Time `ts_type:"string"`
 }

--- a/pkg/api/screenshots.go
+++ b/pkg/api/screenshots.go
@@ -40,6 +40,7 @@ func IsDiscMenuSelectionSource(source string) bool {
 }
 
 type ScreenshotSelection struct {
+	// DiscID is required when the prepared source contains multiple discs.
 	DiscID           string
 	Index            int
 	TimestampSeconds float64
@@ -57,8 +58,13 @@ type ScreenshotOverrides struct {
 // ScreenshotSubject contains only source facts required to plan and manage
 // screenshots. Workflow modules build it from an exact prepared generation.
 type ScreenshotSubject struct {
-	MediaBinding          PreparedMediaBinding
-	SourcePath            string
+	// MediaBinding owns persisted media for one exact prepared generation.
+	MediaBinding PreparedMediaBinding
+	SourcePath   string
+	DiscID       string
+	DiscName     string
+	// DiscRoot is the private filesystem root used only by the selected disc capture.
+	DiscRoot              string
 	DiscType              string
 	VideoPath             string
 	MediaInfoJSONPath     string
@@ -75,9 +81,11 @@ type ScreenshotSubject struct {
 
 // ScreenshotDiscSubject contains private capture inputs for one ordered disc.
 type ScreenshotDiscSubject struct {
-	ID                    string
-	Name                  string
-	Type                  string
+	ID   string
+	Name string
+	Type string
+	// Root is the private filesystem root for this disc.
+	Root                  string
 	VideoPath             string
 	MediaInfoJSONPath     string
 	SelectedBDMVPlaylists []PlaylistInfo
@@ -102,9 +110,18 @@ type DVDMenuDiscSubject struct {
 // ImageHostingSubject scopes image-host operations to one prepared source.
 // GalleryName is the already-resolved display name used by batch hosts.
 type ImageHostingSubject struct {
+	// MediaBinding owns persisted uploads and slot variants for one exact prepared generation.
 	MediaBinding PreparedMediaBinding
 	SourcePath   string
 	GalleryName  string
+	// Discs defines stable display and upload ordering without exposing private roots.
+	Discs []ImageHostingDiscSubject
+}
+
+// ImageHostingDiscSubject identifies one ordered disc without private paths.
+type ImageHostingDiscSubject struct {
+	ID   string
+	Name string
 }
 
 type ScreenshotFinalSelection struct {

--- a/pkg/api/screenshots.go
+++ b/pkg/api/screenshots.go
@@ -40,6 +40,7 @@ func IsDiscMenuSelectionSource(source string) bool {
 }
 
 type ScreenshotSelection struct {
+	DiscID           string
 	Index            int
 	TimestampSeconds float64
 	Frame            int
@@ -56,6 +57,7 @@ type ScreenshotOverrides struct {
 // ScreenshotSubject contains only source facts required to plan and manage
 // screenshots. Workflow modules build it from an exact prepared generation.
 type ScreenshotSubject struct {
+	MediaBinding          PreparedMediaBinding
 	SourcePath            string
 	DiscType              string
 	VideoPath             string
@@ -68,31 +70,56 @@ type ScreenshotSubject struct {
 	SelectedBDMVPlaylists []PlaylistInfo
 	DefaultCount          int
 	ManualFrames          []int
+	Discs                 []ScreenshotDiscSubject
+}
+
+// ScreenshotDiscSubject contains private capture inputs for one ordered disc.
+type ScreenshotDiscSubject struct {
+	ID                    string
+	Name                  string
+	Type                  string
+	VideoPath             string
+	MediaInfoJSONPath     string
+	SelectedBDMVPlaylists []PlaylistInfo
 }
 
 // DVDMenuSubject contains the stable source facts required by DVD-menu
 // capture and lifecycle operations.
 type DVDMenuSubject struct {
-	SourcePath string
-	DiscType   string
+	MediaBinding PreparedMediaBinding
+	SourcePath   string
+	DiscType     string
+	Discs        []DVDMenuDiscSubject
+}
+
+// DVDMenuDiscSubject identifies one private DVD root eligible for menu capture.
+type DVDMenuDiscSubject struct {
+	ID   string
+	Name string
+	Root string
 }
 
 // ImageHostingSubject scopes image-host operations to one prepared source.
 // GalleryName is the already-resolved display name used by batch hosts.
 type ImageHostingSubject struct {
-	SourcePath  string
-	GalleryName string
+	MediaBinding PreparedMediaBinding
+	SourcePath   string
+	GalleryName  string
 }
 
 type ScreenshotFinalSelection struct {
-	SourcePath string
-	ImagePath  string
-	Order      int
-	Source     string
-	SelectedAt time.Time `ts_type:"string"`
+	SourcePath               string
+	PreparedMediaFingerprint string
+	PreparedGeneration       PreparedGeneration
+	DiscID                   string
+	ImagePath                string
+	Order                    int
+	Source                   string
+	SelectedAt               time.Time `ts_type:"string"`
 }
 
 type ScreenshotPlan struct {
+	MediaBinding               PreparedMediaBinding
 	SourcePath                 string
 	DiscType                   string
 	DurationSeconds            float64
@@ -105,6 +132,16 @@ type ScreenshotPlan struct {
 	PreviewImages              []ScreenshotImage
 	MetadataTimestamp          string
 	RequiresManualFrames       bool
+	Discs                      []ScreenshotDiscPlan
+}
+
+// ScreenshotDiscPlan is one ordered disc's timing and selection plan.
+type ScreenshotDiscPlan struct {
+	DiscID              string
+	DiscName            string
+	DurationSeconds     float64
+	FrameRate           float64
+	SuggestedSelections []ScreenshotSelection
 }
 
 type ScreenshotLinkedImage struct {
@@ -115,6 +152,8 @@ type ScreenshotLinkedImage struct {
 }
 
 type ScreenshotImage struct {
+	DiscID           string
+	DiscName         string
 	Index            int
 	TimestampSeconds float64
 	Path             string
@@ -132,6 +171,8 @@ type ScreenshotImage struct {
 }
 
 type ScreenshotPreview struct {
+	DiscID           string
+	DiscName         string
 	TimestampSeconds float64
 	ImageBytes       []byte
 	Width            int
@@ -149,6 +190,7 @@ type ScreenshotResult struct {
 }
 
 type ScreenshotError struct {
+	DiscID  string
 	Index   int
 	Message string
 }

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -95,6 +95,7 @@ type DuplicateSubject struct {
 	ProviderMetadata     SourceScopedMetadata
 	TrackerIDs           map[string]string
 	DiscType             string
+	Disc                 DiscFacts
 	Type                 string
 	Source               string
 	Tag                  string
@@ -158,6 +159,37 @@ type DVDMenuService interface {
 type ImageHostingService interface {
 	ListCandidates(ctx context.Context, subject ImageHostingSubject) ([]ScreenshotImage, error)
 	Upload(ctx context.Context, subject ImageHostingSubject, host string, usageScope string, images []ScreenshotImage) ([]UploadedImageLink, error)
+}
+
+// DiscReportResource contains one selected BDMV report and its private artifacts.
+type DiscReportResource struct {
+	Playlist        PlaylistInfo
+	Summary         string
+	ExtSummary      string
+	FullSummary     string
+	SummaryPath     string
+	ExtSummaryPath  string
+	FullSummaryPath string
+}
+
+// DiscEvidenceResource contains preparation-private evidence for one ordered disc.
+type DiscEvidenceResource struct {
+	ID                  string
+	Name                string
+	Type                string
+	Root                string
+	SelectedPlaylists   []PlaylistInfo
+	VideoPath           string
+	FileList            []string
+	Reports             []DiscReportResource
+	MediaInfoJSONPath   string
+	MediaInfoTextPath   string
+	DVDIFOPath          string
+	DVDVOBPath          string
+	DVDVOBSet           string
+	DurationSeconds     float64
+	DVDVOBMediaInfoJSON string
+	DVDVOBMediaInfoText string
 }
 
 type TrackerBlockReason string
@@ -237,6 +269,7 @@ func validateExactMediaUploads(channel string, uploads []UploadedImageLink, allo
 // instruction, and prerequisite view. It excludes preparation diagnostics,
 // resolver evidence, cache freshness, and client-search implementation state.
 type UploadSubject struct {
+	MediaBinding        PreparedMediaBinding
 	SourcePath          string
 	Paths               []string
 	DiscType            string
@@ -292,6 +325,7 @@ type UploadSubject struct {
 	Identity                    ExternalIdentity
 	ProviderMetadata            SourceScopedMetadata
 	Disc                        DiscFacts
+	Discs                       []DiscEvidenceResource
 	AudioLanguages              []string
 	SubtitleLanguages           []string
 	Container                   string
@@ -1279,6 +1313,7 @@ func NewRuleSubject(subject UploadSubject) RuleSubject {
 // DescriptionSubject contains only facts, local resources, and rendering
 // instructions consumed by tracker description builders.
 type DescriptionSubject struct {
+	MediaBinding          PreparedMediaBinding
 	SourcePath            string
 	DiscType              string
 	MediaInfoTextPath     string
@@ -1288,6 +1323,8 @@ type DescriptionSubject struct {
 	Options               UploadOptions
 	Release               ReleaseInfo
 	SelectedBDMVPlaylists []PlaylistInfo
+	Disc                  DiscFacts
+	Discs                 []DiscEvidenceResource
 	Tag                   string
 	Identity              ExternalIdentity
 	ProviderMetadata      SourceScopedMetadata
@@ -1312,6 +1349,7 @@ type DescriptionSubject struct {
 // read model and detaches mutable collections.
 func NewDescriptionSubject(subject UploadSubject) DescriptionSubject {
 	projected := DescriptionSubject{
+		MediaBinding:          subject.MediaBinding,
 		SourcePath:            subject.SourcePath,
 		DiscType:              subject.DiscType,
 		MediaInfoTextPath:     subject.MediaInfoTextPath,
@@ -1321,6 +1359,8 @@ func NewDescriptionSubject(subject UploadSubject) DescriptionSubject {
 		Options:               subject.Options,
 		Release:               subject.Release,
 		SelectedBDMVPlaylists: append([]PlaylistInfo(nil), subject.SelectedBDMVPlaylists...),
+		Disc:                  subject.Disc,
+		Discs:                 append([]DiscEvidenceResource(nil), subject.Discs...),
 		Tag:                   subject.Tag,
 		Identity:              subject.Identity,
 		ProviderMetadata:      subject.ProviderMetadata,

--- a/pkg/api/services.go
+++ b/pkg/api/services.go
@@ -139,7 +139,7 @@ type TrackerAuthService interface {
 type ScreenshotService interface {
 	Plan(ctx context.Context, subject ScreenshotSubject, count int) (ScreenshotPlan, error)
 	Capture(ctx context.Context, subject ScreenshotSubject, selections []ScreenshotSelection, purpose ScreenshotPurpose) (ScreenshotResult, error)
-	PreviewFrame(ctx context.Context, subject ScreenshotSubject, timestampSeconds float64) (ScreenshotPreview, error)
+	PreviewFrame(ctx context.Context, subject ScreenshotSubject, discID string, timestampSeconds float64) (ScreenshotPreview, error)
 	Delete(ctx context.Context, subject ScreenshotSubject, imagePath string) error
 	SaveFinalSelections(ctx context.Context, subject ScreenshotSubject, images []ScreenshotImage) error
 }

--- a/pkg/api/uploaded_images.go
+++ b/pkg/api/uploaded_images.go
@@ -6,15 +6,18 @@ package api
 import "time"
 
 type UploadedImageLink struct {
-	SourcePath string
-	ImagePath  string
-	Host       string
-	UsageScope string
-	ImgURL     string
-	RawURL     string
-	WebURL     string
-	SizeBytes  int64
-	UploadedAt time.Time `ts_type:"string"`
+	SourcePath               string
+	PreparedMediaFingerprint string
+	PreparedGeneration       PreparedGeneration
+	DiscID                   string
+	ImagePath                string
+	Host                     string
+	UsageScope               string
+	ImgURL                   string
+	RawURL                   string
+	WebURL                   string
+	SizeBytes                int64
+	UploadedAt               time.Time `ts_type:"string"`
 }
 
 // UploadImageHostFailure describes a single host-level image upload failure

--- a/pkg/api/workflow_contracts.go
+++ b/pkg/api/workflow_contracts.go
@@ -498,7 +498,11 @@ const (
 
 // MediaArtifact is a safe opaque projection of one retained private artifact.
 type MediaArtifact struct {
-	ID               PublicResourceID  `json:"id"`
+	ID PublicResourceID `json:"id"`
+	// DiscID identifies the prepared disc that produced this artifact.
+	DiscID string `json:"discId,omitempty"`
+	// DiscName is the safe page-facing label derived from prepared facts.
+	DiscName         string            `json:"discName,omitempty"`
 	Kind             MediaArtifactKind `json:"kind"`
 	Purpose          ScreenshotPurpose `json:"purpose"`
 	Selected         bool              `json:"selected"`
@@ -519,7 +523,9 @@ type MediaCaptureInstructions struct {
 	ScreenshotCount int                   `json:"screenshotCount"`
 	Purpose         ScreenshotPurpose     `json:"purpose"`
 	Selections      []ScreenshotSelection `json:"selections,omitempty"`
-	CaptureDVDMenus bool                  `json:"captureDvdMenus"`
+	// ManualFrames applies the same raw frame numbers to every prepared disc.
+	ManualFrames    []int `json:"manualFrames,omitempty"`
+	CaptureDVDMenus bool  `json:"captureDvdMenus"`
 	// MaxDVDMenuItems caps an explicitly requested automatic menu capture.
 	MaxDVDMenuItems int `json:"maxDvdMenuItems,omitempty"`
 }

--- a/pkg/api/workflow_intent_contracts.go
+++ b/pkg/api/workflow_intent_contracts.go
@@ -37,9 +37,20 @@ type MediaPlan struct {
 	FrameRate           float64                        `json:"frameRate"`
 	DiscType            string                         `json:"discType,omitempty"`
 	SuggestedSelections []ScreenshotSelection          `json:"suggestedSelections,omitempty"`
-	Requirements        []MediaCaptureRequirement      `json:"requirements,omitempty"`
-	ExistingArtifacts   []MediaArtifact                `json:"existingArtifacts,omitempty"`
-	CreatedAt           time.Time                      `json:"createdAt" ts_type:"string"`
+	// Discs contains ordered per-disc timing and suggestions.
+	Discs             []MediaDiscPlan           `json:"discs,omitempty"`
+	Requirements      []MediaCaptureRequirement `json:"requirements,omitempty"`
+	ExistingArtifacts []MediaArtifact           `json:"existingArtifacts,omitempty"`
+	CreatedAt         time.Time                 `json:"createdAt" ts_type:"string"`
+}
+
+// MediaDiscPlan is one safe page-facing disc capture plan.
+type MediaDiscPlan struct {
+	DiscID              string                `json:"discId"`
+	DiscName            string                `json:"discName"`
+	DurationSeconds     float64               `json:"durationSeconds"`
+	FrameRate           float64               `json:"frameRate"`
+	SuggestedSelections []ScreenshotSelection `json:"suggestedSelections,omitempty"`
 }
 
 // FramePreview is one non-authoritative opaque frame preview.
@@ -48,9 +59,13 @@ type FramePreview struct {
 	WorkflowID       WorkflowID         `json:"workflowId"`
 	WorkflowRevision WorkflowRevision   `json:"workflowRevision"`
 	Release          ReleaseSnapshotRef `json:"release"`
-	TimestampSeconds float64            `json:"timestampSeconds"`
-	ContentURL       string             `json:"contentUrl"`
-	ExpiresAt        time.Time          `json:"expiresAt" ts_type:"string"`
+	// DiscID identifies the prepared disc used for the preview.
+	DiscID string `json:"discId,omitempty"`
+	// DiscName is the safe page-facing label for DiscID.
+	DiscName         string    `json:"discName,omitempty"`
+	TimestampSeconds float64   `json:"timestampSeconds"`
+	ContentURL       string    `json:"contentUrl"`
+	ExpiresAt        time.Time `json:"expiresAt" ts_type:"string"`
 }
 
 // MediaAttachment describes staged private bytes to attach to retained workflow media.
@@ -58,7 +73,9 @@ type MediaAttachment struct {
 	Resource WorkflowResourceRef `json:"resource"`
 	Kind     MediaArtifactKind   `json:"kind"`
 	Purpose  ScreenshotPurpose   `json:"purpose"`
-	Order    int                 `json:"order,omitempty"`
+	// DiscID is required for a multi-disc attachment and optional for single-disc compatibility.
+	DiscID string `json:"discId,omitempty"`
+	Order  int    `json:"order,omitempty"`
 }
 
 // HostedImageAttempt is the absolute outcome of one host attempt for exact media lineage.

--- a/pkg/api/workflow_requests.go
+++ b/pkg/api/workflow_requests.go
@@ -138,6 +138,8 @@ func (r GetReleaseWorkflowMediaPlanRequest) Validate() error {
 // PreviewReleaseWorkflowFrameRequest creates a non-authoritative frame preview.
 type PreviewReleaseWorkflowFrameRequest struct {
 	ReleaseWorkflowCommandContext
+	// DiscID is required for multi-disc previews and optional for single-disc compatibility.
+	DiscID           string  `json:"discId,omitempty"`
 	TimestampSeconds float64 `json:"timestampSeconds"`
 }
 
@@ -234,7 +236,13 @@ type CaptureReleaseWorkflowMediaRequest struct {
 
 // Validate verifies exact revision authority.
 func (r CaptureReleaseWorkflowMediaRequest) Validate() error {
-	return r.ReleaseWorkflowCommandContext.Validate()
+	if err := r.ReleaseWorkflowCommandContext.Validate(); err != nil {
+		return err
+	}
+	if len(r.Instructions.Selections) > 0 && len(r.Instructions.ManualFrames) > 0 {
+		return errors.New("media selections and manual frames are mutually exclusive")
+	}
+	return nil
 }
 
 // SetReleaseWorkflowMediaSelectionRequest changes opaque artifact selection.

--- a/webui/src/api/generated/release-workflow.ts
+++ b/webui/src/api/generated/release-workflow.ts
@@ -277,9 +277,26 @@ export type DiagnosticSeverity = string;
 export type DiscFacts = Readonly<{
   DVDVOBSet: string;
   DurationSeconds: number;
+  Items: readonly DiscItemFacts[];
   PlaylistCount: number;
+  PrimaryDiscID: string;
+  PrimaryReportID: string;
   Summary: string;
   Type: string;
+}>;
+
+export type DiscItemFacts = Readonly<{
+  DVDVOBSet: string;
+  DurationSeconds: number;
+  ID: string;
+  Name: string;
+  Reports: readonly DiscReportFacts[];
+  Type: string;
+}>;
+
+export type DiscReportFacts = Readonly<{
+  Playlist: PlaylistInfo;
+  Summary: string;
 }>;
 
 export type DupeAssessment = Readonly<{
@@ -423,6 +440,8 @@ export type FailedTrackerRetryRef = Readonly<{
 
 export type FramePreview = Readonly<{
   contentUrl: string;
+  discId?: string;
+  discName?: string;
   expiresAt: string;
   id: PublicResourceID;
   release: ReleaseSnapshotRef;
@@ -601,6 +620,8 @@ export type InvalidateReleaseWorkflowTrackersRequest = Readonly<{
 }>;
 
 export type MediaArtifact = Readonly<{
+  discId?: string;
+  discName?: string;
   height?: number;
   host?: string;
   id: PublicResourceID;
@@ -646,6 +667,7 @@ export type MediaArtifactSetRef = Readonly<{
 }>;
 
 export type MediaAttachment = Readonly<{
+  discId?: string;
   kind: MediaArtifactKind;
   order?: number;
   purpose: ScreenshotPurpose;
@@ -654,6 +676,7 @@ export type MediaAttachment = Readonly<{
 
 export type MediaCaptureInstructions = Readonly<{
   captureDvdMenus: boolean;
+  manualFrames?: readonly number[];
   maxDvdMenuItems?: number;
   purpose: ScreenshotPurpose;
   screenshotCount: number;
@@ -665,6 +688,14 @@ export type MediaCaptureRequirement = Readonly<{
   purpose: ScreenshotPurpose;
   screenshotCount: number;
   trackerId: TrackerID;
+}>;
+
+export type MediaDiscPlan = Readonly<{
+  discId: string;
+  discName: string;
+  durationSeconds: number;
+  frameRate: number;
+  suggestedSelections?: readonly ScreenshotSelection[];
 }>;
 
 export type MediaFacts = Readonly<{
@@ -699,6 +730,7 @@ export type MediaFacts = Readonly<{
 export type MediaPlan = Readonly<{
   createdAt: string;
   discType?: string;
+  discs?: readonly MediaDiscPlan[];
   durationSeconds: number;
   existingArtifacts?: readonly MediaArtifact[];
   frameRate: number;
@@ -812,9 +844,12 @@ export type OperationRecovery = string;
 export type OverrideState = string;
 
 export type PlaylistInfo = Readonly<{
+  discId: string;
+  discName: string;
   duration: number;
   edition: string;
   file: string;
+  id: string;
   items: readonly PlaylistItem[];
   score: number;
 }>;
@@ -892,6 +927,7 @@ export type PreparedReleaseDisplay = Readonly<{
 }>;
 
 export type PreviewReleaseWorkflowFrameRequest = Readonly<{
+  discId?: string;
   expectedRevision: WorkflowRevision;
   idempotencyKey: string;
   timestampSeconds: number;
@@ -1522,6 +1558,7 @@ export type SaveReleaseWorkflowDescriptionOverrideRequest = Readonly<{
 export type ScreenshotPurpose = string;
 
 export type ScreenshotSelection = Readonly<{
+  DiscID: string;
   Frame: number;
   Index: number;
   Source: string;
@@ -1539,6 +1576,7 @@ export type SetReleaseWorkflowMediaSelectionRequest = Readonly<{
 
 export type SourceClassification = Readonly<{
   Container: string;
+  DiscCount: number;
   DiscType: string;
   MediaType: string;
 }>;
@@ -1555,6 +1593,7 @@ export type SourceManifest = Readonly<{
 
 export type SourceManifestEntry = Readonly<{
   Disc: string;
+  DiscID: string;
   ModifiedAt: string;
   Path: string;
   Playlist: string;


### PR DESCRIPTION
## Review stack: part 1 of 2

Temporary review-only stack for #400 because CodeRabbit caps reviews at 100 files. This PR contains the source-layout, metadata, prepared-release, persistence, screenshot, DVD-menu, image-hosting, API, and contract foundation (70 changed files). Do not merge independently; #400 remains the delivery PR.

## Validation

- Focused Go race suites for source layout, metadata, prepared releases, pathing, screenshots, DVD menus, image hosting, DB, torrent, CLI, core, Web API, and API contracts
- `make test-go`
- `make test-frontend`
- `make lint`
- `make e2e-build`
- `make e2e`
- `make precommit`
- `make prepush`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-disc source detection and disc-aware playlist selection.
  * Media plans, screenshots, DVD menu captures, uploads, and previews now identify their associated disc.
  * Added manual screenshot frame support and per-disc frame previews.
  * Multi-disc collections now capture and include media from every disc.

* **Bug Fixes**
  * Improved media isolation and reuse across prepared releases.
  * Prevented incomplete, duplicate, stale, or conflicting playlist selections.
  * Added clearer warnings when discs remain uncovered during capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->