### PR TITLE
chore: further scope agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Always-loaded AI-agent repo rules. Keep short; nearest scoped `AGENTS.md` owns a
 ## Scoped References
 
 - Backend/Go, path/log policy, trackers/config/domain, runtime architecture, lint/checks: `internal/AGENTS.md`.
+- Tracker definitions, registration, auth, naming, validation, and duplicate contracts, including callers changing them: `internal/trackers/AGENTS.md`.
 - CLI flags/prompts/unattended behavior: `cmd/upbrr/AGENTS.md`.
 - Shared API/runtime contracts: `pkg/api/AGENTS.md`.
 - Frontend/React/CSS/TypeScript/browser checks: `webui/AGENTS.md`.

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -116,28 +116,11 @@ Expected local/generated ignores: `dist/`, `webui/dist/`, `internal/webserver/as
 
 ## Domain Guardrails
 
-- Duplicate-search, evaluation, adapter, or policy work anywhere under `internal/trackers` must also read and follow `internal/trackers/dupe/AGENTS.md`, including tracker-local `dupe.go` and `dupe_policy.go` files.
-- Standalone behavior belongs in `internal/trackers/impl/standalone/<tracker>`; Unit3D exceptions in `internal/trackers/impl/unit3d/sites/<tracker>`. Each standalone package composes identity/static capabilities in `profile.go`; dynamic data/claim factories may wrap `standalone.Definition` locally. Explicitly register definitions in `internal/trackers/impl/registry.go`; generic packages never import implementations.
-- `internal/trackers/impl/registry.go` is the sole complete supported-tracker composition list, grouped by family. Profiles/definitions own endpoints/typed policy; `internal/config/defaults/example.yaml` owns ordered config/defaults. Generic metadata, auth, image-hosting, torrent-client, frontend code consume registry/catalog capabilities without tracker-name dispatch.
-- Strict tracker semantic ownership:
-  - `profile.go` / `definition.go`: identity, endpoint, family, static capabilities, policy bindings, callback wiring; no substantial algorithms.
-  - `name.go`: pure versioned upload/search-name policy.
-  - `auth.go` / `auth_*.go`: local login/session validation, CSRF/auth-key extraction, cookie selection, typed auth failures.
-  - `taxonomy.go`: pure category/type/source/codec/resolution/audio/language/tag/flag mappings; no I/O.
-  - `validation.go`: side-effect-free pre-dupe payload constructibility/prepared-resource checks over `api.TrackerValidationSubject`; no network, FS reads, runtime secrets, mutable services. Release-eligibility extensions to `rules.go` may expose validation binding there.
-  - `description.go` + optional `bbcode.go`: description preparation/composition and tracker markup.
-  - `media.go`: MediaInfo/BDInfo/NFO selection, reads, parsing, normalized technical facts.
-  - `questionnaire.go`: schema, stable answer keys, defaults, normalization, validation; no prompting/UI.
-  - `payload.go`: payload-only field/file encoding when separated.
-  - `upload.go`: prepare/submit/preview orchestration, transport, response parsing, immutable prepared-state capture. May call semantic modules; never define their algorithms, validation, or constructibility checks.
-- No empty marker files. Unit3D/AZ defaults and central declarative auth count as owned behavior. Unit3D shares family auth/taxonomy/description/media; site callbacks only in matching semantic files. AZ behavior stays family-owned. Unrelated standalone trackers never share taxonomy/description dispatch.
-- `internal/trackers/auth` owns cross-surface status/import/validate/login/2FA/delete coordination, secret-free effective requirements, reusable cookie-login lifecycle, TOTP. `internal/cookies` owns encrypted persistence. Tracker packages retain protocol forms/endpoints, validation markers, cookie filters, challenge interpretation; tracker auth never prompts.
-- Every built-in tracker requires explicit effective auth requirements, versioned release-name policy, resolved versioned validation policy. Family/default validation is explicit. Tracker payload-constructibility checks belong in `validation.go`; release eligibility may remain in `rules.go`. Principal payload fields use `PreparationInput.ReviewedUploadName()` after central projection; no late name derivation in upload/payload code.
-- `internal/architecturepolicy` keeps validation algorithms out of tracker `upload.go`; enforces static banned-group locality, Unit3D callback-file bindings, name locality, reviewed-name payload fences, forbidden imports. Extend rules with accepted/rejected fixtures.
+Tracker definitions, registration, auth, naming, validation, and duplicate behavior: read `internal/trackers/AGENTS.md` before changing those contracts, including callers outside that subtree. Shared upload authority and persistence rules below still apply.
+
 - Upload preparation returns one immutable `trackers.PreparedOperation`; preview/submission use identical captured canonical state. Submission may defer short-lived remote tokens, but never rebuild payloads, reread mutable prepared inputs, or rerun image uploads. Dry-run/upload-review never receive a submittable plan.
 - Downstream media preparation, dry-run, upload, artifact retention, client injection use exact tracker authority selected by workflow mode: durable post-dupe approval for gated workflows or existing WebUI stage controls. Never widen to unapproved/disabled trackers or restore obsolete final upload approval.
 - Successful submission returns registration authority through `api.UploadSummary.UploadedTorrents`. Preserve direct tracker page in `TorrentURL`; retain exact tracker-returned torrent in `TorrentPath` when available. Reconstruct only when protocol makes it deterministic after confirmed success. Client injection uses registered authority, never pre-upload prepared torrent. Local artifact failure never reclassifies successful remote upload.
-- Standard Unit3D addition: site profile, optional rules/validation, one registry entry, one example-config stanza without `url`, combined rule/validation cases. Never infer configured custom trackers; unsupported saved entries remain inert and preserve unknown non-URL fields.
 - DB schema changes: stable, additive, forward-only, idempotent SQLite migrations where practical; preserve `schema_migrations` and legacy `user_version` bridge.
 - WebUI client changes require matching `/api/app/*` routes, typed requests, unit/embedded-browser verification.
 - Generated/built outputs are mostly ignored; never commit populated `internal/webserver/assets` unless intentionally updating generated artifacts.

--- a/internal/trackers/AGENTS.md
+++ b/internal/trackers/AGENTS.md
@@ -1,0 +1,29 @@
+# Tracker Guidelines
+
+Scope: `internal/trackers/` and changes elsewhere to tracker definitions, registration, auth, naming, validation, or duplicate contracts. Root and `internal/AGENTS.md` rules apply.
+
+## Domain Guardrails
+
+- Duplicate-search, evaluation, adapter, or policy work anywhere under `internal/trackers` must also read and follow `internal/trackers/dupe/AGENTS.md`, including tracker-local `dupe.go` and `dupe_policy.go` files.
+- Standalone behavior belongs in `internal/trackers/impl/standalone/<tracker>`; Unit3D exceptions in `internal/trackers/impl/unit3d/sites/<tracker>`. Each standalone package composes identity/static capabilities in `profile.go`; dynamic data/claim factories may wrap `standalone.Definition` locally. Explicitly register definitions in `internal/trackers/impl/registry.go`; generic packages never import implementations.
+- `internal/trackers/impl/registry.go` is the sole complete supported-tracker composition list, grouped by family. Profiles/definitions own endpoints/typed policy; `internal/config/defaults/example.yaml` owns ordered config/defaults. Generic metadata, auth, image-hosting, torrent-client, frontend code consume registry/catalog capabilities without tracker-name dispatch.
+- Strict tracker semantic ownership:
+  - `profile.go` / `definition.go`: identity, endpoint, family, static capabilities, policy bindings, callback wiring; no substantial algorithms.
+  - `name.go`: pure versioned upload/search-name policy.
+  - `auth.go` / `auth_*.go`: local login/session validation, CSRF/auth-key extraction, cookie selection, typed auth failures.
+  - `taxonomy.go`: pure category/type/source/codec/resolution/audio/language/tag/flag mappings; no I/O.
+  - `validation.go`: side-effect-free pre-dupe payload constructibility/prepared-resource checks over `api.TrackerValidationSubject`; no network, FS reads, runtime secrets, mutable services. Release-eligibility extensions to `rules.go` may expose validation binding there.
+  - `description.go` + optional `bbcode.go`: description preparation/composition and tracker markup.
+  - `media.go`: MediaInfo/BDInfo/NFO selection, reads, parsing, normalized technical facts.
+  - `questionnaire.go`: schema, stable answer keys, defaults, normalization, validation; no prompting/UI.
+  - `payload.go`: payload-only field/file encoding when separated.
+  - `upload.go`: prepare/submit/preview orchestration, transport, response parsing, immutable prepared-state capture. May call semantic modules; never define their algorithms, validation, or constructibility checks.
+- No empty marker files. Unit3D/AZ defaults and central declarative auth count as owned behavior. Unit3D shares family auth/taxonomy/description/media; site callbacks only in matching semantic files. AZ behavior stays family-owned. Unrelated standalone trackers never share taxonomy/description dispatch.
+- `internal/trackers/auth` owns cross-surface status/import/validate/login/2FA/delete coordination, secret-free effective requirements, reusable cookie-login lifecycle, TOTP. `internal/cookies` owns encrypted persistence. Tracker packages retain protocol forms/endpoints, validation markers, cookie filters, challenge interpretation; tracker auth never prompts.
+- Every built-in tracker requires explicit effective auth requirements, versioned release-name policy, resolved versioned validation policy. Family/default validation is explicit. Tracker payload-constructibility checks belong in `validation.go`; release eligibility may remain in `rules.go`. Principal payload fields use `PreparationInput.ReviewedUploadName()` after central projection; no late name derivation in upload/payload code.
+- `internal/architecturepolicy` keeps validation algorithms out of tracker `upload.go`; enforces static banned-group locality, Unit3D callback-file bindings, name locality, reviewed-name payload fences, forbidden imports. Extend rules with accepted/rejected fixtures.
+- Standard Unit3D addition: site profile, optional rules/validation, one registry entry, one example-config stanza without `url`, combined rule/validation cases. Never infer configured custom trackers; unsupported saved entries remain inert and preserve unknown non-URL fields.
+
+## Checks
+
+Follow the root and backend check selection. Test the implementation and touched shared tracker packages; include config/default/catalog checks when definitions or auth material change. Duplicate behavior also follows `internal/trackers/dupe/AGENTS.md`.

--- a/internal/trackers/dupe/AGENTS.md
+++ b/internal/trackers/dupe/AGENTS.md
@@ -1,6 +1,6 @@
 # Duplicate Checking Guidelines
 
-Scoped rules for the shared duplicate-search coordinator and evaluator. Root and `internal/AGENTS.md` rules still apply.
+Scoped rules for the shared duplicate-search coordinator and evaluator. Root, `internal/AGENTS.md`, and `internal/trackers/AGENTS.md` rules still apply.
 
 ## Contract
 


### PR DESCRIPTION
Tracker-specific guardrails currently live in the general backend guidance, making unrelated backend tasks load rules they do not need.

Move those rules verbatim into `internal/trackers/AGENTS.md`, add discovery references in the root and backend guidance, and update duplicate-checking guidance to include the new parent. The scope explicitly includes callers outside the tracker subtree that change tracker contracts. Shared upload authority and persistence rules remain in the backend guidance.

This changes agent instruction organization only; application code and runtime behavior are unchanged. The cross-subtree references preserve access to the tracker rules after the move.

Validation: `git diff --check origin/main...HEAD` passed, all 19 moved rule lines were verified verbatim in the new file, and all four guidance paths were checked. Go and frontend tests were not run because only `AGENTS.md` files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added scoped guidance for tracker-related development and maintenance.
  - Consolidated tracker domain rules, ownership boundaries, authentication, validation, naming, registration, and testing expectations in a dedicated reference.
  - Updated existing guidance to point contributors to the new tracker-specific documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->