### PR TITLE
fix(ptp): include DVD VOB MediaInfo in descriptions

### DIFF
--- a/internal/trackers/impl/standalone/ptp/definition_test.go
+++ b/internal/trackers/impl/standalone/ptp/definition_test.go
@@ -94,6 +94,27 @@ func TestDefinitionBuildDescriptionUsesResolvedAssetsAndMediaInfo(t *testing.T) 
 	}
 }
 
+func TestBuildMediaSectionIncludesDVDIFOAndVOBMediaInfo(t *testing.T) {
+	tmp := t.TempDir()
+	ifoMediaInfoPath := filepath.Join(tmp, "ifo-mediainfo.txt")
+	if err := os.WriteFile(ifoMediaInfoPath, []byte("General\nFormat : DVD Video"), 0o600); err != nil {
+		t.Fatalf("write IFO mediainfo: %v", err)
+	}
+
+	got, err := buildMediaSection(api.UploadSubject{
+		DiscType:            "DVD",
+		MediaInfoTextPath:   ifoMediaInfoPath,
+		DVDVOBMediaInfoText: "General\nFormat : MPEG-PS",
+	}, "")
+	if err != nil {
+		t.Fatalf("build media section: %v", err)
+	}
+	want := "[mediainfo]General\nFormat : DVD Video\n\nGeneral\nFormat : MPEG-PS[/mediainfo]"
+	if got != want {
+		t.Fatalf("media section = %q, want %q", got, want)
+	}
+}
+
 func TestPTPFreshUploadTaxonomy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/impl/standalone/ptp/definition_test.go
+++ b/internal/trackers/impl/standalone/ptp/definition_test.go
@@ -109,7 +109,7 @@ func TestBuildMediaSectionIncludesDVDIFOAndVOBMediaInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build media section: %v", err)
 	}
-	want := "[mediainfo]General\nFormat : DVD Video\n\nGeneral\nFormat : MPEG-PS[/mediainfo]"
+	want := "[mediainfo]General\nFormat : DVD Video[/mediainfo]\n\n[mediainfo]General\nFormat : MPEG-PS[/mediainfo]"
 	if got != want {
 		t.Fatalf("media section = %q, want %q", got, want)
 	}

--- a/internal/trackers/impl/standalone/ptp/media.go
+++ b/internal/trackers/impl/standalone/ptp/media.go
@@ -45,7 +45,8 @@ func readTextFile(path string) (string, error) {
 }
 
 func buildMediaSection(meta api.UploadSubject, dbPath string) (string, error) {
-	switch strings.ToUpper(strings.TrimSpace(meta.DiscType)) {
+	discType := strings.ToUpper(strings.TrimSpace(meta.DiscType))
+	switch discType {
 	case "BDMV":
 		text, err := readBDSummary(meta, dbPath)
 		if err != nil {
@@ -60,9 +61,16 @@ func buildMediaSection(meta api.UploadSubject, dbPath string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if strings.TrimSpace(text) == "" {
+		text = strings.TrimSpace(text)
+		if vobText := strings.TrimSpace(meta.DVDVOBMediaInfoText); discType == "DVD" && vobText != "" {
+			if text != "" {
+				text += "\n\n"
+			}
+			text += vobText
+		}
+		if text == "" {
 			return "", nil
 		}
-		return "[mediainfo]" + strings.TrimSpace(text) + "[/mediainfo]", nil
+		return "[mediainfo]" + text + "[/mediainfo]", nil
 	}
 }

--- a/internal/trackers/impl/standalone/ptp/media.go
+++ b/internal/trackers/impl/standalone/ptp/media.go
@@ -62,15 +62,13 @@ func buildMediaSection(meta api.UploadSubject, dbPath string) (string, error) {
 			return "", err
 		}
 		text = strings.TrimSpace(text)
+		var sections []string
+		if text != "" {
+			sections = append(sections, "[mediainfo]"+text+"[/mediainfo]")
+		}
 		if vobText := strings.TrimSpace(meta.DVDVOBMediaInfoText); discType == "DVD" && vobText != "" {
-			if text != "" {
-				text += "\n\n"
-			}
-			text += vobText
+			sections = append(sections, "[mediainfo]"+vobText+"[/mediainfo]")
 		}
-		if text == "" {
-			return "", nil
-		}
-		return "[mediainfo]" + text + "[/mediainfo]", nil
+		return strings.Join(sections, "\n\n"), nil
 	}
 }


### PR DESCRIPTION
PTP DVD descriptions now include both prepared MediaInfo reports: the IFO report and the VOB report. Each non-empty report is wrapped in its own complete `[mediainfo]...[/mediainfo]` block, with a blank line between blocks; BDMV and other media paths are unchanged.

This matches PTP's per-report BBCode handling while preserving the existing behavior when either DVD report is empty.

Checks run:
- `go test -race -v -timeout 20m ./internal/trackers/impl/standalone/ptp`
- `golangci-lint run --allow-parallel-runners --timeout=5m ./internal/trackers/impl/standalone/ptp`
- `make logpolicy`
- `make gofix-check-changed`
- `git diff --check`
- Pre-commit formatting and policy hooks

`make lint` passed architecture, path, literal, and workflow-contract checks; its full-tree golangci phase still reports 11 existing findings outside the touched PTP package.