### PR TITLE
fix: surface HTML tracker response errors

### DIFF
--- a/internal/trackers/impl/azfamily/upload.go
+++ b/internal/trackers/impl/azfamily/upload.go
@@ -229,10 +229,7 @@ func submitPreparedUpload(
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusFound {
 		_, responseDetail, readErr := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
-		if readErr != nil {
-			return api.UploadSummary{}, fmt.Errorf("trackers: %s read upload response: %w", site.Name, readErr)
-		}
-		return api.UploadSummary{}, commonhttp.UploadHTTPError(site.Name, resp.StatusCode, responseDetail)
+		return api.UploadSummary{}, errors.Join(commonhttp.UploadHTTPError(site.Name, resp.StatusCode, responseDetail), readErr)
 	}
 
 	location := strings.TrimSpace(resp.Header.Get("Location"))
@@ -361,13 +358,10 @@ func createTask(
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusFound {
 		_, responseDetail, readErr := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
-		if readErr != nil {
-			return taskInfo{}, fmt.Errorf("trackers: %s read task creation response: %w", site.Name, readErr)
-		}
 		return taskInfo{}, fmt.Errorf(
 			"trackers: %s task creation failed: %w",
 			site.Name,
-			commonhttp.UploadHTTPError(site.Name, resp.StatusCode, responseDetail),
+			errors.Join(commonhttp.UploadHTTPError(site.Name, resp.StatusCode, responseDetail), readErr),
 		)
 	}
 	location := strings.TrimSpace(resp.Header.Get("Location"))

--- a/internal/trackers/impl/azfamily/upload.go
+++ b/internal/trackers/impl/azfamily/upload.go
@@ -228,8 +228,11 @@ func submitPreparedUpload(
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusFound {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
-		return api.UploadSummary{}, commonhttp.UploadHTTPError(site.Name, resp.StatusCode, body)
+		_, responseDetail, readErr := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
+		if readErr != nil {
+			return api.UploadSummary{}, fmt.Errorf("trackers: %s read upload response: %w", site.Name, readErr)
+		}
+		return api.UploadSummary{}, commonhttp.UploadHTTPError(site.Name, resp.StatusCode, responseDetail)
 	}
 
 	location := strings.TrimSpace(resp.Header.Get("Location"))
@@ -357,8 +360,15 @@ func createTask(
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusFound {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
-		return taskInfo{}, fmt.Errorf("trackers: %s task creation failed: %w", site.Name, commonhttp.UploadHTTPError(site.Name, resp.StatusCode, body))
+		_, responseDetail, readErr := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
+		if readErr != nil {
+			return taskInfo{}, fmt.Errorf("trackers: %s read task creation response: %w", site.Name, readErr)
+		}
+		return taskInfo{}, fmt.Errorf(
+			"trackers: %s task creation failed: %w",
+			site.Name,
+			commonhttp.UploadHTTPError(site.Name, resp.StatusCode, responseDetail),
+		)
 	}
 	location := strings.TrimSpace(resp.Header.Get("Location"))
 	taskID := extractPatternGroup(azTaskIDPattern, absoluteURL(site.BaseURL, location))

--- a/internal/trackers/impl/azfamily/upload_response_test.go
+++ b/internal/trackers/impl/azfamily/upload_response_test.go
@@ -4,6 +4,8 @@
 package azfamily
 
 import (
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,6 +16,25 @@ import (
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
+
+func TestSubmitPreparedUploadPreservesPartialHTMLFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "200")
+		_, _ = io.WriteString(w, `<div class="error">Invalid category</div>`)
+	}))
+	defer server.Close()
+	summary, err := submitPreparedUpload(
+		t.Context(), siteDefinition{Name: "AZ", BaseURL: server.URL}, server.Client(), server.URL, nil, "", api.NopLogger{},
+	)
+	if !errors.Is(err, io.ErrUnexpectedEOF) || !strings.Contains(err.Error(), "status=200") || !strings.Contains(err.Error(), "Invalid category") {
+		t.Fatalf("partial response lost status, detail or read cause: %v", err)
+	}
+	if summary.Uploaded != 0 || len(summary.UploadedTorrents) != 0 {
+		t.Fatalf("partial response returned registration authority: %+v", summary)
+	}
+}
 
 func TestSubmitPreparedUploadPreservesLateHTMLFailure(t *testing.T) {
 	t.Parallel()

--- a/internal/trackers/impl/azfamily/upload_response_test.go
+++ b/internal/trackers/impl/azfamily/upload_response_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package azfamily
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/trackers"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestSubmitPreparedUploadPreservesLateHTMLFailure(t *testing.T) {
+	t.Parallel()
+
+	const detail = "AZ final submission rejected this release"
+	server := lateHTMLFailureServer(t, http.StatusOK, detail)
+	_, err := submitPreparedUpload(
+		t.Context(),
+		siteDefinition{Name: "AZ", BaseURL: server.URL},
+		server.Client(),
+		server.URL,
+		nil,
+		"",
+		api.NopLogger{},
+	)
+	if err == nil || !strings.Contains(err.Error(), detail) {
+		t.Fatalf("expected late HTML error detail, got %v", err)
+	}
+}
+
+func TestCreateTaskPreservesLateNonSuccessHTMLFailure(t *testing.T) {
+	t.Parallel()
+
+	const detail = "AZ task rejected after form validation"
+	server := lateHTMLFailureServer(t, http.StatusUnprocessableEntity, detail)
+	torrentPath := filepath.Join(t.TempDir(), "release.torrent")
+	if err := os.WriteFile(torrentPath, []byte("torrent"), 0o600); err != nil {
+		t.Fatalf("write torrent: %v", err)
+	}
+
+	_, err := createTask(
+		t.Context(),
+		siteDefinition{Name: "AZ", BaseURL: server.URL},
+		sessionState{client: server.Client(), token: "token"},
+		trackers.PreparationInput{Meta: api.UploadSubject{Identity: api.ExternalIdentity{Category: api.CanonicalCategoryMovie}}},
+		"1",
+		"media info",
+		torrentPath,
+	)
+	if err == nil || !strings.Contains(err.Error(), detail) {
+		t.Fatalf("expected late task HTML error detail, got %v", err)
+	}
+}
+
+func lateHTMLFailureServer(t *testing.T, status int, detail string) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte("<html><body>" + strings.Repeat("padding ", 10*1024) + `<div class="alert-danger">` + detail + "</div></body></html>"))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}

--- a/internal/trackers/impl/commonhttp/commonhttp.go
+++ b/internal/trackers/impl/commonhttp/commonhttp.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -36,6 +37,8 @@ const maxHTTPErrorDetailLength = 700
 const maxHTTPErrorDetailDepth = 10
 
 const maxHTTPErrorResponseBytes int64 = 1 << 20
+
+var cssCommentsStringsAndEscapes = regexp.MustCompile(`(?s)/\*.*?(?:\*/|$)|"(?:\\.|[^"\\])*(?:"|$)|'(?:\\.|[^'\\])*(?:'|$)|\\.`)
 
 // DefaultResponsePreviewBytes bounds tracker response bodies used for failure
 // artifacts and error text.
@@ -522,6 +525,13 @@ func ExtractHTTPErrorDetail(body []byte) string {
 	return withHTTPErrorLimitDetail(compactHTTPErrorText(text), exceeded)
 }
 
+// ExtractHTMLFormErrorDetail returns compact, redacted text from visible HTML
+// error or alert containers. It scans at most 1 MiB and omits unrelated page text.
+func ExtractHTMLFormErrorDetail(body []byte) string {
+	marked, _ := extractHTTPErrorText(body)
+	return compactHTTPErrorText(marked)
+}
+
 func withHTTPErrorLimitDetail(detail string, exceeded bool) string {
 	if !exceeded {
 		return detail
@@ -540,7 +550,61 @@ func extractJSONErrorDetail(body []byte) string {
 	return compactHTTPErrorText(formatErrorValue(decoded, "", 0))
 }
 
+// inlineStyleHidesContent recognizes literal inline display and visibility values.
+// It does not resolve escaped keywords, variables, or stylesheet rules.
+func inlineStyleHidesContent(style string) bool {
+	style = cssCommentsStringsAndEscapes.ReplaceAllString(strings.ToLower(style), " ") + ";"
+	start := 0
+	var delimiters []rune
+	type propertyState struct {
+		hidden    bool
+		important bool
+	}
+	properties := make(map[string]propertyState, 2)
+	for i, char := range style {
+		switch char {
+		case '(', '[', '{':
+			delimiters = append(delimiters, char)
+		case ')', ']', '}':
+			if len(delimiters) > 0 {
+				last := delimiters[len(delimiters)-1]
+				if (last == '(' && char == ')') || (last == '[' && char == ']') || (last == '{' && char == '}') {
+					delimiters = delimiters[:len(delimiters)-1]
+				}
+			}
+		case ';':
+			if len(delimiters) != 0 {
+				continue
+			}
+			property, value, _ := strings.Cut(style[start:i], ":")
+			start = i + 1
+			property = strings.TrimSpace(property)
+			if property != "display" && property != "visibility" {
+				continue
+			}
+			important := false
+			if plain, priority, found := strings.Cut(value, "!"); found {
+				if strings.TrimSpace(priority) != "important" {
+					continue
+				}
+				important = true
+				value = plain
+			}
+			value = strings.TrimSpace(value)
+			if value == "" || (properties[property].important && !important) {
+				continue
+			}
+			properties[property] = propertyState{
+				hidden:    (property == "display" && value == "none") || (property == "visibility" && value == "hidden"),
+				important: important,
+			}
+		}
+	}
+	return properties["display"].hidden || properties["visibility"].hidden
+}
+
 func extractHTTPErrorText(body []byte) (string, string) {
+	body = body[:min(len(body), int(maxHTTPErrorResponseBytes))]
 	doc, err := xhtml.Parse(bytes.NewReader(body))
 	if err != nil {
 		return "", ""
@@ -563,13 +627,8 @@ func extractHTTPErrorText(body []byte) (string, string) {
 						return
 					}
 				case "style":
-					for declaration := range strings.SplitSeq(strings.ToLower(attr.Val), ";") {
-						property, value, _ := strings.Cut(declaration, ":")
-						property = strings.TrimSpace(property)
-						value = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(value), "!important"))
-						if (property == "display" && value == "none") || (property == "visibility" && value == "hidden") {
-							return
-						}
+					if inlineStyleHidesContent(attr.Val) {
+						return
 					}
 				case "role":
 					switch strings.ToLower(strings.TrimSpace(attr.Val)) {

--- a/internal/trackers/impl/commonhttp/commonhttp.go
+++ b/internal/trackers/impl/commonhttp/commonhttp.go
@@ -562,11 +562,29 @@ func extractHTTPErrorText(body []byte) (string, string) {
 					if strings.EqualFold(strings.TrimSpace(attr.Val), "true") {
 						return
 					}
+				case "style":
+					for declaration := range strings.SplitSeq(strings.ToLower(attr.Val), ";") {
+						property, value, _ := strings.Cut(declaration, ":")
+						property = strings.TrimSpace(property)
+						value = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(value), "!important"))
+						if (property == "display" && value == "none") || (property == "visibility" && value == "hidden") {
+							return
+						}
+					}
 				case "role":
-					if strings.EqualFold(strings.TrimSpace(attr.Val), "alert") {
+					switch strings.ToLower(strings.TrimSpace(attr.Val)) {
+					case "banner", "navigation", "contentinfo":
+						return
+					case "alert":
 						isError = true
 					}
-				case "class", "id":
+				case "id":
+					switch strings.ToLower(strings.TrimSpace(attr.Val)) {
+					case "header", "footer":
+						return
+					}
+					fallthrough
+				case "class":
 					for token := range strings.FieldsSeq(strings.ToLower(attr.Val)) {
 						switch token {
 						case "error", "errors", "error-message", "error_message", "alert-danger", "alert-error", "alert--error":

--- a/internal/trackers/impl/commonhttp/commonhttp.go
+++ b/internal/trackers/impl/commonhttp/commonhttp.go
@@ -10,15 +10,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	stdhtml "html"
 	"io"
 	"maps"
 	"mime/multipart"
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
+
+	xhtml "golang.org/x/net/html"
 
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	paths "github.com/autobrr/upbrr/internal/pathing/layout"
@@ -33,11 +35,11 @@ const maxHTTPErrorDetailLength = 700
 
 const maxHTTPErrorDetailDepth = 10
 
+const maxHTTPErrorResponseBytes int64 = 1 << 20
+
 // DefaultResponsePreviewBytes bounds tracker response bodies used for failure
 // artifacts and error text.
 const DefaultResponsePreviewBytes int64 = 64 * 1024
-
-var htmlTagPattern = regexp.MustCompile(`<[^>]+>`)
 
 // FileField describes one file part in a tracker multipart upload. FieldName is
 // the form field; Content is used when present; otherwise Path is read from disk
@@ -328,26 +330,27 @@ func ApplyCookies(req *http.Request, cookies []*http.Cookie) {
 	}
 }
 
-// ReadUploadResponseBody reads a full success-candidate response for parsers and
-// always returns a bounded preview for diagnostics. Non-success responses are
-// read only up to previewLimit.
+// ReadUploadResponseBody reads a full success-candidate response and a bounded,
+// unredacted preview. Non-success responses return up to 1 MiB of raw body and
+// a compact, redacted preview that can include late error messages. On a failed
+// non-success read, the returned body and preview retain partial diagnostics.
 func ReadUploadResponseBody(resp *http.Response, successCandidate bool, previewLimit int64) ([]byte, []byte, error) {
 	if previewLimit <= 0 {
 		previewLimit = DefaultResponsePreviewBytes
 	}
-	var (
-		body []byte
-		err  error
-	)
 	if successCandidate {
-		body, err = io.ReadAll(resp.Body)
-	} else {
-		body, err = io.ReadAll(io.LimitReader(resp.Body, previewLimit))
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read upload response body: %w", err)
+		}
+		return body, ResponseBodyPreview(body, previewLimit), nil
 	}
+
+	body, preview, err := readHTTPErrorResponse(resp.Body, previewLimit)
 	if err != nil {
-		return nil, nil, fmt.Errorf("read upload response body: %w", err)
+		return body, preview, fmt.Errorf("read upload response body: %w", err)
 	}
-	return body, ResponseBodyPreview(body, previewLimit), nil
+	return body, preview, nil
 }
 
 // ResponseBodyPreview returns body unchanged when it fits the limit, otherwise
@@ -486,27 +489,47 @@ func RedactErrorDetail(value string) string {
 	return strings.TrimSpace(redaction.RedactValue(value, nil))
 }
 
-// ExtractHTTPErrorDetail returns a compact, redacted error detail from plain
-// text, HTML, or JSON response bodies.
+// ExtractHTTPErrorDetail scans at most 1 MiB and returns a compact, redacted
+// error detail from plain text, HTML, or JSON response bodies. HTML extraction
+// ignores executable, hidden, navigation, and form-control content.
 func ExtractHTTPErrorDetail(body []byte) string {
-	text := RedactErrorDetail(string(body))
-	if text == "" {
-		return ""
+	exceeded := int64(len(body)) > maxHTTPErrorResponseBytes
+	if exceeded {
+		body = body[:maxHTTPErrorResponseBytes]
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		return withHTTPErrorLimitDetail("", exceeded)
 	}
 
-	if detail := extractJSONErrorDetail([]byte(text)); detail != "" {
-		return detail
+	if detail := extractJSONErrorDetail(body); detail != "" {
+		return withHTTPErrorLimitDetail(detail, exceeded)
+	}
+
+	marked, visible := extractHTTPErrorText(body)
+	text := visible
+	if marked != "" {
+		text = marked
 	}
 	for _, block := range redaction.ExtractJSONBlocks(text) {
 		if block.Start < 0 || block.End > len(text) || block.Start >= block.End {
 			continue
 		}
 		if detail := extractJSONErrorDetail([]byte(text[block.Start:block.End])); detail != "" {
-			return detail
+			return withHTTPErrorLimitDetail(detail, exceeded)
 		}
 	}
 
-	return compactHTTPErrorText(text)
+	return withHTTPErrorLimitDetail(compactHTTPErrorText(text), exceeded)
+}
+
+func withHTTPErrorLimitDetail(detail string, exceeded bool) string {
+	if !exceeded {
+		return detail
+	}
+	if detail == "" {
+		return "response exceeded 1 MiB"
+	}
+	return compactHTTPErrorText("response exceeded 1 MiB; " + detail)
 }
 
 func extractJSONErrorDetail(body []byte) string {
@@ -515,6 +538,58 @@ func extractJSONErrorDetail(body []byte) string {
 		return ""
 	}
 	return compactHTTPErrorText(formatErrorValue(decoded, "", 0))
+}
+
+func extractHTTPErrorText(body []byte) (string, string) {
+	doc, err := xhtml.Parse(bytes.NewReader(body))
+	if err != nil {
+		return "", ""
+	}
+
+	var visible, messages strings.Builder
+	var visit func(*xhtml.Node, bool)
+	visit = func(node *xhtml.Node, isError bool) {
+		if node.Type == xhtml.ElementNode {
+			switch strings.ToLower(node.Data) {
+			case "head", "script", "style", "nav", "header", "footer", "input", "textarea", "select", "button", "noscript", "template":
+				return
+			}
+			for _, attr := range node.Attr {
+				switch strings.ToLower(attr.Key) {
+				case "hidden":
+					return
+				case "aria-hidden":
+					if strings.EqualFold(strings.TrimSpace(attr.Val), "true") {
+						return
+					}
+				case "role":
+					if strings.EqualFold(strings.TrimSpace(attr.Val), "alert") {
+						isError = true
+					}
+				case "class", "id":
+					for token := range strings.FieldsSeq(strings.ToLower(attr.Val)) {
+						switch token {
+						case "error", "errors", "error-message", "error_message", "alert-danger", "alert-error", "alert--error":
+							isError = true
+						}
+					}
+				}
+			}
+		}
+		if node.Type == xhtml.TextNode {
+			visible.WriteString(node.Data)
+			visible.WriteByte(' ')
+			if isError {
+				messages.WriteString(node.Data)
+				messages.WriteByte(' ')
+			}
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			visit(child, isError)
+		}
+	}
+	visit(doc, false)
+	return strings.Join(strings.Fields(messages.String()), " "), strings.Join(strings.Fields(visible.String()), " ")
 }
 
 func formatErrorValue(value any, key string, depth int) string {
@@ -541,7 +616,8 @@ func formatErrorValue(value any, key string, depth int) string {
 		}
 		return strings.Join(parts, "; ")
 	case string:
-		return RedactErrorDetail(typed)
+		_, visible := extractHTTPErrorText([]byte(typed))
+		return compactHTTPErrorText(visible)
 	case nil:
 		return ""
 	default:
@@ -596,15 +672,43 @@ func valueForKey(values map[string]any, target string) (any, bool) {
 }
 
 func compactHTTPErrorText(text string) string {
-	text = strings.TrimSpace(text)
+	text = strings.Join(strings.Fields(stdhtml.UnescapeString(text)), " ")
 	if text == "" {
 		return ""
 	}
 	text = RedactErrorDetail(text)
-	text = htmlTagPattern.ReplaceAllString(text, " ")
-	text = strings.Join(strings.Fields(text), " ")
 	if len(text) <= maxHTTPErrorDetailLength {
 		return text
 	}
 	return strings.TrimSpace(text[:maxHTTPErrorDetailLength]) + "..."
+}
+
+func readHTTPErrorResponse(reader io.Reader, previewLimit int64) ([]byte, []byte, error) {
+	if previewLimit <= 0 {
+		previewLimit = DefaultResponsePreviewBytes
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, maxHTTPErrorResponseBytes+1))
+	exceeded := int64(len(body)) > maxHTTPErrorResponseBytes
+	if exceeded {
+		body = body[:maxHTTPErrorResponseBytes]
+	}
+	preview := ResponseBodyPreview(failureResponseDetail(body, exceeded, err != nil), previewLimit)
+	if err != nil {
+		return body, preview, fmt.Errorf("%s: %w", preview, safeWrappedError(err))
+	}
+	return body, preview, nil
+}
+
+func failureResponseDetail(body []byte, exceeded bool, readFailed bool) []byte {
+	parts := make([]string, 0, 3)
+	if readFailed {
+		parts = append(parts, "response body read failed")
+	}
+	if exceeded {
+		parts = append(parts, "response exceeded 1 MiB")
+	}
+	if detail := ExtractHTTPErrorDetail(body); detail != "" {
+		parts = append(parts, detail)
+	}
+	return []byte(compactHTTPErrorText(strings.Join(parts, "; ")))
 }

--- a/internal/trackers/impl/commonhttp/commonhttp_test.go
+++ b/internal/trackers/impl/commonhttp/commonhttp_test.go
@@ -371,6 +371,34 @@ func TestExtractHTTPErrorDetailHandlesMalformedAndEmbeddedJSON(t *testing.T) {
 	}
 }
 
+func TestExtractHTTPErrorDetailSkipsInlineHiddenStyles(t *testing.T) {
+	t.Parallel()
+
+	for _, style := range []string{"display:none", "visibility:hidden", "color:red; DISPLAY : none !important", " VISIBILITY: hidden; color:red"} {
+		t.Run(style, func(t *testing.T) {
+			body := []byte(`<div class="error">Invalid category<span style="` + style + `"><b>private-hidden-text</b></span>` +
+				`<span style="display:block;visibility:visible">remains visible</span></div>`)
+			if got := ExtractHTTPErrorDetail(body); got != "Invalid category remains visible" {
+				t.Fatalf("inline hidden text entered diagnostics: %q", got)
+			}
+		})
+	}
+}
+
+func TestExtractHTTPErrorDetailSkipsNavigationContainers(t *testing.T) {
+	t.Parallel()
+
+	for _, attr := range []string{`id="header"`, `id="footer"`, `role="banner"`, `role="navigation"`, `role="contentinfo"`} {
+		t.Run(attr, func(t *testing.T) {
+			body := []byte(`<div ` + attr + `>` + strings.Repeat("Upload Bonus Torrents Forums Rules ", 100) +
+				`<span class="error">private-navigation-error</span></div><div id="content">Autofill could not find the series.</div>`)
+			if got := ExtractHTTPErrorDetail(body); got != "Autofill could not find the series." {
+				t.Fatalf("navigation obscured response detail: %q", got)
+			}
+		})
+	}
+}
+
 func TestExtractHTTPErrorDetailBoundsOversizedInput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/impl/commonhttp/commonhttp_test.go
+++ b/internal/trackers/impl/commonhttp/commonhttp_test.go
@@ -6,6 +6,7 @@ package commonhttp
 import (
 	"context"
 	"errors"
+	"html"
 	"io"
 	"net/http"
 	"os"
@@ -374,14 +375,58 @@ func TestExtractHTTPErrorDetailHandlesMalformedAndEmbeddedJSON(t *testing.T) {
 func TestExtractHTTPErrorDetailSkipsInlineHiddenStyles(t *testing.T) {
 	t.Parallel()
 
-	for _, style := range []string{"display:none", "visibility:hidden", "color:red; DISPLAY : none !important", " VISIBILITY: hidden; color:red"} {
+	for _, style := range []string{
+		"display:none", "visibility:hidden", "color:red; DISPLAY : none !important", " VISIBILITY: hidden; color:red",
+		"display: none /* hidden */", "visibility: hidden /* hidden */", "display /* hidden */: none !important",
+		"display: /* comment ; */ none", `content:"/*"; display:none`, `content:'/*'; visibility:hidden`,
+		"display:none !/*x*/important", "visibility:hidden ! important", "--x:fn(a;b);display:none",
+		`--x:\(;display:none`,
+		"display:block;display:none", "display:none!important;display:block", "visibility:visible;visibility:hidden",
+		"visibility:hidden!important;visibility:visible", "display:none;display:block!invalid",
+	} {
 		t.Run(style, func(t *testing.T) {
-			body := []byte(`<div class="error">Invalid category<span style="` + style + `"><b>private-hidden-text</b></span>` +
+			body := []byte(`<div class="error">Invalid category<span style="` + html.EscapeString(style) + `"><b>private-hidden-text</b></span>` +
 				`<span style="display:block;visibility:visible">remains visible</span></div>`)
 			if got := ExtractHTTPErrorDetail(body); got != "Invalid category remains visible" {
 				t.Fatalf("inline hidden text entered diagnostics: %q", got)
 			}
 		})
+	}
+}
+
+func TestExtractHTTPErrorDetailPreservesVisibleInlineStyles(t *testing.T) {
+	t.Parallel()
+
+	for _, style := range []string{
+		`content:"x;display:none;y"`, `content:'x;visibility:hidden;y'`, `content:"x\";display:none;y"`,
+		"--x:fn(a;display:none;b)", "--x:[a;visibility:hidden;b]", "--x:{a;display:none;b}",
+		`content:"x;display:none`, `--x:foo\;display:none;`, "--x:fn(a];display:none;b)",
+		"display:none;display:block", "display:none;display:block!important", "display:block!important;display:none",
+		"visibility:hidden;visibility:visible", "visibility:visible!important;visibility:hidden",
+	} {
+		t.Run(style, func(t *testing.T) {
+			body := []byte(`<div class="error" style="` + html.EscapeString(style) + `">Invalid category</div>`)
+			if got := ExtractHTTPErrorDetail(body); got != "Invalid category" {
+				t.Fatalf("inline style hid visible diagnostic: %q", got)
+			}
+		})
+	}
+}
+
+func TestExtractHTMLFormErrorDetailOmitsUnrelatedPageText(t *testing.T) {
+	t.Parallel()
+
+	form := []byte(`<p>Unrelated upload rules</p><div class="error"></div><input name="artist" value="Autofill Fail">`)
+	if got := ExtractHTMLFormErrorDetail(form); got != "" {
+		t.Fatalf("empty form error included page text: %q", got)
+	}
+	form = append(form, []byte(`<div role="alert">Series lookup unavailable</div>`)...)
+	if got := ExtractHTMLFormErrorDetail(form); got != "Series lookup unavailable" {
+		t.Fatalf("form lost visible error detail: %q", got)
+	}
+	oversized := []byte(strings.Repeat(" ", int(maxHTTPErrorResponseBytes)) + `<div class="error">Beyond scan limit</div>`)
+	if got := ExtractHTMLFormErrorDetail(oversized); got != "" {
+		t.Fatalf("form error scanned beyond limit: %q", got)
 	}
 }
 
@@ -421,15 +466,15 @@ func TestReadUploadResponseBodyFindsLateHTMLFailure(t *testing.T) {
 		want string
 	}{
 		{
-name: "marked",
- html: `<div class="errors">Invalid category selected.</div>`,
- want: "Invalid category selected.",
-},
+			name: "marked",
+			html: `<div class="errors">Invalid category selected.</div>`,
+			want: "Invalid category selected.",
+		},
 		{
-name: "unmarked",
- html: `<h1>Upload failed!</h1><p>A matching torrent already exists.</p>`,
- want: "Upload failed! A matching torrent already exists.",
-},
+			name: "unmarked",
+			html: `<h1>Upload failed!</h1><p>A matching torrent already exists.</p>`,
+			want: "Upload failed! A matching torrent already exists.",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			bodyText := `<html><head>` + strings.Repeat(`<link href="/favicon">`, 4000) + `</head><body>` + tt.html + `</body></html>`

--- a/internal/trackers/impl/commonhttp/commonhttp_test.go
+++ b/internal/trackers/impl/commonhttp/commonhttp_test.go
@@ -28,7 +28,7 @@ func (s stubCookieStore) GetAllTrackerCookies(context.Context, string, []byte) (
 	return s.cookies, nil
 }
 
-func TestReadUploadResponseBodyUsesFullSuccessAndBoundedFailurePreview(t *testing.T) {
+func TestReadUploadResponseBodyUsesFullSuccessAndExtractedFailurePreview(t *testing.T) {
 	t.Parallel()
 
 	large := strings.Repeat("a", int(DefaultResponsePreviewBytes)+32)
@@ -49,11 +49,11 @@ func TestReadUploadResponseBodyUsesFullSuccessAndBoundedFailurePreview(t *testin
 	if err != nil {
 		t.Fatalf("ReadUploadResponseBody failure: %v", err)
 	}
-	if int64(len(body)) != DefaultResponsePreviewBytes {
-		t.Fatalf("expected bounded failure body length %d, got %d", DefaultResponsePreviewBytes, len(body))
+	if len(body) != len(large) {
+		t.Fatalf("expected failure scan body length %d, got %d", len(large), len(body))
 	}
-	if string(preview) != string(body) {
-		t.Fatal("expected failure preview to match bounded body")
+	if string(preview) != "[REDACTED]" {
+		t.Fatalf("expected compact redacted failure preview, got %q", preview)
 	}
 }
 
@@ -341,6 +341,132 @@ func TestExtractHTTPErrorDetailFallsBackToCompactBody(t *testing.T) {
 		t.Fatalf("unexpected compact body: %q", got)
 	}
 }
+
+func TestExtractHTTPErrorDetailUsesVisibleHTML(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`<html><head><title>Upload</title></head><body><nav>Browse</nav><p>Upload form</p>` +
+		`<script>{"message":"private-script"}</script><div role="alert">Invalid passkey&#61;synthetic-secret` +
+		`<input value="private-input"><textarea>private-textarea</textarea><select><option>private-select</option></select>` +
+		`<button>private-button</button><style>private-style</style><span hidden>private-hidden</span>` +
+		`<span aria-hidden="true">private-aria</span></div></body></html>`)
+	got := ExtractHTTPErrorDetail(body)
+
+	if got != "Invalid passkey=[REDACTED]" {
+		t.Fatalf("unexpected visible HTML detail: %q", got)
+	}
+}
+
+func TestExtractHTTPErrorDetailHandlesMalformedAndEmbeddedJSON(t *testing.T) {
+	t.Parallel()
+
+	if got := ExtractHTTPErrorDetail([]byte(`<div class=error>Invalid <b>category`)); got != "Invalid category" {
+		t.Fatalf("malformed HTML detail = %q", got)
+	}
+	if got := ExtractHTTPErrorDetail([]byte(`prefix {"message":"Invalid category selected."} suffix`)); got != "Invalid category selected." {
+		t.Fatalf("embedded JSON detail = %q", got)
+	}
+	if got := ExtractHTTPErrorDetail(nil); got != "" {
+		t.Fatalf("empty detail = %q", got)
+	}
+}
+
+func TestExtractHTTPErrorDetailBoundsOversizedInput(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`<div class="error">Invalid category</div>` + strings.Repeat("x", int(maxHTTPErrorResponseBytes)))
+	got := ExtractHTTPErrorDetail(body)
+	if got != "response exceeded 1 MiB; Invalid category" {
+		t.Fatalf("oversized detail = %q", got)
+	}
+	if got := ExtractHTTPErrorDetail([]byte(strings.Repeat(" ", int(maxHTTPErrorResponseBytes)+1))); got != "response exceeded 1 MiB" {
+		t.Fatalf("oversized blank detail = %q", got)
+	}
+}
+
+func TestReadUploadResponseBodyFindsLateHTMLFailure(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		html string
+		want string
+	}{
+		{
+name: "marked",
+ html: `<div class="errors">Invalid category selected.</div>`,
+ want: "Invalid category selected.",
+},
+		{
+name: "unmarked",
+ html: `<h1>Upload failed!</h1><p>A matching torrent already exists.</p>`,
+ want: "Upload failed! A matching torrent already exists.",
+},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			bodyText := `<html><head>` + strings.Repeat(`<link href="/favicon">`, 4000) + `</head><body>` + tt.html + `</body></html>`
+			resp := &http.Response{Body: ioNopCloser(bodyText)}
+			body, preview, err := ReadUploadResponseBody(resp, false, DefaultResponsePreviewBytes)
+			if err != nil {
+				t.Fatalf("ReadUploadResponseBody: %v", err)
+			}
+			if len(body) <= int(DefaultResponsePreviewBytes) {
+				t.Fatalf("expected scan beyond old preview limit, got %d bytes", len(body))
+			}
+			if string(preview) != tt.want {
+				t.Fatalf("late error preview = %q, want %q", preview, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadUploadResponseBodyReportsOversizeAndPartialRead(t *testing.T) {
+	t.Parallel()
+
+	oversized := `<div class="error">Invalid category</div>` + strings.Repeat("x", int(maxHTTPErrorResponseBytes))
+	body, preview, err := ReadUploadResponseBody(&http.Response{Body: ioNopCloser(oversized)}, false, DefaultResponsePreviewBytes)
+	if err != nil {
+		t.Fatalf("oversized response: %v", err)
+	}
+	if int64(len(body)) != maxHTTPErrorResponseBytes {
+		t.Fatalf("oversized body length = %d", len(body))
+	}
+	if string(preview) != "response exceeded 1 MiB; Invalid category" {
+		t.Fatalf("oversized preview = %q", preview)
+	}
+
+	sentinel := errors.New("synthetic read failure")
+	resp := &http.Response{Body: &partialErrorReadCloser{payload: []byte(`<div class="error">Invalid source</div>`), err: sentinel}}
+	body, preview, err = ReadUploadResponseBody(resp, false, DefaultResponsePreviewBytes)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected read error identity, got %v", err)
+	}
+	if string(body) != `<div class="error">Invalid source</div>` {
+		t.Fatalf("partial body = %q", body)
+	}
+	if string(preview) != "response body read failed; Invalid source" {
+		t.Fatalf("partial read preview = %q", preview)
+	}
+}
+
+type partialErrorReadCloser struct {
+	payload []byte
+	err     error
+}
+
+func (r *partialErrorReadCloser) Read(p []byte) (int, error) {
+	if len(r.payload) == 0 {
+		return 0, r.err
+	}
+	n := copy(p, r.payload)
+	r.payload = r.payload[n:]
+	if len(r.payload) == 0 {
+		return n, r.err
+	}
+	return n, nil
+}
+
+func (*partialErrorReadCloser) Close() error { return nil }
 
 func TestFormatErrorValueStopsAtMaxDepth(t *testing.T) {
 	t.Parallel()

--- a/internal/trackers/impl/commonhttp/html.go
+++ b/internal/trackers/impl/commonhttp/html.go
@@ -44,7 +44,8 @@ func GetText(ctx context.Context, client *http.Client, endpoint string, params u
 }
 
 // GetHTML performs a tracker GET request and parses successful responses.
-// Non-2xx responses return their status with a nil document and nil error.
+// Non-2xx responses return their status with a nil document and a redacted
+// error containing compact response detail when available.
 func GetHTML(ctx context.Context, client *http.Client, endpoint string, params url.Values, cookies []*http.Cookie) (int, *xhtml.Node, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -61,7 +62,14 @@ func GetHTML(ctx context.Context, client *http.Client, endpoint string, params u
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return resp.StatusCode, nil, nil
+		_, preview, readErr := readHTTPErrorResponse(resp.Body, DefaultResponsePreviewBytes)
+		if readErr != nil {
+			return resp.StatusCode, nil, fmt.Errorf("commonhttp: HTML GET request failed status=%d: %w", resp.StatusCode, readErr)
+		}
+		if len(preview) == 0 {
+			return resp.StatusCode, nil, fmt.Errorf("commonhttp: HTML GET request failed status=%d", resp.StatusCode)
+		}
+		return resp.StatusCode, nil, fmt.Errorf("commonhttp: HTML GET request failed status=%d: %s", resp.StatusCode, preview)
 	}
 	root, err := xhtml.Parse(resp.Body)
 	if err != nil {

--- a/internal/trackers/impl/commonhttp/html_test.go
+++ b/internal/trackers/impl/commonhttp/html_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package commonhttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	xhtml "golang.org/x/net/html"
+)
+
+func TestGetHTMLReturnsVisibleNonSuccessDetail(t *testing.T) {
+	t.Parallel()
+
+	body := `<html><head>` + strings.Repeat(`<link href="/favicon">`, 4000) +
+		`<script>{"message":"private-script"}</script></head><body>` +
+		`<div role="alert">Session expired: token&#61;synthetic-secret</div></body></html>`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	status, root, err := GetHTML(t.Context(), server.Client(), server.URL, nil, nil)
+	if status != http.StatusForbidden || root != nil {
+		t.Fatalf("status=%d root=%v", status, root)
+	}
+	want := "commonhttp: HTML GET request failed status=403: Session expired: token=[REDACTED]"
+	if err == nil || err.Error() != want {
+		t.Fatalf("error = %v, want %q", err, want)
+	}
+}
+
+func TestGetHTMLPreservesSuccessfulParsing(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<html><body><div id="result">ok</div></body></html>`))
+	}))
+	defer server.Close()
+
+	status, root, err := GetHTML(t.Context(), server.Client(), server.URL, nil, nil)
+	if err != nil {
+		t.Fatalf("GetHTML: %v", err)
+	}
+	if status != http.StatusOK || root == nil {
+		t.Fatalf("status=%d root=%v", status, root)
+	}
+	result := FirstNode(root, func(node *xhtml.Node) bool { return Attr(node, "id") == "result" })
+	if result == nil || strings.TrimSpace(NodeText(result)) != "ok" {
+		t.Fatalf("result node = %v", result)
+	}
+}

--- a/internal/trackers/impl/commonhttp/upload_executor.go
+++ b/internal/trackers/impl/commonhttp/upload_executor.go
@@ -77,7 +77,7 @@ func ExecuteUpload(client *http.Client, req *http.Request, options UploadExecuti
 		return UploadExecution{}, fmt.Errorf("trackers: %s upload request: %w", tracker, safeWrappedError(err))
 	}
 	success := successStatus(resp.StatusCode)
-	body, readErr := readExecutedUploadBody(resp.Body, success, options.SuccessBody, options.SuccessBodyLimit, previewLimit)
+	body, preview, readErr := readExecutedUploadBody(resp.Body, success, options.SuccessBody, options.SuccessBodyLimit, previewLimit)
 	closeErr := resp.Body.Close()
 	if readErr != nil || closeErr != nil {
 		return UploadExecution{}, fmt.Errorf("trackers: %s read upload response: %w", tracker, errors.Join(readErr, closeErr))
@@ -87,9 +87,10 @@ func ExecuteUpload(client *http.Client, req *http.Request, options UploadExecuti
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = redaction.RedactValue(resp.Request.URL.String(), nil)
 	}
-	preview := ResponseBodyPreview(body, previewLimit)
-	preview = []byte(redaction.RedactValue(string(preview), nil))
-	if !success {
+	if success {
+		preview = ResponseBodyPreview(body, previewLimit)
+		preview = []byte(redaction.RedactValue(string(preview), nil))
+	} else {
 		body = append([]byte(nil), preview...)
 	}
 	return UploadExecution{
@@ -108,32 +109,28 @@ func readExecutedUploadBody(
 	policy SuccessBodyPolicy,
 	successLimit int64,
 	previewLimit int64,
-) ([]byte, error) {
+) ([]byte, []byte, error) {
 	if !success {
-		payload, err := io.ReadAll(io.LimitReader(body, previewLimit))
-		if err != nil {
-			return nil, fmt.Errorf("read bounded upload failure response: %w", err)
-		}
-		return payload, nil
+		return readHTTPErrorResponse(body, previewLimit)
 	}
 	if policy == FullSuccessBody {
 		payload, err := io.ReadAll(body)
 		if err != nil {
-			return nil, fmt.Errorf("read full upload success response: %w", err)
+			return nil, nil, fmt.Errorf("read full upload success response: %w", err)
 		}
-		return payload, nil
+		return payload, nil, nil
 	}
 	if successLimit <= 0 {
 		successLimit = defaultSuccessBodyBytes
 	}
 	payload, err := io.ReadAll(io.LimitReader(body, successLimit+1))
 	if err != nil {
-		return nil, fmt.Errorf("read bounded upload success response: %w", err)
+		return nil, nil, fmt.Errorf("read bounded upload success response: %w", err)
 	}
 	if int64(len(payload)) > successLimit {
-		return nil, fmt.Errorf("successful upload response exceeds %d bytes", successLimit)
+		return nil, nil, fmt.Errorf("successful upload response exceeds %d bytes", successLimit)
 	}
-	return payload, nil
+	return payload, nil, nil
 }
 
 type wrappedSafeError struct {

--- a/internal/trackers/impl/commonhttp/upload_executor_test.go
+++ b/internal/trackers/impl/commonhttp/upload_executor_test.go
@@ -5,6 +5,7 @@ package commonhttp
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -70,5 +71,64 @@ func TestExecuteUploadRejectsOversizedSuccessUnlessFullBodyIsExplicit(t *testing
 	}
 	if string(result.Body) != "artifact" {
 		t.Fatalf("success body = %q", result.Body)
+	}
+}
+
+func TestExecuteUploadFindsLateHTMLFailureForPublicError(t *testing.T) {
+	t.Parallel()
+
+	responseBody := `<html><head>` + strings.Repeat(`<link href="/favicon">`, 4000) +
+		`</head><body><div class="alert-danger">Upload permission denied.</div></body></html>`
+	client := &http.Client{Transport: uploadRoundTripper(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(responseBody)),
+			Request:    req,
+		}, nil
+	})}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://tracker.invalid/upload", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	result, err := ExecuteUpload(client, req, UploadExecutionOptions{Tracker: "DC"})
+	if err != nil {
+		t.Fatalf("execute upload: %v", err)
+	}
+	if result.Success || string(result.Body) != "Upload permission denied." || string(result.Preview) != "Upload permission denied." {
+		t.Fatalf("unexpected failure projection: %#v", result)
+	}
+
+	publicErr := UploadHTTPError("DC", result.StatusCode, result.Preview)
+	if publicErr.Error() != "trackers: DC upload failed status=403: Upload permission denied." {
+		t.Fatalf("public error = %v", publicErr)
+	}
+}
+
+func TestExecuteUploadPreservesFailureReadErrorIdentityAndDetail(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("api_key=synthetic-secret")
+	client := &http.Client{Transport: uploadRoundTripper(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Header:     make(http.Header),
+			Body:       &partialErrorReadCloser{payload: []byte(`<div class="error">Invalid source</div>`), err: sentinel},
+			Request:    req,
+		}, nil
+	})}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://tracker.invalid/upload", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	_, err = ExecuteUpload(client, req, UploadExecutionOptions{Tracker: "DC"})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected read error identity, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "response body read failed; Invalid source") {
+		t.Fatalf("expected partial response detail, got %v", err)
+	}
+	if strings.Contains(err.Error(), "synthetic-secret") {
+		t.Fatalf("read error leaked secret: %v", err)
 	}
 }

--- a/internal/trackers/impl/standalone/ar/upload.go
+++ b/internal/trackers/impl/standalone/ar/upload.go
@@ -125,14 +125,18 @@ func submitPreparedUpload(
 		redactedBody := []byte(redaction.RedactValue(string(responsePreview), nil))
 		_ = os.WriteFile(failurePath, redactedBody, 0o600)
 	}
+	errorResponse := responsePreview
+	if resp.StatusCode == http.StatusOK {
+		errorResponse = bodyBytes
+	}
 	if failurePath != "" {
 		return api.UploadSummary{}, fmt.Errorf(
 			"%w failure=%s",
-			commonhttp.UploadHTTPErrorWithURL("AR", resp.StatusCode, finalURL, responsePreview),
+			commonhttp.UploadHTTPErrorWithURL("AR", resp.StatusCode, finalURL, errorResponse),
 			failurePath,
 		)
 	}
-	return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("AR", resp.StatusCode, finalURL, responsePreview)
+	return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("AR", resp.StatusCode, finalURL, errorResponse)
 }
 
 func buildUploadPreview(state uploadState) api.TrackerDryRunEntry {

--- a/internal/trackers/impl/standalone/ar/upload_test.go
+++ b/internal/trackers/impl/standalone/ar/upload_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	cookiepkg "github.com/autobrr/upbrr/internal/cookies"
 	servicedb "github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/internal/trackers"
 	trackerauth "github.com/autobrr/upbrr/internal/trackers/auth"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -31,6 +32,36 @@ func TestResolveARNameUsesSourceFilenameWithoutExtension(t *testing.T) {
 	})
 	if got != "My Movie (2024)" {
 		t.Fatalf("unexpected AR name %q", got)
+	}
+}
+
+func TestSubmitPreparedUploadPreservesLateHTMLFailure(t *testing.T) {
+	t.Parallel()
+
+	const detail = "AR rejected the torrent after validation"
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body: io.NopCloser(strings.NewReader(
+				"<html><body>" + strings.Repeat("padding ", 10*1024) + `<div class="alert-danger">` + detail + "</div></body></html>",
+			)),
+			Request: req,
+		}, nil
+	})}
+
+	_, err := submitPreparedUpload(
+		t.Context(),
+		trackers.PreparationInput{},
+		uploadState{},
+		client,
+		nil,
+		"application/octet-stream",
+		"",
+		"",
+	)
+	if err == nil || !strings.Contains(err.Error(), detail) {
+		t.Fatalf("expected late HTML error detail, got %v", err)
 	}
 }
 

--- a/internal/trackers/impl/standalone/asc/upload.go
+++ b/internal/trackers/impl/standalone/asc/upload.go
@@ -134,14 +134,18 @@ func submitPreparedUpload(
 		redactedBody := []byte(redaction.RedactValue(string(responsePreview), nil))
 		_ = os.WriteFile(failurePath, redactedBody, 0o600)
 	}
+	errorResponse := responsePreview
+	if resp.StatusCode == http.StatusOK {
+		errorResponse = bodyBytes
+	}
 	if failurePath != "" {
 		return api.UploadSummary{}, fmt.Errorf(
 			"%w failure=%s",
-			commonhttp.UploadHTTPErrorWithURL("ASC", resp.StatusCode, finalURL, responsePreview),
+			commonhttp.UploadHTTPErrorWithURL("ASC", resp.StatusCode, finalURL, errorResponse),
 			failurePath,
 		)
 	}
-	return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("ASC", resp.StatusCode, finalURL, responsePreview)
+	return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("ASC", resp.StatusCode, finalURL, errorResponse)
 }
 
 func buildUploadPreview(state uploadState) api.TrackerDryRunEntry {

--- a/internal/trackers/impl/standalone/bjs/upload.go
+++ b/internal/trackers/impl/standalone/bjs/upload.go
@@ -132,7 +132,11 @@ func submitPreparedUpload(
 		}, nil
 	}
 	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.Runtime.DBPath, "BJS", "upload_failure", responsePreview, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("BJS", resp.StatusCode, responsePreview)
+	errorResponse := responsePreview
+	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+		errorResponse = responseBody
+	}
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("BJS", resp.StatusCode, errorResponse)
 }
 
 func buildUploadPreview(state uploadState) api.TrackerDryRunEntry {

--- a/internal/trackers/impl/standalone/bt/upload.go
+++ b/internal/trackers/impl/standalone/bt/upload.go
@@ -135,7 +135,11 @@ func submitPreparedUpload(
 		}, nil
 	}
 	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.Runtime.DBPath, "BT", "upload_failure", responsePreview, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("BT", resp.StatusCode, responsePreview)
+	errorResponse := responsePreview
+	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+		errorResponse = responseBody
+	}
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("BT", resp.StatusCode, errorResponse)
 }
 
 func buildUploadPreview(state uploadState) api.TrackerDryRunEntry {

--- a/internal/trackers/impl/standalone/btn/autofill_response_test.go
+++ b/internal/trackers/impl/standalone/btn/autofill_response_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -25,6 +26,7 @@ func TestBTNAutofillResponseErrors(t *testing.T) {
 		lookup      string
 		want        string
 		wantFailure bool
+		partial     bool
 	}{
 		{
 			name:        "tvdb explicit failure with late message",
@@ -63,10 +65,29 @@ func TestBTNAutofillResponseErrors(t *testing.T) {
 			lookup: "tvdb",
 			want:   "response exceeded 1 MiB",
 		},
+		{
+			name:    "partial success-status response retains diagnostic",
+			status:  http.StatusOK,
+			body:    `<div class="error">Metadata response interrupted</div>`,
+			lookup:  "tvdb",
+			want:    "Metadata response interrupted",
+			partial: true,
+		},
+		{
+			name:    "partial HTTP error retains diagnostic",
+			status:  http.StatusServiceUnavailable,
+			body:    `<div class="error">Metadata response interrupted</div>`,
+			lookup:  "release_name",
+			want:    "Metadata response interrupted",
+			partial: true,
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if testCase.partial {
+					w.Header().Set("Content-Length", strconv.Itoa(len(testCase.body)+1))
+				}
 				w.WriteHeader(testCase.status)
 				_, _ = io.WriteString(w, testCase.body)
 			}))
@@ -81,6 +102,12 @@ func TestBTNAutofillResponseErrors(t *testing.T) {
 			}
 			if errors.Is(err, errBTNExplicitAutofillFailure) != testCase.wantFailure {
 				t.Fatalf("explicit failure classification changed: %v", err)
+			}
+			if !strings.Contains(err.Error(), "status="+strconv.Itoa(testCase.status)) {
+				t.Fatalf("response lost HTTP status: %v", err)
+			}
+			if testCase.partial && !errors.Is(err, io.ErrUnexpectedEOF) {
+				t.Fatalf("partial response lost read cause: %v", err)
 			}
 			for _, privateValue := range []string{"private-script", "private-description", "synthetic-secret"} {
 				if strings.Contains(err.Error(), privateValue) {

--- a/internal/trackers/impl/standalone/btn/autofill_response_test.go
+++ b/internal/trackers/impl/standalone/btn/autofill_response_test.go
@@ -45,6 +45,14 @@ func TestBTNAutofillResponseErrors(t *testing.T) {
 			wantFailure: true,
 		},
 		{
+			name:        "empty error container does not expose page boilerplate",
+			status:      http.StatusOK,
+			body:        `<p>unrelated-page-text</p><div class="error"></div><input name="artist" value="Autofill Fail">`,
+			lookup:      "release_name",
+			want:        "fields=artist: Autofill Fail",
+			wantFailure: true,
+		},
+		{
 			name:   "http error beyond preview",
 			status: http.StatusServiceUnavailable,
 			body:   header + `<div class="errors">Metadata service unavailable</div>`,
@@ -109,7 +117,7 @@ func TestBTNAutofillResponseErrors(t *testing.T) {
 			if testCase.partial && !errors.Is(err, io.ErrUnexpectedEOF) {
 				t.Fatalf("partial response lost read cause: %v", err)
 			}
-			for _, privateValue := range []string{"private-script", "private-description", "synthetic-secret"} {
+			for _, privateValue := range []string{"private-script", "private-description", "synthetic-secret", "unrelated-page-text"} {
 				if strings.Contains(err.Error(), privateValue) {
 					t.Fatalf("response exposed excluded content: %v", err)
 				}

--- a/internal/trackers/impl/standalone/btn/autofill_response_test.go
+++ b/internal/trackers/impl/standalone/btn/autofill_response_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package btn
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestBTNAutofillResponseErrors(t *testing.T) {
+	t.Parallel()
+
+	const failureFields = `<input name="artist" value="Autofill Fail"><input name="title" value="Autofill Fail">`
+	header := `<head><script>` + strings.Repeat("private-script ", 6000) + `</script></head>`
+	for _, testCase := range []struct {
+		name        string
+		status      int
+		body        string
+		lookup      string
+		want        string
+		wantFailure bool
+	}{
+		{
+			name:        "tvdb explicit failure with late message",
+			status:      http.StatusOK,
+			body:        header + failureFields + `<div class="error">Episode lookup unavailable</div>`,
+			lookup:      "tvdb",
+			want:        "Episode lookup unavailable",
+			wantFailure: true,
+		},
+		{
+			name:        "release name explicit failure",
+			status:      http.StatusOK,
+			body:        failureFields + `<div role="alert">No matching release found</div>`,
+			lookup:      "release_name",
+			want:        "No matching release found",
+			wantFailure: true,
+		},
+		{
+			name:   "http error beyond preview",
+			status: http.StatusServiceUnavailable,
+			body:   header + `<div class="errors">Metadata service unavailable</div>`,
+			lookup: "tvdb",
+			want:   "Metadata service unavailable",
+		},
+		{
+			name:   "invalid form retains reason and redacts decoded secret",
+			status: http.StatusOK,
+			body:   `<div class="error">Invalid passkey&#61;synthetic-secret</div><textarea>private-description</textarea>`,
+			lookup: "tvdb",
+			want:   "Invalid passkey=[REDACTED]",
+		},
+		{
+			name:   "oversized response does not become a valid form",
+			status: http.StatusOK,
+			body:   `<div class="error">Response too large</div><!--` + strings.Repeat("x", 1<<20),
+			lookup: "tvdb",
+			want:   "response exceeded 1 MiB",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(testCase.status)
+				_, _ = io.WriteString(w, testCase.body)
+			}))
+			defer server.Close()
+			payload := url.Values{"scene_yesno": {"No"}}
+			if testCase.lookup == "release_name" {
+				payload.Set("scene_yesno", "Yes")
+			}
+			fields, err := requestBTNAutofillFields(t.Context(), uploadContext{client: server.Client(), uploadURL: server.URL}, payload, "Episode")
+			if err == nil || fields != nil || !strings.Contains(err.Error(), testCase.want) || !strings.Contains(err.Error(), "lookup="+testCase.lookup) {
+				t.Fatalf("fields=%v error=%v, want %q with lookup=%s", fields, err, testCase.want, testCase.lookup)
+			}
+			if errors.Is(err, errBTNExplicitAutofillFailure) != testCase.wantFailure {
+				t.Fatalf("explicit failure classification changed: %v", err)
+			}
+			for _, privateValue := range []string{"private-script", "private-description", "synthetic-secret"} {
+				if strings.Contains(err.Error(), privateValue) {
+					t.Fatalf("response exposed excluded content: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestBTNPreparationPreservesAutofillErrorDetail(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `<input name="artist" value="Autofill Fail"><div class="error">Series mapping unavailable</div>`)
+	}))
+	defer server.Close()
+	req := newBTNDryRunTestRequest(t, "")
+	_, err := prepareUploadData(t.Context(), req, uploadContext{client: server.Client(), uploadURL: server.URL})
+	if !errors.Is(err, errBTNExplicitAutofillFailure) || !strings.Contains(err.Error(), "Series mapping unavailable") {
+		t.Fatalf("preparation lost tracker response detail: %v", err)
+	}
+}

--- a/internal/trackers/impl/standalone/btn/media.go
+++ b/internal/trackers/impl/standalone/btn/media.go
@@ -25,6 +25,8 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+var errBTNExplicitAutofillFailure = errors.New("trackers: BTN autofill validation failed: explicit autofill failure")
+
 // buildBTNAutofillPayload returns the form fields for BTN's first upload.php
 // POST. TVDB-backed uploads submit the series id plus season or episode token;
 // scene-name autofill is used only when no TVDB series id is available.
@@ -163,16 +165,43 @@ func requestBTNAutofillFields(
 		return nil, fmt.Errorf("trackers: BTN autofill request: %w", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("trackers: BTN autofill failed status=%d", resp.StatusCode)
+	lookup := "tvdb"
+	if autofillPayload.Get("scene_yesno") == "Yes" {
+		lookup = "release_name"
 	}
-	htmlPayload, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_, detail, readErr := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
+		if readErr != nil {
+			return nil, fmt.Errorf("trackers: BTN read autofill failure lookup=%s: %w", lookup, readErr)
+		}
+		return nil, fmt.Errorf("trackers: BTN autofill failed lookup=%s status=%d: %s", lookup, resp.StatusCode, detail)
+	}
+	const responseLimit = 1 << 20
+	htmlPayload, err := io.ReadAll(io.LimitReader(resp.Body, responseLimit+1))
+	boundedPayload := htmlPayload[:min(len(htmlPayload), responseLimit)]
 	if err != nil {
-		return nil, fmt.Errorf("trackers: BTN read autofill response: %w", err)
+		return nil, fmt.Errorf("trackers: BTN read autofill response lookup=%s: %w; %s", lookup, err, commonhttp.ExtractHTTPErrorDetail(boundedPayload))
+	}
+	if len(htmlPayload) > responseLimit {
+		return nil, fmt.Errorf("trackers: BTN autofill response exceeded 1 MiB lookup=%s: %s", lookup, commonhttp.ExtractHTTPErrorDetail(boundedPayload))
 	}
 	fields := extractAutofillFields(string(htmlPayload))
+	if strings.EqualFold(strings.TrimSpace(fields["artist"]), "autofill fail") || strings.EqualFold(strings.TrimSpace(fields["title"]), "autofill fail") {
+		return nil, fmt.Errorf(
+			"%w lookup=%s status=%d: %s",
+			errBTNExplicitAutofillFailure,
+			lookup,
+			resp.StatusCode,
+			commonhttp.ExtractHTTPErrorDetail(htmlPayload),
+		)
+	}
 	if !validateAutofill(fields, uploadType) {
-		return nil, errors.New("trackers: BTN autofill validation failed")
+		return nil, fmt.Errorf(
+			"trackers: BTN autofill validation failed lookup=%s status=%d: %s",
+			lookup,
+			resp.StatusCode,
+			commonhttp.ExtractHTTPErrorDetail(htmlPayload),
+		)
 	}
 	return fields, nil
 }

--- a/internal/trackers/impl/standalone/btn/media.go
+++ b/internal/trackers/impl/standalone/btn/media.go
@@ -172,7 +172,7 @@ func requestBTNAutofillFields(
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		_, detail, readErr := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
 		if readErr != nil {
-			return nil, fmt.Errorf("trackers: BTN read autofill failure lookup=%s: %w", lookup, readErr)
+			return nil, fmt.Errorf("trackers: BTN read autofill failure lookup=%s status=%d: %w", lookup, resp.StatusCode, readErr)
 		}
 		return nil, fmt.Errorf("trackers: BTN autofill failed lookup=%s status=%d: %s", lookup, resp.StatusCode, detail)
 	}
@@ -180,10 +180,17 @@ func requestBTNAutofillFields(
 	htmlPayload, err := io.ReadAll(io.LimitReader(resp.Body, responseLimit+1))
 	boundedPayload := htmlPayload[:min(len(htmlPayload), responseLimit)]
 	if err != nil {
-		return nil, fmt.Errorf("trackers: BTN read autofill response lookup=%s: %w; %s", lookup, err, commonhttp.ExtractHTTPErrorDetail(boundedPayload))
+		return nil, fmt.Errorf(
+			"trackers: BTN read autofill response lookup=%s status=%d: %w; %s", lookup, resp.StatusCode, err, commonhttp.ExtractHTTPErrorDetail(boundedPayload),
+		)
 	}
 	if len(htmlPayload) > responseLimit {
-		return nil, fmt.Errorf("trackers: BTN autofill response exceeded 1 MiB lookup=%s: %s", lookup, commonhttp.ExtractHTTPErrorDetail(boundedPayload))
+		return nil, fmt.Errorf(
+			"trackers: BTN autofill response exceeded 1 MiB lookup=%s status=%d: %s",
+			lookup,
+			resp.StatusCode,
+			commonhttp.ExtractHTTPErrorDetail(boundedPayload),
+		)
 	}
 	fields := extractAutofillFields(string(htmlPayload))
 	if strings.EqualFold(strings.TrimSpace(fields["artist"]), "autofill fail") || strings.EqualFold(strings.TrimSpace(fields["title"]), "autofill fail") {

--- a/internal/trackers/impl/standalone/btn/media.go
+++ b/internal/trackers/impl/standalone/btn/media.go
@@ -193,13 +193,24 @@ func requestBTNAutofillFields(
 		)
 	}
 	fields := extractAutofillFields(string(htmlPayload))
-	if strings.EqualFold(strings.TrimSpace(fields["artist"]), "autofill fail") || strings.EqualFold(strings.TrimSpace(fields["title"]), "autofill fail") {
+	failedFields := make([]string, 0, 2)
+	for _, name := range []string{"artist", "title"} {
+		if strings.EqualFold(strings.TrimSpace(fields[name]), "autofill fail") {
+			failedFields = append(failedFields, name)
+		}
+	}
+	if len(failedFields) > 0 {
+		detail := commonhttp.ExtractHTMLFormErrorDetail(htmlPayload)
+		if detail == "" {
+			detail = "Autofill Fail"
+		}
 		return nil, fmt.Errorf(
-			"%w lookup=%s status=%d: %s",
+			"%w lookup=%s status=%d fields=%s: %s",
 			errBTNExplicitAutofillFailure,
 			lookup,
 			resp.StatusCode,
-			commonhttp.ExtractHTTPErrorDetail(htmlPayload),
+			strings.Join(failedFields, ","),
+			detail,
 		)
 	}
 	if !validateAutofill(fields, uploadType) {

--- a/internal/trackers/impl/standalone/btn/upload.go
+++ b/internal/trackers/impl/standalone/btn/upload.go
@@ -257,15 +257,19 @@ func submitPreparedUpload(
 			groupID, torrentID, matched = btnUploadIDsFromText(string(responseBody))
 		}
 		if !matched && groupID == "" && torrentID == "" {
+			errorBody := responseBody
+			if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+				errorBody = responsePreview
+			}
 			failurePath, _ := commonhttp.WriteFailureArtifact(req.Meta, req.Runtime.DBPath, "BTN", "upload-failure", responsePreview, ".html")
 			if failurePath != "" {
 				return api.UploadSummary{}, fmt.Errorf(
 					"%w failure=%s",
-					commonhttp.UploadHTTPErrorWithURL("BTN", resp.StatusCode, finalURL, responsePreview),
+					commonhttp.UploadHTTPErrorWithURL("BTN", resp.StatusCode, finalURL, errorBody),
 					failurePath,
 				)
 			}
-			return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("BTN", resp.StatusCode, finalURL, responsePreview)
+			return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("BTN", resp.StatusCode, finalURL, errorBody)
 		}
 	}
 	torrentURL := buildBTNTorrentURL(uploadCtx.baseURL, groupID, torrentID)

--- a/internal/trackers/impl/standalone/ff/upload.go
+++ b/internal/trackers/impl/standalone/ff/upload.go
@@ -111,7 +111,11 @@ func submitPreparedUpload(
 		}}}, nil
 	}
 	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.Runtime.DBPath, "FF", "upload_failure", result.Preview, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("FF", result.StatusCode, result.Preview)
+	errorResponse := result.Preview
+	if result.Success {
+		errorResponse = result.Body
+	}
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("FF", result.StatusCode, errorResponse)
 }
 
 func buildUploadPreview(state uploadState) api.TrackerDryRunEntry {

--- a/internal/trackers/impl/standalone/fl/dupe.go
+++ b/internal/trackers/impl/standalone/fl/dupe.go
@@ -5,6 +5,7 @@ package fl
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -71,7 +72,11 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return dupe.Failed(dupe.FailureResponseStatus, "FL search failed", nil)
+		_, detail, readErr := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
+		if readErr != nil {
+			return dupe.Failed(dupe.FailureResponseStatus, "FL search failed", readErr)
+		}
+		return dupe.Failed(dupe.FailureResponseStatus, "FL search failed", fmt.Errorf("FL search failed status=%d: %s", resp.StatusCode, detail))
 	}
 	root, err := xhtml.Parse(resp.Body)
 	if err != nil {

--- a/internal/trackers/impl/standalone/fl/dupe_response_test.go
+++ b/internal/trackers/impl/standalone/fl/dupe_response_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package fl
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/authmaterial/authfixture"
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/cookies"
+	"github.com/autobrr/upbrr/internal/trackers/dupe"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestSearchPreservesHTMLFailureDetail(t *testing.T) {
+	t.Parallel()
+	dbPath := newFLAuthTestDB(t)
+	authfixture.Write(t, dbPath)
+	if err := cookies.SaveTrackerCookieMap(t.Context(), dbPath, "FL", map[string]string{"session": "synthetic"}); err != nil {
+		t.Fatalf("save cookies: %v", err)
+	}
+	searcher := dupeSearcher{
+		cfg: config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}},
+		http: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body := `<head><script>` + strings.Repeat("private-script ", 6000) + `</script></head><div class="error">Search unavailable</div>`
+			return &http.Response{
+StatusCode: http.StatusServiceUnavailable,
+ Body: io.NopCloser(strings.NewReader(body)),
+ Header: make(http.Header),
+ Request: req,
+}, nil
+		})},
+	}
+	result := searcher.Search(t.Context(), api.DuplicateSubject{Identity: api.ExternalIdentity{IMDBID: 1234567}})
+	if result.Disposition() != dupe.DispositionFailed || result.Code() != dupe.FailureResponseStatus || result.Cause() == nil {
+		t.Fatalf("search classification changed: disposition=%v code=%s cause=%v", result.Disposition(), result.Code(), result.Cause())
+	}
+	if !strings.Contains(result.Cause().Error(), "Search unavailable") || strings.Contains(result.Cause().Error(), "private-script") {
+		t.Fatalf("search lost safe response detail: %v", result.Cause())
+	}
+}

--- a/internal/trackers/impl/standalone/fl/upload.go
+++ b/internal/trackers/impl/standalone/fl/upload.go
@@ -119,7 +119,11 @@ func submitPreparedUpload(
 		}, nil
 	}
 	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.Runtime.DBPath, "FL", "upload_failure", result.Preview, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("FL", result.StatusCode, result.FinalURL, result.Preview)
+	errorResponse := result.Preview
+	if result.Success {
+		errorResponse = result.Body
+	}
+	return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("FL", result.StatusCode, result.FinalURL, errorResponse)
 }
 
 func buildUploadPreview(state uploadState) api.TrackerDryRunEntry {

--- a/internal/trackers/impl/standalone/fl/upload_test.go
+++ b/internal/trackers/impl/standalone/fl/upload_test.go
@@ -216,6 +216,27 @@ func TestEnsureLoginCookieStorageAvailableRequiresWebAuth(t *testing.T) {
 	}
 }
 
+func TestSubmitPreparedUploadPreservesLateHTMLFailure(t *testing.T) {
+	t.Parallel()
+
+	const detail = "FL rejected the torrent after validation"
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body: io.NopCloser(strings.NewReader(
+				"<html><body>" + strings.Repeat("padding ", 10*1024) + `<div class="alert-danger">` + detail + "</div></body></html>",
+			)),
+			Request: req,
+		}, nil
+	})}
+
+	_, err := submitPreparedUpload(t.Context(), trackers.PreparationInput{}, client, nil, "application/octet-stream")
+	if err == nil || !strings.Contains(err.Error(), detail) {
+		t.Fatalf("expected late HTML error detail, got %v", err)
+	}
+}
+
 func newFLAuthTestDB(t *testing.T) string {
 	t.Helper()
 

--- a/internal/trackers/impl/standalone/hdb/upload.go
+++ b/internal/trackers/impl/standalone/hdb/upload.go
@@ -19,8 +19,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/html"
-
 	"github.com/autobrr/upbrr/internal/config"
 	pathutil "github.com/autobrr/upbrr/internal/pathing"
 	"github.com/autobrr/upbrr/internal/providerid"
@@ -194,15 +192,11 @@ func submitPreparedUpload(ctx context.Context, req trackers.PreparationInput, st
 	}
 	matches := hdbSuccessURLPattern.FindStringSubmatch(finalURL)
 	if len(matches) < 2 {
-		const responseLimit = 1 << 20
-		body, readErr := io.ReadAll(io.LimitReader(resp.Body, responseLimit+1))
-		detail := extractHDBUploadError(body[:min(len(body), responseLimit)])
-		if readErr != nil {
-			detail = "response body read failed; " + detail
-		} else if len(body) > responseLimit {
-			detail = "response exceeded 1 MiB; " + detail
+		_, responsePreview, _ := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
+		if len(responsePreview) == 0 {
+			responsePreview = []byte("no readable error message in upload response")
 		}
-		return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("HDB", resp.StatusCode, finalURL, []byte(detail))
+		return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("HDB", resp.StatusCode, finalURL, responsePreview)
 	}
 
 	torrentID := strings.TrimSpace(matches[1])
@@ -238,59 +232,6 @@ func submitPreparedUpload(ctx context.Context, req trackers.PreparationInput, st
 			TorrentPath: trackerTorrentPath,
 		}},
 	}, nil
-}
-
-func extractHDBUploadError(body []byte) string {
-	doc, err := html.Parse(bytes.NewReader(body))
-	if err != nil {
-		return "could not parse upload response"
-	}
-	var visible, messages strings.Builder
-	var visit func(*html.Node, bool)
-	visit = func(node *html.Node, isError bool) {
-		if node.Type == html.ElementNode {
-			switch node.Data {
-			case "head", "script", "style", "nav", "header", "footer", "input", "textarea", "select", "button", "noscript", "template":
-				return
-			}
-			for _, attr := range node.Attr {
-				if attr.Key == "hidden" || (attr.Key == "aria-hidden" && attr.Val == "true") {
-					return
-				}
-				if attr.Key == "role" && attr.Val == "alert" {
-					isError = true
-				}
-				if attr.Key == "class" || attr.Key == "id" {
-					for token := range strings.FieldsSeq(strings.ToLower(attr.Val)) {
-						switch token {
-						case "error", "errors", "error-message", "error_message", "alert-danger", "alert-error":
-							isError = true
-						}
-					}
-				}
-			}
-		}
-		if node.Type == html.TextNode {
-			visible.WriteString(node.Data)
-			visible.WriteByte(' ')
-			if isError {
-				messages.WriteString(node.Data)
-				messages.WriteByte(' ')
-			}
-		}
-		for child := node.FirstChild; child != nil; child = child.NextSibling {
-			visit(child, isError)
-		}
-	}
-	visit(doc, false)
-	detail := strings.Join(strings.Fields(messages.String()), " ")
-	if detail == "" {
-		detail = strings.Join(strings.Fields(visible.String()), " ")
-	}
-	if detail == "" {
-		return "no readable error message in upload response"
-	}
-	return detail
 }
 
 func buildUploadFields(

--- a/internal/trackers/impl/standalone/hdb/upload.go
+++ b/internal/trackers/impl/standalone/hdb/upload.go
@@ -192,11 +192,11 @@ func submitPreparedUpload(ctx context.Context, req trackers.PreparationInput, st
 	}
 	matches := hdbSuccessURLPattern.FindStringSubmatch(finalURL)
 	if len(matches) < 2 {
-		_, responsePreview, _ := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
+		_, responsePreview, readErr := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
 		if len(responsePreview) == 0 {
 			responsePreview = []byte("no readable error message in upload response")
 		}
-		return api.UploadSummary{}, commonhttp.UploadHTTPErrorWithURL("HDB", resp.StatusCode, finalURL, responsePreview)
+		return api.UploadSummary{}, errors.Join(commonhttp.UploadHTTPErrorWithURL("HDB", resp.StatusCode, finalURL, responsePreview), readErr)
 	}
 
 	torrentID := strings.TrimSpace(matches[1])

--- a/internal/trackers/impl/standalone/hdb/upload_response_test.go
+++ b/internal/trackers/impl/standalone/hdb/upload_response_test.go
@@ -61,7 +61,7 @@ func TestSubmitPreparedUploadErrorResponse(t *testing.T) {
 			defer server.Close()
 			summary, err := submitPreparedUpload(t.Context(), trackers.PreparationInput{}, preparedUploadState{
 				uploadURL: server.URL + hdbUploadPath,
-				client: server.Client(),
+				client:    server.Client(),
 			})
 			want := "trackers: HDB upload failed status=200 url=" + server.URL + hdbUploadPath + ": " + tt.want
 			if err == nil || err.Error() != want {

--- a/internal/trackers/impl/standalone/hdb/upload_response_test.go
+++ b/internal/trackers/impl/standalone/hdb/upload_response_test.go
@@ -4,6 +4,7 @@
 package hdb
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,31 @@ import (
 
 	"github.com/autobrr/upbrr/internal/trackers"
 )
+
+func TestSubmitPreparedUploadPreservesPartialResponseCause(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "200")
+		_, _ = io.WriteString(w, `<div class="error">Invalid category</div>`)
+	}))
+	defer server.Close()
+	summary, err := submitPreparedUpload(t.Context(), trackers.PreparationInput{}, preparedUploadState{
+		uploadURL: server.URL + hdbUploadPath,
+		client:    server.Client(),
+	})
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("partial response lost read cause: %v", err)
+	}
+	for _, want := range []string{"HDB upload failed status=200", server.URL + hdbUploadPath, "Invalid category", "response body read failed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("partial response lost %q: %v", want, err)
+		}
+	}
+	if summary.Uploaded != 0 || len(summary.UploadedTorrents) != 0 {
+		t.Fatalf("partial response returned registration authority: %+v", summary)
+	}
+}
 
 func TestSubmitPreparedUploadErrorResponse(t *testing.T) {
 	for _, tt := range []struct {

--- a/internal/trackers/impl/standalone/hds/upload.go
+++ b/internal/trackers/impl/standalone/hds/upload.go
@@ -125,7 +125,11 @@ func submitPreparedUpload(
 	}
 
 	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.Runtime.DBPath, "HDS", "upload_failure", result.Preview, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("HDS", result.StatusCode, result.Preview)
+	errorResponse := result.Preview
+	if result.Success {
+		errorResponse = result.Body
+	}
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("HDS", result.StatusCode, errorResponse)
 }
 
 func buildUploadPreview(state uploadState) api.TrackerDryRunEntry {

--- a/internal/trackers/impl/standalone/hdt/upload.go
+++ b/internal/trackers/impl/standalone/hdt/upload.go
@@ -127,7 +127,11 @@ func submitPreparedUpload(
 		}, nil
 	}
 	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.Runtime.DBPath, "HDT", "upload_failure", result.Preview, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("HDT", result.StatusCode, result.Preview)
+	errorResponse := result.Preview
+	if result.Success {
+		errorResponse = result.Body
+	}
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("HDT", result.StatusCode, errorResponse)
 }
 
 func buildUploadPreview(state uploadState) api.TrackerDryRunEntry {

--- a/internal/trackers/impl/standalone/is/upload.go
+++ b/internal/trackers/impl/standalone/is/upload.go
@@ -141,7 +141,11 @@ func submitPreparedUpload(
 		return api.UploadSummary{Uploaded: 1}, nil
 	}
 	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.Runtime.DBPath, "IS", "upload_failure", responsePreview, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("IS", resp.StatusCode, responsePreview)
+	errorResponse := responsePreview
+	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+		errorResponse = responseBody
+	}
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("IS", resp.StatusCode, errorResponse)
 }
 
 func successfulUploadResponse(finalURL string, responseBody string) (string, bool) {

--- a/internal/trackers/impl/standalone/ptp/upload.go
+++ b/internal/trackers/impl/standalone/ptp/upload.go
@@ -117,10 +117,6 @@ func submitPreparedUpload(
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
 	}
-	_, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, resp.StatusCode == http.StatusOK, commonhttp.DefaultResponsePreviewBytes)
-	if err != nil {
-		return api.UploadSummary{}, fmt.Errorf("trackers: PTP read upload response: %w", err)
-	}
 	if matches := ptpSuccessPattern.FindStringSubmatch(finalURL); len(matches) == 3 {
 		groupID := strings.TrimSpace(matches[1])
 		torrentID := strings.TrimSpace(matches[2])
@@ -139,16 +135,17 @@ func submitPreparedUpload(
 		}, nil
 	}
 
+	_, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: PTP read upload response: %w", err)
+	}
 	failurePath := ""
 	if pathValue, pathErr := resolveFailurePath(req.Meta, req.Runtime.DBPath); pathErr == nil {
 		failurePath = pathValue
 		redactedBody := []byte(redaction.RedactValue(string(responsePreview), nil))
 		_ = os.WriteFile(failurePath, redactedBody, 0o600)
 	}
-	errText := commonhttp.RedactErrorDetail(extractAlertError(string(responsePreview)))
-	if errText == "" {
-		errText = commonhttp.ExtractHTTPErrorDetail(responsePreview)
-	}
+	errText := commonhttp.ExtractHTTPErrorDetail(responsePreview)
 	if errText == "" {
 		errText = "upload failed"
 	}
@@ -559,37 +556,6 @@ func resolveGroupTitleYear(meta api.UploadSubject) (string, string) {
 		return title, ""
 	}
 	return title, strconv.Itoa(year)
-}
-
-func extractAlertError(body string) string {
-	start := strings.Index(body, `alert alert--error`)
-	if start == -1 {
-		return ""
-	}
-	segment := body[start:]
-	end := strings.Index(segment, "</div>")
-	if end != -1 {
-		segment = segment[:end]
-	}
-	return stripTags(segment)
-}
-
-func stripTags(value string) string {
-	inTag := false
-	var builder strings.Builder
-	for _, r := range value {
-		switch r {
-		case '<':
-			inTag = true
-		case '>':
-			inTag = false
-		default:
-			if !inTag {
-				builder.WriteRune(r)
-			}
-		}
-	}
-	return strings.Join(strings.Fields(builder.String()), " ")
 }
 
 func compactError(value string) string {

--- a/internal/trackers/impl/standalone/ptp/upload_test.go
+++ b/internal/trackers/impl/standalone/ptp/upload_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/autobrr/upbrr/internal/config"
 	cookiepkg "github.com/autobrr/upbrr/internal/cookies"
 	servicedb "github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -691,6 +692,36 @@ func TestLoginAndFetchAntiCsrfTokenClassifiesHTMLResponseWithoutDecodeNoise(t *t
 	}
 	if strings.Contains(err.Error(), "invalid character") || strings.Contains(err.Error(), "temporary outage") {
 		t.Fatalf("HTML-response error exposed parser or remote-body detail: %v", err)
+	}
+}
+
+func TestSubmitPreparedUploadPreservesLateHTMLFailure(t *testing.T) {
+	t.Parallel()
+
+	const detail = "PTP rejected the torrent after validation"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte("<html><body>" + strings.Repeat("padding ", 10*1024) + `<div class="alert alert--error">` + detail + `<textarea>private-description</textarea><script>private-script</script></div></body></html>`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := submitPreparedUpload(
+		t.Context(),
+		trackers.PreparationInput{},
+		uploadState{
+baseURL: server.URL,
+ uploadURL: server.URL,
+ client: server.Client(),
+},
+		nil,
+		"application/octet-stream",
+		"",
+	)
+	if err == nil || !strings.Contains(err.Error(), detail) {
+		t.Fatalf("expected late HTML error detail, got %v", err)
+	}
+	if strings.Contains(err.Error(), "private-description") || strings.Contains(err.Error(), "private-script") || strings.Contains(err.Error(), "padding") {
+		t.Fatalf("error included content outside the visible alert: %v", err)
 	}
 }
 

--- a/internal/trackers/impl/standalone/pts/upload.go
+++ b/internal/trackers/impl/standalone/pts/upload.go
@@ -126,7 +126,11 @@ func submitPreparedUpload(
 	}
 
 	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.Runtime.DBPath, "PTS", "upload_failure", responsePreview, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("PTS", resp.StatusCode, responsePreview)
+	errorResponse := responsePreview
+	if resp.StatusCode == http.StatusFound || resp.StatusCode == http.StatusSeeOther {
+		errorResponse = responseBody
+	}
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("PTS", resp.StatusCode, errorResponse)
 }
 
 func buildUploadPreview(state uploadState) api.TrackerDryRunEntry {

--- a/internal/trackers/impl/standalone/thr/dupe.go
+++ b/internal/trackers/impl/standalone/thr/dupe.go
@@ -134,14 +134,14 @@ func thrLogin(ctx context.Context, client *http.Client, baseURL, username, passw
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
 		_, detail, readErr := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
 		if readErr != nil {
-			return nil, fmt.Errorf("read THR login failure: %w", readErr)
+			return nil, fmt.Errorf("read THR login failure status=%d: %w", resp.StatusCode, readErr)
 		}
 		return nil, fmt.Errorf("THR login failed status=%d: %s", resp.StatusCode, detail)
 	}
 	if len(resp.Cookies()) == 0 {
 		_, detail, readErr := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
 		if readErr != nil {
-			return nil, fmt.Errorf("read THR login failure: %w", readErr)
+			return nil, fmt.Errorf("read THR login failure status=%d: %w", resp.StatusCode, readErr)
 		}
 		return nil, fmt.Errorf("THR login failed: no cookies returned: %s", detail)
 	}

--- a/internal/trackers/impl/standalone/thr/dupe.go
+++ b/internal/trackers/impl/standalone/thr/dupe.go
@@ -5,7 +5,6 @@ package thr
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -133,10 +132,18 @@ func thrLogin(ctx context.Context, client *http.Client, baseURL, username, passw
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
+		_, detail, readErr := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
+		if readErr != nil {
+			return nil, fmt.Errorf("read THR login failure: %w", readErr)
+		}
+		return nil, fmt.Errorf("THR login failed status=%d: %s", resp.StatusCode, detail)
 	}
 	if len(resp.Cookies()) == 0 {
-		return nil, errors.New("no cookies returned")
+		_, detail, readErr := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
+		if readErr != nil {
+			return nil, fmt.Errorf("read THR login failure: %w", readErr)
+		}
+		return nil, fmt.Errorf("THR login failed: no cookies returned: %s", detail)
 	}
 	return resp.Cookies(), nil
 }

--- a/internal/trackers/impl/standalone/thr/dupe_response_test.go
+++ b/internal/trackers/impl/standalone/thr/dupe_response_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package thr
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDuplicateLoginPreservesHTMLFailureDetail(t *testing.T) {
+	t.Parallel()
+	for _, status := range []int{http.StatusForbidden, http.StatusOK} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.Method == http.MethodGet {
+					_, _ = io.WriteString(w, `<form><input name="token" value="synthetic"></form>`)
+					return
+				}
+				w.WriteHeader(status)
+				_, _ = io.WriteString(w, `<head><script>`+strings.Repeat("private-script ", 6000)+`</script></head><div class="error">Login unavailable</div>`)
+			}))
+			defer server.Close()
+			cookies, err := thrLogin(t.Context(), server.Client(), server.URL, "synthetic-user", "synthetic-password")
+			if err == nil || len(cookies) != 0 || !strings.Contains(err.Error(), "Login unavailable") || strings.Contains(err.Error(), "private-script") {
+				t.Fatalf("cookies=%v error=%v", cookies, err)
+			}
+		})
+	}
+}

--- a/internal/trackers/impl/standalone/thr/upload.go
+++ b/internal/trackers/impl/standalone/thr/upload.go
@@ -109,7 +109,7 @@ func submitPreparedUpload(
 
 	_, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
 	if err != nil {
-		return api.UploadSummary{}, fmt.Errorf("trackers: THR read upload response: %w", err)
+		return api.UploadSummary{}, fmt.Errorf("trackers: THR read upload response status=%d: %w", resp.StatusCode, err)
 	}
 	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.Runtime.DBPath, "THR", "upload_failure", responsePreview, ".html")
 	return api.UploadSummary{}, commonhttp.UploadHTTPError("THR", resp.StatusCode, responsePreview)

--- a/internal/trackers/impl/standalone/thr/upload.go
+++ b/internal/trackers/impl/standalone/thr/upload.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -88,8 +87,6 @@ func submitPreparedUpload(
 		return api.UploadSummary{}, fmt.Errorf("trackers: THR upload request: %w", err)
 	}
 	defer resp.Body.Close()
-	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
-
 	finalURL := ""
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalURL = resp.Request.URL.String()
@@ -110,8 +107,12 @@ func submitPreparedUpload(
 		}}}, nil
 	}
 
-	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.Runtime.DBPath, "THR", "upload_failure", bodyBytes, ".html")
-	return api.UploadSummary{}, commonhttp.UploadHTTPError("THR", resp.StatusCode, bodyBytes)
+	_, responsePreview, err := commonhttp.ReadUploadResponseBody(resp, false, commonhttp.DefaultResponsePreviewBytes)
+	if err != nil {
+		return api.UploadSummary{}, fmt.Errorf("trackers: THR read upload response: %w", err)
+	}
+	_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.Runtime.DBPath, "THR", "upload_failure", responsePreview, ".html")
+	return api.UploadSummary{}, commonhttp.UploadHTTPError("THR", resp.StatusCode, responsePreview)
 }
 
 func buildUploadPreview(state uploadState) api.TrackerDryRunEntry {

--- a/internal/trackers/impl/standalone/thr/upload_test.go
+++ b/internal/trackers/impl/standalone/thr/upload_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackers"
 )
 
 func TestLoginSessionBootstrapsHiddenFieldsAndFollowsRedirect(t *testing.T) {
@@ -161,4 +164,40 @@ func TestLoginSessionRejectsWeakAuthenticatedMarkers(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSubmitPreparedUploadPreservesLateNonSuccessHTMLFailure(t *testing.T) {
+	t.Parallel()
+
+	const detail = "THR rejected the torrent after validation"
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Header:     make(http.Header),
+			Body: io.NopCloser(strings.NewReader(
+				"<html><body>" + strings.Repeat("padding ", 10*1024) + `<div class="alert-danger">` + detail + "</div></body></html>",
+			)),
+			Request: req,
+		}, nil
+	})}
+
+	_, err := submitPreparedUpload(
+		t.Context(),
+		trackers.PreparationInput{},
+		uploadState{},
+		client,
+		nil,
+		"application/octet-stream",
+		"",
+		"",
+	)
+	if err == nil || !strings.Contains(err.Error(), detail) {
+		t.Fatalf("expected late HTML error detail, got %v", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
 }

--- a/internal/trackers/impl/standalone/tl/upload.go
+++ b/internal/trackers/impl/standalone/tl/upload.go
@@ -106,7 +106,11 @@ func submitPreparedUpload(
 	}
 	if torrentID == "" {
 		_, _ = commonhttp.WriteFailureArtifact(req.Meta, req.Runtime.DBPath, "TL", "upload_failure", responsePreview, ".html")
-		return api.UploadSummary{}, commonhttp.UploadHTTPError("TL", resp.StatusCode, responsePreview)
+		errorResponse := responsePreview
+		if successCandidate {
+			errorResponse = responseBody
+		}
+		return api.UploadSummary{}, commonhttp.UploadHTTPError("TL", resp.StatusCode, errorResponse)
 	}
 
 	urlValue := torrentURL + torrentID


### PR DESCRIPTION
HTML trackers can place validation errors after large page headers or return them with HTTP 200. Truncated response previews and generic autofill errors hid those messages. Fixes #441.

The shared HTTP error extractor now scans up to 1 MiB, prefers visible error or alert containers, and excludes executable content, hidden elements, navigation, and form controls. It decodes entities before redaction and retains JSON and plain-text error handling. Partial reads and oversized responses produce explicit diagnostics. Successful response bodies remain available to existing parsers and artifact handling.

HDB and PTP use the shared extraction path. HTML upload adapters preserve response detail before preview truncation, while shared HTML search requests and the FileList/legacy THR paths retain diagnostic causes. BTN autofill errors identify the lookup mode, HTTP status, and failed fields. Explicit failures use marked error containers and fall back to the actual Autofill Fail field marker when the form provides no explanation, excluding unrelated upload instructions. Error wrapping preserves explicit failure and read-cause identities. Existing registration detection, authentication classifications, and duplicate decisions remain authoritative.

Validation covers late HTML errors, native PTP alerts, excluded controls and scripts, entity-encoded secrets, malformed and empty responses, oversized and partial responses, JSON compatibility, successful artifacts, and BTN preparation error propagation. Full Go race tests, repository lint, log policy, changed-package modernization checks, and backend build pass. CodeRabbit CLI --agent, Ponytail, source documentation, and independent correctness review cover the change.

A controlled local integration retry covers BTN cases TV-480, TV-576, and TV-720. All three still fail autofill, but now report lookup=release_name status=200 fields=artist: Autofill Fail without unrelated form instructions. Separate response inspection found an empty error container and no additional server explanation. The run completes cleanup with no image uploads, tracker submissions, or client mutations. CI tests pass on Linux, macOS, and Windows.
