### PR TITLE
chore(live-testing): cache multidisc BDInfo and preserve resume selections

### DIFF
--- a/scripts/live-testing/README.md
+++ b/scripts/live-testing/README.md
@@ -157,7 +157,7 @@ pwsh -NoProfile -File .\scripts\live-testing\run.ps1 -Suite Screenshots -CaseId 
 pwsh -NoProfile -File .\scripts\live-testing\run.ps1 -Suite Screenshots -CaseId MY-BD-DISC
 ```
 
-Only explicit five-digit MPLS filenames are accepted; no playlist is chosen by
+Only explicit playlist selections are accepted; no playlist is chosen by
 size or guessed from the folder name. Changing directory membership, file sizes
 or timestamps requires reviewing and recording the selection again. A fresh
 run passes the selection through the production preparation instructions and
@@ -165,11 +165,22 @@ checks the prepared playlist list. Duplicate, tracker and image-host gates still
 apply. Identical sanitized temporary basenames for different sources require
 separate runs, including two inputs both ending in `BDMV`.
 
+For a multidisc Blu-ray collection, point `input_path` at the collection parent.
+Use the exact disc-scoped option values from the accepted production playlist
+question in `bdmv_selection.playlists`: each value has the form
+`disc-<64-lowercase-hex-digits>:00000.MPLS`. Keep the selection bound to the reviewed
+collection fingerprint. At least one playlist must be selected for every disc;
+plain filenames are accepted only when the source contains one Blu-ray disc.
+Preflight checks each disc identity and playlist against the current layout.
+Repeated filenames on different discs remain separate selections.
+
 The first preparation scans the selected playlists with production BDInfo and
-saves its quick, extended and full reports under
+saves every disc's quick, extended and full reports under
 `%LOCALAPPDATA%\upbrr-live-testing\bdinfo`. Later runs validate report hashes and
-restore those files into their own private profile before preparation. They
-recollect release facts while the production metadata service reuses the reports.
+restore those files into the matching per-disc directories in their own private
+profile before preparation. Single-disc sources use the same namespaced layout.
+The runner recollects release facts while the production metadata service reuses
+the reports.
 The cache survives run cleanup and is keyed by source membership/stat evidence,
 playlist order, dependency lockfiles and the BDInfo scanner/report parser and
 artifact-layout source.

--- a/scripts/live-testing/README.md
+++ b/scripts/live-testing/README.md
@@ -171,6 +171,8 @@ question in `bdmv_selection.playlists`: each value has the form
 `disc-<64-lowercase-hex-digits>:00000.MPLS`. Keep the selection bound to the reviewed
 collection fingerprint. At least one playlist must be selected for every disc;
 plain filenames are accepted only when the source contains one Blu-ray disc.
+A source with one Blu-ray disc requires plain filenames; disc-scoped values are
+rejected with `bdmv_disc_scope_unexpected`.
 Preflight checks each disc identity and playlist against the current layout.
 Repeated filenames on different discs remain separate selections.
 

--- a/scripts/live-testing/bdinfo.ps1
+++ b/scripts/live-testing/bdinfo.ps1
@@ -8,11 +8,61 @@ function Get-CaseBDMVPlaylists($Case) {
       $selection.playlists -isnot [System.Collections.IList] -or $selection.playlists.Count -eq 0 -or
       $selection.source_fingerprint -isnot [string] -or $selection.source_fingerprint -cnotmatch '^[a-f0-9]{64}$') { throw 'corpus_bdmv_selection_invalid' }
   $seen = @{}
+  $scoped = $null
   foreach ($playlist in $selection.playlists) {
-    if ($playlist -isnot [string] -or $playlist -notmatch '^[0-9]{5}\.mpls$' -or $seen.ContainsKey($playlist)) { throw 'corpus_bdmv_selection_invalid' }
+    if ($playlist -isnot [string] -or $playlist -cnotmatch '^(disc-[a-f0-9]{64}:)?[0-9]{5}\.[mM][pP][lL][sS]$' -or $seen.ContainsKey($playlist)) { throw 'corpus_bdmv_selection_invalid' }
+    $hasDisc = $playlist.Contains(':')
+    if ($null -ne $scoped -and $scoped -ne $hasDisc) { throw 'corpus_bdmv_selection_invalid' }
+    $scoped = $hasDisc
     $seen[$playlist] = $true
-    $playlist.ToUpperInvariant()
+    if ($hasDisc) { $parts = $playlist.Split(':'); $parts[0] + ':' + $parts[1].ToUpperInvariant() }
+    else { $playlist.ToUpperInvariant() }
   }
+}
+
+function Get-CaseBDMVDiscs($Case) {
+  $source = [IO.Path]::GetFullPath($Case.input_path)
+  $pending = [Collections.Generic.Stack[string]]::new()
+  $pending.Push($source)
+  while ($pending.Count -gt 0) {
+    $directory = $pending.Pop()
+    if ((Get-Item -LiteralPath $directory -Force).Attributes -band [IO.FileAttributes]::ReparsePoint) { throw 'source_membership_reparse_point' }
+    $name = [IO.Path]::GetFileName($directory.TrimEnd('\', '/'))
+    if ($name -ieq 'BDMV') {
+      $relative = [IO.Path]::GetRelativePath($source, $directory)
+      if ($relative -eq '.') { $relative = $name }
+      # Match sourcelayout.newDiscoveredDisc and layout.DiscTempDir.
+      $id = 'disc-' + (Get-TextHash ('BDMV' + [char]0 + $relative.Replace('\', '/').ToLowerInvariant()))
+      @{ id = $id; root = $directory }
+      continue
+    }
+    if ($name -iin @('VIDEO_TS', 'HVDVD_TS')) { continue }
+    foreach ($child in @(Get-ChildItem -LiteralPath $directory -Directory -Force)) { $pending.Push($child.FullName) }
+  }
+}
+
+function Get-CaseBDMVScopedPlaylists($Case) {
+  $playlists = @(Get-CaseBDMVPlaylists $Case)
+  if ($playlists.Count -eq 0) { return }
+  $discs = @(Get-CaseBDMVDiscs $Case)
+  if ($discs.Count -eq 0) { throw 'bdmv_disc_missing' }
+  $selected = @()
+  foreach ($playlist in $playlists) {
+    if ($playlist.Contains(':')) {
+      if ($discs.Count -eq 1) { throw 'bdmv_disc_scope_unexpected' }
+      $parts = $playlist.Split(':')
+      $disc = @($discs | Where-Object id -CEQ $parts[0])
+      if ($disc.Count -ne 1) { throw 'bdmv_disc_missing' }
+      $file = $parts[1]
+    } else {
+      if ($discs.Count -ne 1) { throw 'bdmv_disc_scope_required' }
+      $disc = $discs; $file = $playlist
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $disc[0].root "PLAYLIST/$file") -PathType Leaf)) { throw 'bdmv_playlist_missing' }
+    $selected += $disc[0].id + ':' + $file
+  }
+  if (@($selected | ForEach-Object { $_.Split(':')[0] } | Select-Object -Unique).Count -ne $discs.Count) { throw 'bdmv_disc_selection_incomplete' }
+  $selected
 }
 
 function Get-BDInfoTempName($Case) {
@@ -34,7 +84,9 @@ function Get-BDInfoScannerFingerprint {
 
 function Get-BDInfoReportNames([string[]]$Playlists) {
   foreach ($playlist in $Playlists) {
-    foreach ($prefix in @('BD_SUMMARY_', 'BD_SUMMARY_EXT_', 'BD_SUMMARY_FULL_')) { "${prefix}${playlist}.txt" }
+    if ($playlist -cnotmatch '^(disc-[a-f0-9]{64}):([0-9]{5}\.MPLS)$') { throw 'bdinfo_playlist_key_invalid' }
+    $discID = $Matches[1]; $file = $Matches[2]
+    foreach ($prefix in @('BD_SUMMARY_', 'BD_SUMMARY_EXT_', 'BD_SUMMARY_FULL_')) { "discs/$discID/${prefix}${file}.txt" }
   }
 }
 
@@ -46,26 +98,28 @@ function Get-BDInfoReports($Directory, [string[]]$Playlists, $PrivateRoot) {
     $reports += @{ name = $name; sha256 = (Get-FileHash -LiteralPath $path).Hash }
   }
   foreach ($playlist in $Playlists) {
-    $summary = Get-Content -LiteralPath (Join-Path $Directory "BD_SUMMARY_${playlist}.txt") -Raw
+    $names = @(Get-BDInfoReportNames @($playlist))
+    $file = $playlist.Split(':')[1]
+    $summary = Get-Content -LiteralPath (Join-Path $Directory $names[0]) -Raw
     $matches = [regex]::Matches($summary, '(?mi)^Playlist:\s*([^\r\n]+?)\s*$')
-    if ($matches.Count -ne 1 -or $matches[0].Groups[1].Value.Trim() -ine $playlist) { throw 'bdinfo_report_playlist_mismatch' }
-    if ((Get-Item -LiteralPath (Join-Path $Directory "BD_SUMMARY_FULL_${playlist}.txt")).Length -eq 0) { throw 'bdinfo_full_report_empty' }
+    if ($matches.Count -ne 1 -or $matches[0].Groups[1].Value.Trim() -ine $file) { throw 'bdinfo_report_playlist_mismatch' }
+    if ((Get-Item -LiteralPath (Join-Path $Directory $names[2])).Length -eq 0) { throw 'bdinfo_full_report_empty' }
   }
   $reports
 }
 
 function Restore-BDInfoReports($Entry, $Profile, $PrivateRoot, [string]$ScannerFingerprint) {
-  $playlists = @(Get-CaseBDMVPlaylists $Entry.case)
-  if ($playlists.Count -eq 0) { return }
+  if (@(Get-CaseBDMVPlaylists $Entry.case).Count -eq 0) { return }
   if ((Get-SourceFingerprint $Entry.case).fingerprint -cne $Entry.stat.fingerprint) { throw 'source_changed_during_run' }
-  $key = Get-TextHash ('1|' + $Entry.stat.fingerprint + '|' + $ScannerFingerprint + '|' + ($playlists -join ','))
+  $playlists = @(Get-CaseBDMVScopedPlaylists $Entry.case)
+  $key = Get-TextHash ('2|' + $Entry.stat.fingerprint + '|' + $ScannerFingerprint + '|' + ($playlists -join ','))
   $directory = Assert-PrivatePath (Join-Path $PrivateRoot "bdinfo/$key") $PrivateRoot
   $target = Assert-PrivatePath (Join-Path (Split-Path -Parent $Profile.dbPath) ('tmp/' + (Get-BDInfoTempName $Entry.case))) $Profile.runDir
   $cache = @{ directory = $directory; target = $target; sourceFingerprint = $Entry.stat.fingerprint; scannerFingerprint = $ScannerFingerprint; playlists = $playlists; restored = $false }
   $manifestPath = Assert-PrivatePath (Join-Path $directory 'manifest.private.json') $PrivateRoot
   if (-not (Test-Path -LiteralPath $manifestPath)) { return $cache }
   $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -AsHashtable -NoEnumerate
-  if ($manifest -isnot [System.Collections.IDictionary] -or $manifest.version -isnot [long] -or $manifest.version -ne 1 -or
+  if ($manifest -isnot [System.Collections.IDictionary] -or $manifest.version -isnot [long] -or $manifest.version -ne 2 -or
       $manifest.sourceFingerprint -isnot [string] -or $manifest.sourceFingerprint -cne $cache.sourceFingerprint -or
       $manifest.scannerFingerprint -isnot [string] -or $manifest.scannerFingerprint -cne $ScannerFingerprint -or
       $manifest.playlists -isnot [System.Collections.IList] -or $manifest.playlists.Count -ne $playlists.Count) { throw 'bdinfo_cache_identity_mismatch' }
@@ -83,6 +137,7 @@ function Restore-BDInfoReports($Entry, $Profile, $PrivateRoot, [string]$ScannerF
   New-Item -ItemType Directory -Path $target -Force | Out-Null
   foreach ($report in $reports) {
     $destination = Assert-PrivatePath (Join-Path $target $report.name) $Profile.runDir
+    New-Item -ItemType Directory -Path (Split-Path -Parent $destination) -Force | Out-Null
     Copy-Item -LiteralPath (Join-Path $directory $report.name) -Destination $destination -Force
     if ((Get-FileHash -LiteralPath $destination).Hash -cne $report.sha256) { throw 'bdinfo_cache_report_changed' }
   }
@@ -107,10 +162,11 @@ function Save-BDInfoReports($Cache, $Entry, $PrivateRoot, [string]$BinarySHA256)
   New-Item -ItemType Directory -Path $Cache.directory -Force | Out-Null
   foreach ($report in $reports) {
     $destination = Assert-PrivatePath (Join-Path $Cache.directory $report.name) $PrivateRoot
+    New-Item -ItemType Directory -Path (Split-Path -Parent $destination) -Force | Out-Null
     Copy-Item -LiteralPath (Join-Path $Cache.target $report.name) -Destination $destination -Force
     if ((Get-FileHash -LiteralPath $destination).Hash -cne $report.sha256) { throw 'bdinfo_report_changed_during_save' }
   }
-  $manifest = @{ version = 1; sourceFingerprint = $Cache.sourceFingerprint; scannerFingerprint = $Cache.scannerFingerprint; playlists = $Cache.playlists; reports = $reports; producerBinarySHA256 = $BinarySHA256 }
+  $manifest = @{ version = 2; sourceFingerprint = $Cache.sourceFingerprint; scannerFingerprint = $Cache.scannerFingerprint; playlists = $Cache.playlists; reports = $reports; producerBinarySHA256 = $BinarySHA256 }
   Write-PrivateJson (Join-Path $Cache.directory 'manifest.private.json') $manifest
   $manifest
 }

--- a/scripts/live-testing/functions.ps1
+++ b/scripts/live-testing/functions.ps1
@@ -115,19 +115,13 @@ function Read-Corpus([string]$Path, [string[]]$Selected) {
         if ($entry.fingerprint.fingerprint -cne $stat.fingerprint) {
           $status = 'needs_input'; $reason = 'source_changed_since_inventory'
         }
-        $bdmvRoot = [IO.Path]::GetFullPath($entry.input_path)
-        if ([IO.Path]::GetFileName($bdmvRoot.TrimEnd('\', '/')) -ine 'BDMV') { $bdmvRoot = Join-Path $bdmvRoot 'BDMV' }
         # DVD and episode directories use production preparation without MPLS instructions.
-        # Inspect the layout so a BDMV directory cannot bypass selection through its case shape.
-        if ($entry.bdmv_selection -or (Test-Path -LiteralPath $bdmvRoot -PathType Container)) {
+        # Nested discs also require source-bound, disc-scoped selections.
+        if ($entry.bdmv_selection -or @(Get-CaseBDMVDiscs $entry).Count -gt 0) {
           $playlists = @(Get-CaseBDMVPlaylists $entry)
           if ($playlists.Count -eq 0) { $status = 'needs_input'; $reason = 'source_selection_unconfirmed' }
           elseif ($entry.bdmv_selection.source_fingerprint -cne $stat.fingerprint) { $status = 'needs_input'; $reason = 'source_changed_since_selection' }
-          else {
-            foreach ($playlist in $playlists) {
-              if (-not (Test-Path -LiteralPath (Join-Path $bdmvRoot "PLAYLIST/$playlist") -PathType Leaf)) { throw 'bdmv_playlist_missing' }
-            }
-          }
+          else { $null = @(Get-CaseBDMVScopedPlaylists $entry) }
         }
       }
       @{ case = $entry; stat = $stat; status = $status; reason = $reason }
@@ -463,7 +457,10 @@ function Record-Stage($Lane, $Current, [string]$Goal) {
       }
     }
     if ($Lane.expectedPlaylists -and
-        (@($value.release.Source.SelectedPlaylists | ForEach-Object { ([string]$_.file).ToUpperInvariant() }) -join ',') -cne ($Lane.expectedPlaylists -join ',')) {
+        (@($value.release.Source.SelectedPlaylists | ForEach-Object {
+          $file = ([string]$_.file).ToUpperInvariant()
+          if ($Lane.expectedPlaylists[0].Contains(':')) { ([string]$_.discId) + ':' + $file } else { $file }
+        }) -join ',') -cne ($Lane.expectedPlaylists -join ',')) {
       $status = 'fail'; $reason = 'bdmv_playlist_selection_mismatch'
     }
   }
@@ -491,6 +488,17 @@ function Continue-Lane($Lane, [string]$Goal, $Current, $Intent, $Answers = @()) 
   $remainingAnswers = @()
   foreach ($answer in $Answers) {
     $action = @(Get-PendingActions $Current | Where-Object id -CEQ $answer.actionId)[0]
+    if ($action.kind -eq 'select_playlist') {
+      if ($Answers.Count -ne 1 -or $answer.workflowRevision -ne $Current.workflow.revision -or
+          -not $intentCopy.preparation -or @($answer.selectedValues).Count -eq 0 -or
+          @($answer.selectedValues | Where-Object { $_ -cnotin @($action.options.value) }).Count -gt 0) { throw 'feedback_playlist_answer_invalid' }
+      # Playlist answers replace preparation facts; generic action answers only dismiss the prompt.
+      $instructions = ConvertTo-Json -InputObject $Current.factInstructions.instructions -Depth 100 | ConvertFrom-Json -AsHashtable
+      $instructions.Playlist = @{ Set = $true; Selected = @($answer.selectedValues); UseAll = $false }
+      $intentCopy.preparation.Instructions = $instructions
+      $intentCopy.factInstructions = $instructions
+      continue
+    }
     if ($action.kind -ne 'review_duplicates') { $remainingAnswers += $answer; continue }
     if ($answer.workflowRevision -ne $Current.workflow.revision -or $action.trackerId -cnotin $Lane.trackerIds -or
         @($answer.selectedValues).Count -ne 1 -or $answer.selectedValues[0] -cnotin @('accepted', 'ignored') -or

--- a/scripts/live-testing/run.ps1
+++ b/scripts/live-testing/run.ps1
@@ -129,6 +129,7 @@ try {
       version = 1; runId = $runID; state = 'running'; createdAt = [datetime]::UtcNow.ToString('o')
       buildIdentifier = $buildIdentifier; binaryPath = $script:Binary; binarySha256 = (Get-FileHash -LiteralPath $script:Binary).Hash
       candidate = $candidateAfter; frontend = $assets; tools = $versions; rules = @(Get-RuleState)
+      bdinfoScannerFingerprint = $bdinfoScannerFingerprint
       configFingerprint = $profile.sourceFingerprint; profileConfigSha256 = (Get-FileHash -LiteralPath $profile.configPath).Hash
       configDefaultTrackers = @($profile.defaultTrackers); selectedTrackers = $trackers; trackerScope = $(if ($Tracker) { 'explicit' } else { 'config_defaults' })
       suite = $Suite; caseIds = @($selected); corpusPath = $Corpus; corpusSha256 = $corpusSHA256
@@ -185,41 +186,41 @@ try {
 
     if ($ResumeRun) {
       Write-PrivateJson (Join-Path $script:RunDir ('feedback-input-' + [guid]::NewGuid().ToString('N') + '.private.json')) $script:Feedback
-      foreach ($feedback in @($script:Feedback)) {
-        if (-not $feedback.authority) { continue }
-        $lane = @($script:Lanes | Where-Object laneId -CEQ $feedback.laneId)[0]
-        if (-not $lane -or $lane.sourceFingerprint -cne $feedback.sourceFingerprint) { throw 'feedback_lane_mismatch' }
-        $current = Invoke-LiveAPI 'GetReleaseWorkflow' @{ workflowId = $feedback.authority.workflowId }
-        if ((Resolve-FeedbackAuthority $lane $feedback $current) -eq 'refreshed') {
+      foreach ($feedbackItem in @($script:Feedback)) {
+        if (-not $feedbackItem.authority) { continue }
+        $lane = @($script:Lanes | Where-Object laneId -CEQ $feedbackItem.laneId)[0]
+        if (-not $lane -or $lane.sourceFingerprint -cne $feedbackItem.sourceFingerprint) { throw 'feedback_lane_mismatch' }
+        $current = Invoke-LiveAPI 'GetReleaseWorkflow' @{ workflowId = $feedbackItem.authority.workflowId }
+        if ((Resolve-FeedbackAuthority $lane $feedbackItem $current) -eq 'refreshed') {
           Add-Result $lane.caseId $lane.laneId 'feedback' 'needs_input' 'changed_evidence_requires_acceptance'
           continue
         }
-        if (@($feedback.answers).Count -eq 0) { continue }
-        if (-not $feedback.acceptedAt -or -not $feedback.rationale) { throw 'feedback_acceptance_receipt_missing' }
+        if (@($feedbackItem.answers).Count -eq 0) { continue }
+        if (-not $feedbackItem.acceptedAt -or -not $feedbackItem.rationale) { throw 'feedback_acceptance_receipt_missing' }
         $actions = @(Get-PendingActions $current)
-        foreach ($answer in $feedback.answers) {
+        foreach ($answer in $feedbackItem.answers) {
           $action = @($actions | Where-Object id -CEQ $answer.actionId)[0]
-          $saved = @($feedback.requiredActions | Where-Object id -CEQ $answer.actionId)[0]
+          $saved = @($feedbackItem.requiredActions | Where-Object id -CEQ $answer.actionId)[0]
           if (-not $action -or -not $saved -or $answer.workflowRevision -ne $current.workflow.revision -or (Get-ActionSemantics @($action)) -cne (Get-ActionSemantics @($saved))) { throw 'feedback_action_stale' }
           if ($action.kind -in @('approve_upload', 'authenticate_tracker', 'provide_two_factor', 'reconcile_submission')) { throw 'feedback_action_not_permitted' }
         }
         $intent = @{ executionMode = $script:Run.executionMode; interaction = 'unattended'; trackerIds = $lane.trackerIds; noSeed = $true; skipRemoteDuplicates = [bool]$script:Run.skipRemoteDuplicates }
-        if ($feedback.goal -in @('media_ready', 'descriptions_ready', 'dry_run')) { $intent.media = Get-LiveMediaInstructions $lane $current }
+        if ($feedbackItem.goal -in @('media_ready', 'descriptions_ready', 'dry_run')) { $intent.media = Get-LiveMediaInstructions $lane $current }
         if ($lane.preparation) {
           $intent.preparation = $lane.preparation
           $intent.preparation.Instructions = $current.factInstructions.instructions
           if (@($actions | Where-Object kind -EQ 'reprepare').Count -gt 0) { $intent.preparation.Force = $true }
         }
-        $current = Continue-Lane $lane $feedback.goal $current $intent $feedback.answers
+        $current = Continue-Lane $lane $feedbackItem.goal $current $intent $feedbackItem.answers
         foreach ($completedGoal in @('prepared', 'trackers_assessed', 'duplicates_decided', 'media_ready')) {
-          if ($completedGoal -eq $feedback.goal) { break }
+          if ($completedGoal -eq $feedbackItem.goal) { break }
           $null = Record-Stage $lane $current $completedGoal
         }
-        $status = Record-Stage $lane $current $feedback.goal
+        $status = Record-Stage $lane $current $feedbackItem.goal
         if (@(Get-PendingActions $current).Count -eq 0) {
           $script:Results = @($script:Results | Where-Object { $_.laneId -cne $lane.laneId -or $_.stage -ne 'feedback' })
           $script:Feedback = @($script:Feedback | Where-Object laneId -CNE $lane.laneId)
-          if ($status -eq 'pass') { $current = Resume-Lane $lane $current $feedback.goal }
+          if ($status -eq 'pass') { $current = Resume-Lane $lane $current $feedbackItem.goal }
         }
       }
     } else {

--- a/scripts/live-testing/validate-images.ps1
+++ b/scripts/live-testing/validate-images.ps1
@@ -279,14 +279,14 @@ Assert-ImageCheck (($ownedLanes.laneId -join ',') -ceq 'lane-a,lane-b,lane-pendi
 $script:Lanes = @(@{ caseId = 'EXPLICIT'; laneId = 'explicit-sat'; sat = $true }); $script:Results = @()
 Assert-ImageCheck (Test-LiveContentLane $script:Lanes[0]) 'explicit_sat_content_disabled'
 $feedbackStatement = @($runnerAst.FindAll({ param($node)
-  $node -is [Management.Automation.Language.IfStatementAst] -and $node.Extent.Text.StartsWith('if ($feedback.goal -in')
+  $node -is [Management.Automation.Language.IfStatementAst] -and $node.Extent.Text.StartsWith('if ($feedbackItem.goal -in')
 }, $true))
 Assert-ImageCheck ($feedbackStatement.Count -eq 1) 'feedback_media_binding_missing'
 foreach ($goal in @('prepared', 'trackers_assessed', 'duplicates_decided', 'media_ready', 'descriptions_ready', 'dry_run')) {
   foreach ($count in @(0, 5)) {
     foreach ($coverage in @($false, $true)) {
       $script:Run = @{ suite = 'Full'; imageHostCoverage = $coverage; budgets = @{ screenshotCount = 3 } }
-      $feedback = @{ goal = $goal }; $intent = @{}; $lane = $resumeLane
+      $feedbackItem = @{ goal = $goal }; $intent = @{}; $lane = $resumeLane
       $laterGoal = $goal -in @('media_ready', 'descriptions_ready', 'dry_run')
       $current = $(if ($laterGoal) { @{ projections = @{ projections = @(@{ trackerId = 'NONE'; artifacts = @{ screenshotCount = $count } }) } } } else { @{} })
       . ([scriptblock]::Create($feedbackStatement[0].Extent.Text))

--- a/scripts/live-testing/validate.ps1
+++ b/scripts/live-testing/validate.ps1
@@ -144,6 +144,38 @@ try {
   # Execute the runner's real snapshot/build statements with deterministic edits at
   # read/build boundaries; external processes are replaced only in this child probe.
   $runnerSource = Get-Content -LiteralPath (Join-Path $PSScriptRoot 'run.ps1') -Raw
+  # Execute the real resume loop at script scope, where its iterator must not alias
+  # the retained feedback collection or erase another lane's pending question.
+  $parseTokens = $null; $parseErrors = $null
+  $runnerAST = [System.Management.Automation.Language.Parser]::ParseInput($runnerSource, [ref]$parseTokens, [ref]$parseErrors)
+  $feedbackLoop = $runnerAST.Find({ param($node)
+    $node -is [System.Management.Automation.Language.ForEachStatementAst] -and $node.Condition.Extent.Text -ceq '@($script:Feedback)'
+  }, $true)
+  Assert-Check ([bool]$feedbackLoop) 'resume_feedback_loop_missing'
+  $resumeProbe = Join-Path $validationDir 'resume-feedback-probe.ps1'
+  $resumeHeader = @'
+param($Repo)
+$ErrorActionPreference = 'Stop'
+. (Join-Path $Repo 'scripts/live-testing/functions.ps1')
+$action = @{ id='playlist-1'; kind='select_playlist'; status='pending'; options=@(@{ value='disc-one:00000.MPLS' }) }
+$script:Feedback = @(
+  @{ laneId='lane-answered'; caseId='CASE-ANSWERED'; sourceFingerprint='source'; authority=@{ workflowId='workflow-1' }; goal='prepared'; requiredActions=@($action); answers=@(@{ actionId='playlist-1'; workflowRevision=1; selectedValues=@('disc-one:00000.MPLS') }); acceptedAt='2026-09-08T00:00:00Z'; rationale='Operator selected the retained option.' },
+  @{ laneId='lane-pending'; caseId='CASE-PENDING'; sourceFingerprint='source'; authority=@{ workflowId='workflow-2' }; goal='prepared'; requiredActions=@($action); answers=@() }
+)
+$script:Lanes = @($script:Feedback | ForEach-Object { @{ laneId=$_.laneId; caseId=$_.caseId; sourceFingerprint='source'; trackerIds=@('ULCX') } })
+$script:Run=@{ executionMode='normal'; skipRemoteDuplicates=$false }; $script:Results=@(); $script:ResumedGoals=@()
+function Invoke-LiveAPI { @{ workflow=@{ id='workflow-1'; revision=1; requiredActions=@($action) } } }
+function Resolve-FeedbackAuthority { 'current' }
+function Continue-Lane { @{ workflow=@{ id='workflow-1'; revision=2; requiredActions=@() }; release=@{ id='release-1' } } }
+function Record-Stage { 'pass' }
+function Resume-Lane($Lane,$Current,[string]$CompletedGoal) { $script:ResumedGoals += $CompletedGoal; $Current }
+'@
+  $resumeAssertions = @'
+if ($script:ResumedGoals.Count -ne 1 -or $script:ResumedGoals[0] -cne 'prepared') { throw 'accepted_feedback_goal_lost' }
+if ($script:Feedback.Count -ne 1 -or $script:Feedback[0].laneId -cne 'lane-pending') { throw 'unanswered_feedback_lost' }
+'@
+  [IO.File]::WriteAllText($resumeProbe, $resumeHeader + "`n" + $feedbackLoop.Extent.Text + "`n" + $resumeAssertions)
+  Invoke-OwnedProcess (Get-ToolPath 'pwsh') @('-NoProfile', '-File', $resumeProbe, '-Repo', $script:RepoRoot) (Join-Path $validationDir 'resume-feedback') 30
   $preflightStart = $runnerSource.IndexOf('    $scenariosSHA256 =')
   $preflightEnd = $runnerSource.IndexOf('    # The production temporary layout')
   $buildStart = $runnerSource.IndexOf('    $candidateBefore =')
@@ -243,12 +275,18 @@ exit $LASTEXITCODE
   $profileTwo = @{ runDir = (Join-Path $cacheRoot 'runs/two'); dbPath = (Join-Path $cacheRoot 'runs/two/profile/db.sqlite') }
   New-Item -ItemType Directory -Path $cacheRoot -Force | Out-Null
   $coldCache = Restore-BDInfoReports $discEntry $profileOne $cacheRoot 'scanner-one'
+  $scopedSingle = $disc.Clone()
+  $scopedSingle.bdmv_selection = @{ playlists = @($coldCache.playlists); source_fingerprint = $discStat.fingerprint }
+  $rejected = $false
+  try { Get-CaseBDMVScopedPlaylists $scopedSingle | Out-Null } catch { $rejected = $_.Exception.Message -eq 'bdmv_disc_scope_unexpected' }
+  Assert-Check $rejected 'scoped_single_disc_selection_accepted'
   $binaryOne = (Get-TextHash 'binary-one').ToUpperInvariant()
   $binaryTwo = Get-TextHash 'binary-two'
   Assert-Check (-not $coldCache.restored) 'cold_cache_reported_as_restored'
   Assert-Check (-not (Save-BDInfoReports $coldCache $discEntry $cacheRoot $binaryOne)) 'missing_reports_saved'
   New-Item -ItemType Directory -Path $coldCache.target -Force | Out-Null
-  foreach ($name in @(Get-BDInfoReportNames @('00001.MPLS'))) {
+  foreach ($name in @(Get-BDInfoReportNames $coldCache.playlists)) {
+    New-Item -ItemType Directory -Path (Split-Path -Parent (Join-Path $coldCache.target $name)) -Force | Out-Null
     [IO.File]::WriteAllText((Join-Path $coldCache.target $name), "Playlist: 00001.MPLS`nSynthetic report for cache transport testing.")
   }
   foreach ($invalid in @($null, 'binary-one', ('g' * 64), ($binaryOne + "`n"))) {
@@ -303,7 +341,8 @@ exit $LASTEXITCODE
   try { Restore-BDInfoReports $discEntry $profileTwo $cacheRoot 'scanner-one' | Out-Null } catch { $rejected = $_.Exception.Message -eq 'bdinfo_cache_identity_mismatch' }
   Assert-Check $rejected 'wrong_source_cache_manifest_accepted'
   [IO.File]::WriteAllBytes($manifestPath, $manifestBytes)
-  $summaryPath = Join-Path $warmCache.directory 'BD_SUMMARY_00001.MPLS.txt'
+  $singleReportNames = @(Get-BDInfoReportNames $warmCache.playlists)
+  $summaryPath = Join-Path $warmCache.directory $singleReportNames[0]
   $summaryBytes = [IO.File]::ReadAllBytes($summaryPath)
   [IO.File]::WriteAllText($summaryPath, 'Playlist: 00002.MPLS')
   $rejected = $false
@@ -312,7 +351,7 @@ exit $LASTEXITCODE
   [IO.File]::WriteAllBytes($summaryPath, $summaryBytes)
   $differentScanner = Restore-BDInfoReports $discEntry $profileTwo $cacheRoot 'scanner-two'
   Assert-Check (-not $differentScanner.restored -and $differentScanner.directory -cne $warmCache.directory) 'changed_scanner_reused_reports'
-  [IO.File]::AppendAllText((Join-Path $warmCache.directory 'BD_SUMMARY_FULL_00001.MPLS.txt'), 'changed report')
+  [IO.File]::AppendAllText((Join-Path $warmCache.directory $singleReportNames[2]), 'changed report')
   $rejected = $false
   try { Restore-BDInfoReports $discEntry $profileTwo $cacheRoot 'scanner-one' | Out-Null } catch { $rejected = $_.Exception.Message -eq 'bdinfo_cache_report_changed' }
   Assert-Check $rejected 'corrupt_cached_report_accepted'
@@ -321,6 +360,60 @@ exit $LASTEXITCODE
   $rejected = $false
   try { Save-BDInfoReports $coldCache $discEntry $cacheRoot $binaryOne | Out-Null } catch { $rejected = $_.Exception.Message -eq 'source_changed_during_run' }
   Assert-Check $rejected 'changed_source_published_cache'
+
+  $multi = @{ case_id = 'MY-MULTIDISC'; input_path = (Join-Path $validationDir 'Example.MultiDisc-GRP'); input_shape = 'disc-directory'; probe_status = 'ok' }
+  foreach ($part in @('Disc1', 'Disc2')) {
+    $multiDiscRoot = Join-Path $multi.input_path "$part/BDMV"
+    New-Item -ItemType Directory -Path (Join-Path $multiDiscRoot 'PLAYLIST') -Force | Out-Null
+    foreach ($file in @('00001.mpls', '00002.mpls')) { [IO.File]::WriteAllText((Join-Path $multiDiscRoot "PLAYLIST/$file"), 'synthetic playlist') }
+    [IO.File]::WriteAllText((Join-Path $multiDiscRoot 'stream.m2ts'), 'synthetic stream')
+  }
+  $multi.probe_path = Join-Path $multi.input_path 'Disc1/BDMV/stream.m2ts'
+  $multi.fingerprint = Get-SourceFingerprint $multi
+  $multiCorpus = Join-Path $validationDir 'multidisc-corpus.private.json'
+  Write-PrivateJson $multiCorpus @{ schema_version = 1; cases = @($multi) }
+  Assert-Check (@(Read-Corpus $multiCorpus @('MY-MULTIDISC'))[0].reason -eq 'source_selection_unconfirmed') 'nested_discs_bypassed_selection'
+  $discIDs = @((Get-CaseBDMVDiscs $multi).id | Sort-Object)
+  $multi.bdmv_selection = @{ playlists = @($discIDs | ForEach-Object { $_ + ':00001.MPLS' }); source_fingerprint = $multi.fingerprint.fingerprint }
+  Write-PrivateJson $multiCorpus @{ schema_version = 1; cases = @($multi) }
+  $multiEntry = @(Read-Corpus $multiCorpus @('MY-MULTIDISC'))[0]
+  Assert-Check ($multiEntry.status -eq 'ready') 'multidisc_selection_not_ready'
+  foreach ($badSelection in @(@('00001.MPLS'), @($discIDs[0] + ':00001.MPLS'), @(('disc-' + ('f' * 64) + ':00001.MPLS'), ($discIDs[1] + ':00001.MPLS')))) {
+    $invalidMulti = $multi.Clone(); $invalidMulti.bdmv_selection = @{ playlists = $badSelection; source_fingerprint = $multi.fingerprint.fingerprint }
+    Write-PrivateJson $multiCorpus @{ schema_version = 1; cases = @($invalidMulti) }
+    Assert-Check (@(Read-Corpus $multiCorpus @('MY-MULTIDISC'))[0].status -eq 'blocked') 'unbound_or_incomplete_disc_selection_accepted'
+  }
+  $multiCold = Restore-BDInfoReports $multiEntry $profileOne $cacheRoot 'scanner-one'
+  foreach ($name in @(Get-BDInfoReportNames $multiCold.playlists)) {
+    $path = Join-Path $multiCold.target $name
+    New-Item -ItemType Directory -Path (Split-Path -Parent $path) -Force | Out-Null
+    [IO.File]::WriteAllText($path, "Playlist: 00001.MPLS`nSynthetic disc report $name")
+  }
+  $multiSaved = Save-BDInfoReports $multiCold $multiEntry $cacheRoot $binaryOne
+  $multiWarm = Restore-BDInfoReports $multiEntry $profileTwo $cacheRoot 'scanner-one'
+  Assert-Check ($multiWarm.restored -and $multiSaved.reports.Count -eq 6 -and @($multiSaved.reports.name | Select-Object -Unique).Count -eq 6) 'same_playlist_discs_collided_in_cache'
+  Assert-Check ((Save-BDInfoReports $multiWarm $multiEntry $cacheRoot $binaryTwo).producerBinarySHA256 -ceq $binaryOne) 'multidisc_cache_producer_relabelled'
+  foreach ($choice in @(@($multiCold.playlists[1], $multiCold.playlists[0]), @($multiCold.playlists[0].Replace('00001', '00002'), $multiCold.playlists[1]))) {
+    $changed = $multi.Clone(); $changed.bdmv_selection = @{ playlists = $choice; source_fingerprint = $multi.fingerprint.fingerprint }
+    $changedCache = Restore-BDInfoReports @{ case = $changed; stat = $multi.fingerprint } $profileTwo $cacheRoot 'scanner-one'
+    Assert-Check (-not $changedCache.restored -and $changedCache.directory -cne $multiWarm.directory) 'changed_multidisc_selection_reused_cache'
+  }
+  $multiNames = @(Get-BDInfoReportNames $multiCold.playlists)
+  $firstReport = Join-Path $multiWarm.directory $multiNames[0]
+  $originalReport = [IO.File]::ReadAllBytes($firstReport)
+  Remove-Item -LiteralPath $firstReport
+  $rejected = $false
+  try { Restore-BDInfoReports $multiEntry $profileTwo $cacheRoot 'scanner-one' | Out-Null } catch { $rejected = $_.Exception.Message -eq 'bdinfo_cache_incomplete' }
+  Assert-Check $rejected 'incomplete_multidisc_cache_accepted'
+  Copy-Item -LiteralPath (Join-Path $multiWarm.directory $multiNames[3]) -Destination $firstReport
+  $rejected = $false
+  try { Restore-BDInfoReports $multiEntry $profileTwo $cacheRoot 'scanner-one' | Out-Null } catch { $rejected = $_.Exception.Message -eq 'bdinfo_cache_report_changed' }
+  Assert-Check $rejected 'cross_disc_report_swap_accepted'
+  [IO.File]::WriteAllBytes($firstReport, $originalReport)
+  [IO.File]::AppendAllText((Join-Path $multi.input_path 'Disc2/BDMV/PLAYLIST/00002.mpls'), ' changed source')
+  $rejected = $false
+  try { Restore-BDInfoReports $multiEntry $profileTwo $cacheRoot 'scanner-one' | Out-Null } catch { $rejected = $_.Exception.Message -eq 'source_changed_during_run' }
+  Assert-Check $rejected 'changed_secondary_disc_reused_cache'
   $probeScript = Join-Path $validationDir 'child.ps1'
   [IO.File]::WriteAllText($probeScript, '[pscustomobject]@{e2e=$env:UPBRR_E2E_RUNNER_VALIDATION;literal=$args[0]}|ConvertTo-Json -Compress')
   $prior = $env:UPBRR_E2E_RUNNER_VALIDATION
@@ -463,6 +556,14 @@ exit $LASTEXITCODE
   Assert-Check ((Record-Stage $identityLane $identityCurrent 'prepared') -eq 'pass') 'confirmed_prepared_playlist_rejected'
   $identityCurrent.release.release.Source.Remove('SelectedPlaylists')
   Assert-Check ((Record-Stage $identityLane $identityCurrent 'prepared') -eq 'fail') 'missing_prepared_playlist_accepted'
+  $identityLane.expectedPlaylists = @(('disc-' + ('a' * 64) + ':00001.MPLS'), ('disc-' + ('b' * 64) + ':00001.MPLS'))
+  $identityCurrent.release.release.Source.SelectedPlaylists = @(
+    @{ discId = ('disc-' + ('a' * 64)); file = '00001.mpls' },
+    @{ discId = ('disc-' + ('b' * 64)); file = '00001.mpls' }
+  )
+  Assert-Check ((Record-Stage $identityLane $identityCurrent 'prepared') -eq 'pass') 'prepared_disc_scoped_playlists_rejected'
+  $identityCurrent.release.release.Source.SelectedPlaylists[1].discId = 'disc-' + ('a' * 64)
+  Assert-Check ((Record-Stage $identityLane $identityCurrent 'prepared') -eq 'fail') 'prepared_playlist_wrong_disc_accepted'
   $gitPath = Get-ToolPath 'git'
   Assert-Check ($gitPath -is [string] -and $gitPath -ceq (Get-Command git -CommandType Application | Select-Object -First 1).Source) 'tool_path_not_single_application'
   Invoke-OwnedProcess $gitPath @('--version') (Join-Path $validationDir 'git-single-path') 30
@@ -519,6 +620,29 @@ exit $LASTEXITCODE
     Assert-Check ($script:FakeRequests[1].intent.preparation.Instructions.SourceLookup -ceq 'operator-selected-synthetic-source' -and -not $intent.preparation.Instructions.SourceLookup) 'accepted_facts_reset_or_caller_intent_mutated'
     Assert-Check ($lane.expectedIdentity.IMDBID -eq 1234567 -and $lane.preparation.Instructions.Identity.IMDBID -eq 7654321) 'answered_identity_replaced_case_expectation'
     Assert-Check ((Record-Stage $lane $answered 'prepared') -eq 'fail' -and $script:Results[-1].reason -eq 'metadata_identity_mismatch') 'answered_identity_mismatch_accepted'
+  } finally { Set-Item Function:Invoke-LiveAPI -Value $originalAPI }
+
+  $script:FakeRequests = @()
+  function Invoke-LiveAPI([string]$Method, $Body = @{}, [switch]$Poll, [int]$ExpectedStatus = 200) {
+    $script:FakeRequests += @(ConvertTo-Json $Body -Depth 40 | ConvertFrom-Json -AsHashtable)
+    if ($Body.answers -or -not $Body.intent.factInstructions.Playlist.Set -or
+        ($Body.intent.factInstructions.Playlist.Selected -join ',') -cne 'disc-one:00000.MPLS,disc-two:00000.MPLS,disc-three:00000.MPLS' -or
+        $Body.intent.preparation.Instructions.Identity.IMDBID -ne 1234567) { throw 'playlist_answer_not_routed_to_facts' }
+    @{ workflow = @{ id = 'workflow-1'; revision = 2 }; release = @{ id = 'release-1' } }
+  }
+  try {
+    $values = @('disc-one:00000.MPLS', 'disc-two:00000.MPLS', 'disc-three:00000.MPLS')
+    $action = @{ id = 'playlist-1'; kind = 'select_playlist'; status = 'pending'; options = @($values | ForEach-Object { @{ value = $_ } }) }
+    $old = @{ workflow = @{ id = 'workflow-1'; revision = 7; requiredActions = @($action) }; factInstructions = @{ instructions = @{ Identity = @{ IMDBID = 1234567 }; Playlist = @{ Set = $false } } } }
+    $intent = @{ preparation = @{ SourcePath = $source; Instructions = $old.factInstructions.instructions }; noSeed = $true }
+    $answer = @{ actionId = 'playlist-1'; workflowRevision = 7; selectedValues = $values }
+    $null = Continue-Lane $lane 'prepared' $old $intent @($answer)
+    Assert-Check ($script:FakeRequests.Count -eq 2 -and -not $intent.preparation.Instructions.Playlist.Set) 'playlist_resume_mutated_original_or_stopped_early'
+    foreach ($invalid in @(@{ actionId = 'playlist-1'; workflowRevision = 6; selectedValues = $values }, @{ actionId = 'playlist-1'; workflowRevision = 7; selectedValues = @('unknown:00000.MPLS') }, @{ actionId = 'playlist-1'; workflowRevision = 7; selectedValues = @() })) {
+      $rejected = $false
+      try { Continue-Lane $lane 'prepared' $old $intent @($invalid) | Out-Null } catch { $rejected = $_.Exception.Message -eq 'feedback_playlist_answer_invalid' }
+      Assert-Check $rejected 'invalid_playlist_feedback_accepted'
+    }
   } finally { Set-Item Function:Invoke-LiveAPI -Value $originalAPI }
 
   $script:FakeRequests = @()


### PR DESCRIPTION
Live testing loses accepted playlist selections during preparation and can drop pending feedback while resuming lanes. Repeated multidisc Blu-ray runs also rescan BDInfo because the runner restores reports outside the per-disc directories used by the multidisc implementation.

Route accepted playlist choices into preparation facts, preserve pending feedback and resume goals, and cache each disc's quick, extended, and full BDInfo reports. Validate disc identities, selection completeness, source and scanner fingerprints, report hashes, and cache manifests. Add runner regressions and document the private corpus format.

This PR contains only live-testing scripts and their README. Merge after #400: per-disc playlist IDs and report directories depend on that PR's production implementation. Private corpus entries, reports, screenshots, and credentials remain outside Git. Existing duplicate, image-host, tracker-submission, and client-mutation safeguards remain in force.

Validation on the branch from main: runner validation, PowerShell parsing, JavaScript syntax, Playwright test discovery, whitespace checks, and changed-Go check (no Go changes). Independent correctness review covers the intended multidisc integration. Live runs with #400's implementation restored all nine reports unchanged, with BDInfo stages taking 0.6–2.1 seconds. ULCX captured four screenshots across three Blu-ray discs and preserved selection through reload and restart. Existing-client matches blocked PTP and DVD lanes. Image hosting, payload dry runs, and screenshot cancellation/delete-recapture remain unverified. All owned runs were cleaned, with no image uploads, tracker submissions, or client mutations.

CodeRabbit CLI reviewed the complete change against main with zero findings. The simplification gate is clean; the docstring gate has no applicable source changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting playlists across multi-disc Blu-ray collections.
  - Playlist selections now identify the source disc, preventing cross-disc mix-ups.
  - Added safer handling for applying playlist selections during workflow continuation.
  - Improved workflow resumption so completed feedback is cleared and processing continues automatically.

- **Bug Fixes**
  - Improved Blu-ray report caching and restoration for multi-disc sources.
  - Added validation for incomplete, mismatched, outdated, or incorrectly scoped cached reports.

- **Documentation**
  - Updated live-testing guidance for multi-disc playlist selection and per-disc report storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->