### PR TITLE
fix(workflow): avoid cancellation checkpoint races

### DIFF
--- a/internal/releaseworkflow/module.go
+++ b/internal/releaseworkflow/module.go
@@ -1430,6 +1430,22 @@ func (m *Module) mutateOperation(
 	operationID api.WorkflowOperationID,
 	mutate func(*api.WorkflowOperationStatus),
 ) (api.WorkflowOperationStatus, error) {
+	return m.mutateOperationIf(ctx, ownerID, workflowID, operationID, func(status *api.WorkflowOperationStatus) bool {
+		mutate(status)
+		return true
+	})
+}
+
+// mutateOperationIf runs mutate under the operation lock. Returning false
+// discards the mutation and returns the prior status without writing a receipt,
+// checkpoint, or events.
+func (m *Module) mutateOperationIf(
+	ctx context.Context,
+	ownerID string,
+	workflowID api.WorkflowID,
+	operationID api.WorkflowOperationID,
+	mutate func(*api.WorkflowOperationStatus) bool,
+) (api.WorkflowOperationStatus, error) {
 	lock := m.operationLock(operationID)
 	lock.Lock()
 	defer lock.Unlock()
@@ -1444,7 +1460,9 @@ func (m *Module) mutateOperation(
 		return api.WorkflowOperationStatus{}, err
 	}
 	record.Status.Events = nil
-	mutate(&record.Status)
+	if !mutate(&record.Status) {
+		return previousStatus, nil
+	}
 	record.Status.Sequence = expectedSequence + 1
 	record.Status.UpdatedAt = m.clock.Now().UTC()
 	ownsWorkLease := record.ProcessEpoch == m.processEpoch
@@ -2204,6 +2222,8 @@ func (m *Module) waitForOperationCleanup(ctx context.Context, operationID api.Wo
 }
 
 // CancelOperation requests cancellation of one active owner-scoped operation.
+// If the operation finishes before the cancellation message is saved, its
+// terminal status is returned unchanged.
 func (m *Module) CancelOperation(
 	ctx context.Context,
 	ownerID string,
@@ -2226,8 +2246,12 @@ func (m *Module) CancelOperation(
 	if worker.cancel != nil {
 		worker.cancel()
 	}
-	return m.mutateOperation(ctx, record.OwnerID, workflowID, operationID, func(status *api.WorkflowOperationStatus) {
+	return m.mutateOperationIf(ctx, record.OwnerID, workflowID, operationID, func(status *api.WorkflowOperationStatus) bool {
+		if !workflowOperationActive(status.Status) {
+			return false
+		}
 		status.Message = "Cancellation requested."
+		return true
 	})
 }
 

--- a/internal/releaseworkflow/module_test.go
+++ b/internal/releaseworkflow/module_test.go
@@ -5,6 +5,7 @@ package releaseworkflow
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -3134,6 +3135,86 @@ func TestModuleOperationCancellationIsIdempotent(t *testing.T) {
 	}
 	if repeated.Sequence != terminal.Sequence || repeated.Status != api.StageStatusCanceled {
 		t.Fatalf("idempotent cancel = %#v, terminal=%#v", repeated, terminal)
+	}
+}
+
+func TestModuleCancellationPreservesRacingTerminalOperation(t *testing.T) {
+	t.Parallel()
+	for _, cancelFirst := range []bool{true, false} {
+		t.Run(fmt.Sprintf("cancel_first=%t", cancelFirst), func(t *testing.T) {
+			t.Parallel()
+			started := make(chan struct{})
+			release := make(chan struct{})
+			base := testPreparer()
+			preparer := ReleasePreparerFunc{
+				PrepareFunc: func(ctx context.Context, input api.PrepareInput) (api.PrepareResult, error) {
+					close(started)
+					select {
+					case <-ctx.Done():
+						return api.PrepareResult{}, fmt.Errorf("wait for cancellation: %w", ctx.Err())
+					case <-release:
+						return base.Prepare(ctx, input)
+					}
+				},
+				DisplayFunc:   base.ResolveDisplay,
+				SubjectFunc:   base.ResolveUploadSubject,
+				DuplicateFunc: base.ResolveDuplicateSubject,
+			}
+			module, repository := newTestModule(t, preparer)
+			created := executeCommand(t, module, CreateWorkflowCommand{})
+			operation, err := module.Start(t.Context(), testOwnerID, PrepareReleaseCommand{
+				WorkflowID:       created.Workflow.ID,
+				ExpectedRevision: created.Workflow.Revision,
+				Input:            api.PrepareInput{SourcePath: "source"},
+				IdempotencyKey:   "cancel-racing-terminal",
+			})
+			if err != nil {
+				t.Fatalf("start operation: %v", err)
+			}
+			<-started
+			module.operationWorkersMu.Lock()
+			worker := module.operationWorkers[operation.ID]
+			cancel := worker.cancel
+			worker.cancel = func() {
+				// Force completion after cancellation's initial active-state read,
+				// but before it can publish the cancellation-request message.
+				if cancelFirst {
+					cancel()
+				} else {
+					close(release)
+				}
+				<-worker.done
+			}
+			module.operationWorkers[operation.ID] = worker
+			module.operationWorkersMu.Unlock()
+			t.Cleanup(cancel)
+
+			status, err := module.CancelOperation(t.Context(), testOwnerID, created.Workflow.ID, operation.ID)
+			if err != nil {
+				t.Fatalf("cancel racing terminal operation: %v", err)
+			}
+			wantStatus := api.StageStatusCompleted
+			if cancelFirst {
+				wantStatus = api.StageStatusCanceled
+			}
+			if status.Status != wantStatus {
+				t.Fatalf("cancel status = %s, want %s", status.Status, wantStatus)
+			}
+			work, err := repository.LoadWork(t.Context(), testOwnerID, created.Workflow.ID, operation.ID)
+			if err != nil {
+				t.Fatalf("load terminal checkpoint: %v", err)
+			}
+			var checkpoint api.WorkflowOperationStatus
+			if err := json.Unmarshal(work.Checkpoint, &checkpoint); err != nil {
+				t.Fatalf("decode terminal checkpoint: %v", err)
+			}
+			// Events are appended after the durable checkpoint is written.
+			status.Events = nil
+			checkpoint.Events = nil
+			if !reflect.DeepEqual(status, checkpoint) {
+				t.Fatalf("cancel changed terminal receipt: got %#v, want %#v", status, checkpoint)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Canceling a workflow operation can race with its worker finishing. The cancellation path then rewrites the terminal receipt and tries to checkpoint completed work, returning an operation conflict. This caused the intermittent `TestModuleOperationCancellationIsIdempotent` failure in [PR #417's Ubuntu run](https://github.com/autobrr/upbrr/actions/runs/34196786003/job/101966178409).

Recheck whether the operation is active under the existing operation lock. If completion wins, return the terminal status without changing the receipt, checkpoint, sequence, or events. A conditional mutation path preserves the existing behavior of other operation updates. Doc comments describe this cancellation contract.

The regression test forces both canceled and successfully completed outcomes to finish between cancellation's initial read and its update. Both cases fail on the previous implementation and pass with the fix. The original idempotency test also passes repeated race runs.

Validation passes: `make test-go`, `make lint`, `make logpolicy`, `make backend`, `make gofix-check-changed`, and `git diff --check`. CodeRabbit CLI reviewed all changes against main with zero findings; Ponytail found no simplifications. Subsequent edits only add doc comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved operation cancellation handling when cancellation occurs at the same time as operation completion.
  - Prevented cancellation messages and state updates from overwriting an operation that has already reached a terminal status.
  - Ensured the reported operation status remains consistent with its saved terminal state and event history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->