### PR TITLE
fix(metadata): avoid duplicate DVD release tokens

### DIFF
--- a/internal/metadata/naming.go
+++ b/internal/metadata/naming.go
@@ -97,6 +97,11 @@ func buildReleaseName(req api.ReleaseNameRequest, logger api.Logger) api.Release
 	}
 	region := strings.TrimSpace(req.Region)
 	dvdSize := strings.TrimSpace(req.DVDSize)
+	dvdFormat := joinParts(source, dvdSize)
+	if sourceIn(source, "DVD", "PAL DVD", "NTSC DVD") &&
+		(strings.EqualFold(dvdSize, "DVD5") || strings.EqualFold(dvdSize, "DVD9")) {
+		dvdFormat = joinParts(strings.TrimSpace(source[:len(source)-len("DVD")]), dvdSize)
+	}
 	edition := strings.TrimSpace(req.Edition)
 
 	hybrid := ""
@@ -166,7 +171,7 @@ func buildReleaseName(req api.ReleaseNameRequest, logger api.Logger) api.Release
 				name = joinParts(title, altTitle, yearValue, threeD, edition, hybrid, repack, resolution, region, uhd, source, hdr, videoCodec, audio)
 				missing = []string{"edition", "region", "distributor"}
 			case "DVD":
-				name = joinParts(title, altTitle, yearValue, repack, edition, region, source, dvdSize, audio)
+				name = joinParts(title, altTitle, yearValue, repack, edition, region, dvdFormat, audio)
 				missing = []string{"edition", "distributor"}
 			case "HDDVD":
 				name = joinParts(title, altTitle, yearValue, edition, repack, resolution, source, videoCodec, audio)
@@ -216,7 +221,7 @@ func buildReleaseName(req api.ReleaseNameRequest, logger api.Logger) api.Release
 				)
 				missing = []string{"edition", "region", "distributor"}
 			case "DVD":
-				name = joinParts(title, yearValue, altTitle, seasonEpisode+threeD, repack, edition, region, source, dvdSize, audio)
+				name = joinParts(title, yearValue, altTitle, seasonEpisode+threeD, repack, edition, region, dvdFormat, audio)
 				missing = []string{"edition", "distributor"}
 			case "HDDVD":
 				name = joinParts(title, altTitle, yearValue, edition, repack, resolution, source, videoCodec, audio)

--- a/internal/metadata/naming_test.go
+++ b/internal/metadata/naming_test.go
@@ -44,6 +44,68 @@ func TestBuildReleaseNameMovieWebDL(t *testing.T) {
 	}
 }
 
+func TestBuildReleaseNameDVDDiscDoesNotRepeatDVD(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		category string
+		title    string
+		season   string
+		source   string
+		size     string
+		want     string
+	}{
+		{
+			name:     "PAL movie",
+			category: "MOVIE",
+			title:    "Example Release",
+			source:   "PAL DVD",
+			size:     "DVD9",
+			want:     "Example Release 2026 PAL DVD9",
+		},
+		{
+			name:     "NTSC TV",
+			category: "TV",
+			title:    "Example Show",
+			season:   "S01",
+			source:   "NTSC DVD",
+			size:     "DVD5",
+			want:     "Example Show 2026 S01 NTSC DVD5",
+		},
+		{
+			name:     "unspecified system",
+			category: "MOVIE",
+			title:    "Example Release",
+			source:   "DVD",
+			size:     "DVD9",
+			want:     "Example Release 2026 DVD9",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := BuildReleaseName(api.ReleaseNameRequest{
+				Category:   test.category,
+				Type:       "DISC",
+				Title:      test.title,
+				Year:       2026,
+				SearchYear: "2026",
+				Season:     test.season,
+				DiscType:   "DVD",
+				Source:     test.source,
+				DVDSize:    test.size,
+			}, api.NopLogger{})
+
+			if result.NameNoTag != test.want {
+				t.Fatalf("name = %q, want %q", result.NameNoTag, test.want)
+			}
+		})
+	}
+}
+
 func TestBuildReleaseNameMovieBareWebEncodeUsesWebDLNaming(t *testing.T) {
 	result := BuildReleaseName(api.ReleaseNameRequest{
 		Category:    "MOVIE",

--- a/internal/trackers/impl/responsibility_ledger_test.go
+++ b/internal/trackers/impl/responsibility_ledger_test.go
@@ -97,7 +97,7 @@ var trackerResponsibilityLedger = []trackerResponsibilityRow{
 	unit3DResponsibility("R4E", "canonical"),
 	unit3DResponsibility("RAS", "canonical"),
 	unit3DResponsibilityVersion("RF", "rf", "", "v2"),
-	unit3DResponsibilityVersion("RHD", "rhd", "", "v2"),
+	unit3DResponsibilityVersion("RHD", "rhd", "", "v3"),
 	unit3DResponsibilityVersion("RMC", "rmc", "", "v2"),
 	unit3DResponsibility("SAM", "sam"),
 	unit3DResponsibility("SHRI", "canonical"),

--- a/internal/trackers/impl/unit3d/sites/rhd/name.go
+++ b/internal/trackers/impl/unit3d/sites/rhd/name.go
@@ -155,11 +155,18 @@ func typeAndSource(meta api.UploadSubject) []string {
 		if meta.Region != "" {
 			parts = append(parts, meta.Region)
 		}
-		if meta.Release.Source != "" {
-			parts = append(parts, meta.Release.Source)
+		source := strings.TrimSpace(meta.Release.Source)
+		size := strings.TrimSpace(meta.Release.Size)
+		if strings.EqualFold(meta.DiscType, "DVD") &&
+			(strings.EqualFold(size, "DVD5") || strings.EqualFold(size, "DVD9")) &&
+			(strings.EqualFold(source, "DVD") || strings.EqualFold(source, "PAL DVD") || strings.EqualFold(source, "NTSC DVD")) {
+			source = strings.TrimSpace(source[:len(source)-len("DVD")])
 		}
-		if meta.Release.Size != "" {
-			parts = append(parts, meta.Release.Size)
+		if source != "" {
+			parts = append(parts, source)
+		}
+		if size != "" {
+			parts = append(parts, size)
 		}
 		name = ""
 	}

--- a/internal/trackers/impl/unit3d/sites/rhd/profile.go
+++ b/internal/trackers/impl/unit3d/sites/rhd/profile.go
@@ -17,7 +17,7 @@ func Profile() unit3d.Profile {
 		BannedGroups: BannedGroups(),
 		Site: unit3d.SiteProfile{
 			BuildName:           buildName,
-			BuildNameVersion:    "v2",
+			BuildNameVersion:    "v3",
 			ResolveResolutionID: resolutionID,
 		},
 	}

--- a/internal/trackers/impl/unit3d/sites/rhd/profile_test.go
+++ b/internal/trackers/impl/unit3d/sites/rhd/profile_test.go
@@ -143,6 +143,56 @@ func TestProfileNameParity(t *testing.T) {
 	}
 }
 
+func TestTypeAndSourceDVDDoesNotRepeatCapacity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source string
+		size   string
+		want   string
+	}{
+		{
+			name:   "PAL DVD9",
+			source: "PAL DVD",
+			size:   "DVD9",
+			want:   "COMPLETE PAL DVD9",
+		},
+		{
+			name:   "bare DVD9",
+			source: "DVD",
+			size:   "DVD9",
+			want:   "COMPLETE DVD9",
+		},
+		{
+			name:   "NTSC DVD5",
+			source: "NTSC DVD",
+			size:   "DVD5",
+			want:   "COMPLETE NTSC DVD5",
+		},
+		{
+			name:   "surrounding whitespace",
+			source: " PAL DVD ",
+			size:   " DVD9 ",
+			want:   "COMPLETE PAL DVD9",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := strings.Join(typeAndSource(api.UploadSubject{
+				Type:     "DISC",
+				DiscType: "DVD",
+				Release:  api.ReleaseInfo{Source: test.source, Size: test.size},
+			}), " ")
+			if got != test.want {
+				t.Fatalf("typeAndSource() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestProfileResolutionAndLanguages(t *testing.T) {
 	if got := Profile().Site.ResolveResolutionID(api.UploadSubject{Release: api.ReleaseInfo{Resolution: "576p"}}); got != "12" {
 		t.Fatalf("resolution = %q", got)

--- a/internal/trackers/impl/unit3d/sites/rhd/profile_test.go
+++ b/internal/trackers/impl/unit3d/sites/rhd/profile_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestProfileNameParity(t *testing.T) {
 	profile := Profile().Site
-	if profile.BuildNameVersion != "v2" {
+	if profile.BuildNameVersion != "v3" {
 		t.Fatalf("RHD build-name version = %q", profile.BuildNameVersion)
 	}
 	build := profile.BuildName
@@ -53,6 +53,21 @@ func TestProfileNameParity(t *testing.T) {
 				},
 			},
 			want: "Example Movie 2024 1080p COMPLETE GER Blu-ray BD50 DTS-HD MA 5.1 AVC-GRP",
+		},
+		{
+			name: "full DVD does not repeat capacity",
+			meta: api.UploadSubject{
+				Type:     "DISC",
+				DiscType: "DVD",
+				Tag:      "-GRP",
+				Release: api.ReleaseInfo{
+					Title:  "Example Release",
+					Year:   2026,
+					Source: "PAL DVD",
+					Size:   "DVD9",
+				},
+			},
+			want: "Example Release 2026 COMPLETE PAL DVD9-GRP",
 		},
 		{
 			name: "markers",


### PR DESCRIPTION
## Description

Prevent full DVD release names from repeating the `DVD` token when the source already includes it. Movie and TV names now render formats such as `PAL DVD9`, `NTSC DVD5`, and `DVD9` while preserving the underlying source and capacity metadata.

No linked issue.

## How has this been tested?

- `go test -race -v -timeout 20m ./internal/metadata`
- `make precommit`
- `git diff --check`

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/upbrr/blob/main/CONTRIBUTING.md)
- [x] I ran `make precommit`
- [x] CSS validation is not applicable because this PR has no CSS changes

## AI disclosure

Yes. OpenAI Codex wrote most of the implementation and regression tests under user direction; the resulting diff was reviewed and verified with repository checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DVD release naming to avoid repeating the “DVD” label.
  * Standardized DVD5 and DVD9 naming across movie and TV releases.
  * Preserved correct naming for PAL, NTSC, and unspecified video systems.
  * Updated RHD release naming to the latest naming policy version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->