### PR TITLE
fix(metadata): improve IMDb persisted query handling

### DIFF
--- a/internal/metadata/imdb/client.go
+++ b/internal/metadata/imdb/client.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/autobrr/rls"
@@ -37,9 +38,10 @@ const (
 // Client queries IMDb's public GraphQL endpoint for title, search, and episode
 // metadata.
 type Client struct {
-	baseURL string
-	http    *http.Client
-	logger  api.Logger
+	baseURL               string
+	http                  *http.Client
+	logger                api.Logger
+	knownPersistedQueries sync.Map
 }
 
 // NewClient substitutes a 15-second HTTP client and no-op logger for nil
@@ -69,13 +71,10 @@ func (c *Client) GetInfo(ctx context.Context, imdbID string, manualLanguage stri
 		return info, nil
 	}
 
-	query := fmt.Sprintf(
-		`query GetTitleInfo { title(id: "%s") { id titleText { text isOriginalTitle country { text } } originalTitleText { text } releaseYear { year endYear } titleType { id } plot { plotText { plainText } } ratingsSummary { aggregateRating voteCount } primaryImage { url } runtime { displayableProperty { value { plainText } } seconds } titleGenres { genres { genre { text } } } principalCredits { category { text id } credits { name { id nameText { text } } } } episodes { episodes(first: 500) { edges { node { id series { displayableEpisodeNumber { displayableSeason { season } episodeNumber { text } } } titleText { text } releaseYear { year } releaseDate { year month day } } } pageInfo { hasNextPage hasPreviousPage } total } } runtimes(first: 10) { edges { node { id seconds displayableProperty { value { plainText } } attributes { text } } } } technicalSpecifications { soundMixes { items { text attributes { text } } } } akas(first: 100) { edges { node { text country { text } language { text } attributes { text } } } } countriesOfOrigin { countries { text } } } }`,
-		escapeGraphQLString(id),
-	)
+	const query = `query GetTitleInfo($id: ID!) { title(id: $id) { id titleText { text isOriginalTitle country { text } } originalTitleText { text } releaseYear { year endYear } titleType { id } plot { plotText { plainText } } ratingsSummary { aggregateRating voteCount } primaryImage { url } runtime { displayableProperty { value { plainText } } seconds } titleGenres { genres { genre { text } } } principalCredits { category { text id } credits { name { id nameText { text } } } } episodes { episodes(first: 500) { edges { node { id series { displayableEpisodeNumber { displayableSeason { season } episodeNumber { text } } } titleText { text } releaseYear { year } releaseDate { year month day } } } pageInfo { hasNextPage hasPreviousPage } total } } runtimes(first: 10) { edges { node { id seconds displayableProperty { value { plainText } } attributes { text } } } } technicalSpecifications { soundMixes { items { text attributes { text } } } } akas(first: 100) { edges { node { text country { text } language { text } attributes { text } } } } countriesOfOrigin { countries { text } } } }`
 
 	var response map[string]any
-	if err := c.postGraphQL(ctx, "GetTitleInfo", query, &response); err != nil {
+	if err := c.postGraphQL(ctx, "GetTitleInfo", query, map[string]any{"id": id}, &response); err != nil {
 		return info, err
 	}
 
@@ -482,12 +481,9 @@ func (c *Client) GetEpisodeInfo(ctx context.Context, imdbID string, debug bool) 
 		return EpisodeLookup{}, nil
 	}
 
-	query := fmt.Sprintf(
-		`query GetEpisodeInfo { title(id: "%s") { id titleText { text } series { displayableEpisodeNumber { displayableSeason { id season text } episodeNumber { id text } } nextEpisode { id titleText { text } } previousEpisode { id titleText { text } } series { id titleText { text } } } } }`,
-		escapeGraphQLString(id),
-	)
+	const query = `query GetEpisodeInfo($id: ID!) { title(id: $id) { id titleText { text } series { displayableEpisodeNumber { displayableSeason { id season text } episodeNumber { id text } } nextEpisode { id titleText { text } } previousEpisode { id titleText { text } } series { id titleText { text } } } } }`
 	var response map[string]any
-	if err := c.postGraphQL(ctx, "GetEpisodeInfo", query, &response); err != nil {
+	if err := c.postGraphQL(ctx, "GetEpisodeInfo", query, map[string]any{"id": id}, &response); err != nil {
 		return EpisodeLookup{}, err
 	}
 	title := getMap(response, "data", "title")
@@ -553,23 +549,31 @@ func (c *Client) runSearch(ctx context.Context, filename string, searchYear int,
 		filename = strings.ReplaceAll(filename, "AND", "&")
 	}
 
-	constraints := []string{fmt.Sprintf("titleTextConstraint: {searchTerm: \"%s\"}", escapeGraphQLString(filename))}
+	constraints := map[string]any{
+		"titleTextConstraint": map[string]any{"searchTerm": filename},
+	}
 	if !wide && searchYear > 0 {
 		start := searchYear - 1
 		end := searchYear + 1
-		constraints = append(constraints, fmt.Sprintf("releaseDateConstraint: {releaseDateRange: {start: \"%d-01-01\", end: \"%d-12-31\"}}", start, end))
+		constraints["releaseDateConstraint"] = map[string]any{
+			"releaseDateRange": map[string]any{
+				"start": fmt.Sprintf("%d-01-01", start),
+				"end":   fmt.Sprintf("%d-12-31", end),
+			},
+		}
 	}
 	if !wide && duration > 0 {
-		constraints = append(constraints, fmt.Sprintf("runtimeConstraint: {runtimeRangeMinutes: {min: %d, max: %d}}", duration-10, duration+10))
+		constraints["runtimeConstraint"] = map[string]any{
+			"runtimeRangeMinutes": map[string]any{
+				"min": duration - 10,
+				"max": duration + 10,
+			},
+		}
 	}
-	constraintsString := strings.Join(constraints, ", ")
 
-	query := fmt.Sprintf(
-		`query SearchTitles { advancedTitleSearch(first: 10, constraints: {%s}) { total edges { node { title { id titleText { text } titleType { text } releaseYear { year } plot { plotText { plainText } } } } } } }`,
-		constraintsString,
-	)
+	const query = `query SearchTitles($constraints: AdvancedTitleSearchConstraints!) { advancedTitleSearch(first: 10, constraints: $constraints) { total edges { node { title { id titleText { text } titleType { text } releaseYear { year } plot { plotText { plainText } } } } } } }`
 	var response map[string]any
-	if err := c.postGraphQL(ctx, "SearchTitles", query, &response); err != nil {
+	if err := c.postGraphQL(ctx, "SearchTitles", query, map[string]any{"constraints": constraints}, &response); err != nil {
 		return nil
 	}
 	return getList(response, "data", "advancedTitleSearch", "edges")
@@ -591,6 +595,11 @@ type graphQLPersistedQuery struct {
 	SHA256Hash string `json:"sha256Hash"`
 }
 
+type persistedQueryCacheKey struct {
+	endpoint string
+	hash     string
+}
+
 type graphQLErrorEnvelope struct {
 	Errors []struct {
 		Message    string `json:"message"`
@@ -600,24 +609,35 @@ type graphQLErrorEnvelope struct {
 	} `json:"errors"`
 }
 
-func (c *Client) postGraphQL(ctx context.Context, operationName string, query string, target any) error {
+func (c *Client) postGraphQL(ctx context.Context, operationName string, query string, variables map[string]any, target any) error {
 	queryHash := sha256.Sum256([]byte(query))
+	hash := hex.EncodeToString(queryHash[:])
 	payload := graphQLRequest{
 		OperationName: operationName,
-		Variables:     map[string]any{},
+		Variables:     variables,
 		Extensions: graphQLExtensions{
 			PersistedQuery: graphQLPersistedQuery{
 				Version:    1,
-				SHA256Hash: hex.EncodeToString(queryHash[:]),
+				SHA256Hash: hash,
 			},
 		},
 	}
 
-	responseBody, err := c.executeGraphQLRequest(ctx, http.MethodGet, payload)
+	cacheKey := persistedQueryCacheKey{endpoint: c.baseURL, hash: hash}
+	_, known := c.knownPersistedQueries.Load(cacheKey)
+	method := http.MethodPost
+	if known {
+		method = http.MethodGet
+	} else {
+		payload.Query = query
+	}
+
+	responseBody, err := c.executeGraphQLRequest(ctx, method, payload)
 	if err != nil {
 		return err
 	}
-	if persistedQueryNotFound(responseBody) {
+	if known && persistedQueryNotFound(responseBody) {
+		c.knownPersistedQueries.Delete(cacheKey)
 		if c.logger != nil {
 			c.logger.Debugf("imdb: persisted query cache miss operation=%s action=register", operationName)
 		}
@@ -634,6 +654,7 @@ func (c *Client) postGraphQL(ctx context.Context, operationName string, query st
 	if err := json.Unmarshal(responseBody, target); err != nil {
 		return fmt.Errorf("imdb: decode GraphQL response: %w", err)
 	}
+	c.knownPersistedQueries.Store(cacheKey, struct{}{})
 	return nil
 }
 
@@ -692,6 +713,9 @@ func (c *Client) executeGraphQLRequest(ctx context.Context, method string, paylo
 		return nil, fmt.Errorf("imdb: GraphQL response exceeds %d bytes", maxGraphQLResponseSize)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if method == http.MethodGet && persistedQueryNotFound(responseBody) {
+			return responseBody, nil
+		}
 		return nil, fmt.Errorf(
 			"imdb: http %d: %s",
 			resp.StatusCode,
@@ -839,12 +863,6 @@ func fallbackParsedTitle(untouched string) string {
 	}
 	release := rls.ParseString(trimmed)
 	return strings.TrimSpace(release.Title)
-}
-
-func escapeGraphQLString(value string) string {
-	value = strings.ReplaceAll(value, "\\", "\\\\")
-	value = strings.ReplaceAll(value, "\"", "\\\"")
-	return value
 }
 
 func getMap(root map[string]any, path ...string) map[string]any {

--- a/internal/metadata/imdb/client_test.go
+++ b/internal/metadata/imdb/client_test.go
@@ -4,21 +4,21 @@
 package imdb
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-func TestPostGraphQLRegistersPersistedQueryOnCacheMiss(t *testing.T) {
-	const query = `query TestOperation { title(id: "tt1234567") { id } }`
+func TestPostGraphQLPostsUnseenHashThenGetsKnownHash(t *testing.T) {
+	const query = `query TestOperation($id: ID!) { title(id: $id) { id } }`
 
 	queryHash := sha256.Sum256([]byte(query))
 	expectedHash := hex.EncodeToString(queryHash[:])
@@ -29,32 +29,8 @@ func TestPostGraphQLRegistersPersistedQueryOnCacheMiss(t *testing.T) {
 
 		switch requestCount.Add(1) {
 		case 1:
-			if r.Method != http.MethodGet {
-				t.Errorf("expected initial GET, got %s", r.Method)
-			}
-			params := r.URL.Query()
-			if got := params.Get("operationName"); got != "TestOperation" {
-				t.Errorf("unexpected operation name %q", got)
-			}
-			if got := params.Get("variables"); got != "{}" {
-				t.Errorf("unexpected variables %q", got)
-			}
-			if got := params.Get("query"); got != "" {
-				t.Errorf("initial request included query %q", got)
-			}
-
-			var extensions graphQLExtensions
-			if err := json.Unmarshal([]byte(params.Get("extensions")), &extensions); err != nil {
-				t.Errorf("decode extensions: %v", err)
-			} else if extensions.PersistedQuery.Version != 1 || extensions.PersistedQuery.SHA256Hash != expectedHash {
-				t.Errorf("unexpected persisted query %#v", extensions.PersistedQuery)
-			}
-
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"errors":[{"message":"PersistedQueryNotFound","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}`))
-		case 2:
 			if r.Method != http.MethodPost {
-				t.Errorf("expected registration POST, got %s", r.Method)
+				t.Errorf("expected initial POST, got %s", r.Method)
 			}
 
 			var payload graphQLRequest
@@ -67,8 +43,8 @@ func TestPostGraphQLRegistersPersistedQueryOnCacheMiss(t *testing.T) {
 				if payload.Query != query {
 					t.Errorf("unexpected query %q", payload.Query)
 				}
-				if len(payload.Variables) != 0 {
-					t.Errorf("unexpected variables %#v", payload.Variables)
+				if got := getStringFromMap(payload.Variables, "id"); got != "tt1234567" {
+					t.Errorf("unexpected id variable %q", got)
 				}
 				if payload.Extensions.PersistedQuery.Version != 1 || payload.Extensions.PersistedQuery.SHA256Hash != expectedHash {
 					t.Errorf("unexpected persisted query %#v", payload.Extensions.PersistedQuery)
@@ -76,7 +52,34 @@ func TestPostGraphQLRegistersPersistedQueryOnCacheMiss(t *testing.T) {
 			}
 
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"data":{"title":{"id":"tt1234567"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"query":{"id":"tt1234567"}}}`))
+		case 2:
+			if r.Method != http.MethodGet {
+				t.Errorf("expected known-hash GET, got %s", r.Method)
+			}
+
+			params := r.URL.Query()
+			if got := params.Get("operationName"); got != "TestOperation" {
+				t.Errorf("unexpected operation name %q", got)
+			}
+			if got := params.Get("query"); got != "" {
+				t.Errorf("known-hash request included query %q", got)
+			}
+			var variables map[string]any
+			if err := json.Unmarshal([]byte(params.Get("variables")), &variables); err != nil {
+				t.Errorf("decode variables: %v", err)
+			} else if got := getStringFromMap(variables, "id"); got != "tt7654321" {
+				t.Errorf("unexpected id variable %q", got)
+			}
+			var extensions graphQLExtensions
+			if err := json.Unmarshal([]byte(params.Get("extensions")), &extensions); err != nil {
+				t.Errorf("decode extensions: %v", err)
+			} else if extensions.PersistedQuery.Version != 1 || extensions.PersistedQuery.SHA256Hash != expectedHash {
+				t.Errorf("unexpected persisted query %#v", extensions.PersistedQuery)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"query":{"id":"tt7654321"}}}`))
 		default:
 			t.Errorf("unexpected extra request")
 			http.Error(w, "unexpected request", http.StatusInternalServerError)
@@ -89,25 +92,105 @@ func TestPostGraphQLRegistersPersistedQueryOnCacheMiss(t *testing.T) {
 	client.baseURL = server.URL
 
 	var response map[string]any
-	if err := client.postGraphQL(context.Background(), "TestOperation", query, &response); err != nil {
-		t.Fatalf("post GraphQL: %v", err)
+	if err := client.postGraphQL(t.Context(), "TestOperation", query, map[string]any{"id": "tt1234567"}, &response); err != nil {
+		t.Fatalf("first GraphQL request: %v", err)
 	}
-	if got := getString(response, "data", "title", "id"); got != "tt1234567" {
+	if got := getString(response, "data", "query", "id"); got != "tt1234567" {
+		t.Fatalf("unexpected title ID %q", got)
+	}
+	response = nil
+	if err := client.postGraphQL(t.Context(), "TestOperation", query, map[string]any{"id": "tt7654321"}, &response); err != nil {
+		t.Fatalf("second GraphQL request: %v", err)
+	}
+	if got := getString(response, "data", "query", "id"); got != "tt7654321" {
 		t.Fatalf("unexpected title ID %q", got)
 	}
 	if got := requestCount.Load(); got != 2 {
 		t.Fatalf("expected two requests, got %d", got)
 	}
-	if len(logger.debugMessages) != 1 ||
-		logger.debugMessages[0] != "imdb: persisted query cache miss operation=TestOperation action=register" {
+	if len(logger.debugMessages) != 0 {
 		t.Fatalf("unexpected debug messages %#v", logger.debugMessages)
+	}
+}
+
+func TestPostGraphQLReregistersKnownHashOnCacheMiss(t *testing.T) {
+	const query = `query TestOperation($id: ID!) { title(id: $id) { id } }`
+	queryHash := sha256.Sum256([]byte(query))
+	expectedHash := hex.EncodeToString(queryHash[:])
+
+	for _, statusCode := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(fmt.Sprintf("http_%d", statusCode), func(t *testing.T) {
+			var requestCount atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertIMDbGraphQLHeaders(t, r)
+				w.Header().Set("Content-Type", "application/json")
+
+				switch requestCount.Add(1) {
+				case 1:
+					if r.Method != http.MethodGet {
+						t.Errorf("expected cached GET, got %s", r.Method)
+					}
+					if statusCode != http.StatusOK {
+						w.WriteHeader(statusCode)
+					}
+					_, _ = w.Write([]byte(`{"errors":[{"message":"PersistedQueryNotFound","extensions":{"code":"PERSISTED_QUERY_NOT_FOUND"}}]}`))
+				case 2:
+					if r.Method != http.MethodPost {
+						t.Errorf("expected registration POST, got %s", r.Method)
+					}
+					var payload graphQLRequest
+					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+						t.Errorf("decode request payload: %v", err)
+					} else {
+						if payload.Query != query {
+							t.Errorf("unexpected query %q", payload.Query)
+						}
+						if got := getStringFromMap(payload.Variables, "id"); got != "tt1234567" {
+							t.Errorf("unexpected id variable %q", got)
+						}
+					}
+					_, _ = w.Write([]byte(`{"data":{"query":{"id":"tt1234567"}}}`))
+				default:
+					t.Errorf("unexpected extra request")
+					http.Error(w, "unexpected request", http.StatusInternalServerError)
+				}
+			}))
+			defer server.Close()
+
+			logger := &imdbTestLogger{}
+			client := NewClient(server.Client(), logger)
+			client.baseURL = server.URL
+			cacheKey := persistedQueryCacheKey{endpoint: server.URL, hash: expectedHash}
+			client.knownPersistedQueries.Store(cacheKey, struct{}{})
+
+			var response map[string]any
+			if err := client.postGraphQL(t.Context(), "TestOperation", query, map[string]any{"id": "tt1234567"}, &response); err != nil {
+				t.Fatalf("GraphQL request: %v", err)
+			}
+			if got := getString(response, "data", "query", "id"); got != "tt1234567" {
+				t.Fatalf("unexpected title ID %q", got)
+			}
+			if got := requestCount.Load(); got != 2 {
+				t.Fatalf("expected two requests, got %d", got)
+			}
+			if _, ok := client.knownPersistedQueries.Load(cacheKey); !ok {
+				t.Fatal("expected successful registration to restore cached hash")
+			}
+			if len(logger.debugMessages) != 1 ||
+				logger.debugMessages[0] != "imdb: persisted query cache miss operation=TestOperation action=register" {
+				t.Fatalf("unexpected debug messages %#v", logger.debugMessages)
+			}
+		})
 	}
 }
 
 func TestPostGraphQLReturnsGraphQLErrors(t *testing.T) {
 	var requestCount atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount.Add(1)
+		if r.Method != http.MethodPost {
+			t.Errorf("expected initial POST, got %s", r.Method)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(
 			`{"errors":[{"message":"request rejected","extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}]}`,
@@ -119,7 +202,8 @@ func TestPostGraphQLReturnsGraphQLErrors(t *testing.T) {
 	client.baseURL = server.URL
 	response := map[string]any{"sentinel": "unchanged"}
 
-	err := client.postGraphQL(context.Background(), "TestOperation", "query TestOperation { title { id } }", &response)
+	const query = `query TestOperation { title { id } }`
+	err := client.postGraphQL(t.Context(), "TestOperation", query, map[string]any{}, &response)
 	if err == nil {
 		t.Fatal("expected GraphQL error")
 	}
@@ -135,6 +219,141 @@ func TestPostGraphQLReturnsGraphQLErrors(t *testing.T) {
 	}
 	if got := requestCount.Load(); got != 1 {
 		t.Fatalf("expected one request, got %d", got)
+	}
+	queryHash := sha256.Sum256([]byte(query))
+	cacheKey := persistedQueryCacheKey{endpoint: server.URL, hash: hex.EncodeToString(queryHash[:])}
+	if _, ok := client.knownPersistedQueries.Load(cacheKey); ok {
+		t.Fatal("GraphQL error marked query hash as known")
+	}
+}
+
+func TestPostGraphQLDoesNotPostForOtherKnownQueryErrors(t *testing.T) {
+	const query = `query TestOperation($id: ID!) { title(id: $id) { id } }`
+	queryHash := sha256.Sum256([]byte(query))
+	expectedHash := hex.EncodeToString(queryHash[:])
+
+	for _, statusCode := range []int{http.StatusOK, http.StatusBadRequest} {
+		t.Run(fmt.Sprintf("http_%d", statusCode), func(t *testing.T) {
+			var requestCount atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount.Add(1)
+				if r.Method != http.MethodGet {
+					t.Errorf("expected known-hash GET, got %s", r.Method)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if statusCode != http.StatusOK {
+					w.WriteHeader(statusCode)
+				}
+				_, _ = w.Write([]byte(`{"errors":[{"message":"bad query","extensions":null}]}`))
+			}))
+			defer server.Close()
+
+			client := NewClient(server.Client(), nil)
+			client.baseURL = server.URL
+			cacheKey := persistedQueryCacheKey{endpoint: server.URL, hash: expectedHash}
+			client.knownPersistedQueries.Store(cacheKey, struct{}{})
+
+			var response map[string]any
+			err := client.postGraphQL(t.Context(), "TestOperation", query, map[string]any{"id": "tt1234567"}, &response)
+			if err == nil {
+				t.Fatal("expected request error")
+			}
+			if statusCode == http.StatusOK && !strings.Contains(err.Error(), "GraphQL error operation=TestOperation message=bad query") {
+				t.Fatalf("unexpected GraphQL error %q", err)
+			}
+			if statusCode == http.StatusBadRequest && !strings.Contains(err.Error(), "imdb: http 400:") {
+				t.Fatalf("unexpected HTTP error %q", err)
+			}
+			if got := requestCount.Load(); got != 1 {
+				t.Fatalf("expected one request, got %d", got)
+			}
+			if _, ok := client.knownPersistedQueries.Load(cacheKey); !ok {
+				t.Fatal("unrelated error evicted known query hash")
+			}
+		})
+	}
+}
+
+func TestRunSearchUsesStableGraphQLVariables(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertIMDbGraphQLHeaders(t, r)
+		w.Header().Set("Content-Type", "application/json")
+
+		var variables map[string]any
+		switch requestCount.Add(1) {
+		case 1:
+			if r.Method != http.MethodPost {
+				t.Errorf("expected initial POST, got %s", r.Method)
+			}
+			var payload graphQLRequest
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Errorf("decode request payload: %v", err)
+			} else {
+				if !strings.Contains(payload.Query, "query SearchTitles($constraints: AdvancedTitleSearchConstraints!)") {
+					t.Errorf("unexpected search query %q", payload.Query)
+				}
+				if strings.Contains(payload.Query, "Example Release 2026") {
+					t.Error("search query embedded the search term")
+				}
+				variables = payload.Variables
+			}
+		case 2:
+			if r.Method != http.MethodGet {
+				t.Errorf("expected known-hash GET, got %s", r.Method)
+			}
+			if got := r.URL.Query().Get("query"); got != "" {
+				t.Errorf("known-hash request included query %q", got)
+			}
+			if err := json.Unmarshal([]byte(r.URL.Query().Get("variables")), &variables); err != nil {
+				t.Errorf("decode variables: %v", err)
+			}
+		default:
+			t.Errorf("unexpected extra request")
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+
+		if requestCount.Load() == 1 {
+			if got := getStringFromMap(variables, "constraints", "titleTextConstraint", "searchTerm"); got != "Example Release 2026" {
+				t.Errorf("unexpected search term %q", got)
+			}
+			if got := getStringFromMap(variables, "constraints", "releaseDateConstraint", "releaseDateRange", "start"); got != "2025-01-01" {
+				t.Errorf("unexpected start date %q", got)
+			}
+			if got := getStringFromMap(variables, "constraints", "releaseDateConstraint", "releaseDateRange", "end"); got != "2027-12-31" {
+				t.Errorf("unexpected end date %q", got)
+			}
+			if got := getIntFromMap(variables, "constraints", "runtimeConstraint", "runtimeRangeMinutes", "min"); got != 110 {
+				t.Errorf("unexpected minimum runtime %d", got)
+			}
+			if got := getIntFromMap(variables, "constraints", "runtimeConstraint", "runtimeRangeMinutes", "max"); got != 130 {
+				t.Errorf("unexpected maximum runtime %d", got)
+			}
+		} else {
+			if got := getStringFromMap(variables, "constraints", "titleTextConstraint", "searchTerm"); got != "Example Alternate" {
+				t.Errorf("unexpected search term %q", got)
+			}
+			constraints := getMapFromMap(variables, "constraints")
+			if _, ok := constraints["releaseDateConstraint"]; ok {
+				t.Error("wide search included release date constraint")
+			}
+			if _, ok := constraints["runtimeConstraint"]; ok {
+				t.Error("wide search included runtime constraint")
+			}
+		}
+
+		_, _ = w.Write([]byte(`{"data":{"advancedTitleSearch":{"edges":[]}}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), nil)
+	client.baseURL = server.URL
+	client.runSearch(t.Context(), "Example Release 2026", 2026, "MOVIE", 120, false)
+	client.runSearch(t.Context(), "Example Alternate", 2026, "MOVIE", 120, true)
+
+	if got := requestCount.Load(); got != 2 {
+		t.Fatalf("expected two requests, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Description

Use stable GraphQL variables for IMDb title, episode, and search documents so persisted-query hashes are reusable across request values.

Track successfully registered hashes per client: send a full-query POST for unseen hashes, use GET for known hashes, and evict/re-register stale hashes when IMDb returns PersistedQueryNotFound with HTTP 200 or 400.

Add regression coverage for cold and warm requests, stale-query recovery, unrelated GraphQL errors, null error extensions, and stable search constraints.

Related: https://github.com/MiM-MiM/MyMovieGraphQLPy/pull/9

## How has this been tested?

- go test -race -v -timeout 20m ./internal/metadata/imdb
- golangci-lint run --timeout=5m ./internal/metadata/imdb
- make gofix-check-changed
- make logpolicy
- git diff --check
- Lefthook staged-file format, literal-policy, log-policy, path-policy, and commit-message hooks
- make lint was attempted; it remains blocked by 11 unrelated existing findings outside this branch

## Checklist

- [x] My PR title follows the Conventional Commits format
- [x] I have read CONTRIBUTING.md
- [ ] I ran make precommit (the repository-wide lint phase is blocked by unrelated existing findings)
- [x] No CSS changes

## AI disclosure

Yes. OpenAI Codex implemented and tested most of the change with human-directed scope and an explicit post-implementation review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved IMDb metadata request efficiency through persisted-query caching.
  * Reduced repeated request payloads by reusing known queries where supported.

* **Reliability**
  * Added automatic recovery when cached IMDb queries are no longer recognized.
  * Improved handling of query errors and fallback requests.

* **Search**
  * Standardized search parameters across repeated IMDb requests for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->