### PR TITLE
fix(nbl): ignore screenshot evidence during validation

### DIFF
--- a/internal/trackers/impl/standalone/nbl/definition_test.go
+++ b/internal/trackers/impl/standalone/nbl/definition_test.go
@@ -5,6 +5,7 @@ package nbl
 
 import (
 	"context"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -33,6 +34,7 @@ func TestDefinitionBuildUploadDryRunBuildsPayload(t *testing.T) {
 	tmp := t.TempDir()
 	mediaInfoPath := filepath.Join(tmp, "MEDIAINFO.txt")
 	torrentPath := filepath.Join(tmp, "Show.torrent")
+	screenshotPath := filepath.Join(tmp, "screenshot.png")
 	if err := os.WriteFile(mediaInfoPath, []byte("General\nUnique ID : 123"), 0o600); err != nil {
 		t.Fatalf("write mediainfo: %v", err)
 	}
@@ -49,6 +51,13 @@ func TestDefinitionBuildUploadDryRunBuildsPayload(t *testing.T) {
 			MediaInfoTextPath: mediaInfoPath,
 			Identity:          api.ExternalIdentity{TVmazeID: 987},
 			TVPack:            true,
+			ExactMedia: &api.ExactMediaAssets{
+				Screenshots: []api.ScreenshotImage{{Path: screenshotPath, Purpose: api.ScreenshotPurposeFinal}},
+				ScreenshotUploads: []api.UploadedImageLink{{
+					ImagePath: screenshotPath,
+					ImgURL:    "https://images.example.test/screenshot.png",
+				}},
+			},
 		},
 		TrackerConfig: config.TrackerConfig{APIKey: "token"},
 		Runtime:       trackers.PreparationRuntimeFromConfig(config.Config{}),
@@ -58,11 +67,19 @@ func TestDefinitionBuildUploadDryRunBuildsPayload(t *testing.T) {
 		t.Fatalf("unexpected failure: %v", failure)
 	}
 	entry := plan.DryRun()
-	if entry.Payload["tvmazeid"] != "987" {
-		t.Fatalf("expected tvmazeid 987, got %q", entry.Payload["tvmazeid"])
+	wantPayload := map[string]string{
+		"action":      "upload",
+		"api_key":     "token",
+		"tvmazeid":    "987",
+		"mediainfo":   "General\nUnique ID : 123",
+		"category":    "3",
+		"ignoredupes": "1",
 	}
-	if entry.Payload["category"] != "3" {
-		t.Fatalf("expected pack category 3, got %q", entry.Payload["category"])
+	if !maps.Equal(entry.Payload, wantPayload) {
+		t.Fatalf("payload = %#v, want %#v", entry.Payload, wantPayload)
+	}
+	if len(entry.Files) != 1 || entry.Files[0].Field != "file_input" || entry.Files[0].Path != torrentPath {
+		t.Fatalf("expected only the torrent attachment, got %+v", entry.Files)
 	}
 	if entry.Questionnaire != nil {
 		t.Fatal("expected no questionnaire")

--- a/internal/trackers/impl/standalone/nbl/validation.go
+++ b/internal/trackers/impl/standalone/nbl/validation.go
@@ -13,7 +13,7 @@ import (
 
 func validationPolicy() trackers.ValidationPolicyBinding {
 	return trackers.ValidationPolicyBinding{
-		ID:    "standalone-nbl-policy-v2",
+		ID:    "standalone-nbl-policy-v3",
 		Check: checkEvidenceRules,
 	}
 }
@@ -56,7 +56,6 @@ func checkEvidenceRules(ctx context.Context, subject api.TrackerValidationSubjec
 			}},
 		},
 	)...)
-	failures = append(failures, validateNBLScreenshots(subject.AssetFacts.Screenshots)...)
 	if !trackers.IsDiscType(subject.DiscType) {
 		failures = append(failures, trackers.ValidateLanguageCombination(
 			subject.MediaFileFacts,
@@ -74,26 +73,5 @@ func nblEvidencePolicy(rule string) trackers.EvidencePredicatePolicy {
 		Rule:                       rule,
 		ViolationDisposition:       api.RuleDispositionStrict,
 		MissingEvidenceDisposition: api.RuleDispositionAdvisory,
-	}
-}
-
-func validateNBLScreenshots(evidence api.AssetEvidence) []api.RuleFailure {
-	switch {
-	case evidence.Status != api.MetadataEvidenceStatusComplete:
-		return []api.RuleFailure{trackers.NewEvidenceRuleFailure(
-			"nbl_screenshots",
-			"complete screenshot evidence is required",
-			api.RuleDispositionAdvisory,
-			evidence.Status,
-		)}
-	case evidence.Ready || evidence.Count > 0:
-		return []api.RuleFailure{trackers.NewEvidenceRuleFailure(
-			"nbl_screenshots",
-			"screenshots are not allowed",
-			api.RuleDispositionStrict,
-			evidence.Status,
-		)}
-	default:
-		return nil
 	}
 }

--- a/internal/trackers/impl/standalone/nbl/validation_test.go
+++ b/internal/trackers/impl/standalone/nbl/validation_test.go
@@ -39,7 +39,7 @@ func TestNBLEvidencePolicyPassViolationAndMissingEvidence(t *testing.T) {
 	)
 }
 
-func TestNBLRejectsEpisodeFolderAndScreenshots(t *testing.T) {
+func TestNBLRejectsEpisodeFolder(t *testing.T) {
 	t.Parallel()
 
 	subject := nblPassingSubject()
@@ -51,17 +51,28 @@ func TestNBLRejectsEpisodeFolderAndScreenshots(t *testing.T) {
 		api.RuleDispositionStrict,
 		api.MetadataEvidenceStatusComplete,
 	)
+}
 
-	subject = nblPassingSubject()
-	subject.AssetFacts.Screenshots.Ready = true
-	subject.AssetFacts.Screenshots.Count = 1
-	assertNBLFailure(
-		t,
-		evaluateNBLEvidence(t, subject),
-		"nbl_screenshots",
-		api.RuleDispositionStrict,
-		api.MetadataEvidenceStatusComplete,
-	)
+func TestNBLIgnoresScreenshotEvidence(t *testing.T) {
+	t.Parallel()
+
+	for _, evidence := range []api.AssetEvidence{
+		{},
+		{Status: api.MetadataEvidenceStatusPartial},
+		{Status: api.MetadataEvidenceStatusComplete},
+		{
+			Status: api.MetadataEvidenceStatusComplete,
+			Ready:  true,
+			Count:  4,
+		},
+	} {
+		subject := nblPassingSubject()
+		subject.AssetFacts.Screenshots = evidence
+		subject.AssetFacts.HostedScreenshots = evidence
+		if failures := evaluateNBLEvidence(t, subject); len(failures) != 0 {
+			t.Errorf("screenshot evidence %+v affected NBL validation: %+v", evidence, failures)
+		}
+	}
 }
 
 func TestNBLDoesNotApplyMediaOnlyPackageRuleToDiscs(t *testing.T) {
@@ -81,7 +92,7 @@ func TestNBLDoesNotApplyMediaOnlyPackageRuleToDiscs(t *testing.T) {
 func TestNBLValidationPolicyVersion(t *testing.T) {
 	t.Parallel()
 
-	if got := Profile().ValidationPolicy.ID; got != "standalone-nbl-policy-v2" {
+	if got := Profile().ValidationPolicy.ID; got != "standalone-nbl-policy-v3" {
 		t.Fatalf("validation policy ID = %q", got)
 	}
 }
@@ -112,7 +123,6 @@ func nblPassingSubject() api.TrackerValidationSubject {
 				Ready:  true,
 				Count:  1,
 			},
-			Screenshots: api.AssetEvidence{Status: api.MetadataEvidenceStatusComplete},
 		},
 	}
 }


### PR DESCRIPTION
## Description

NBL preparation rejected releases with shared screenshots even though its upload payload does not use images. Missing or incomplete screenshot evidence also produced an unnecessary advisory.

Remove the screenshot rule entirely and advance the NBL validation policy to `standalone-nbl-policy-v3`. Screenshot presence and upload status no longer affect NBL validation. Regression coverage checks absent, incomplete, and populated screenshot evidence, and verifies that preparation with uploaded screenshots still produces only the expected metadata fields and torrent attachment.

## How has this been tested?

- Confirmed the new regression tests fail against the original screenshot rule, then pass with the fix.
- `go test -race -v -timeout 20m ./internal/trackers/impl/standalone/nbl ./internal/trackers/impl/standalone ./internal/trackers/impl`
- `make lint`
- `make logpolicy`
- `make gofix-check-changed`
- `make backend`
- `git diff --check`
- Pre-commit, commit-message, and pre-push hooks passed.

## Checklist

- [x] My PR title follows Conventional Commits.
- [x] I have read CONTRIBUTING.md.
- [ ] I ran `make precommit` (the focused Go checks, full repository lint, and hooks listed above were run).
- [x] No CSS changes; Stylelint is not applicable.

## AI disclosure

Yes. Codex authored the code and regression-test changes under user direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Validation**
  * Standalone NBL validation now ignores screenshot evidence, including empty, partial, or complete screenshot submissions.
  * Episode folder layout validation remains enforced.
* **Bug Fixes**
  * Updated validation behavior to prevent screenshot-related failures during standalone NBL checks.
  * Dry-run processing now handles local and uploaded screenshot assets while continuing to attach the torrent file correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->