### PR TITLE
build: target development host for local binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ GO_TEST_FAST_FLAGS := -timeout 20m
 GOLANGCI_FLAGS := --timeout=5m
 help:
 	@echo Build
-	@echo   make build              Full build: WebUI, embedded assets, CLI
-	@echo   make backend            Build CLI binary only
+	@echo   make build              Full native build: WebUI, embedded assets, CLI
+	@echo   make backend            Build native CLI binary only
 	@echo   make frontend           Typecheck and build frontend bundle
 	@echo   make frontend-bundle    Build frontend bundle only
 	@$(BLANK)
@@ -62,6 +62,10 @@ help:
 	@echo   make gofix-check        Check Go fix drift with omitzero disabled
 	@echo   make gofix-changed      Apply Go fixes to changed packages
 	@echo   make gofix-check-changed Check Go fix drift on changed packages
+
+# Local binaries must run on the development host despite cross-compilation defaults.
+build backend e2e-build: export GOOS := $(shell go env GOHOSTOS)
+build backend e2e-build: export GOARCH := $(shell go env GOHOSTARCH)
 
 build:
 	$(FULL_BUILD)

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ help:
 	@echo   make gofix-check-changed Check Go fix drift on changed packages
 
 # Local binaries must run on the development host despite cross-compilation defaults.
-build backend e2e-build: export GOOS := $(shell go env GOHOSTOS)
-build backend e2e-build: export GOARCH := $(shell go env GOHOSTARCH)
+build backend e2e-build: override export GOOS := $(shell go env GOHOSTOS)
+build backend e2e-build: override export GOARCH := $(shell go env GOHOSTARCH)
 
 build:
 	$(FULL_BUILD)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,6 +15,6 @@ sh scripts/sync-webui-assets.sh
 
 echo "Building upbrr binary..."
 mkdir -p dist
-GOOS="" GOARCH="" go build -o dist/upbrr ./cmd/upbrr
+GOOS="$(go env GOHOSTOS)" GOARCH="$(go env GOHOSTARCH)" go build -o dist/upbrr ./cmd/upbrr
 
 echo "Done. Binary: dist/upbrr"


### PR DESCRIPTION
## Description

Local Make builds can inherit cross-compilation settings and produce a binary that does not run on the development machine. Force `make build`, `make backend`, and `make e2e-build` to use Go's host OS and architecture, including command-line `GOOS` and `GOARCH` overrides. The Unix full-build script also selects the host explicitly so saved Go cross-compilation defaults cannot take effect through empty overrides.

Related issue: none.

## How has this been tested?

- Ran `make build` and `make backend` on Windows with inherited `GOOS=linux` and `GOARCH=arm64`; both produced a Windows/amd64 binary, verified with `go version -m` and a successful `--version` invocation.
- Verified command-line override precedence with a `make build` environment probe, then ran `make backend GOOS=linux GOARCH=arm64`; the result remained Windows/amd64 and `--version` succeeded. Changed-package Go fix and whitespace checks also passed.
- Checked the Unix script with Git Bash `bash -n scripts/build.sh`.
- Ran `make help` and `git diff --check` successfully.
- `make precommit`: whitespace, changed-package Go fix, architecture, path, literal, and workflow-contract checks passed. Full Go lint reported three existing failures: `gofmt` in `internal/core/workflow_media.go:1267`, and `wastedassign` in `internal/trackers/impl/unit3d/definition.go:298` and `internal/trackers/impl/unit3d/upload.go:401`. All three files are identical to `origin/main` at `a870067af`; no Go files changed. The wrapper stopped before log-policy and frontend checks.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/upbrr/blob/main/CONTRIBUTING.md)
- [x] I ran `make precommit` (existing Go lint failures documented above)
- [ ] For CSS changes, I ran `pnpm --dir webui run lint:style` (not applicable; no CSS changes)

## AI disclosure

Yes. Codex wrote all changes in this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build Improvements**
  * Build, backend, and end-to-end build targets now compile for the development machine’s operating system and architecture.
  * Build scripts consistently detect and use the host platform and architecture.
  * Updated build help text clarifies the behavior of these targets and the platforms they support.
  * Build commands now provide more predictable results when platform settings are specified externally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
