### PR TITLE
fix(trackers): correct Anthelion audio mapping

### DIFF
--- a/internal/trackers/impl/standalone/ant/taxonomy.go
+++ b/internal/trackers/impl/standalone/ant/taxonomy.go
@@ -72,11 +72,13 @@ func normalizeTypeName(value string) string {
 func resolveAudioFormat(meta api.UploadSubject) string {
 	audio := strings.ToUpper(strings.TrimSpace(meta.Audio))
 	switch {
+	case audio == "":
+		return "NoAudio"
 	case strings.Contains(audio, "DD+"), strings.Contains(audio, "EAC3"):
 		return "EAC3"
 	case strings.Contains(audio, " DD "), strings.HasPrefix(audio, "DD"), strings.Contains(audio, "AC3"):
 		return "AC3"
-	case strings.Contains(audio, "DTS-HD MA"), strings.Contains(audio, "DTS MA"):
+	case strings.Contains(audio, "DTS-HD MA"), strings.Contains(audio, "DTS MA"), strings.Contains(audio, "DTS:X"), strings.Contains(audio, "DTS-HD HRA"):
 		return "DTSMA"
 	case strings.Contains(audio, "DTS"):
 		return "DTS"

--- a/internal/trackers/impl/standalone/ant/taxonomy_test.go
+++ b/internal/trackers/impl/standalone/ant/taxonomy_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package ant
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestResolveAudioFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		audio string
+		want  string
+	}{
+		{name: "no audio", want: "NoAudio"},
+		{
+			name:  "DTS X",
+			audio: "DTS:X 7.1",
+			want:  "DTSMA",
+		},
+		{
+			name:  "DTS HD HRA",
+			audio: "DTS-HD HRA 5.1",
+			want:  "DTSMA",
+		},
+		{
+			name:  "DTS HD MA",
+			audio: "DTS-HD MA 7.1",
+			want:  "DTSMA",
+		},
+		{
+			name:  "DTS",
+			audio: "DTS 5.1",
+			want:  "DTS",
+		},
+		{
+			name:  "unknown",
+			audio: "VORBIS 2.0",
+			want:  "Other",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := resolveAudioFormat(api.UploadSubject{Audio: test.audio}); got != test.want {
+				t.Fatalf("resolveAudioFormat() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Correct Anthelion's upload audio taxonomy so DTS:X and DTS-HD HRA map to `DTSMA`, while releases without an audio track use `NoAudio` instead of `Other`. Preserve the existing mappings for DTS-HD MA, plain DTS, and unknown non-empty codecs.

## How has this been tested?

- `go test -race -v -timeout 20m ./internal/trackers/impl/standalone/ant`
- `golangci-lint run --timeout=5m ./internal/trackers/impl/standalone/ant` (0 issues)
- `make gofix-check-changed`
- `git diff --check`
- Pre-commit format, literal, log, path, and commit-message hooks passed
- `make lint` reached full `golangci-lint`; it reports only unchanged `origin/main` findings in `internal/core/workflow_media.go`, `internal/torrentclient/reflink_windows.go`, and two Unit3D files

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/upbrr/blob/main/CONTRIBUTING.md)
- [ ] I ran `make precommit` (the equivalent scoped checks pass; the full lint step is blocked by the unchanged baseline findings listed above)
- [x] For CSS changes, I ran `pnpm --dir webui run lint:style` (not applicable; no CSS changes)

## AI disclosure

Yes. OpenAI Codex implemented and tested this small change from the user-provided requirements; approximately all changed code was AI-written and then reviewed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio format detection so DTS:X and DTS-HD HRA tracks are correctly identified as DTS Master Audio.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->