### PR TITLE
fix(torrent): correct metadata and registration artifacts

### DIFF
--- a/internal/torrent/metainfo/comment.go
+++ b/internal/torrent/metainfo/comment.go
@@ -4,11 +4,21 @@
 // Package metainfo defines application-owned torrent metainfo values.
 package metainfo
 
+import "strings"
+
 const (
 	// UploadCreatedBy identifies torrents uploaded directly by upbrr.
-	UploadCreatedBy = "uploaded with upbrr"
+	UploadCreatedBy = "upbrr"
 	// MkbrrUploadCreatedBy identifies upbrr uploads whose torrent was created by mkbrr.
-	MkbrrUploadCreatedBy = UploadCreatedBy + " using mkbrr"
-	// UploadCommentFallback is used when no tracker-specific torrent comment is available.
-	UploadCommentFallback = "upbrr"
+	MkbrrUploadCreatedBy = UploadCreatedBy + " with mkbrr"
+	// UploadComment identifies torrents uploaded with upbrr.
+	UploadComment = "uploaded with upbrr"
 )
+
+// CanonicalCreatedBy preserves mkbrr provenance while applying upbrr's creator value.
+func CanonicalCreatedBy(createdBy string) string {
+	if strings.Contains(strings.ToLower(createdBy), "mkbrr") {
+		return MkbrrUploadCreatedBy
+	}
+	return UploadCreatedBy
+}

--- a/internal/torrent/service.go
+++ b/internal/torrent/service.go
@@ -248,7 +248,7 @@ func (s *Service) Create(ctx context.Context, meta api.TorrentSubject) (api.Torr
 		}
 		s.logger.Infof("torrent: tracker policy validation tracker=%s state=completed decision=accepted count=%d", policy.name, trackerCount)
 	}
-	if err := setCreatedBy(info.Path, torrentmeta.MkbrrUploadCreatedBy); err != nil {
+	if err := setUploadMetadata(info.Path); err != nil {
 		emitTorrentProgress(ctx, meta, "failed", "Torrent metadata update failed")
 		return api.TorrentResult{}, err
 	}
@@ -263,12 +263,13 @@ func (s *Service) Create(ctx context.Context, meta api.TorrentSubject) (api.Torr
 	}, nil
 }
 
-func setCreatedBy(path string, createdBy string) error {
+func setUploadMetadata(path string) error {
 	torrentMeta, err := metainfo.LoadFromFile(path)
 	if err != nil {
 		return fmt.Errorf("torrent: load created torrent metadata: %w", err)
 	}
-	torrentMeta.CreatedBy = createdBy
+	torrentMeta.CreatedBy = torrentmeta.MkbrrUploadCreatedBy
+	torrentMeta.Comment = torrentmeta.UploadComment
 	torrentMeta.Announce = ""
 	torrentMeta.AnnounceList = nil
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600)

--- a/internal/torrent/service_test.go
+++ b/internal/torrent/service_test.go
@@ -129,11 +129,11 @@ func TestCreateNewTorrent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load torrent: %v", err)
 	}
-	if torrentMeta.CreatedBy != "uploaded with upbrr using mkbrr" {
+	if torrentMeta.CreatedBy != "upbrr with mkbrr" {
 		t.Fatalf("expected mkbrr created-by, got %q", torrentMeta.CreatedBy)
 	}
-	if torrentMeta.Comment != "" {
-		t.Fatalf("expected mkbrr comment to be empty, got %q", torrentMeta.Comment)
+	if torrentMeta.Comment != "uploaded with upbrr" {
+		t.Fatalf("expected upbrr comment, got %q", torrentMeta.Comment)
 	}
 }
 

--- a/internal/trackers/impl/registry_test.go
+++ b/internal/trackers/impl/registry_test.go
@@ -419,7 +419,7 @@ func TestNewRegistryCapabilityInventory(t *testing.T) {
 	if groups, ok := registry.LookupBannedGroups("ANT"); !ok || !slices.Contains(groups, "ZMNT") {
 		t.Fatalf("ANT banned groups = %#v, %t", groups, ok)
 	}
-	if policy, ok := registry.LookupUploadArtifactPolicy("ANT"); !ok || policy.Source != "ANT" {
+	if policy, ok := registry.LookupUploadArtifactPolicy("ANT"); !ok || policy.Source != "ANT" || !policy.RequireAnnounce {
 		t.Fatalf("ANT upload artifact policy = %#v, %t", policy, ok)
 	}
 	if _, ok := registry.LookupMetadataPolicy("ANT"); !ok {
@@ -540,30 +540,34 @@ func TestNewRegistryOwnsUploadArtifactPolicies(t *testing.T) {
 		t.Fatalf("new registry: %v", err)
 	}
 	want := map[string]trackers.UploadArtifactPolicy{
-		"ACM":   {Source: "AsianCinema"},
-		"AR":    {Source: "AlphaRatio"},
-		"ASC":   {Source: "ASC"},
-		"AZ":    {Source: "AvistaZ", DefaultAnnounce: "https://tracker.avistaz.to/announce"},
-		"BHDTV": {Source: "BIT-HDTV", UseMyAnnounce: true},
-		"BJS":   {Source: "BJ"},
-		"BT":    {Source: "BT"},
-		"CZ":    {Source: "CinemaZ", DefaultAnnounce: "https://tracker.cinemaz.to/announce"},
-		"CZT":   {Source: "CzT"},
-		"DC":    {Source: "DigitalCore.club"},
-		"FF":    {Source: "FunFile"},
-		"FL":    {Source: "FL"},
-		"GPW":   {Source: "GreatPosterWall"},
-		"HDS":   {Source: "HD-Space"},
-		"HDT":   {Source: "hd-torrents.org"},
-		"IS":    {Source: "https://immortalseed.me"},
-		"NBL":   {Source: "NBL"},
-		"PHD":   {Source: "PrivateHD", DefaultAnnounce: "https://tracker.privatehd.to/announce"},
-		"PTS":   {Source: "[www.ptskit.org] PTSKIT"},
-		"RTF":   {Source: "sunshine"},
-		"THR":   {Source: "[https://www.torrenthr.org] TorrentHR.org"},
-		"TL":    {Source: "TorrentLeech.org"},
-		"TOS":   {Source: "TheOldSchool"},
-		"TVC":   {Source: "TVCHAOS"},
+		"ACM": {Source: "AsianCinema"},
+		"AR":  {Source: "AlphaRatio", RequireAnnounce: true},
+		"ASC": {Source: "ASC", RequireAnnounce: true},
+		"AZ":  {Source: "AvistaZ", DefaultAnnounce: "https://tracker.avistaz.to/announce"},
+		"BHDTV": {
+			Source:          "BIT-HDTV",
+			UseMyAnnounce:   true,
+			RequireAnnounce: true,
+		},
+		"BJS": {Source: "BJ", RequireAnnounce: true},
+		"BT":  {Source: "BT", RequireAnnounce: true},
+		"CZ":  {Source: "CinemaZ", DefaultAnnounce: "https://tracker.cinemaz.to/announce"},
+		"CZT": {Source: "CzT"},
+		"DC":  {Source: "DigitalCore.club"},
+		"FF":  {Source: "FunFile", RequireAnnounce: true},
+		"FL":  {Source: "FL"},
+		"GPW": {Source: "GreatPosterWall", RequireAnnounce: true},
+		"HDS": {Source: "HD-Space", RequireAnnounce: true},
+		"HDT": {Source: "hd-torrents.org", RequireAnnounce: true},
+		"IS":  {Source: "https://immortalseed.me", RequireAnnounce: true},
+		"NBL": {Source: "NBL", RequireAnnounce: true},
+		"PHD": {Source: "PrivateHD", DefaultAnnounce: "https://tracker.privatehd.to/announce"},
+		"PTS": {Source: "[www.ptskit.org] PTSKIT", RequireAnnounce: true},
+		"RTF": {Source: "sunshine", RequireAnnounce: true},
+		"THR": {Source: "[https://www.torrenthr.org] TorrentHR.org", RequireAnnounce: true},
+		"TL":  {Source: "TorrentLeech.org"},
+		"TOS": {Source: "TheOldSchool"},
+		"TVC": {Source: "TVCHAOS", RequireAnnounce: true},
 	}
 	for name, expected := range want {
 		got, ok := registry.LookupUploadArtifactPolicy(name)
@@ -619,7 +623,7 @@ func TestNewRegistryIncludesBHDPolicies(t *testing.T) {
 	if _, ok := registry.LookupMetadataPolicy("BHD"); !ok {
 		t.Fatal("expected BHD metadata policy")
 	}
-	if policy, ok := registry.LookupUploadArtifactPolicy("BHD"); !ok || policy.Source != "BHD" {
+	if policy, ok := registry.LookupUploadArtifactPolicy("BHD"); !ok || policy.Source != "BHD" || !policy.RequireAnnounce {
 		t.Fatalf("BHD upload artifact policy = %#v, %t", policy, ok)
 	}
 	if policy, ok := registry.LookupAudioPolicy("BHD"); !ok || !policy.BlockEnglishOriginalWithForeign {
@@ -859,10 +863,13 @@ func TestNewRegistryResolvesHybridAuthRequirements(t *testing.T) {
 			wantFirst: []trackers.AuthRequirement{trackers.AuthRequirementPasskey},
 		},
 		{
-			name:      "TL form upload",
-			tracker:   "TL",
-			wantMode:  "form_upload",
-			wantFirst: []trackers.AuthRequirement{trackers.AuthRequirementStoredCookie},
+			name:     "TL form upload",
+			tracker:  "TL",
+			wantMode: "form_upload",
+			wantFirst: []trackers.AuthRequirement{
+				trackers.AuthRequirementStoredCookie,
+				trackers.AuthRequirementPasskey,
+			},
 		},
 	}
 	for _, test := range tests {

--- a/internal/trackers/impl/standalone/ant/profile.go
+++ b/internal/trackers/impl/standalone/ant/profile.go
@@ -29,7 +29,7 @@ func Profile() standalone.Profile {
 		ValidationPolicy:     validationPolicy(),
 		ArtifactPolicy:       &trackers.ArtifactPolicy{MaxPieceSizeMiB: 128, MaxTorrentBytes: 250 << 10},
 		BannedGroups:         bannedGroups(),
-		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: "ANT"},
+		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: "ANT", RequireAnnounce: true},
 		DupePolicy: &trackers.DupePolicy{
 			ID:         "ant/duplicate/v3",
 			EvidenceID: "ant-dupes-trumping",

--- a/internal/trackers/impl/standalone/ant/upload.go
+++ b/internal/trackers/impl/standalone/ant/upload.go
@@ -123,7 +123,7 @@ func submitPreparedUpload(
 	}
 
 	registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-		logger, "ANT", state.torrentPath, artifactPath, announceURL, viewURL, "ANT",
+		logger, "ANT", state.torrentPath, artifactPath, announceURL, "ANT",
 	)
 
 	return api.UploadSummary{

--- a/internal/trackers/impl/standalone/ar/profile.go
+++ b/internal/trackers/impl/standalone/ar/profile.go
@@ -67,7 +67,7 @@ func Profile() standalone.Profile {
 				{Scope: trackers.MetadataScopeAny, AnyOf: []trackers.MetadataField{trackers.MetadataFieldPoster}},
 			},
 		},
-		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: arSourceFlag},
+		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: arSourceFlag, RequireAnnounce: true},
 		TorrentIdentityPolicy: &trackers.TorrentIdentityPolicy{TrackerURLPatterns: []string{"tracker.alpharatio"}},
 		AuthCapability: &api.TrackerAuthCapability{
 			TrackerID:          "AR",

--- a/internal/trackers/impl/standalone/ar/upload.go
+++ b/internal/trackers/impl/standalone/ar/upload.go
@@ -104,7 +104,7 @@ func submitPreparedUpload(
 		torrentURL := buildTorrentURL(groupID, torrentID)
 		downloadURL := buildDownloadURL(torrentID, torrentURL)
 		registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-			req.Logger, "AR", state.torrentPath, artifactPath, announceURL, torrentURL, arSourceFlag,
+			req.Logger, "AR", state.torrentPath, artifactPath, announceURL, arSourceFlag,
 		)
 		id := metautil.FirstNonEmptyTrimmed(torrentID, groupID)
 		return api.UploadSummary{

--- a/internal/trackers/impl/standalone/asc/profile.go
+++ b/internal/trackers/impl/standalone/asc/profile.go
@@ -34,7 +34,7 @@ func Profile() standalone.Profile {
 			return trackers.ResolvedReleaseNames{Upload: uploadName, Duplicate: searchName}, nil
 		}),
 		NewDuplicateAdapter:   newDuplicateAdapter,
-		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: sourceFlag},
+		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: sourceFlag, RequireAnnounce: true},
 		AudioPolicy:           &trackers.AudioPolicy{AllowBloat: true},
 		TorrentIdentityPolicy: &trackers.TorrentIdentityPolicy{TrackerURLPatterns: []string{"amigos-share.club"}},
 		AuthCapability:        authcontract.CookieCapability("ASC"),

--- a/internal/trackers/impl/standalone/asc/upload.go
+++ b/internal/trackers/impl/standalone/asc/upload.go
@@ -113,7 +113,7 @@ func submitPreparedUpload(
 	if resp.StatusCode == http.StatusOK && torrentID != "" {
 		torrentURL := baseURL + "/torrents-details.php?id=" + url.QueryEscape(torrentID)
 		registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-			req.Logger, "ASC", state.torrentPath, artifactPath, announceURL, torrentURL, sourceFlag,
+			req.Logger, "ASC", state.torrentPath, artifactPath, announceURL, sourceFlag,
 		)
 		maybeAutoApprove(ctx, client, cookies, req.TrackerConfig, torrentID, req.Logger)
 		maybeSetInternal(ctx, client, cookies, req.TrackerConfig, req.Meta, torrentID, req.Logger)

--- a/internal/trackers/impl/standalone/bhd/profile.go
+++ b/internal/trackers/impl/standalone/bhd/profile.go
@@ -28,7 +28,7 @@ func Profile() standalone.Profile {
 		Rules:                rules(),
 		ValidationPolicy:     validationPolicy(),
 		BannedGroups:         bannedGroups(),
-		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: "BHD"},
+		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: "BHD", RequireAnnounce: true},
 		AudioPolicy:          &trackers.AudioPolicy{BlockEnglishOriginalWithForeign: true},
 		ImageHostPolicy:      &trackers.ImageHostPolicy{AllowedHosts: []string{"imgbox", "imgbb", "pixhost", "bhd", "passtheimage"}},
 		DupePolicy: &trackers.DupePolicy{

--- a/internal/trackers/impl/standalone/bhd/upload.go
+++ b/internal/trackers/impl/standalone/bhd/upload.go
@@ -121,7 +121,7 @@ func submitPreparedUpload(
 	downloadURL := strings.TrimRight(bhdBaseURL, "/") + "/torrent/download/" + torrentID
 
 	registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-		req.Logger, "BHD", state.torrentPath, artifactPath, announceURL, torrentURL, "BHD",
+		req.Logger, "BHD", state.torrentPath, artifactPath, announceURL, "BHD",
 	)
 
 	return api.UploadSummary{

--- a/internal/trackers/impl/standalone/bhdtv/profile.go
+++ b/internal/trackers/impl/standalone/bhdtv/profile.go
@@ -13,17 +13,21 @@ import (
 // Profile returns BHDTV identity, preparation, dupe, and artifact behavior.
 func Profile() standalone.Profile {
 	return standalone.Profile{
-		Name:                 "BHDTV",
-		BaseURL:              "https://www.bit-hdtv.com",
-		DescriptionGroup:     "bhdtv",
-		UploadContentMode:    trackers.UploadContentModeDescription,
-		AuthCapability:       authcontract.APIKeyCapability("BHDTV"),
-		PrepareDescription:   prepareDescription,
-		PrepareUpload:        prepareUpload,
-		ReleaseNamePolicy:    trackers.SimpleSubjectReleaseNamePolicy("standalone/bhdtv/v1", resolveUploadName),
-		NewDuplicateAdapter:  func(dupe.Dependencies) dupe.Adapter { return bhdtvDuplicateAdapter{} },
-		ValidationPolicy:     validationPolicy(),
-		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: "BIT-HDTV", UseMyAnnounce: true},
+		Name:                "BHDTV",
+		BaseURL:             "https://www.bit-hdtv.com",
+		DescriptionGroup:    "bhdtv",
+		UploadContentMode:   trackers.UploadContentModeDescription,
+		AuthCapability:      authcontract.APIKeyCapability("BHDTV"),
+		PrepareDescription:  prepareDescription,
+		PrepareUpload:       prepareUpload,
+		ReleaseNamePolicy:   trackers.SimpleSubjectReleaseNamePolicy("standalone/bhdtv/v1", resolveUploadName),
+		NewDuplicateAdapter: func(dupe.Dependencies) dupe.Adapter { return bhdtvDuplicateAdapter{} },
+		ValidationPolicy:    validationPolicy(),
+		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{
+			Source:          "BIT-HDTV",
+			UseMyAnnounce:   true,
+			RequireAnnounce: true,
+		},
 	}
 }
 

--- a/internal/trackers/impl/standalone/bhdtv/upload.go
+++ b/internal/trackers/impl/standalone/bhdtv/upload.go
@@ -112,7 +112,6 @@ func submitPreparedUpload(
 				state.torrentPath,
 				artifactPath,
 				req.TrackerConfig.MyAnnounceURL,
-				viewURL,
 				sourceFlag,
 			)
 		}

--- a/internal/trackers/impl/standalone/bjs/profile.go
+++ b/internal/trackers/impl/standalone/bjs/profile.go
@@ -34,7 +34,7 @@ func Profile() standalone.Profile {
 				Disposition: api.RuleDispositionStrict,
 			}},
 		},
-		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: sourceFlag},
+		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: sourceFlag, RequireAnnounce: true},
 		AudioPolicy:           &trackers.AudioPolicy{AllowBloat: true},
 		TorrentIdentityPolicy: &trackers.TorrentIdentityPolicy{TrackerURLPatterns: []string{"tracker.bj-share.info"}},
 		AuthCapability:        authcontract.CookieCapability("BJS"),

--- a/internal/trackers/impl/standalone/bjs/upload.go
+++ b/internal/trackers/impl/standalone/bjs/upload.go
@@ -119,7 +119,7 @@ func submitPreparedUpload(
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 && id != "" {
 		tURL := torrentURL + id
 		registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-			req.Logger, "BJS", state.torrentPath, artifactPath, announceURL, tURL, sourceFlag,
+			req.Logger, "BJS", state.torrentPath, artifactPath, announceURL, sourceFlag,
 		)
 		return api.UploadSummary{
 			Uploaded: 1,

--- a/internal/trackers/impl/standalone/bt/profile.go
+++ b/internal/trackers/impl/standalone/bt/profile.go
@@ -22,7 +22,7 @@ func Profile() standalone.Profile {
 		ValidationPolicy:        validationPolicy(),
 		ReleaseNamePolicy:       trackers.SimpleSubjectReleaseNameSearchPolicy("standalone/bt/v1", resolveUploadName, resolveSearchName),
 		NewDuplicateAdapter:     newDuplicateAdapter,
-		UploadArtifactPolicy:    &trackers.UploadArtifactPolicy{Source: sourceFlag},
+		UploadArtifactPolicy:    &trackers.UploadArtifactPolicy{Source: sourceFlag, RequireAnnounce: true},
 		AudioPolicy:             &trackers.AudioPolicy{AllowBloat: true},
 		TorrentIdentityPolicy:   &trackers.TorrentIdentityPolicy{TrackerURLPatterns: []string{"t.brasiltracker.org"}},
 		AuthCapability:          authcontract.CookieCapability("BT"),

--- a/internal/trackers/impl/standalone/bt/upload.go
+++ b/internal/trackers/impl/standalone/bt/upload.go
@@ -122,7 +122,7 @@ func submitPreparedUpload(
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 && id != "" {
 		tURL := torrentURL + id
 		registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-			req.Logger, "BT", state.torrentPath, artifactPath, announceURL, tURL, sourceFlag,
+			req.Logger, "BT", state.torrentPath, artifactPath, announceURL, sourceFlag,
 		)
 		return api.UploadSummary{
 			Uploaded: 1,

--- a/internal/trackers/impl/standalone/ff/profile.go
+++ b/internal/trackers/impl/standalone/ff/profile.go
@@ -24,7 +24,8 @@ func Profile() standalone.Profile {
 		NewDuplicateAdapter: newDuplicateAdapter,
 		ValidationPolicy:    validationPolicy(),
 		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{
-			Source: sourceFlag,
+			Source:          sourceFlag,
+			RequireAnnounce: true,
 		},
 		AudioPolicy: &trackers.AudioPolicy{
 			AllowBloat: true,

--- a/internal/trackers/impl/standalone/ff/upload.go
+++ b/internal/trackers/impl/standalone/ff/upload.go
@@ -101,7 +101,7 @@ func submitPreparedUpload(
 		id := match[1]
 		tURL := torrentURL + id
 		registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-			req.Logger, "FF", state.torrentPath, artifactPath, announceURL, tURL, sourceFlag,
+			req.Logger, "FF", state.torrentPath, artifactPath, announceURL, sourceFlag,
 		)
 		return api.UploadSummary{Uploaded: 1, UploadedTorrents: []api.UploadedTorrent{{
 			Tracker:     "FF",

--- a/internal/trackers/impl/standalone/gpw/profile.go
+++ b/internal/trackers/impl/standalone/gpw/profile.go
@@ -22,7 +22,7 @@ func Profile() standalone.Profile {
 		NewDuplicateAdapter:  newDuplicateAdapter,
 		ValidationPolicy:     validationPolicy(),
 		BannedGroups:         bannedGroups(),
-		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: sourceFlag},
+		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: sourceFlag, RequireAnnounce: true},
 		ImageHostPolicy: &trackers.ImageHostPolicy{
 			AllowedHosts: []string{"kshare", "pixhost", "pterclub", "ilikeshots", "imgbox"},
 		},

--- a/internal/trackers/impl/standalone/gpw/upload.go
+++ b/internal/trackers/impl/standalone/gpw/upload.go
@@ -131,7 +131,7 @@ func submitPreparedUpload(
 	if (status == "success" || status == "ok" || status == "200") && id != "" {
 		tURL := torrentURL + id
 		registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-			req.Logger, "GPW", state.torrentPath, artifactPath, announceURL, tURL, sourceFlag,
+			req.Logger, "GPW", state.torrentPath, artifactPath, announceURL, sourceFlag,
 		)
 		return api.UploadSummary{Uploaded: 1, UploadedTorrents: []api.UploadedTorrent{{
 			Tracker:     "GPW",

--- a/internal/trackers/impl/standalone/hds/profile.go
+++ b/internal/trackers/impl/standalone/hds/profile.go
@@ -21,7 +21,8 @@ func Profile() standalone.Profile {
 		NewDuplicateAdapter: newDuplicateAdapter,
 		ValidationPolicy:    validationPolicy(),
 		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{
-			Source: sourceFlag,
+			Source:          sourceFlag,
+			RequireAnnounce: true,
 		},
 		TorrentIdentityPolicy: &trackers.TorrentIdentityPolicy{
 			TrackerURLPatterns: []string{"hd-space.pw"},

--- a/internal/trackers/impl/standalone/hds/upload.go
+++ b/internal/trackers/impl/standalone/hds/upload.go
@@ -110,7 +110,7 @@ func submitPreparedUpload(
 		id := strings.TrimSpace(match[1])
 		tURL := torrentURL + id
 		registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-			req.Logger, "HDS", state.torrentPath, artifactPath, announceURL, tURL, sourceFlag,
+			req.Logger, "HDS", state.torrentPath, artifactPath, announceURL, sourceFlag,
 		)
 		return api.UploadSummary{
 			Uploaded: 1,

--- a/internal/trackers/impl/standalone/hdt/profile.go
+++ b/internal/trackers/impl/standalone/hdt/profile.go
@@ -22,7 +22,8 @@ func Profile() standalone.Profile {
 		NewDuplicateAdapter: newDuplicateAdapter,
 		ValidationPolicy:    validationPolicy(),
 		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{
-			Source: "hd-torrents.org",
+			Source:          "hd-torrents.org",
+			RequireAnnounce: true,
 		},
 		TorrentIdentityPolicy: &trackers.TorrentIdentityPolicy{
 			TrackerURLPatterns: []string{"https://hdts-announce.ru"},

--- a/internal/trackers/impl/standalone/hdt/upload.go
+++ b/internal/trackers/impl/standalone/hdt/upload.go
@@ -114,7 +114,7 @@ func submitPreparedUpload(
 			tURL = state.baseURL + "/details.php?id=" + id
 		}
 		registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-			req.Logger, "HDT", state.torrentPath, artifactPath, announceURL, tURL, "hd-torrents.org",
+			req.Logger, "HDT", state.torrentPath, artifactPath, announceURL, "hd-torrents.org",
 		)
 		return api.UploadSummary{
 			Uploaded: 1,

--- a/internal/trackers/impl/standalone/is/profile.go
+++ b/internal/trackers/impl/standalone/is/profile.go
@@ -22,7 +22,7 @@ func Profile() standalone.Profile {
 		ReleaseNamePolicy:     trackers.SimpleSubjectReleaseNameSearchPolicy("standalone/is/v1", resolveSubject, resolveSearchName),
 		NewDuplicateAdapter:   newDuplicateAdapter,
 		AuthCapability:        authcontract.CookieCapability("IS"),
-		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: sourceFlag},
+		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: sourceFlag, RequireAnnounce: true},
 		TorrentIdentityPolicy: &trackers.TorrentIdentityPolicy{TrackerURLPatterns: []string{baseURL}},
 	}
 }

--- a/internal/trackers/impl/standalone/is/upload.go
+++ b/internal/trackers/impl/standalone/is/upload.go
@@ -126,7 +126,7 @@ func submitPreparedUpload(
 		if id != "" {
 			tURL := torrentURL + id
 			registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-				req.Logger, "IS", state.torrentPath, artifactPath, announceURL, tURL, sourceFlag,
+				req.Logger, "IS", state.torrentPath, artifactPath, announceURL, sourceFlag,
 			)
 			return api.UploadSummary{
 				Uploaded: 1,

--- a/internal/trackers/impl/standalone/nbl/profile.go
+++ b/internal/trackers/impl/standalone/nbl/profile.go
@@ -42,7 +42,7 @@ func Profile() standalone.Profile {
 				Disposition: api.RuleDispositionStrict,
 			}},
 		},
-		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: "NBL"},
+		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: "NBL", RequireAnnounce: true},
 		TorrentIdentityPolicy: &trackers.TorrentIdentityPolicy{TrackerURLPatterns: []string{"tracker.nebulance"}},
 	}
 }

--- a/internal/trackers/impl/standalone/nbl/upload.go
+++ b/internal/trackers/impl/standalone/nbl/upload.go
@@ -98,7 +98,7 @@ func submitPreparedUpload(
 	torrentURL, torrentID := extractUploadLinkAndID(payload)
 
 	registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-		logger, "NBL", state.torrentPath, artifactPath, announceURL, torrentURL, "NBL",
+		logger, "NBL", state.torrentPath, artifactPath, announceURL, "NBL",
 	)
 
 	return api.UploadSummary{

--- a/internal/trackers/impl/standalone/ptp/definition_test.go
+++ b/internal/trackers/impl/standalone/ptp/definition_test.go
@@ -443,7 +443,7 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 		t.Fatalf("resolve PTP torrent artifact: %v", err)
 	}
 	meta.TorrentPath = torrentPath
-	if err := trackers.WritePersonalizedTorrent(baseTorrentPath, torrentPath, announceURL, "", "PTP"); err != nil {
+	if err := trackers.WritePersonalizedTorrent(baseTorrentPath, torrentPath, announceURL, "PTP"); err != nil {
 		t.Fatalf("prepare PTP torrent artifact: %v", err)
 	}
 	preparedMeta, err := metainfo.LoadFromFile(torrentPath)
@@ -502,11 +502,11 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 					t.Errorf("load uploaded torrent: %v", err)
 					return
 				}
-				if uploadedMeta.Comment != "upbrr" {
+				if uploadedMeta.Comment != "uploaded with upbrr" {
 					t.Errorf("expected cleaned upload torrent comment, got %q", uploadedMeta.Comment)
 					return
 				}
-				if uploadedMeta.CreatedBy != "uploaded with upbrr" {
+				if uploadedMeta.CreatedBy != "upbrr with mkbrr" {
 					t.Errorf("expected cleaned upload torrent created-by, got %q", uploadedMeta.CreatedBy)
 					return
 				}
@@ -583,8 +583,8 @@ func TestDefinitionUploadSuccess(t *testing.T) {
 	if registeredInfo.Source != "PTP" {
 		t.Fatalf("expected registered PTP source, got %q", registeredInfo.Source)
 	}
-	if registeredMeta.Comment != result.UploadedTorrents[0].TorrentURL {
-		t.Fatalf("expected registered PTP comment %q, got %q", result.UploadedTorrents[0].TorrentURL, registeredMeta.Comment)
+	if registeredMeta.Comment != "uploaded with upbrr" {
+		t.Fatalf("expected upbrr comment, got %q", registeredMeta.Comment)
 	}
 	expectedBase := filepath.Base(meta.SourcePath)
 	expectedName := "[ptp]." + expectedBase + ".torrent"

--- a/internal/trackers/impl/standalone/ptp/upload.go
+++ b/internal/trackers/impl/standalone/ptp/upload.go
@@ -126,7 +126,7 @@ func submitPreparedUpload(
 		torrentID := strings.TrimSpace(matches[2])
 		torrentURL := strings.TrimRight(state.baseURL, "/") + "/torrents.php?id=" + url.QueryEscape(groupID) + "&torrentid=" + url.QueryEscape(torrentID)
 		registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-			req.Logger, "PTP", state.torrentPath, trackerTorrentPath, state.announceURL, torrentURL, "PTP",
+			req.Logger, "PTP", state.torrentPath, trackerTorrentPath, state.announceURL, "PTP",
 		)
 		return api.UploadSummary{
 			Uploaded: 1,

--- a/internal/trackers/impl/standalone/pts/profile.go
+++ b/internal/trackers/impl/standalone/pts/profile.go
@@ -21,7 +21,7 @@ func Profile() standalone.Profile {
 		ValidationPolicy:      validationPolicy(),
 		NewDuplicateAdapter:   newDuplicateAdapter,
 		AuthCapability:        authcontract.CookieCapability("PTS"),
-		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: sourceFlag},
+		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: sourceFlag, RequireAnnounce: true},
 		TorrentIdentityPolicy: &trackers.TorrentIdentityPolicy{TrackerURLPatterns: []string{"https://tracker.ptskit.com"}},
 	}
 }

--- a/internal/trackers/impl/standalone/pts/upload.go
+++ b/internal/trackers/impl/standalone/pts/upload.go
@@ -111,7 +111,7 @@ func submitPreparedUpload(
 	if (resp.StatusCode == http.StatusFound || resp.StatusCode == http.StatusSeeOther) && torrentID != "" {
 		tURL := baseURL + "/details.php?id=" + url.QueryEscape(torrentID)
 		registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-			req.Logger, "PTS", state.torrentPath, artifactPath, announceURL, tURL, sourceFlag,
+			req.Logger, "PTS", state.torrentPath, artifactPath, announceURL, sourceFlag,
 		)
 		return api.UploadSummary{
 			Uploaded: 1,

--- a/internal/trackers/impl/standalone/rtf/profile.go
+++ b/internal/trackers/impl/standalone/rtf/profile.go
@@ -26,7 +26,7 @@ func Profile() standalone.Profile {
 		NewDuplicateAdapter:  newDuplicateAdapter,
 		DupePolicy:           duplicatePolicy(),
 		ValidationPolicy:     validationPolicy(),
-		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: sourceFlag},
+		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: sourceFlag, RequireAnnounce: true},
 		TorrentIdentityPolicy: &trackers.TorrentIdentityPolicy{
 			TrackerURLPatterns: []string{"peer.retroflix"},
 			CommentURLPatterns: []string{defaultBaseURL},

--- a/internal/trackers/impl/standalone/rtf/upload.go
+++ b/internal/trackers/impl/standalone/rtf/upload.go
@@ -162,7 +162,7 @@ func submitPreparedUpload(
 		}
 		tURL := torrentURL + id
 		registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-			req.Logger, "RTF", state.torrentPath, artifactPath, announceURL, tURL, sourceFlag,
+			req.Logger, "RTF", state.torrentPath, artifactPath, announceURL, sourceFlag,
 		)
 		return api.UploadSummary{
 			Uploaded: 1,

--- a/internal/trackers/impl/standalone/thr/profile.go
+++ b/internal/trackers/impl/standalone/thr/profile.go
@@ -42,7 +42,7 @@ func Profile() standalone.Profile {
 				Disposition: api.RuleDispositionStrict,
 			}},
 		},
-		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: sourceFlag},
+		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: sourceFlag, RequireAnnounce: true},
 		ImageHostPolicy: &trackers.ImageHostPolicy{
 			AllowedHosts:      []string{"thr"},
 			OwnedHosts:        []string{"thr"},

--- a/internal/trackers/impl/standalone/thr/upload.go
+++ b/internal/trackers/impl/standalone/thr/upload.go
@@ -100,7 +100,7 @@ func submitPreparedUpload(
 			torrentID = match[1]
 		}
 		registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-			req.Logger, "THR", state.torrentPath, artifactPath, announceURL, finalURL, sourceFlag,
+			req.Logger, "THR", state.torrentPath, artifactPath, announceURL, sourceFlag,
 		)
 		return api.UploadSummary{Uploaded: 1, UploadedTorrents: []api.UploadedTorrent{{
 			Tracker:     "THR",

--- a/internal/trackers/impl/standalone/tl/profile.go
+++ b/internal/trackers/impl/standalone/tl/profile.go
@@ -56,7 +56,10 @@ func Profile() standalone.Profile {
 				return authcontract.Requirements(
 					"form_upload",
 					false,
-					[]trackers.AuthRequirement{trackers.AuthRequirementStoredCookie},
+					[]trackers.AuthRequirement{
+						trackers.AuthRequirementStoredCookie,
+						trackers.AuthRequirementPasskey,
+					},
 				)
 			},
 		},

--- a/internal/trackers/impl/standalone/tl/upload.go
+++ b/internal/trackers/impl/standalone/tl/upload.go
@@ -114,7 +114,7 @@ func submitPreparedUpload(
 		announceURL = announces[0]
 	}
 	registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-		req.Logger, "TL", state.torrentPath, artifactPath, announceURL, urlValue, sourceFlag,
+		req.Logger, "TL", state.torrentPath, artifactPath, announceURL, sourceFlag,
 	)
 	return api.UploadSummary{Uploaded: 1, UploadedTorrents: []api.UploadedTorrent{{
 		Tracker:     "TL",

--- a/internal/trackers/impl/standalone/tl/upload.go
+++ b/internal/trackers/impl/standalone/tl/upload.go
@@ -6,6 +6,7 @@ package tl
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -41,6 +42,10 @@ func prepareUpload(ctx context.Context, req trackers.PreparationInput) (trackers
 	if err := standalone.ValidatePreparation(ctx, req, validationPolicy()); err != nil {
 		return trackers.PreparedOperation{}, fmt.Errorf("trackers: validate preparation: %w", err)
 	}
+	announces := announceList(req.TrackerConfig)
+	if req.Intent == trackers.PreparationIntentUpload && len(announces) == 0 {
+		return trackers.PreparedOperation{}, errors.New("trackers: TL required passkey-derived announce URL is missing")
+	}
 	state, client, err := prepareUploadState(ctx, req)
 	if err != nil {
 		return trackers.PreparedOperation{}, err
@@ -53,13 +58,9 @@ func prepareUpload(ctx context.Context, req trackers.PreparationInput) (trackers
 	if err != nil {
 		return trackers.PreparedOperation{}, fmt.Errorf("trackers: %w", err)
 	}
-	announces := announceList(req.TrackerConfig)
-	artifactPath := ""
-	if len(announces) > 0 {
-		artifactPath, err = trackers.ResolveTrackerTorrentArtifactPath(req.Meta, req.Runtime.DBPath, "TL")
-		if err != nil {
-			return trackers.PreparedOperation{}, fmt.Errorf("trackers: %w", err)
-		}
+	artifactPath, err := trackers.ResolveTrackerTorrentArtifactPath(req.Meta, req.Runtime.DBPath, "TL")
+	if err != nil {
+		return trackers.PreparedOperation{}, fmt.Errorf("trackers: %w", err)
 	}
 	return trackers.NewPreparedOperation(preview, func(submitCtx context.Context) (api.UploadSummary, error) {
 		return submitPreparedUpload(submitCtx, req, state, client, body, contentType, announces, artifactPath)

--- a/internal/trackers/impl/standalone/tl/upload_test.go
+++ b/internal/trackers/impl/standalone/tl/upload_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package tl
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/trackers"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestPrepareUploadRequiresPasskeyDerivedAnnounce(t *testing.T) {
+	t.Parallel()
+
+	_, err := prepareUpload(context.Background(), trackers.PreparationInput{
+		Tracker: "TL",
+		Intent:  trackers.PreparationIntentUpload,
+		Meta: api.UploadSubject{Identity: api.ExternalIdentity{
+			Category: api.CanonicalCategoryMovie,
+			IMDBID:   1234567,
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "required passkey-derived announce URL is missing") {
+		t.Fatalf("prepare upload error = %v", err)
+	}
+}

--- a/internal/trackers/impl/standalone/tvc/profile.go
+++ b/internal/trackers/impl/standalone/tvc/profile.go
@@ -42,7 +42,7 @@ func Profile() standalone.Profile {
 				Disposition: api.RuleDispositionStrict,
 			}},
 		},
-		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: "TVCHAOS"},
+		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: "TVCHAOS", RequireAnnounce: true},
 		ImageHostPolicy:       &trackers.ImageHostPolicy{AllowedHosts: []string{"imgbb", "imgbox", "pixhost", "bam", "onlyimage"}},
 		TorrentIdentityPolicy: &trackers.TorrentIdentityPolicy{TrackerURLPatterns: []string{"https://tvchaosuk.com"}},
 	}

--- a/internal/trackers/impl/standalone/tvc/upload.go
+++ b/internal/trackers/impl/standalone/tvc/upload.go
@@ -125,7 +125,7 @@ func submitPreparedUpload(
 	torrentID := path.Base(strings.TrimRight(dataURL, "/"))
 
 	registeredPath := trackers.PersistReconstructedRegisteredTorrent(
-		req.Logger, "TVC", state.torrentPath, artifactPath, announceURL, dataURL, sourceFlag,
+		req.Logger, "TVC", state.torrentPath, artifactPath, announceURL, sourceFlag,
 	)
 	return api.UploadSummary{Uploaded: 1, UploadedTorrents: []api.UploadedTorrent{{
 		Tracker:     "TVC",

--- a/internal/trackers/registered_torrent.go
+++ b/internal/trackers/registered_torrent.go
@@ -147,14 +147,13 @@ func PersistReconstructedRegisteredTorrent(
 	sourcePath string,
 	outputPath string,
 	announceURL string,
-	comment string,
 	source string,
 ) string {
 	if strings.TrimSpace(announceURL) == "" || strings.TrimSpace(outputPath) == "" {
 		LogRegisteredTorrentUnavailable(logger, tracker)
 		return ""
 	}
-	if err := WritePersonalizedTorrent(sourcePath, outputPath, announceURL, comment, source); err != nil {
+	if err := WritePersonalizedTorrent(sourcePath, outputPath, announceURL, source); err != nil {
 		LogRegisteredTorrentUnavailable(logger, tracker)
 		return ""
 	}

--- a/internal/trackers/upload_artifact.go
+++ b/internal/trackers/upload_artifact.go
@@ -50,7 +50,7 @@ func prepareTrackerUploadTorrentWithRegistry(
 	if err != nil {
 		return api.UploadSubject{}, fmt.Errorf("trackers: prepare %s upload torrent path: %w", normalizeTrackerName(tracker), err)
 	}
-	if err := WritePersonalizedTorrent(basePath, artifactPath, announce, "", source); err != nil {
+	if err := WritePersonalizedTorrent(basePath, artifactPath, announce, source); err != nil {
 		return api.UploadSubject{}, fmt.Errorf("trackers: prepare %s upload torrent artifact: %w", normalizeTrackerName(tracker), err)
 	}
 	meta.TorrentPath = artifactPath
@@ -230,9 +230,9 @@ func WriteUploadTorrent(sourcePath string, outputPath string) error {
 }
 
 // WritePersonalizedTorrent strips inherited tracker fields, applies the supplied
-// announce, comment, and source values plus the canonical creator, and atomically
-// writes outputPath with mode 0600.
-func WritePersonalizedTorrent(sourcePath string, outputPath string, announceURL string, comment string, source string) error {
+// announce and source values plus canonical upload metadata, and atomically writes
+// outputPath with mode 0600.
+func WritePersonalizedTorrent(sourcePath string, outputPath string, announceURL string, source string) error {
 	torrentMeta, err := metainfo.LoadFromFile(sourcePath)
 	if err != nil {
 		return fmt.Errorf("trackers: load torrent artifact: %w", err)
@@ -247,11 +247,6 @@ func WritePersonalizedTorrent(sourcePath string, outputPath string, announceURL 
 		torrentMeta.Announce = trimmedAnnounce
 		torrentMeta.AnnounceList = metainfo.AnnounceList{{trimmedAnnounce}}
 	}
-	torrentMeta.Comment = torrentmeta.UploadCommentFallback
-	if trimmedComment := strings.TrimSpace(comment); trimmedComment != "" {
-		torrentMeta.Comment = trimmedComment
-	}
-	torrentMeta.CreatedBy = torrentmeta.UploadCreatedBy
 
 	return writeTorrentMeta(*torrentMeta, outputPath, "torrent artifact")
 }
@@ -271,12 +266,13 @@ func rewriteTorrentInfoSource(torrentMeta *metainfo.MetaInfo, source string, con
 }
 
 func cleanTorrentMeta(torrentMeta *metainfo.MetaInfo) {
+	createdBy := torrentmeta.CanonicalCreatedBy(torrentMeta.CreatedBy)
 	torrentMeta.Announce = ""
 	torrentMeta.AnnounceList = nil
 	torrentMeta.Nodes = nil
 	torrentMeta.UrlList = nil
-	torrentMeta.Comment = torrentmeta.UploadCommentFallback
-	torrentMeta.CreatedBy = torrentmeta.UploadCreatedBy
+	torrentMeta.Comment = torrentmeta.UploadComment
+	torrentMeta.CreatedBy = createdBy
 }
 
 func writeTorrentMeta(torrentMeta metainfo.MetaInfo, outputPath string, context string) error {

--- a/internal/trackers/upload_artifact_test.go
+++ b/internal/trackers/upload_artifact_test.go
@@ -64,11 +64,11 @@ func TestResolveUploadTorrentBasePathWritesCleanBaseCopy(t *testing.T) {
 	}
 	assertInfoSource(t, cleaned, "")
 	assertInfoSourceKeyAbsent(t, cleaned)
-	if cleaned.Comment != "upbrr" {
+	if cleaned.Comment != "uploaded with upbrr" {
 		t.Fatalf("expected upbrr comment, got %q", cleaned.Comment)
 	}
-	if cleaned.CreatedBy != "uploaded with upbrr" {
-		t.Fatalf("expected upbrr created-by, got %q", cleaned.CreatedBy)
+	if cleaned.CreatedBy != "upbrr with mkbrr" {
+		t.Fatalf("expected mkbrr created-by, got %q", cleaned.CreatedBy)
 	}
 
 	original := readTestMetaInfo(t, dirtyTorrentPath)
@@ -175,8 +175,11 @@ func TestWriteUploadTorrentCleansTrackerFields(t *testing.T) {
 	if len(cleaned.UrlList) != 0 {
 		t.Fatalf("expected url-list cleared, got %#v", cleaned.UrlList)
 	}
-	if cleaned.Comment != "upbrr" {
+	if cleaned.Comment != "uploaded with upbrr" {
 		t.Fatalf("expected upbrr comment, got %q", cleaned.Comment)
+	}
+	if cleaned.CreatedBy != "upbrr" {
+		t.Fatalf("expected upbrr created-by, got %q", cleaned.CreatedBy)
 	}
 	assertInfoSource(t, cleaned, "")
 	assertInfoSourceKeyAbsent(t, cleaned)
@@ -230,7 +233,7 @@ func TestWritePersonalizedTorrentSetsTrackerFields(t *testing.T) {
 		InfoBytes:    testInfoBytes(t, "BHD"),
 	})
 
-	if err := WritePersonalizedTorrent(sourcePath, outputPath, "https://new.example/announce", "https://tracker.example/torrents/123", "PTP"); err != nil {
+	if err := WritePersonalizedTorrent(sourcePath, outputPath, "https://new.example/announce", "PTP"); err != nil {
 		t.Fatalf("write personalized torrent: %v", err)
 	}
 
@@ -241,10 +244,10 @@ func TestWritePersonalizedTorrentSetsTrackerFields(t *testing.T) {
 	if len(updated.AnnounceList) != 1 || len(updated.AnnounceList[0]) != 1 || updated.AnnounceList[0][0] != "https://new.example/announce" {
 		t.Fatal("expected announce-list set")
 	}
-	if updated.Comment != "https://tracker.example/torrents/123" {
-		t.Fatalf("expected tracker comment, got %q", updated.Comment)
+	if updated.Comment != "uploaded with upbrr" {
+		t.Fatalf("expected upbrr comment, got %q", updated.Comment)
 	}
-	if updated.CreatedBy != "uploaded with upbrr" {
+	if updated.CreatedBy != "upbrr" {
 		t.Fatalf("expected upbrr created-by, got %q", updated.CreatedBy)
 	}
 	if len(updated.UrlList) != 0 {
@@ -265,6 +268,7 @@ func TestPrepareTrackerUploadTorrentCreatesSpecificArtifact(t *testing.T) {
 	writeTestMetaInfo(t, baseTorrentPath, metainfo.MetaInfo{
 		Announce:  "https://old.example/announce",
 		Comment:   "private comment",
+		CreatedBy: "mkbrr",
 		InfoBytes: testInfoBytes(t, "old-source"),
 	})
 
@@ -283,6 +287,12 @@ func TestPrepareTrackerUploadTorrentCreatesSpecificArtifact(t *testing.T) {
 	artifact := readTestMetaInfo(t, meta.TorrentPath)
 	if artifact.Announce != "https://new.example/announce" {
 		t.Fatal("expected announce set")
+	}
+	if artifact.Comment != "uploaded with upbrr" {
+		t.Fatalf("expected upbrr comment, got %q", artifact.Comment)
+	}
+	if artifact.CreatedBy != "upbrr with mkbrr" {
+		t.Fatalf("expected mkbrr created-by, got %q", artifact.CreatedBy)
 	}
 	assertInfoSource(t, artifact, "HDBits")
 


### PR DESCRIPTION
## Summary

- write `uploaded with upbrr` only to the torrent comment field
- write `upbrr` or `upbrr with mkbrr` to the created-by field, preserving mkbrr provenance from existing torrents
- require announce data before uploads whose registered torrent must be reconstructed
- derive TorrentLeech announce URLs from its required passkey while leaving exact tracker-returned torrents unchanged

## Why

Torrent comment and created-by values were reversed. Several reconstruction adapters could also complete a remote upload without enough announce data to create the registered local torrent required for reliable client injection.

## Impact

Generated and reused torrents now carry canonical upbrr metadata. Reconstruction-only uploads fail during preparation when announce data is missing instead of succeeding remotely and failing client injection afterward.

## Testing

- focused tracker race tests
- `go test -race -timeout 20m ./internal/trackers/...`
- `make gofix-check-changed`
- `make lint`
- `make test-go`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Torrent metadata now uses consistent upload comments and creator attribution while preserving mkbrr provenance.
  * Tracker upload artifacts now consistently include required announce information and tracker source details.
  * TorrentLeech uploads now validate passkey-derived announce URLs before preparation.

* **Bug Fixes**
  * Corrected reconstructed torrent metadata across supported trackers.
  * Improved form-upload authentication requirements by requiring both cookies and passkeys where applicable.
  * Prevented upload details-page URLs from being incorrectly used as artifact metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->