### PR TITLE
fix(workflow): isolate recoverable media failures

### DIFF
--- a/internal/core/workflow_media.go
+++ b/internal/core/workflow_media.go
@@ -562,25 +562,27 @@ func (b workflowMediaBuilder) Build(
 		}
 		images := mergeWorkflowScreenshotImages(existingScreenshots, capture.Images, plan.Discs, captureTotal)
 		privateArtifacts.Screenshots = append(privateArtifacts.Screenshots, images...)
+		captureStatus := api.StageStatusCompleted
+		captureMessage := "Screenshot capture complete."
+		if len(capture.Errors) > 0 {
+			captureStatus = api.StageStatusPartial
+			captureMessage = "Screenshot capture completed with partial coverage."
+		}
 		api.EmitWorkflowProgress(ctx, api.WorkflowProgressUpdate{
 			Phase:     "screenshots",
 			ItemID:    "screenshots",
 			Kind:      "media",
 			Label:     "Screenshots",
-			Status:    api.StageStatusCompleted,
+			Status:    captureStatus,
 			Completed: len(images),
 			Total:     captureTotal,
-			Message:   "Screenshot capture complete.",
+			Message:   captureMessage,
 		})
 		for index, image := range images {
 			snapshot.Artifacts = append(
 				snapshot.Artifacts,
 				publicMediaArtifact(captureFingerprint, "screenshot", index, api.MediaArtifactScreenshot, purpose, image),
 			)
-		}
-		if len(capture.Errors) > 0 {
-			snapshot.Status = api.StageStatusBlocked
-			snapshot.Failures = append(snapshot.Failures, mediaFailure("Some screenshots could not be captured. Retry or choose different frames."))
 		}
 	}
 	if dvdMenuCount > 0 {
@@ -1093,10 +1095,12 @@ func (b workflowMediaBuilder) UploadImages(
 			return strings.EqualFold(strings.TrimSpace(candidate), host)
 		})
 	}
-	snapshot.Failures = slices.DeleteFunc(snapshot.Failures, func(failure api.WorkflowFailure) bool {
-		return failure.Failure.Operation == api.OperationKindImageHosting &&
-			(host == "" || strings.EqualFold(strings.TrimSpace(failure.Resource), host))
-	})
+	if !retry {
+		snapshot.Failures = slices.DeleteFunc(snapshot.Failures, func(failure api.WorkflowFailure) bool {
+			return failure.Failure.Operation == api.OperationKindImageHosting &&
+				(host == "" || strings.EqualFold(strings.TrimSpace(failure.Resource), host))
+		})
+	}
 	effectFingerprint, err := api.CanonicalWorkflowFingerprint(struct {
 		Release       api.ReleaseRef
 		ProjectionSet api.TrackerReleaseProjectionSetRef
@@ -1247,14 +1251,20 @@ func (b workflowMediaBuilder) UploadImages(
 		}
 		attempts = append(attempts, attempt)
 	}
+	currentFailures := make([]api.WorkflowFailure, 0, len(result.Failures))
 	for _, failure := range result.Failures {
 		if len(failure.Trackers) == 0 {
-			snapshot.Failures = append(snapshot.Failures, hostedImageFailure("", failure.Host, failure.Message))
+			currentFailures = append(currentFailures, hostedImageFailure("", failure.Host, failure.Message))
 			continue
 		}
 		for _, tracker := range failure.Trackers {
-			snapshot.Failures = append(snapshot.Failures, hostedImageFailure(api.TrackerID(tracker), failure.Host, failure.Message))
+			currentFailures = append(currentFailures, hostedImageFailure(api.TrackerID(tracker), failure.Host, failure.Message))
 		}
+	}
+	if retry {
+		reconcileRetriedImageHostFailures(&snapshot, projections.Projections, attempts, currentFailures)
+	} else {
+		snapshot.Failures = append(snapshot.Failures, currentFailures...)
 	}
 	failedHosts := make(map[string]struct{}, len(snapshot.FailedHosts)+len(result.FailedHosts))
 	for _, failed := range snapshot.FailedHosts {
@@ -1271,6 +1281,108 @@ func (b workflowMediaBuilder) UploadImages(
 	}
 	snapshot.FailedHosts = sortedNonEmptyKeys(failedHosts)
 	return snapshot, retained, attempts, nil
+}
+
+func reconcileRetriedImageHostFailures(
+	snapshot *api.MediaArtifactSet,
+	projections []api.TrackerReleaseProjection,
+	attempts []api.HostedImageAttempt,
+	currentFailures []api.WorkflowFailure,
+) {
+	artifacts := make(map[api.PublicResourceID]api.MediaArtifact, len(snapshot.Artifacts))
+	for _, artifact := range snapshot.Artifacts {
+		artifacts[artifact.ID] = artifact
+	}
+	allAttempts := make([]api.HostedImageAttempt, 0, len(snapshot.HostAttempts)+len(attempts))
+	allAttempts = append(allAttempts, snapshot.HostAttempts...)
+	allAttempts = append(allAttempts, attempts...)
+	attemptApplies := func(attempt api.HostedImageAttempt, tracker string) bool {
+		if !slices.ContainsFunc(attempt.TrackerIDs, func(candidate api.TrackerID) bool {
+			return strings.EqualFold(strings.TrimSpace(string(candidate)), tracker)
+		}) {
+			return false
+		}
+		scope := normalizeImageUploadUsageScope(attempt.UsageScope)
+		return scope == "global" || scope == "tracker:"+tracker
+	}
+
+	satisfied := make(map[string]struct{}, len(projections))
+	for _, projection := range projections {
+		tracker := strings.ToUpper(strings.TrimSpace(string(projection.TrackerID)))
+		required := projection.Artifacts.ScreenshotCount
+		if tracker == "" || !slices.ContainsFunc(attempts, func(attempt api.HostedImageAttempt) bool {
+			return attempt.Status == api.StageStatusCompleted && attemptApplies(attempt, tracker)
+		}) {
+			continue
+		}
+		sources := make(map[api.PublicResourceID]struct{}, required)
+		for _, attempt := range allAttempts {
+			if !attemptApplies(attempt, tracker) {
+				continue
+			}
+			for _, result := range attempt.Results {
+				hosted, hostedOK := artifacts[result.ID]
+				source, sourceOK := artifacts[api.PublicResourceID(strings.TrimSpace(hosted.Source))]
+				if hostedOK && sourceOK && hosted.Selected && hosted.Kind == api.MediaArtifactHostedImage &&
+					hosted.Purpose == api.ScreenshotPurposeFinal && source.Selected &&
+					source.Kind == api.MediaArtifactScreenshot && source.Purpose == api.ScreenshotPurposeFinal {
+					sources[source.ID] = struct{}{}
+				}
+			}
+		}
+		if len(sources) >= required {
+			satisfied[tracker] = struct{}{}
+		}
+	}
+
+	type failureKey struct {
+		tracker string
+		host    string
+	}
+	keyFor := func(failure api.WorkflowFailure) (failureKey, bool) {
+		if failure.Failure.Operation != api.OperationKindImageHosting {
+			return failureKey{}, false
+		}
+		return failureKey{
+			tracker: strings.ToUpper(strings.TrimSpace(string(failure.TrackerID))),
+			host:    strings.ToLower(strings.TrimSpace(failure.Resource)),
+		}, true
+	}
+	replacements := make(map[failureKey]struct{}, len(currentFailures))
+	for _, failure := range currentFailures {
+		if key, ok := keyFor(failure); ok {
+			replacements[key] = struct{}{}
+		}
+	}
+	snapshot.Failures = slices.DeleteFunc(snapshot.Failures, func(failure api.WorkflowFailure) bool {
+		key, ok := keyFor(failure)
+		if !ok {
+			return false
+		}
+		if key.tracker != "" {
+			if _, ok := satisfied[key.tracker]; ok {
+				return true
+			}
+		}
+		_, replaced := replacements[key]
+		return replaced
+	})
+	appended := make(map[failureKey]struct{}, len(currentFailures))
+	for _, failure := range currentFailures {
+		key, ok := keyFor(failure)
+		if ok {
+			if key.tracker != "" {
+				if _, ok := satisfied[key.tracker]; ok {
+					continue
+				}
+			}
+			if _, duplicate := appended[key]; duplicate {
+				continue
+			}
+			appended[key] = struct{}{}
+		}
+		snapshot.Failures = append(snapshot.Failures, failure)
+	}
 }
 
 func imageHostingEffectScope(host string, projections api.TrackerReleaseProjectionSet) string {

--- a/internal/core/workflow_media_test.go
+++ b/internal/core/workflow_media_test.go
@@ -51,6 +51,7 @@ func (workflowMediaResolverFake) ResolveDVDMenuSubject(
 type workflowScreenshotFake struct {
 	root       string
 	plan       *api.ScreenshotPlan
+	result     *api.ScreenshotResult
 	plans      int
 	captures   int
 	selections []api.ScreenshotSelection
@@ -80,6 +81,11 @@ func (f *workflowScreenshotFake) Capture(
 	f.selections = append(f.selections, selections...)
 	if f.err != nil {
 		return api.ScreenshotResult{}, f.err
+	}
+	if f.result != nil {
+		result := *f.result
+		result.Purpose = purpose
+		return result, nil
 	}
 	images := make([]api.ScreenshotImage, len(selections))
 	discNames := make(map[string]string, len(subject.Discs))
@@ -510,6 +516,220 @@ func TestWorkflowMediaBuilderReportsFrameCorruption(t *testing.T) {
 		return update.ItemID == "screenshots" && update.Status == api.StageStatusFailed
 	}) {
 		t.Fatalf("frame corruption progress was not emitted: %#v", progress)
+	}
+}
+
+func TestWorkflowMediaBuilderPartialScreenshotCaptureUsesSurvivingMinimum(t *testing.T) {
+	for _, testCase := range []struct {
+		name             string
+		required         int
+		wantStatus       api.StageStatus
+		wantRequiredTask bool
+	}{
+		{
+			name:       "minimum met",
+			required:   1,
+			wantStatus: api.StageStatusCompleted,
+		},
+		{
+			name:             "minimum not met",
+			required:         2,
+			wantStatus:       api.StageStatusBlocked,
+			wantRequiredTask: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			capture := api.ScreenshotResult{
+				Images: []api.ScreenshotImage{{
+					Index:            0,
+					TimestampSeconds: 10,
+					Path:             filepath.Join(t.TempDir(), "screen-0.png"),
+					Purpose:          api.ScreenshotPurposeFinal,
+				}},
+				Errors: []api.ScreenshotError{{Index: 1, Message: "synthetic capture failure"}},
+			}
+			screenshots := &workflowScreenshotFake{root: t.TempDir(), result: &capture}
+			builder := workflowMediaBuilder{resolver: workflowMediaResolverFake{}, screenshots: screenshots}
+			var progress []api.WorkflowProgressUpdate
+			ctx := api.WithWorkflowProgressReporter(context.Background(), func(update api.WorkflowProgressUpdate) {
+				progress = append(progress, update)
+			})
+			snapshot, privateArtifacts, err := builder.Build(
+				ctx,
+				api.ReleaseRef{SourcePath: filepath.Join(t.TempDir(), "Example.Release.2026"), Generation: 1},
+				api.TrackerReleaseProjectionSet{
+					ID:       api.TrackerReleaseProjectionSetID("projections-partial-" + testCase.name),
+					Revision: 1,
+					Projections: []api.TrackerReleaseProjection{{
+						TrackerID: "SYNTHETIC",
+						Artifacts: api.TrackerArtifactRequirements{ScreenshotCount: testCase.required},
+					}},
+				},
+				api.MediaCaptureInstructions{
+					Purpose: api.ScreenshotPurposeFinal,
+					Selections: []api.ScreenshotSelection{
+						{Index: 0, TimestampSeconds: 10},
+						{Index: 1, TimestampSeconds: 20},
+					},
+				},
+				time.Now(),
+			)
+			if err != nil {
+				t.Fatalf("build workflow media: %v", err)
+			}
+			if snapshot.Status != testCase.wantStatus || len(snapshot.Artifacts) != 1 || len(snapshot.Failures) != 0 {
+				t.Fatalf("partial capture snapshot = %#v", snapshot)
+			}
+			if got := len(snapshot.RequiredActions) > 0; got != testCase.wantRequiredTask {
+				t.Fatalf("required action present = %t, want %t: %#v", got, testCase.wantRequiredTask, snapshot.RequiredActions)
+			}
+			private, ok := privateArtifacts.(workflowMediaPrivateArtifacts)
+			if !ok || len(private.Screenshots) != 1 {
+				t.Fatalf("partial private artifacts = %#v", privateArtifacts)
+			}
+			if !slices.ContainsFunc(progress, func(update api.WorkflowProgressUpdate) bool {
+				return update.ItemID == "screenshots" && update.Status == api.StageStatusPartial &&
+					update.Completed == 1 && update.Total == 2 && strings.Contains(update.Message, "partial coverage")
+			}) {
+				t.Fatalf("partial screenshot diagnostics were not emitted: %#v", progress)
+			}
+		})
+	}
+}
+
+func TestReconcileRetriedImageHostFailuresClearsOnlySatisfiedTracker(t *testing.T) {
+	t.Parallel()
+
+	const (
+		alpha api.TrackerID = "ALPHA"
+		beta  api.TrackerID = "BETA"
+	)
+	artifacts := []api.MediaArtifact{
+		{
+			ID:       "screen-0",
+			Kind:     api.MediaArtifactScreenshot,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+		},
+		{
+			ID:       "hosted-0",
+			Kind:     api.MediaArtifactHostedImage,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+			Source:   "screen-0",
+		},
+		{
+			ID:       "screen-1",
+			Kind:     api.MediaArtifactScreenshot,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+		},
+		{
+			ID:       "hosted-1",
+			Kind:     api.MediaArtifactHostedImage,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+			Source:   "screen-1",
+		},
+	}
+	priorAttempts := []api.HostedImageAttempt{
+		{
+			Host:       "primary",
+			UsageScope: "tracker:ALPHA",
+			TrackerIDs: []api.TrackerID{alpha},
+			Status:     api.StageStatusFailed,
+			Results:    []api.MediaArtifact{artifacts[1]},
+		},
+		{
+			Host:       "fallback",
+			UsageScope: "tracker:ALPHA",
+			TrackerIDs: []api.TrackerID{alpha},
+			Status:     api.StageStatusFailed,
+		},
+	}
+	priorFailures := []api.WorkflowFailure{
+		hostedImageFailure(alpha, "primary", "old primary failure"),
+		hostedImageFailure(alpha, "fallback", "old fallback failure"),
+		hostedImageFailure(beta, "primary", "old sibling failure"),
+		hostedImageFailure("", "primary", "unscoped failure"),
+	}
+	projections := []api.TrackerReleaseProjection{
+		{TrackerID: alpha, Artifacts: api.TrackerArtifactRequirements{ScreenshotCount: 2}},
+		{TrackerID: beta, Artifacts: api.TrackerArtifactRequirements{ScreenshotCount: 1}},
+	}
+	currentFailures := []api.WorkflowFailure{hostedImageFailure(beta, "primary", "current sibling failure")}
+
+	for _, test := range []struct {
+		name              string
+		required          int
+		results           []api.MediaArtifact
+		wantAlphaFailures int
+	}{
+		{
+			name:     "successful retry restores satisfied tracker",
+			required: 2,
+			results:  []api.MediaArtifact{artifacts[3]},
+		},
+		{
+			name:              "completed attempt without required sources retains failures",
+			required:          2,
+			wantAlphaFailures: 2,
+		},
+		{name: "successful retry satisfies zero screenshot requirement"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := api.MediaArtifactSet{
+				Artifacts:    append([]api.MediaArtifact(nil), artifacts...),
+				HostAttempts: append([]api.HostedImageAttempt(nil), priorAttempts...),
+				FailedHosts:  []string{"fallback", "primary"},
+				Failures:     append([]api.WorkflowFailure(nil), priorFailures...),
+			}
+			attempts := []api.HostedImageAttempt{
+				{
+					Host:       "primary",
+					UsageScope: "tracker:ALPHA",
+					TrackerIDs: []api.TrackerID{alpha},
+					Status:     api.StageStatusCompleted,
+					Results:    test.results,
+				},
+				{
+					Host:       "primary",
+					UsageScope: "tracker:BETA",
+					TrackerIDs: []api.TrackerID{beta},
+					Status:     api.StageStatusFailed,
+				},
+			}
+
+			testProjections := append([]api.TrackerReleaseProjection(nil), projections...)
+			testProjections[0].Artifacts.ScreenshotCount = test.required
+			reconcileRetriedImageHostFailures(&snapshot, testProjections, attempts, currentFailures)
+			alphaFailures, betaFailures, unscopedFailures := 0, 0, 0
+			for _, failure := range snapshot.Failures {
+				switch failure.TrackerID {
+				case alpha:
+					alphaFailures++
+				case beta:
+					betaFailures++
+					if failure.Failure.Message != "current sibling failure" {
+						t.Fatalf("sibling retry failure was not replaced: %#v", failure)
+					}
+				case "":
+					unscopedFailures++
+				}
+			}
+			if alphaFailures != test.wantAlphaFailures || betaFailures != 1 || unscopedFailures != 1 {
+				t.Fatalf(
+					"retained image-host failures alpha=%d beta=%d unscoped=%d: %#v",
+					alphaFailures,
+					betaFailures,
+					unscopedFailures,
+					snapshot.Failures,
+				)
+			}
+			if len(snapshot.HostAttempts) != len(priorAttempts) || !slices.Equal(snapshot.FailedHosts, []string{"fallback", "primary"}) {
+				t.Fatalf("historical diagnostics changed: attempts=%#v failedHosts=%v", snapshot.HostAttempts, snapshot.FailedHosts)
+			}
+		})
 	}
 }
 

--- a/internal/releaseworkflow/composite_upload.go
+++ b/internal/releaseworkflow/composite_upload.go
@@ -823,7 +823,7 @@ func (m *Module) runCompositeUpload(
 				Recovery:  api.OperationRecoverySelectTrackers,
 			}, errors.New("release workflow composite upload has no remaining trackers"))
 		}
-		recoveryRequest := api.ContinueReleaseWorkflowRequest{
+		request := api.ContinueReleaseWorkflowRequest{
 			Authority: &api.WorkflowAuthority{
 				WorkflowID:       current.Workflow.ID,
 				ExpectedRevision: current.Workflow.Revision,
@@ -835,7 +835,7 @@ func (m *Module) runCompositeUpload(
 		_, recovered, plannerTransition, recoveryErr := m.recoverPersistedMediaForContinuation(
 			ctx,
 			ownerID,
-			recoveryRequest,
+			request,
 			current,
 			m.clock.Now().UTC(),
 		)
@@ -879,15 +879,6 @@ func (m *Module) runCompositeUpload(
 				return CommandResult{}, fmt.Errorf("release workflow composite attach media: %w", err)
 			}
 			continue
-		}
-		request := api.ContinueReleaseWorkflowRequest{
-			Authority: &api.WorkflowAuthority{
-				WorkflowID:       current.Workflow.ID,
-				ExpectedRevision: current.Workflow.Revision,
-			},
-			IdempotencyKey: compositeUploadOperationKey(string(session.RequestFingerprint), uint64(current.Workflow.Revision)),
-			Goal:           session.Goal,
-			Intent:         session.Intent,
 		}
 		next, stage := planContinuationCommand(request, current, m.clock.Now().UTC())
 		if next == nil {

--- a/internal/releaseworkflow/composite_upload.go
+++ b/internal/releaseworkflow/composite_upload.go
@@ -823,7 +823,28 @@ func (m *Module) runCompositeUpload(
 				Recovery:  api.OperationRecoverySelectTrackers,
 			}, errors.New("release workflow composite upload has no remaining trackers"))
 		}
-		if blocked := compositeUploadPendingAction(current, session); blocked != nil {
+		recoveryRequest := api.ContinueReleaseWorkflowRequest{
+			Authority: &api.WorkflowAuthority{
+				WorkflowID:       current.Workflow.ID,
+				ExpectedRevision: current.Workflow.Revision,
+			},
+			IdempotencyKey: compositeUploadOperationKey(string(session.RequestFingerprint), uint64(current.Workflow.Revision)),
+			Goal:           session.Goal,
+			Intent:         session.Intent,
+		}
+		_, recovered, plannerTransition, recoveryErr := m.recoverPersistedMediaForContinuation(
+			ctx,
+			ownerID,
+			recoveryRequest,
+			current,
+			m.clock.Now().UTC(),
+		)
+		if recoveryErr != nil {
+			return CommandResult{}, recoveryErr
+		} else if recovered {
+			continue
+		}
+		if blocked := compositeUploadPendingAction(current, session); blocked != nil && !plannerTransition {
 			if err := m.finishCompositeSession(ctx, ownerID, command.WorkflowID, operationID, "feedback_required"); err != nil {
 				return CommandResult{}, err
 			}
@@ -834,7 +855,7 @@ func (m *Module) runCompositeUpload(
 		} else if changed {
 			continue
 		}
-		if current.Media != nil && len(session.ManualMedia.Attachments) > 0 && !session.ManualMedia.Attached {
+		if !plannerTransition && current.Media != nil && len(session.ManualMedia.Attachments) > 0 && !session.ManualMedia.Attached {
 			m.reportCompositeStage(
 				ctx,
 				ownerID,

--- a/internal/releaseworkflow/composite_upload_test.go
+++ b/internal/releaseworkflow/composite_upload_test.go
@@ -672,6 +672,206 @@ func TestCompositeUploadTrackerRemovalUpdateIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestCompositeUploadRefreshesOnlyRecoverablePersistedMediaBlock(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		failures         []api.WorkflowFailure
+		additionalAction *api.RequiredAction
+		wantDescriptions bool
+	}{
+		{
+			name:             "surviving tracker continues to descriptions",
+			failures:         []api.WorkflowFailure{compositeImageHostFailure("BETA")},
+			wantDescriptions: true,
+		},
+		{
+			name:     "genuine tracker action remains blocked",
+			failures: []api.WorkflowFailure{compositeImageHostFailure("BETA")},
+			additionalAction: &api.RequiredAction{
+				ID:             "action-tracker-input",
+				Kind:           api.RequiredActionProvideTrackerInput,
+				Status:         api.RequiredActionStatusPending,
+				TrackerID:      "ALPHA",
+				Prompt:         "Provide the required tracker value.",
+				AllowsFreeText: true,
+			},
+		},
+		{
+			name: "all tracker hosts failed",
+			failures: []api.WorkflowFailure{
+				compositeImageHostFailure("ALPHA"),
+				compositeImageHostFailure("BETA"),
+			},
+		},
+		{
+			name:     "unscoped host failure remains blocked",
+			failures: []api.WorkflowFailure{compositeImageHostFailure("")},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			module, repository, _ := newCompositeUploadTestModule(t)
+			request := compositeUploadTestRequest(false, api.ReleaseWorkflowUploadModeDebug, "persisted-media-"+strings.ReplaceAll(test.name, " ", "-"))
+			started, err := module.StartUpload(t.Context(), testOwnerID, request)
+			if err != nil {
+				t.Fatalf("start composite upload: %v", err)
+			}
+			blocked := waitCompositeUploadTestOperation(t, module, started)
+			completed := approveCompositeUploadTrackers(
+				t,
+				module,
+				blocked,
+				[]api.TrackerID{"ALPHA", "BETA"},
+				"approve-persisted-media-"+strings.ReplaceAll(test.name, " ", "-"),
+			)
+			command, operationID, initialRevision, initialMediaCount := seedPersistedCompositeMediaBlock(
+				t,
+				repository,
+				completed.Workflow.ID,
+				test.failures,
+				test.additionalAction,
+			)
+			ctx := context.WithValue(t.Context(), operationExecutionContextKey{}, operationID)
+			result, err := module.runCompositeUpload(ctx, testOwnerID, command)
+			if err != nil {
+				t.Fatalf("resume persisted media block: %v", err)
+			}
+			state, err := repository.Load(t.Context(), testOwnerID, completed.Workflow.ID)
+			if err != nil {
+				t.Fatalf("load resumed composite state: %v", err)
+			}
+			if test.wantDescriptions {
+				if result.Descriptions == nil || result.Media == nil || result.Media.Status != api.StageStatusCompleted {
+					t.Fatalf("recovered composite result = %#v", result)
+				}
+				if _, failed := TrackerImageHostFailure(*result.Media, "BETA"); !failed {
+					t.Fatalf("recovered media lost tracker-scoped failure: %#v", result.Media.Failures)
+				}
+				if len(state.Media) != initialMediaCount+1 {
+					t.Fatalf("recovered media revisions = %d, want %d", len(state.Media), initialMediaCount+1)
+				}
+				return
+			}
+			if result.Descriptions != nil || result.Media == nil || result.Media.Status != api.StageStatusBlocked {
+				t.Fatalf("blocked composite result = %#v", result)
+			}
+			if state.Workflow.Revision != initialRevision+1 {
+				t.Fatalf("blocked composite revision = %d, want %d (single terminal checkpoint)", state.Workflow.Revision, initialRevision+1)
+			}
+			if len(state.Media) != initialMediaCount {
+				t.Fatalf("blocked composite refreshed media %d times, want none", len(state.Media)-initialMediaCount)
+			}
+		})
+	}
+}
+
+func seedPersistedCompositeMediaBlock(
+	t *testing.T,
+	repository *MemoryRepository,
+	workflowID api.WorkflowID,
+	failures []api.WorkflowFailure,
+	additionalAction *api.RequiredAction,
+) (CompositeUploadCommand, api.WorkflowOperationID, api.WorkflowRevision, int) {
+	t.Helper()
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	state := repository.states[workflowID]
+	if state.Composite == nil || state.Workflow.Media == nil {
+		t.Fatalf("completed composite state is missing session or media: %#v", state.Workflow)
+	}
+	media := state.Media[state.Workflow.Media.ID]
+	action := api.RequiredAction{
+		ID:               "action-media-input",
+		Kind:             api.RequiredActionProvideTrackerInput,
+		Status:           api.RequiredActionStatusPending,
+		WorkflowRevision: state.Workflow.Revision,
+		Prompt:           "Capture, select, or host the required release images before continuing.",
+		CreatedAt:        state.Workflow.UpdatedAt,
+	}
+	media.Artifacts = []api.MediaArtifact{
+		{
+			ID:       "screen-0",
+			Kind:     api.MediaArtifactScreenshot,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+		},
+		{
+			ID:       "hosted-0",
+			Kind:     api.MediaArtifactHostedImage,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+			Source:   "screen-0",
+		},
+	}
+	media.HostAttempts = []api.HostedImageAttempt{{
+		UsageScope: "global",
+		TrackerIDs: []api.TrackerID{"ALPHA"},
+		Results:    []api.MediaArtifact{media.Artifacts[1]},
+	}}
+	if intent := state.Composite.Intent.Media; intent != nil {
+		fingerprint, fingerprintErr := api.CanonicalWorkflowFingerprint(struct {
+			Release      api.ReleaseRef
+			ProjectionID api.TrackerReleaseProjectionSetID
+			Revision     api.WorkflowRevision
+			Instructions api.MediaCaptureInstructions
+			Requirements api.WorkflowFingerprint
+		}{
+			Release:      state.Projections[state.Workflow.TrackerProjections.ID].ReleaseRef,
+			ProjectionID: state.Workflow.TrackerProjections.ID,
+			Revision:     state.Workflow.TrackerProjections.Revision,
+			Instructions: *intent,
+			Requirements: media.RequirementsFingerprint,
+		})
+		if fingerprintErr != nil {
+			t.Fatalf("fingerprint persisted media fixture: %v", fingerprintErr)
+		}
+		media.CaptureFingerprint = fingerprint
+	}
+	media.ImageRequirementsPrepared = true
+	media.Status = api.StageStatusBlocked
+	media.Failures = append([]api.WorkflowFailure(nil), failures...)
+	media.RequiredActions = []api.RequiredAction{action}
+	if additionalAction != nil {
+		genuine := *additionalAction
+		genuine.WorkflowRevision = state.Workflow.Revision
+		genuine.CreatedAt = state.Workflow.UpdatedAt
+		media.RequiredActions = append(media.RequiredActions, genuine)
+	}
+	state.Media[media.ID] = media
+	state.Workflow.Descriptions = nil
+	state.Workflow.DryRun = nil
+	state.Workflow.UploadResult = nil
+	state.Workflow.Status = api.WorkflowStatusBlocked
+	state.Workflow.RequiredActions = append([]api.RequiredAction(nil), media.RequiredActions...)
+	state.Workflow.Failures = append([]api.WorkflowFailure(nil), failures...)
+	operationID := api.WorkflowOperationID("operation-persisted-media")
+	state.Composite.ActiveOperationID = operationID
+	state.Composite.TerminalReason = ""
+	state.Composite.Goal = api.WorkflowGoalDescriptionsReady
+	repository.states[workflowID] = state
+	return CompositeUploadCommand{
+		WorkflowID:         workflowID,
+		ExpectedRevision:   state.Workflow.Revision,
+		SessionFingerprint: state.Composite.RequestFingerprint,
+		IdempotencyKey:     "resume-persisted-media",
+	}, operationID, state.Workflow.Revision, len(state.Media)
+}
+
+func compositeImageHostFailure(trackerID api.TrackerID) api.WorkflowFailure {
+	return api.WorkflowFailure{
+		Failure: api.OperationFailure{
+			Code:      api.OperationFailureImageHostUnavailable,
+			Operation: api.OperationKindImageHosting,
+			Message:   "Required image host failed.",
+			Recovery:  api.OperationRecoveryRetry,
+		},
+		TrackerID: trackerID,
+		Resource:  "synthetic-host",
+	}
+}
+
 func compositeUploadTestOperationCount(repository *MemoryRepository, workflowID api.WorkflowID) int {
 	repository.mu.RLock()
 	defer repository.mu.RUnlock()

--- a/internal/releaseworkflow/contracts.go
+++ b/internal/releaseworkflow/contracts.go
@@ -695,6 +695,25 @@ type mediaArtifactsPublication struct {
 	IdempotencyKey   string
 }
 
+// refreshPersistedMediaStatusCommand re-evaluates a persisted media block
+// without exposing a new adapter-facing mutation.
+type refreshPersistedMediaStatusCommand struct {
+	WorkflowID       api.WorkflowID
+	ExpectedRevision api.WorkflowRevision
+	Media            api.MediaArtifactSetRef
+	IdempotencyKey   string
+}
+
+func (refreshPersistedMediaStatusCommand) commandName() string {
+	return "refresh_persisted_media_status"
+}
+func (c refreshPersistedMediaStatusCommand) commandFingerprint() (api.WorkflowFingerprint, error) {
+	return canonicalCommandFingerprint(struct {
+		ExpectedRevision api.WorkflowRevision
+		Media            api.MediaArtifactSetRef
+	}{c.ExpectedRevision, c.Media})
+}
+
 // CaptureMediaCommand plans and captures all required screenshots/DVD menus.
 type CaptureMediaCommand struct {
 	WorkflowID       api.WorkflowID

--- a/internal/releaseworkflow/module.go
+++ b/internal/releaseworkflow/module.go
@@ -4685,6 +4685,9 @@ func (m *Module) refreshPersistedMediaStatus(
 	if snapshot == nil || snapshot.Status != api.StageStatusBlocked || !snapshot.ImageRequirementsPrepared {
 		return CommandResult{}, fmt.Errorf("%w: persisted media is not eligible for readiness refresh", ErrInvalidTransition)
 	}
+	if len(eligible.Projections) == 0 {
+		return CommandResult{}, fmt.Errorf("%w: persisted media requirements remain blocked", ErrInvalidTransition)
+	}
 	refreshed := *snapshot
 	refreshMutatedMediaStatus(&refreshed, eligible.Projections)
 	if refreshed.Status != api.StageStatusCompleted {

--- a/internal/releaseworkflow/module.go
+++ b/internal/releaseworkflow/module.go
@@ -2674,6 +2674,8 @@ func commandTarget(command mutation) (api.WorkflowID, api.WorkflowRevision, stri
 		return typed.WorkflowID, typed.ExpectedRevision, typed.IdempotencyKey, nil
 	case ApproveTrackersCommand:
 		return typed.WorkflowID, typed.ExpectedRevision, typed.IdempotencyKey, nil
+	case refreshPersistedMediaStatusCommand:
+		return typed.WorkflowID, typed.ExpectedRevision, typed.IdempotencyKey, nil
 	case CaptureMediaCommand:
 		return typed.WorkflowID, typed.ExpectedRevision, typed.IdempotencyKey, nil
 	case SetMediaSelectionCommand:
@@ -2745,6 +2747,8 @@ func (m *Module) apply(
 		return m.decideDuplicates(ownerID, state, nextRevision, now, typed)
 	case ApproveTrackersCommand:
 		return m.approveTrackers(state, nextRevision, now, typed)
+	case refreshPersistedMediaStatusCommand:
+		return m.refreshPersistedMediaStatus(ctx, ownerID, state, nextRevision, now, typed)
 	case CaptureMediaCommand:
 		return m.captureMedia(ctx, ownerID, state, nextRevision, now, typed)
 	case SetMediaSelectionCommand:
@@ -4623,7 +4627,7 @@ func (m *Module) publishMediaReplacement(
 	nextRevision api.WorkflowRevision,
 	now time.Time,
 	snapshot api.MediaArtifactSet,
-	resource RetainedMediaResource,
+	resource any,
 ) (CommandResult, error) {
 	targets, err := resolveDownstreamTrackerSet(state, nil, downstreamStageMedia, now)
 	if err != nil {
@@ -4666,10 +4670,33 @@ func (m *Module) publishMediaReplacement(
 	return result, nil
 }
 
+func (m *Module) refreshPersistedMediaStatus(
+	ctx context.Context,
+	ownerID string,
+	state *State,
+	nextRevision api.WorkflowRevision,
+	now time.Time,
+	command refreshPersistedMediaStatusCommand,
+) (CommandResult, error) {
+	_, _, eligible, snapshot, resource, err := m.mediaExtensionContext(ctx, ownerID, state, &command.Media, now)
+	if err != nil {
+		return CommandResult{}, err
+	}
+	if snapshot == nil || snapshot.Status != api.StageStatusBlocked || !snapshot.ImageRequirementsPrepared {
+		return CommandResult{}, fmt.Errorf("%w: persisted media is not eligible for readiness refresh", ErrInvalidTransition)
+	}
+	refreshed := *snapshot
+	refreshMutatedMediaStatus(&refreshed, eligible.Projections)
+	if refreshed.Status != api.StageStatusCompleted {
+		return CommandResult{}, fmt.Errorf("%w: persisted media requirements remain blocked", ErrInvalidTransition)
+	}
+	return m.publishMediaReplacement(ownerID, state, nextRevision, now, refreshed, resource)
+}
+
 // refreshMutatedMediaStatus recomputes media readiness after a mutation while
 // retaining image-host failures and pending reconciliation actions. Before
 // required hosting runs, selected local assets determine readiness; afterward,
-// each tracker must have enough applicable hosted screenshot sources.
+// each surviving tracker must have enough applicable hosted screenshot sources.
 func refreshMutatedMediaStatus(snapshot *api.MediaArtifactSet, projections []api.TrackerReleaseProjection) {
 	hostFailures := make([]api.WorkflowFailure, 0, len(snapshot.Failures))
 	for _, failure := range snapshot.Failures {
@@ -4677,11 +4704,25 @@ func refreshMutatedMediaStatus(snapshot *api.MediaArtifactSet, projections []api
 			hostFailures = append(hostFailures, failure)
 		}
 	}
+	readinessProjections := projections
+	allTrackerHostsFailed := false
+	unmatchedTrackerHostFailure := false
+	if snapshot.ImageRequirementsPrepared {
+		unmatchedTrackerHostFailure = mediaHasUnscopedOrUnknownImageHostFailure(*snapshot, projections)
+		readinessProjections = slices.DeleteFunc(
+			append([]api.TrackerReleaseProjection(nil), projections...),
+			func(projection api.TrackerReleaseProjection) bool {
+				_, failed := TrackerImageHostFailure(*snapshot, projection.TrackerID)
+				return failed
+			},
+		)
+		allTrackerHostsFailed = len(projections) > 0 && len(readinessProjections) == 0
+	}
 	reconcileActions := slices.DeleteFunc(append([]api.RequiredAction(nil), snapshot.RequiredActions...), func(action api.RequiredAction) bool {
 		return action.Kind != api.RequiredActionReconcileSubmission
 	})
 	requiredScreenshots, requiredMenus := 0, 0
-	for _, projection := range projections {
+	for _, projection := range readinessProjections {
 		requiredScreenshots = max(requiredScreenshots, projection.Artifacts.ScreenshotCount)
 		requiredMenus = max(requiredMenus, projection.Artifacts.DVDMenuCount)
 	}
@@ -4702,7 +4743,8 @@ func refreshMutatedMediaStatus(snapshot *api.MediaArtifactSet, projections []api
 	snapshot.RequiredActions = reconcileActions
 	screenshotsReady := selectedScreenshots >= requiredScreenshots
 	if snapshot.ImageRequirementsPrepared {
-		screenshotsReady = hostedScreenshotRequirementsMet(*snapshot, projections)
+		screenshotsReady = !allTrackerHostsFailed && !unmatchedTrackerHostFailure &&
+			hostedScreenshotRequirementsMet(*snapshot, readinessProjections)
 	}
 	if !screenshotsReady || selectedMenus < requiredMenus {
 		snapshot.Status = api.StageStatusBlocked
@@ -4721,6 +4763,20 @@ func refreshMutatedMediaStatus(snapshot *api.MediaArtifactSet, projections []api
 		return
 	}
 	snapshot.Status = api.StageStatusCompleted
+}
+
+func mediaHasUnscopedOrUnknownImageHostFailure(media api.MediaArtifactSet, projections []api.TrackerReleaseProjection) bool {
+	known := make(map[api.TrackerID]struct{}, len(projections))
+	for _, projection := range projections {
+		known[normalizeDownstreamTrackerID(projection.TrackerID)] = struct{}{}
+	}
+	return slices.ContainsFunc(media.Failures, func(failure api.WorkflowFailure) bool {
+		if failure.Failure.Operation != api.OperationKindImageHosting {
+			return false
+		}
+		_, ok := known[normalizeDownstreamTrackerID(failure.TrackerID)]
+		return !ok
+	})
 }
 
 // hostedScreenshotRequirementsMet reports whether every projection has enough

--- a/internal/releaseworkflow/module_test.go
+++ b/internal/releaseworkflow/module_test.go
@@ -3729,6 +3729,149 @@ func TestRefreshMutatedMediaStatusRequiresHostedScreenshotsPerTracker(t *testing
 	}
 }
 
+func TestRefreshMutatedMediaStatusExcludesOnlyTrackerScopedHostFailures(t *testing.T) {
+	t.Parallel()
+
+	const (
+		alpha api.TrackerID = "ALPHA"
+		beta  api.TrackerID = "BETA"
+	)
+	artifacts := []api.MediaArtifact{
+		{
+			ID:       "screen-0",
+			Kind:     api.MediaArtifactScreenshot,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+		},
+		{
+			ID:       "hosted-0",
+			Kind:     api.MediaArtifactHostedImage,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+			Source:   "screen-0",
+		},
+		{
+			ID:       "screen-1",
+			Kind:     api.MediaArtifactScreenshot,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+		},
+		{
+			ID:       "hosted-1",
+			Kind:     api.MediaArtifactHostedImage,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+			Source:   "screen-1",
+		},
+	}
+	hostAttempt := api.HostedImageAttempt{
+		UsageScope: "global",
+		TrackerIDs: []api.TrackerID{alpha},
+		Results:    []api.MediaArtifact{artifacts[1], artifacts[3]},
+	}
+	betaFailure := api.WorkflowFailure{
+		Failure:   api.OperationFailure{Operation: api.OperationKindImageHosting},
+		TrackerID: beta,
+		Resource:  "beta-host",
+	}
+	alphaFailure := api.WorkflowFailure{
+		Failure:   api.OperationFailure{Operation: api.OperationKindImageHosting},
+		TrackerID: alpha,
+		Resource:  "alpha-host",
+	}
+	unscopedFailure := api.WorkflowFailure{
+		Failure:  api.OperationFailure{Operation: api.OperationKindImageHosting},
+		Resource: "global-host",
+	}
+	unknownTrackerFailure := api.WorkflowFailure{
+		Failure:   api.OperationFailure{Operation: api.OperationKindImageHosting},
+		TrackerID: "GAMMA",
+		Resource:  "gamma-host",
+	}
+
+	tests := []struct {
+		name        string
+		projections []api.TrackerReleaseProjection
+		failures    []api.WorkflowFailure
+		wantStatus  api.StageStatus
+	}{
+		{
+			name: "surviving tracker completes",
+			projections: []api.TrackerReleaseProjection{
+				{TrackerID: alpha, Artifacts: api.TrackerArtifactRequirements{ScreenshotCount: 2}},
+				{TrackerID: beta, Artifacts: api.TrackerArtifactRequirements{ScreenshotCount: 3, DVDMenuCount: 1}},
+			},
+			failures:   []api.WorkflowFailure{betaFailure},
+			wantStatus: api.StageStatusCompleted,
+		},
+		{
+			name: "surviving tracker requirements remain enforced",
+			projections: []api.TrackerReleaseProjection{
+				{TrackerID: alpha, Artifacts: api.TrackerArtifactRequirements{ScreenshotCount: 3}},
+				{TrackerID: beta, Artifacts: api.TrackerArtifactRequirements{ScreenshotCount: 3}},
+			},
+			failures:   []api.WorkflowFailure{betaFailure},
+			wantStatus: api.StageStatusBlocked,
+		},
+		{
+			name: "every tracker failed",
+			projections: []api.TrackerReleaseProjection{
+				{TrackerID: alpha},
+				{TrackerID: beta},
+			},
+			failures:   []api.WorkflowFailure{alphaFailure, betaFailure},
+			wantStatus: api.StageStatusBlocked,
+		},
+		{
+			name: "unscoped failure blocks otherwise satisfied requirements",
+			projections: []api.TrackerReleaseProjection{
+				{TrackerID: alpha, Artifacts: api.TrackerArtifactRequirements{ScreenshotCount: 2}},
+			},
+			failures:   []api.WorkflowFailure{unscopedFailure},
+			wantStatus: api.StageStatusBlocked,
+		},
+		{
+			name: "unknown tracker failure blocks otherwise satisfied requirements",
+			projections: []api.TrackerReleaseProjection{
+				{TrackerID: alpha, Artifacts: api.TrackerArtifactRequirements{ScreenshotCount: 2}},
+			},
+			failures:   []api.WorkflowFailure{unknownTrackerFailure},
+			wantStatus: api.StageStatusBlocked,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := api.MediaArtifactSet{
+				Artifacts:                 append([]api.MediaArtifact(nil), artifacts...),
+				HostAttempts:              []api.HostedImageAttempt{hostAttempt},
+				ImageRequirementsPrepared: true,
+				Failures:                  append([]api.WorkflowFailure(nil), test.failures...),
+			}
+
+			refreshMutatedMediaStatus(&snapshot, test.projections)
+			if snapshot.Status != test.wantStatus {
+				t.Fatalf("media status = %q, want %q: %#v", snapshot.Status, test.wantStatus, snapshot)
+			}
+			if len(snapshot.Failures) != len(test.failures) {
+				t.Fatalf("retained failures = %#v, want %#v", snapshot.Failures, test.failures)
+			}
+			if test.wantStatus == api.StageStatusCompleted {
+				if len(snapshot.RequiredActions) != 0 {
+					t.Fatalf("completed media actions = %#v", snapshot.RequiredActions)
+				}
+				failure, failed := TrackerImageHostFailure(snapshot, beta)
+				if !failed || failure.Resource != betaFailure.Resource {
+					t.Fatalf("retained tracker image-host failure = %#v, found=%t", failure, failed)
+				}
+				return
+			}
+			if len(snapshot.RequiredActions) != 1 || snapshot.RequiredActions[0].Kind != api.RequiredActionProvideTrackerInput {
+				t.Fatalf("blocked media actions = %#v", snapshot.RequiredActions)
+			}
+		})
+	}
+}
+
 func waitForWorkflowOperation(
 	t *testing.T,
 	module *Module,

--- a/internal/releaseworkflow/planner.go
+++ b/internal/releaseworkflow/planner.go
@@ -6,6 +6,7 @@ package releaseworkflow
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -122,6 +123,15 @@ func (m *Module) Continue(
 	if continuationGoalReached(current, request) {
 		return current, nil
 	}
+	if refreshed, handled, _, refreshErr := m.recoverPersistedMediaForContinuation(
+		ctx,
+		ownerID,
+		request,
+		current,
+		m.clock.Now().UTC(),
+	); handled || refreshErr != nil {
+		return refreshed, refreshErr
+	}
 
 	command, stage := planContinuationCommand(request, current, m.clock.Now().UTC())
 	if command == nil {
@@ -139,6 +149,89 @@ func (m *Module) Continue(
 		return CommandResult{}, fmt.Errorf("release workflow continue %s: %w", stage, err)
 	}
 	return m.Current(ctx, ownerID, operation.WorkflowID)
+}
+
+func (m *Module) recoverPersistedMediaForContinuation(
+	ctx context.Context,
+	ownerID string,
+	request api.ContinueReleaseWorkflowRequest,
+	current CommandResult,
+	now time.Time,
+) (CommandResult, bool, bool, error) {
+	command, stage := planContinuationCommand(request, current, now)
+	if !persistedMediaRecoveryCandidate(current) {
+		return current, false, false, nil
+	}
+	if command != nil || stage != "capture-media" {
+		return current, false, command != nil, nil
+	}
+	state, err := m.repository.Load(ctx, ownerID, current.Workflow.ID)
+	if err != nil {
+		return CommandResult{}, true, false, fmt.Errorf("release workflow load persisted media recovery: %w", err)
+	}
+	if state.Workflow.Revision != current.Workflow.Revision {
+		return CommandResult{}, true, false, ErrRevisionConflict
+	}
+	targets, err := resolveDownstreamTrackerSet(&state, nil, downstreamStageMedia, now)
+	if err != nil {
+		if errors.Is(err, ErrInvalidTransition) {
+			return current, false, false, nil
+		}
+		return CommandResult{}, true, false, err
+	}
+	projections := targets.Projections().Projections
+	if len(projections) == 0 {
+		return current, false, false, nil
+	}
+	refreshed := *current.Media
+	refreshMutatedMediaStatus(&refreshed, projections)
+	if refreshed.Status != api.StageStatusCompleted {
+		return current, false, false, nil
+	}
+	result, err := m.execute(ctx, ownerID, refreshPersistedMediaStatusCommand{
+		WorkflowID:       current.Workflow.ID,
+		ExpectedRevision: current.Workflow.Revision,
+		Media:            *current.Workflow.Media,
+		IdempotencyKey: continuationIdempotencyKey(
+			request.IdempotencyKey,
+			"refresh-persisted-media",
+			current.Workflow.Revision,
+		),
+	})
+	if err != nil {
+		return CommandResult{}, true, false, fmt.Errorf("release workflow refresh persisted media: %w", err)
+	}
+	updated, err := m.Current(ctx, ownerID, result.Workflow.ID)
+	return updated, true, false, err
+}
+
+func persistedMediaRecoveryCandidate(current CommandResult) bool {
+	if current.Media == nil || current.Workflow.Media == nil || current.Media.Status != api.StageStatusBlocked ||
+		!current.Media.ImageRequirementsPrepared {
+		return false
+	}
+	mediaActionIDs := make(map[api.RequiredActionID]struct{})
+	for _, action := range current.Media.RequiredActions {
+		if action.Status != api.RequiredActionStatusPending {
+			continue
+		}
+		if action.Kind != api.RequiredActionProvideTrackerInput || action.TrackerID != "" {
+			return false
+		}
+		mediaActionIDs[action.ID] = struct{}{}
+	}
+	if len(mediaActionIDs) != 1 {
+		return false
+	}
+	for _, action := range current.Continuation.RequiredActions {
+		if action.Status != api.RequiredActionStatusPending {
+			continue
+		}
+		if _, mediaAction := mediaActionIDs[action.ID]; !mediaAction {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *Module) acceptContinuationIntent(

--- a/internal/releaseworkflow/planner.go
+++ b/internal/releaseworkflow/planner.go
@@ -158,10 +158,10 @@ func (m *Module) recoverPersistedMediaForContinuation(
 	current CommandResult,
 	now time.Time,
 ) (CommandResult, bool, bool, error) {
-	command, stage := planContinuationCommand(request, current, now)
 	if !persistedMediaRecoveryCandidate(current) {
 		return current, false, false, nil
 	}
+	command, stage := planContinuationCommand(request, current, now)
 	if command != nil || stage != "capture-media" {
 		return current, false, command != nil, nil
 	}

--- a/internal/releaseworkflow/planner_test.go
+++ b/internal/releaseworkflow/planner_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -116,6 +117,230 @@ func TestContinueCreationPersistsTrustedTrackerDecisionMode(t *testing.T) {
 	if appState.TrackerDecisionMode != TrackerDecisionModeWebUIControls {
 		t.Fatalf("app continuation tracker mode = %q", appState.TrackerDecisionMode)
 	}
+}
+
+func TestContinueRefreshesOnlyRecoverablePersistedMediaBlockForWebUIControls(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		failures         []api.WorkflowFailure
+		additionalAction *api.RequiredAction
+		wantDescriptions bool
+	}{
+		{
+			name:             "surviving tracker reaches descriptions",
+			failures:         []api.WorkflowFailure{compositeImageHostFailure("BETA")},
+			wantDescriptions: true,
+		},
+		{
+			name:     "genuine tracker action remains blocked",
+			failures: []api.WorkflowFailure{compositeImageHostFailure("BETA")},
+			additionalAction: &api.RequiredAction{
+				ID:             "action-webui-tracker-input",
+				Kind:           api.RequiredActionProvideTrackerInput,
+				Status:         api.RequiredActionStatusPending,
+				TrackerID:      "ALPHA",
+				Prompt:         "Provide the required tracker value.",
+				AllowsFreeText: true,
+			},
+		},
+		{
+			name: "all tracker hosts failed",
+			failures: []api.WorkflowFailure{
+				compositeImageHostFailure("ALPHA"),
+				compositeImageHostFailure("BETA"),
+			},
+		},
+		{
+			name:     "unscoped host failure remains blocked",
+			failures: []api.WorkflowFailure{compositeImageHostFailure("")},
+		},
+		{
+			name:     "unknown tracker host failure remains blocked",
+			failures: []api.WorkflowFailure{compositeImageHostFailure("GAMMA")},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			module, repository, request, initialRevision, initialMediaCount := preparePersistedWebUIMediaContinuation(
+				t,
+				test.failures,
+				test.additionalAction,
+			)
+			first, err := module.Continue(t.Context(), testOwnerID, request)
+			if err != nil {
+				t.Fatalf("continue persisted media: %v", err)
+			}
+			if !test.wantDescriptions {
+				state, loadErr := repository.Load(t.Context(), testOwnerID, first.Workflow.ID)
+				if loadErr != nil {
+					t.Fatalf("load blocked continuation: %v", loadErr)
+				}
+				if first.Media == nil || first.Media.Status != api.StageStatusBlocked || first.Descriptions != nil {
+					t.Fatalf("blocked WebUI continuation = %#v", first)
+				}
+				if state.Workflow.TrackerApproval != nil || state.Workflow.Revision != initialRevision || len(state.Media) != initialMediaCount {
+					t.Fatalf("blocked WebUI continuation churned state: workflow=%#v media=%d", state.Workflow, len(state.Media))
+				}
+				return
+			}
+			if first.Media == nil || first.Media.Status != api.StageStatusCompleted || first.Descriptions != nil {
+				t.Fatalf("first recovered WebUI transition = %#v", first)
+			}
+			request.Authority.ExpectedRevision = first.Workflow.Revision
+			describing, err := module.Continue(t.Context(), testOwnerID, request)
+			if err != nil {
+				t.Fatalf("continue recovered media to descriptions: %v", err)
+			}
+			if describing.Operation != nil && !isTerminalProgressStatus(describing.Operation.Status) {
+				waitForWorkflowOperation(t, module, first.Workflow.ID, describing.Operation.ID, func(status api.WorkflowOperationStatus) bool {
+					return isTerminalProgressStatus(status.Status)
+				})
+			}
+			active, activeErr := repository.ListActiveOperations(t.Context())
+			if activeErr != nil {
+				t.Fatalf("list active description operations: %v", activeErr)
+			}
+			for _, record := range active {
+				if record.WorkflowID != first.Workflow.ID {
+					continue
+				}
+				waitForWorkflowOperation(t, module, first.Workflow.ID, record.OperationID, func(status api.WorkflowOperationStatus) bool {
+					return isTerminalProgressStatus(status.Status)
+				})
+			}
+			current, err := module.Current(t.Context(), testOwnerID, first.Workflow.ID)
+			if err != nil {
+				t.Fatalf("load described WebUI continuation: %v", err)
+			}
+			if current.Descriptions == nil || len(current.Descriptions.Descriptions) != 1 ||
+				!slices.Equal(current.Descriptions.Descriptions[0].TrackerIDs, []api.TrackerID{"ALPHA"}) {
+				t.Fatalf("recovered WebUI descriptions retained failed lane: %#v", current.Descriptions)
+			}
+			if current.TrackerApproval != nil || current.Media == nil {
+				t.Fatalf("WebUI recovery unexpectedly required approval: approval=%#v media=%#v", current.TrackerApproval, current.Media)
+			}
+			if _, failed := TrackerImageHostFailure(*current.Media, "BETA"); !failed {
+				t.Fatalf("recovered WebUI media lost scoped failure: %#v", current.Media.Failures)
+			}
+		})
+	}
+}
+
+func TestContinueExpiredDupesReplansBeforePersistedMediaRecovery(t *testing.T) {
+	t.Parallel()
+
+	module, repository, request, initialRevision, initialMediaCount := preparePersistedWebUIMediaContinuation(
+		t,
+		[]api.WorkflowFailure{compositeImageHostFailure("BETA")},
+		nil,
+	)
+	state, err := repository.Load(t.Context(), testOwnerID, request.Authority.WorkflowID)
+	if err != nil {
+		t.Fatalf("load persisted media state: %v", err)
+	}
+	dupes := state.Dupes[state.Workflow.Dupes.ID]
+	dupes.ExpiresAt = module.clock.Now().UTC().Add(-time.Minute)
+	repository.mu.Lock()
+	state.Dupes[dupes.ID] = dupes
+	repository.states[state.Workflow.ID] = state
+	repository.mu.Unlock()
+
+	base := module.dupeBuilder
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	module.dupeBuilder = dupeAssessmentBuilderFunc(func(
+		ctx context.Context,
+		subject api.DuplicateSubject,
+		projections api.TrackerReleaseProjectionSet,
+		preflight api.TrackerPreflightAssessment,
+		now time.Time,
+		skipRemote bool,
+	) (api.DupeAssessment, any, error) {
+		close(entered)
+		<-release
+		return base.Build(ctx, subject, projections, preflight, now, skipRemote)
+	})
+
+	replanning, err := module.Continue(t.Context(), testOwnerID, request)
+	if err != nil {
+		t.Fatalf("continue expired duplicate evidence: %v", err)
+	}
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("duplicate replanning did not start")
+	}
+	active, err := repository.ListActiveOperations(t.Context())
+	if err != nil {
+		t.Fatalf("list duplicate replanning operations: %v", err)
+	}
+	operationIndex := slices.IndexFunc(active, func(record api.ReleaseWorkflowOperationRecord) bool {
+		return record.WorkflowID == request.Authority.WorkflowID && record.Status.Command == (CheckDuplicatesCommand{}).commandName()
+	})
+	if operationIndex < 0 {
+		t.Fatalf("expired duplicate continuation = %#v", replanning.Operation)
+	}
+	replanningOperation := active[operationIndex]
+	retained, err := repository.Load(t.Context(), testOwnerID, request.Authority.WorkflowID)
+	if err != nil {
+		t.Fatalf("load duplicate replanning state: %v", err)
+	}
+	if retained.Workflow.Revision != initialRevision || retained.Workflow.Media == nil ||
+		*retained.Workflow.Media != *state.Workflow.Media || len(retained.Media) != initialMediaCount {
+		t.Fatalf("expired duplicate evidence refreshed stale media: workflow=%#v media=%d", retained.Workflow, len(retained.Media))
+	}
+	releaseOnce.Do(func() { close(release) })
+	waitForWorkflowOperation(t, module, retained.Workflow.ID, replanningOperation.OperationID, func(status api.WorkflowOperationStatus) bool {
+		return isTerminalProgressStatus(status.Status)
+	})
+}
+
+func preparePersistedWebUIMediaContinuation(
+	t *testing.T,
+	failures []api.WorkflowFailure,
+	additionalAction *api.RequiredAction,
+) (*Module, *MemoryRepository, api.ContinueReleaseWorkflowRequest, api.WorkflowRevision, int) {
+	t.Helper()
+	module, repository, _ := newCompositeUploadTestModule(t)
+	requestID := "webui-persisted-media-" + string(failures[0].TrackerID)
+	request := compositeUploadTestRequest(false, api.ReleaseWorkflowUploadModeDebug, requestID)
+	started, err := module.StartUpload(t.Context(), testOwnerID, request)
+	if err != nil {
+		t.Fatalf("start setup composite upload: %v", err)
+	}
+	blocked := waitCompositeUploadTestOperation(t, module, started)
+	completed := approveCompositeUploadTrackers(t, module, blocked, []api.TrackerID{"ALPHA", "BETA"}, "approve-"+requestID)
+	_, _, initialRevision, initialMediaCount := seedPersistedCompositeMediaBlock(
+		t,
+		repository,
+		completed.Workflow.ID,
+		failures,
+		additionalAction,
+	)
+	repository.mu.Lock()
+	state := repository.states[completed.Workflow.ID]
+	state.TrackerDecisionMode = TrackerDecisionModeWebUIControls
+	state.Workflow.TrackerApproval = nil
+	media := state.Media[state.Workflow.Media.ID]
+	media.TrackerApproval = nil
+	state.Media[media.ID] = media
+	state.Composite.ActiveOperationID = ""
+	intent := state.Composite.Intent
+	repository.states[completed.Workflow.ID] = state
+	repository.mu.Unlock()
+	return module, repository, api.ContinueReleaseWorkflowRequest{
+		Authority: &api.WorkflowAuthority{
+			WorkflowID:       completed.Workflow.ID,
+			ExpectedRevision: initialRevision,
+		},
+		IdempotencyKey: requestID + "-continue",
+		Goal:           api.WorkflowGoalDescriptionsReady,
+		Intent:         intent,
+	}, initialRevision, initialMediaCount
 }
 
 func TestContinuationNameReviewBlocksUploadButNotDuplicateChecking(t *testing.T) {

--- a/internal/releaseworkflow/planner_test.go
+++ b/internal/releaseworkflow/planner_test.go
@@ -250,6 +250,7 @@ func TestContinueExpiredDupesReplansBeforePersistedMediaRecovery(t *testing.T) {
 	base := module.dupeBuilder
 	entered := make(chan struct{})
 	release := make(chan struct{})
+	var enteredOnce sync.Once
 	var releaseOnce sync.Once
 	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
 	module.dupeBuilder = dupeAssessmentBuilderFunc(func(
@@ -260,7 +261,7 @@ func TestContinueExpiredDupesReplansBeforePersistedMediaRecovery(t *testing.T) {
 		now time.Time,
 		skipRemote bool,
 	) (api.DupeAssessment, any, error) {
-		close(entered)
+		enteredOnce.Do(func() { close(entered) })
 		<-release
 		return base.Build(ctx, subject, projections, preflight, now, skipRemote)
 	})
@@ -297,6 +298,87 @@ func TestContinueExpiredDupesReplansBeforePersistedMediaRecovery(t *testing.T) {
 	waitForWorkflowOperation(t, module, retained.Workflow.ID, replanningOperation.OperationID, func(status api.WorkflowOperationStatus) bool {
 		return isTerminalProgressStatus(status.Status)
 	})
+}
+
+func TestRefreshPersistedMediaStatusRejectsEmptyApprovedTrackerSet(t *testing.T) {
+	t.Parallel()
+
+	module, repository, request, initialRevision, initialMediaCount := preparePersistedWebUIMediaContinuation(
+		t,
+		[]api.WorkflowFailure{compositeImageHostFailure("BETA")},
+		nil,
+	)
+	state, err := repository.Load(t.Context(), testOwnerID, request.Authority.WorkflowID)
+	if err != nil {
+		t.Fatalf("load persisted media state: %v", err)
+	}
+	state.TrackerDecisionMode = TrackerDecisionModePostDupeGate
+	now := module.clock.Now().UTC()
+	_, dupes, candidateIDs, err := trackerApprovalCandidates(&state, now)
+	if err != nil {
+		t.Fatalf("resolve tracker approval candidates: %v", err)
+	}
+	if !slices.Equal(candidateIDs, []api.TrackerID{"ALPHA", "BETA"}) {
+		t.Fatalf("tracker approval candidates = %#v", candidateIDs)
+	}
+	actionInput, err := trackerApprovalActionInput(&state, dupes, candidateIDs)
+	if err != nil {
+		t.Fatalf("fingerprint tracker approval action: %v", err)
+	}
+	approvedIDs := []api.TrackerID{}
+	approvalFingerprint, err := trackerApprovalFingerprint(actionInput, candidateIDs, approvedIDs)
+	if err != nil {
+		t.Fatalf("fingerprint empty tracker approval: %v", err)
+	}
+	// Simulate legacy persisted authority with current lineage but no approved
+	// trackers. New approval commands reject this state; reads must not advance it.
+	approval := api.TrackerApprovalSnapshot{
+		ID:                  "tracker-approval-empty",
+		WorkflowID:          state.Workflow.ID,
+		Revision:            state.Workflow.Revision,
+		Release:             *state.Workflow.Release,
+		Selection:           *state.Workflow.Selection,
+		ProjectionSet:       *state.Workflow.TrackerProjections,
+		Preflight:           *state.Workflow.TrackerPreflight,
+		Dupes:               *state.Workflow.Dupes,
+		CandidateTrackerIDs: append([]api.TrackerID(nil), candidateIDs...),
+		ApprovedTrackerIDs:  approvedIDs,
+		InputFingerprint:    approvalFingerprint,
+		CreatedAt:           now,
+	}
+	approvalRef := api.TrackerApprovalSnapshotRef{ID: approval.ID, Revision: approval.Revision}
+	media := state.Media[state.Workflow.Media.ID]
+	media.TrackerApproval = &approvalRef
+	media.Failures = nil
+	state.Media[media.ID] = media
+	state.TrackerApprovals[approval.ID] = approval
+	state.Workflow.TrackerApproval = &approvalRef
+	state.Workflow.Failures = nil
+	repository.mu.Lock()
+	repository.states[state.Workflow.ID] = state
+	repository.mu.Unlock()
+
+	withoutGuard := media
+	refreshMutatedMediaStatus(&withoutGuard, nil)
+	if withoutGuard.Status != api.StageStatusCompleted {
+		t.Fatalf("empty tracker fixture remains blocked without guard: %#v", withoutGuard)
+	}
+	_, err = module.execute(t.Context(), testOwnerID, refreshPersistedMediaStatusCommand{
+		WorkflowID:       state.Workflow.ID,
+		ExpectedRevision: state.Workflow.Revision,
+		Media:            *state.Workflow.Media,
+		IdempotencyKey:   "refresh-empty-approved-trackers",
+	})
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("refresh persisted media error = %v, want %v", err, ErrInvalidTransition)
+	}
+	retained, err := repository.Load(t.Context(), testOwnerID, state.Workflow.ID)
+	if err != nil {
+		t.Fatalf("reload persisted media state: %v", err)
+	}
+	if retained.Workflow.Revision != initialRevision || len(retained.Media) != initialMediaCount {
+		t.Fatalf("rejected persisted media refresh churned state: workflow=%#v media=%d", retained.Workflow, len(retained.Media))
+	}
 }
 
 func preparePersistedWebUIMediaContinuation(

--- a/internal/services/screenshots/ffmpeg.go
+++ b/internal/services/screenshots/ffmpeg.go
@@ -426,6 +426,12 @@ func probeVideoDuration(ctx context.Context, runner Runner, cmdPath, inputPath s
 		"-",
 	}
 	result, err := runner.Run(ctx, cmdPath, args, "")
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return 0, fmt.Errorf("screenshots: ffmpeg duration probe canceled: %w", ctxErr)
+	}
+	if corruptionErr := ffmpegFrameCorruptionError(result.Stderr); corruptionErr != nil {
+		return 0, corruptionErr
+	}
 	if err != nil || result.ExitCode != 0 {
 		return 0, fmt.Errorf("screenshots: ffmpeg duration probe failed: %s", ffmpegResultPreview(result, err))
 	}

--- a/internal/services/screenshots/ffmpeg_test.go
+++ b/internal/services/screenshots/ffmpeg_test.go
@@ -352,6 +352,25 @@ func TestFFmpegFrameCorruptionIndicators(t *testing.T) {
 	}
 }
 
+func TestProbeVideoDurationCancellationPrecedesCorruption(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	runner := &cancelingResultRunner{
+		cancel: cancel,
+		result: CommandResult{
+			Stderr:   []byte("corrupt input packet in stream 0"),
+			ExitCode: 1,
+		},
+	}
+
+	_, err := probeVideoDuration(ctx, runner, "ffmpeg", "example.vob")
+	if !errors.Is(err, ctx.Err()) {
+		t.Fatalf("duration probe error = %v, want %v", err, ctx.Err())
+	}
+	if errors.Is(err, internalerrors.ErrFrameCorruption) {
+		t.Fatalf("duration probe cancellation was replaced by frame corruption: %v", err)
+	}
+}
+
 type timestampSensitiveRunner struct {
 	blackTimestamps       map[string]struct{}
 	noImageTimestamps     map[string]struct{}
@@ -403,6 +422,16 @@ type singleResultRunner struct {
 
 func (r *singleResultRunner) Run(context.Context, string, []string, string) (CommandResult, error) {
 	return r.result, r.err
+}
+
+type cancelingResultRunner struct {
+	cancel context.CancelFunc
+	result CommandResult
+}
+
+func (r *cancelingResultRunner) Run(context.Context, string, []string, string) (CommandResult, error) {
+	r.cancel()
+	return r.result, nil
 }
 
 type writeOutputRunner struct {

--- a/internal/services/screenshots/helpers.go
+++ b/internal/services/screenshots/helpers.go
@@ -864,7 +864,7 @@ func resolveDVDVideoSegmentTimings(
 				}
 			} else {
 				difference := math.Abs(duration - remaining)
-				if difference > dvdSegmentDurationToleranceSeconds {
+				if duration > remaining && difference > dvdSegmentDurationToleranceSeconds {
 					logger.Debugf(
 						"screenshots: DVD segment timing reconciled segment=%d decision=use_title_remainder start_seconds=%.3f probed_seconds=%.3f remaining_seconds=%.3f difference_seconds=%.3f title_seconds=%.3f",
 						idx+1,

--- a/internal/services/screenshots/helpers.go
+++ b/internal/services/screenshots/helpers.go
@@ -61,10 +61,7 @@ type mediaInfoDoc struct {
 
 var durationTokenPattern = regexp.MustCompile(`(?i)(\d+(?:\.\d+)?)\s*(milliseconds?|msecs?|ms|hours?|hrs?|h|minutes?|mins?|min|seconds?|secs?|sec|s)\b`)
 
-const (
-	dvdSegmentDurationToleranceSeconds = 5.0
-	mpegPSTimestampWrapSeconds         = float64(uint64(1)<<33) / 90000
-)
+const dvdSegmentDurationToleranceSeconds = 5.0
 
 // resolveVideoInfo selects timing metadata and the ffmpeg inputs used for
 // screenshot planning/capture. DVD releases keep ordered title-set segments so
@@ -867,20 +864,17 @@ func resolveDVDVideoSegmentTimings(
 				}
 			} else {
 				difference := math.Abs(duration - remaining)
-				switch {
-				case difference <= dvdSegmentDurationToleranceSeconds:
-				case duration > remaining+dvdSegmentDurationToleranceSeconds &&
-					math.Abs(start+duration-mpegPSTimestampWrapSeconds) <= dvdSegmentDurationToleranceSeconds:
+				if difference > dvdSegmentDurationToleranceSeconds {
 					logger.Debugf(
-						"screenshots: DVD segment timing reconciled segment=%d decision=use_title_remainder probed_seconds=%.3f remaining_seconds=%.3f title_seconds=%.3f",
+						"screenshots: DVD segment timing reconciled segment=%d decision=use_title_remainder start_seconds=%.3f probed_seconds=%.3f remaining_seconds=%.3f difference_seconds=%.3f title_seconds=%.3f",
 						idx+1,
+						start,
 						duration,
 						remaining,
+						difference,
 						titleDuration,
 					)
 					duration = remaining
-				default:
-					return fmt.Errorf("screenshots: DVD segment %d contradicts title duration", idx+1)
 				}
 			}
 		}

--- a/internal/services/screenshots/helpers_test.go
+++ b/internal/services/screenshots/helpers_test.go
@@ -408,6 +408,28 @@ func TestResolveDVDVideoSegmentTimingsReconcilesMPEGPSWrap(t *testing.T) {
 	}
 }
 
+func TestResolveDVDVideoSegmentTimingsReconcilesArbitraryFinalContradiction(t *testing.T) {
+	segments := buildVideoSegments([]dvdTitleVOB{
+		{path: "VTS_01_1.VOB"},
+		{path: "VTS_01_2.VOB"},
+	})
+	logger := &screenshotRecordingLogger{}
+	runner := &scriptedRunner{results: []CommandResult{
+		{Stderr: []byte("Duration: 00:00:20.00, start: 0.000000, bitrate: 4000 kb/s\n")},
+		{Stderr: []byte("Duration: 00:00:37.00, start: 0.000000, bitrate: 500 kb/s\n")},
+	}}
+
+	if err := resolveDVDVideoSegmentTimings(context.Background(), runner, "ffmpeg", segments, 120, logger); err != nil {
+		t.Fatalf("resolve DVD segment timings: %v", err)
+	}
+	if segments[1].StartSeconds != 20 || segments[1].DurationSeconds != 100 {
+		t.Fatalf("reconciled segments = %#v", segments)
+	}
+	if !logger.Contains("decision=use_title_remainder start_seconds=20.000 probed_seconds=37.000 remaining_seconds=100.000 difference_seconds=63.000 title_seconds=120.000") {
+		t.Fatalf("reconciliation diagnostic missing: %#v", logger.entries)
+	}
+}
+
 func TestResolveDVDVideoSegmentTimingsRejectsNonFinalOverrun(t *testing.T) {
 	segments := buildVideoSegments([]dvdTitleVOB{
 		{path: "VTS_01_1.VOB"},

--- a/internal/services/screenshots/helpers_test.go
+++ b/internal/services/screenshots/helpers_test.go
@@ -408,7 +408,7 @@ func TestResolveDVDVideoSegmentTimingsReconcilesMPEGPSWrap(t *testing.T) {
 	}
 }
 
-func TestResolveDVDVideoSegmentTimingsReconcilesArbitraryFinalContradiction(t *testing.T) {
+func TestResolveDVDVideoSegmentTimingsReconcilesArbitraryFinalOverrun(t *testing.T) {
 	segments := buildVideoSegments([]dvdTitleVOB{
 		{path: "VTS_01_1.VOB"},
 		{path: "VTS_01_2.VOB"},
@@ -416,7 +416,7 @@ func TestResolveDVDVideoSegmentTimingsReconcilesArbitraryFinalContradiction(t *t
 	logger := &screenshotRecordingLogger{}
 	runner := &scriptedRunner{results: []CommandResult{
 		{Stderr: []byte("Duration: 00:00:20.00, start: 0.000000, bitrate: 4000 kb/s\n")},
-		{Stderr: []byte("Duration: 00:00:37.00, start: 0.000000, bitrate: 500 kb/s\n")},
+		{Stderr: []byte("Duration: 00:02:17.00, start: 0.000000, bitrate: 500 kb/s\n")},
 	}}
 
 	if err := resolveDVDVideoSegmentTimings(context.Background(), runner, "ffmpeg", segments, 120, logger); err != nil {
@@ -425,8 +425,23 @@ func TestResolveDVDVideoSegmentTimingsReconcilesArbitraryFinalContradiction(t *t
 	if segments[1].StartSeconds != 20 || segments[1].DurationSeconds != 100 {
 		t.Fatalf("reconciled segments = %#v", segments)
 	}
-	if !logger.Contains("decision=use_title_remainder start_seconds=20.000 probed_seconds=37.000 remaining_seconds=100.000 difference_seconds=63.000 title_seconds=120.000") {
+	if !logger.Contains("decision=use_title_remainder start_seconds=20.000 probed_seconds=137.000 remaining_seconds=100.000 difference_seconds=37.000 title_seconds=120.000") {
 		t.Fatalf("reconciliation diagnostic missing: %#v", logger.entries)
+	}
+}
+
+func TestResolveDVDVideoSegmentTimingsRejectsShortFinalSegment(t *testing.T) {
+	segments := buildVideoSegments([]dvdTitleVOB{
+		{path: "VTS_01_1.VOB"},
+		{path: "VTS_01_2.VOB"},
+	})
+	runner := &scriptedRunner{results: []CommandResult{
+		{Stderr: []byte("Duration: 00:00:20.00, start: 0.000000, bitrate: 4000 kb/s\n")},
+		{Stderr: []byte("Duration: 00:00:37.00, start: 0.000000, bitrate: 500 kb/s\n")},
+	}}
+
+	if err := resolveDVDVideoSegmentTimings(context.Background(), runner, "ffmpeg", segments, 120, api.NopLogger{}); err == nil {
+		t.Fatal("expected a short final DVD segment to contradict the title duration")
 	}
 }
 

--- a/internal/services/screenshots/service.go
+++ b/internal/services/screenshots/service.go
@@ -98,7 +98,10 @@ func NewServiceWithRepo(cfg config.Config, logger api.Logger, tmpRoot string, ru
 // matching managed screenshots already present on disk and in the repository.
 // A non-positive count falls back to the subject default and then config. When
 // timing is unavailable, the returned plan requests manual frames instead of
-// failing; stored tracker images are merged into final selections.
+// failing; stored tracker images are merged into final selections. For a
+// multi-disc subject, ordinary per-disc planning failures leave that disc empty
+// while usable discs remain; cancellation, deadlines, and frame corruption
+// still return an error.
 func (s *Service) Plan(ctx context.Context, meta api.ScreenshotSubject, count int) (api.ScreenshotPlan, error) {
 	if s.repo != nil && !meta.MediaBinding.Valid() {
 		return api.ScreenshotPlan{}, internalerrors.ErrInvalidInput
@@ -127,6 +130,7 @@ func (s *Service) Plan(ctx context.Context, meta api.ScreenshotSubject, count in
 		MetadataTimestamp: time.Now().UTC().Format(time.RFC3339),
 		Discs:             make([]api.ScreenshotDiscPlan, 0, len(discs)),
 	}
+	haveDiscPlan := false
 	for index, disc := range discs {
 		discCount := baseCount
 		if index < remainder {
@@ -134,11 +138,23 @@ func (s *Service) Plan(ctx context.Context, meta api.ScreenshotSubject, count in
 		}
 		discPlan, err := s.planDisc(ctx, screenshotSubjectForDisc(meta, disc), discCount)
 		if err != nil {
-			return api.ScreenshotPlan{}, err
+			if len(discs) == 1 {
+				return api.ScreenshotPlan{}, err
+			}
+			if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+				errors.Is(err, internalerrors.ErrFrameCorruption) {
+				return api.ScreenshotPlan{}, err
+			}
+			plan.Discs = append(plan.Discs, api.ScreenshotDiscPlan{
+				DiscID:   disc.ID,
+				DiscName: disc.Name,
+			})
+			continue
 		}
-		if index == 0 {
+		if !haveDiscPlan {
 			plan.DurationSeconds = discPlan.DurationSeconds
 			plan.FrameRate = discPlan.FrameRate
+			haveDiscPlan = true
 		}
 		plan.SuggestedSelections = append(plan.SuggestedSelections, discPlan.SuggestedSelections...)
 		plan.ExistingScreenshots = append(plan.ExistingScreenshots, discPlan.ExistingScreenshots...)
@@ -217,6 +233,12 @@ func (s *Service) planDisc(ctx context.Context, meta api.ScreenshotSubject, coun
 				redaction.RedactValue(resolveErr.Error(), nil),
 			)
 		} else if duration, probeErr := probeVideoDuration(ctx, s.runner, cmd, info.SourcePath); probeErr != nil {
+			if ctx.Err() != nil {
+				return api.ScreenshotPlan{}, fmt.Errorf("screenshots: duration fallback canceled: %w", ctx.Err())
+			}
+			if errors.Is(probeErr, internalerrors.ErrFrameCorruption) {
+				return api.ScreenshotPlan{}, probeErr
+			}
 			s.logger.Debugf(
 				"screenshots: duration fallback failed input=%s err=%s",
 				info.SourcePath,
@@ -359,7 +381,9 @@ func (s *Service) planDisc(ctx context.Context, meta api.ScreenshotSubject, coun
 
 // Capture renders the requested frames into the prepared release's managed temp
 // directory and records each image with purpose. It returns successful images
-// plus per-selection failures and honors context cancellation.
+// plus per-selection failures. For a multi-disc subject, ordinary disc failures
+// do not discard images from other discs; cancellation, deadlines, and frame
+// corruption still return an error.
 func (s *Service) Capture(
 	ctx context.Context,
 	meta api.ScreenshotSubject,
@@ -388,7 +412,19 @@ func (s *Service) Capture(
 		}
 		discResult, err := s.captureDisc(ctx, screenshotSubjectForDisc(meta, disc), discSelections, purpose)
 		if err != nil {
-			return result, err
+			if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+				errors.Is(err, internalerrors.ErrFrameCorruption) {
+				return result, err
+			}
+			message := logging.SanitizeMessage(err.Error())
+			for _, selection := range discSelections {
+				result.Errors = append(result.Errors, api.ScreenshotError{
+					DiscID:  disc.ID,
+					Index:   selection.Index,
+					Message: message,
+				})
+			}
+			continue
 		}
 		result.Images = append(result.Images, discResult.Images...)
 		result.Errors = append(result.Errors, discResult.Errors...)

--- a/internal/services/screenshots/service_test.go
+++ b/internal/services/screenshots/service_test.go
@@ -247,6 +247,74 @@ func TestPlanAllocatesScreenshotsAcrossEveryDisc(t *testing.T) {
 	}
 }
 
+func TestPlanAndCapturePreserveGoodDiscWhenAnotherDiscSetupFails(t *testing.T) {
+	subject, _, _ := multiDiscScreenshotSubject(t)
+	subject.Discs[0].Type = "DVD"
+	subject.Discs[0].Root = filepath.Join(t.TempDir(), "missing-dvd")
+	ffmpegRoot := t.TempDir()
+	if err := writeTestBundledFFmpeg(ffmpegRoot); err != nil {
+		t.Fatalf("write bundled ffmpeg: %v", err)
+	}
+	t.Chdir(ffmpegRoot)
+
+	runner := &writingScreenshotRunner{payload: testPNGBytes(t, color.RGBA{
+		R: 16,
+		G: 16,
+		B: 16,
+		A: 255,
+	})}
+	service := NewService(config.Config{}, api.NopLogger{}, t.TempDir(), runner)
+	plan, err := service.Plan(context.Background(), subject, 2)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	if len(plan.Discs) != 2 || len(plan.Discs[0].SuggestedSelections) != 0 || len(plan.Discs[1].SuggestedSelections) != 1 {
+		t.Fatalf("disc plans = %#v", plan.Discs)
+	}
+	if plan.DurationSeconds != 600 || plan.FrameRate != 24 || plan.RequiresManualFrames {
+		t.Fatalf("aggregate timing/manual state = %#v", plan)
+	}
+	if len(plan.SuggestedSelections) != 1 || plan.SuggestedSelections[0].DiscID != "disc-b" {
+		t.Fatalf("aggregate suggestions = %#v", plan.SuggestedSelections)
+	}
+
+	selections := append([]api.ScreenshotSelection{{
+		DiscID:           "disc-a",
+		Index:            0,
+		TimestampSeconds: 10,
+	}}, plan.SuggestedSelections...)
+	result, err := service.Capture(context.Background(), subject, selections, api.ScreenshotPurposeFinal)
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if len(result.Images) != 1 || result.Images[0].DiscID != "disc-b" || len(result.Errors) != 1 || result.Errors[0].DiscID != "disc-a" {
+		t.Fatalf("minimum-one Plan to Capture result = %#v", result)
+	}
+}
+
+func TestPlanReturnsHardDiscDurationProbeCorruption(t *testing.T) {
+	subject, _, videoB := multiDiscScreenshotSubject(t)
+	subject.Discs[1].MediaInfoJSONPath = ""
+	ffmpegRoot := t.TempDir()
+	if err := writeTestBundledFFmpeg(ffmpegRoot); err != nil {
+		t.Fatalf("write bundled ffmpeg: %v", err)
+	}
+	t.Chdir(ffmpegRoot)
+
+	runner := &scriptedRunner{results: []CommandResult{{
+		Stderr:   []byte("corrupt input packet in stream 0"),
+		ExitCode: 1,
+	}}}
+	service := NewService(config.Config{}, api.NopLogger{}, t.TempDir(), runner)
+	_, err := service.Plan(context.Background(), subject, 2)
+	if !errors.Is(err, internalerrors.ErrFrameCorruption) {
+		t.Fatalf("plan error = %v, want frame corruption", err)
+	}
+	if len(runner.calls) != 1 || ffmpegInputArg(runner.calls[0].args) != videoB {
+		t.Fatalf("duration probe calls = %#v", runner.calls)
+	}
+}
+
 func TestPlanExpandsRawManualFramesAcrossEveryDisc(t *testing.T) {
 	t.Parallel()
 
@@ -328,6 +396,140 @@ func TestMultiDiscPreviewRequiresDiscAndCaptureNamesDoNotCollide(t *testing.T) {
 	}
 	if len(captureRunner.calls) != 2 || ffmpegInputArg(captureRunner.calls[0].args) != videoA || ffmpegInputArg(captureRunner.calls[1].args) != videoB {
 		t.Fatalf("capture calls = %#v", captureRunner.calls)
+	}
+}
+
+func TestCapturePreservesSuccessfulDiscsWhenDiscSetupFails(t *testing.T) {
+	subject, _, _ := multiDiscScreenshotSubject(t)
+	subject.Discs[1].Type = "DVD"
+	subject.Discs[1].Root = filepath.Join(t.TempDir(), "missing-dvd")
+	ffmpegRoot := t.TempDir()
+	if err := writeTestBundledFFmpeg(ffmpegRoot); err != nil {
+		t.Fatalf("write bundled ffmpeg: %v", err)
+	}
+	t.Chdir(ffmpegRoot)
+
+	runner := &writingScreenshotRunner{payload: testPNGBytes(t, color.RGBA{
+		R: 16,
+		G: 16,
+		B: 16,
+		A: 255,
+	})}
+	service := NewService(config.Config{}, api.NopLogger{}, t.TempDir(), runner)
+	result, err := service.Capture(context.Background(), subject, []api.ScreenshotSelection{
+		{
+			DiscID:           "disc-a",
+			Index:            0,
+			TimestampSeconds: 10,
+		},
+		{
+			DiscID:           "disc-b",
+			Index:            1,
+			TimestampSeconds: 20,
+		},
+		{
+			DiscID:           "disc-b",
+			Index:            2,
+			TimestampSeconds: 30,
+		},
+	}, api.ScreenshotPurposeFinal)
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if len(result.Images) != 1 || result.Images[0].DiscID != "disc-a" {
+		t.Fatalf("successful disc images = %#v", result.Images)
+	}
+	if len(result.Errors) != 2 {
+		t.Fatalf("failed disc errors = %#v", result.Errors)
+	}
+	for offset, captureErr := range result.Errors {
+		if captureErr.DiscID != "disc-b" || captureErr.Index != offset+1 || strings.TrimSpace(captureErr.Message) == "" {
+			t.Fatalf("failed disc error[%d] = %#v", offset, captureErr)
+		}
+		if strings.Contains(captureErr.Message, subject.Discs[1].Root) {
+			t.Fatalf("failed disc error exposed local path: %q", captureErr.Message)
+		}
+	}
+}
+
+func TestCaptureReturnsHardDiscCorruptionAfterSuccessfulDisc(t *testing.T) {
+	subject, _, videoB := multiDiscScreenshotSubject(t)
+	ffmpegRoot := t.TempDir()
+	if err := writeTestBundledFFmpeg(ffmpegRoot); err != nil {
+		t.Fatalf("write bundled ffmpeg: %v", err)
+	}
+	t.Chdir(ffmpegRoot)
+
+	runner := &aggregateCaptureRunner{
+		payload: testPNGBytes(t, color.RGBA{
+			R: 16,
+			G: 16,
+			B: 16,
+			A: 255,
+		}),
+		corruptInput: videoB,
+	}
+	service := NewService(config.Config{}, api.NopLogger{}, t.TempDir(), runner)
+	result, err := service.Capture(context.Background(), subject, []api.ScreenshotSelection{
+		{
+			DiscID:           "disc-a",
+			Index:            0,
+			TimestampSeconds: 10,
+		},
+		{
+			DiscID:           "disc-b",
+			Index:            0,
+			TimestampSeconds: 10,
+		},
+	}, api.ScreenshotPurposeFinal)
+	if !errors.Is(err, internalerrors.ErrFrameCorruption) {
+		t.Fatalf("capture error = %v, want frame corruption", err)
+	}
+	if len(result.Images) != 1 || result.Images[0].DiscID != "disc-a" || len(result.Errors) != 0 {
+		t.Fatalf("partial hard-error result = %#v", result)
+	}
+}
+
+func TestCaptureReturnsHardCorruptionFromDVDDurationProbe(t *testing.T) {
+	root := t.TempDir()
+	videoTS := filepath.Join(root, "VIDEO_TS")
+	if err := os.MkdirAll(videoTS, 0o700); err != nil {
+		t.Fatalf("mkdir VIDEO_TS: %v", err)
+	}
+	for _, name := range []string{"VTS_01_1.VOB", "VTS_01_2.VOB"} {
+		if err := os.WriteFile(filepath.Join(videoTS, name), []byte("synthetic video"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	mediaInfoPath := filepath.Join(root, "mediainfo.json")
+	if err := os.WriteFile(
+		mediaInfoPath,
+		[]byte(`{"media":{"track":[{"@type":"General","Duration":"120"},{"@type":"Video","FrameRate":"24.000"}]}}`),
+		0o600,
+	); err != nil {
+		t.Fatalf("write mediainfo: %v", err)
+	}
+	ffmpegRoot := t.TempDir()
+	if err := writeTestBundledFFmpeg(ffmpegRoot); err != nil {
+		t.Fatalf("write bundled ffmpeg: %v", err)
+	}
+	t.Chdir(ffmpegRoot)
+
+	runner := &scriptedRunner{results: []CommandResult{{
+		Stderr:   []byte("corrupt input packet in stream 0"),
+		ExitCode: 1,
+	}}}
+	service := NewService(config.Config{}, api.NopLogger{}, t.TempDir(), runner)
+	_, err := service.Capture(context.Background(), api.ScreenshotSubject{
+		SourcePath:        root,
+		DiscType:          "DVD",
+		MediaInfoJSONPath: mediaInfoPath,
+	}, []api.ScreenshotSelection{{Index: 0, TimestampSeconds: 10}}, api.ScreenshotPurposeFinal)
+	if !errors.Is(err, internalerrors.ErrFrameCorruption) {
+		t.Fatalf("capture error = %v, want frame corruption", err)
+	}
+	if len(runner.calls) != 1 || ffmpegInputArg(runner.calls[0].args) != filepath.Join(videoTS, "VTS_01_1.VOB") {
+		t.Fatalf("duration probe calls = %#v", runner.calls)
 	}
 }
 
@@ -473,6 +675,11 @@ type writingScreenshotRunner struct {
 	calls   []runnerCall
 }
 
+type aggregateCaptureRunner struct {
+	payload      []byte
+	corruptInput string
+}
+
 type corruptionCancelRunner struct {
 	started    atomic.Int32
 	canceled   atomic.Int32
@@ -509,6 +716,19 @@ func (r *scriptedRunner) Run(_ context.Context, _ string, args []string, _ strin
 
 func (r *writingScreenshotRunner) Run(_ context.Context, _ string, args []string, _ string) (CommandResult, error) {
 	r.calls = append(r.calls, runnerCall{args: append([]string(nil), args...)})
+	if len(args) == 0 {
+		return CommandResult{ExitCode: 1}, errors.New("missing screenshot output")
+	}
+	if err := os.WriteFile(args[len(args)-1], r.payload, 0o600); err != nil {
+		return CommandResult{ExitCode: 1}, fmt.Errorf("write screenshot output: %w", err)
+	}
+	return CommandResult{ExitCode: 0}, nil
+}
+
+func (r *aggregateCaptureRunner) Run(_ context.Context, _ string, args []string, _ string) (CommandResult, error) {
+	if ffmpegInputArg(args) == r.corruptInput {
+		return CommandResult{Stderr: []byte("corrupt decoded frame in stream 0"), ExitCode: 0}, nil
+	}
 	if len(args) == 0 {
 		return CommandResult{ExitCode: 1}, errors.New("missing screenshot output")
 	}


### PR DESCRIPTION
## Summary

- preserve successful multi-disc screenshots when another disc has an ordinary setup or capture failure
- isolate image-host failures to affected trackers while eligible trackers continue to descriptions and upload
- recover persisted media blocks when fresh workflow evidence shows surviving trackers are ready

## Why

A recoverable disc or tracker-specific image-host failure could block the entire upload workflow and leave the frontend stuck before descriptions.

## Behavior and impact

Trackers without a usable image-host result are excluded while eligible trackers continue. Unscoped failures, corruption, cancellation, true media shortages, and cases where every tracker fails remain blocking.

## Checks

- `go test -race -v -timeout 20m ./internal/core ./internal/releaseworkflow ./internal/services/screenshots`
- `make test-go`
- `make lint`
- `make logpolicy`
- `make gofix-check-changed`
- `make backend`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Multi-disc screenshot processing preserves successful discs when another disc encounters a recoverable error.
  - Capture results report partial progress and affected selections.
  - Previously blocked media can recover when only resolved, tracker-specific hosting issues remain.

- **Bug Fixes**
  - Improved retry handling for image-hosting failures.
  - Corrected video duration and DVD segment timing validation.
  - Cancellation and severe media corruption errors now stop processing reliably.
  - Persisted media status refreshes more accurately distinguish recoverable and blocking issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->