### PR TITLE
fix(trackers): align CinemaZ release naming

### DIFF
--- a/internal/trackers/impl/azfamily/definition.go
+++ b/internal/trackers/impl/azfamily/definition.go
@@ -33,13 +33,20 @@ func (d *Definition) Name() string {
 // TrackerFamily identifies the definition as AZ-family-backed.
 func (d *Definition) TrackerFamily() trackers.Family { return trackers.FamilyAZFamily }
 
-// ReleaseNamePolicy returns the versioned AZ-family naming policy with TMDB-authoritative movie years.
+// ReleaseNamePolicy returns the site's versioned upload/search naming contract.
+// CinemaZ v3 uses IMDb as movie-year authority; AZ and PHD v2 use TMDB.
 func (d *Definition) ReleaseNamePolicy() trackers.ReleaseNamePolicyBinding {
+	version := "v2"
+	movieYearProvider := api.IdentityProviderTMDB
+	if d.site.Name == "CZ" {
+		version = "v3"
+		movieYearProvider = api.IdentityProviderIMDB
+	}
 	return trackers.WithMovieYearProvider(trackers.SubjectReleaseNameSearchPolicy(
-		fmt.Sprintf("azfamily/%s/v2", strings.ToLower(d.site.Name)),
+		fmt.Sprintf("azfamily/%s/%s", strings.ToLower(d.site.Name), version),
 		func(meta api.UploadSubject, _ config.TrackerConfig) string { return editName(d.site, meta) },
 		func(meta api.UploadSubject, _ config.TrackerConfig) string { return resolveSearchName(meta) },
-	), api.IdentityProviderTMDB)
+	), movieYearProvider)
 }
 
 // UploadContentMode declares the aggregate description workflow shared by AZ-family sites.

--- a/internal/trackers/impl/azfamily/name.go
+++ b/internal/trackers/impl/azfamily/name.go
@@ -211,7 +211,7 @@ func avistaZEnglishTitle(meta api.UploadSubject) string {
 func cinemaZTitle(meta api.UploadSubject) string {
 	original := cinemaZOriginalTitle(meta)
 	originalUsesNonLatin := containsNonLatinLetter(original)
-	if title := cinemaZEnglishCountryAKA(meta.ProviderMetadata.IMDB, originalUsesNonLatin); title != "" && !containsNonLatinLetter(title) {
+	if title := cinemaZEnglishCountryAKA(meta.ProviderMetadata.IMDB, originalUsesNonLatin); title != "" {
 		return title
 	}
 	if original == "" || !containsNonLatinLetter(original) {
@@ -229,9 +229,9 @@ func cinemaZTitle(meta api.UploadSubject) string {
 	return ""
 }
 
-// cinemaZEnglishCountryAKA returns the first English IMDb AKA with a non-Worldwide
-// country and permitted attributes. A transliterated AKA is eligible only when
-// the original title contains non-Latin letters.
+// cinemaZEnglishCountryAKA returns the first Latin-safe English IMDb AKA with a
+// non-Worldwide country and permitted attributes. A transliterated AKA is
+// eligible only when the original title contains non-Latin letters.
 func cinemaZEnglishCountryAKA(metadata *api.IMDBMetadata, originalUsesNonLatin bool) string {
 	if metadata == nil {
 		return ""
@@ -239,7 +239,7 @@ func cinemaZEnglishCountryAKA(metadata *api.IMDBMetadata, originalUsesNonLatin b
 	for _, aka := range metadata.Akas {
 		title := strings.TrimSpace(aka.Title)
 		country := strings.TrimSpace(aka.Country)
-		if title == "" || !isCinemaZCountry(country) || !isEnglishName(aka.Language) ||
+		if title == "" || containsNonLatinLetter(title) || !isCinemaZCountry(country) || !isEnglishName(aka.Language) ||
 			cinemaZAKAAttributesDisallowed(aka.Attributes, originalUsesNonLatin) {
 			continue
 		}

--- a/internal/trackers/impl/azfamily/name.go
+++ b/internal/trackers/impl/azfamily/name.go
@@ -20,10 +20,19 @@ var (
 	azPHDExtCutPattern    = regexp.MustCompile(`(?i)\bExtended\s+Cut\b`)
 	azPHDTheatrical       = regexp.MustCompile(`(?i)\bTheatrical\s+Cut\b`)
 	azNoGroupPattern      = regexp.MustCompile(`(?i)-(?:nogrp|nogroup|unknown|unk)`)
+	czLimitedPattern      = regexp.MustCompile(`(?i)\bLIMITED\b`)
+	czCriterionPattern    = regexp.MustCompile(`(?i)\bCriterion\s+Collection\b`)
+	czResolutionTag       = regexp.MustCompile(`(?i)\b(?:2K|4K)\b`)
+	czAnniversaryPattern  = regexp.MustCompile(`(?i)\b\d{1,3}(?:st|nd|rd|th)\s+Anniversary(?:\s+Edition)?\b`)
+	czExtendedPattern     = regexp.MustCompile(`(?i)\b(?:Extended(?:\s+Cut)?|EXT)\b`)
+	czDirectorCutPattern  = regexp.MustCompile("(?i)\\b(?:Director[’'`]s\\s+Cut|Directors\\s+Cut|DC)\\b")
+	czTheatricalPattern   = regexp.MustCompile(`(?i)\b(?:Theatrical\s+Cut|TC)\b`)
+	czUppercaseTagPattern = regexp.MustCompile(`(?i)\b(?:REPACK|PROPER|RESTORED|REMASTERED)\b`)
 )
 
-// editName applies the site's naming policy only to generated names; explicit
-// scene names and caller-provided names remain authoritative.
+// editName applies AZ/CZ policy only to structurally generated names, preserving
+// scene and caller-provided names; PHD retains its legacy normalization. CinemaZ
+// returns an empty name when no Latin-safe generated result can be built.
 func editName(site siteDefinition, meta api.UploadSubject) string {
 	name := selectedReleaseName(meta)
 	if site.Name == "AZ" || site.Name == "CZ" {
@@ -34,6 +43,9 @@ func editName(site siteDefinition, meta api.UploadSubject) string {
 			return name
 		}
 		name = editGeneratedName(site, meta, name)
+		if site.Name == "CZ" && (name == "" || containsNonLatinLetter(name)) {
+			return ""
+		}
 	} else {
 		name = editPHDName(meta, name)
 	}
@@ -51,6 +63,8 @@ func editName(site siteDefinition, meta api.UploadSubject) string {
 	return strings.Join(strings.Fields(name), " ")
 }
 
+// selectedReleaseName returns the first retained name in upload, no-tag, then
+// filename order.
 func selectedReleaseName(meta api.UploadSubject) string {
 	for _, candidate := range []string{meta.ReleaseName, meta.ReleaseNameNoTag, meta.Filename} {
 		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
@@ -60,30 +74,38 @@ func selectedReleaseName(meta api.UploadSubject) string {
 	return ""
 }
 
+// isGeneratedReleaseName reports whether name matches a canonical structural
+// variant. Empty variants leave the selected name exact and unmodified.
 func isGeneratedReleaseName(meta api.UploadSubject, name string) bool {
+	return releaseNameVariantMatches(meta.GeneratedReleaseNames.IncludeEpisodeTitle, name) ||
+		releaseNameVariantMatches(meta.GeneratedReleaseNames.OmitEpisodeTitle, name)
+}
+
+func releaseNameVariantMatches(variant api.ReleaseNameVariant, name string) bool {
 	name = strings.TrimSpace(name)
-	variants := []api.ReleaseNameVariant{
-		meta.GeneratedReleaseNames.IncludeEpisodeTitle,
-		meta.GeneratedReleaseNames.OmitEpisodeTitle,
+	if name == "" {
+		return false
 	}
-	for _, variant := range variants {
-		for _, candidate := range []string{variant.Name, variant.NameNoTag, variant.CleanName} {
-			if name != "" && name == strings.TrimSpace(candidate) {
-				return true
-			}
+	for _, candidate := range []string{variant.Name, variant.NameNoTag, variant.CleanName} {
+		if name == strings.TrimSpace(candidate) {
+			return true
 		}
 	}
 	return false
 }
 
-// editGeneratedName rebuilds the title/year/season prefix while preserving the
-// generated release's technical suffix.
+// editGeneratedName replaces the title/year/season prefix of an eligible
+// generated name. CinemaZ then normalizes guide-owned tags and technical order
+// while retaining protected title and episode-title text.
 func editGeneratedName(site siteDefinition, meta api.UploadSubject, name string) string {
 	title := avistaZEnglishTitle(meta)
 	if site.Name == "CZ" {
 		title = cinemaZTitle(meta)
 	}
 	if title == "" {
+		if site.Name == "CZ" {
+			return ""
+		}
 		title = strings.TrimSpace(meta.Release.Title)
 	}
 	year := releaseYear(meta)
@@ -116,7 +138,11 @@ func editGeneratedName(site siteDefinition, meta api.UploadSubject, name string)
 			name = joinNameWithSuffix(strings.TrimSpace(title+" "+strconv.Itoa(year)), suffix)
 		}
 	}
-	return removeGeneratedLanguageMarkers(name)
+	name = removeGeneratedLanguageMarkers(name)
+	if site.Name == "CZ" {
+		name = normalizeCinemaZGeneratedName(meta, title, name)
+	}
+	return name
 }
 
 func editPHDName(meta api.UploadSubject, name string) string {
@@ -178,58 +204,76 @@ func avistaZEnglishTitle(meta api.UploadSubject) string {
 	return strings.TrimSpace(meta.Release.Title)
 }
 
-// cinemaZTitle selects an English or transliterated title for CinemaZ routing,
-// falling back to the original title when no safe alternative is available.
+// cinemaZTitle selects the first permitted country-scoped English IMDb AKA, or
+// the original title when none qualifies. A non-Latin original may fall back to
+// provider romanization and then supported local transliteration; an empty
+// result means no Latin-safe title is available.
 func cinemaZTitle(meta api.UploadSubject) string {
-	if title := cinemaZEnglishCountryAKA(meta.ProviderMetadata.IMDB); title != "" {
+	original := cinemaZOriginalTitle(meta)
+	originalUsesNonLatin := containsNonLatinLetter(original)
+	if title := cinemaZEnglishCountryAKA(meta.ProviderMetadata.IMDB, originalUsesNonLatin); title != "" && !containsNonLatinLetter(title) {
 		return title
 	}
-	original := cinemaZOriginalTitle(meta)
 	if original == "" || !containsNonLatinLetter(original) {
 		return original
-	}
-	transliterated := transliterateCinemaZTitle(original)
-	if !containsNonLatinLetter(transliterated) {
-		return transliterated
 	}
 	for _, candidate := range cinemaZRomanizedCandidates(meta) {
 		if candidate != "" && !containsNonLatinLetter(candidate) {
 			return candidate
 		}
 	}
-	return original
-}
-
-func cinemaZEnglishCountryAKA(metadata *api.IMDBMetadata) string {
-	if metadata == nil {
-		return ""
-	}
-	countries := imdbCountries(metadata)
-	for _, aka := range metadata.Akas {
-		title := strings.TrimSpace(aka.Title)
-		country := strings.TrimSpace(aka.Country)
-		if title == "" || country == "" || !isEnglishName(aka.Language) {
-			continue
-		}
-		if len(countries) == 0 || containsEqualFold(countries, country) {
-			return title
-		}
+	transliterated := transliterateCinemaZTitle(original)
+	if transliterated != "" && !containsNonLatinLetter(transliterated) {
+		return transliterated
 	}
 	return ""
 }
 
-func imdbCountries(metadata *api.IMDBMetadata) []string {
-	countries := make([]string, 0)
-	if country := strings.TrimSpace(metadata.Country); country != "" {
-		countries = append(countries, country)
+// cinemaZEnglishCountryAKA returns the first English IMDb AKA with a non-Worldwide
+// country and permitted attributes. A transliterated AKA is eligible only when
+// the original title contains non-Latin letters.
+func cinemaZEnglishCountryAKA(metadata *api.IMDBMetadata, originalUsesNonLatin bool) string {
+	if metadata == nil {
+		return ""
 	}
-	for country := range strings.SplitSeq(metadata.CountryList, ",") {
-		country = strings.TrimSpace(country)
-		if country != "" && !containsEqualFold(countries, country) {
-			countries = append(countries, country)
+	for _, aka := range metadata.Akas {
+		title := strings.TrimSpace(aka.Title)
+		country := strings.TrimSpace(aka.Country)
+		if title == "" || !isCinemaZCountry(country) || !isEnglishName(aka.Language) ||
+			cinemaZAKAAttributesDisallowed(aka.Attributes, originalUsesNonLatin) {
+			continue
+		}
+		return title
+	}
+	return ""
+}
+
+// isCinemaZCountry treats any nonblank, non-Worldwide IMDb country label as
+// country-scoped.
+func isCinemaZCountry(country string) bool {
+	country = strings.ToLower(strings.TrimSpace(country))
+	if country == "" {
+		return false
+	}
+	country = strings.NewReplacer("-", "", "_", "", " ", "").Replace(country)
+	return !strings.Contains(country, "worldwide")
+}
+
+// cinemaZAKAAttributesDisallowed rejects informal, working, and festival titles,
+// plus transliterated titles when the original already uses the Latin alphabet.
+func cinemaZAKAAttributesDisallowed(attributes []string, originalUsesNonLatin bool) bool {
+	for _, attribute := range attributes {
+		attribute = strings.ToLower(strings.TrimSpace(attribute))
+		switch {
+		case strings.Contains(attribute, "informal"),
+			strings.Contains(attribute, "working"),
+			strings.Contains(attribute, "festival"):
+			return true
+		case strings.Contains(attribute, "transliter") && !originalUsesNonLatin:
+			return true
 		}
 	}
-	return countries
+	return false
 }
 
 func isEnglishName(language string) bool {
@@ -241,15 +285,8 @@ func isEnglishName(language string) bool {
 	}
 }
 
-func containsEqualFold(values []string, target string) bool {
-	for _, value := range values {
-		if strings.EqualFold(value, target) {
-			return true
-		}
-	}
-	return false
-}
-
+// cinemaZOriginalTitle returns the IMDb original title when present, followed by
+// the TMDB original, parsed alternate title, and parsed primary title.
 func cinemaZOriginalTitle(meta api.UploadSubject) string {
 	if meta.ProviderMetadata.IMDB != nil {
 		if title := strings.TrimSpace(meta.ProviderMetadata.IMDB.AKA); title != "" {
@@ -269,6 +306,8 @@ func cinemaZOriginalTitle(meta api.UploadSubject) string {
 	return strings.TrimSpace(meta.Release.Title)
 }
 
+// cinemaZRomanizedCandidates returns provider and parsed title candidates in
+// the order CinemaZ uses before local transliteration.
 func cinemaZRomanizedCandidates(meta api.UploadSubject) []string {
 	candidates := make([]string, 0, 5)
 	if meta.ProviderMetadata.TMDB != nil {
@@ -292,6 +331,284 @@ func trimAKAPrefix(value string) string {
 		return strings.TrimSpace(value[len("AKA "):])
 	}
 	return value
+}
+
+// normalizeCinemaZGeneratedName applies CinemaZ's suffix-only rules to one
+// structural name. It protects the title/year/season and selected episode title,
+// normalizes release tags, and rebuilds disc/remux technical tails from canonical
+// metadata; a name without the expected prefix is returned unchanged.
+func normalizeCinemaZGeneratedName(meta api.UploadSubject, title, name string) string {
+	title = strings.TrimSpace(title)
+	prefix := cinemaZGeneratedNamePrefix(meta, title)
+	suffix := strings.TrimSpace(strings.TrimPrefix(name, prefix))
+	if suffix == name {
+		return name
+	}
+	if isTV(meta) && selectedGeneratedNameUsesIncludeVariant(meta) {
+		for _, candidate := range cinemaZEpisodeTitleCandidates(meta) {
+			if episodeTitle, remainder, ok := cutLeadingNameElement(suffix, candidate); ok {
+				prefix = joinNameWithSuffix(prefix, episodeTitle)
+				suffix = remainder
+				break
+			}
+		}
+	}
+	for _, pattern := range []*regexp.Regexp{czLimitedPattern, czCriterionPattern, czResolutionTag, czAnniversaryPattern} {
+		suffix = pattern.ReplaceAllString(suffix, "")
+	}
+	suffix = czExtendedPattern.ReplaceAllString(suffix, "EXT")
+	suffix = czDirectorCutPattern.ReplaceAllString(suffix, "DC")
+	suffix = czTheatricalPattern.ReplaceAllString(suffix, "TC")
+	suffix = czUppercaseTagPattern.ReplaceAllStringFunc(suffix, strings.ToUpper)
+	suffix = moveCinemaZHybridAfterResolution(suffix, meta.Release.Resolution)
+
+	typeValue := strings.ToUpper(strings.TrimSpace(meta.Type))
+	if typeValue == "" {
+		typeValue = strings.ToUpper(strings.TrimSpace(meta.Release.Type))
+	}
+	discType := strings.ToUpper(strings.TrimSpace(meta.DiscType))
+	source := strings.TrimSpace(meta.Source)
+	if source == "" {
+		source = strings.TrimSpace(meta.Release.Source)
+	}
+	dvdSource := strings.EqualFold(source, "DVD") || strings.EqualFold(source, "PAL DVD") || strings.EqualFold(source, "NTSC DVD")
+	bluRaySource := strings.EqualFold(source, "BluRay") || strings.EqualFold(source, "Blu-ray")
+	resolution := strings.TrimSpace(meta.Release.Resolution)
+	region := strings.TrimSpace(meta.Region)
+	if region == "" {
+		region = strings.TrimSpace(meta.Release.Region)
+	}
+	hybrid := ""
+	if _, ok := suffixAfterNameElement(suffix, "HYBRID"); ok {
+		hybrid = "HYBRID"
+	}
+	uhd := strings.TrimSpace(meta.UHD)
+	if uhd == "" {
+		if _, ok := suffixAfterNameElement(suffix, "UHD"); ok {
+			uhd = "UHD"
+		}
+	}
+	video := strings.TrimSpace(meta.VideoCodec)
+	switch {
+	case typeValue == "DVDRIP":
+		video = strings.TrimSpace(meta.VideoEncode)
+		if video == "" {
+			video = strings.TrimSpace(meta.VideoCodec)
+		}
+		suffix = removeCinemaZNameElements(suffix, source, "DVD", "DVDRip", meta.Audio, meta.VideoEncode, meta.VideoCodec, video)
+		suffix = reorderCinemaZTechnicalTail(suffix, meta.Tag, []string{"DVDRip", meta.Audio, video})
+	case typeValue == "REMUX" && (dvdSource || (source == "" && discType == "DVD")):
+		video = cinemaZDVDVideo(video)
+		suffix = removeCinemaZNameElements(suffix, source, "DVD", "REMUX", "DVD Remux", resolution, meta.Audio, meta.VideoCodec, video)
+		suffix = reorderCinemaZTechnicalTail(suffix, meta.Tag, []string{resolution, "DVD Remux", meta.Audio, video})
+	case typeValue == "REMUX" && (bluRaySource || (source == "" && discType == "BDMV")):
+		suffix = removeCinemaZNameElements(
+			suffix,
+			source,
+			"BluRay",
+			"Blu-ray",
+			"REMUX",
+			"BluRay REMUX",
+			resolution,
+			hybrid,
+			uhd,
+			meta.HDR,
+			video,
+			meta.Audio,
+		)
+		suffix = reorderCinemaZTechnicalTail(
+			suffix,
+			meta.Tag,
+			[]string{resolution, hybrid, uhd, "BluRay REMUX", meta.HDR, video, meta.Audio},
+		)
+	case typeValue == "REMUX":
+		suffix = reorderCinemaZTechnicalTail(suffix, meta.Tag, []string{meta.HDR, video, meta.Audio})
+	case discType == "DVD":
+		video = cinemaZDVDVideo(video)
+		dvdSize := strings.TrimSpace(meta.Release.Size)
+		if dvdSize == "" {
+			switch {
+			case nameHasElement(suffix, "DVD9"):
+				dvdSize = "DVD9"
+			case nameHasElement(suffix, "DVD5"):
+				dvdSize = "DVD5"
+			default:
+				dvdSize = "DVD"
+			}
+		}
+		suffix = removeCinemaZNameElements(
+			suffix,
+			region,
+			source,
+			"DVD",
+			"DVD5",
+			"DVD9",
+			resolution,
+			meta.Audio,
+			meta.VideoCodec,
+			video,
+		)
+		suffix = reorderCinemaZTechnicalTail(suffix, meta.Tag, []string{resolution, dvdSize, meta.Audio, video})
+	case discType == "BDMV":
+		suffix = removeCinemaZNameElements(
+			suffix,
+			source,
+			"BluRay",
+			"Blu-ray",
+			"RAW",
+			"Blu-ray RAW",
+			resolution,
+			hybrid,
+			region,
+			uhd,
+			meta.HDR,
+			video,
+			meta.Audio,
+		)
+		suffix = reorderCinemaZTechnicalTail(
+			suffix,
+			meta.Tag,
+			[]string{resolution, hybrid, region, uhd, "Blu-ray RAW", meta.HDR, video, meta.Audio},
+		)
+	}
+	name = joinNameWithSuffix(prefix, suffix)
+	return strings.Join(strings.Fields(name), " ")
+}
+
+// cinemaZGeneratedNamePrefix returns the title/year/season segment that bounds
+// CinemaZ suffix normalization.
+func cinemaZGeneratedNamePrefix(meta api.UploadSubject, title string) string {
+	parts := []string{title}
+	year := formattedYear(releaseYear(meta))
+	if isTV(meta) {
+		if seasonEpisode := releaseSeasonEpisode(meta); seasonEpisode != "" {
+			return strings.Join(nonEmptyStrings(append(parts, year, seasonEpisode)), " ")
+		}
+	}
+	return strings.Join(nonEmptyStrings(append(parts, year)), " ")
+}
+
+// selectedGeneratedNameUsesIncludeVariant reports whether the selected name
+// matches an include-episode-title variant. Include and omit variants may be
+// identical when a manual episode title is authoritative.
+func selectedGeneratedNameUsesIncludeVariant(meta api.UploadSubject) bool {
+	return releaseNameVariantMatches(meta.GeneratedReleaseNames.IncludeEpisodeTitle, selectedReleaseName(meta))
+}
+
+// cinemaZEpisodeTitleCandidates returns the effective prepared episode title
+// first, followed by provider titles that canonical generation may have chosen.
+func cinemaZEpisodeTitleCandidates(meta api.UploadSubject) []string {
+	candidates := []string{meta.EpisodeTitle}
+	if meta.ProviderMetadata.TVDB != nil {
+		candidates = append(candidates, meta.ProviderMetadata.TVDB.EpisodeNameEnglish, meta.ProviderMetadata.TVDB.EpisodeName)
+	}
+	return candidates
+}
+
+// cutLeadingNameElement removes a separator-delimited element only from the
+// start of name and returns the spelling found there. A group-separating hyphen
+// remains attached to the returned remainder.
+func cutLeadingNameElement(name, element string) (string, string, bool) {
+	nameRunes := []rune(strings.TrimSpace(name))
+	elementRunes := []rune(strings.TrimSpace(element))
+	if len(nameRunes) == 0 || len(elementRunes) == 0 || len(elementRunes) > len(nameRunes) {
+		return "", name, false
+	}
+	end := len(elementRunes)
+	if !strings.EqualFold(string(nameRunes[:end]), string(elementRunes)) || (end < len(nameRunes) && !isNameSeparator(nameRunes[end])) {
+		return "", name, false
+	}
+	rawRemainder := string(nameRunes[end:])
+	remainder := strings.TrimLeftFunc(rawRemainder, isNameSeparator)
+	if strings.HasPrefix(rawRemainder, "-") && remainder != "" && !strings.ContainsAny(remainder, " ._") {
+		remainder = "-" + remainder
+	}
+	return string(nameRunes[:end]), remainder, true
+}
+
+// moveCinemaZHybridAfterResolution places an exact HYBRID token immediately
+// after resolution. When the resolution is absent or not found, HYBRID remains
+// normalized in its original position.
+func moveCinemaZHybridAfterResolution(name, resolution string) string {
+	fields := strings.Fields(name)
+	for index, field := range fields {
+		if strings.EqualFold(field, "Hybrid") {
+			fields[index] = "HYBRID"
+		}
+	}
+	resolution = strings.TrimSpace(resolution)
+	if resolution == "" {
+		return strings.Join(fields, " ")
+	}
+	foundHybrid := false
+	result := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if strings.EqualFold(field, "Hybrid") {
+			foundHybrid = true
+			continue
+		}
+		result = append(result, field)
+	}
+	if !foundHybrid {
+		return strings.Join(result, " ")
+	}
+	for index, field := range result {
+		if strings.EqualFold(field, resolution) {
+			result = append(result, "")
+			copy(result[index+2:], result[index+1:])
+			result[index+1] = "HYBRID"
+			return strings.Join(result, " ")
+		}
+	}
+	return strings.Join(fields, " ")
+}
+
+func nameHasElement(name, element string) bool {
+	_, ok := suffixAfterNameElement(name, element)
+	return ok
+}
+
+func removeCinemaZNameElements(name string, elements ...string) string {
+	for _, element := range elements {
+		if element = strings.TrimSpace(element); element != "" {
+			name = replaceNameElements(name, element, "")
+		}
+	}
+	return name
+}
+
+// cinemaZDVDVideo normalizes accepted MPEG-2 spellings to CinemaZ's MPEG2 token.
+func cinemaZDVDVideo(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.EqualFold(value, "MPEG-2") || strings.EqualFold(value, "MPEG 2") {
+		return "MPEG2"
+	}
+	return value
+}
+
+// reorderCinemaZTechnicalTail removes known elements from a generated suffix,
+// appends them in the requested order, and restores its exact trailing group tag.
+// Callers pass suffixes so title and episode-title text cannot be rewritten.
+func reorderCinemaZTechnicalTail(name, tag string, elements []string) string {
+	tag = strings.TrimSpace(tag)
+	base := strings.TrimSpace(name)
+	if tag != "" && len(base) >= len(tag) && strings.EqualFold(base[len(base)-len(tag):], tag) {
+		base = strings.TrimSpace(base[:len(base)-len(tag)])
+	} else {
+		tag = ""
+	}
+	ordered := make([]string, 0, len(elements))
+	for _, element := range elements {
+		element = strings.TrimSpace(element)
+		if element == "" {
+			continue
+		}
+		base = replaceNameElements(base, element, "")
+		ordered = append(ordered, element)
+	}
+	base = strings.Join(strings.Fields(base), " ")
+	base = strings.TrimSpace(strings.Join(nonEmptyStrings(append([]string{base}, ordered...)), " "))
+	return base + tag
 }
 
 func releaseYear(meta api.UploadSubject) int {
@@ -472,6 +789,8 @@ func containsNonLatinLetter(value string) bool {
 	return false
 }
 
+// transliterateCinemaZTitle converts supported Cyrillic and Greek runes while
+// leaving unsupported runes intact so the caller can reject a non-Latin result.
 func transliterateCinemaZTitle(value string) string {
 	var result strings.Builder
 	for _, current := range value {

--- a/internal/trackers/impl/azfamily/name_test.go
+++ b/internal/trackers/impl/azfamily/name_test.go
@@ -60,7 +60,7 @@ func TestEditNameAZCZPolicyFixtures(t *testing.T) {
 			want: "Example Series S01 2026 1080p WEB-DL H.265-GRP",
 		},
 		{
-			name: "CZ uses one English country AKA",
+			name: "CZ uses a country English AKA independent of production country",
 			site: "CZ",
 			meta: generatedCZSubject(
 				"MOVIE",
@@ -77,13 +77,13 @@ func TestEditNameAZCZPolicyFixtures(t *testing.T) {
 					CountryList: "Exampleland, Secondland",
 					Akas: []api.IMDBAKA{
 						{
-							Title:    "Invalid Other Country",
-							Country:  "Otherland",
+							Title:    "Invalid Worldwide Title",
+							Country:  "World-wide",
 							Language: "English",
 						},
 						{
 							Title:    "Example Film",
-							Country:  "Exampleland",
+							Country:  "Otherland",
 							Language: "English",
 						},
 						{
@@ -116,7 +116,7 @@ func TestEditNameAZCZPolicyFixtures(t *testing.T) {
 			want: "Primer Filma 2026 1080p WEB-DL H.265-GRP",
 		},
 		{
-			name: "CZ transliterates native original title",
+			name: "CZ prefers provider romanization to local transliteration",
 			site: "CZ",
 			meta: generatedCZSubject(
 				"MOVIE",
@@ -132,7 +132,7 @@ func TestEditNameAZCZPolicyFixtures(t *testing.T) {
 					Country: "Exampleland",
 				},
 			),
-			want: "Primer Film 2026 1080p WEB-DL H.265-GRP",
+			want: "Example Localized 2026 1080p WEB-DL H.265-GRP",
 		},
 		{
 			name: "CZ TV always includes year",
@@ -206,21 +206,403 @@ func TestEditNameAZCZPolicyFixtures(t *testing.T) {
 	}
 }
 
-func TestAZFamilyNamingPolicyVersions(t *testing.T) {
+func TestCinemaZEnglishCountryAKA(t *testing.T) {
 	tests := []struct {
-		site string
+		name                 string
+		aka                  api.IMDBAKA
+		originalUsesNonLatin bool
+		want                 string
+	}{
+		{
+			name: "country need not match production country",
+			aka: api.IMDBAKA{
+				Title:    "Example English Title",
+				Country:  "Otherland",
+				Language: "English",
+			},
+			want: "Example English Title",
+		},
+		{
+			name: "worldwide is not country scoped",
+			aka: api.IMDBAKA{
+				Title:    "Example English Title",
+				Country:  "World-wide",
+				Language: "English",
+			},
+		},
+		{
+			name: "blank country is rejected",
+			aka:  api.IMDBAKA{Title: "Example English Title", Language: "English"},
+		},
+		{
+			name: "informal title is rejected",
+			aka: api.IMDBAKA{
+				Title:      "Example English Title",
+				Country:    "Otherland",
+				Language:   "English",
+				Attributes: []string{"informal title"},
+			},
+		},
+		{
+			name: "working title is rejected",
+			aka: api.IMDBAKA{
+				Title:      "Example English Title",
+				Country:    "Otherland",
+				Language:   "English",
+				Attributes: []string{"working title"},
+			},
+		},
+		{
+			name: "festival title is rejected",
+			aka: api.IMDBAKA{
+				Title:      "Example English Title",
+				Country:    "Otherland",
+				Language:   "English",
+				Attributes: []string{"festival title"},
+			},
+		},
+		{
+			name: "transliterated Latin original is rejected",
+			aka: api.IMDBAKA{
+				Title:      "Example English Title",
+				Country:    "Otherland",
+				Language:   "English",
+				Attributes: []string{"transliterated title"},
+			},
+		},
+		{
+			name: "transliterated non-Latin original is allowed",
+			aka: api.IMDBAKA{
+				Title:      "Example Romanization",
+				Country:    "Otherland",
+				Language:   "English",
+				Attributes: []string{"transliterated title"},
+			},
+			originalUsesNonLatin: true,
+			want:                 "Example Romanization",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			metadata := &api.IMDBMetadata{
+				Country: "Exampleland",
+				Akas:    []api.IMDBAKA{test.aka},
+			}
+			if got := cinemaZEnglishCountryAKA(metadata, test.originalUsesNonLatin); got != test.want {
+				t.Fatalf("cinemaZEnglishCountryAKA() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCinemaZNonLatinTitleFallbacks(t *testing.T) {
+	tests := []struct {
+		name string
+		meta api.UploadSubject
 		want string
 	}{
-		{site: "AZ", want: "azfamily/az/v2"},
-		{site: "CZ", want: "azfamily/cz/v2"},
-		{site: "PHD", want: "azfamily/phd/v2"},
+		{
+			name: "provider romanization wins",
+			meta: api.UploadSubject{
+				Release: api.ReleaseInfo{Title: "Пример Фильм"},
+				ProviderMetadata: api.SourceScopedMetadata{
+					IMDB: &api.IMDBMetadata{Title: "Provider Romanization", AKA: "Пример Фильм"},
+					TMDB: &api.TMDBMetadata{RetrievedAKA: "AKA Other Romanization", OriginalTitle: "Пример Фильм"},
+				},
+			},
+			want: "Other Romanization",
+		},
+		{
+			name: "supported local transliteration is last resort",
+			meta: api.UploadSubject{
+				Release: api.ReleaseInfo{Title: "Пример Фильм"},
+				ProviderMetadata: api.SourceScopedMetadata{
+					IMDB: &api.IMDBMetadata{Title: "Пример Фильм", AKA: "Пример Фильм"},
+					TMDB: &api.TMDBMetadata{Title: "Пример Фильм", OriginalTitle: "Пример Фильм"},
+				},
+			},
+			want: "Primer Film",
+		},
+		{
+			name: "unsupported non-Latin title fails closed",
+			meta: api.UploadSubject{
+				Release: api.ReleaseInfo{Title: "例の作品"},
+				ProviderMetadata: api.SourceScopedMetadata{
+					IMDB: &api.IMDBMetadata{Title: "例の作品", AKA: "例の作品"},
+					TMDB: &api.TMDBMetadata{Title: "例の作品", OriginalTitle: "例の作品"},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := cinemaZTitle(test.meta); got != test.want {
+				t.Fatalf("cinemaZTitle() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestEditNameCinemaZFailsClosedOnlyForGeneratedNonLatinNames(t *testing.T) {
+	generated := generatedCZSubject(
+		"MOVIE",
+		"例の作品 2026 1080p WEB-DL H.265-GRP",
+		api.ReleaseInfo{
+			Title: "例の作品",
+			Alt:   "例の作品",
+			Year:  2026,
+		},
+		&api.IMDBMetadata{Title: "例の作品", AKA: "例の作品"},
+	)
+	generated.ProviderMetadata.TMDB.Title = "例の作品"
+	generated.ProviderMetadata.TMDB.OriginalTitle = "例の作品"
+	if got := editName(siteFor("CZ"), generated); got != "" {
+		t.Fatalf("generated non-Latin editName() = %q, want empty", got)
+	}
+	if _, failure := trackers.PrepareInputWithReleaseNamePolicy(
+		trackers.PreparationInput{Tracker: "CZ", Meta: generated},
+		New("CZ").ReleaseNamePolicy(),
+	); failure == nil || failure.Code() != "name_policy" {
+		t.Fatalf("generated non-Latin policy failure = %v, want name_policy", failure)
+	}
+
+	requested := generated
+	requested.ReleaseName = "Exact Requested 例の作品 2026-GRP"
+	requested.GeneratedReleaseNames = api.GeneratedReleaseNameVariants{}
+	if got := editName(siteFor("CZ"), requested); got != requested.ReleaseName {
+		t.Fatalf("requested editName() = %q, want %q", got, requested.ReleaseName)
+	}
+}
+
+func TestNormalizeCinemaZGeneratedName(t *testing.T) {
+	tests := []struct {
+		name        string
+		category    string
+		releaseName string
+		configure   func(*api.UploadSubject)
+		want        string
+	}{
+		{
+			name: "edition rules and HYBRID placement",
+			releaseName: "Example Film 2026 LIMITED Criterion Collection 25th Anniversary Edition Extended Cut Director's Cut 4K " +
+				"REPACK Hybrid 2160p WEB-DL DD 5.1 H.265-GRP",
+			configure: func(meta *api.UploadSubject) {
+				meta.Type = "WEBDL"
+				meta.Release.Resolution = "2160p"
+			},
+			want: "Example Film 2026 EXT DC REPACK 2160p HYBRID WEB-DL DD 5.1 H.265-GRP",
+		},
+		{
+			name:        "BluRay remux orders HDR video and audio",
+			releaseName: "Example Film 2026 2160p Hybrid UHD BluRay REMUX TrueHD 7.1 Atmos DV HDR10+ HEVC-GRP",
+			configure: func(meta *api.UploadSubject) {
+				meta.Type = "REMUX"
+				meta.DiscType = "BDMV"
+				meta.Source = "BluRay"
+				meta.Release.Resolution = "2160p"
+				meta.UHD = "UHD"
+				meta.HDR = "DV HDR10+"
+				meta.VideoCodec = "HEVC"
+				meta.Audio = "TrueHD 7.1 Atmos"
+			},
+			want: "Example Film 2026 2160p HYBRID UHD BluRay REMUX DV HDR10+ HEVC TrueHD 7.1 Atmos-GRP",
+		},
+		{
+			name:        "Blu-ray raw adds the rip type and orders its technical tail",
+			releaseName: "Example Film 2026 2160p USA UHD BluRay HDR HEVC DTS-HD MA 2.0-GRP",
+			configure: func(meta *api.UploadSubject) {
+				meta.Type = "DISC"
+				meta.DiscType = "BDMV"
+				meta.Source = "BluRay"
+				meta.Release.Resolution = "2160p"
+				meta.Region = "USA"
+				meta.UHD = "UHD"
+				meta.HDR = "HDR"
+				meta.VideoCodec = "HEVC"
+				meta.Audio = "DTS-HD MA 2.0"
+			},
+			want: "Example Film 2026 2160p USA UHD Blu-ray RAW HDR HEVC DTS-HD MA 2.0-GRP",
+		},
+		{
+			name:        "DVD raw adds resolution and video from metadata",
+			releaseName: "Example Film 2026 R1 DVD DVD9 DD 5.1-GRP",
+			configure: func(meta *api.UploadSubject) {
+				meta.Type = "DISC"
+				meta.DiscType = "DVD"
+				meta.Source = "DVD"
+				meta.Release.Resolution = "480p"
+				meta.Release.Size = "DVD9"
+				meta.Region = "R1"
+				meta.Audio = "DD 5.1"
+				meta.VideoCodec = "MPEG-2"
+			},
+			want: "Example Film 2026 480p DVD9 DD 5.1 MPEG2-GRP",
+		},
+		{
+			name:        "DVD remux wins over persisted disc type and adds omitted fields",
+			releaseName: "Example Film 2026 DVD REMUX DD 2.0-GRP",
+			configure: func(meta *api.UploadSubject) {
+				meta.Type = "REMUX"
+				meta.DiscType = "DVD"
+				meta.Source = "DVD"
+				meta.Release.Resolution = "576p"
+				meta.Audio = "DD 2.0"
+				meta.VideoCodec = "MPEG-2"
+			},
+			want: "Example Film 2026 576p DVD Remux DD 2.0 MPEG2-GRP",
+		},
+		{
+			name:        "DVDRip removes source and orders audio before video",
+			releaseName: "Example Film 2026 DVD XviD DVDRip MP3-GRP",
+			configure: func(meta *api.UploadSubject) {
+				meta.Type = "DVDRIP"
+				meta.Source = "DVD"
+				meta.Audio = "MP3"
+				meta.VideoEncode = "XviD"
+			},
+			want: "Example Film 2026 DVDRip MP3 XviD-GRP",
+		},
+		{
+			name:        "TV episode title words are not treated as release tags",
+			category:    "TV",
+			releaseName: "Example Film 2026 S01E02 Limited Hybrid Extended Cut Hybrid 1080p WEB-DL DD 5.1 H.265-GRP",
+			configure: func(meta *api.UploadSubject) {
+				meta.Type = "WEBDL"
+				meta.EpisodeTitle = "Parsed Episode"
+				meta.ProviderMetadata.TVDB.EpisodeNameEnglish = "Limited Hybrid"
+				meta.Release.Resolution = "1080p"
+			},
+			want: "Example Film 2026 S01E02 Limited Hybrid EXT 1080p HYBRID WEB-DL DD 5.1 H.265-GRP",
+		},
+		{
+			name:        "manual TV episode title remains protected when variants match",
+			category:    "TV",
+			releaseName: "Example Film 2026 S01E02 Limited Hybrid 1080p WEB-DL DD 5.1 H.265-GRP",
+			configure: func(meta *api.UploadSubject) {
+				meta.Type = "WEBDL"
+				meta.EpisodeTitle = "Limited Hybrid"
+				meta.GeneratedReleaseNames.OmitEpisodeTitle = meta.GeneratedReleaseNames.IncludeEpisodeTitle
+				meta.Release.Resolution = "1080p"
+			},
+			want: "Example Film 2026 S01E02 Limited Hybrid 1080p WEB-DL DD 5.1 H.265-GRP",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			category := test.category
+			if category == "" {
+				category = "MOVIE"
+			}
+			meta := generatedCZSubject(
+				category,
+				test.releaseName,
+				api.ReleaseInfo{
+					Title: "Example Localized",
+					Alt:   "Example Original",
+					Year:  2026,
+				},
+				&api.IMDBMetadata{
+					AKA: "Example Original",
+					Akas: []api.IMDBAKA{{
+						Title:    "Example Film",
+						Country:  "Otherland",
+						Language: "English",
+					}},
+				},
+			)
+			test.configure(&meta)
+			if got := editName(siteFor("CZ"), meta); got != test.want {
+				t.Fatalf("editName() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeCinemaZGeneratedNameDoesNotEditTitleWords(t *testing.T) {
+	meta := api.UploadSubject{
+		DiscType:   "BDMV",
+		Source:     "BluRay",
+		UHD:        "UHD",
+		HDR:        "HDR",
+		Region:     "USA",
+		VideoCodec: "HEVC",
+		Audio:      "DTS-HD MA 2.0",
+		Tag:        "-GRP",
+		Release:    api.ReleaseInfo{Resolution: "2160p"},
+	}
+	name := "Example HDR 2026 2160p USA UHD BluRay HDR HEVC DTS-HD MA 2.0-GRP"
+	want := "Example HDR 2026 2160p USA UHD Blu-ray RAW HDR HEVC DTS-HD MA 2.0-GRP"
+	if got := normalizeCinemaZGeneratedName(meta, "Example HDR", name); got != want {
+		t.Fatalf("normalizeCinemaZGeneratedName() = %q, want %q", got, want)
+	}
+}
+
+func TestAZFamilyNamingPolicyVersions(t *testing.T) {
+	tests := []struct {
+		site         string
+		want         string
+		yearProvider api.IdentityProvider
+	}{
+		{
+			site:         "AZ",
+			want:         "azfamily/az/v2",
+			yearProvider: api.IdentityProviderTMDB,
+		},
+		{
+			site:         "CZ",
+			want:         "azfamily/cz/v3",
+			yearProvider: api.IdentityProviderIMDB,
+		},
+		{
+			site:         "PHD",
+			want:         "azfamily/phd/v2",
+			yearProvider: api.IdentityProviderTMDB,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.site, func(t *testing.T) {
-			if got := New(test.site).ReleaseNamePolicy().ID; got != test.want {
+			policy := New(test.site).ReleaseNamePolicy()
+			if got := policy.ID; got != test.want {
 				t.Fatalf("policy ID = %q, want %q", got, test.want)
 			}
+			if got := policy.MovieYearProvider; got != test.yearProvider {
+				t.Fatalf("movie year provider = %q, want %q", got, test.yearProvider)
+			}
 		})
+	}
+}
+
+func TestCinemaZReleaseNamePolicyUsesIMDbProductionYear(t *testing.T) {
+	meta := generatedCZSubject(
+		"MOVIE",
+		"Example Localized Example Original 2025 1080p WEB-DL H.265-GRP",
+		api.ReleaseInfo{
+			Title: "Example Localized",
+			Alt:   "Example Original",
+			Year:  2025,
+		},
+		&api.IMDBMetadata{
+			Title: "Example Film",
+			AKA:   "Example Original",
+			Year:  2024,
+			Akas: []api.IMDBAKA{{
+				Title:    "Example Film",
+				Country:  "Otherland",
+				Language: "English",
+			}},
+		},
+	)
+	meta.ProviderMetadata.TMDB.Year = 2026
+
+	input, failure := trackers.PrepareInputWithReleaseNamePolicy(
+		trackers.PreparationInput{Tracker: "CZ", Meta: meta},
+		New("CZ").ReleaseNamePolicy(),
+	)
+	if failure != nil {
+		t.Fatalf("resolve CinemaZ release name: %v", failure)
+	}
+	if got, want := input.Projection.UploadReleaseName, "Example Film 2024 1080p WEB-DL H.265-GRP"; got != want {
+		t.Fatalf("CinemaZ upload name = %q, want %q", got, want)
 	}
 }
 

--- a/internal/trackers/impl/azfamily/name_test.go
+++ b/internal/trackers/impl/azfamily/name_test.go
@@ -293,6 +293,24 @@ func TestCinemaZEnglishCountryAKA(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("non-Latin title does not hide later Latin AKA", func(t *testing.T) {
+		metadata := &api.IMDBMetadata{Akas: []api.IMDBAKA{
+			{
+				Title:    "Пример фильма",
+				Country:  "Otherland",
+				Language: "English",
+			},
+			{
+				Title:    "Example English Title",
+				Country:  "Otherland",
+				Language: "English",
+			},
+		}}
+		if got, want := cinemaZEnglishCountryAKA(metadata, true), "Example English Title"; got != want {
+			t.Fatalf("cinemaZEnglishCountryAKA() = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestCinemaZNonLatinTitleFallbacks(t *testing.T) {

--- a/internal/trackers/impl/registry_test.go
+++ b/internal/trackers/impl/registry_test.go
@@ -111,20 +111,21 @@ func TestMovieYearProvidersFollowTrackerMetadataAuthority(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new registry: %v", err)
 	}
-	for _, family := range []trackers.Family{trackers.FamilyUnit3D, trackers.FamilyAZFamily} {
-		for _, name := range registry.NamesByFamily(family) {
-			descriptor, ok := registry.LookupDescriptor(name)
-			if !ok || descriptor.ReleaseNamePolicy.MovieYearProvider != api.IdentityProviderTMDB {
-				t.Fatalf("%s movie-year provider = %q", name, descriptor.ReleaseNamePolicy.MovieYearProvider)
-			}
+	for _, name := range registry.NamesByFamily(trackers.FamilyUnit3D) {
+		descriptor, ok := registry.LookupDescriptor(name)
+		if !ok || descriptor.ReleaseNamePolicy.MovieYearProvider != api.IdentityProviderTMDB {
+			t.Fatalf("%s movie-year provider = %q", name, descriptor.ReleaseNamePolicy.MovieYearProvider)
 		}
 	}
 	for name, provider := range map[string]api.IdentityProvider{
 		"ANT": api.IdentityProviderTMDB,
+		"AZ":  api.IdentityProviderTMDB,
 		"BJS": api.IdentityProviderTMDB,
 		"BHD": api.IdentityProviderIMDB,
+		"CZ":  api.IdentityProviderIMDB,
 		"CZT": api.IdentityProviderIMDB,
 		"HDB": api.IdentityProviderIMDB,
+		"PHD": api.IdentityProviderTMDB,
 		"PTP": api.IdentityProviderIMDB,
 	} {
 		descriptor, ok := registry.LookupDescriptor(name)

--- a/internal/trackers/impl/responsibility_ledger_test.go
+++ b/internal/trackers/impl/responsibility_ledger_test.go
@@ -112,7 +112,7 @@ var trackerResponsibilityLedger = []trackerResponsibilityRow{
 	unit3DResponsibilityVersion("YUS", "yus", "", "v2"),
 	unit3DResponsibility("ZNTH", "znth"),
 	azFamilyResponsibilityVersion("AZ", "v2"),
-	azFamilyResponsibilityVersion("CZ", "v2"),
+	azFamilyResponsibilityVersion("CZ", "v3"),
 	azFamilyResponsibilityVersion("PHD", "v2"),
 	{
 		name:              "ANT",


### PR DESCRIPTION
## Summary

- add a CinemaZ v3 release-name policy using IMDb production years
- select permitted country-scoped English IMDb AKAs, with romanization and supported transliteration fallbacks
- normalize CinemaZ edition, disc, remux, and codec ordering while protecting title and TV episode-title text

## Why

CinemaZ naming differs from the existing AvistaZ and PrivateHD v2 rules. The tracker guide data requires site-specific title authority, Latin-safe generated names, and technical-tail ordering. This PR is stacked on #382 because it uses the naming presentation and provider metadata established there.

## Impact

Generated CinemaZ names now follow the tracker-specific rules. Scene names and caller-provided names remain authoritative, unsupported non-Latin generated titles fail preparation with `name_policy`, and AvistaZ/PrivateHD behavior remains on v2.

## Checks

- `go test -race -v -timeout 20m ./internal/trackers/impl/azfamily ./internal/trackers/impl`
- `make lint`
- `make gofix-check-changed`
- `git diff --check`
- pre-commit and pre-push hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved CinemaZ release naming with better title selection, transliteration, episode handling, and technical suffix formatting.
  - Added support for safer handling of non-Latin titles and more accurate alternate-title filtering.
- **Bug Fixes**
  - CinemaZ now uses IMDb production years when determining movie release names.
  - Prevented generated names from using unsuitable titles or altering protected title and episode text.
- **Refactor**
  - Updated tracker naming policies for site-specific behavior and versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->