### PR TITLE
chore(deps): upgrade Go to 1.27.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.12.2
+          version: v2.13.2
           args: --timeout=5m

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,14 +26,14 @@ Install the following on your machine:
 - [Node.js](https://nodejs.org) (`^20.19.0`, `^22.13.0`, or `>=24`)
 - [pnpm](https://pnpm.io/installation) (10 or newer — version is pinned in `webui/package.json` via `packageManager`)
 - [GNU Make](https://www.gnu.org/software/make/) — top-level shortcuts for builds, checks, formatting, and hooks
-- [golangci-lint](https://golangci-lint.run/) — used by hooks and CI
+- [golangci-lint](https://golangci-lint.run/) — use the version pinned in the [CI workflow](./.github/workflows/golangci-lint.yml) for hooks and local checks
 - [Lefthook](https://github.com/evilmartians/lefthook) — git hooks runner (see [Git hooks](#git-hooks-lefthook))
 
 ### Supported platforms
 
 Every script, hook, and VS Code task runs on macOS, Linux, and Windows using native tooling:
 
-- **macOS** — zsh or bash.
+- **macOS 13 Ventura or newer** — zsh or bash (required by Go 1.27).
 - **Linux** — bash.
 - **Windows** — PowerShell 7+ or Git Bash. WSL works but is not required.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # below. The predefined platform args (BUILDPLATFORM, TARGET*) are auto-available
 # to FROM, and VERSION/BUILD_ID are declared inside the build stage where they are
 # consumed (see below), so they do not need global declarations.
-ARG GO_VERSION=1.26.6
+ARG GO_VERSION=1.27.1
 
 FROM --platform=$BUILDPLATFORM node:24-alpine AS frontend
 

--- a/cmd/commitmsgcheck/main.go
+++ b/cmd/commitmsgcheck/main.go
@@ -333,8 +333,8 @@ func splitBodyFooter(lines []string) parsedMessage {
 
 	// Find the start of the last non-empty block.
 	lastBlockStart := len(rest)
-	for i := len(rest) - 1; i >= 0; i-- {
-		if rest[i] == "" {
+	for i, r := range slices.Backward(rest) {
+		if r == "" {
 			lastBlockStart = i + 1
 			break
 		}

--- a/cmd/upbrr/command.go
+++ b/cmd/upbrr/command.go
@@ -373,16 +373,13 @@ func addExplicitHelpFlag(cmd *cobra.Command) {
 }
 
 func translatePFlagError(err error) error {
-	var notExist *pflag.NotExistError
-	if errors.As(err, &notExist) {
+	if notExist, ok := errors.AsType[*pflag.NotExistError](err); ok {
 		return fmt.Errorf("flag provided but not defined: -%s", notExist.GetSpecifiedName())
 	}
-	var valueRequired *pflag.ValueRequiredError
-	if errors.As(err, &valueRequired) {
+	if valueRequired, ok := errors.AsType[*pflag.ValueRequiredError](err); ok {
 		return fmt.Errorf("flag needs an argument: -%s", valueRequired.GetSpecifiedName())
 	}
-	var invalidValue *pflag.InvalidValueError
-	if errors.As(err, &invalidValue) {
+	if invalidValue, ok := errors.AsType[*pflag.InvalidValueError](err); ok {
 		return fmt.Errorf(
 			"invalid value %q for flag -%s: %w",
 			invalidValue.GetValue(),
@@ -390,8 +387,7 @@ func translatePFlagError(err error) error {
 			errors.Unwrap(invalidValue),
 		)
 	}
-	var invalidSyntax *pflag.InvalidSyntaxError
-	if errors.As(err, &invalidSyntax) {
+	if invalidSyntax, ok := errors.AsType[*pflag.InvalidSyntaxError](err); ok {
 		return fmt.Errorf("bad flag syntax: %s", invalidSyntax.GetSpecifiedFlag())
 	}
 	return err

--- a/cmd/upbrr/command_test.go
+++ b/cmd/upbrr/command_test.go
@@ -35,8 +35,7 @@ func executeCLIForTest(ctx context.Context, t *testing.T, args []string) cliExec
 	code := 0
 	if err != nil {
 		code = 1
-		var exitErr *cliExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*cliExitError](err); ok {
 			code = exitErr.code
 		}
 	}

--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -40,8 +40,7 @@ func main() {
 	exitCode := 0
 	if err := run(); err != nil {
 		printTerminalError(err)
-		var cliErr *cliExitError
-		if errors.As(err, &cliErr) {
+		if cliErr, ok := errors.AsType[*cliExitError](err); ok {
 			exitCode = cliErr.code
 		} else {
 			exitCode = 1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/autobrr/upbrr
 
-go 1.26.6
+go 1.27.1
 
 require (
 	github.com/autobrr/go-bdinfo v0.4.0

--- a/internal/authmaterial/store.go
+++ b/internal/authmaterial/store.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -429,8 +430,8 @@ func (s *Store) ListAPITokens(ctx context.Context) ([]apitoken.Record, error) {
 		return nil, ErrUnavailable
 	}
 	result := make([]apitoken.Record, 0, len(record.APIKeys))
-	for index := len(record.APIKeys) - 1; index >= 0; index-- {
-		result = append(result, apiKeyMetadata(record.APIKeys[index]))
+	for _, v := range slices.Backward(record.APIKeys) {
+		result = append(result, apiKeyMetadata(v))
 	}
 	return result, nil
 }

--- a/internal/cookies/loader.go
+++ b/internal/cookies/loader.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"modernc.org/sqlite"
@@ -295,8 +296,8 @@ func removeLegacyCookieCandidate(path string) (legacyCookieCandidateSnapshot, bo
 // rollback rebuilds parent paths after later candidates have been handled.
 func restoreLegacyCookieCandidates(snapshots []legacyCookieCandidateSnapshot) error {
 	var errs []error
-	for i := len(snapshots) - 1; i >= 0; i-- {
-		if err := snapshots[i].restore(); err != nil {
+	for _, snapshot := range slices.Backward(snapshots) {
+		if err := snapshot.restore(); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/internal/core/workflow_description_test.go
+++ b/internal/core/workflow_description_test.go
@@ -144,10 +144,9 @@ func TestWorkflowDescriptionBuilderBindsProjectionMediaInputsAndImageFeedback(t 
 	}
 	privateMedia := workflowMediaPrivateArtifacts{
 		Screenshots: []api.ScreenshotImage{{Path: "C:\\private\\screen.png", Purpose: api.ScreenshotPurposeFinal}},
-		DVDMenus: []api.DVDMenuCaptureImage{{ScreenshotImage: api.ScreenshotImage{
+		DVDMenus: []api.DVDMenuCaptureImage{{
 			Path:    "C:\\private\\menu.png",
-			Purpose: api.ScreenshotPurposeMenu,
-		}}},
+			Purpose: api.ScreenshotPurposeMenu}},
 		HostedImages: map[api.PublicResourceID]api.UploadedImageLink{
 			"hosted-1": {
 				ImagePath: "C:\\private\\screen.png",
@@ -231,62 +230,62 @@ func TestResolveWorkflowExactMediaKeepsChannelsAndHostedVariantsSeparate(t *test
 
 	media := api.MediaArtifactSet{Artifacts: []api.MediaArtifact{
 		{
-ID: "screen-1",
- Kind: api.MediaArtifactScreenshot,
- Purpose: api.ScreenshotPurposeFinal,
- Selected: true,
- Order: 2,
-},
-		{
-ID: "menu-1",
- Kind: api.MediaArtifactDVDMenu,
- Purpose: api.ScreenshotPurposeMenu,
- Selected: true,
- Order: 1,
-},
-		{
-ID: "screen-2",
- Kind: api.MediaArtifactScreenshot,
- Purpose: api.ScreenshotPurposeFinal,
- Selected: true,
- Order: 0,
-},
-		{
-ID: "menu-2",
- Kind: api.MediaArtifactDVDMenu,
- Purpose: api.ScreenshotPurposeMenu,
- Selected: true,
- Order: 0,
-},
-		{
-ID: "screen-3",
- Kind: api.MediaArtifactScreenshot,
- Purpose: api.ScreenshotPurposeFinal,
- Selected: true,
- Order: 3,
-},
-		{
-ID: "screen-4",
- Kind: api.MediaArtifactScreenshot,
- Purpose: api.ScreenshotPurposeFinal,
- Selected: true,
- Order: 1,
-},
-		{
-			ID: "hosted-screen",
- Kind: api.MediaArtifactHostedImage,
- Purpose: api.ScreenshotPurposeFinal,
+			ID:       "screen-1",
+			Kind:     api.MediaArtifactScreenshot,
+			Purpose:  api.ScreenshotPurposeFinal,
 			Selected: true,
- Order: 6,
- Source: "screen-2",
+			Order:    2,
 		},
 		{
-			ID: "hosted-menu",
- Kind: api.MediaArtifactHostedImage,
- Purpose: api.ScreenshotPurposeMenu,
+			ID:       "menu-1",
+			Kind:     api.MediaArtifactDVDMenu,
+			Purpose:  api.ScreenshotPurposeMenu,
 			Selected: true,
- Order: 7,
- Source: "menu-2",
+			Order:    1,
+		},
+		{
+			ID:       "screen-2",
+			Kind:     api.MediaArtifactScreenshot,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+			Order:    0,
+		},
+		{
+			ID:       "menu-2",
+			Kind:     api.MediaArtifactDVDMenu,
+			Purpose:  api.ScreenshotPurposeMenu,
+			Selected: true,
+			Order:    0,
+		},
+		{
+			ID:       "screen-3",
+			Kind:     api.MediaArtifactScreenshot,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+			Order:    3,
+		},
+		{
+			ID:       "screen-4",
+			Kind:     api.MediaArtifactScreenshot,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+			Order:    1,
+		},
+		{
+			ID:       "hosted-screen",
+			Kind:     api.MediaArtifactHostedImage,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+			Order:    6,
+			Source:   "screen-2",
+		},
+		{
+			ID:       "hosted-menu",
+			Kind:     api.MediaArtifactHostedImage,
+			Purpose:  api.ScreenshotPurposeMenu,
+			Selected: true,
+			Order:    7,
+			Source:   "menu-2",
 		},
 	}}
 	private := workflowMediaPrivateArtifacts{
@@ -297,8 +296,8 @@ ID: "screen-4",
 			{Path: "screen-4.png", Purpose: api.ScreenshotPurposeFinal},
 		},
 		DVDMenus: []api.DVDMenuCaptureImage{
-			{ScreenshotImage: api.ScreenshotImage{Path: "menu-1.png", Purpose: api.ScreenshotPurposeMenu}},
-			{ScreenshotImage: api.ScreenshotImage{Path: "menu-2.png", Purpose: api.ScreenshotPurposeMenu}},
+			{Path: "menu-1.png", Purpose: api.ScreenshotPurposeMenu},
+			{Path: "menu-2.png", Purpose: api.ScreenshotPurposeMenu},
 		},
 		HostedImages: map[api.PublicResourceID]api.UploadedImageLink{
 			"hosted-screen": {ImagePath: "screen-2.png", RawURL: "https://img.example/screen-2.png"},

--- a/internal/core/workflow_media.go
+++ b/internal/core/workflow_media.go
@@ -1264,20 +1264,20 @@ func (b workflowMediaBuilder) mediaMutationBase(
 		return api.MediaArtifactSet{}, workflowMediaPrivateArtifacts{}, fmt.Errorf("workflow media fingerprint: %w", err)
 	}
 	return api.MediaArtifactSet{
-			CaptureFingerprint:      fingerprint,
-			RequirementsFingerprint: requirements,
-			Artifacts:               []api.MediaArtifact{},
-			Status:                  api.StageStatusCompleted,
-		}, workflowMediaPrivateArtifacts{
-			ArtifactImages:    make(map[api.PublicResourceID]api.ScreenshotImage),
-			DVDMenuImages:     make(map[api.PublicResourceID]api.DVDMenuCaptureImage),
-			HostedImages:      make(map[api.PublicResourceID]api.UploadedImageLink),
-			HostedSources:     make(map[api.PublicResourceID]api.PublicResourceID),
-			screenshotService: b.screenshots,
-			dvdMenuService:    b.dvdMenus,
-			hostedRepository:  b.media.repo,
-			commitState:       &workflowMediaCommitState{},
-		}, nil
+		CaptureFingerprint:      fingerprint,
+		RequirementsFingerprint: requirements,
+		Artifacts:               []api.MediaArtifact{},
+		Status:                  api.StageStatusCompleted,
+	}, workflowMediaPrivateArtifacts{
+		ArtifactImages:    make(map[api.PublicResourceID]api.ScreenshotImage),
+		DVDMenuImages:     make(map[api.PublicResourceID]api.DVDMenuCaptureImage),
+		HostedImages:      make(map[api.PublicResourceID]api.UploadedImageLink),
+		HostedSources:     make(map[api.PublicResourceID]api.PublicResourceID),
+		screenshotService: b.screenshots,
+		dvdMenuService:    b.dvdMenus,
+		hostedRepository:  b.media.repo,
+		commitState:       &workflowMediaCommitState{},
+	}, nil
 }
 
 func hostedImageKey(sourceID api.PublicResourceID, link api.UploadedImageLink) string {

--- a/internal/core/workflow_media_test.go
+++ b/internal/core/workflow_media_test.go
@@ -123,13 +123,14 @@ func (f *workflowDVDMenuFake) Capture(
 		return *f.result, nil
 	}
 	return api.DVDMenuCaptureResult{
-		Images: []api.DVDMenuCaptureImage{{ScreenshotImage: api.ScreenshotImage{
+		Images: []api.DVDMenuCaptureImage{{
 			Path:      "C:\\private\\menu.png",
 			Purpose:   api.ScreenshotPurposeMenu,
 			Width:     720,
 			Height:    480,
 			SizeBytes: 4321,
-		}, Discovery: api.DVDMenuDiscoveryReachable}},
+			Discovery: api.DVDMenuDiscoveryReachable,
+		}},
 		MaxItems: maxItems,
 		Complete: true,
 	}, nil
@@ -322,10 +323,9 @@ func TestWorkflowMediaBuilderMenuRecaptureReplacesAutomaticAndPreservesManual(t 
 	t.Parallel()
 
 	dvdMenus := &workflowDVDMenuFake{result: &api.DVDMenuCaptureResult{
-		Images: []api.DVDMenuCaptureImage{{ScreenshotImage: api.ScreenshotImage{
+		Images: []api.DVDMenuCaptureImage{{
 			Path:    "new-auto-menu.png",
-			Purpose: api.ScreenshotPurposeMenu,
-		}}},
+			Purpose: api.ScreenshotPurposeMenu}},
 		Partial: true,
 		Warnings: []api.DVDMenuCaptureWarning{{
 			Code: "partial_coverage", Message: "Synthetic partial coverage.",
@@ -373,8 +373,8 @@ func TestWorkflowMediaBuilderMenuRecaptureReplacesAutomaticAndPreservesManual(t 
 	retained := workflowMediaPrivateArtifacts{
 		Screenshots: []api.ScreenshotImage{{Path: "screen.png", Purpose: api.ScreenshotPurposeFinal}},
 		DVDMenus: []api.DVDMenuCaptureImage{
-			{ScreenshotImage: api.ScreenshotImage{Path: "manual-menu.png", Purpose: api.ScreenshotPurposeMenu}},
-			{ScreenshotImage: api.ScreenshotImage{Path: "old-auto-menu.png", Purpose: api.ScreenshotPurposeMenu}},
+			{Path: "manual-menu.png", Purpose: api.ScreenshotPurposeMenu},
+			{Path: "old-auto-menu.png", Purpose: api.ScreenshotPurposeMenu},
 		},
 		ArtifactImages: map[api.PublicResourceID]api.ScreenshotImage{
 			"screen":      {Path: "screen.png", Purpose: api.ScreenshotPurposeFinal},
@@ -743,8 +743,8 @@ func TestWorkflowMediaPrivateResourceDeletesThroughManagedServices(t *testing.T)
 	resource := workflowMediaPrivateArtifacts{
 		Screenshots: []api.ScreenshotImage{{Path: "C:\\private\\screen.png"}},
 		DVDMenus: []api.DVDMenuCaptureImage{{
-			ScreenshotImage: api.ScreenshotImage{Path: "C:\\private\\menu.png"},
-			Discovery:       api.DVDMenuDiscoveryReachable,
+			Path:      "C:\\private\\menu.png",
+			Discovery: api.DVDMenuDiscoveryReachable,
 		}},
 		screenshotService: screenshots,
 		dvdMenuService:    dvdMenus,
@@ -786,8 +786,8 @@ func TestWorkflowMediaCommitPropagatesMenuDeletionFailure(t *testing.T) {
 	}
 	resource := workflowMediaPrivateArtifacts{
 		DVDMenus: []api.DVDMenuCaptureImage{{
-			ScreenshotImage: api.ScreenshotImage{Path: menuPath},
-			Discovery:       api.DVDMenuDiscoveryReachable,
+			Path:      menuPath,
+			Discovery: api.DVDMenuDiscoveryReachable,
 		}},
 		dvdMenuService: dvdMenus,
 	}

--- a/internal/core/workflow_upload_plan_test.go
+++ b/internal/core/workflow_upload_plan_test.go
@@ -681,9 +681,8 @@ func TestWorkflowUploadPlanOmitsSkippedTrackersAndKeepsPreparationFailuresLocal(
 	}
 	privateMedia := workflowMediaPrivateArtifacts{
 		Screenshots: []api.ScreenshotImage{{Path: exactScreenshotPath, Purpose: api.ScreenshotPurposeFinal}},
-		DVDMenus: []api.DVDMenuCaptureImage{{ScreenshotImage: api.ScreenshotImage{
-			Path: exactMenuPath, Purpose: api.ScreenshotPurposeMenu,
-		}}},
+		DVDMenus: []api.DVDMenuCaptureImage{{
+			Path: exactMenuPath, Purpose: api.ScreenshotPurposeMenu}},
 		HostedImages: map[api.PublicResourceID]api.UploadedImageLink{
 			"hosted-1":      exactUpload,
 			"hosted-menu-1": exactMenuUpload,

--- a/internal/imagehosting/uploaders.go
+++ b/internal/imagehosting/uploaders.go
@@ -521,7 +521,7 @@ func imgboxPickCookie(resp *http.Response) string {
 	}
 	parts := make([]string, 0, len(cookies))
 	for _, raw := range cookies {
-		segment := strings.SplitN(raw, ";", 2)[0]
+		segment, _, _ := strings.Cut(raw, ";")
 		if strings.TrimSpace(segment) != "" {
 			parts = append(parts, segment)
 		}

--- a/internal/logpolicy/checker.go
+++ b/internal/logpolicy/checker.go
@@ -991,9 +991,9 @@ func (m *sensitiveModel) declare(name string, value sensitiveValue, sensitive bo
 // assign updates the nearest existing binding or declares one when assignment
 // targets a name not yet seen by the model.
 func (m *sensitiveModel) assign(name string, value sensitiveValue, sensitive bool) {
-	for i := len(m.scopes) - 1; i >= 0; i-- {
-		if _, ok := m.scopes[i][name]; ok {
-			m.scopes[i][name] = sensitiveBinding{value: value, sensitive: sensitive}
+	for _, v := range slices.Backward(m.scopes) {
+		if _, ok := v[name]; ok {
+			v[name] = sensitiveBinding{value: value, sensitive: sensitive}
 			return
 		}
 	}
@@ -1003,8 +1003,8 @@ func (m *sensitiveModel) assign(name string, value sensitiveValue, sensitive boo
 // lookup resolves a binding from innermost to outermost scope and returns
 // whether the current value is sensitive.
 func (m *sensitiveModel) lookup(name string) (sensitiveValue, bool) {
-	for i := len(m.scopes) - 1; i >= 0; i-- {
-		binding, ok := m.scopes[i][name]
+	for _, v := range slices.Backward(m.scopes) {
+		binding, ok := v[name]
 		if !ok {
 			continue
 		}

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -1851,8 +1851,8 @@ func parseMediaDurationColonValue(value string) float64 {
 	}
 	var seconds float64
 	multiplier := 1.0
-	for i := len(parts) - 1; i >= 0; i-- {
-		part := strings.TrimSpace(parts[i])
+	for _, part := range slices.Backward(parts) {
+		part := strings.TrimSpace(part)
 		if part == "" {
 			continue
 		}

--- a/internal/metadata/mediainfo/duration.go
+++ b/internal/metadata/mediainfo/duration.go
@@ -6,6 +6,7 @@ package mediainfo
 import (
 	"math"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -85,8 +86,8 @@ func durationColonSeconds(value string) float64 {
 	}
 	var total float64
 	multiplier := 1.0
-	for idx := len(parts) - 1; idx >= 0; idx-- {
-		part := strings.TrimSpace(parts[idx])
+	for _, part := range slices.Backward(parts) {
+		part := strings.TrimSpace(part)
 		if part == "" {
 			continue
 		}

--- a/internal/metadata/thexem/client.go
+++ b/internal/metadata/thexem/client.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -390,11 +391,8 @@ func similarity(a, b string) float64 {
 	}
 	common := 0
 	for _, token := range aTokens {
-		for _, other := range bTokens {
-			if token == other {
-				common++
-				break
-			}
+		if slices.Contains(bTokens, token) {
+			common++
 		}
 	}
 	return (2.0 * float64(common)) / float64(len(aTokens)+len(bTokens))

--- a/internal/metadata/tmdb/anilist.go
+++ b/internal/metadata/tmdb/anilist.go
@@ -288,8 +288,7 @@ func isRetryableAniListError(err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}
-	var rateLimitErr *anilistRateLimitError
-	if errors.As(err, &rateLimitErr) {
+	if _, ok := errors.AsType[*anilistRateLimitError](err); ok {
 		return true
 	}
 	var netErr net.Error

--- a/internal/metadata/tracker_artifacts_test.go
+++ b/internal/metadata/tracker_artifacts_test.go
@@ -30,8 +30,8 @@ func (f artifactRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, err
 func TestPersistUnit3DArtifactsMaxConcurrentImageDownloads(t *testing.T) {
 	const imageCount = 12
 
-	var inFlight int32
-	var maxInFlight int32
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
 
 	png1x1 := []byte{
 		137, 80, 78, 71, 13, 10, 26, 10,
@@ -56,17 +56,17 @@ func TestPersistUnit3DArtifactsMaxConcurrentImageDownloads(t *testing.T) {
 				}, nil
 			}
 
-			current := atomic.AddInt32(&inFlight, 1)
+			current := inFlight.Add(1)
 			for {
-				peak := atomic.LoadInt32(&maxInFlight)
+				peak := maxInFlight.Load()
 				if current <= peak {
 					break
 				}
-				if atomic.CompareAndSwapInt32(&maxInFlight, peak, current) {
+				if maxInFlight.CompareAndSwap(peak, current) {
 					break
 				}
 			}
-			defer atomic.AddInt32(&inFlight, -1)
+			defer inFlight.Add(-1)
 
 			time.Sleep(75 * time.Millisecond)
 			return &http.Response{
@@ -102,10 +102,10 @@ func TestPersistUnit3DArtifactsMaxConcurrentImageDownloads(t *testing.T) {
 	if len(successful) != imageCount {
 		t.Fatalf("expected %d downloaded images, got %d", imageCount, len(successful))
 	}
-	if got := atomic.LoadInt32(&maxInFlight); got > unit3dImageWorkers {
+	if got := maxInFlight.Load(); got > unit3dImageWorkers {
 		t.Fatalf("expected max in-flight <= %d, got %d", unit3dImageWorkers, got)
 	}
-	if got := atomic.LoadInt32(&maxInFlight); got < 2 {
+	if got := maxInFlight.Load(); got < 2 {
 		t.Fatalf("expected concurrent downloads, max in-flight was %d", got)
 	}
 }

--- a/internal/pathing/pathutil.go
+++ b/internal/pathing/pathutil.go
@@ -8,6 +8,7 @@ import (
 	"path" //nolint:depguard // Normalizes slash-style metadata paths, not local filesystem paths.
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 )
 
@@ -122,8 +123,8 @@ func evalExistingPrefix(value string) (string, bool) {
 	for {
 		resolved, ok := resolveExistingPath(current)
 		if ok {
-			for idx := len(missing) - 1; idx >= 0; idx-- {
-				resolved = filepath.Join(resolved, missing[idx])
+			for _, m := range slices.Backward(missing) {
+				resolved = filepath.Join(resolved, m)
 			}
 			return filepath.Clean(resolved), true
 		}

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -6,6 +6,7 @@ package redaction
 import (
 	"encoding/json"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -125,8 +126,7 @@ func RedactValue(value string, sensitiveKeys map[string]struct{}) string {
 
 	blocks := ExtractJSONBlocks(value)
 	if len(blocks) > 0 {
-		for i := len(blocks) - 1; i >= 0; i-- {
-			block := blocks[i]
+		for _, block := range slices.Backward(blocks) {
 			if block.Start < 0 || block.End > len(value) || block.Start >= block.End {
 				continue
 			}

--- a/internal/releaseworkflow/module.go
+++ b/internal/releaseworkflow/module.go
@@ -2877,8 +2877,7 @@ func (m *Module) prepareRelease(
 	command.Input.Instructions = facts.Instructions
 	prepared, err := m.preparer.Prepare(ctx, command.Input)
 	if err != nil {
-		var playlistRequired *api.PlaylistSelectionRequiredError
-		if errors.As(err, &playlistRequired) {
+		if playlistRequired, ok := errors.AsType[*api.PlaylistSelectionRequiredError](err); ok {
 			options := make([]api.RequiredActionOption, 0, min(len(playlistRequired.Candidates), maxPlaylistActionOptions))
 			for _, candidate := range playlistRequired.Candidates {
 				playlist := strings.TrimSpace(candidate.File)

--- a/internal/releaseworkflow/request_mapping_test.go
+++ b/internal/releaseworkflow/request_mapping_test.go
@@ -24,13 +24,11 @@ func TestCommandFromRequestMapsDirectUploadExactly(t *testing.T) {
 	t.Parallel()
 
 	request := api.UploadReleaseWorkflowRequest{
-		ReleaseWorkflowCommandContext: api.ReleaseWorkflowCommandContext{
-			WorkflowID:       api.WorkflowID("workflow-1"),
-			ExpectedRevision: 7,
-			IdempotencyKey:   "upload-1",
-		},
-		NoSeed:     true,
-		TrackerIDs: []api.TrackerID{"ALPHA"},
+		WorkflowID:       api.WorkflowID("workflow-1"),
+		ExpectedRevision: 7,
+		IdempotencyKey:   "upload-1",
+		NoSeed:           true,
+		TrackerIDs:       []api.TrackerID{"ALPHA"},
 	}
 
 	mapped, err := CommandFromRequest(request)

--- a/internal/services/dvdmenus/service.go
+++ b/internal/services/dvdmenus/service.go
@@ -683,14 +683,12 @@ func writeCaptureImages(
 		bounds := capture.Image.Bounds()
 		discovery := api.DVDMenuDiscovery(capture.Discovery)
 		images = append(images, api.DVDMenuCaptureImage{
-			ScreenshotImage: api.ScreenshotImage{
-				Index:     index,
-				Path:      finalPath,
-				Purpose:   api.ScreenshotPurposeMenu,
-				Width:     bounds.Dx(),
-				Height:    bounds.Dy(),
-				SizeBytes: stat.Size(),
-			},
+			Index:     index,
+			Path:      finalPath,
+			Purpose:   api.ScreenshotPurposeMenu,
+			Width:     bounds.Dx(),
+			Height:    bounds.Dy(),
+			SizeBytes: stat.Size(),
 			Discovery: discovery,
 		})
 		records = append(records, api.Screenshot{

--- a/internal/services/screenshots/ffmpeg.go
+++ b/internal/services/screenshots/ffmpeg.go
@@ -56,8 +56,7 @@ func (commandRunner) Run(ctx context.Context, name string, args []string, dir st
 	}
 	if err != nil {
 		exitCode := 1
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			exitCode = exitErr.ExitCode()
 		}
 		result.ExitCode = exitCode

--- a/internal/services/screenshots/helpers.go
+++ b/internal/services/screenshots/helpers.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -593,8 +594,8 @@ func parseDurationSeconds(value string) float64 {
 	}
 	var seconds float64
 	multiplier := 1.0
-	for i := len(parts) - 1; i >= 0; i-- {
-		part := strings.TrimSpace(parts[i])
+	for _, part := range slices.Backward(parts) {
+		part := strings.TrimSpace(part)
 		if part == "" {
 			continue
 		}

--- a/internal/services/trackericon/service.go
+++ b/internal/services/trackericon/service.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -212,10 +213,8 @@ func iconCandidates(domain string, customURL string) []string {
 		if value == "" {
 			return
 		}
-		for _, existing := range candidates {
-			if existing == value {
-				return
-			}
+		if slices.Contains(candidates, value) {
+			return
 		}
 		candidates = append(candidates, value)
 	}

--- a/internal/torrent/service.go
+++ b/internal/torrent/service.go
@@ -866,7 +866,7 @@ func expectedTorrentFiles(meta api.TorrentSubject) ([]sourceContentFile, bool, e
 	info, err := os.Stat(source)
 	if err == nil && !info.IsDir() {
 		return []sourceContentFile{{
-			contentFile: contentFile{path: filepath.Base(source), length: info.Size()},
+			path: filepath.Base(source), length: info.Size(),
 		}}, true, nil
 	}
 	if err != nil {
@@ -889,7 +889,7 @@ func expectedTorrentFiles(meta api.TorrentSubject) ([]sourceContentFile, bool, e
 			return nil, false, fmt.Errorf("torrent: stat wanted file %q: %w", wanted[0], err)
 		}
 		return []sourceContentFile{{
-			contentFile: contentFile{path: filepath.Base(wanted[0]), length: info.Size()},
+			path: filepath.Base(wanted[0]), length: info.Size(),
 		}}, true, nil
 	}
 	expected := make([]sourceContentFile, 0, len(wanted))
@@ -907,7 +907,7 @@ func expectedTorrentFiles(meta api.TorrentSubject) ([]sourceContentFile, bool, e
 			return nil, false, fmt.Errorf("torrent: stat wanted file %q: %w", file, err)
 		}
 		expected = append(expected, sourceContentFile{
-			contentFile: contentFile{path: filepath.ToSlash(rel), length: info.Size()},
+			path: filepath.ToSlash(rel), length: info.Size(),
 		})
 	}
 	return expected, true, nil
@@ -966,7 +966,7 @@ func diskContentFiles(root string) ([]sourceContentFile, error) {
 	}
 	if !info.IsDir() {
 		return []sourceContentFile{{
-			contentFile: contentFile{path: filepath.Base(root), length: info.Size()},
+			path: filepath.Base(root), length: info.Size(),
 		}}, nil
 	}
 	paths := make([]sourceContentFile, 0)
@@ -1007,7 +1007,7 @@ func diskContentFiles(root string) ([]sourceContentFile, error) {
 			return nil
 		}
 		paths = append(paths, sourceContentFile{
-			contentFile: contentFile{path: filepath.ToSlash(rel), length: info.Size()},
+			path: filepath.ToSlash(rel), length: info.Size(),
 		})
 		return nil
 	})

--- a/internal/torrentclient/linking_torrent.go
+++ b/internal/torrentclient/linking_torrent.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/autobrr/go-torrent/metainfo"
@@ -385,8 +386,7 @@ func createTorrentLinkPlan(ctx context.Context, trackerDir string, plan torrentL
 // cleanup failures with the original plan error.
 func rollbackTorrentLinkPlan(trackerDir string, created []string, planErr error) error {
 	var rollbackErrs []error
-	for i := len(created) - 1; i >= 0; i-- {
-		dest := created[i]
+	for _, dest := range slices.Backward(created) {
 		if !pathutil.IsWithinRoot(trackerDir, dest) {
 			rollbackErrs = append(rollbackErrs, errors.New("torrent link rollback destination escapes tracker directory"))
 			continue

--- a/internal/torrentclient/reflink_windows.go
+++ b/internal/torrentclient/reflink_windows.go
@@ -241,7 +241,7 @@ func clusterSizeForVolume(volumeRoot string) (int64, error) {
 		uintptr(unsafe.Pointer(&totalClusters)),
 	)
 	if r1 == 0 {
-		if callErr != nil && !errors.Is(callErr, windows.ERROR_SUCCESS) {
+		if !errors.Is(callErr, windows.ERROR_SUCCESS) {
 			return 0, fmt.Errorf("get cluster size: %w", callErr)
 		}
 		return 0, errors.New("get cluster size: unknown error")
@@ -256,7 +256,7 @@ func isSparseFile(path string) (bool, error) {
 	}
 	r1, _, callErr := procGetFileAttributesW.Call(uintptr(unsafe.Pointer(pathPtr)))
 	if r1 == invalidFileAttributes {
-		if callErr != nil && !errors.Is(callErr, windows.ERROR_SUCCESS) {
+		if !errors.Is(callErr, windows.ERROR_SUCCESS) {
 			return false, fmt.Errorf("get file attributes: %w", callErr)
 		}
 		return false, errors.New("get file attributes: unknown error")
@@ -285,14 +285,14 @@ func setFileEnd(fileHandle windows.Handle, path string, size int64) error {
 		uintptr(fileBegin),
 	)
 	if r1 == 0 {
-		if callErr != nil && !errors.Is(callErr, windows.ERROR_SUCCESS) {
+		if !errors.Is(callErr, windows.ERROR_SUCCESS) {
 			return fmt.Errorf("seek EOF for %s: %w", path, callErr)
 		}
 		return fmt.Errorf("seek EOF for %s: unknown error", path)
 	}
 	r1, _, callErr = procSetEndOfFile.Call(uintptr(fileHandle))
 	if r1 == 0 {
-		if callErr != nil && !errors.Is(callErr, windows.ERROR_SUCCESS) {
+		if !errors.Is(callErr, windows.ERROR_SUCCESS) {
 			return fmt.Errorf("set EOF for %s: %w", path, callErr)
 		}
 		return fmt.Errorf("set EOF for %s: unknown error", path)

--- a/internal/trackers/auth/adapters.go
+++ b/internal/trackers/auth/adapters.go
@@ -115,23 +115,19 @@ func classifyAdapterError(trackerID string, err error) error {
 	if err == nil {
 		return nil
 	}
-	var authRequired *AuthRequiredError
-	if errors.As(err, &authRequired) {
+	if authRequired, ok := errors.AsType[*AuthRequiredError](err); ok {
 		return authRequired
 	}
-	var needs2FA *Needs2FAError
-	if errors.As(err, &needs2FA) {
+	if needs2FA, ok := errors.AsType[*Needs2FAError](err); ok {
 		return needs2FA
 	}
-	var unsupported *UnsupportedAuthError
-	if errors.As(err, &unsupported) {
+	if unsupported, ok := errors.AsType[*UnsupportedAuthError](err); ok {
 		return unsupported
 	}
 	if validation, ok := asValidationError(err); ok {
 		return validation
 	}
-	var resolution *trackerscatalog.AuthResolutionError
-	if errors.As(err, &resolution) {
+	if resolution, ok := errors.AsType[*trackerscatalog.AuthResolutionError](err); ok {
 		if resolution.AuthRequired {
 			return &AuthRequiredError{
 				TrackerID: trackerID,

--- a/internal/trackers/auth/ensure.go
+++ b/internal/trackers/auth/ensure.go
@@ -137,16 +137,14 @@ func (s *Service) ensureSession(ctx context.Context, req EnsureRequest, mode ens
 }
 
 func asNeeds2FAError(err error) (*Needs2FAError, bool) {
-	var needsErr *Needs2FAError
-	if errors.As(err, &needsErr) {
+	if needsErr, ok := errors.AsType[*Needs2FAError](err); ok {
 		return needsErr, true
 	}
 	return nil, false
 }
 
 func asAuthRequiredError(err error) (*AuthRequiredError, bool) {
-	var authRequired *AuthRequiredError
-	if errors.As(err, &authRequired) {
+	if authRequired, ok := errors.AsType[*AuthRequiredError](err); ok {
 		return authRequired, true
 	}
 	return nil, false

--- a/internal/trackers/auth/ensure_test.go
+++ b/internal/trackers/auth/ensure_test.go
@@ -117,10 +117,10 @@ func TestEnsureSessionDeletesConfirmedInvalidAndLogsIn(t *testing.T) {
 
 	adapter := &fakeAdapter{
 		capability: api.TrackerAuthCapability{
-TrackerID: "FAKE",
- SupportsLogin: true,
- SupportsAutoLogin: true,
-},
+			TrackerID:         "FAKE",
+			SupportsLogin:     true,
+			SupportsAutoLogin: true,
+		},
 		validate: func() (Session, error) {
 			return Session{}, &ValidationError{
 				TrackerID:        "FAKE",
@@ -174,8 +174,7 @@ func TestEnsureSessionAutomaticLoginRequiresCapability(t *testing.T) {
 		Config:    config.TrackerConfig{Username: "user", Password: "pass"},
 		AutoLogin: true,
 	})
-	var authRequired *AuthRequiredError
-	if !errors.As(err, &authRequired) {
+	if _, ok := errors.AsType[*AuthRequiredError](err); !ok {
 		t.Fatalf("automatic login without capability error = %v", err)
 	}
 	if adapter.validateCalls != 1 || adapter.loginCalls != 0 || adapter.deleteCalls != 0 {
@@ -211,8 +210,7 @@ func TestEnsureSessionAutomaticLoginRequiresCredentials(t *testing.T) {
 	service := &Service{adapters: map[string]Adapter{"FAKE": adapter}, challenges: NewChallengeManager(defaultChallengeTTL)}
 
 	_, err := service.EnsureSession(context.Background(), EnsureRequest{TrackerID: "FAKE", AutoLogin: true})
-	var authRequired *AuthRequiredError
-	if !errors.As(err, &authRequired) {
+	if _, ok := errors.AsType[*AuthRequiredError](err); !ok {
 		t.Fatalf("automatic login without credentials error = %v", err)
 	}
 	if adapter.validateCalls != 1 || adapter.loginCalls != 0 || adapter.deleteCalls != 1 {

--- a/internal/trackers/auth/service.go
+++ b/internal/trackers/auth/service.go
@@ -1257,8 +1257,7 @@ func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
 		return
 	}
 
-	var authRequired *AuthRequiredError
-	if errors.As(err, &authRequired) {
+	if _, ok := errors.AsType[*AuthRequiredError](err); ok {
 		status.State = StateLoginRequired
 		if validation, ok := asValidationError(err); ok && validation.ConfirmedInvalid {
 			status.CookieCount = 0
@@ -1269,8 +1268,7 @@ func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
 		return
 	}
 
-	var needs2FA *Needs2FAError
-	if errors.As(err, &needs2FA) {
+	if needs2FA, ok := errors.AsType[*Needs2FAError](err); ok {
 		challengeID := strings.TrimSpace(needs2FA.ChallengeID)
 		if challengeID == "" {
 			status.State = StateLoginRequired
@@ -1286,8 +1284,7 @@ func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
 		return
 	}
 
-	var unsupported *UnsupportedAuthError
-	if errors.As(err, &unsupported) {
+	if _, ok := errors.AsType[*UnsupportedAuthError](err); ok {
 		status.Message = "remote auth validation is not supported"
 		return
 	}

--- a/internal/trackers/auth/types.go
+++ b/internal/trackers/auth/types.go
@@ -158,8 +158,7 @@ func trackerAuthError(kind string, trackerID string, reason string, err error) s
 }
 
 func asValidationError(err error) (*ValidationError, bool) {
-	var validationErr *ValidationError
-	if errors.As(err, &validationErr) {
+	if validationErr, ok := errors.AsType[*ValidationError](err); ok {
 		return validationErr, true
 	}
 	return nil, false

--- a/internal/trackers/description_assets_test.go
+++ b/internal/trackers/description_assets_test.go
@@ -1832,10 +1832,9 @@ func TestResolveDescriptionAssetsKeepsExactScreenshotsAndMenusSeparate(t *testin
 	}
 	for index := range 2 {
 		imagePath := filepath.Join(t.TempDir(), fmt.Sprintf("menu-%d.png", index))
-		exact.DVDMenus = append(exact.DVDMenus, api.DVDMenuCaptureImage{ScreenshotImage: api.ScreenshotImage{
+		exact.DVDMenus = append(exact.DVDMenus, api.DVDMenuCaptureImage{
 			Path:    imagePath,
-			Purpose: api.ScreenshotPurposeMenu,
-		}})
+			Purpose: api.ScreenshotPurposeMenu})
 		exact.DVDMenuUploads = append(exact.DVDMenuUploads, api.UploadedImageLink{
 			ImagePath:  imagePath,
 			UsageScope: globalImageUsageScope,

--- a/internal/trackers/impl/azfamily/auth.go
+++ b/internal/trackers/impl/azfamily/auth.go
@@ -33,8 +33,7 @@ func (d *Definition) AuthSessionResolver() trackers.AuthSessionResolver {
 		if err == nil {
 			return nil
 		}
-		var resolution *trackers.AuthResolutionError
-		if errors.As(err, &resolution) {
+		if _, ok := errors.AsType[*trackers.AuthResolutionError](err); ok {
 			return err
 		}
 		if errors.Is(err, cookiepkg.ErrTrackerCookiesNotFound) {

--- a/internal/trackers/impl/standalone/dc/dupe_test.go
+++ b/internal/trackers/impl/standalone/dc/dupe_test.go
@@ -129,7 +129,7 @@ func TestDuplicateSearchPaginatesUntilTerminalTotal(t *testing.T) {
 				Index:           0,
 				Count:           100,
 				Total:           101,
-				IncludesPending: boolPtr(true),
+				IncludesPending: new(true),
 			}) {
 				return
 			}
@@ -139,7 +139,7 @@ func TestDuplicateSearchPaginatesUntilTerminalTotal(t *testing.T) {
 				Index:           100,
 				Count:           1,
 				Total:           101,
-				IncludesPending: boolPtr(true),
+				IncludesPending: new(true),
 			}) {
 				return
 			}
@@ -174,7 +174,7 @@ func TestDuplicateSearchRequiresPendingCoverageForCompleteness(t *testing.T) {
 		name            string
 		includesPending *bool
 	}{
-		{name: "false", includesPending: boolPtr(false)},
+		{name: "false", includesPending: new(false)},
 		{name: "missing", includesPending: nil},
 	}
 	for _, tc := range tests {
@@ -219,7 +219,7 @@ func TestDuplicateSearchRejectsInconsistentPagination(t *testing.T) {
 				Index:           0,
 				Count:           100,
 				Total:           101,
-				IncludesPending: boolPtr(true),
+				IncludesPending: new(true),
 			}) {
 				return
 			}
@@ -228,7 +228,7 @@ func TestDuplicateSearchRejectsInconsistentPagination(t *testing.T) {
 				Index:           100,
 				Count:           1,
 				Total:           102,
-				IncludesPending: boolPtr(true),
+				IncludesPending: new(true),
 			}) {
 				return
 			}
@@ -258,7 +258,7 @@ func TestDuplicateSearchRejectsNonProgressingPagination(t *testing.T) {
 			Index:           0,
 			Count:           0,
 			Total:           1,
-			IncludesPending: boolPtr(true),
+			IncludesPending: new(true),
 		}) {
 			return
 		}
@@ -281,7 +281,7 @@ func TestDuplicateSearchPaginationBoundFailsClosed(t *testing.T) {
 			Index:           0,
 			Count:           100,
 			Total:           101,
-			IncludesPending: boolPtr(true),
+			IncludesPending: new(true),
 		}) {
 			return
 		}
@@ -453,8 +453,4 @@ func writeDCDupePage(t *testing.T, w http.ResponseWriter, page dcTestPage) bool 
 		return false
 	}
 	return true
-}
-
-func boolPtr(value bool) *bool {
-	return &value
 }

--- a/internal/trackers/impl/unit3d/definition.go
+++ b/internal/trackers/impl/unit3d/definition.go
@@ -295,7 +295,7 @@ func (d *Definition) prepareDescription(ctx context.Context, req trackers.Prepar
 		req.Logger.Debugf("trackers: %s building unit3d description", d.profile.Name)
 	}
 	var err error
-	assets := trackers.DescriptionAssets{}
+	var assets trackers.DescriptionAssets
 	if req.Assets != nil {
 		assets = *req.Assets
 	} else {

--- a/internal/trackers/impl/unit3d/sites/znth/name.go
+++ b/internal/trackers/impl/unit3d/sites/znth/name.go
@@ -4,6 +4,7 @@
 package znth
 
 import (
+	"slices"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -59,8 +60,7 @@ func findZNTHTitleStartBefore(prefix string, normalizedTitle string) (int, bool)
 		}
 	}
 
-	for i := len(candidates) - 1; i >= 0; i-- {
-		start := candidates[i]
+	for _, start := range slices.Backward(candidates) {
 		if normalizeZNTHAlphaNum(prefix[start:]) == normalizedTitle {
 			return start, true
 		}

--- a/internal/trackers/impl/unit3d/upload.go
+++ b/internal/trackers/impl/unit3d/upload.go
@@ -398,7 +398,7 @@ func buildUploadDryRunUnit3D(
 		logger.Infof("trackers: %s dry-run name formatting applied", trackerName)
 	}
 
-	assets := trackers.DescriptionAssets{}
+	var assets trackers.DescriptionAssets
 	if req.Assets != nil {
 		assets = *req.Assets
 	} else {

--- a/internal/trackers/plan.go
+++ b/internal/trackers/plan.go
@@ -259,8 +259,7 @@ func PrepareAdapter(
 	case PreparationIntentUpload:
 		operation, err := prepareUpload(ctx, input)
 		if err != nil {
-			var preparationFailure *PreparationFailure
-			if errors.As(err, &preparationFailure) {
+			if preparationFailure, ok := errors.AsType[*PreparationFailure](err); ok {
 				return TrackerPlan{}, preparationFailure
 			}
 			return TrackerPlan{}, NewPreparationFailure(input.Tracker, "upload", err.Error(), err)
@@ -291,8 +290,7 @@ func preparedUploadPlan(input PreparationInput, operation PreparedOperation) (Tr
 		plan.state.resolve = func(ctx context.Context) (TrackerPlan, *PreparationFailure) {
 			next, err := operation.resolve(ctx)
 			if err != nil {
-				var failure *PreparationFailure
-				if errors.As(err, &failure) {
+				if failure, ok := errors.AsType[*PreparationFailure](err); ok {
 					return TrackerPlan{}, failure
 				}
 				return TrackerPlan{}, NewPreparationFailure(input.Tracker, "upload", err.Error(), err)
@@ -305,8 +303,7 @@ func preparedUploadPlan(input PreparationInput, operation PreparedOperation) (Tr
 		plan.state.decide = func(ctx context.Context, confirmed bool) (TrackerPlan, *PreparationFailure) {
 			next, err := operation.decide(ctx, confirmed)
 			if err != nil {
-				var failure *PreparationFailure
-				if errors.As(err, &failure) {
+				if failure, ok := errors.AsType[*PreparationFailure](err); ok {
 					return TrackerPlan{}, failure
 				}
 				return TrackerPlan{}, NewPreparationFailure(input.Tracker, "upload", err.Error(), err)

--- a/internal/trackers/projection_test.go
+++ b/internal/trackers/projection_test.go
@@ -50,7 +50,7 @@ func TestRegistryCatalogAndProjectionUseStableIdentityAndFinalPreviewSemantics(t
 
 	registry := NewRegistry()
 	prepareCalls := 0
-	definition := projectionStubDefinition{stubDefinition: stubDefinition{name: "EXAMPLE"}, prepareCalls: &prepareCalls}
+	definition := projectionStubDefinition{name: "EXAMPLE", prepareCalls: &prepareCalls}
 	if err := registry.RegisterDescriptor(Descriptor{
 		Name:              "EXAMPLE",
 		DisplayName:       "Example Tracker",
@@ -271,7 +271,7 @@ func TestRegistryProjectionRequiresNonSceneUploadNameConfirmationWithoutBlocking
 func TestPrepareAdapterRejectsPayloadSemanticsThatDifferFromReviewedProjection(t *testing.T) {
 	t.Parallel()
 
-	definition := projectionStubDefinition{stubDefinition: stubDefinition{name: "EXAMPLE"}}
+	definition := projectionStubDefinition{name: "EXAMPLE"}
 	input := PreparationInput{
 		Intent:  PreparationIntentDryRun,
 		Tracker: "EXAMPLE",

--- a/internal/webserver/api_v1_routes.go
+++ b/internal/webserver/api_v1_routes.go
@@ -651,8 +651,7 @@ func decodeAPIV1JSON(w http.ResponseWriter, r *http.Request, destination any) bo
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(destination); err != nil {
 		status := http.StatusBadRequest
-		var maxBytesError *http.MaxBytesError
-		if errors.As(err, &maxBytesError) {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 			status = http.StatusRequestEntityTooLarge
 		}
 		writeJSON(w, status, map[string]string{"error": "invalid API request body"})

--- a/internal/webserver/release_workflow.go
+++ b/internal/webserver/release_workflow.go
@@ -132,8 +132,7 @@ func releaseWorkflowDiagnosticMessage(err error) string {
 		return "unknown error"
 	}
 	diagnostic := err
-	var operationError *api.OperationError
-	if errors.As(err, &operationError) {
+	if operationError, ok := errors.AsType[*api.OperationError](err); ok {
 		if cause := errors.Unwrap(operationError); cause != nil {
 			diagnostic = cause
 		}
@@ -314,8 +313,7 @@ func classifyReleaseWorkflowError(err error) error {
 	if err == nil {
 		return nil
 	}
-	var operationError *api.OperationError
-	if errors.As(err, &operationError) {
+	if operationError, ok := errors.AsType[*api.OperationError](err); ok {
 		return operationError
 	}
 	failure := api.OperationFailure{

--- a/internal/webserver/runtime_activation.go
+++ b/internal/webserver/runtime_activation.go
@@ -181,8 +181,7 @@ func (a *RuntimeActivator) Activate(ctx context.Context, candidate config.Config
 		return activationError(ActivationStageCookies, err)
 	}
 	if err := a.deps.persist(ctx, stored, a.repo, a.fixedDBPath, generation.Logger); err != nil {
-		var cookieErr *runtimeCookiePersistenceError
-		if errors.As(err, &cookieErr) {
+		if _, ok := errors.AsType[*runtimeCookiePersistenceError](err); ok {
 			return activationError(ActivationStageCookies, err)
 		}
 		return activationError(ActivationStagePersist, err)

--- a/pkg/api/services_test.go
+++ b/pkg/api/services_test.go
@@ -25,10 +25,8 @@ func TestNewDescriptionSubjectDetachesNestedFacts(t *testing.T) {
 				Purpose: ScreenshotPurposeFinal,
 			}},
 			DVDMenus: []DVDMenuCaptureImage{{
-				ScreenshotImage: ScreenshotImage{
-					Path:    `C:\private\menu.png`,
-					Purpose: ScreenshotPurposeMenu,
-				},
+				Path:    `C:\private\menu.png`,
+				Purpose: ScreenshotPurposeMenu,
 			}},
 		},
 	}
@@ -77,10 +75,8 @@ func TestExactMediaAssetsValidateRejectsCrossChannelPurposesAndUploads(t *testin
 			Purpose: ScreenshotPurposeFinal,
 		}},
 		DVDMenus: []DVDMenuCaptureImage{{
-			ScreenshotImage: ScreenshotImage{
-				Path:    `C:\private\menu.png`,
-				Purpose: ScreenshotPurposeMenu,
-			},
+			Path:    `C:\private\menu.png`,
+			Purpose: ScreenshotPurposeMenu,
 		}},
 		ScreenshotUploads: []UploadedImageLink{{
 			ImagePath: `C:\private\menu.png`,


### PR DESCRIPTION
## Description

Upgrade the module and Docker build from Go 1.26.6 to Go 1.27.1, and pin golangci-lint 2.13.2 so local checks and CI support the new toolchain. Update contributor guidance for the matching linter and Go 1.27's macOS 13 minimum.

Apply the modernizations required by the Go fix gate: typed error matching and atomics, standard-library slice/string operations, and promoted embedded-field literals. Remove impossible nil checks around Windows syscall errors while preserving the return-value and error-code checks. Public CLI/WebUI contracts remain unchanged.

Related compatibility work: [harbrr #523](https://github.com/autobrr/harbrr/pull/523), [qui #2381](https://github.com/autobrr/qui/pull/2381). The existing OSV failures concern npm dependencies and are being addressed separately; this upgrade does not resolve them.

## How has this been tested?

- `make test-go`: all 122 tested packages passed with the race detector on Windows.
- `make lint` using golangci-lint 2.13.2, `make logpolicy`, `make gofix-check-changed`, `make gofix-check`, `go mod tidy`, and `git diff --check` passed.
- CLI and E2E-tagged builds passed, plus all seven release cross-builds: Windows amd64/arm64, Linux amd64/arm64/armv7, and macOS amd64/arm64.
- Linux/Darwin Go fix previews and Linux lint passed for the platform-specific pathing and torrent-client packages.
- CI-pinned `govulncheck@v1.6.0 ./...` passed with no reachable or imported-package vulnerabilities.
- Git pre-commit and pre-push hooks passed. Docker execution and native Linux/macOS tests were not available locally; the official Go 1.27.1 Alpine image manifest was verified.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/upbrr/blob/main/CONTRIBUTING.md)
- [ ] I ran `make precommit` (the targeted checks and Git hooks listed above were run)
- [ ] For CSS changes, I ran `pnpm --dir webui run lint:style` (not applicable)

## AI disclosure

Yes. OpenAI Codex assisted with all changes in this PR, including implementation, review, and validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Upgraded the application and Docker builds to Go 1.27.1.
  - Updated the pinned linting tool version used by automated checks.
  - macOS support now requires macOS 13 Ventura or newer, with zsh or bash.

- **Bug Fixes**
  - Improved error reporting for certain Windows file-operation failures.

- **Refactor**
  - Modernized internal error handling and collection processing without changing expected application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->