### PR TITLE
fix(metadata): preserve authoritative provider IDs

### DIFF
--- a/cmd/upbrr/cli_options.go
+++ b/cmd/upbrr/cli_options.go
@@ -73,10 +73,10 @@ type cliOptions struct {
 	DeleteTmp             bool
 	Cleanup               bool
 	TMDB                  string
-	TVDB                  int
-	TVmaze                int
+	TVDB                  string
+	TVmaze                string
 	IMDb                  string
-	MAL                   int
+	MAL                   string
 	Unattended            bool
 	UnattendedConfirm     bool
 	SkipDupeCheck         bool
@@ -219,11 +219,11 @@ func bindUploadFlags(fs *pflag.FlagSet, opts *cliOptions) {
 	fs.BoolVar(&opts.Cleanup, "cleanup", false, "Delete all stored database content for all releases and exit")
 	fs.StringVar(&opts.Region, "region", "", "Override disc region")
 	fs.StringVar(&opts.Region, "reg", "", "Override disc region")
-	fs.StringVar(&opts.TMDB, "tmdb", "", "Override TMDB id")
-	fs.StringVar(&opts.IMDb, "imdb", "", "Override IMDb id")
-	fs.IntVar(&opts.MAL, "mal", 0, "Override MAL id")
-	fs.IntVar(&opts.TVDB, "tvdb", 0, "Override TVDB id")
-	fs.IntVar(&opts.TVmaze, "tvmaze", 0, "Override TVmaze id")
+	fs.StringVar(&opts.TMDB, "tmdb", "", "Override TMDB id; empty or 0 clears and skips this provider")
+	fs.StringVar(&opts.IMDb, "imdb", "", "Override IMDb id; empty or 0 clears and skips this provider")
+	fs.StringVar(&opts.MAL, "mal", "", "Override MAL id; empty or 0 clears and skips this provider")
+	fs.StringVar(&opts.TVDB, "tvdb", "", "Override TVDB id; empty or 0 clears and skips this provider")
+	fs.StringVar(&opts.TVmaze, "tvmaze", "", "Override TVmaze id; empty or 0 clears and skips this provider")
 	fs.StringVar(&opts.PTP, "ptp", "", "PTP torrent id or URL")
 	fs.StringVar(&opts.BLU, "blu", "", "BLU torrent id or URL")
 	fs.StringVar(&opts.Aither, "aither", "", "Aither torrent id or URL")
@@ -329,13 +329,6 @@ func normalizeCLIOptions(opts *cliOptions, visited map[string]bool) error {
 		visited["unattended"] = true
 		visited["unattended_confirm"] = true
 	}
-	if visited["imdb"] {
-		if trimmed := strings.TrimSpace(opts.IMDb); trimmed != "" {
-			if _, err := parseIMDbID(trimmed); err != nil {
-				return err
-			}
-		}
-	}
 	if visited["infohash"] {
 		if _, err := parseInfoHash(opts.InfoHash); err != nil {
 			return err
@@ -392,13 +385,6 @@ func normalizeCLIOptions(opts *cliOptions, visited map[string]bool) error {
 		}
 		opts.ConsoleLogLevel = normalized
 	}
-	if visited["tmdb"] {
-		if trimmed := strings.TrimSpace(opts.TMDB); trimmed != "" {
-			if _, _, err := parseTMDBID(trimmed); err != nil {
-				return err
-			}
-		}
-	}
 	if visited["site-upload"] {
 		normalized := strings.ToUpper(strings.TrimSpace(opts.SiteUpload))
 		if normalized == "" {
@@ -423,6 +409,9 @@ func normalizeCLIOptions(opts *cliOptions, visited map[string]bool) error {
 		return errors.New("--export-config must have a non-empty value when --export-config-plaintext is used")
 	}
 	if _, err := buildTrackerIDOverrides(*opts, visited); err != nil {
+		return err
+	}
+	if _, err := buildExternalIDOverrides(*opts, visited); err != nil {
 		return err
 	}
 	return nil
@@ -1112,6 +1101,9 @@ func buildTrackerIDOverrides(opts cliOptions, visited map[string]bool) (map[stri
 	return overrides, nil
 }
 
+// buildExternalIDOverrides parses only explicitly supplied provider flags.
+// Omitted flags leave nil fields; blank or zero values produce explicit provider clears.
+// Invalid input returns an empty override set and an error.
 func buildExternalIDOverrides(opts cliOptions, visited map[string]bool) (api.ExternalIDOverrides, error) {
 	overrides := api.ExternalIDOverrides{}
 	if visited["tmdb"] {
@@ -1121,14 +1113,39 @@ func buildExternalIDOverrides(opts cliOptions, visited map[string]bool) (api.Ext
 		}
 		overrides.TMDBID = intPtr(id)
 	}
-	if visited["tvdb"] {
-		overrides.TVDBID = intPtr(opts.TVDB)
-	}
-	if visited["tvmaze"] {
-		overrides.TVmazeID = intPtr(opts.TVmaze)
-	}
-	if visited["mal"] {
-		overrides.MALID = intPtr(opts.MAL)
+	for _, input := range []struct {
+		name   string
+		value  string
+		target **int
+	}{
+		{
+			name:   "tvdb",
+			value:  opts.TVDB,
+			target: &overrides.TVDBID,
+		},
+		{
+			name:   "tvmaze",
+			value:  opts.TVmaze,
+			target: &overrides.TVmazeID,
+		},
+		{
+			name:   "mal",
+			value:  opts.MAL,
+			target: &overrides.MALID,
+		},
+	} {
+		if !visited[input.name] {
+			continue
+		}
+		var id int64
+		if value := strings.TrimSpace(input.value); value != "" {
+			var err error
+			id, err = strconv.ParseInt(value, 0, strconv.IntSize)
+			if err != nil {
+				return api.ExternalIDOverrides{}, fmt.Errorf("invalid %s id %q", input.name, input.value)
+			}
+		}
+		*input.target = intPtr(int(id))
 	}
 	if visited["imdb"] {
 		if strings.TrimSpace(opts.IMDb) == "" {
@@ -1144,10 +1161,13 @@ func buildExternalIDOverrides(opts cliOptions, visited map[string]bool) (api.Ext
 	return overrides, nil
 }
 
+// parseTMDBID accepts a positive ID, a movie/ or tv/ prefix, or a URL ending in an ID.
+// It returns a category hint when present. Blank or literal zero input clears the ID
+// without a category hint; other invalid input returns an error.
 func parseTMDBID(raw string) (int, string, error) {
 	trimmed := strings.TrimSpace(strings.ToLower(raw))
-	if trimmed == "" {
-		return 0, "", fmt.Errorf("invalid tmdb id %q", raw)
+	if trimmed == "" || trimmed == "0" {
+		return 0, "", nil
 	}
 
 	category := ""

--- a/cmd/upbrr/cli_options.go
+++ b/cmd/upbrr/cli_options.go
@@ -1141,7 +1141,7 @@ func buildExternalIDOverrides(opts cliOptions, visited map[string]bool) (api.Ext
 		if value := strings.TrimSpace(input.value); value != "" {
 			var err error
 			id, err = strconv.ParseInt(value, 0, strconv.IntSize)
-			if err != nil {
+			if err != nil || id < 0 {
 				return api.ExternalIDOverrides{}, fmt.Errorf("invalid %s id %q", input.name, input.value)
 			}
 		}

--- a/cmd/upbrr/cli_options_test.go
+++ b/cmd/upbrr/cli_options_test.go
@@ -992,6 +992,20 @@ func TestCLIProviderIDsRejectInvalidValues(t *testing.T) {
 	}
 }
 
+func TestCLIProviderIDsRejectNegativeNumericValues(t *testing.T) {
+	t.Parallel()
+	for _, provider := range []string{"tvdb", "tvmaze", "mal"} {
+		for _, value := range []string{"-1", "-0x1", " -1 "} {
+			t.Run(provider+"/"+value, func(t *testing.T) {
+				result := executeCLIForTest(t.Context(), t, []string{"--" + provider + "=" + value, "--version"})
+				if result.code != 2 || !strings.Contains(result.stderr, "invalid "+provider+" id") {
+					t.Fatalf("negative provider ID result: %#v", result)
+				}
+			})
+		}
+	}
+}
+
 func TestCLIProviderIDsBlankRootFlags(t *testing.T) {
 	t.Parallel()
 	for _, args := range [][]string{

--- a/cmd/upbrr/cli_options_test.go
+++ b/cmd/upbrr/cli_options_test.go
@@ -929,6 +929,82 @@ func TestBuildCLIRequestTMDBCompatibilityParsing(t *testing.T) {
 	}
 }
 
+func TestCLIProviderIDOverrides(t *testing.T) {
+	t.Parallel()
+	for _, provider := range []string{"tmdb", "imdb", "tvdb", "tvmaze", "mal"} {
+		for _, tc := range []struct {
+			name  string
+			value string
+			want  int
+		}{
+			{name: "blank"},
+			{name: "zero", value: "0"},
+			{
+				name:  "positive",
+				value: "123",
+				want:  123,
+			},
+		} {
+			t.Run(provider+"/"+tc.name, func(t *testing.T) {
+				args := []string{"--" + provider + "=" + tc.value, "Example.Release.2026.1080p-GRP.mkv"}
+				opts, visited, paths, err := parseCLIOptions(args)
+				if err != nil {
+					t.Fatalf("parse: %v", err)
+				}
+				req, err := buildCLIRequest(opts, visited, paths, 4)
+				if err != nil {
+					t.Fatalf("build request: %v", err)
+				}
+				for name, id := range map[string]*int{
+					"tmdb":   req.ExternalIDOverrides.TMDBID,
+					"imdb":   req.ExternalIDOverrides.IMDBID,
+					"tvdb":   req.ExternalIDOverrides.TVDBID,
+					"tvmaze": req.ExternalIDOverrides.TVmazeID,
+					"mal":    req.ExternalIDOverrides.MALID,
+				} {
+					if name == provider {
+						if id == nil || *id != tc.want {
+							t.Fatalf("%s override = %v, want %d", name, id, tc.want)
+						}
+					} else if id != nil {
+						t.Fatalf("omitted %s override = %d, want unset", name, *id)
+					}
+				}
+				if req.ReleaseNameOverrides.Category != nil {
+					t.Fatalf("provider ID set category unexpectedly: %q", *req.ReleaseNameOverrides.Category)
+				}
+			})
+		}
+	}
+}
+
+func TestCLIProviderIDsRejectInvalidValues(t *testing.T) {
+	t.Parallel()
+	for _, provider := range []string{"tmdb", "imdb", "tvdb", "tvmaze", "mal"} {
+		for _, value := range []string{"not-an-id", "18446744073709551616"} {
+			t.Run(provider+"/"+value, func(t *testing.T) {
+				result := executeCLIForTest(t.Context(), t, []string{"--" + provider + "=" + value, "--version"})
+				if result.code != 2 || !strings.Contains(result.stderr, "invalid "+provider+" id") {
+					t.Fatalf("invalid provider ID result: %#v", result)
+				}
+			})
+		}
+	}
+}
+
+func TestCLIProviderIDsBlankRootFlags(t *testing.T) {
+	t.Parallel()
+	for _, args := range [][]string{
+		{"--tmdb=", "--imdb=", "--tvdb=", "--tvmaze=", "--mal=", "--version"},
+		{"--tmdb", "", "--imdb", "", "--tvdb", "", "--tvmaze", "", "--mal", "", "--version"},
+	} {
+		result := executeCLIForTest(t.Context(), t, args)
+		if result.code != 0 || result.stderr != "" || result.stdout == "" {
+			t.Fatalf("args %v: blank provider ID result: %#v", args, result)
+		}
+	}
+}
+
 func TestParseCLIOptionsRejectsInvalidTMDBCompatibilityValue(t *testing.T) {
 	if _, _, _, err := parseCLIOptions([]string{"--tmdb", "movie/not-a-number", "movie.mkv"}); err == nil {
 		t.Fatal("expected invalid tmdb compatibility input to fail")

--- a/cmd/upbrr/composite_upload_test.go
+++ b/cmd/upbrr/composite_upload_test.go
@@ -57,6 +57,44 @@ func TestCLICompositeMediaUsesOnlyRequestedScreenshots(t *testing.T) {
 	}
 }
 
+func TestCLICompositePreservesProviderClears(t *testing.T) {
+	t.Parallel()
+	opts, visited, paths, err := parseCLIOptions([]string{
+		"--tmdb=", "--imdb=", "--tvdb=", "--tvmaze=", "--mal=", "--category=MOVIE", "Example.Release.2026.1080p-GRP.mkv",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	request, err := buildCLIRequest(opts, visited, paths, opts.Screens)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if request.ReleaseNameOverrides.Category == nil || *request.ReleaseNameOverrides.Category != "MOVIE" {
+		t.Fatalf("clearing TMDB replaced the explicit category: %#v", request.ReleaseNameOverrides.Category)
+	}
+	mapped, err := mapCLICompositeUploadRequest(request, false, "provider-clear-test")
+	if err != nil {
+		t.Fatalf("map request: %v", err)
+	}
+	if err := mapped.Validate(); err != nil {
+		t.Fatalf("validate provider clears: %v", err)
+	}
+	ids := mapped.Preparation.Facts.ExternalIDs
+	for provider, id := range map[string]*api.ReleaseWorkflowUploadNumericID{
+		"tmdb":   ids.TMDB,
+		"tvdb":   ids.TVDB,
+		"tvmaze": ids.TVmaze,
+		"mal":    ids.MAL,
+	} {
+		if id == nil || id.Value == nil || *id.Value != 0 {
+			t.Fatalf("%s clear missing from composite request: %#v", provider, id)
+		}
+	}
+	if ids.IMDB == nil || ids.IMDB.Value == nil || *ids.IMDB.Value != "" {
+		t.Fatalf("IMDb clear missing from composite request: %#v", ids.IMDB)
+	}
+}
+
 func TestMapCLICompositeUploadRequestPreservesPerUploadOptions(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/upbrr/testdata/help/root.txt
+++ b/cmd/upbrr/testdata/help/root.txt
@@ -139,15 +139,15 @@ Release Overrides:
 
 Metadata IDs:
   -tmdb, --tmdb string
-      Override TMDB id
+      Override TMDB id; empty or 0 clears and skips this provider
   -imdb, --imdb string
-      Override IMDb id
-  -mal, --mal int
-      Override MAL id
-  -tvdb, --tvdb int
-      Override TVDB id
-  -tvmaze, --tvmaze int
-      Override TVmaze id
+      Override IMDb id; empty or 0 clears and skips this provider
+  -mal, --mal string
+      Override MAL id; empty or 0 clears and skips this provider
+  -tvdb, --tvdb string
+      Override TVDB id; empty or 0 clears and skips this provider
+  -tvmaze, --tvmaze string
+      Override TVmaze id; empty or 0 clears and skips this provider
 
 Tracker Overrides:
   -skip-dupe-check, --skip-dupe-check, -sdc

--- a/documentation/docs/cli/index.md
+++ b/documentation/docs/cli/index.md
@@ -162,6 +162,24 @@ For BDMV, interactive preparation groups playlist choices by disc and requires a
 | `--tvdb <id>`   | `-tvdb`   | Override TVDB ID.   |
 | `--tvmaze <id>` | `-tvmaze` | Override TVmaze ID. |
 
+### Clear a metadata provider
+
+Pass an empty value or `0` to stop using a provider for this release. This works with `--tmdb`, `--imdb`, `--tvdb`, `--tvmaze`, and `--mal`.
+
+For example, clear TMDB and use a known IMDb ID:
+
+```powershell
+.\upbrr.exe --tmdb= --imdb tt1234567 "E:\Media\Example.Release.2026.1080p-GRP.mkv"
+```
+
+Use the equals sign in `--tmdb=` to pass an empty value reliably in PowerShell. `--tmdb=0` has the same effect. You can clear several providers in one command.
+
+Clearing removes that provider's ID and metadata from the prepared release. It also prevents automatic rediscovery through title searches, tracker data, or other providers. Other providers can still supply metadata.
+
+The clear is saved for that source path. Omitting the flag on a later run preserves the clear. Supply a positive ID to use that provider again, such as `--tmdb 123456`. Provider settings for other releases stay unchanged.
+
+Trackers that require the cleared provider can remain blocked. Continue with trackers whose metadata requirements are satisfied, or supply a correct ID before retrying. See [metadata troubleshooting](../troubleshooting/index.md#a-metadata-provider-fails-or-selects-the-wrong-title).
+
 ## Tracker overrides
 
 | Option                | Aliases                      | Purpose                                   |

--- a/documentation/docs/troubleshooting/index.md
+++ b/documentation/docs/troubleshooting/index.md
@@ -65,6 +65,16 @@ The selected FFmpeg must expose the `dvdvideo` demuxer plus `menu`, `menu_lu`, `
 
 Use manual disc-menu image import when automatic capture is not available.
 
+## A metadata provider fails or selects the wrong title
+
+Supply the correct provider ID, or clear the provider when you want to continue without it. For example, `--tmdb=` or `--tmdb=0` clears TMDB in the CLI. See [clearing a metadata provider](../cli/index.md#clear-a-metadata-provider) for all supported flags and examples.
+
+In the Web UI, use the [metadata ID controls on Input](../web-ui/index.md#clear-a-metadata-provider), then click **Refresh metadata**. If the first fetch fails before a preview appears, remove the provider and click **Retry metadata** instead.
+
+Clearing prevents that provider's ID and metadata from being rediscovered for this source. It persists across release reloads. Supply a positive ID to use the provider again.
+
+Check tracker eligibility after the change. A tracker that requires the missing provider can remain blocked, while other eligible trackers can continue.
+
 ## Tracker authentication is blocked
 
 1. Open the tracker in **Settings**.

--- a/documentation/docs/web-ui/index.md
+++ b/documentation/docs/web-ui/index.md
@@ -39,6 +39,18 @@ The left navigation follows the release workflow. Some pages appear or unlock on
 
 Navigation guards prevent later operations from silently using missing or stale prerequisites. When a page is unavailable, read the notice and return to the required stage.
 
+### Clear a metadata provider
+
+On **Input**, open **Edit Release Details** and find **External IDs**. Click **Remove** beside TMDB, IMDb, TVDB, TVmaze, or MAL. You can also delete an existing ID from its field.
+
+Click **Refresh metadata** to apply the change. The provider's ID and metadata are removed from the prepared release, and automatic lookups cannot restore them. Other providers remain available.
+
+If the first fetch fails before a preview appears, **Edit Release Details** is still available. Remove the failing provider and click **Retry metadata**.
+
+The clear is saved for this source and survives release reloads. Enter a positive ID and refresh metadata to use that provider again. Check tracker eligibility afterward: trackers that require the cleared provider can remain blocked.
+
+See [metadata troubleshooting](../troubleshooting/index.md#a-metadata-provider-fails-or-selects-the-wrong-title) for CLI examples and recovery guidance.
+
 ### Multi-disc sources
 
 On **Input**, select the parent containing all DVD or BDMV disc folders. BDMV playlist choices are grouped by disc, and preparation cannot continue until every disc has at least one selected playlist. Identical playlist filenames on different discs remain independent choices.

--- a/documentation/docs/workflow/index.md
+++ b/documentation/docs/workflow/index.md
@@ -44,6 +44,8 @@ Metadata providers and local media inspection produce shared release facts. Revi
 
 Overrides change the prepared generation. Later operations must use that exact generation rather than silently rebuilding it.
 
+If a provider fails or selects the wrong title, supply a correct ID or [clear that provider](../cli/index.md#clear-a-metadata-provider). Clearing suppresses its ID and metadata for this source, including later reloads. Other providers remain available, but trackers that require the cleared provider may be blocked.
+
 ## 3. Resolve tracker names and eligibility
 
 Each tracker can project its own upload and duplicate-search names from the reviewed source facts. upbrr resolves those names before duplicate checks so the search evidence and eventual payload refer to the same reviewed identity.

--- a/internal/externalidentity/resolver.go
+++ b/internal/externalidentity/resolver.go
@@ -24,7 +24,7 @@ import (
 
 // ContractVersion changes whenever identity resolution semantics become
 // incompatible with a previously resolved identity.
-const ContractVersion = "external-identity-v1"
+const ContractVersion = "external-identity-v2"
 
 // Request contains normalized source scope and identity-resolution intent. It
 // carries no gathered MediaInfo, scene, Arr, tracker, or provider evidence.
@@ -287,13 +287,19 @@ func applyCandidateEvidence(
 	if result == nil {
 		return nil
 	}
+	authoritativeProviders := hasExplicitProviderValue(candidate.Identity)
 	if hasCandidateIdentity(candidate.Identity) && sourceEvidenceMatches(candidate.Identity.SourcePath, sourcePath) {
-		applyCandidateIdentity(&result.Identity, candidate.Identity)
+		if authoritativeProviders {
+			applyAuthoritativeCandidateProviders(&result.Identity, candidate.Identity)
+			applyCandidateCategory(&result.Identity, candidate.Identity)
+		} else {
+			applyCandidateIdentity(&result.Identity, candidate.Identity)
+		}
 		if err := appendEvidenceFingerprint(result, "provider_candidate", candidate.Identity); err != nil {
 			return err
 		}
 	}
-	if hasCandidateMetadata(candidate.Metadata) && sourceEvidenceMatches(candidate.Metadata.SourcePath, sourcePath) {
+	if (authoritativeProviders || hasCandidateMetadata(candidate.Metadata)) && sourceEvidenceMatches(candidate.Metadata.SourcePath, sourcePath) {
 		result.ProviderMetadata = sourceScopedMetadata(candidate.Metadata, sourcePath, generation, resolvedAt)
 		if err := appendEvidenceFingerprint(result, "provider_metadata_candidate", candidate.Metadata); err != nil {
 			return err
@@ -303,6 +309,80 @@ func applyCandidateEvidence(
 		result.Diagnostics = append(result.Diagnostics, diagnostics...)
 	}
 	return nil
+}
+
+func hasExplicitProviderValue(identity api.ExternalIdentity) bool {
+	return identity.TMDBID > 0 && providerIdentityLocked(identity.Overrides.TMDB, identity.Provenance.TMDB) ||
+		identity.IMDBID > 0 && providerIdentityLocked(identity.Overrides.IMDB, identity.Provenance.IMDB) ||
+		identity.TVDBID > 0 && providerIdentityLocked(identity.Overrides.TVDB, identity.Provenance.TVDB) ||
+		identity.TVmazeID > 0 && providerIdentityLocked(identity.Overrides.TVmaze, identity.Provenance.TVmaze) ||
+		identity.MALID > 0 && providerIdentityLocked(identity.Overrides.MAL, identity.Provenance.MAL)
+}
+
+func applyAuthoritativeCandidateProviders(identity *api.ExternalIdentity, candidate api.ExternalIdentity) {
+	if identity == nil {
+		return
+	}
+	applyAuthoritativeCandidateProvider(
+		&identity.TMDBID,
+		&identity.Provenance.TMDB,
+		&identity.Overrides.TMDB,
+		candidate.TMDBID,
+		candidate.Provenance.TMDB,
+		candidate.Overrides.TMDB,
+	)
+	applyAuthoritativeCandidateProvider(
+		&identity.IMDBID,
+		&identity.Provenance.IMDB,
+		&identity.Overrides.IMDB,
+		candidate.IMDBID,
+		candidate.Provenance.IMDB,
+		candidate.Overrides.IMDB,
+	)
+	applyAuthoritativeCandidateProvider(
+		&identity.TVDBID,
+		&identity.Provenance.TVDB,
+		&identity.Overrides.TVDB,
+		candidate.TVDBID,
+		candidate.Provenance.TVDB,
+		candidate.Overrides.TVDB,
+	)
+	applyAuthoritativeCandidateProvider(
+		&identity.TVmazeID,
+		&identity.Provenance.TVmaze,
+		&identity.Overrides.TVmaze,
+		candidate.TVmazeID,
+		candidate.Provenance.TVmaze,
+		candidate.Overrides.TVmaze,
+	)
+	applyAuthoritativeCandidateProvider(
+		&identity.MALID,
+		&identity.Provenance.MAL,
+		&identity.Overrides.MAL,
+		candidate.MALID,
+		candidate.Provenance.MAL,
+		candidate.Overrides.MAL,
+	)
+}
+
+func applyAuthoritativeCandidateProvider(
+	target *int,
+	provenance *api.IdentityProvenance,
+	override *api.OverrideState,
+	value int,
+	source api.IdentityProvenance,
+	candidateOverride api.OverrideState,
+) {
+	if providerIdentityLocked(*override, *provenance) && !providerIdentityLocked(candidateOverride, source) {
+		return
+	}
+	*target = value
+	*provenance = source
+	*override = candidateOverride
+}
+
+func providerIdentityLocked(override api.OverrideState, provenance api.IdentityProvenance) bool {
+	return override == api.OverrideStateValue || override == api.OverrideStateClear || provenance == api.IdentityProvenanceExplicit
 }
 
 func hasCandidateIdentity(value api.ExternalIdentity) bool {
@@ -322,6 +402,10 @@ func applyCandidateIdentity(identity *api.ExternalIdentity, candidate api.Extern
 	applyCandidateProvider(&identity.TVDBID, &identity.Provenance.TVDB, candidate.TVDBID, candidate.Provenance.TVDB)
 	applyCandidateProvider(&identity.TVmazeID, &identity.Provenance.TVmaze, candidate.TVmazeID, candidate.Provenance.TVmaze)
 	applyCandidateProvider(&identity.MALID, &identity.Provenance.MAL, candidate.MALID, candidate.Provenance.MAL)
+	applyCandidateCategory(identity, candidate)
+}
+
+func applyCandidateCategory(identity *api.ExternalIdentity, candidate api.ExternalIdentity) {
 	if category, err := api.NormalizeCanonicalCategory(string(candidate.Category)); err == nil && category != api.CanonicalCategoryUnknown {
 		identity.Category = category
 		identity.Provenance.Category = candidate.Provenance.Category
@@ -387,6 +471,7 @@ func applyStoredIdentity(identity *api.ExternalIdentity, stored api.ExternalIden
 		identity.Category = category
 	}
 	identity.Provenance = stored.Provenance
+	identity.Overrides = stored.Overrides
 	ensureStoredProvenance(&identity.Provenance.TMDB, stored.TMDBID)
 	ensureStoredProvenance(&identity.Provenance.IMDB, stored.IMDBID)
 	ensureStoredProvenance(&identity.Provenance.TVDB, stored.TVDBID)
@@ -464,7 +549,9 @@ func invalidateMismatchedMetadata(metadata *api.SourceScopedMetadata, identity a
 	if metadata == nil {
 		return
 	}
-	if metadata.TMDB != nil && metadata.TMDB.TMDBID != identity.TMDBID {
+	if metadata.TMDB != nil && (metadata.TMDB.TMDBID != identity.TMDBID ||
+		lockedProviderIDMismatch(identity.Overrides.IMDB, identity.IMDBID, metadata.TMDB.IMDBID) ||
+		lockedProviderIDMismatch(identity.Overrides.TVDB, identity.TVDBID, metadata.TMDB.TVDBID)) {
 		metadata.TMDB = nil
 	}
 	if metadata.IMDB != nil && metadata.IMDB.IMDBID != identity.IMDBID {
@@ -473,12 +560,18 @@ func invalidateMismatchedMetadata(metadata *api.SourceScopedMetadata, identity a
 	if metadata.TVDB != nil && metadata.TVDB.TVDBID != identity.TVDBID {
 		metadata.TVDB = nil
 	}
-	if metadata.TVmaze != nil && metadata.TVmaze.TVmazeID != identity.TVmazeID {
+	if metadata.TVmaze != nil && (metadata.TVmaze.TVmazeID != identity.TVmazeID ||
+		lockedProviderIDMismatch(identity.Overrides.IMDB, identity.IMDBID, metadata.TVmaze.IMDBID) ||
+		lockedProviderIDMismatch(identity.Overrides.TVDB, identity.TVDBID, metadata.TVmaze.TVDBID)) {
 		metadata.TVmaze = nil
 	}
 	if metadata.AniList != nil && metadata.AniList.MALID != identity.MALID {
 		metadata.AniList = nil
 	}
+}
+
+func lockedProviderIDMismatch(state api.OverrideState, expected, actual int) bool {
+	return state == api.OverrideStateValue && expected > 0 && actual > 0 && actual != expected
 }
 
 func missingRequirements(identity api.ExternalIdentity) []api.MissingRequirementError {

--- a/internal/externalidentity/resolver.go
+++ b/internal/externalidentity/resolver.go
@@ -550,8 +550,8 @@ func invalidateMismatchedMetadata(metadata *api.SourceScopedMetadata, identity a
 		return
 	}
 	if metadata.TMDB != nil && (metadata.TMDB.TMDBID != identity.TMDBID ||
-		lockedProviderIDMismatch(identity.Overrides.IMDB, identity.IMDBID, metadata.TMDB.IMDBID) ||
-		lockedProviderIDMismatch(identity.Overrides.TVDB, identity.TVDBID, metadata.TMDB.TVDBID)) {
+		lockedProviderIDMismatch(identity.Overrides.IMDB, identity.Provenance.IMDB, identity.IMDBID, metadata.TMDB.IMDBID) ||
+		lockedProviderIDMismatch(identity.Overrides.TVDB, identity.Provenance.TVDB, identity.TVDBID, metadata.TMDB.TVDBID)) {
 		metadata.TMDB = nil
 	}
 	if metadata.IMDB != nil && metadata.IMDB.IMDBID != identity.IMDBID {
@@ -561,8 +561,8 @@ func invalidateMismatchedMetadata(metadata *api.SourceScopedMetadata, identity a
 		metadata.TVDB = nil
 	}
 	if metadata.TVmaze != nil && (metadata.TVmaze.TVmazeID != identity.TVmazeID ||
-		lockedProviderIDMismatch(identity.Overrides.IMDB, identity.IMDBID, metadata.TVmaze.IMDBID) ||
-		lockedProviderIDMismatch(identity.Overrides.TVDB, identity.TVDBID, metadata.TVmaze.TVDBID)) {
+		lockedProviderIDMismatch(identity.Overrides.IMDB, identity.Provenance.IMDB, identity.IMDBID, metadata.TVmaze.IMDBID) ||
+		lockedProviderIDMismatch(identity.Overrides.TVDB, identity.Provenance.TVDB, identity.TVDBID, metadata.TVmaze.TVDBID)) {
 		metadata.TVmaze = nil
 	}
 	if metadata.AniList != nil && metadata.AniList.MALID != identity.MALID {
@@ -570,8 +570,8 @@ func invalidateMismatchedMetadata(metadata *api.SourceScopedMetadata, identity a
 	}
 }
 
-func lockedProviderIDMismatch(state api.OverrideState, expected, actual int) bool {
-	return state == api.OverrideStateValue && expected > 0 && actual > 0 && actual != expected
+func lockedProviderIDMismatch(override api.OverrideState, provenance api.IdentityProvenance, expected, actual int) bool {
+	return providerIdentityLocked(override, provenance) && expected > 0 && actual > 0 && actual != expected
 }
 
 func missingRequirements(identity api.ExternalIdentity) []api.MissingRequirementError {

--- a/internal/externalidentity/resolver_test.go
+++ b/internal/externalidentity/resolver_test.go
@@ -80,6 +80,273 @@ func TestResolvePromotesProviderEvidenceAndKeepsCandidateListsDiagnostic(t *test
 	}
 }
 
+func TestResolveDropsProviderMetadataConflictingWithExplicitCrossReference(t *testing.T) {
+	t.Parallel()
+	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
+	imdbID := 1234567
+	resolver := &Resolver{
+		evidence: evidenceLoaderFunc(func(context.Context, string) (legacyEvidence, error) {
+			return legacyEvidence{}, nil
+		}),
+		candidate: candidateSourceFunc(func(_ context.Context, request Request) (CandidateEvidence, error) {
+			return CandidateEvidence{
+				Identity: api.ExternalIdentity{
+					SourcePath: request.SourcePath,
+					TMDBID:     222333,
+					IMDBID:     imdbID,
+					TVmazeID:   444555,
+				},
+				Metadata: api.SourceScopedMetadata{
+					SourcePath: request.SourcePath,
+					TMDB: &api.TMDBMetadata{
+						TMDBID: 222333,
+						IMDBID: 7654321,
+						Title:  "Conflicting TMDB",
+					},
+					TVmaze: &api.TVmazeMetadata{
+						TVmazeID: 444555,
+						IMDBID:   7654321,
+						Name:     "Conflicting TVmaze",
+					},
+				},
+			}, nil
+		}),
+		now: time.Now,
+	}
+
+	result, err := resolver.Resolve(context.Background(), Request{
+		SourcePath:        sourcePath,
+		SourceFingerprint: "source-fingerprint",
+		Generation:        1,
+		Intent: ResolutionIntent{ProviderOverrides: api.ExternalIDOverrides{
+			IMDBID: &imdbID,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if result.Identity.TMDBID != 222333 || result.Identity.TVmazeID != 444555 || result.Identity.IMDBID != imdbID {
+		t.Fatalf("identity = %#v", result.Identity)
+	}
+	if result.ProviderMetadata.TMDB != nil || result.ProviderMetadata.TVmaze != nil {
+		t.Fatalf("conflicting metadata retained: %#v", result.ProviderMetadata)
+	}
+}
+
+func TestResolveClearsStoredProviderGuessesFromAuthoritativeCandidate(t *testing.T) {
+	t.Parallel()
+	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
+	imdbID := 1234567
+	resolver := &Resolver{
+		evidence: evidenceLoaderFunc(func(context.Context, string) (legacyEvidence, error) {
+			return legacyEvidence{
+				identity: api.ExternalIdentity{
+					SourcePath: sourcePath,
+					TMDBID:     999888,
+					Provenance: api.IdentityProvenanceSet{TMDB: api.IdentityProvenanceProvider},
+				},
+				metadata: api.SourceScopedMetadata{
+					SourcePath: sourcePath,
+					TMDB:       &api.TMDBMetadata{TMDBID: 999888, Title: "Stale Provider Guess"},
+				},
+				hasIDs:  true,
+				hasMeta: true,
+			}, nil
+		}),
+		candidate: candidateSourceFunc(func(_ context.Context, request Request) (CandidateEvidence, error) {
+			return CandidateEvidence{
+				Identity: api.ExternalIdentity{
+					SourcePath: request.SourcePath,
+					IMDBID:     imdbID,
+					Provenance: api.IdentityProvenanceSet{IMDB: api.IdentityProvenanceExplicit},
+					Overrides:  api.IdentityOverrideState{IMDB: api.OverrideStateValue},
+				},
+				Metadata: api.SourceScopedMetadata{SourcePath: request.SourcePath},
+			}, nil
+		}),
+		now: time.Now,
+	}
+
+	result, err := resolver.Resolve(context.Background(), Request{
+		SourcePath:        sourcePath,
+		SourceFingerprint: "source-fingerprint",
+		Generation:        1,
+		Intent: ResolutionIntent{ProviderOverrides: api.ExternalIDOverrides{
+			IMDBID: &imdbID,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if result.Identity.IMDBID != imdbID || result.Identity.TMDBID != 0 || result.ProviderMetadata.TMDB != nil {
+		t.Fatalf("stored provider guess restored: identity=%#v metadata=%#v", result.Identity, result.ProviderMetadata)
+	}
+}
+
+func TestHasExplicitProviderValueRecognizesProvenanceOnlyPins(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  func(*api.ExternalIdentity)
+		want bool
+	}{
+		{
+			name: "TMDB",
+			set: func(identity *api.ExternalIdentity) {
+				identity.TMDBID = 1
+				identity.Provenance.TMDB = api.IdentityProvenanceExplicit
+			},
+			want: true,
+		},
+		{
+			name: "IMDb",
+			set: func(identity *api.ExternalIdentity) {
+				identity.IMDBID = 1
+				identity.Provenance.IMDB = api.IdentityProvenanceExplicit
+			},
+			want: true,
+		},
+		{
+			name: "TVDB",
+			set: func(identity *api.ExternalIdentity) {
+				identity.TVDBID = 1
+				identity.Provenance.TVDB = api.IdentityProvenanceExplicit
+			},
+			want: true,
+		},
+		{
+			name: "TVmaze",
+			set: func(identity *api.ExternalIdentity) {
+				identity.TVmazeID = 1
+				identity.Provenance.TVmaze = api.IdentityProvenanceExplicit
+			},
+			want: true,
+		},
+		{
+			name: "MAL",
+			set: func(identity *api.ExternalIdentity) {
+				identity.MALID = 1
+				identity.Provenance.MAL = api.IdentityProvenanceExplicit
+			},
+			want: true,
+		},
+		{
+			name: "inferred",
+			set: func(identity *api.ExternalIdentity) {
+				identity.IMDBID = 1
+				identity.Provenance.IMDB = api.IdentityProvenanceProvider
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			identity := api.ExternalIdentity{}
+			tc.set(&identity)
+			if identity.Overrides != (api.IdentityOverrideState{}) {
+				t.Fatalf("test identity unexpectedly has override state: %#v", identity.Overrides)
+			}
+			if got := hasExplicitProviderValue(identity); got != tc.want {
+				t.Fatalf("hasExplicitProviderValue() = %t, want %t for %#v", got, tc.want, identity)
+			}
+		})
+	}
+}
+
+func TestResolveAuthoritativeCandidatePreservesOrReplacesStoredExplicitSibling(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		currentIMDBID    *int
+		candidateIMDBID  int
+		candidateIMDBRef int
+		candidateState   api.OverrideState
+		wantIMDBID       int
+		wantState        api.OverrideState
+		wantTMDBMetadata bool
+	}{
+		{
+			name:             "omitted sibling preserves stored pin and rejects conflicting metadata",
+			candidateIMDBID:  7654321,
+			candidateIMDBRef: 7654321,
+			wantIMDBID:       1234567,
+			wantState:        api.OverrideStateValue,
+		},
+		{
+			name:             "explicit clear replaces stored pin",
+			currentIMDBID:    new(0),
+			candidateIMDBRef: 7654321,
+			candidateState:   api.OverrideStateClear,
+			wantState:        api.OverrideStateClear,
+			wantTMDBMetadata: true,
+		},
+		{
+			name:             "explicit replacement replaces stored pin",
+			currentIMDBID:    new(7777777),
+			candidateIMDBID:  7777777,
+			candidateIMDBRef: 7777777,
+			candidateState:   api.OverrideStateValue,
+			wantIMDBID:       7777777,
+			wantState:        api.OverrideStateValue,
+			wantTMDBMetadata: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
+			tmdbID := 999888
+			resolver := &Resolver{
+				evidence: evidenceLoaderFunc(func(context.Context, string) (legacyEvidence, error) {
+					return legacyEvidence{
+						identity: api.ExternalIdentity{
+							SourcePath: sourcePath,
+							IMDBID:     1234567,
+							Provenance: api.IdentityProvenanceSet{IMDB: api.IdentityProvenanceExplicit},
+							Overrides:  api.IdentityOverrideState{IMDB: api.OverrideStateValue},
+						},
+						hasIDs: true,
+					}, nil
+				}),
+				candidate: candidateSourceFunc(func(_ context.Context, request Request) (CandidateEvidence, error) {
+					return CandidateEvidence{
+						Identity: api.ExternalIdentity{
+							SourcePath: request.SourcePath,
+							TMDBID:     tmdbID,
+							IMDBID:     tc.candidateIMDBID,
+							Provenance: api.IdentityProvenanceSet{TMDB: api.IdentityProvenanceExplicit, IMDB: api.IdentityProvenanceProvider},
+							Overrides:  api.IdentityOverrideState{TMDB: api.OverrideStateValue, IMDB: tc.candidateState},
+						},
+						Metadata: api.SourceScopedMetadata{
+							SourcePath: request.SourcePath,
+							TMDB: &api.TMDBMetadata{
+								TMDBID: tmdbID,
+								IMDBID: tc.candidateIMDBRef,
+								Title:  "Candidate TMDB",
+							},
+						},
+					}, nil
+				}),
+				now: time.Now,
+			}
+
+			result, err := resolver.Resolve(context.Background(), Request{
+				SourcePath:        sourcePath,
+				SourceFingerprint: "source-fingerprint",
+				Generation:        1,
+				Intent: ResolutionIntent{ProviderOverrides: api.ExternalIDOverrides{
+					TMDBID: &tmdbID,
+					IMDBID: tc.currentIMDBID,
+				}},
+			})
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			if result.Identity.TMDBID != tmdbID || result.Identity.IMDBID != tc.wantIMDBID || result.Identity.Overrides.IMDB != tc.wantState {
+				t.Fatalf("identity = %#v", result.Identity)
+			}
+			if got := result.ProviderMetadata.TMDB != nil; got != tc.wantTMDBMetadata {
+				t.Fatalf("TMDB metadata = %#v", result.ProviderMetadata.TMDB)
+			}
+		})
+	}
+}
+
 func TestResolveAppliesTriStateIntentWithoutPersisting(t *testing.T) {
 	repoPath := filepath.Join(t.TempDir(), "external-identity.db")
 	repo, err := db.OpenWithLogger(repoPath, api.NopLogger{})
@@ -214,10 +481,10 @@ func TestResolveCancellationDoesNotReorderSourceWaiters(t *testing.T) {
 		now: time.Now,
 	}
 	request := Request{
-SourcePath: sourcePath,
- SourceFingerprint: "source-fingerprint",
- Generation: 1,
-}
+		SourcePath:        sourcePath,
+		SourceFingerprint: "source-fingerprint",
+		Generation:        1,
+	}
 	errs := make(chan error, 3)
 	go func() {
 		_, err := resolver.Resolve(context.Background(), request)

--- a/internal/externalidentity/resolver_test.go
+++ b/internal/externalidentity/resolver_test.go
@@ -133,6 +133,107 @@ func TestResolveDropsProviderMetadataConflictingWithExplicitCrossReference(t *te
 	}
 }
 
+func TestResolveCrossReferenceMetadataHonorsStoredProvenancePins(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		provider           api.IdentityProvider
+		provenance         api.IdentityProvenance
+		wantTMDBMetadata   bool
+		wantTVmazeMetadata bool
+	}{
+		{
+			name:       "explicit IMDb provenance with unset override drops conflicting metadata",
+			provider:   api.IdentityProviderIMDB,
+			provenance: api.IdentityProvenanceExplicit,
+		},
+		{
+			name:       "explicit TVDB provenance with unset override drops conflicting metadata",
+			provider:   api.IdentityProviderTVDB,
+			provenance: api.IdentityProvenanceExplicit,
+		},
+		{
+			name:               "provider IMDb provenance retains conflicting metadata",
+			provider:           api.IdentityProviderIMDB,
+			provenance:         api.IdentityProvenanceProvider,
+			wantTMDBMetadata:   true,
+			wantTVmazeMetadata: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
+			storedID := 1234567
+			metadataIMDBID := 0
+			metadataTVDBID := 0
+			identity := api.ExternalIdentity{
+				SourcePath: sourcePath,
+				Overrides: api.IdentityOverrideState{
+					IMDB: api.OverrideStateUnset,
+					TVDB: api.OverrideStateUnset,
+				},
+			}
+			if tc.provider == api.IdentityProviderIMDB {
+				identity.IMDBID = storedID
+				identity.Provenance.IMDB = tc.provenance
+				metadataIMDBID = 9999999
+			} else {
+				identity.TVDBID = storedID
+				identity.Provenance.TVDB = tc.provenance
+				metadataTVDBID = 8888888
+			}
+			resolver := &Resolver{
+				evidence: evidenceLoaderFunc(func(context.Context, string) (legacyEvidence, error) {
+					return legacyEvidence{
+						identity: identity,
+						hasIDs:   true,
+					}, nil
+				}),
+				candidate: candidateSourceFunc(func(_ context.Context, request Request) (CandidateEvidence, error) {
+					return CandidateEvidence{
+						Identity: api.ExternalIdentity{
+							SourcePath: request.SourcePath,
+							TMDBID:     111222,
+							TVmazeID:   333444,
+						},
+						Metadata: api.SourceScopedMetadata{
+							SourcePath: request.SourcePath,
+							TMDB: &api.TMDBMetadata{
+								TMDBID: 111222,
+								IMDBID: metadataIMDBID,
+								TVDBID: metadataTVDBID,
+							},
+							TVmaze: &api.TVmazeMetadata{
+								TVmazeID: 333444,
+								IMDBID:   metadataIMDBID,
+								TVDBID:   metadataTVDBID,
+							},
+						},
+					}, nil
+				}),
+				now: time.Now,
+			}
+
+			result, err := resolver.Resolve(context.Background(), Request{
+				SourcePath:        sourcePath,
+				SourceFingerprint: "source-fingerprint",
+				Generation:        1,
+			})
+			if err != nil {
+				t.Fatalf("resolve: %v", err)
+			}
+			if id, ok := result.Identity.ProviderID(tc.provider); !ok || id != storedID {
+				t.Fatalf("stored %s identity = %#v", tc.provider, result.Identity)
+			}
+			if got := result.ProviderMetadata.TMDB != nil; got != tc.wantTMDBMetadata {
+				t.Fatalf("TMDB metadata = %#v", result.ProviderMetadata.TMDB)
+			}
+			if got := result.ProviderMetadata.TVmaze != nil; got != tc.wantTVmazeMetadata {
+				t.Fatalf("TVmaze metadata = %#v", result.ProviderMetadata.TVmaze)
+			}
+		})
+	}
+}
+
 func TestResolveClearsStoredProviderGuessesFromAuthoritativeCandidate(t *testing.T) {
 	t.Parallel()
 	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -132,6 +133,10 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 		if strings.TrimSpace(ids.SourcePath) == "" {
 			ids.SourcePath = meta.SourcePath
 		}
+	} else if storedIDs, err := s.repo.GetExternalIdentity(ctx, meta.SourcePath); err == nil {
+		copyStoredProviderPins(&ids, storedIDs)
+	} else if !errors.Is(err, internalerrors.ErrNotFound) {
+		return preparationstate.State{}, fmt.Errorf("metadata: load stored external identity: %w", err)
 	}
 	metadata := api.SourceScopedMetadata{SourcePath: meta.SourcePath}
 	if meta.StoredDataFresh && sourceScopedMetadataMatches(meta.ProviderMetadata.SourcePath, meta.SourcePath) {
@@ -159,11 +164,17 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 		s.logger.Debugf("metadata: external ids start path=%q category=%q", meta.SourcePath, ids.Category)
 	}
 
-	overrideTMDB, clearedTMDB := applyOverrideID(&ids.TMDBID, &ids.Provenance.TMDB, &ids.Overrides.TMDB, meta.ExternalIDOverrides.TMDBID)
-	overrideIMDB, clearedIMDB := applyOverrideID(&ids.IMDBID, &ids.Provenance.IMDB, &ids.Overrides.IMDB, meta.ExternalIDOverrides.IMDBID)
-	overrideTVDB, clearedTVDB := applyOverrideID(&ids.TVDBID, &ids.Provenance.TVDB, &ids.Overrides.TVDB, meta.ExternalIDOverrides.TVDBID)
-	overrideTVmaze, _ := applyOverrideID(&ids.TVmazeID, &ids.Provenance.TVmaze, &ids.Overrides.TVmaze, meta.ExternalIDOverrides.TVmazeID)
-	overrideMAL, clearedMAL := applyOverrideID(&ids.MALID, &ids.Provenance.MAL, &ids.Overrides.MAL, meta.ExternalIDOverrides.MALID)
+	applyOverrideID(&ids.TMDBID, &ids.Provenance.TMDB, &ids.Overrides.TMDB, meta.ExternalIDOverrides.TMDBID)
+	applyOverrideID(&ids.IMDBID, &ids.Provenance.IMDB, &ids.Overrides.IMDB, meta.ExternalIDOverrides.IMDBID)
+	applyOverrideID(&ids.TVDBID, &ids.Provenance.TVDB, &ids.Overrides.TVDB, meta.ExternalIDOverrides.TVDBID)
+	applyOverrideID(&ids.TVmazeID, &ids.Provenance.TVmaze, &ids.Overrides.TVmaze, meta.ExternalIDOverrides.TVmazeID)
+	applyOverrideID(&ids.MALID, &ids.Provenance.MAL, &ids.Overrides.MAL, meta.ExternalIDOverrides.MALID)
+	effectiveOverrides := effectiveProviderOverrides(meta.ExternalIDOverrides, ids)
+	overrideTMDB, clearedTMDB := positiveProviderOverride(effectiveOverrides.TMDBID), clearedProviderOverride(effectiveOverrides.TMDBID)
+	overrideIMDB, clearedIMDB := positiveProviderOverride(effectiveOverrides.IMDBID), clearedProviderOverride(effectiveOverrides.IMDBID)
+	overrideTVDB, clearedTVDB := positiveProviderOverride(effectiveOverrides.TVDBID), clearedProviderOverride(effectiveOverrides.TVDBID)
+	overrideTVmaze, clearedTVmaze := positiveProviderOverride(effectiveOverrides.TVmazeID), clearedProviderOverride(effectiveOverrides.TVmazeID)
+	overrideMAL, clearedMAL := positiveProviderOverride(effectiveOverrides.MALID), clearedProviderOverride(effectiveOverrides.MALID)
 
 	trackerTMDB, trackerIMDB, trackerTVDB, trackerMAL := resolveTrackerIDs(meta.TrackerData)
 	if !overrideTMDB && !clearedTMDB {
@@ -198,7 +209,7 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 	if !overrideTVDB && !clearedTVDB {
 		applyResolvedID(&ids.TVDBID, &ids.Provenance.TVDB, meta.SceneTVDBID, "scene")
 	}
-	if !overrideTVmaze {
+	if !overrideTVmaze && !clearedTVmaze {
 		applyResolvedID(&ids.TVmazeID, &ids.Provenance.TVmaze, meta.SceneTVmazeID, "scene")
 	}
 	if !overrideMAL && !clearedMAL {
@@ -216,8 +227,12 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 	if !overrideTVDB && !clearedTVDB {
 		applyResolvedID(&ids.TVDBID, &ids.Provenance.TVDB, meta.ArrTVDBID, metautil.FirstNonEmptyTrimmed(strings.TrimSpace(meta.ArrSource), "arr"))
 	}
-	if !overrideTVmaze {
+	if !overrideTVmaze && !clearedTVmaze {
 		applyResolvedID(&ids.TVmazeID, &ids.Provenance.TVmaze, meta.ArrTVmazeID, metautil.FirstNonEmptyTrimmed(strings.TrimSpace(meta.ArrSource), "arr"))
+	}
+	hasExplicitProviderAnchor := hasPositiveProviderOverride(effectiveOverrides)
+	if hasExplicitProviderAnchor {
+		clearPreviouslyResolvedProviderIDs(&ids)
 	}
 	if s.logger != nil {
 		s.logger.Debugf(
@@ -231,6 +246,7 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 		)
 	}
 	invalidateMismatchedProviderMetadata(&metadata, ids)
+	invalidateProviderMetadataForExplicitReconciliation(&metadata, effectiveOverrides)
 
 	tmdbClient, anilistClient, imdbClient, tvdbClient, tvmazeClient := s.ensureExternalClients()
 
@@ -241,9 +257,19 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 		manualLanguage = strings.TrimSpace(*meta.MetadataOverrides.OriginalLanguage)
 	}
 	unattendedSearch := isUnattendedMetadataSearch(meta)
-	if tmdbClient != nil && !overrideTMDB && ids.TMDBID == 0 && ids.IMDBID != 0 {
+	lastTMDBLookupIMDB := 0
+	lastTMDBLookupTVDB := 0
+	resolveTMDBFromProviderIDs := func() {
+		if tmdbClient == nil || overrideTMDB || clearedTMDB || ids.TMDBID != 0 || ids.IMDBID == 0 && ids.TVDBID == 0 {
+			return
+		}
+		if ids.IMDBID == lastTMDBLookupIMDB && ids.TVDBID == lastTMDBLookupTVDB {
+			return
+		}
+		lastTMDBLookupIMDB = ids.IMDBID
+		lastTMDBLookupTVDB = ids.TVDBID
 		if s.logger != nil {
-			s.logger.Debugf("metadata: external ids lookup tmdb from imdb=%d", ids.IMDBID)
+			s.logger.Debugf("metadata: external ids lookup tmdb from imdb=%d tvdb=%d", ids.IMDBID, ids.TVDBID)
 		}
 		result, err := tmdbClient.FindByExternalID(ctx, tmdb.FindInput{
 			IMDbID:             formatIMDbID(ids.IMDBID),
@@ -256,26 +282,31 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 				OriginalTitle: secondary,
 				Year:          year,
 			},
-			Unattended: unattendedSearch,
-			Debug:      false,
+			RequireExternalIDAgreement: hasExplicitProviderAnchor,
+			Unattended:                 unattendedSearch,
+			Debug:                      false,
 		})
 		if err != nil {
 			if s.logger != nil {
 				s.logger.Warnf("metadata: tmdb external lookup failed: %v", err)
 			}
-		} else if result.TMDBID != 0 {
+		} else if result.TMDBID != 0 && (!result.FilenameSearch || !hasExplicitProviderAnchor) {
 			applyResolvedID(&ids.TMDBID, &ids.Provenance.TMDB, result.TMDBID, "tmdb_external")
 			if ids.Category == "" && result.Category != "" {
 				ids.Category, _ = api.NormalizeCanonicalCategory(result.Category)
 			}
 		}
+		if result.ExternalIDConflict {
+			appendIdentityCorrectionWarning(&meta, "TMDB could not reconcile the supplied IMDb and TVDB IDs. Correct one of the supplied provider IDs.")
+		}
 		if len(result.Candidates) > 0 && len(candidates.TMDB) == 0 {
 			candidates.TMDB = mapTMDBCandidates(result.Candidates, result.Category)
 		}
 	}
+	resolveTMDBFromProviderIDs()
 
-	needsTMDBSearch := tmdbClient != nil && !overrideTMDB && ids.TMDBID == 0
-	needsIMDBSearch := !overrideIMDB && ids.IMDBID == 0
+	needsTMDBSearch := tmdbClient != nil && !overrideTMDB && !clearedTMDB && ids.TMDBID == 0 && !hasExplicitProviderAnchor
+	needsIMDBSearch := !overrideIMDB && !clearedIMDB && ids.IMDBID == 0 && !hasExplicitProviderAnchor
 
 	if needsTMDBSearch || needsIMDBSearch {
 		searchYears := buildSearchYears(year)
@@ -297,8 +328,8 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 				break
 			}
 
-			stageNeedsTMDB := tmdbClient != nil && !overrideTMDB && ids.TMDBID == 0
-			stageNeedsIMDB := !overrideIMDB && ids.IMDBID == 0
+			stageNeedsTMDB := tmdbClient != nil && !overrideTMDB && !clearedTMDB && ids.TMDBID == 0
+			stageNeedsIMDB := !overrideIMDB && !clearedIMDB && ids.IMDBID == 0
 			if !stageNeedsTMDB && !stageNeedsIMDB {
 				break
 			}
@@ -412,12 +443,24 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 	}
 
 	tmdbLogoFetchAttempted := false
+	tmdbAnchorVerificationAttempted := false
+	tmdbMetadataRejected := false
+	tvdbMetadataRejected := false
+	tvmazeMetadataRejected := false
+	tvmazeAnchorVerificationAttempted := false
 	anilistFetchAttempted := false
 	tvdbMetadataFetchAttempted := false
 	tvdbDisambiguationFetchAttempted := false
+	var acceptedTMDBLinks providerExternalLinks
+	var acceptedTVmazeLinks providerExternalLinks
+	hasAcceptedTMDBLinks := false
+	hasAcceptedTVmazeLinks := false
 	shouldFetchTMDBMetadata := func() bool {
 		if tmdbClient == nil || ids.TMDBID == 0 {
 			return false
+		}
+		if overrideTMDB {
+			return !tmdbAnchorVerificationAttempted
 		}
 		if !usableTMDBMetadata(metadata.TMDB, ids.TMDBID) {
 			return true
@@ -437,7 +480,13 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 			!reusableTVDBNameDisambiguation(metadata.TVDB)
 	}
 	shouldFetchTVmazeMetadata := func() bool {
-		return tvmazeClient != nil && isTVForTVmaze() && ids.TVmazeID != 0 && !usableTVmazeMetadata(metadata.TVmaze, ids.TVmazeID)
+		if tvmazeClient == nil || !isTVForTVmaze() || ids.TVmazeID == 0 {
+			return false
+		}
+		if overrideTVmaze {
+			return !tvmazeAnchorVerificationAttempted
+		}
+		return !usableTVmazeMetadata(metadata.TVmaze, ids.TVmazeID)
 	}
 
 	shouldRunFetchPass := func() bool {
@@ -450,17 +499,22 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 		if shouldFetchIMDBMetadata() || shouldFetchTVDBMetadata() || shouldRefreshTVDBDisambiguation() || shouldFetchTVmazeMetadata() {
 			return true
 		}
-		if shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && ids.TVDBID == 0 && (ids.IMDBID != 0 || ids.TMDBID != 0) {
+		if shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && !clearedTVDB && ids.TVDBID == 0 && (ids.IMDBID != 0 || ids.TMDBID != 0) {
 			return true
 		}
-		if isTVForTVmaze() && (shouldFetchTVmazeMetadata() || (!overrideTVmaze && ids.TVmazeID == 0 && (ids.IMDBID != 0 || ids.TVDBID != 0))) {
+		if isTVForTVmaze() &&
+			(shouldFetchTVmazeMetadata() || (!overrideTVmaze && !clearedTVmaze && ids.TVmazeID == 0 && (ids.IMDBID != 0 || ids.TVDBID != 0))) {
 			return true
 		}
 		return false
 	}
 
 	runFetchPass := func(allowTVmazeNameFallback bool) {
+		allowTVmazeNameFallback = allowTVmazeNameFallback && !hasExplicitProviderAnchor
 		fetchTMDB := shouldFetchTMDBMetadata()
+		if fetchTMDB && overrideTMDB {
+			tmdbAnchorVerificationAttempted = true
+		}
 		if fetchTMDB && s.cfg.Description.AddLogo {
 			tmdbLogoFetchAttempted = true
 		}
@@ -474,8 +528,12 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 		if fetchTVDB {
 			tvdbMetadataFetchAttempted = true
 		}
-		lookupTVDB := shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && ids.TVDBID == 0 && (ids.IMDBID != 0 || ids.TMDBID != 0)
-		lookupTVmaze := isTVForTVmaze() && (shouldFetchTVmazeMetadata() || (!overrideTVmaze && ids.TVmazeID == 0 && (ids.IMDBID != 0 || ids.TVDBID != 0)))
+		lookupTVDB := shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && !clearedTVDB && ids.TVDBID == 0 && (ids.IMDBID != 0 || ids.TMDBID != 0)
+		lookupTVmaze := isTVForTVmaze() &&
+			(shouldFetchTVmazeMetadata() || (!overrideTVmaze && !clearedTVmaze && ids.TVmazeID == 0 && (ids.IMDBID != 0 || ids.TVDBID != 0)))
+		if lookupTVmaze && overrideTVmaze {
+			tvmazeAnchorVerificationAttempted = true
+		}
 
 		if s.logger != nil {
 			s.logger.Debugf(
@@ -502,16 +560,17 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 		if fetchTMDB {
 			group.Go(func() error {
 				result, err := tmdbClient.FetchMetadata(gctx, tmdb.MetadataInput{
-					TMDBID:         ids.TMDBID,
-					Category:       string(ids.Category),
-					SearchYear:     year,
-					IMDbID:         ids.IMDBID,
-					TVDBID:         ids.TVDBID,
-					ManualLanguage: manualLanguage,
-					AddLogo:        s.cfg.Description.AddLogo,
-					LogoLanguages:  descriptionLogoLanguages(s.cfg.Description.LogoLanguage),
-					Filename:       filename,
-					Debug:          false,
+					TMDBID:          ids.TMDBID,
+					Category:        string(ids.Category),
+					SearchYear:      year,
+					IMDbID:          ids.IMDBID,
+					TVDBID:          ids.TVDBID,
+					ManualLanguage:  manualLanguage,
+					SkipAnimeLookup: hasExplicitProviderAnchor || clearedMAL,
+					AddLogo:         s.cfg.Description.AddLogo,
+					LogoLanguages:   descriptionLogoLanguages(s.cfg.Description.LogoLanguage),
+					Filename:        filename,
+					Debug:           false,
 				})
 				if err != nil {
 					mu.Lock()
@@ -635,36 +694,106 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 
 		_ = group.Wait()
 
+		tmdbAccepted := tmdbResult != nil && tmdbMetadataMatchesExplicitIDs(effectiveOverrides, *tmdbResult, &meta)
+		tvmazeAccepted := tvmazeResult != nil && tvmazeMetadataMatchesExplicitIDs(effectiveOverrides, *tvmazeResult, &meta)
+		candidateTMDBLinks := acceptedTMDBLinks
+		candidateTVmazeLinks := acceptedTVmazeLinks
+		candidateHasTMDBLinks := hasAcceptedTMDBLinks
+		candidateHasTVmazeLinks := hasAcceptedTVmazeLinks
+		if tmdbAccepted {
+			candidateTMDBLinks = providerExternalLinks{IMDBID: tmdbResult.ExternalIMDbID, TVDBID: tmdbResult.ExternalTVDBID}
+			candidateHasTMDBLinks = true
+		}
+		if tvmazeAccepted {
+			candidateTVmazeLinks = tvmazeResultExternalLinks(*tvmazeResult)
+			candidateHasTVmazeLinks = true
+		}
+		if hasExplicitProviderAnchor && candidateHasTMDBLinks && candidateHasTVmazeLinks &&
+			providerExternalLinksConflict(candidateTMDBLinks, candidateTVmazeLinks) {
+			appendIdentityCorrectionWarning(&meta, "TMDB and TVmaze metadata reference different IMDb or TVDB IDs. Correct one of the supplied provider IDs.")
+			switch {
+			case overrideTMDB && !overrideTVmaze:
+				tvmazeAccepted = false
+				metadata.TVmaze = nil
+				clearInferredProviderID(&ids.TVmazeID, &ids.Provenance.TVmaze)
+				tvmazeMetadataRejected = ids.TVmazeID != 0
+				candidateHasTVmazeLinks = false
+			case overrideTVmaze && !overrideTMDB:
+				tmdbAccepted = false
+				metadata.TMDB = nil
+				clearInferredProviderID(&ids.TMDBID, &ids.Provenance.TMDB)
+				tmdbMetadataRejected = ids.TMDBID != 0
+				candidateHasTMDBLinks = false
+			default:
+				tmdbAccepted = false
+				tvmazeAccepted = false
+				metadata.TMDB = nil
+				metadata.TVmaze = nil
+				clearInferredProviderID(&ids.TMDBID, &ids.Provenance.TMDB)
+				clearInferredProviderID(&ids.TVmazeID, &ids.Provenance.TVmaze)
+				tmdbMetadataRejected = ids.TMDBID != 0
+				tvmazeMetadataRejected = ids.TVmazeID != 0
+				candidateHasTMDBLinks = false
+				candidateHasTVmazeLinks = false
+			}
+		}
+		acceptedTMDBLinks = candidateTMDBLinks
+		acceptedTVmazeLinks = candidateTVmazeLinks
+		hasAcceptedTMDBLinks = candidateHasTMDBLinks
+		hasAcceptedTVmazeLinks = candidateHasTVmazeLinks
+
 		if tmdbResult != nil {
-			metadata.TMDB = mapTMDBMetadata(ids, *tmdbResult)
-			if !overrideIMDB && ids.IMDBID == 0 && tmdbResult.IMDbID != 0 {
-				applyResolvedID(&ids.IMDBID, &ids.Provenance.IMDB, tmdbResult.IMDbID, "tmdb")
-			}
-			if ids.Category == "" && tmdbResult.TMDBType != "" {
-				ids.Category, _ = api.NormalizeCanonicalCategory(tmdbResult.TMDBType)
-			}
-			if shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && ids.TVDBID == 0 && tmdbResult.TVDBID != 0 {
-				applyResolvedID(&ids.TVDBID, &ids.Provenance.TVDB, tmdbResult.TVDBID, "tmdb")
-			}
-			if !overrideMAL && !clearedMAL && ids.MALID == 0 && tmdbResult.MALID != 0 {
-				applyResolvedID(&ids.MALID, &ids.Provenance.MAL, tmdbResult.MALID, "tmdb")
+			if tmdbAccepted {
+				tmdbMetadataRejected = false
+				metadata.TMDB = mapTMDBMetadata(ids, *tmdbResult)
+				if !overrideIMDB && !clearedIMDB && ids.IMDBID == 0 && tmdbResult.IMDbID != 0 {
+					applyResolvedID(&ids.IMDBID, &ids.Provenance.IMDB, tmdbResult.IMDbID, "tmdb")
+				}
+				if ids.Category == "" && tmdbResult.TMDBType != "" {
+					ids.Category, _ = api.NormalizeCanonicalCategory(tmdbResult.TMDBType)
+				}
+				if shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && !clearedTVDB && ids.TVDBID == 0 && tmdbResult.TVDBID != 0 {
+					applyResolvedID(&ids.TVDBID, &ids.Provenance.TVDB, tmdbResult.TVDBID, "tmdb")
+				}
+				if !hasExplicitProviderAnchor && !overrideMAL && !clearedMAL && ids.MALID == 0 && tmdbResult.MALID != 0 {
+					applyResolvedID(&ids.MALID, &ids.Provenance.MAL, tmdbResult.MALID, "tmdb")
+				}
+			} else {
+				metadata.TMDB = nil
+				clearInferredProviderID(&ids.TMDBID, &ids.Provenance.TMDB)
+				tmdbMetadataRejected = ids.TMDBID != 0
 			}
 		}
 
-		if anilistResult != nil {
-			metadata.AniList = mapAniListMetadata(*anilistResult)
-		} else if fetchAniList {
-			if metadata.AniList != nil {
+		switch {
+		case anilistResult == nil:
+			if fetchAniList && metadata.AniList != nil {
 				metadata.AniList = nil
 			}
+		case providerIDMatchesExplicit(effectiveOverrides.MALID, anilistResult.MALID):
+			metadata.AniList = mapAniListMetadata(*anilistResult)
+		default:
+			appendProviderIDConflictWarning(&meta, "AniList", "MAL", *effectiveOverrides.MALID, anilistResult.MALID)
+			metadata.AniList = nil
+			clearInferredProviderID(&ids.MALID, &ids.Provenance.MAL)
 		}
 
-		if imdbInfo != nil {
+		if imdbInfo != nil && providerIDMatchesExplicit(effectiveOverrides.IMDBID, metautil.ParseIMDbNumeric(imdbInfo.IMDbID)) {
 			metadata.IMDB = mapIMDBMetadata(*imdbInfo)
+		} else if imdbInfo != nil {
+			appendProviderIDConflictWarning(
+				&meta,
+				"IMDb",
+				"IMDb",
+				*effectiveOverrides.IMDBID,
+				metautil.ParseIMDbNumeric(imdbInfo.IMDbID),
+			)
+			metadata.IMDB = nil
+			clearInferredProviderID(&ids.IMDBID, &ids.Provenance.IMDB)
 		}
 
 		if fetchedTVDBID != 0 {
-			if !overrideTVDB {
+			if !overrideTVDB && !clearedTVDB {
 				applyResolvedID(&ids.TVDBID, &ids.Provenance.TVDB, fetchedTVDBID, "tvdb")
 			}
 			if metadata.TVDB == nil || metadata.TVDB.TVDBID == 0 {
@@ -687,7 +816,13 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 					}
 				}
 			}
-			if err == nil {
+			switch {
+			case err != nil:
+				if tvdbErr == nil {
+					tvdbErr = err
+				}
+			case providerIDMatchesExplicit(effectiveOverrides.TVDBID, tvdbSeries.TVDBID):
+				tvdbMetadataRejected = false
 				mapped := mapTVDBMetadata(ids.TVDBID, fetchedTVDBName, tvdbSeries)
 				if metadata.TVDB == nil {
 					metadata.TVDB = mapped
@@ -712,8 +847,11 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 				if strings.TrimSpace(tvdbName) == "" {
 					tvdbName = strings.TrimSpace(mapped.Name)
 				}
-			} else if tvdbErr == nil {
-				tvdbErr = err
+			default:
+				appendProviderIDConflictWarning(&meta, "TVDB", "TVDB", *effectiveOverrides.TVDBID, tvdbSeries.TVDBID)
+				metadata.TVDB = nil
+				clearInferredProviderID(&ids.TVDBID, &ids.Provenance.TVDB)
+				tvdbMetadataRejected = ids.TVDBID != 0
 			}
 		}
 
@@ -723,17 +861,22 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 			metadata.TVDB.NameDisambiguation = mapTVDBNameDisambiguation(refreshed)
 		}
 
-		if tvmazeResult != nil {
-			if !overrideTVmaze {
+		if tvmazeResult != nil && tvmazeAccepted {
+			tvmazeMetadataRejected = false
+			if !overrideTVmaze && !clearedTVmaze {
 				applyResolvedID(&ids.TVmazeID, &ids.Provenance.TVmaze, tvmazeResult.SelectedID, "tvmaze")
 			}
-			if !overrideIMDB && ids.IMDBID == 0 && tvmazeResult.IMDBID != 0 {
+			if !overrideIMDB && !clearedIMDB && ids.IMDBID == 0 && tvmazeResult.IMDBID != 0 {
 				applyResolvedID(&ids.IMDBID, &ids.Provenance.IMDB, tvmazeResult.IMDBID, "tvmaze")
 			}
-			if shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && ids.TVDBID == 0 && tvmazeResult.TVDBID != 0 {
+			if shouldUseTVDBForCategory(meta, ids) && !overrideTVDB && !clearedTVDB && ids.TVDBID == 0 && tvmazeResult.TVDBID != 0 {
 				applyResolvedID(&ids.TVDBID, &ids.Provenance.TVDB, tvmazeResult.TVDBID, "tvmaze")
 			}
 			metadata.TVmaze = mapTVmazeMetadata(*tvmazeResult)
+		} else if tvmazeResult != nil {
+			metadata.TVmaze = nil
+			clearInferredProviderID(&ids.TVmazeID, &ids.Provenance.TVmaze)
+			tvmazeMetadataRejected = ids.TVmazeID != 0
 		}
 
 		if manualLanguage != "" {
@@ -755,10 +898,12 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 	if shouldRunFetchPass() {
 		runFetchPass(false)
 	}
+	resolveTMDBFromProviderIDs()
 	// Tracker and media metadata can supply an episode IMDb ID where downstream
 	// providers require the parent series ID. Clear the episode snapshot so the
 	// second fetch pass refreshes series metadata after a successful adjustment.
-	if episodeClient, ok := imdbClient.(imdbEpisodeClient); ok && shouldUseTVDBForCategory(meta, ids) && metadata.IMDB != nil &&
+	if episodeClient, ok := imdbClient.(imdbEpisodeClient); ok && !overrideIMDB && !clearedIMDB && shouldUseTVDBForCategory(meta, ids) &&
+		metadata.IMDB != nil &&
 		strings.EqualFold(strings.TrimSpace(metadata.IMDB.Type), "tvEpisode") {
 		lookup, err := episodeClient.GetEpisodeInfo(ctx, formatIMDbID(ids.IMDBID), false)
 		if err != nil {
@@ -774,21 +919,36 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 			}
 		}
 	}
+	resolveTMDBFromProviderIDs()
 	if shouldRunFetchPass() {
 		runFetchPass(true)
 	}
 
+	if positiveProviderOverride(effectiveOverrides.TVDBID) && !shouldUseTVDBForCategory(meta, ids) {
+		appendIdentityCorrectionWarning(&meta, "The supplied TVDB ID conflicts with the resolved movie category. Correct the TVDB ID or category.")
+	}
 	clearTVDBForNonTVCategory(meta, &ids, &metadata)
-	meta = s.applyTVEpisodeMetadata(ctx, meta, &ids, &metadata, tmdbClient, tvdbClient, tvmazeClient)
+	downstreamIDs := ids
+	if tmdbMetadataRejected {
+		downstreamIDs.TMDBID = 0
+	}
+	if tvdbMetadataRejected {
+		downstreamIDs.TVDBID = 0
+	}
+	if tvmazeMetadataRejected {
+		downstreamIDs.TVmazeID = 0
+	}
+	meta = s.applyTVEpisodeMetadata(ctx, meta, &downstreamIDs, &metadata, tmdbClient, tvdbClient, tvmazeClient)
+	ids.Category = downstreamIDs.Category
 
 	needsPTBR := s.registry.NeedsLocalizedMetadata(meta.EvidenceTrackers, "pt-BR") || s.registry.NeedsLocalizedMetadata(meta.MatchedEvidenceTrackers, "pt-BR")
 
-	if tmdbClient != nil && needsPTBR && ids.TMDBID != 0 {
+	if tmdbClient != nil && needsPTBR && downstreamIDs.TMDBID != 0 {
 		var mainData, seasonData, episodeData map[string]any
 		var localizedErr error
 		isTV := strings.EqualFold(string(ids.Category), "TV")
 		mainInput := tmdb.LocalizedDataInput{
-			TMDBID:           ids.TMDBID,
+			TMDBID:           downstreamIDs.TMDBID,
 			Category:         string(ids.Category),
 			DataType:         "main",
 			Language:         "pt-BR",
@@ -802,7 +962,7 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 
 		if isTV && meta.SeasonInt > 0 {
 			seasonInput := tmdb.LocalizedDataInput{
-				TMDBID:           ids.TMDBID,
+				TMDBID:           downstreamIDs.TMDBID,
 				Season:           meta.SeasonInt,
 				Category:         "TV",
 				DataType:         "season",
@@ -816,7 +976,7 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 			}
 			if meta.EpisodeInt > 0 {
 				episodeInput := tmdb.LocalizedDataInput{
-					TMDBID:           ids.TMDBID,
+					TMDBID:           downstreamIDs.TMDBID,
 					Season:           meta.SeasonInt,
 					Episode:          meta.EpisodeInt,
 					Category:         "TV",
@@ -835,7 +995,7 @@ func (s *Service) collectProviderIdentityCandidate(ctx context.Context, meta pre
 		if mainData != nil || seasonData != nil || episodeData != nil {
 			localized := parseTMDBLocalizedData(mainData, seasonData, episodeData)
 			if metadata.TMDB == nil {
-				metadata.TMDB = &api.TMDBMetadata{TMDBID: ids.TMDBID}
+				metadata.TMDB = &api.TMDBMetadata{TMDBID: downstreamIDs.TMDBID}
 			}
 			if metadata.TMDB.Localized == nil {
 				metadata.TMDB.Localized = make(map[string]api.TMDBLocalizedData)
@@ -905,6 +1065,215 @@ func sourceScopedMetadataMatches(storedSourcePath string, currentSourcePath stri
 	return strings.EqualFold(trimmedStored, strings.TrimSpace(currentSourcePath))
 }
 
+func copyStoredProviderPins(target *api.ExternalIdentity, stored api.ExternalIdentity) {
+	if target == nil || !sourceScopedMetadataMatches(stored.SourcePath, target.SourcePath) {
+		return
+	}
+	copyStoredProviderPin(&target.TMDBID, &target.Provenance.TMDB, &target.Overrides.TMDB, stored.TMDBID, stored.Provenance.TMDB, stored.Overrides.TMDB)
+	copyStoredProviderPin(&target.IMDBID, &target.Provenance.IMDB, &target.Overrides.IMDB, stored.IMDBID, stored.Provenance.IMDB, stored.Overrides.IMDB)
+	copyStoredProviderPin(&target.TVDBID, &target.Provenance.TVDB, &target.Overrides.TVDB, stored.TVDBID, stored.Provenance.TVDB, stored.Overrides.TVDB)
+	copyStoredProviderPin(
+		&target.TVmazeID,
+		&target.Provenance.TVmaze,
+		&target.Overrides.TVmaze,
+		stored.TVmazeID,
+		stored.Provenance.TVmaze,
+		stored.Overrides.TVmaze,
+	)
+	copyStoredProviderPin(&target.MALID, &target.Provenance.MAL, &target.Overrides.MAL, stored.MALID, stored.Provenance.MAL, stored.Overrides.MAL)
+}
+
+func copyStoredProviderPin(
+	target *int,
+	provenance *api.IdentityProvenance,
+	override *api.OverrideState,
+	storedID int,
+	storedProvenance api.IdentityProvenance,
+	storedOverride api.OverrideState,
+) {
+	switch {
+	case storedOverride == api.OverrideStateClear || storedID == 0 && storedProvenance == api.IdentityProvenanceExplicit:
+		*target = 0
+		*provenance = api.IdentityProvenanceExplicit
+		*override = api.OverrideStateClear
+	case storedID > 0 && (storedOverride == api.OverrideStateValue || storedProvenance == api.IdentityProvenanceExplicit):
+		*target = storedID
+		*provenance = api.IdentityProvenanceExplicit
+		*override = api.OverrideStateValue
+	}
+}
+
+func hasPositiveProviderOverride(overrides api.ExternalIDOverrides) bool {
+	return positiveProviderOverride(overrides.TMDBID) || positiveProviderOverride(overrides.IMDBID) ||
+		positiveProviderOverride(overrides.TVDBID) || positiveProviderOverride(overrides.TVmazeID) || positiveProviderOverride(overrides.MALID)
+}
+
+func positiveProviderOverride(value *int) bool {
+	return value != nil && *value > 0
+}
+
+func clearedProviderOverride(value *int) bool {
+	return value != nil && *value == 0
+}
+
+func effectiveProviderOverrides(current api.ExternalIDOverrides, ids api.ExternalIdentity) api.ExternalIDOverrides {
+	return api.ExternalIDOverrides{
+		TMDBID:   effectiveProviderOverride(current.TMDBID, ids.TMDBID, ids.Provenance.TMDB, ids.Overrides.TMDB),
+		IMDBID:   effectiveProviderOverride(current.IMDBID, ids.IMDBID, ids.Provenance.IMDB, ids.Overrides.IMDB),
+		TVDBID:   effectiveProviderOverride(current.TVDBID, ids.TVDBID, ids.Provenance.TVDB, ids.Overrides.TVDB),
+		TVmazeID: effectiveProviderOverride(current.TVmazeID, ids.TVmazeID, ids.Provenance.TVmaze, ids.Overrides.TVmaze),
+		MALID:    effectiveProviderOverride(current.MALID, ids.MALID, ids.Provenance.MAL, ids.Overrides.MAL),
+	}
+}
+
+func effectiveProviderOverride(current *int, id int, provenance api.IdentityProvenance, state api.OverrideState) *int {
+	if current != nil {
+		return current
+	}
+	if state == api.OverrideStateClear {
+		return new(0)
+	}
+	if state == api.OverrideStateValue || provenance == api.IdentityProvenanceExplicit {
+		return new(id)
+	}
+	return nil
+}
+
+type providerExternalLinks struct {
+	IMDBID int
+	TVDBID int
+}
+
+func tvmazeResultExternalLinks(result tvmaze.SearchResult) providerExternalLinks {
+	for _, candidate := range result.Candidates {
+		if candidate.ID == result.SelectedID {
+			return providerExternalLinks{
+				IMDBID: metautil.ParseIMDbNumeric(candidate.Externals.IMDB),
+				TVDBID: candidate.Externals.TVDB,
+			}
+		}
+	}
+	return providerExternalLinks{}
+}
+
+func providerExternalLinksConflict(first, second providerExternalLinks) bool {
+	return first.IMDBID != 0 && second.IMDBID != 0 && first.IMDBID != second.IMDBID ||
+		first.TVDBID != 0 && second.TVDBID != 0 && first.TVDBID != second.TVDBID
+}
+
+func clearPreviouslyResolvedProviderIDs(ids *api.ExternalIdentity) {
+	if ids == nil {
+		return
+	}
+	clearInferredProviderID(&ids.TMDBID, &ids.Provenance.TMDB)
+	clearInferredProviderID(&ids.IMDBID, &ids.Provenance.IMDB)
+	clearInferredProviderID(&ids.TVDBID, &ids.Provenance.TVDB)
+	clearInferredProviderID(&ids.TVmazeID, &ids.Provenance.TVmaze)
+	clearInferredProviderID(&ids.MALID, &ids.Provenance.MAL)
+}
+
+func clearInferredProviderID(id *int, provenance *api.IdentityProvenance) {
+	if id == nil || provenance == nil || *provenance == api.IdentityProvenanceExplicit {
+		return
+	}
+	*id = 0
+	*provenance = api.IdentityProvenanceUnknown
+}
+
+func providerIDMatchesExplicit(explicit *int, actual int) bool {
+	return !positiveProviderOverride(explicit) || actual == 0 || actual == *explicit
+}
+
+func tmdbMetadataMatchesExplicitIDs(overrides api.ExternalIDOverrides, result tmdb.MetadataResult, meta *preparationstate.State) bool {
+	matches := true
+	if !providerIDMatchesExplicit(overrides.IMDBID, result.ExternalIMDbID) {
+		appendProviderIDConflictWarning(meta, "TMDB", "IMDb", *overrides.IMDBID, result.ExternalIMDbID)
+		matches = false
+	}
+	if !providerIDMatchesExplicit(overrides.TVDBID, result.ExternalTVDBID) {
+		appendProviderIDConflictWarning(meta, "TMDB", "TVDB", *overrides.TVDBID, result.ExternalTVDBID)
+		matches = false
+	}
+	return matches
+}
+
+func tvmazeMetadataMatchesExplicitIDs(overrides api.ExternalIDOverrides, result tvmaze.SearchResult, meta *preparationstate.State) bool {
+	selected := tvmaze.Candidate{}
+	for _, candidate := range result.Candidates {
+		if candidate.ID == result.SelectedID {
+			selected = candidate
+			break
+		}
+	}
+	actualIMDB := metautil.ParseIMDbNumeric(selected.Externals.IMDB)
+	actualTVDB := selected.Externals.TVDB
+	matches := true
+	if !providerIDVerifiesExplicit(overrides.IMDBID, actualIMDB) {
+		appendProviderIDVerificationWarning(meta, "TVmaze", "IMDb", *overrides.IMDBID, actualIMDB)
+		matches = false
+	}
+	if !providerIDVerifiesExplicit(overrides.TVDBID, actualTVDB) {
+		appendProviderIDVerificationWarning(meta, "TVmaze", "TVDB", *overrides.TVDBID, actualTVDB)
+		matches = false
+	}
+	return matches
+}
+
+func providerIDVerifiesExplicit(explicit *int, actual int) bool {
+	return !positiveProviderOverride(explicit) || actual == *explicit
+}
+
+func appendProviderIDVerificationWarning(meta *preparationstate.State, source, provider string, expected, actual int) {
+	if actual == 0 {
+		appendIdentityCorrectionWarning(
+			meta,
+			fmt.Sprintf("%s metadata did not verify the supplied %s ID %d. Review the supplied provider IDs before upload.", source, provider, expected),
+		)
+		return
+	}
+	appendProviderIDConflictWarning(meta, source, provider, expected, actual)
+}
+
+func appendProviderIDConflictWarning(meta *preparationstate.State, source, provider string, expected, actual int) {
+	appendIdentityCorrectionWarning(
+		meta,
+		fmt.Sprintf(
+			"%s metadata references %s ID %d, but the supplied %s ID is %d. Correct one of the supplied provider IDs.",
+			source,
+			provider,
+			actual,
+			provider,
+			expected,
+		),
+	)
+}
+
+func appendIdentityCorrectionWarning(meta *preparationstate.State, warning string) {
+	if meta == nil || strings.TrimSpace(warning) == "" {
+		return
+	}
+	if slices.Contains(meta.LookupWarnings, warning) {
+		return
+	}
+	meta.LookupWarnings = append(meta.LookupWarnings, warning)
+}
+
+func invalidateProviderMetadataForExplicitReconciliation(metadata *api.SourceScopedMetadata, overrides api.ExternalIDOverrides) {
+	if metadata == nil {
+		return
+	}
+	if positiveProviderOverride(overrides.TMDBID) && (positiveProviderOverride(overrides.IMDBID) || positiveProviderOverride(overrides.TVDBID)) {
+		metadata.TMDB = nil
+	}
+	if positiveProviderOverride(overrides.TVmazeID) && (positiveProviderOverride(overrides.IMDBID) || positiveProviderOverride(overrides.TVDBID)) {
+		metadata.TVmaze = nil
+	}
+	if positiveProviderOverride(overrides.TMDBID) && positiveProviderOverride(overrides.TVmazeID) {
+		metadata.TMDB = nil
+		metadata.TVmaze = nil
+	}
+}
+
 func invalidateMismatchedProviderMetadata(metadata *api.SourceScopedMetadata, ids api.ExternalIdentity) bool {
 	if metadata == nil {
 		return false
@@ -924,6 +1293,10 @@ func invalidateMismatchedProviderMetadata(metadata *api.SourceScopedMetadata, id
 	}
 	if metadata.TVmaze != nil && (ids.TVmazeID == 0 || metadata.TVmaze.TVmazeID != ids.TVmazeID) {
 		metadata.TVmaze = nil
+		changed = true
+	}
+	if metadata.AniList != nil && (ids.MALID == 0 || metadata.AniList.MALID != ids.MALID) {
+		metadata.AniList = nil
 		changed = true
 	}
 	return changed
@@ -992,6 +1365,12 @@ func clearTVDBForNonTVCategory(meta preparationstate.State, ids *api.ExternalIde
 		return
 	}
 	if shouldUseTVDBForCategory(meta, *ids) {
+		return
+	}
+	if ids.Overrides.TVDB == api.OverrideStateValue || ids.Provenance.TVDB == api.IdentityProvenanceExplicit {
+		if metadata != nil {
+			metadata.TVDB = nil
+		}
 		return
 	}
 	ids.TVDBID = 0
@@ -1403,20 +1782,19 @@ func normalizeCategory(value string) string {
 	return ""
 }
 
-func applyOverrideID(target *int, source *api.IdentityProvenance, state *api.OverrideState, override *int) (bool, bool) {
+func applyOverrideID(target *int, source *api.IdentityProvenance, state *api.OverrideState, override *int) {
 	if target == nil || source == nil || state == nil || override == nil {
-		return false, false
+		return
 	}
 	if *override == 0 {
 		*target = 0
 		*source = api.IdentityProvenanceExplicit
 		*state = api.OverrideStateClear
-		return false, true
+		return
 	}
 	*target = *override
 	*source = api.IdentityProvenanceExplicit
 	*state = api.OverrideStateValue
-	return true, false
 }
 
 func applyResolvedID(target *int, source *api.IdentityProvenance, value int, origin string) {

--- a/internal/metadata/external_ids.go
+++ b/internal/metadata/external_ids.go
@@ -33,6 +33,7 @@ import (
 	"github.com/autobrr/upbrr/internal/metadata/tvmaze"
 	pathutil "github.com/autobrr/upbrr/internal/pathing"
 	"github.com/autobrr/upbrr/internal/providerid"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -2530,14 +2531,16 @@ func (s *Service) applyTVEpisodeMetadata(
 			if mappedSeason, mappedEpisode, err := xemClient.MapAbsoluteEpisode(ctx, ids.TVDBID, absoluteEpisode); err == nil {
 				season = metautil.FirstInt(mappedSeason, season)
 				episode = metautil.FirstInt(mappedEpisode, episode)
-			} else if !errors.Is(err, thexem.ErrUnavailable) && s.logger != nil {
-				s.logger.Debugf("metadata: thexem absolute mapping failed: %v", err)
+			} else if s.logger != nil {
+				s.logger.Debugf("metadata: thexem absolute mapping failed tvdb_id=%d error=%s", ids.TVDBID, redaction.RedactValue(err.Error(), nil))
 			}
 			if season == 0 {
 				title := resolveSeriesTitle(meta, external)
 				if title != "" {
 					if matchedSeason, err := xemClient.MatchSeasonByName(ctx, ids.TVDBID, title); err == nil && matchedSeason > 0 {
 						season = matchedSeason
+					} else if err != nil && s.logger != nil {
+						s.logger.Debugf("metadata: thexem season lookup failed tvdb_id=%d error=%s", ids.TVDBID, redaction.RedactValue(err.Error(), nil))
 					}
 				}
 			}

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -6,6 +6,7 @@ package metadata
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -15,10 +16,13 @@ import (
 
 	"github.com/autobrr/upbrr/internal/config"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	"github.com/autobrr/upbrr/internal/externalidentity"
 	"github.com/autobrr/upbrr/internal/metadata/imdb"
 	"github.com/autobrr/upbrr/internal/metadata/tmdb"
 	"github.com/autobrr/upbrr/internal/metadata/tvdb"
 	"github.com/autobrr/upbrr/internal/metadata/tvmaze"
+	"github.com/autobrr/upbrr/internal/preparedrelease"
+	"github.com/autobrr/upbrr/internal/services/db"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
@@ -60,6 +64,20 @@ type fakeRepo struct {
 	externalMetaSaves   int
 }
 
+type recordingEvidencePipeline struct {
+	service *Service
+	state   preparationstate.State
+}
+
+func (p *recordingEvidencePipeline) CollectPreparationEvidence(
+	ctx context.Context,
+	request preparationstate.Request,
+) (preparationstate.State, error) {
+	state, err := p.service.CollectPreparationEvidence(ctx, request)
+	p.state = state
+	return state, err
+}
+
 // resolveExternalIdentity keeps provider-adapter tests focused on the candidate
 // returned to canonical preparation; production collection never publishes it.
 func (s *Service) resolveExternalIdentity(ctx context.Context, meta preparationstate.State) (preparationstate.State, error) {
@@ -78,7 +96,10 @@ func (f *fakeRepo) Save(_ context.Context, metadata api.FileMetadata) error {
 	return nil
 }
 
-func (f *fakeRepo) GetExternalIdentity(_ context.Context, _ string) (api.ExternalIdentity, error) {
+func (f *fakeRepo) GetExternalIdentity(_ context.Context, path string) (api.ExternalIdentity, error) {
+	if strings.EqualFold(strings.TrimSpace(f.ids.SourcePath), strings.TrimSpace(path)) {
+		return f.ids, nil
+	}
 	return api.ExternalIdentity{}, internalerrors.ErrNotFound
 }
 
@@ -280,9 +301,13 @@ type stubTMDB struct {
 	metadataErr     error
 	anilistErr      error
 	searchFn        func(tmdb.SearchInput) (tmdb.SearchOutcome, error)
+	findFn          func(tmdb.FindInput) (tmdb.FindResult, error)
+	metadataFn      func(tmdb.MetadataInput) (tmdb.MetadataResult, error)
 	dailySeason     int
 	dailyEpisode    int
 	dailyErr        error
+	episodeDetails  tmdb.EpisodeDetails
+	seasonDetails   tmdb.SeasonDetails
 	localizedData   map[string]any
 	localizedByType map[string]map[string]any
 	localizedErr    error
@@ -292,6 +317,9 @@ type stubTMDB struct {
 	findCalls       int
 	metaCalls       int
 	anilistCalls    int
+	dailyCalls      int
+	episodeCalls    int
+	seasonCalls     int
 	localizedInputs []tmdb.LocalizedDataInput
 	searchInputs    []tmdb.SearchInput
 	findInputs      []tmdb.FindInput
@@ -302,6 +330,9 @@ type stubTMDB struct {
 func (s *stubTMDB) FindByExternalID(_ context.Context, input tmdb.FindInput) (tmdb.FindResult, error) {
 	s.findCalls++
 	s.findInputs = append(s.findInputs, input)
+	if s.findFn != nil {
+		return s.findFn(input)
+	}
 	if s.findErr != nil {
 		return tmdb.FindResult{}, s.findErr
 	}
@@ -323,6 +354,9 @@ func (s *stubTMDB) SearchID(_ context.Context, input tmdb.SearchInput) (tmdb.Sea
 func (s *stubTMDB) FetchMetadata(_ context.Context, input tmdb.MetadataInput) (tmdb.MetadataResult, error) {
 	s.metaCalls++
 	s.metaInputs = append(s.metaInputs, input)
+	if s.metadataFn != nil {
+		return s.metadataFn(input)
+	}
 	if s.metadataErr != nil {
 		return tmdb.MetadataResult{}, s.metadataErr
 	}
@@ -339,14 +373,17 @@ func (s *stubTMDB) FetchAniListMetadata(_ context.Context, malID int) (tmdb.AniL
 }
 
 func (s *stubTMDB) GetEpisodeDetails(_ context.Context, _, _, _ int) (tmdb.EpisodeDetails, error) {
-	return tmdb.EpisodeDetails{}, nil
+	s.episodeCalls++
+	return s.episodeDetails, nil
 }
 
 func (s *stubTMDB) GetSeasonDetails(_ context.Context, _, _ int) (tmdb.SeasonDetails, error) {
-	return tmdb.SeasonDetails{}, nil
+	s.seasonCalls++
+	return s.seasonDetails, nil
 }
 
 func (s *stubTMDB) DailyToSeasonEpisode(_ context.Context, _ int, _ time.Time) (int, int, error) {
+	s.dailyCalls++
 	return s.dailySeason, s.dailyEpisode, s.dailyErr
 }
 
@@ -488,12 +525,14 @@ func (s *stubTVDB) GetEpisodeTranslation(_ context.Context, episodeID int, _ str
 }
 
 type stubTVmaze struct {
-	result      tvmaze.SearchResult
-	episodeData *tvmaze.EpisodeData
-	calls       int
-	inputs      []tvmaze.SearchInput
-	lastSeason  int
-	lastEpisode int
+	result             tvmaze.SearchResult
+	episodeData        *tvmaze.EpisodeData
+	calls              int
+	episodeNumberCalls int
+	episodeDateCalls   int
+	inputs             []tvmaze.SearchInput
+	lastSeason         int
+	lastEpisode        int
 }
 
 func (s *stubTVmaze) Search(_ context.Context, input tvmaze.SearchInput) (tvmaze.SearchResult, error) {
@@ -503,12 +542,14 @@ func (s *stubTVmaze) Search(_ context.Context, input tvmaze.SearchInput) (tvmaze
 }
 
 func (s *stubTVmaze) GetEpisodeByNumber(_ context.Context, _, season, episode int, _ tvmaze.EpisodeLookupContext) (*tvmaze.EpisodeData, error) {
+	s.episodeNumberCalls++
 	s.lastSeason = season
 	s.lastEpisode = episode
 	return s.episodeData, nil
 }
 
 func (s *stubTVmaze) GetEpisodeByDate(_ context.Context, _ int, _ string) (*tvmaze.EpisodeData, error) {
+	s.episodeDateCalls++
 	return nil, nil
 }
 
@@ -587,7 +628,7 @@ func TestResolveExternalIDsWithoutTMDBAPIKey(t *testing.T) {
 	}
 }
 
-func TestResolveExternalIDsAdjustsEpisodeIMDbIDToParentSeries(t *testing.T) {
+func TestResolveExternalIDsPreservesExplicitEpisodeIMDbID(t *testing.T) {
 	repo := &fakeRepo{}
 	imdbClient := &stubIMDB{
 		infoFn: func(imdbID string) imdb.Info {
@@ -633,14 +674,14 @@ func TestResolveExternalIDsAdjustsEpisodeIMDbIDToParentSeries(t *testing.T) {
 		t.Fatalf("resolve episode IMDb ID: %v", err)
 	}
 
-	if result.Identity.IMDBID != 1234567 || result.Identity.Provenance.IMDB != api.IdentityProvenanceProvider {
-		t.Fatalf("expected parent-series IMDb ID, got %#v", result.Identity)
+	if result.Identity.IMDBID != 7654321 || result.Identity.Provenance.IMDB != api.IdentityProvenanceExplicit {
+		t.Fatalf("expected explicit episode IMDb ID, got %#v", result.Identity)
 	}
-	if result.ProviderMetadata.IMDB == nil || result.ProviderMetadata.IMDB.Title != "Example Series" || result.ProviderMetadata.IMDB.Type != "tvSeries" {
-		t.Fatalf("expected parent-series IMDb metadata, got %#v", result.ProviderMetadata.IMDB)
+	if result.ProviderMetadata.IMDB == nil || result.ProviderMetadata.IMDB.Title != "Example Episode" || result.ProviderMetadata.IMDB.Type != "tvEpisode" {
+		t.Fatalf("expected explicit episode IMDb metadata, got %#v", result.ProviderMetadata.IMDB)
 	}
-	if imdbClient.episodeLookupCalls != 1 || imdbClient.infoCalls != 2 {
-		t.Fatalf("expected one parent lookup and parent metadata refetch, got lookups=%d info=%d", imdbClient.episodeLookupCalls, imdbClient.infoCalls)
+	if imdbClient.episodeLookupCalls != 0 || imdbClient.infoCalls != 1 {
+		t.Fatalf("explicit IMDb ID was rewritten: lookups=%d info=%d", imdbClient.episodeLookupCalls, imdbClient.infoCalls)
 	}
 }
 
@@ -1345,6 +1386,81 @@ func TestResolveExternalIDsUsesStoredFreshData(t *testing.T) {
 	}
 }
 
+func TestResolveExternalIDsClearsNonExplicitSiblingBeforeAnchoredResolution(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		provenance api.IdentityProvenance
+		source     string
+	}{
+		{name: "fresh stored blank provenance", source: "stored"},
+		{
+			name:       "fresh stored tracker provenance",
+			provenance: api.IdentityProvenanceTracker,
+			source:     "stored",
+		},
+		{name: "tracker evidence", source: "tracker"},
+		{name: "MediaInfo evidence", source: "mediainfo"},
+		{name: "scene evidence", source: "scene"},
+		{name: "Arr evidence", source: "arr"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			imdbID := 1234567
+			state := preparationstate.State{
+				SourcePath:        "/media/Example.Movie.2026.1080p-GRP.mkv",
+				MediaInfoCategory: "MOVIE",
+				ExternalIDOverrides: api.ExternalIDOverrides{
+					IMDBID: &imdbID,
+				},
+			}
+			switch tc.source {
+			case "stored":
+				state.StoredDataFresh = true
+				state.Identity = api.ExternalIdentity{
+					SourcePath: state.SourcePath,
+					TMDBID:     999888,
+					Provenance: api.IdentityProvenanceSet{TMDB: tc.provenance},
+				}
+				state.ProviderMetadata = api.SourceScopedMetadata{
+					SourcePath: state.SourcePath,
+					TMDB:       &api.TMDBMetadata{TMDBID: 999888, Title: "Stale Metadata"},
+				}
+			case "tracker":
+				state.TrackerData = []api.TrackerMetadata{{TMDBID: 999888}}
+			case "mediainfo":
+				state.MediaInfoTMDBID = 999888
+			case "scene":
+				state.SceneTMDBID = 999888
+			case "arr":
+				state.ArrTMDBID = 999888
+			}
+
+			svc := NewService(&fakeRepo{},
+				WithTMDBClient(&stubTMDB{}),
+				WithIMDBClient(&stubIMDB{info: imdb.Info{
+					IMDbID: "tt1234567",
+					Title:  "Example Movie",
+					Type:   "movie",
+				}}),
+				WithTVDBClient(&stubTVDB{}),
+				WithTVmazeClient(&stubTVmaze{}),
+			)
+			result, err := svc.resolveExternalIdentity(context.Background(), state)
+			if err != nil {
+				t.Fatalf("resolve anchored identity: %v", err)
+			}
+			if result.Identity.IMDBID != imdbID || result.Identity.Provenance.IMDB != api.IdentityProvenanceExplicit {
+				t.Fatalf("explicit IMDb identity = %#v", result.Identity)
+			}
+			if result.Identity.TMDBID != 0 || result.Identity.Provenance.TMDB != api.IdentityProvenanceUnknown {
+				t.Fatalf("non-explicit TMDB sibling retained: %#v", result.Identity)
+			}
+			if result.ProviderMetadata.TMDB != nil {
+				t.Fatalf("dependent cached TMDB metadata retained: %#v", result.ProviderMetadata.TMDB)
+			}
+		})
+	}
+}
+
 func TestResolveExternalIDsRefreshesTVDBDisambiguationWithoutRefetchingSeries(t *testing.T) {
 	sourcePath := filepath.Join(t.TempDir(), "Example.Series.S01E01.mkv")
 	tvdbClient := &stubTVDB{
@@ -1474,8 +1590,1239 @@ func TestResolveExternalIDsPrefersTMDBFromIMDbBeforeSearch(t *testing.T) {
 	if tmdbClient.searchCalls != 0 {
 		t.Fatalf("expected no tmdb filename search when imdb lookup resolves tmdb, got %d", tmdbClient.searchCalls)
 	}
-	if len(tmdbClient.findInputs) != 1 || tmdbClient.findInputs[0].CategoryPreference != "TV" {
+	if len(tmdbClient.findInputs) != 1 || tmdbClient.findInputs[0].CategoryPreference != "TV" || tmdbClient.findInputs[0].RequireExternalIDAgreement {
 		t.Fatalf("expected tmdb external lookup category preference TV, got %#v", tmdbClient.findInputs)
+	}
+}
+
+func TestResolveExternalIDsKeepsAnchoredFilenameMatchAsCandidate(t *testing.T) {
+	imdbID := 1234567
+	tmdbClient := &stubTMDB{
+		findResult: tmdb.FindResult{
+			TMDBID:         253,
+			Category:       "TV",
+			FilenameSearch: true,
+			Candidates: []tmdb.Candidate{{
+				TMDBID: 253,
+				Title:  "Example Candidate",
+				Year:   2026,
+			}},
+		},
+		searchOutcome: tmdb.SearchOutcome{TMDBID: 253, Category: "TV"},
+	}
+	svc := NewService(&fakeRepo{},
+		WithTMDBClient(tmdbClient),
+		WithIMDBClient(&stubIMDB{info: imdb.Info{
+			IMDbID: "tt1234567",
+			Title:  "Example Anchor",
+			Type:   "tvSeries",
+		}}),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(&stubTVmaze{}),
+	)
+
+	result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        "Example.Anchor.S01E01.1080p-GRP.mkv",
+		MediaInfoCategory: "TV",
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			IMDBID: &imdbID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve anchored identity: %v", err)
+	}
+	if result.Identity.IMDBID != imdbID || result.Identity.TMDBID != 0 || result.ProviderMetadata.TMDB != nil {
+		t.Fatalf("filename match became canonical: identity=%#v metadata=%#v", result.Identity, result.ProviderMetadata.TMDB)
+	}
+	if tmdbClient.searchCalls != 0 || tmdbClient.metaCalls != 0 {
+		t.Fatalf("anchored filename match triggered automatic TMDB selection: search=%d metadata=%d", tmdbClient.searchCalls, tmdbClient.metaCalls)
+	}
+	if len(result.ExternalIdentityCandidates) != 1 || result.ExternalIdentityCandidates[0].ID != 253 {
+		t.Fatalf("filename candidates = %#v", result.ExternalIdentityCandidates)
+	}
+}
+
+func TestResolveExternalIDsRejectsTMDBMetadataConflictingWithExplicitIMDb(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		explicitTMDB bool
+		trackerTMDB  bool
+		wantTMDB     int
+	}{
+		{name: "clear inferred TMDB", wantTMDB: 0},
+		{
+			name:        "clear conflicting tracker TMDB",
+			trackerTMDB: true,
+			wantTMDB:    0,
+		},
+		{
+			name:         "preserve explicit TMDB",
+			explicitTMDB: true,
+			wantTMDB:     456789,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			imdbID := 1234567
+			tmdbID := 456789
+			overrides := api.ExternalIDOverrides{IMDBID: &imdbID}
+			if tc.explicitTMDB {
+				overrides.TMDBID = &tmdbID
+			}
+			tmdbClient := &stubTMDB{
+				findResult: tmdb.FindResult{TMDBID: tmdbID, Category: "MOVIE"},
+				metadata: tmdb.MetadataResult{
+					Title:          "Conflicting Metadata",
+					TMDBType:       "Movie",
+					IMDbID:         imdbID,
+					ExternalIMDbID: 7654321,
+				},
+			}
+			svc := NewService(&fakeRepo{},
+				WithTMDBClient(tmdbClient),
+				WithIMDBClient(&stubIMDB{info: imdb.Info{IMDbID: "tt1234567", Title: "Example Anchor"}}),
+				WithTVDBClient(&stubTVDB{}),
+				WithTVmazeClient(&stubTVmaze{}),
+			)
+
+			state := preparationstate.State{
+				SourcePath:          "Example.Anchor.2026.1080p-GRP.mkv",
+				MediaInfoCategory:   "MOVIE",
+				ExternalIDOverrides: overrides,
+			}
+			if tc.trackerTMDB {
+				state.TrackerData = []api.TrackerMetadata{{TMDBID: tmdbID}}
+			}
+			result, err := svc.resolveExternalIdentity(context.Background(), state)
+			if err != nil {
+				t.Fatalf("resolve conflicting identity: %v", err)
+			}
+			if result.Identity.IMDBID != imdbID || result.Identity.TMDBID != tc.wantTMDB {
+				t.Fatalf("explicit identity changed: %#v", result.Identity)
+			}
+			if result.ProviderMetadata.TMDB != nil {
+				t.Fatalf("conflicting TMDB metadata retained: %#v", result.ProviderMetadata.TMDB)
+			}
+			if len(result.LookupWarnings) != 1 || !strings.Contains(result.LookupWarnings[0], "Correct one of the supplied provider IDs") {
+				t.Fatalf("correction warnings = %#v", result.LookupWarnings)
+			}
+		})
+	}
+}
+
+func TestResolveExternalIDsGatesRejectedTMDBFromDownstreamMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		tmdbIMDbID         int
+		tvPack             bool
+		dailyDate          string
+		season             int
+		wantDailyCalls     int
+		wantEpisodeCalls   int
+		wantSeasonCalls    int
+		wantLocalizedCalls int
+		wantSeason         int
+		wantEpisode        int
+		wantEpisodeTitle   string
+		wantTMDBMetadata   bool
+	}{
+		{
+			name:       "conflicting explicit IDs daily episode",
+			tmdbIMDbID: 7654321,
+			dailyDate:  "2026-09-08",
+		},
+		{
+			name:               "matching explicit IDs daily episode",
+			tmdbIMDbID:         1234567,
+			dailyDate:          "2026-09-08",
+			wantDailyCalls:     1,
+			wantEpisodeCalls:   1,
+			wantLocalizedCalls: 3,
+			wantSeason:         2,
+			wantEpisode:        7,
+			wantEpisodeTitle:   "Matched Episode",
+			wantTMDBMetadata:   true,
+		},
+		{
+			name:       "conflicting explicit IDs season pack",
+			tmdbIMDbID: 7654321,
+			tvPack:     true,
+			season:     3,
+			wantSeason: 3,
+		},
+		{
+			name:               "matching explicit IDs season pack",
+			tmdbIMDbID:         1234567,
+			tvPack:             true,
+			season:             3,
+			wantSeasonCalls:    1,
+			wantLocalizedCalls: 2,
+			wantSeason:         3,
+			wantEpisodeTitle:   "Matched Season",
+			wantTMDBMetadata:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			imdbID := 1234567
+			tmdbID := 456789
+			tmdbClient := &stubTMDB{
+				metadata: tmdb.MetadataResult{
+					Title:          "Example Series",
+					TMDBType:       "Scripted",
+					IMDbID:         imdbID,
+					ExternalIMDbID: tc.tmdbIMDbID,
+				},
+				dailySeason:  2,
+				dailyEpisode: 7,
+				episodeDetails: tmdb.EpisodeDetails{
+					Name:          "Matched Episode",
+					SeasonNumber:  2,
+					EpisodeNumber: 7,
+				},
+				seasonDetails: tmdb.SeasonDetails{Name: "Matched Season", SeasonNumber: 3},
+				localizedByType: map[string]map[string]any{
+					"main":    {"name": "Série Localizada", "overview": "Sinopse localizada"},
+					"season":  {"name": "Temporada Localizada", "overview": "Sinopse da temporada"},
+					"episode": {"name": "Episódio Localizado", "overview": "Sinopse do episódio"},
+				},
+			}
+			svc := NewService(&fakeRepo{},
+				WithTrackerRegistry(localizedMetadataTestRegistry(t)),
+				WithTMDBClient(tmdbClient),
+				WithIMDBClient(&stubIMDB{info: imdb.Info{
+					IMDbID: "tt1234567",
+					Title:  "Example Series",
+					Type:   "tvSeries",
+				}}),
+				WithTVDBClient(&stubTVDB{}),
+				WithTVmazeClient(&stubTVmaze{}),
+			)
+
+			result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+				SourcePath:          "/media/Example.Series.2026-09-08.1080p-GRP.mkv",
+				MediaInfoCategory:   "TV",
+				DailyEpisodeDate:    tc.dailyDate,
+				SeasonInt:           tc.season,
+				TVPack:              tc.tvPack,
+				EvidenceTrackers:    []string{"BJS"},
+				ExternalIDOverrides: api.ExternalIDOverrides{TMDBID: &tmdbID, IMDBID: &imdbID},
+			})
+			if err != nil {
+				t.Fatalf("resolve downstream TMDB metadata: %v", err)
+			}
+			if result.Identity.TMDBID != tmdbID || result.Identity.IMDBID != imdbID {
+				t.Fatalf("explicit identity changed: %#v", result.Identity)
+			}
+			if tmdbClient.dailyCalls != tc.wantDailyCalls || tmdbClient.episodeCalls != tc.wantEpisodeCalls ||
+				len(tmdbClient.localizedInputs) != tc.wantLocalizedCalls {
+				t.Fatalf(
+					"downstream TMDB calls = daily:%d episode:%d localized:%d",
+					tmdbClient.dailyCalls,
+					tmdbClient.episodeCalls,
+					len(tmdbClient.localizedInputs),
+				)
+			}
+			if tmdbClient.seasonCalls != tc.wantSeasonCalls {
+				t.Fatalf("TMDB season calls = %d, want %d", tmdbClient.seasonCalls, tc.wantSeasonCalls)
+			}
+			if result.SeasonInt != tc.wantSeason || result.EpisodeInt != tc.wantEpisode || result.EpisodeTitle != tc.wantEpisodeTitle {
+				t.Fatalf("episode metadata = season:%d episode:%d title:%q", result.SeasonInt, result.EpisodeInt, result.EpisodeTitle)
+			}
+			if (result.ProviderMetadata.TMDB != nil) != tc.wantTMDBMetadata {
+				t.Fatalf("TMDB metadata = %#v", result.ProviderMetadata.TMDB)
+			}
+		})
+	}
+}
+
+func TestResolveExternalIDsGatesRejectedTVDBFromEpisodeMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		metadataTVDBID   int
+		wantEpisodeCalls int
+		wantEpisodeTitle string
+		wantMetadata     bool
+	}{
+		{name: "conflicting explicit TVDB", metadataTVDBID: 999},
+		{
+			name:             "matching explicit TVDB",
+			metadataTVDBID:   200,
+			wantEpisodeCalls: 1,
+			wantEpisodeTitle: "Matched TVDB Episode",
+			wantMetadata:     true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tvdbID := 200
+			tvdbClient := &stubTVDB{
+				seriesMetadata: tvdb.SeriesMetadata{TVDBID: tc.metadataTVDBID, Name: "Example Series"},
+				episodes: tvdb.EpisodesData{Episodes: []tvdb.Episode{{
+					ID:           201,
+					SeasonNumber: 1,
+					Number:       1,
+					Name:         "Matched TVDB Episode",
+				}}},
+			}
+			svc := NewService(&fakeRepo{},
+				WithTMDBClient(&stubTMDB{}),
+				WithIMDBClient(&stubIMDB{}),
+				WithTVDBClient(tvdbClient),
+				WithTVmazeClient(&stubTVmaze{}),
+			)
+
+			result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+				SourcePath:        "/media/Example.Series.S01E01.1080p-GRP.mkv",
+				MediaInfoCategory: "TV",
+				SeasonInt:         1,
+				EpisodeInt:        1,
+				ExternalIDOverrides: api.ExternalIDOverrides{
+					TVDBID: &tvdbID,
+				},
+			})
+			if err != nil {
+				t.Fatalf("resolve TVDB identity: %v", err)
+			}
+			if result.Identity.TVDBID != tvdbID || result.Identity.Provenance.TVDB != api.IdentityProvenanceExplicit {
+				t.Fatalf("explicit TVDB identity changed: %#v", result.Identity)
+			}
+			if tvdbClient.episodeCalls != tc.wantEpisodeCalls || result.EpisodeTitle != tc.wantEpisodeTitle {
+				t.Fatalf("TVDB downstream metadata = calls:%d title:%q", tvdbClient.episodeCalls, result.EpisodeTitle)
+			}
+			if (result.ProviderMetadata.TVDB != nil) != tc.wantMetadata {
+				t.Fatalf("TVDB metadata = %#v", result.ProviderMetadata.TVDB)
+			}
+		})
+	}
+}
+
+func TestResolveExternalIDsUsesStaleStoredExplicitPinBeforeProviderFacts(t *testing.T) {
+	const sourcePath = "/media/Example.Series.2026-09-08.1080p-GRP.mkv"
+	const storedIMDBID = 1234567
+	tmdbID := 456789
+	repo := &fakeRepo{ids: api.ExternalIdentity{
+		SourcePath: sourcePath,
+		IMDBID:     storedIMDBID,
+		Provenance: api.IdentityProvenanceSet{IMDB: api.IdentityProvenanceExplicit},
+	}}
+	tmdbClient := &stubTMDB{
+		metadata: tmdb.MetadataResult{
+			Title:          "Conflicting Series",
+			TMDBType:       "Scripted",
+			IMDbID:         7654321,
+			ExternalIMDbID: 7654321,
+		},
+		dailySeason:  2,
+		dailyEpisode: 7,
+		episodeDetails: tmdb.EpisodeDetails{
+			Name:          "Conflicting Episode",
+			SeasonNumber:  2,
+			EpisodeNumber: 7,
+		},
+		localizedData: map[string]any{"name": "Conflicting Localized Series"},
+	}
+	svc := NewService(repo,
+		WithTrackerRegistry(localizedMetadataTestRegistry(t)),
+		WithTMDBClient(tmdbClient),
+		WithIMDBClient(&stubIMDB{info: imdb.Info{
+			IMDbID: "tt1234567",
+			Title:  "Stored Pin Series",
+			Type:   "tvSeries",
+		}}),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(&stubTVmaze{}),
+	)
+
+	result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        sourcePath,
+		StoredDataFresh:   false,
+		MediaInfoCategory: "TV",
+		DailyEpisodeDate:  "2026-09-08",
+		EvidenceTrackers:  []string{"BJS"},
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			TMDBID: &tmdbID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve stale stored pin: %v", err)
+	}
+	if result.Identity.IMDBID != storedIMDBID || result.Identity.Overrides.IMDB != api.OverrideStateValue || result.Identity.TMDBID != tmdbID {
+		t.Fatalf("stored pin identity = %#v", result.Identity)
+	}
+	if result.ProviderMetadata.TMDB != nil {
+		t.Fatalf("conflicting TMDB metadata reached candidate facts: %#v", result.ProviderMetadata.TMDB)
+	}
+	if tmdbClient.dailyCalls != 0 || tmdbClient.episodeCalls != 0 || tmdbClient.seasonCalls != 0 || len(tmdbClient.localizedInputs) != 0 {
+		t.Fatalf("conflicting TMDB reached downstream calls: daily=%d episode=%d season=%d localized=%d", tmdbClient.dailyCalls, tmdbClient.episodeCalls, tmdbClient.seasonCalls, len(tmdbClient.localizedInputs))
+	}
+	if result.SeasonInt != 0 || result.EpisodeInt != 0 || result.EpisodeTitle != "" {
+		t.Fatalf("conflicting TMDB changed episode facts: season=%d episode=%d title=%q", result.SeasonInt, result.EpisodeInt, result.EpisodeTitle)
+	}
+}
+
+func TestResolveExternalIDsGatesRejectedTVmazeFromEpisodeMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		metadataIMDbID   int
+		wantEpisodeCalls int
+		wantEpisodeTitle string
+		wantMetadata     bool
+	}{
+		{name: "conflicting explicit TVmaze", metadataIMDbID: 7654321},
+		{
+			name:             "matching explicit TVmaze",
+			metadataIMDbID:   1234567,
+			wantEpisodeCalls: 1,
+			wantEpisodeTitle: "Matched TVmaze Episode",
+			wantMetadata:     true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			imdbID := 1234567
+			tvmazeID := 55
+			tvmazeClient := &stubTVmaze{
+				result: tvmaze.SearchResult{
+					SelectedID: tvmazeID,
+					Candidates: []tvmaze.Candidate{{
+						ID:        tvmazeID,
+						Name:      "Example Series",
+						Externals: tvmaze.Externals{IMDB: formatIMDbID(tc.metadataIMDbID)},
+					}},
+				},
+				episodeData: &tvmaze.EpisodeData{
+					EpisodeName:   "Matched TVmaze Episode",
+					SeasonNumber:  1,
+					EpisodeNumber: 1,
+				},
+			}
+			svc := NewService(&fakeRepo{},
+				WithTMDBClient(&stubTMDB{}),
+				WithIMDBClient(&stubIMDB{info: imdb.Info{
+					IMDbID: "tt1234567",
+					Title:  "Example Series",
+					Type:   "tvSeries",
+				}}),
+				WithTVDBClient(&stubTVDB{}),
+				WithTVmazeClient(tvmazeClient),
+			)
+
+			result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+				SourcePath:        "/media/Example.Series.S01E01.1080p-GRP.mkv",
+				MediaInfoCategory: "TV",
+				SeasonInt:         1,
+				EpisodeInt:        1,
+				ExternalIDOverrides: api.ExternalIDOverrides{
+					IMDBID:   &imdbID,
+					TVmazeID: &tvmazeID,
+				},
+			})
+			if err != nil {
+				t.Fatalf("resolve TVmaze identity: %v", err)
+			}
+			if result.Identity.TVmazeID != tvmazeID || result.Identity.Provenance.TVmaze != api.IdentityProvenanceExplicit {
+				t.Fatalf("explicit TVmaze identity changed: %#v", result.Identity)
+			}
+			if tvmazeClient.episodeNumberCalls != tc.wantEpisodeCalls || result.EpisodeTitle != tc.wantEpisodeTitle {
+				t.Fatalf("TVmaze downstream metadata = calls:%d title:%q", tvmazeClient.episodeNumberCalls, result.EpisodeTitle)
+			}
+			if (result.ProviderMetadata.TVmaze != nil) != tc.wantMetadata {
+				t.Fatalf("TVmaze metadata = %#v", result.ProviderMetadata.TVmaze)
+			}
+		})
+	}
+}
+
+func TestResolveExternalIDsAllowsDownstreamTMDBAfterConflictingInferredIDIsReplaced(t *testing.T) {
+	imdbID := 1234567
+	tmdbClient := &stubTMDB{
+		findResult: tmdb.FindResult{TMDBID: 222, Category: "TV"},
+		metadataFn: func(input tmdb.MetadataInput) (tmdb.MetadataResult, error) {
+			if input.TMDBID == 111 {
+				return tmdb.MetadataResult{TMDBType: "Scripted", ExternalIMDbID: 7654321}, nil
+			}
+			return tmdb.MetadataResult{}, errors.New("replacement metadata unavailable")
+		},
+		dailySeason:  2,
+		dailyEpisode: 7,
+		localizedData: map[string]any{
+			"name":     "Série Localizada",
+			"overview": "Sinopse localizada",
+		},
+	}
+	svc := NewService(&fakeRepo{},
+		WithTrackerRegistry(localizedMetadataTestRegistry(t)),
+		WithTMDBClient(tmdbClient),
+		WithIMDBClient(&stubIMDB{info: imdb.Info{
+			IMDbID: "tt1234567",
+			Title:  "Example Series",
+			Type:   "tvSeries",
+		}}),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(&stubTVmaze{}),
+	)
+
+	result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        "/media/Example.Series.2026-09-08.1080p-GRP.mkv",
+		MediaInfoCategory: "TV",
+		DailyEpisodeDate:  "2026-09-08",
+		EvidenceTrackers:  []string{"BJS"},
+		TrackerData:       []api.TrackerMetadata{{TMDBID: 111}},
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			IMDBID: &imdbID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve replacement TMDB identity: %v", err)
+	}
+	if result.Identity.TMDBID != 222 || result.Identity.Provenance.TMDB != api.IdentityProvenanceProvider {
+		t.Fatalf("replacement TMDB identity = %#v", result.Identity)
+	}
+	if tmdbClient.dailyCalls != 1 || tmdbClient.episodeCalls != 1 || len(tmdbClient.localizedInputs) != 3 {
+		t.Fatalf(
+			"replacement downstream calls = daily:%d episode:%d localized:%d",
+			tmdbClient.dailyCalls,
+			tmdbClient.episodeCalls,
+			len(tmdbClient.localizedInputs),
+		)
+	}
+}
+
+func TestResolveExternalIDsReconcilesExplicitTMDBAndTVmazeLinks(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		tvmazeIMDBID   int
+		tvmazeTVDBID   int
+		wantSiblingIDs bool
+		wantMetadata   bool
+		wantCorrection bool
+	}{
+		{
+			name:           "conflicting links",
+			tvmazeIMDBID:   7654321,
+			tvmazeTVDBID:   999888,
+			wantCorrection: true,
+		},
+		{
+			name:           "matching links",
+			tvmazeIMDBID:   1234567,
+			tvmazeTVDBID:   222333,
+			wantSiblingIDs: true,
+			wantMetadata:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmdbID := 444555
+			tvmazeID := 55
+			tmdbClient := &stubTMDB{metadata: tmdb.MetadataResult{
+				Title:          "Example Series",
+				TMDBType:       "Scripted",
+				IMDbID:         1234567,
+				TVDBID:         222333,
+				ExternalIMDbID: 1234567,
+				ExternalTVDBID: 222333,
+			}}
+			tvmazeClient := &stubTVmaze{result: tvmaze.SearchResult{
+				SelectedID: tvmazeID,
+				IMDBID:     tc.tvmazeIMDBID,
+				TVDBID:     tc.tvmazeTVDBID,
+				Candidates: []tvmaze.Candidate{{
+					ID:        tvmazeID,
+					Name:      "Example Series",
+					Externals: tvmaze.Externals{IMDB: formatIMDbID(tc.tvmazeIMDBID), TVDB: tc.tvmazeTVDBID},
+				}},
+			}}
+			svc := NewService(&fakeRepo{},
+				WithTMDBClient(tmdbClient),
+				WithIMDBClient(&stubIMDB{info: imdb.Info{
+					IMDbID: "tt1234567",
+					Title:  "Example Series",
+					Type:   "tvSeries",
+				}}),
+				WithTVDBClient(&stubTVDB{seriesMetadata: tvdb.SeriesMetadata{TVDBID: 222333, Name: "Example Series"}}),
+				WithTVmazeClient(tvmazeClient),
+			)
+
+			result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+				SourcePath:        "Example.Series.S01E01.1080p-GRP.mkv",
+				MediaInfoCategory: "TV",
+				ExternalIDOverrides: api.ExternalIDOverrides{
+					TMDBID:   &tmdbID,
+					TVmazeID: &tvmazeID,
+				},
+			})
+			if err != nil {
+				t.Fatalf("resolve explicit anchors: %v", err)
+			}
+			if result.Identity.TMDBID != tmdbID || result.Identity.TVmazeID != tvmazeID {
+				t.Fatalf("explicit anchors changed: %#v", result.Identity)
+			}
+			if got := result.Identity.IMDBID != 0 && result.Identity.TVDBID != 0; got != tc.wantSiblingIDs {
+				t.Fatalf("sibling identity = %#v", result.Identity)
+			}
+			if got := result.ProviderMetadata.TMDB != nil && result.ProviderMetadata.TVmaze != nil; got != tc.wantMetadata {
+				t.Fatalf("provider metadata = %#v", result.ProviderMetadata)
+			}
+			if got := len(result.LookupWarnings) > 0; got != tc.wantCorrection {
+				t.Fatalf("lookup warnings = %#v", result.LookupWarnings)
+			}
+		})
+	}
+}
+
+func TestResolveExternalIDsReverifiesFreshStoredExplicitTMDBAnchor(t *testing.T) {
+	const sourcePath = "/media/Example.Movie.2026.1080p-GRP.mkv"
+	tmdbID := 444555
+	tmdbClient := &stubTMDB{metadata: tmdb.MetadataResult{
+		Title:          "Example Movie",
+		TMDBType:       "Movie",
+		IMDbID:         1234567,
+		ExternalIMDbID: 1234567,
+	}}
+	repo := &fakeRepo{}
+	svc := NewService(repo,
+		WithTMDBClient(tmdbClient),
+		WithIMDBClient(&stubIMDB{info: imdb.Info{
+			IMDbID: "tt1234567",
+			Title:  "Example Movie",
+			Type:   "movie",
+		}}),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(&stubTVmaze{}),
+	)
+
+	first, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        sourcePath,
+		MediaInfoCategory: "MOVIE",
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			TMDBID: &tmdbID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve first preparation: %v", err)
+	}
+	if first.Identity.IMDBID != 1234567 || first.Identity.Provenance.TMDB != api.IdentityProvenanceExplicit ||
+		first.Identity.Overrides.TMDB != api.OverrideStateValue || first.ProviderMetadata.TMDB == nil {
+		t.Fatalf("first preparation did not resolve TMDB siblings: identity=%#v metadata=%#v", first.Identity, first.ProviderMetadata.TMDB)
+	}
+
+	repo.ids = first.Identity
+	repo.meta = first.ProviderMetadata
+	fresh := preparationstate.State{
+		SourcePath:       sourcePath,
+		StoredDataFresh:  true,
+		Identity:         repo.ids,
+		ProviderMetadata: repo.meta,
+	}
+	second, err := svc.resolveExternalIdentity(context.Background(), fresh)
+	if err != nil {
+		t.Fatalf("resolve fresh preparation: %v", err)
+	}
+	if tmdbClient.metaCalls != 2 {
+		t.Fatalf("TMDB metadata calls = %d, want one per preparation", tmdbClient.metaCalls)
+	}
+	if second.Identity.TMDBID != tmdbID || second.Identity.IMDBID != 1234567 {
+		t.Fatalf("fresh preparation identity = %#v", second.Identity)
+	}
+	if second.ProviderMetadata.TMDB == nil || second.ProviderMetadata.TMDB.TMDBID != tmdbID {
+		t.Fatalf("fresh TMDB metadata = %#v", second.ProviderMetadata.TMDB)
+	}
+}
+
+func TestResolveExternalIDsReverifiesFreshStoredExplicitTVmazeAnchor(t *testing.T) {
+	const sourcePath = "/media/Example.Series.S01E01.1080p-GRP.mkv"
+	tvmazeID := 55
+	tvmazeClient := &stubTVmaze{result: tvmaze.SearchResult{
+		SelectedID: tvmazeID,
+		IMDBID:     1234567,
+		Candidates: []tvmaze.Candidate{{
+			ID:        tvmazeID,
+			Name:      "Example Series",
+			Externals: tvmaze.Externals{IMDB: "tt1234567"},
+		}},
+	}}
+	repo := &fakeRepo{}
+	svc := NewService(repo,
+		WithTMDBClient(&stubTMDB{}),
+		WithIMDBClient(&stubIMDB{info: imdb.Info{
+			IMDbID: "tt1234567",
+			Title:  "Example Series",
+			Type:   "tvSeries",
+		}}),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(tvmazeClient),
+	)
+
+	first, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        sourcePath,
+		MediaInfoCategory: "TV",
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			TVmazeID: &tvmazeID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve first preparation: %v", err)
+	}
+	if first.Identity.IMDBID != 1234567 || first.Identity.Provenance.TVmaze != api.IdentityProvenanceExplicit ||
+		first.Identity.Overrides.TVmaze != api.OverrideStateValue || first.ProviderMetadata.TVmaze == nil {
+		t.Fatalf("first preparation did not resolve TVmaze siblings: identity=%#v metadata=%#v", first.Identity, first.ProviderMetadata.TVmaze)
+	}
+
+	repo.ids = first.Identity
+	repo.meta = first.ProviderMetadata
+	fresh := preparationstate.State{
+		SourcePath:       sourcePath,
+		StoredDataFresh:  true,
+		Identity:         repo.ids,
+		ProviderMetadata: repo.meta,
+	}
+	second, err := svc.resolveExternalIdentity(context.Background(), fresh)
+	if err != nil {
+		t.Fatalf("resolve fresh preparation: %v", err)
+	}
+	if tvmazeClient.calls != 2 {
+		t.Fatalf("TVmaze metadata calls = %d, want one per preparation", tvmazeClient.calls)
+	}
+	if second.Identity.TVmazeID != tvmazeID || second.Identity.IMDBID != 1234567 {
+		t.Fatalf("fresh preparation identity = %#v", second.Identity)
+	}
+	if second.ProviderMetadata.TVmaze == nil || second.ProviderMetadata.TVmaze.TVmazeID != tvmazeID {
+		t.Fatalf("fresh TVmaze metadata = %#v", second.ProviderMetadata.TVmaze)
+	}
+}
+
+func TestResolveExternalIDsReconcilesFreshStoredExplicitAnchorLinks(t *testing.T) {
+	const sourcePath = "/media/Example.Series.S01E01.1080p-GRP.mkv"
+	tmdbID := 444555
+	tvmazeID := 55
+	tmdbClient := &stubTMDB{metadata: tmdb.MetadataResult{
+		Title:          "Example Series",
+		TMDBType:       "Scripted",
+		IMDbID:         1234567,
+		TVDBID:         222333,
+		ExternalIMDbID: 1234567,
+		ExternalTVDBID: 222333,
+	}}
+	tvmazeClient := &stubTVmaze{result: tvmaze.SearchResult{
+		SelectedID: tvmazeID,
+		IMDBID:     1234567,
+		TVDBID:     222333,
+		Candidates: []tvmaze.Candidate{{
+			ID:        tvmazeID,
+			Name:      "Example Series",
+			Externals: tvmaze.Externals{IMDB: "tt1234567", TVDB: 222333},
+		}},
+	}}
+	repo := &fakeRepo{}
+	svc := NewService(repo,
+		WithTMDBClient(tmdbClient),
+		WithIMDBClient(&stubIMDB{info: imdb.Info{
+			IMDbID: "tt1234567",
+			Title:  "Example Series",
+			Type:   "tvSeries",
+		}}),
+		WithTVDBClient(&stubTVDB{seriesMetadata: tvdb.SeriesMetadata{TVDBID: 222333, Name: "Example Series"}}),
+		WithTVmazeClient(tvmazeClient),
+	)
+
+	first, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        sourcePath,
+		MediaInfoCategory: "TV",
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			TMDBID:   &tmdbID,
+			TVmazeID: &tvmazeID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve first preparation: %v", err)
+	}
+	if first.ProviderMetadata.TMDB == nil || first.ProviderMetadata.TVmaze == nil {
+		t.Fatalf("first preparation metadata = %#v", first.ProviderMetadata)
+	}
+
+	tvmazeClient.result.IMDBID = 7654321
+	tvmazeClient.result.TVDBID = 999888
+	tvmazeClient.result.Candidates[0].Externals = tvmaze.Externals{IMDB: "tt7654321", TVDB: 999888}
+	repo.ids = first.Identity
+	repo.meta = first.ProviderMetadata
+	fresh := preparationstate.State{
+		SourcePath:       sourcePath,
+		StoredDataFresh:  true,
+		Identity:         repo.ids,
+		ProviderMetadata: repo.meta,
+	}
+	second, err := svc.resolveExternalIdentity(context.Background(), fresh)
+	if err != nil {
+		t.Fatalf("resolve fresh preparation: %v", err)
+	}
+	if tmdbClient.metaCalls != 2 || tvmazeClient.calls != 2 {
+		t.Fatalf("fresh anchor verification calls = TMDB:%d TVmaze:%d", tmdbClient.metaCalls, tvmazeClient.calls)
+	}
+	if second.Identity.TMDBID != tmdbID || second.Identity.TVmazeID != tvmazeID || second.Identity.IMDBID != 0 || second.Identity.TVDBID != 0 {
+		t.Fatalf("reconciled fresh identity = %#v", second.Identity)
+	}
+	if second.ProviderMetadata.TMDB != nil || second.ProviderMetadata.TVmaze != nil || len(second.LookupWarnings) == 0 {
+		t.Fatalf("reconciled fresh metadata=%#v warnings=%#v", second.ProviderMetadata, second.LookupWarnings)
+	}
+}
+
+func TestResolveExternalIDsPreservesUnanchoredProviderResultsWithConflictingLinks(t *testing.T) {
+	tmdbClient := &stubTMDB{metadata: tmdb.MetadataResult{
+		Title:          "Example Series",
+		TMDBType:       "Scripted",
+		IMDbID:         1234567,
+		TVDBID:         222333,
+		ExternalIMDbID: 1234567,
+		ExternalTVDBID: 222333,
+	}}
+	tvmazeClient := &stubTVmaze{result: tvmaze.SearchResult{
+		SelectedID: 55,
+		IMDBID:     7654321,
+		TVDBID:     999888,
+		Candidates: []tvmaze.Candidate{{
+			ID:        55,
+			Name:      "Example Series",
+			Externals: tvmaze.Externals{IMDB: "tt7654321", TVDB: 999888},
+		}},
+	}}
+	svc := NewService(&fakeRepo{},
+		WithTMDBClient(tmdbClient),
+		WithIMDBClient(&stubIMDB{info: imdb.Info{
+			IMDbID: "tt1234567",
+			Title:  "Example Series",
+			Type:   "tvSeries",
+		}}),
+		WithTVDBClient(&stubTVDB{seriesMetadata: tvdb.SeriesMetadata{TVDBID: 222333, Name: "Example Series"}}),
+		WithTVmazeClient(tvmazeClient),
+	)
+
+	result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        "/media/Example.Series.S01E01.1080p-GRP.mkv",
+		MediaInfoCategory: "TV",
+		TrackerData: []api.TrackerMetadata{{
+			TMDBID: 444555,
+			IMDBID: 1234567,
+			TVDBID: 222333,
+		}},
+		SceneTVmazeID: 55,
+	})
+	if err != nil {
+		t.Fatalf("resolve unanchored identity: %v", err)
+	}
+	if result.Identity.TMDBID != 444555 || result.Identity.TVmazeID != 55 || result.Identity.IMDBID != 1234567 || result.Identity.TVDBID != 222333 {
+		t.Fatalf("unanchored identity = %#v", result.Identity)
+	}
+	if result.ProviderMetadata.TMDB == nil || result.ProviderMetadata.TVmaze == nil || len(result.LookupWarnings) != 0 {
+		t.Fatalf("unanchored metadata=%#v warnings=%#v", result.ProviderMetadata, result.LookupWarnings)
+	}
+}
+
+func TestResolveExternalIDsSQLiteFreshProvenanceOnlyAnchorClearsStoredGuess(t *testing.T) {
+	ctx := context.Background()
+	base := t.TempDir()
+	sourcePath := filepath.Join(base, "Example.Movie.2026.1080p-GRP.mkv")
+	if err := os.WriteFile(sourcePath, []byte("video"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	dbPath := filepath.Join(base, "metadata.sqlite")
+	repo, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open repository: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repository: %v", err)
+	}
+
+	service := NewService(repo,
+		WithConfig(config.Config{MainSettings: config.MainSettingsConfig{DBPath: dbPath}}),
+		WithMediaInfoExporter(&stubMediaInfo{}),
+		WithSceneDetector(stubSceneDetector{}),
+		WithTMDBClient(&stubTMDB{}),
+		WithIMDBClient(&stubIMDB{}),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(&stubTVmaze{}),
+	)
+	request := testCollectionRequest(t, api.Request{SourcePath: sourcePath})
+	request.Manifest.SourcePath = sourcePath
+	if _, err := service.CollectPreparationEvidence(ctx, request); err != nil {
+		t.Fatalf("seed source fingerprint: %v", err)
+	}
+	if err := repo.SaveExternalIdentity(ctx, api.ExternalIdentity{
+		SourcePath: sourcePath,
+		TMDBID:     999888,
+		IMDBID:     1234567,
+		Category:   api.CanonicalCategoryMovie,
+		Provenance: api.IdentityProvenanceSet{
+			TMDB:     api.IdentityProvenanceProvider,
+			IMDB:     api.IdentityProvenanceExplicit,
+			Category: api.IdentityProvenanceProvider,
+		},
+	}); err != nil {
+		t.Fatalf("save stored identity: %v", err)
+	}
+	if err := repo.SaveExternalMetadata(ctx, api.SourceScopedMetadata{
+		SourcePath: sourcePath,
+		TMDB:       &api.TMDBMetadata{TMDBID: 999888, Title: "Stale Provider Guess"},
+	}); err != nil {
+		t.Fatalf("save stored metadata: %v", err)
+	}
+	loaded, err := repo.GetExternalIdentity(ctx, sourcePath)
+	if err != nil {
+		t.Fatalf("load stored identity: %v", err)
+	}
+	if loaded.Provenance.IMDB != api.IdentityProvenanceExplicit || loaded.Overrides != (api.IdentityOverrideState{}) {
+		t.Fatalf("SQLite identity shape = %#v", loaded)
+	}
+
+	pipeline := &recordingEvidencePipeline{service: service}
+	collector, err := preparedrelease.NewEvidenceCollector(pipeline)
+	if err != nil {
+		t.Fatalf("new evidence collector: %v", err)
+	}
+	if _, err := collector.Collect(ctx, request); err != nil {
+		t.Fatalf("collect fresh preparation: %v", err)
+	}
+	if !pipeline.state.StoredDataFresh {
+		t.Fatal("expected SQLite-backed source metadata to load as fresh")
+	}
+	if pipeline.state.Identity.IMDBID != 1234567 || pipeline.state.Identity.Provenance.IMDB != api.IdentityProvenanceExplicit ||
+		pipeline.state.Identity.Overrides != (api.IdentityOverrideState{}) || pipeline.state.Identity.TMDBID != 0 || pipeline.state.ProviderMetadata.TMDB != nil {
+		t.Fatalf("collector candidate retained stored guess: identity=%#v metadata=%#v", pipeline.state.Identity, pipeline.state.ProviderMetadata)
+	}
+
+	resolver, err := externalidentity.NewWithCandidateSource(repo, collector)
+	if err != nil {
+		t.Fatalf("new identity resolver: %v", err)
+	}
+	resolved, err := resolver.Resolve(ctx, externalidentity.Request{
+		SourcePath:        sourcePath,
+		SourceFingerprint: "sqlite-fresh-source",
+		Generation:        1,
+	})
+	if err != nil {
+		t.Fatalf("resolve fresh identity: %v", err)
+	}
+	if resolved.Identity.IMDBID != 1234567 || resolved.Identity.Provenance.IMDB != api.IdentityProvenanceExplicit || resolved.Identity.TMDBID != 0 {
+		t.Fatalf("resolved identity restored stored guess: %#v", resolved.Identity)
+	}
+	if resolved.ProviderMetadata.TMDB != nil {
+		t.Fatalf("resolved metadata restored rejected snapshot: %#v", resolved.ProviderMetadata)
+	}
+}
+
+func TestResolveExternalIDsSQLiteStaleProvenanceOnlyClearBlocksSiblingPromotion(t *testing.T) {
+	ctx := context.Background()
+	repo, err := db.Open(filepath.Join(t.TempDir(), "metadata.sqlite"))
+	if err != nil {
+		t.Fatalf("open repository: %v", err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	if err := repo.Migrate(); err != nil {
+		t.Fatalf("migrate repository: %v", err)
+	}
+	const sourcePath = "/media/Example.Movie.2026.1080p-GRP.mkv"
+	if err := repo.SaveExternalIdentity(ctx, api.ExternalIdentity{
+		SourcePath: sourcePath,
+		TMDBID:     444555,
+		Category:   api.CanonicalCategoryMovie,
+		Provenance: api.IdentityProvenanceSet{
+			TMDB: api.IdentityProvenanceExplicit,
+			IMDB: api.IdentityProvenanceExplicit,
+		},
+	}); err != nil {
+		t.Fatalf("save stored identity: %v", err)
+	}
+	loaded, err := repo.GetExternalIdentity(ctx, sourcePath)
+	if err != nil {
+		t.Fatalf("load stored identity: %v", err)
+	}
+	if loaded.IMDBID != 0 || loaded.Provenance.IMDB != api.IdentityProvenanceExplicit || loaded.Overrides != (api.IdentityOverrideState{}) {
+		t.Fatalf("SQLite clear shape = %#v", loaded)
+	}
+
+	tmdbClient := &stubTMDB{metadata: tmdb.MetadataResult{
+		Title:          "Example Movie",
+		TMDBType:       "Movie",
+		IMDbID:         7654321,
+		ExternalIMDbID: 7654321,
+	}}
+	imdbClient := &stubIMDB{}
+	service := NewService(repo,
+		WithTMDBClient(tmdbClient),
+		WithIMDBClient(imdbClient),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(&stubTVmaze{}),
+	)
+	result, err := service.collectExternalIdentityEvidence(ctx, preparationstate.State{SourcePath: sourcePath})
+	if err != nil {
+		t.Fatalf("collect stale identity: %v", err)
+	}
+	if result.Identity.TMDBID != 444555 || result.Identity.IMDBID != 0 || result.Identity.Overrides.IMDB != api.OverrideStateClear {
+		t.Fatalf("stored clear was not preserved: %#v", result.Identity)
+	}
+	if imdbClient.searchCalls != 0 || imdbClient.infoCalls != 0 {
+		t.Fatalf("stored clear triggered IMDb lookup: search=%d info=%d", imdbClient.searchCalls, imdbClient.infoCalls)
+	}
+	if tmdbClient.metaCalls != 1 || result.ProviderMetadata.TMDB == nil {
+		t.Fatalf("TMDB anchor metadata = calls:%d metadata:%#v", tmdbClient.metaCalls, result.ProviderMetadata.TMDB)
+	}
+}
+
+func TestResolveExternalIDsRejectsInferredTVmazeConflictingWithExplicitTMDB(t *testing.T) {
+	tmdbID := 444555
+	tmdbClient := &stubTMDB{metadata: tmdb.MetadataResult{
+		Title:          "Example Series",
+		TMDBType:       "Scripted",
+		IMDbID:         1234567,
+		TVDBID:         222333,
+		ExternalIMDbID: 1234567,
+		ExternalTVDBID: 222333,
+	}}
+	tvmazeClient := &stubTVmaze{result: tvmaze.SearchResult{
+		SelectedID: 55,
+		Candidates: []tvmaze.Candidate{{
+			ID:        55,
+			Name:      "Conflicting Series",
+			Externals: tvmaze.Externals{IMDB: "tt7654321", TVDB: 999888},
+		}},
+	}}
+	svc := NewService(&fakeRepo{},
+		WithTMDBClient(tmdbClient),
+		WithIMDBClient(&stubIMDB{info: imdb.Info{
+			IMDbID: "tt1234567",
+			Title:  "Example Series",
+			Type:   "tvSeries",
+		}}),
+		WithTVDBClient(&stubTVDB{seriesMetadata: tvdb.SeriesMetadata{TVDBID: 222333, Name: "Example Series"}}),
+		WithTVmazeClient(tvmazeClient),
+	)
+
+	result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        "Example.Series.S01E01.1080p-GRP.mkv",
+		MediaInfoCategory: "TV",
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			TMDBID: &tmdbID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve explicit TMDB anchor: %v", err)
+	}
+	if result.Identity.TMDBID != tmdbID || result.Identity.IMDBID != 1234567 || result.Identity.TVDBID != 222333 || result.Identity.TVmazeID != 0 {
+		t.Fatalf("reconciled identity = %#v", result.Identity)
+	}
+	if result.ProviderMetadata.TMDB == nil || result.ProviderMetadata.TVmaze != nil || len(result.LookupWarnings) == 0 {
+		t.Fatalf("reconciled metadata=%#v warnings=%#v", result.ProviderMetadata, result.LookupWarnings)
+	}
+}
+
+func TestResolveExternalIDsUsesExplicitTVmazeCrossReferences(t *testing.T) {
+	tvmazeID := 55
+	tmdbClient := &stubTMDB{
+		findFn: func(input tmdb.FindInput) (tmdb.FindResult, error) {
+			if input.IMDbID != "tt1234567" || input.TVDBID != 222333 {
+				return tmdb.FindResult{}, nil
+			}
+			return tmdb.FindResult{TMDBID: 444555, Category: "TV"}, nil
+		},
+		metadata: tmdb.MetadataResult{
+			Title:          "Example Series",
+			TMDBType:       "Scripted",
+			IMDbID:         1234567,
+			TVDBID:         222333,
+			ExternalIMDbID: 1234567,
+			ExternalTVDBID: 222333,
+		},
+	}
+	tvmazeClient := &stubTVmaze{result: tvmaze.SearchResult{
+		SelectedID: 55,
+		IMDBID:     1234567,
+		TVDBID:     222333,
+		Candidates: []tvmaze.Candidate{{
+			ID:        55,
+			Name:      "Example Series",
+			Externals: tvmaze.Externals{IMDB: "tt1234567", TVDB: 222333},
+		}},
+	}}
+	svc := NewService(&fakeRepo{},
+		WithTMDBClient(tmdbClient),
+		WithIMDBClient(&stubIMDB{info: imdb.Info{
+			IMDbID: "tt1234567",
+			Title:  "Example Series",
+			Type:   "tvSeries",
+		}}),
+		WithTVDBClient(&stubTVDB{seriesMetadata: tvdb.SeriesMetadata{TVDBID: 222333, Name: "Example Series"}}),
+		WithTVmazeClient(tvmazeClient),
+	)
+
+	result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        "Example.Series.S01E01.1080p-GRP.mkv",
+		MediaInfoCategory: "TV",
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			TVmazeID: &tvmazeID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve TVmaze identity: %v", err)
+	}
+	if result.Identity.TVmazeID != 55 || result.Identity.IMDBID != 1234567 || result.Identity.TVDBID != 222333 || result.Identity.TMDBID != 444555 {
+		t.Fatalf("TVmaze cross-reference identity = %#v", result.Identity)
+	}
+	if tmdbClient.findCalls != 1 || tmdbClient.searchCalls != 0 || tmdbClient.metaCalls != 1 {
+		t.Fatalf("TMDB calls = find:%d search:%d metadata:%d", tmdbClient.findCalls, tmdbClient.searchCalls, tmdbClient.metaCalls)
+	}
+	if len(tmdbClient.findInputs) != 1 || !tmdbClient.findInputs[0].RequireExternalIDAgreement {
+		t.Fatalf("anchored TMDB lookup did not require external ID agreement: %#v", tmdbClient.findInputs)
+	}
+}
+
+func TestResolveExternalIDsRejectsInferredTMDBConflictingWithExplicitTVmaze(t *testing.T) {
+	tvmazeID := 55
+	tmdbClient := &stubTMDB{
+		findResult: tmdb.FindResult{TMDBID: 444555, Category: "TV"},
+		metadata: tmdb.MetadataResult{
+			Title:          "Conflicting Series",
+			TMDBType:       "Scripted",
+			IMDbID:         7654321,
+			TVDBID:         222333,
+			ExternalIMDbID: 7654321,
+			ExternalTVDBID: 222333,
+		},
+	}
+	tvmazeClient := &stubTVmaze{result: tvmaze.SearchResult{
+		SelectedID: tvmazeID,
+		IMDBID:     1234567,
+		TVDBID:     222333,
+		Candidates: []tvmaze.Candidate{{
+			ID:        tvmazeID,
+			Name:      "Example Series",
+			Externals: tvmaze.Externals{IMDB: "tt1234567", TVDB: 222333},
+		}},
+	}}
+	svc := NewService(&fakeRepo{},
+		WithTMDBClient(tmdbClient),
+		WithIMDBClient(&stubIMDB{info: imdb.Info{
+			IMDbID: "tt1234567",
+			Title:  "Example Series",
+			Type:   "tvSeries",
+		}}),
+		WithTVDBClient(&stubTVDB{seriesMetadata: tvdb.SeriesMetadata{TVDBID: 222333, Name: "Example Series"}}),
+		WithTVmazeClient(tvmazeClient),
+	)
+
+	result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        "Example.Series.S01E01.1080p-GRP.mkv",
+		MediaInfoCategory: "TV",
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			TVmazeID: &tvmazeID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve explicit TVmaze anchor: %v", err)
+	}
+	if result.Identity.TVmazeID != tvmazeID || result.Identity.IMDBID != 1234567 || result.Identity.TVDBID != 222333 || result.Identity.TMDBID != 0 {
+		t.Fatalf("reconciled identity = %#v", result.Identity)
+	}
+	if result.ProviderMetadata.TVmaze == nil || result.ProviderMetadata.TMDB != nil || len(result.LookupWarnings) == 0 {
+		t.Fatalf("reconciled metadata=%#v warnings=%#v", result.ProviderMetadata, result.LookupWarnings)
+	}
+}
+
+func TestResolveExternalIDsRejectsUnverifiedTVmazeTitleMatch(t *testing.T) {
+	imdbID := 1234567
+	tvmazeClient := &stubTVmaze{result: tvmaze.SearchResult{
+		SelectedID: 55,
+		Candidates: []tvmaze.Candidate{{ID: 55, Name: "Unrelated Title Match"}},
+	}}
+	svc := NewService(&fakeRepo{},
+		WithTMDBClient(&stubTMDB{findResult: tmdb.FindResult{FilenameSearch: true}}),
+		WithIMDBClient(&stubIMDB{info: imdb.Info{
+			IMDbID: "tt1234567",
+			Title:  "Example Anchor",
+			Type:   "tvSeries",
+		}}),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(tvmazeClient),
+	)
+
+	result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        "Example.Anchor.S01E01.1080p-GRP.mkv",
+		MediaInfoCategory: "TV",
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			IMDBID: &imdbID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve TVmaze title match: %v", err)
+	}
+	if result.Identity.TVmazeID != 0 || result.ProviderMetadata.TVmaze != nil {
+		t.Fatalf("unverified TVmaze title match became canonical: identity=%#v metadata=%#v", result.Identity, result.ProviderMetadata.TVmaze)
+	}
+	if len(result.LookupWarnings) != 1 || !strings.Contains(result.LookupWarnings[0], "did not verify the supplied IMDb ID") {
+		t.Fatalf("verification warnings = %#v", result.LookupWarnings)
+	}
+}
+
+func TestResolveExternalIDsTMDBAnchorSuppressesTVmazeNameFallback(t *testing.T) {
+	tmdbID := 123
+	tvmazeClient := &stubTVmaze{}
+	svc := NewService(&fakeRepo{},
+		WithTMDBClient(&stubTMDB{metadata: tmdb.MetadataResult{
+			Title:          "Example Anchor",
+			TMDBType:       "TV",
+			IMDbID:         1234567,
+			ExternalIMDbID: 1234567,
+		}}),
+		WithIMDBClient(&stubIMDB{}),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(tvmazeClient),
+	)
+	result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:          "Example.Anchor.S01E01.1080p-GRP.mkv",
+		MediaInfoCategory:   "TV",
+		ExternalIDOverrides: api.ExternalIDOverrides{TMDBID: &tmdbID},
+	})
+	if err != nil {
+		t.Fatalf("resolve TMDB anchor: %v", err)
+	}
+	if len(tvmazeClient.inputs) == 0 {
+		t.Fatal("expected TVmaze lookup attempts")
+	}
+	for _, input := range tvmazeClient.inputs {
+		if input.AllowNameFallback || !input.StrictIDOnly {
+			t.Fatalf("anchored TVmaze lookup permits title fallback: %#v", input)
+		}
+	}
+	if result.Identity.TVmazeID != 0 || result.ProviderMetadata.TVmaze != nil {
+		t.Fatalf("unverified TVmaze identity: %#v", result.Identity)
+	}
+}
+
+func TestResolveExternalIDsMALOnlySuppressesTitleSelection(t *testing.T) {
+	malID := 999
+	tmdbClient := &stubTMDB{
+		searchOutcome:   tmdb.SearchOutcome{TMDBID: 123, Category: "TV"},
+		anilistMetadata: tmdb.AniListMetadataResult{MALID: malID, TitleRomaji: "Example Anime"},
+	}
+	svc := NewService(&fakeRepo{},
+		WithTMDBClient(tmdbClient),
+		WithIMDBClient(&stubIMDB{searchResult: imdb.SearchResult{IMDbID: 1234567}}),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(&stubTVmaze{}),
+	)
+
+	result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        "Example.Anime.S01E01.1080p-GRP.mkv",
+		MediaInfoCategory: "TV",
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			MALID: &malID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve MAL identity: %v", err)
+	}
+	if result.Identity.MALID != malID || result.Identity.TMDBID != 0 || result.Identity.IMDBID != 0 {
+		t.Fatalf("MAL-only identity = %#v", result.Identity)
+	}
+	if tmdbClient.searchCalls != 0 || tmdbClient.anilistCalls != 1 {
+		t.Fatalf("provider calls = search:%d anilist:%d", tmdbClient.searchCalls, tmdbClient.anilistCalls)
 	}
 }
 
@@ -1907,6 +3254,36 @@ func TestResolveExternalIDsOverride(t *testing.T) {
 	}
 }
 
+func TestResolveExternalIDsPreservesExplicitTVDBIDForMovieConflict(t *testing.T) {
+	tvdbID := 345678
+	svc := NewService(&fakeRepo{},
+		WithTMDBClient(&stubTMDB{}),
+		WithIMDBClient(&stubIMDB{}),
+		WithTVDBClient(&stubTVDB{}),
+		WithTVmazeClient(&stubTVmaze{}),
+	)
+
+	result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        "Example.Movie.2026.1080p-GRP.mkv",
+		MediaInfoCategory: "MOVIE",
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			TVDBID: &tvdbID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve movie conflict: %v", err)
+	}
+	if result.Identity.TVDBID != tvdbID || result.Identity.Provenance.TVDB != api.IdentityProvenanceExplicit {
+		t.Fatalf("explicit TVDB ID changed: %#v", result.Identity)
+	}
+	if result.ProviderMetadata.TVDB != nil {
+		t.Fatalf("movie retained TVDB metadata: %#v", result.ProviderMetadata.TVDB)
+	}
+	if len(result.LookupWarnings) != 1 || !strings.Contains(result.LookupWarnings[0], "Correct the TVDB ID or category") {
+		t.Fatalf("correction warnings = %#v", result.LookupWarnings)
+	}
+}
+
 func TestResolveExternalIDsRefetchesProviderSnapshotsAfterIDOverride(t *testing.T) {
 	repo := &fakeRepo{}
 	tmdbClient := &stubTMDB{metadata: tmdb.MetadataResult{Title: "Current TMDB", TMDBType: "Movie"}}
@@ -1952,7 +3329,7 @@ func TestResolveExternalIDsRefetchesProviderSnapshotsAfterIDOverride(t *testing.
 	}
 }
 
-func TestResolveExternalIDsClearIMDBReresolvesFromOverriddenTMDB(t *testing.T) {
+func TestResolveExternalIDsClearIMDBSuppressesTMDBSiblingEnrichment(t *testing.T) {
 	repo := &fakeRepo{}
 	tmdbClient := &stubTMDB{metadata: tmdb.MetadataResult{
 		IMDbID:   777,
@@ -1987,15 +3364,15 @@ func TestResolveExternalIDsClearIMDBReresolvesFromOverriddenTMDB(t *testing.T) {
 	if result.Identity.TMDBID != 999 {
 		t.Fatalf("expected tmdb override 999, got %d", result.Identity.TMDBID)
 	}
-	if result.Identity.IMDBID != 777 {
-		t.Fatalf("expected imdb re-resolved from tmdb metadata, got %d", result.Identity.IMDBID)
+	if result.Identity.IMDBID != 0 || result.Identity.Overrides.IMDB != api.OverrideStateClear {
+		t.Fatalf("expected imdb clear to remain authoritative, got %#v", result.Identity)
 	}
-	if result.Identity.Provenance.IMDB != api.IdentityProvenanceProvider {
-		t.Fatalf("expected imdb source tmdb after clear, got %q", result.Identity.Provenance.IMDB)
+	if imdbClient.infoCalls != 0 {
+		t.Fatalf("expected imdb lookup suppressed, got %d calls", imdbClient.infoCalls)
 	}
 }
 
-func TestResolveExternalIDsClearTMDBReresolvesFromRetainedIMDB(t *testing.T) {
+func TestResolveExternalIDsClearTMDBSuppressesRetainedIMDBLookup(t *testing.T) {
 	repo := &fakeRepo{}
 	tmdbClient := &stubTMDB{findResult: tmdb.FindResult{TMDBID: 77075, Category: "TV"}}
 	imdbClient := &stubIMDB{}
@@ -2022,14 +3399,55 @@ func TestResolveExternalIDsClearTMDBReresolvesFromRetainedIMDB(t *testing.T) {
 		t.Fatalf("resolve: %v", err)
 	}
 
-	if tmdbClient.findCalls != 1 {
-		t.Fatalf("expected tmdb external lookup call, got %d", tmdbClient.findCalls)
+	if tmdbClient.findCalls != 0 || tmdbClient.searchCalls != 0 || tmdbClient.metaCalls != 0 {
+		t.Fatalf("expected tmdb lookups suppressed, got find=%d search=%d metadata=%d", tmdbClient.findCalls, tmdbClient.searchCalls, tmdbClient.metaCalls)
 	}
-	if result.Identity.TMDBID != 77075 {
-		t.Fatalf("expected tmdb id re-resolved from imdb, got %d", result.Identity.TMDBID)
+	if result.Identity.TMDBID != 0 || result.Identity.Overrides.TMDB != api.OverrideStateClear {
+		t.Fatalf("expected tmdb clear to remain authoritative, got %#v", result.Identity)
 	}
-	if result.Identity.Provenance.TMDB != api.IdentityProvenanceProvider {
-		t.Fatalf("expected tmdb source tmdb_external after clear, got %q", result.Identity.Provenance.TMDB)
+}
+
+func TestResolveExternalIDsClearTVDBAndTVmazeSuppressesSiblingResolution(t *testing.T) {
+	tmdbID := 999
+	clearedID := 0
+	tmdbClient := &stubTMDB{metadata: tmdb.MetadataResult{
+		Title:          "Example Series",
+		TMDBType:       "TV",
+		IMDbID:         777,
+		TVDBID:         888,
+		ExternalIMDbID: 777,
+		ExternalTVDBID: 888,
+	}}
+	tvdbClient := &stubTVDB{id: 888}
+	tvmazeClient := &stubTVmaze{result: tvmaze.SearchResult{SelectedID: 55}}
+	svc := NewService(&fakeRepo{},
+		WithTMDBClient(tmdbClient),
+		WithIMDBClient(&stubIMDB{}),
+		WithTVDBClient(tvdbClient),
+		WithTVmazeClient(tvmazeClient),
+	)
+
+	result, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        "/media/Example.Series.S01E01.1080p-GRP.mkv",
+		MediaInfoCategory: "TV",
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			TMDBID:   &tmdbID,
+			TVDBID:   &clearedID,
+			TVmazeID: &clearedID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if result.Identity.IMDBID != 777 {
+		t.Fatalf("expected uncleared imdb sibling enrichment, got %#v", result.Identity)
+	}
+	if result.Identity.TVDBID != 0 || result.Identity.Overrides.TVDB != api.OverrideStateClear ||
+		result.Identity.TVmazeID != 0 || result.Identity.Overrides.TVmaze != api.OverrideStateClear {
+		t.Fatalf("expected tvdb and tvmaze clears to remain authoritative, got %#v", result.Identity)
+	}
+	if tvdbClient.calls != 0 || tvmazeClient.calls != 0 {
+		t.Fatalf("expected cleared provider lookups suppressed, got tvdb=%d tvmaze=%d", tvdbClient.calls, tvmazeClient.calls)
 	}
 }
 
@@ -3352,7 +4770,7 @@ func TestResolveExternalIDsAppliesMALOverride(t *testing.T) {
 	}
 }
 
-func TestResolveExternalIDsMALPrecedence(t *testing.T) {
+func TestResolveExternalIDsAnchoredTMDBSuppressesUnverifiedMAL(t *testing.T) {
 	tmdbID := 101
 	tmdbClient := &stubTMDB{
 		metadata: tmdb.MetadataResult{
@@ -3381,11 +4799,13 @@ func TestResolveExternalIDsMALPrecedence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	if result.Identity.MALID != 111 || result.Identity.Provenance.MAL != "tracker" {
-		t.Fatalf("expected tracker mal precedence, got %#v", result.Identity)
+	if result.Identity.MALID != 0 || result.MALID != 0 {
+		t.Fatalf("expected anchored TMDB to suppress unverified MAL, got %#v", result.Identity)
 	}
-	if result.MALID != 111 {
-		t.Fatalf("expected prepared mal mirror 111, got %d", result.MALID)
+	for _, input := range tmdbClient.metaInputs {
+		if !input.SkipAnimeLookup {
+			t.Fatalf("anchored TMDB metadata input did not suppress anime lookup: %#v", input)
+		}
 	}
 }
 
@@ -3552,12 +4972,13 @@ func TestResolveExternalIDsAniListFetchErrorDoesNotPersistEmptyMetadata(t *testi
 func TestResolveExternalIDsMALFallbacksAndClear(t *testing.T) {
 	tmdbID := 101
 	clearMAL := 0
+	tmdbClient := &stubTMDB{metadata: tmdb.MetadataResult{
+		TMDBType: "tv",
+		MALID:    444,
+		Anime:    true,
+	}}
 	svc := NewService(&fakeRepo{},
-		WithTMDBClient(&stubTMDB{metadata: tmdb.MetadataResult{
-			TMDBType: "tv",
-			MALID:    444,
-			Anime:    true,
-		}}),
+		WithTMDBClient(tmdbClient),
 		WithIMDBClient(&stubIMDB{}),
 		WithTVDBClient(&stubTVDB{}),
 		WithTVmazeClient(&stubTVmaze{}),
@@ -3575,9 +4996,15 @@ func TestResolveExternalIDsMALFallbacksAndClear(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve scene: %v", err)
 	}
-	if result.Identity.MALID != 222 || result.Identity.Provenance.MAL != "scene" {
-		t.Fatalf("expected scene mal fallback, got %#v", result.Identity)
+	if result.Identity.MALID != 0 || len(tmdbClient.metaInputs) == 0 {
+		t.Fatalf("anchored TMDB anime enrichment = identity:%#v inputs:%#v", result.Identity, tmdbClient.metaInputs)
 	}
+	for _, input := range tmdbClient.metaInputs {
+		if !input.SkipAnimeLookup {
+			t.Fatalf("anchored TMDB anime enrichment = identity:%#v inputs:%#v", result.Identity, tmdbClient.metaInputs)
+		}
+	}
+	anchoredInputCount := len(tmdbClient.metaInputs)
 
 	cleared, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
 		SourcePath:        "/media/Example.Anime.S01E03.mkv",
@@ -3598,6 +5025,29 @@ func TestResolveExternalIDsMALFallbacksAndClear(t *testing.T) {
 	}
 	if cleared.MALID != 0 {
 		t.Fatalf("expected prepared mal mirror cleared, got %d", cleared.MALID)
+	}
+	for _, input := range tmdbClient.metaInputs[anchoredInputCount:] {
+		if !input.SkipAnimeLookup {
+			t.Fatalf("cleared MAL anime enrichment inputs = %#v", tmdbClient.metaInputs)
+		}
+	}
+	clearedInputCount := len(tmdbClient.metaInputs)
+
+	legacy, err := svc.resolveExternalIdentity(context.Background(), preparationstate.State{
+		SourcePath:        "/media/Example.Anime.S01E04.mkv",
+		MediaInfoCategory: "TV",
+		TrackerData:       []api.TrackerMetadata{{TMDBID: tmdbID}},
+	})
+	if err != nil {
+		t.Fatalf("resolve legacy fallback: %v", err)
+	}
+	if legacy.Identity.MALID != 444 || legacy.Identity.Provenance.MAL != api.IdentityProvenanceProvider {
+		t.Fatalf("legacy TMDB MAL enrichment = %#v", legacy.Identity)
+	}
+	for _, input := range tmdbClient.metaInputs[clearedInputCount:] {
+		if input.SkipAnimeLookup {
+			t.Fatalf("legacy TMDB anime enrichment inputs = %#v", tmdbClient.metaInputs)
+		}
 	}
 }
 

--- a/internal/metadata/external_ids_test.go
+++ b/internal/metadata/external_ids_test.go
@@ -2035,8 +2035,8 @@ func TestResolveExternalIDsAllowsDownstreamTMDBAfterConflictingInferredIDIsRepla
 	tmdbClient := &stubTMDB{
 		findResult: tmdb.FindResult{TMDBID: 222, Category: "TV"},
 		metadataFn: func(input tmdb.MetadataInput) (tmdb.MetadataResult, error) {
-			if input.TMDBID == 111 {
-				return tmdb.MetadataResult{TMDBType: "Scripted", ExternalIMDbID: 7654321}, nil
+			if input.TMDBID != 222 {
+				t.Errorf("metadata lookup TMDB ID = %d, want replacement 222", input.TMDBID)
 			}
 			return tmdb.MetadataResult{}, errors.New("replacement metadata unavailable")
 		},

--- a/internal/metadata/imdb/client.go
+++ b/internal/metadata/imdb/client.go
@@ -570,6 +570,9 @@ func (c *Client) runSearch(ctx context.Context, filename string, searchYear int,
 	)
 	var response map[string]any
 	if err := c.postGraphQL(ctx, "SearchTitles", query, &response); err != nil {
+		if c.logger != nil {
+			c.logger.Debugf("imdb: title lookup failed year=%d wide=%t error=%s", searchYear, wide, redaction.RedactValue(err.Error(), nil))
+		}
 		return nil
 	}
 	return getList(response, "data", "advancedTitleSearch", "edges")

--- a/internal/metadata/media_details.go
+++ b/internal/metadata/media_details.go
@@ -320,9 +320,11 @@ func (s *Service) applySceneDetection(ctx context.Context, meta preparationstate
 		}
 	}
 	applySceneResult(&meta, result)
-	// Detection now runs after ID resolution, so backfill a scene-discovered IMDb
-	// id only when resolution found none, so upload payloads still carry it.
-	if meta.Identity.IMDBID == 0 && result.IMDBID > 0 {
+	// Backfill scene-discovered IMDb only when resolution found none and no
+	// explicit provider anchor or IMDb clear constrains the identity.
+	effectiveOverrides := effectiveProviderOverrides(meta.ExternalIDOverrides, meta.Identity)
+	if meta.Identity.IMDBID == 0 && result.IMDBID > 0 && !clearedProviderOverride(effectiveOverrides.IMDBID) &&
+		!hasPositiveProviderOverride(effectiveOverrides) {
 		meta.Identity.IMDBID = result.IMDBID
 	}
 	if s.logger != nil {

--- a/internal/metadata/scene.go
+++ b/internal/metadata/scene.go
@@ -928,16 +928,22 @@ const (
 	srrdbIMDBMaxPages = 25
 )
 
-// sceneIMDbID returns the resolved IMDb id on meta in precedence order. Detection
-// runs during media-detail enrichment after identity resolution, so the canonical IMDB ID
-// is normally populated; 0 means "no id known" and the imdb: search is skipped in
-// favor of the r: fallback.
+// sceneIMDbID returns an explicit or canonical IMDb ID, respecting explicit
+// clears. Arr supplies a fallback only without an explicit provider anchor.
+// Zero skips the IMDb search and leaves release-name detection available.
 func sceneIMDbID(meta preparationstate.State) int {
-	if id := meta.ExternalIDOverrides.IMDBID; id != nil && *id > 0 {
+	effectiveOverrides := effectiveProviderOverrides(meta.ExternalIDOverrides, meta.Identity)
+	if clearedProviderOverride(effectiveOverrides.IMDBID) {
+		return 0
+	}
+	if id := effectiveOverrides.IMDBID; id != nil && *id > 0 {
 		return *id
 	}
 	if meta.Identity.IMDBID > 0 {
 		return meta.Identity.IMDBID
+	}
+	if hasPositiveProviderOverride(effectiveOverrides) {
+		return 0
 	}
 	if meta.ArrIMDBID > 0 {
 		return meta.ArrIMDBID

--- a/internal/metadata/scene_test.go
+++ b/internal/metadata/scene_test.go
@@ -45,6 +45,86 @@ func (r *sceneLogRecorder) join() string {
 	return strings.Join(r.lines, "\n")
 }
 
+func TestSceneIMDbIDRespectsEffectiveProviderLocks(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		meta preparationstate.State
+		want int
+	}{
+		{
+			name: "explicit IMDb clear suppresses Arr fallback",
+			meta: preparationstate.State{
+				ArrIMDBID: 7654321,
+				ExternalIDOverrides: api.ExternalIDOverrides{
+					IMDBID: new(0),
+				},
+			},
+		},
+		{
+			name: "positive TMDB anchor suppresses Arr fallback",
+			meta: preparationstate.State{
+				ArrIMDBID: 7654321,
+				ExternalIDOverrides: api.ExternalIDOverrides{
+					TMDBID: new(42),
+				},
+			},
+		},
+		{
+			name: "stored positive anchor provenance suppresses Arr fallback",
+			meta: preparationstate.State{
+				ArrIMDBID: 7654321,
+				Identity: api.ExternalIdentity{
+					TMDBID: 42,
+					Provenance: api.IdentityProvenanceSet{
+						TMDB: api.IdentityProvenanceExplicit,
+					},
+				},
+			},
+		},
+		{
+			name: "stored IMDb clear suppresses Arr fallback",
+			meta: preparationstate.State{
+				ArrIMDBID: 7654321,
+				Identity: api.ExternalIdentity{
+					Provenance: api.IdentityProvenanceSet{
+						IMDB: api.IdentityProvenanceExplicit,
+					},
+					Overrides: api.IdentityOverrideState{
+						IMDB: api.OverrideStateClear,
+					},
+				},
+			},
+		},
+		{
+			name: "verified canonical IMDb remains usable with another anchor",
+			meta: preparationstate.State{
+				Identity: api.ExternalIdentity{
+					TMDBID: 42,
+					IMDBID: 1234567,
+					Provenance: api.IdentityProvenanceSet{
+						TMDB: api.IdentityProvenanceExplicit,
+						IMDB: api.IdentityProvenanceProvider,
+					},
+				},
+			},
+			want: 1234567,
+		},
+		{
+			name: "unanchored Arr fallback remains available",
+			meta: preparationstate.State{
+				ArrIMDBID: 7654321,
+			},
+			want: 7654321,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sceneIMDbID(tc.meta); got != tc.want {
+				t.Fatalf("scene IMDb ID = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSceneDetectorSRRDB(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/v1/search/r:Example.Release", func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -344,6 +344,50 @@ func TestApplySceneDetectionBackfillsIMDbID(t *testing.T) {
 	if meta.Identity.IMDBID != 999 {
 		t.Fatalf("expected resolved imdb preserved, got %d", meta.Identity.IMDBID)
 	}
+
+	clearIMDB := 0
+	meta, err = service.applySceneDetection(context.Background(), preparationstate.State{
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			IMDBID: &clearIMDB,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if meta.Identity.IMDBID != 0 || meta.SceneIMDB != 132245 {
+		t.Fatalf("explicit IMDb clear allowed canonical backfill: identity=%d scene=%d", meta.Identity.IMDBID, meta.SceneIMDB)
+	}
+
+	tmdbID := 42
+	meta, err = service.applySceneDetection(context.Background(), preparationstate.State{
+		Identity: api.ExternalIdentity{
+			TMDBID: tmdbID,
+		},
+		ExternalIDOverrides: api.ExternalIDOverrides{
+			TMDBID: &tmdbID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if meta.Identity.IMDBID != 0 || meta.SceneIMDB != 132245 {
+		t.Fatalf("positive TMDB anchor allowed canonical backfill: identity=%d scene=%d", meta.Identity.IMDBID, meta.SceneIMDB)
+	}
+
+	meta, err = service.applySceneDetection(context.Background(), preparationstate.State{
+		Identity: api.ExternalIdentity{
+			TMDBID: tmdbID,
+			Provenance: api.IdentityProvenanceSet{
+				TMDB: api.IdentityProvenanceExplicit,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if meta.Identity.IMDBID != 0 || meta.SceneIMDB != 132245 {
+		t.Fatalf("stored TMDB anchor allowed canonical backfill: identity=%d scene=%d", meta.Identity.IMDBID, meta.SceneIMDB)
+	}
 }
 
 func TestApplySceneDetectionPropagatesCancellation(t *testing.T) {

--- a/internal/metadata/tmdb/client.go
+++ b/internal/metadata/tmdb/client.go
@@ -380,6 +380,9 @@ func applySearchHints(input SearchInput) SearchInput {
 
 func (c *Client) searchTMDb(ctx context.Context, input SearchInput, category string) SearchOutcome {
 	items, err := c.searchTitle(ctx, input.Filename, input.SearchYear, category)
+	if err != nil && c.logger != nil {
+		c.logger.Debugf("tmdb: title lookup failed category=%s year=%d error=%s", category, input.SearchYear, redaction.RedactValue(err.Error(), nil))
+	}
 	if err != nil || len(items) == 0 {
 		return SearchOutcome{TMDBID: 0, Category: category}
 	}
@@ -603,6 +606,9 @@ func (c *Client) findByExternal(ctx context.Context, externalID, source string) 
 	path := "/find/" + url.PathEscape(externalID)
 	var resp FindResponse
 	if err := c.getJSON(ctx, path, params, &resp); err != nil {
+		if c.logger != nil {
+			c.logger.Debugf("tmdb: external lookup failed source=%s id=%s error=%s", source, externalID, redaction.RedactValue(err.Error(), nil))
+		}
 		return FindResponse{}, err
 	}
 	return resp, nil

--- a/internal/metadata/tmdb/client.go
+++ b/internal/metadata/tmdb/client.go
@@ -62,83 +62,36 @@ func NormalizeTitle(title string) string {
 	return strings.TrimSpace(value)
 }
 
-// FindByExternalID tries IMDb, then TVDB, then filename search. External-ID
-// lookup errors are treated as misses. When an IMDb ID maps to movie and TV,
-// CategoryPreference chooses; otherwise movie wins. FilenameSearch reports that
-// identifier lookup did not resolve the result.
+// FindByExternalID tries IMDb, then TVDB, then filename search. When
+// RequireExternalIDAgreement is set and both IDs are supplied, an external-ID
+// match must appear in both result sets. Lookup errors are treated as misses.
+// CategoryPreference disambiguates movie and TV matches; otherwise movie wins.
+// FilenameSearch reports that identifier lookup did not resolve the result.
 func (c *Client) FindByExternalID(ctx context.Context, input FindInput) (FindResult, error) {
 	imdbID := metautil.NormalizeIMDbID(input.IMDbID)
-	filenameSearch := false
-
-	info, _ := c.findByExternal(ctx, imdbID, "imdb_id")
-	hasMovie := len(info.MovieResults) > 0
-	hasTV := len(info.TVResults) > 0
-
-	if hasMovie && hasTV && input.CategoryPreference != "" {
-		pref := strings.ToUpper(strings.TrimSpace(input.CategoryPreference))
-		switch pref {
-		case "MOVIE":
-			if c.logger != nil {
-				c.logger.Infof("tmdb: external match imdb=%s selected=movie tmdb_id=%d", imdbID, info.MovieResults[0].ID)
-			}
-			return FindResult{
-				Category:         "MOVIE",
-				TMDBID:           info.MovieResults[0].ID,
-				OriginalLanguage: info.MovieResults[0].OriginalLanguage,
-				FilenameSearch:   filenameSearch,
-			}, nil
-		case "TV":
-			if c.logger != nil {
-				c.logger.Infof("tmdb: external match imdb=%s selected=tv tmdb_id=%d", imdbID, info.TVResults[0].ID)
-			}
-			return FindResult{
-				Category:         "TV",
-				TMDBID:           info.TVResults[0].ID,
-				OriginalLanguage: info.TVResults[0].OriginalLanguage,
-				FilenameSearch:   filenameSearch,
-			}, nil
-		}
+	var imdbMatches FindResponse
+	if imdbID != "" {
+		imdbMatches, _ = c.findByExternal(ctx, imdbID, "imdb_id")
 	}
-
-	if hasMovie {
+	var tvdbMatches FindResponse
+	if input.TVDBID != 0 && (input.RequireExternalIDAgreement || len(imdbMatches.MovieResults)+len(imdbMatches.TVResults) == 0) {
+		tvdbMatches, _ = c.findByExternal(ctx, strconv.Itoa(input.TVDBID), "tvdb_id")
+	}
+	externalResult, externalConflict := selectExternalFindResult(
+		imdbMatches,
+		tvdbMatches,
+		imdbID != "",
+		input.TVDBID != 0,
+		input.CategoryPreference,
+		input.RequireExternalIDAgreement,
+	)
+	if externalResult.TMDBID != 0 {
 		if c.logger != nil {
-			c.logger.Infof("tmdb: external match imdb=%s selected=movie tmdb_id=%d", imdbID, info.MovieResults[0].ID)
+			c.logger.Infof("tmdb: external match selected=%s tmdb_id=%d", strings.ToLower(externalResult.Category), externalResult.TMDBID)
 		}
-		return FindResult{
-			Category:         "MOVIE",
-			TMDBID:           info.MovieResults[0].ID,
-			OriginalLanguage: info.MovieResults[0].OriginalLanguage,
-			FilenameSearch:   filenameSearch,
-		}, nil
-	}
-	if hasTV {
-		if c.logger != nil {
-			c.logger.Infof("tmdb: external match imdb=%s selected=tv tmdb_id=%d", imdbID, info.TVResults[0].ID)
-		}
-		return FindResult{
-			Category:         "TV",
-			TMDBID:           info.TVResults[0].ID,
-			OriginalLanguage: info.TVResults[0].OriginalLanguage,
-			FilenameSearch:   filenameSearch,
-		}, nil
+		return externalResult, nil
 	}
 
-	if input.TVDBID != 0 {
-		infoTVDB, _ := c.findByExternal(ctx, strconv.Itoa(input.TVDBID), "tvdb_id")
-		if len(infoTVDB.TVResults) > 0 {
-			if c.logger != nil {
-				c.logger.Infof("tmdb: external match tvdb=%d selected=tv tmdb_id=%d", input.TVDBID, infoTVDB.TVResults[0].ID)
-			}
-			return FindResult{
-				Category:         "TV",
-				TMDBID:           infoTVDB.TVResults[0].ID,
-				OriginalLanguage: infoTVDB.TVResults[0].OriginalLanguage,
-				FilenameSearch:   filenameSearch,
-			}, nil
-		}
-	}
-
-	filenameSearch = true
 	input = applyReleaseHints(input)
 	imdbInfo := input.IMDbInfo
 	title := ""
@@ -149,7 +102,7 @@ func (c *Client) FindByExternalID(ctx context.Context, input FindInput) (FindRes
 		title = strings.TrimSpace(input.Filename)
 	}
 	if title == "" {
-		return FindResult{FilenameSearch: filenameSearch}, nil
+		return FindResult{FilenameSearch: true, ExternalIDConflict: externalConflict}, nil
 	}
 
 	searchYear := input.SearchYear
@@ -184,13 +137,89 @@ func (c *Client) FindByExternalID(ctx context.Context, input FindInput) (FindRes
 		c.logger.Infof("tmdb: search match title=%q year=%d category=%s tmdb_id=%d", title, searchYear, outcome.Category, outcome.TMDBID)
 	}
 	return FindResult{
-		Category:         outcome.Category,
-		TMDBID:           outcome.TMDBID,
-		OriginalLanguage: originalLanguage,
-		FilenameSearch:   filenameSearch,
-		Candidates:       outcome.Candidates,
-		AutoSelected:     outcome.AutoSelected,
+		Category:           outcome.Category,
+		TMDBID:             outcome.TMDBID,
+		OriginalLanguage:   originalLanguage,
+		FilenameSearch:     true,
+		ExternalIDConflict: externalConflict,
+		Candidates:         outcome.Candidates,
+		AutoSelected:       outcome.AutoSelected,
 	}, nil
+}
+
+type externalFindCandidate struct {
+	category string
+	item     FindItem
+}
+
+func selectExternalFindResult(imdb, tvdb FindResponse, hasIMDb, hasTVDB bool, categoryPreference string, requireAgreement bool) (FindResult, bool) {
+	imdbCandidates := externalFindCandidates(imdb)
+	tvdbCandidates := externalFindCandidates(tvdb)
+	candidates := imdbCandidates
+	conflict := false
+	if requireAgreement && hasIMDb && hasTVDB {
+		candidates = intersectExternalFindCandidates(imdbCandidates, tvdbCandidates)
+		conflict = len(imdbCandidates) > 0 && len(tvdbCandidates) > 0 && len(candidates) == 0
+	} else if len(candidates) == 0 && hasTVDB {
+		candidates = tvdbCandidates
+	}
+	selected, ok := preferredExternalFindCandidate(candidates, categoryPreference)
+	if !ok {
+		return FindResult{}, conflict
+	}
+	return FindResult{
+		Category:         selected.category,
+		TMDBID:           selected.item.ID,
+		OriginalLanguage: selected.item.OriginalLanguage,
+	}, conflict
+}
+
+func externalFindCandidates(response FindResponse) []externalFindCandidate {
+	result := make([]externalFindCandidate, 0, len(response.MovieResults)+len(response.TVResults))
+	for _, item := range response.MovieResults {
+		if item.ID != 0 {
+			result = append(result, externalFindCandidate{category: "MOVIE", item: item})
+		}
+	}
+	for _, item := range response.TVResults {
+		if item.ID != 0 {
+			result = append(result, externalFindCandidate{category: "TV", item: item})
+		}
+	}
+	return result
+}
+
+func intersectExternalFindCandidates(left, right []externalFindCandidate) []externalFindCandidate {
+	result := make([]externalFindCandidate, 0, min(len(left), len(right)))
+	for _, candidate := range left {
+		for _, other := range right {
+			if candidate.category == other.category && candidate.item.ID == other.item.ID {
+				result = append(result, candidate)
+				break
+			}
+		}
+	}
+	return result
+}
+
+func preferredExternalFindCandidate(candidates []externalFindCandidate, categoryPreference string) (externalFindCandidate, bool) {
+	if len(candidates) == 0 {
+		return externalFindCandidate{}, false
+	}
+	preference := strings.ToUpper(strings.TrimSpace(categoryPreference))
+	if preference != "" {
+		for _, candidate := range candidates {
+			if candidate.category == preference {
+				return candidate, true
+			}
+		}
+	}
+	for _, candidate := range candidates {
+		if candidate.category == "MOVIE" {
+			return candidate, true
+		}
+	}
+	return candidates[0], true
 }
 
 // SearchID tries the parsed title, Roman-numeral and alternate titles, next year,

--- a/internal/metadata/tmdb/client_test.go
+++ b/internal/metadata/tmdb/client_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package tmdb
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestSelectExternalFindResultRequiresAllSuppliedIDs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name             string
+		imdb             FindResponse
+		tvdb             FindResponse
+		hasIMDb          bool
+		hasTVDB          bool
+		requireAgreement bool
+		wantID           int
+		wantConflict     bool
+	}{
+		{
+			name:    "IMDb only",
+			imdb:    FindResponse{TVResults: []FindItem{{ID: 111}}},
+			hasIMDb: true,
+			wantID:  111,
+		},
+		{
+			name:    "TVDB only",
+			tvdb:    FindResponse{TVResults: []FindItem{{ID: 222}}},
+			hasTVDB: true,
+			wantID:  222,
+		},
+		{
+			name:             "matching IMDb and TVDB",
+			imdb:             FindResponse{TVResults: []FindItem{{ID: 333}}},
+			tvdb:             FindResponse{TVResults: []FindItem{{ID: 333}}},
+			hasIMDb:          true,
+			hasTVDB:          true,
+			requireAgreement: true,
+			wantID:           333,
+		},
+		{
+			name:             "conflicting IMDb and TVDB",
+			imdb:             FindResponse{TVResults: []FindItem{{ID: 444}}},
+			tvdb:             FindResponse{TVResults: []FindItem{{ID: 555}}},
+			hasIMDb:          true,
+			hasTVDB:          true,
+			requireAgreement: true,
+			wantConflict:     true,
+		},
+		{
+			name:             "missing TVDB evidence is unverified",
+			imdb:             FindResponse{TVResults: []FindItem{{ID: 666}}},
+			hasIMDb:          true,
+			hasTVDB:          true,
+			requireAgreement: true,
+		},
+		{
+			name:    "legacy IMDb-first selection ignores conflicting TVDB",
+			imdb:    FindResponse{TVResults: []FindItem{{ID: 777}}},
+			tvdb:    FindResponse{TVResults: []FindItem{{ID: 888}}},
+			hasIMDb: true,
+			hasTVDB: true,
+			wantID:  777,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, conflict := selectExternalFindResult(tc.imdb, tc.tvdb, tc.hasIMDb, tc.hasTVDB, "TV", tc.requireAgreement)
+			if result.TMDBID != tc.wantID || conflict != tc.wantConflict {
+				t.Fatalf("result=%#v conflict=%t, want id=%d conflict=%t", result, conflict, tc.wantID, tc.wantConflict)
+			}
+		})
+	}
+}
+
+func TestFindByExternalIDWithoutAgreementSkipsTVDBAfterIMDbMatch(t *testing.T) {
+	t.Parallel()
+	var tvdbRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/find/tt1234567":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"movie_results":[],"tv_results":[{"id":321,"original_language":"en"}]}`))
+		case "/find/987654":
+			tvdbRequests.Add(1)
+			http.Error(w, "unexpected TVDB request", http.StatusServiceUnavailable)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := NewClient(server.Client(), nil, "test-key")
+	client.baseURL = server.URL
+
+	result, err := client.FindByExternalID(context.Background(), FindInput{
+		IMDbID:             "tt1234567",
+		TVDBID:             987654,
+		CategoryPreference: "TV",
+	})
+	if err != nil {
+		t.Fatalf("find by external ID: %v", err)
+	}
+	if result.TMDBID != 321 || result.Category != "TV" || result.FilenameSearch || result.ExternalIDConflict {
+		t.Fatalf("IMDb-first result = %#v", result)
+	}
+	if got := tvdbRequests.Load(); got != 0 {
+		t.Fatalf("TVDB requests = %d, want none after an IMDb match", got)
+	}
+}
+
+func TestApplyExternalIDsRetainsReturnedReferences(t *testing.T) {
+	t.Parallel()
+	result := applyExternalIDs(MetadataResult{}, externalIDsResponse{
+		IMDbID: "tt7654321",
+		TVDBID: 654321,
+	}, MetadataInput{
+		IMDbID: 1234567,
+		TVDBID: 234567,
+	}, mediaResponse{})
+
+	if result.IMDbID != 1234567 || result.TVDBID != 234567 {
+		t.Fatalf("effective IDs = IMDb:%d TVDB:%d", result.IMDbID, result.TVDBID)
+	}
+	if result.ExternalIMDbID != 7654321 || result.ExternalTVDBID != 654321 {
+		t.Fatalf("returned IDs = IMDb:%d TVDB:%d", result.ExternalIMDbID, result.ExternalTVDBID)
+	}
+}

--- a/internal/metadata/tmdb/client_test.go
+++ b/internal/metadata/tmdb/client_test.go
@@ -7,9 +7,41 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
+
+func TestFindByExternalIDLogsRedactedErrorsAndPreservesFallback(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"api_key":"synthetic-secret","message":"lookup unavailable"}`, http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+	logger := &captureTMDBLogger{}
+	client := NewClient(server.Client(), logger, "test-key")
+	client.baseURL = server.URL
+	result, err := client.FindByExternalID(t.Context(), FindInput{
+		IMDbID:                     "tt1234567",
+		TVDBID:                     987654,
+		RequireExternalIDAgreement: true,
+	})
+	if err != nil || !result.FilenameSearch || result.TMDBID != 0 {
+		t.Fatalf("external lookup no longer falls back: result=%#v err=%v", result, err)
+	}
+	if len(logger.debugs) != 2 {
+		t.Fatalf("debug messages = %d, want 2", len(logger.debugs))
+	}
+	for i, source := range []string{"source=imdb_id id=tt1234567", "source=tvdb_id id=987654"} {
+		message := logger.debugs[i]
+		if !strings.Contains(message, source) || !strings.Contains(message, "http 503") || !strings.Contains(message, "lookup unavailable") {
+			t.Error("debug message lacks lookup source or error details")
+		}
+		if strings.Contains(message, "synthetic-secret") {
+			t.Error("debug message exposes secret")
+		}
+	}
+}
 
 func TestSelectExternalFindResultRequiresAllSuppliedIDs(t *testing.T) {
 	t.Parallel()

--- a/internal/metadata/tmdb/metadata.go
+++ b/internal/metadata/tmdb/metadata.go
@@ -243,7 +243,7 @@ func (c *Client) FetchMetadata(ctx context.Context, input MetadataInput) (Metada
 	if !result.Anime {
 		result.Anime = isAnime(media.OriginalLanguage, media.Genres)
 	}
-	if result.Anime {
+	if result.Anime && !input.SkipAnimeLookup {
 		// requestCtx, not ctx: the errgroup context above is canceled once Wait
 		// returns, which would fail every AniList request.
 		animeResult, err := c.ResolveAnime(requestCtx, title, input)
@@ -740,26 +740,25 @@ func shouldKeepAKA(title, aka string, year int) bool {
 }
 
 func applyExternalIDs(result MetadataResult, external externalIDsResponse, input MetadataInput, media mediaResponse) MetadataResult {
+	result.ExternalIMDbID = ExtractIMDbID(external.IMDbID)
+	result.ExternalTVDBID = external.TVDBID
 	originalIMDbID := input.IMDbID
 	imdbID := originalIMDbID
 	if input.QuickieSearch || imdbID == 0 {
-		if external.IMDbID != "" {
-			parsed := ExtractIMDbID(external.IMDbID)
-			if parsed != 0 {
-				if originalIMDbID != 0 && parsed != originalIMDbID && input.QuickieSearch {
-					result.IMDbMismatch = true
-					result.MismatchedIMDbID = parsed
-					imdbID = originalIMDbID
-				} else {
-					imdbID = parsed
-				}
+		if result.ExternalIMDbID != 0 {
+			if originalIMDbID != 0 && result.ExternalIMDbID != originalIMDbID && input.QuickieSearch {
+				result.IMDbMismatch = true
+				result.MismatchedIMDbID = result.ExternalIMDbID
+				imdbID = originalIMDbID
+			} else {
+				imdbID = result.ExternalIMDbID
 			}
 		}
 	}
 	result.IMDbID = imdbID
 	result.TVDBID = input.TVDBID
-	if result.TVDBID == 0 && external.TVDBID != 0 {
-		result.TVDBID = external.TVDBID
+	if result.TVDBID == 0 && result.ExternalTVDBID != 0 {
+		result.TVDBID = result.ExternalTVDBID
 	}
 	if result.IMDbID == 0 && media.IMDbID != "" {
 		result.IMDbID = ExtractIMDbID(media.IMDbID)

--- a/internal/metadata/tmdb/metadata_test.go
+++ b/internal/metadata/tmdb/metadata_test.go
@@ -488,3 +488,43 @@ func TestFetchMetadataResolvesAnimeAKA(t *testing.T) {
 		t.Fatalf("expected romaji AKA, got %q", result.RetrievedAKA)
 	}
 }
+
+func TestFetchMetadataSkipsUnverifiedAnimeLookup(t *testing.T) {
+	var anilistRequested atomic.Bool
+	anilist := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		anilistRequested.Store(true)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"Page":{"media":[{"id":1,"idMal":67890,"title":{"romaji":"Rei No Sakuhin"}}]}}}`))
+	}))
+	defer anilist.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/tv/12345":
+			_, _ = w.Write([]byte(`{"name":"Example Anime Series","original_name":"サンプル作品","first_air_date":"2026-07-11","original_language":"ja","genres":[{"id":16,"name":"Animation"}]}`))
+		case "/tv/12345/credits":
+			_, _ = w.Write([]byte(`{"crew":[],"cast":[]}`))
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.Client(), nil, "api-key")
+	client.baseURL = server.URL
+	client.anilistURL = anilist.URL
+	result, err := client.FetchMetadata(context.Background(), MetadataInput{
+		TMDBID:          12345,
+		Category:        "TV",
+		SkipAnimeLookup: true,
+	})
+	if err != nil {
+		t.Fatalf("fetch metadata: %v", err)
+	}
+	if anilistRequested.Load() {
+		t.Fatal("AniList request dispatched despite skip flag")
+	}
+	if !result.Anime || result.MALID != 0 || result.RetrievedAKA != "" {
+		t.Fatalf("skipped anime enrichment result = %#v", result)
+	}
+}

--- a/internal/metadata/tmdb/metadata_test.go
+++ b/internal/metadata/tmdb/metadata_test.go
@@ -407,12 +407,17 @@ func TestBuildLocalizedTitlesUsesTVTranslationName(t *testing.T) {
 }
 
 type captureTMDBLogger struct {
-	mu    sync.Mutex
-	warns []string
+	mu     sync.Mutex
+	warns  []string
+	debugs []string
 }
 
 func (l *captureTMDBLogger) Tracef(string, ...any) {}
-func (l *captureTMDBLogger) Debugf(string, ...any) {}
+func (l *captureTMDBLogger) Debugf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.debugs = append(l.debugs, fmt.Sprintf(format, args...))
+}
 func (l *captureTMDBLogger) Infof(string, ...any)  {}
 func (l *captureTMDBLogger) Errorf(string, ...any) {}
 

--- a/internal/metadata/tmdb/types.go
+++ b/internal/metadata/tmdb/types.go
@@ -13,27 +13,32 @@ type IMDbInfo struct {
 
 // FindInput supplies external-ID and filename evidence for TMDB identity
 // resolution. CategoryPreference disambiguates IDs that map to movie and TV.
+// RequireExternalIDAgreement restricts external-ID matches to the intersection
+// when both IMDb and TVDB IDs are supplied; filename fallback remains available.
 type FindInput struct {
-	IMDbID             string
-	TVDBID             int
-	SearchYear         int
-	Filename           string
-	CategoryPreference string
-	IMDbInfo           *IMDbInfo
-	Unattended         bool
-	Debug              bool
+	IMDbID                     string
+	TVDBID                     int
+	SearchYear                 int
+	Filename                   string
+	CategoryPreference         string
+	IMDbInfo                   *IMDbInfo
+	RequireExternalIDAgreement bool
+	Unattended                 bool
+	Debug                      bool
 }
 
 // FindResult retains filename-search candidates when identity cannot be selected
 // automatically. FilenameSearch distinguishes fallback results from external-ID
-// matches.
+// matches. ExternalIDConflict reports nonempty IMDb and TVDB result sets with
+// no shared title when agreement is required; a lookup miss is not a conflict.
 type FindResult struct {
-	Category         string
-	TMDBID           int
-	OriginalLanguage string
-	FilenameSearch   bool
-	Candidates       []Candidate
-	AutoSelected     bool
+	Category           string
+	TMDBID             int
+	OriginalLanguage   string
+	FilenameSearch     bool
+	ExternalIDConflict bool
+	Candidates         []Candidate
+	AutoSelected       bool
 }
 
 // SearchInput controls candidate fallback and selection. DontSwitch prevents
@@ -111,7 +116,8 @@ type TranslationData struct {
 }
 
 // MetadataInput controls primary TMDB enrichment and optional logo, anime,
-// language, identity, and season evidence.
+// language, identity, and season evidence. SkipAnimeLookup suppresses title-based
+// AniList enrichment without disabling anime classification.
 type MetadataInput struct {
 	TMDBID           int
 	Category         string
@@ -120,6 +126,7 @@ type MetadataInput struct {
 	TVDBID           int
 	ManualLanguage   string
 	Anime            bool
+	SkipAnimeLookup  bool
 	MALManual        int
 	AKA              string
 	OriginalLanguage string
@@ -137,13 +144,17 @@ type MetadataInput struct {
 // that completed successfully. Runtime is minutes; LocalizedTitles keys are
 // generic language codes or regional language tags.
 type MetadataResult struct {
-	Title            string
-	Year             int
-	ReleaseDate      string
-	FirstAirDate     string
-	LastAirDate      string
-	IMDbID           int
-	TVDBID           int
+	Title        string
+	Year         int
+	ReleaseDate  string
+	FirstAirDate string
+	LastAirDate  string
+	IMDbID       int
+	TVDBID       int
+	// ExternalIMDbID and ExternalTVDBID retain TMDB's returned references
+	// before caller-supplied IDs are applied; zero means no returned reference.
+	ExternalIMDbID   int
+	ExternalTVDBID   int
 	OriginCountry    []string
 	OriginalLanguage string
 	OriginalTitle    string

--- a/internal/metadata/tvdb/client.go
+++ b/internal/metadata/tvdb/client.go
@@ -271,7 +271,11 @@ func (c *Client) GetEpisodesWithLanguage(ctx context.Context, seriesID int, quer
 							_ = writeEpisodesCache(cachePath, cached)
 						}
 					} else if c.logger != nil {
-						c.logger.Debugf("tvdb: cached episodes series metadata refresh failed series_id=%d: %v", seriesID, err)
+						c.logger.Debugf(
+							"tvdb: cached episodes series metadata refresh failed series_id=%d: %s",
+							seriesID,
+							redaction.RedactValue(err.Error(), nil),
+						)
 					}
 				}
 				return cached, specificSeriesAlias(cached), nil
@@ -289,6 +293,8 @@ func (c *Client) GetEpisodesWithLanguage(ctx context.Context, seriesID int, quer
 	details := seriesDetails{}
 	if fetchedDetails, err := c.fetchSeriesDetails(ctx, seriesID, language); err == nil {
 		details = fetchedDetails
+	} else if c.logger != nil {
+		c.logger.Debugf("tvdb: episodes series metadata lookup failed series_id=%d error=%s", seriesID, redaction.RedactValue(err.Error(), nil))
 	}
 	data := EpisodesData{
 		Episodes:             episodes,

--- a/internal/metadata/tvmaze/client.go
+++ b/internal/metadata/tvmaze/client.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	"github.com/autobrr/upbrr/internal/providerid"
+	"github.com/autobrr/upbrr/internal/redaction"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -249,6 +250,9 @@ func (c *Client) lookupShow(ctx context.Context, key, value string) (Candidate, 
 
 	var show showResponse
 	if err := c.getJSON(ctx, endpoint, params, &show); err != nil {
+		if c.logger != nil {
+			c.logger.Debugf("tvmaze: external lookup failed source=%s id=%s error=%s", key, value, redaction.RedactValue(err.Error(), nil))
+		}
 		return Candidate{}, err
 	}
 	return candidateFromShow(show), nil
@@ -261,6 +265,9 @@ func (c *Client) searchShows(ctx context.Context, query string) ([]Candidate, er
 
 	var items []searchResponse
 	if err := c.getJSON(ctx, endpoint, params, &items); err != nil {
+		if c.logger != nil {
+			c.logger.Debugf("tvmaze: title lookup failed error=%s", redaction.RedactValue(err.Error(), nil))
+		}
 		return nil, err
 	}
 
@@ -279,6 +286,9 @@ func (c *Client) getShow(ctx context.Context, id int) (Candidate, error) {
 
 	var show showResponse
 	if err := c.getJSON(ctx, endpoint, nil, &show); err != nil {
+		if c.logger != nil {
+			c.logger.Debugf("tvmaze: show lookup failed id=%d error=%s", id, redaction.RedactValue(err.Error(), nil))
+		}
 		return Candidate{}, err
 	}
 	return candidateFromShow(show), nil

--- a/internal/preparedrelease/module.go
+++ b/internal/preparedrelease/module.go
@@ -23,7 +23,7 @@ import (
 
 // ContractVersion changes whenever prepared fact semantics or the private seed
 // contract become incompatible, forcing persisted generations to be recomputed.
-const ContractVersion = "prepared-release-v9"
+const ContractVersion = "prepared-release-v10"
 
 // Store is the prepared-release persistence port. Implementations must commit
 // facts, identity, and provider metadata as one generation transaction.

--- a/webui/e2e/web-full-upload.spec.ts
+++ b/webui/e2e/web-full-upload.spec.ts
@@ -115,6 +115,48 @@ test("embedded web reload restores the authoritative prepared workflow", async (
   }
 });
 
+test("embedded web removes and restores a metadata provider ID", async ({ page }) => {
+  const workspace = await createE2EWorkspace();
+  let app: AppServer | undefined;
+  try {
+    app = await startApp(workspace);
+    await fetchMetadata(page, app.url, workspace.sourcePath);
+
+    await page.getByText("Edit Release Details", { exact: true }).click();
+    await expect(page.getByRole("textbox", { name: "MAL ID" })).toHaveValue("");
+    await page.getByRole("button", { name: "Remove MAL ID" }).click();
+    const removed = page.waitForResponse((response) =>
+      response.url().includes("/api/app/ContinueReleaseWorkflow"),
+    );
+    await page.getByRole("button", { name: "Refresh metadata" }).click();
+    await expect((await removed).ok()).toBe(true);
+    await expect(page.getByRole("progressbar")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Remove MAL ID" })).toBeDisabled();
+
+    const restored = page.waitForResponse((response) =>
+      response.url().includes("/api/app/GetReleaseWorkflow"),
+    );
+    await page.reload();
+    await expect((await restored).ok()).toBe(true);
+    await page.getByText("Edit Release Details", { exact: true }).click();
+    await expect(page.getByRole("textbox", { name: "MAL ID" })).toHaveValue("");
+    await expect(page.getByRole("button", { name: "Remove MAL ID" })).toBeDisabled();
+
+    await page.getByRole("textbox", { name: "MAL ID" }).fill("5114");
+    await expect(page.getByRole("button", { name: "Remove MAL ID" })).toBeEnabled();
+    const restoredID = page.waitForResponse((response) =>
+      response.url().includes("/api/app/ContinueReleaseWorkflow"),
+    );
+    await page.getByRole("button", { name: "Refresh metadata" }).click();
+    await expect((await restoredID).ok()).toBe(true);
+    await expect(page.getByRole("progressbar")).toHaveCount(0);
+    await expect(page.getByRole("textbox", { name: "MAL ID" })).toHaveValue("5114");
+  } finally {
+    await app?.stop();
+    await workspace.cleanup();
+  }
+});
+
 test("embedded web selects a Blu-ray candidate through the authoritative workflow", async ({
   page,
 }) => {

--- a/webui/src/pages/input/index.test.tsx
+++ b/webui/src/pages/input/index.test.tsx
@@ -363,6 +363,142 @@ describe("InputPage", () => {
     });
   });
 
+  it("removes each metadata provider without overriding untouched IDs", () => {
+    const facet = readyInputFacet(1);
+    render(
+      <InputPage
+        facet={facet}
+        sourcePathHistory={[]}
+        handleBrowseFile={vi.fn()}
+        handleBrowseFolder={vi.fn()}
+        trackerUploadItems={[]}
+        showExternalIDInputUI={false}
+        setLightboxImage={vi.fn()}
+        setLightboxAlt={vi.fn()}
+        trackerIconSrcByName={{}}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Edit Release Details"));
+    fireEvent.click(screen.getByRole("button", { name: "Remove MAL ID" }));
+    expect(facet.changeIdentity).toHaveBeenLastCalledWith({ MALID: 0 });
+
+    for (const provider of ["TMDB", "IMDB", "TVDB", "TVmaze"]) {
+      fireEvent.click(screen.getByRole("button", { name: `Remove ${provider} ID` }));
+    }
+    expect(facet.changeIdentity).toHaveBeenLastCalledWith({
+      TMDBID: 0,
+      IMDBID: 0,
+      TVDBID: 0,
+      TVmazeID: 0,
+      MALID: 0,
+    });
+  });
+
+  it("retains restored removals when a provider is re-enabled", () => {
+    const base = readyInputFacet(2);
+    const removedIDs = {
+      TMDBID: 0,
+      IMDBID: 0,
+      TVDBID: 0,
+      TVmazeID: 0,
+      MALID: 0,
+    };
+    const facet: InputFacet = {
+      ...base,
+      view: {
+        ...base.view,
+        intent: { ...base.view.intent, identity: removedIDs },
+        preview: {
+          ...metadataPreview(2),
+          Identity: { ...emptyExternalIdentity("C:\\media\\Example.mkv"), Generation: 2 },
+          Display: { ReleaseName: "Example.Release.2026.1080p-GRP", Providers: [] },
+        },
+      },
+    };
+    const pageProps = {
+      sourcePathHistory: [],
+      handleBrowseFile: vi.fn(),
+      handleBrowseFolder: vi.fn(),
+      trackerUploadItems: [],
+      showExternalIDInputUI: false,
+      setLightboxImage: vi.fn(),
+      setLightboxAlt: vi.fn(),
+      trackerIconSrcByName: {},
+    };
+    const { rerender } = render(<InputPage facet={facet} {...pageProps} />);
+
+    fireEvent.click(screen.getByText("Edit Release Details"));
+    for (const provider of ["TMDB", "IMDB", "TVDB", "TVmaze", "MAL"]) {
+      expect(screen.getByRole("button", { name: `Remove ${provider} ID` })).toBeDisabled();
+    }
+
+    fireEvent.change(screen.getByLabelText("TMDB ID"), { target: { value: "550" } });
+    const reenabledIDs = { ...removedIDs, TMDBID: 550 };
+    expect(facet.changeIdentity).toHaveBeenLastCalledWith(reenabledIDs);
+    expect(screen.getByRole("button", { name: "Remove TMDB ID" })).toBeEnabled();
+
+    const reenabledFacet: InputFacet = {
+      ...facet,
+      view: {
+        ...facet.view,
+        intent: { ...facet.view.intent, identity: reenabledIDs },
+      },
+    };
+    rerender(<InputPage facet={reenabledFacet} {...pageProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "Refresh metadata" }));
+    expect(facet.prepareSource).toHaveBeenCalledWith(
+      "C:\\media\\Example.mkv",
+      reenabledFacet.view.intent,
+    );
+  });
+
+  for (const preparation of [
+    { name: "a failed first preparation", status: "error", error: "Metadata preparation failed." },
+    { name: "a first preparation without a metadata match", status: "ready", error: "" },
+  ] as const) {
+    it(`removes a blank provider before retrying ${preparation.name}`, () => {
+      const base = inputFacet();
+      const failedFacet: InputFacet = {
+        ...base,
+        view: {
+          ...base.view,
+          status: preparation.status,
+          error: preparation.error,
+        },
+      };
+      const pageProps = {
+        sourcePathHistory: [],
+        handleBrowseFile: vi.fn(),
+        handleBrowseFolder: vi.fn(),
+        trackerUploadItems: [],
+        showExternalIDInputUI: false,
+        setLightboxImage: vi.fn(),
+        setLightboxAlt: vi.fn(),
+        trackerIconSrcByName: {},
+      };
+      const { rerender } = render(<InputPage facet={failedFacet} {...pageProps} />);
+
+      fireEvent.click(screen.getByText("Edit Release Details"));
+      fireEvent.click(screen.getByRole("button", { name: "Remove TVDB ID" }));
+      expect(failedFacet.changeIdentity).toHaveBeenLastCalledWith({ TVDBID: 0 });
+
+      const retryFacet: InputFacet = {
+        ...failedFacet,
+        view: {
+          ...failedFacet.view,
+          intent: { ...failedFacet.view.intent, identity: { TVDBID: 0 } },
+        },
+      };
+      rerender(<InputPage facet={retryFacet} {...pageProps} />);
+      fireEvent.click(screen.getByRole("button", { name: "Retry metadata" }));
+      expect(failedFacet.prepareSource).toHaveBeenCalledWith(
+        "C:\\media\\Example.mkv",
+        retryFacet.view.intent,
+      );
+    });
+  }
+
   it("edits distributor and original-language metadata", () => {
     const facet = readyInputFacet(1);
     render(

--- a/webui/src/pages/input/index.tsx
+++ b/webui/src/pages/input/index.tsx
@@ -899,9 +899,15 @@ export default function InputPage(props: Props) {
     const normalized = provider === "imdb" ? trimmed.replace(/^tt/i, "") : trimmed;
     return /^\d+$/.test(normalized) ? Number(normalized) : null;
   };
+  /**
+   * Merges valid touched edits into existing intent without mutating it, preserving prior provider clears.
+   * Touched blank fields become explicit zero overrides; any invalid field marks the result invalid.
+   * Dirty means the merged result contains overrides, including those restored from existing intent.
+   */
   const buildIDOverrides = (
     edits: IDEdits,
     touched: Record<keyof IDEdits, boolean>,
+    existing: Readonly<ExternalIDOverrides>,
   ): OverrideState<ExternalIDOverrides> => {
     const parsed = {
       tmdb: parseID("tmdb", edits.tmdb),
@@ -911,7 +917,7 @@ export default function InputPage(props: Props) {
       mal: parseID("mal", edits.mal),
     };
     const invalid = Object.values(parsed).includes(null);
-    const overrides: ExternalIDOverrides = {};
+    const overrides: ExternalIDOverrides = { ...existing };
     if (touched.tmdb && parsed.tmdb !== null) overrides.TMDBID = parsed.tmdb;
     if (touched.imdb && parsed.imdb !== null) overrides.IMDBID = parsed.imdb;
     if (touched.tvdb && parsed.tvdb !== null) overrides.TVDBID = parsed.tvdb;
@@ -978,14 +984,18 @@ export default function InputPage(props: Props) {
     return { overrides, dirty: Object.keys(overrides).length > 0, invalid };
   };
 
-  const idOverrideState = buildIDOverrides(idEdits, idTouched);
+  const idOverrideState = buildIDOverrides(idEdits, idTouched, view.intent.identity);
   const releaseOverrideState = buildReleaseOverrides(releaseEdits, releaseTouched);
   const markIDTouched = (key: keyof IDEdits) => {
     const touched = { ...idTouchedRef.current, [key]: true };
     idTouchedRef.current = touched;
     setIDTouchedState(touched);
-    const next = buildIDOverrides(idEditsRef.current, touched);
+    const next = buildIDOverrides(idEditsRef.current, touched, view.intent.identity);
     if (!next.invalid) facet.changeIdentity(next.overrides);
+  };
+  const clearID = (key: keyof IDEdits) => {
+    setIdEdits((current) => ({ ...current, [key]: "" }));
+    markIDTouched(key);
   };
   const markReleaseTouched = (key: keyof ReleaseNameTouchedState) => {
     const touched = { ...releaseTouchedRef.current, [key]: true };
@@ -1125,6 +1135,9 @@ export default function InputPage(props: Props) {
   );
   const providerDisplays = preview.Display.Providers;
   const hasPreview = preview.ReleaseName || externalIDInfo.length > 0;
+  const showReleaseDetails = Boolean(
+    hasPreview || (path.trim() && (view.status === "ready" || view.status === "error")),
+  );
   const isTVEpisodePreview = (identityDraft.Category || "").trim().toUpperCase() === "TV";
   const hasResolvedPrimaryExternalID = identityDraft.TMDBID > 0 || identityDraft.IMDBID > 0;
   const selectedTrackerCount = useMemo(
@@ -1794,75 +1807,138 @@ export default function InputPage(props: Props) {
               </div>
             </details>
           ) : null}
-          {hasPreview ? (
+          {showReleaseDetails ? (
             <p className="helper edit-helper">Edit external IDs and Release Name attributes.</p>
           ) : null}
-          {hasPreview ? (
+          {showReleaseDetails ? (
             <details className="edit-dropdown">
               <summary>Edit Release Details</summary>
               <div className="edit-dropdown__body">
                 <div className="settings-subgroup">
                   <div className="settings-subgroup__title">External IDs</div>
+                  <p className="muted path-helper">
+                    Remove an ID to skip that provider. Enter an ID to use the provider again.
+                  </p>
                   <div className="id-editor settings-grid">
                     <div className="settings-field">
                       <label htmlFor="external-tmdb-id">TMDB ID</label>
-                      <input
-                        id="external-tmdb-id"
-                        value={idEdits.tmdb}
-                        onChange={(event) => {
-                          setIdEdits((prev) => ({ ...prev, tmdb: event.target.value }));
-                          markIDTouched("tmdb");
-                        }}
-                        placeholder="e.g. 550"
-                      />
+                      <div className="flex items-center gap-2">
+                        <input
+                          id="external-tmdb-id"
+                          className="min-w-0"
+                          value={idEdits.tmdb}
+                          onChange={(event) => {
+                            setIdEdits((prev) => ({ ...prev, tmdb: event.target.value }));
+                            markIDTouched("tmdb");
+                          }}
+                          placeholder="e.g. 550"
+                        />
+                        <Button
+                          type="button"
+                          className="shrink-0"
+                          aria-label="Remove TMDB ID"
+                          disabled={idOverrideState.overrides.TMDBID === 0}
+                          onClick={() => clearID("tmdb")}
+                        >
+                          {idOverrideState.overrides.TMDBID === 0 ? "Removed" : "Remove"}
+                        </Button>
+                      </div>
                     </div>
                     <div className="settings-field">
                       <label htmlFor="external-imdb-id">IMDB ID</label>
-                      <input
-                        id="external-imdb-id"
-                        value={idEdits.imdb}
-                        onChange={(event) => {
-                          setIdEdits((prev) => ({ ...prev, imdb: event.target.value }));
-                          markIDTouched("imdb");
-                        }}
-                        placeholder="e.g. tt0137523"
-                      />
+                      <div className="flex items-center gap-2">
+                        <input
+                          id="external-imdb-id"
+                          className="min-w-0"
+                          value={idEdits.imdb}
+                          onChange={(event) => {
+                            setIdEdits((prev) => ({ ...prev, imdb: event.target.value }));
+                            markIDTouched("imdb");
+                          }}
+                          placeholder="e.g. tt0137523"
+                        />
+                        <Button
+                          type="button"
+                          className="shrink-0"
+                          aria-label="Remove IMDB ID"
+                          disabled={idOverrideState.overrides.IMDBID === 0}
+                          onClick={() => clearID("imdb")}
+                        >
+                          {idOverrideState.overrides.IMDBID === 0 ? "Removed" : "Remove"}
+                        </Button>
+                      </div>
                     </div>
                     <div className="settings-field">
                       <label htmlFor="external-tvdb-id">TVDB ID</label>
-                      <input
-                        id="external-tvdb-id"
-                        value={idEdits.tvdb}
-                        onChange={(event) => {
-                          setIdEdits((prev) => ({ ...prev, tvdb: event.target.value }));
-                          markIDTouched("tvdb");
-                        }}
-                        placeholder="e.g. 80379"
-                      />
+                      <div className="flex items-center gap-2">
+                        <input
+                          id="external-tvdb-id"
+                          className="min-w-0"
+                          value={idEdits.tvdb}
+                          onChange={(event) => {
+                            setIdEdits((prev) => ({ ...prev, tvdb: event.target.value }));
+                            markIDTouched("tvdb");
+                          }}
+                          placeholder="e.g. 80379"
+                        />
+                        <Button
+                          type="button"
+                          className="shrink-0"
+                          aria-label="Remove TVDB ID"
+                          disabled={idOverrideState.overrides.TVDBID === 0}
+                          onClick={() => clearID("tvdb")}
+                        >
+                          {idOverrideState.overrides.TVDBID === 0 ? "Removed" : "Remove"}
+                        </Button>
+                      </div>
                     </div>
                     <div className="settings-field">
                       <label htmlFor="external-tvmaze-id">TVmaze ID</label>
-                      <input
-                        id="external-tvmaze-id"
-                        value={idEdits.tvmaze}
-                        onChange={(event) => {
-                          setIdEdits((prev) => ({ ...prev, tvmaze: event.target.value }));
-                          markIDTouched("tvmaze");
-                        }}
-                        placeholder="e.g. 82"
-                      />
+                      <div className="flex items-center gap-2">
+                        <input
+                          id="external-tvmaze-id"
+                          className="min-w-0"
+                          value={idEdits.tvmaze}
+                          onChange={(event) => {
+                            setIdEdits((prev) => ({ ...prev, tvmaze: event.target.value }));
+                            markIDTouched("tvmaze");
+                          }}
+                          placeholder="e.g. 82"
+                        />
+                        <Button
+                          type="button"
+                          className="shrink-0"
+                          aria-label="Remove TVmaze ID"
+                          disabled={idOverrideState.overrides.TVmazeID === 0}
+                          onClick={() => clearID("tvmaze")}
+                        >
+                          {idOverrideState.overrides.TVmazeID === 0 ? "Removed" : "Remove"}
+                        </Button>
+                      </div>
                     </div>
                     <div className="settings-field">
                       <label htmlFor="external-mal-id">MAL ID</label>
-                      <input
-                        id="external-mal-id"
-                        value={idEdits.mal}
-                        onChange={(event) => {
-                          setIdEdits((prev) => ({ ...prev, mal: event.target.value }));
-                          markIDTouched("mal");
-                        }}
-                        placeholder="e.g. 5114"
-                      />
+                      <div className="flex items-center gap-2">
+                        <input
+                          id="external-mal-id"
+                          className="min-w-0"
+                          value={idEdits.mal}
+                          onChange={(event) => {
+                            setIdEdits((prev) => ({ ...prev, mal: event.target.value }));
+                            markIDTouched("mal");
+                          }}
+                          placeholder="e.g. 5114"
+                        />
+                        <Button
+                          type="button"
+                          className="shrink-0"
+                          aria-label="Remove MAL ID"
+                          disabled={idOverrideState.overrides.MALID === 0}
+                          onClick={() => clearID("mal")}
+                        >
+                          {idOverrideState.overrides.MALID === 0 ? "Removed" : "Remove"}
+                        </Button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -2207,21 +2283,29 @@ export default function InputPage(props: Props) {
                   </p>
                 ) : null}
                 <div className="edit-actions">
-                  <button
-                    className="ghost"
-                    type="button"
-                    onClick={handleResetMetadata}
-                    disabled={loading}
-                  >
-                    {metadataResetting ? "Resetting..." : "Reset data + refresh"}
-                  </button>
+                  {hasPreview ? (
+                    <button
+                      className="ghost"
+                      type="button"
+                      onClick={handleResetMetadata}
+                      disabled={loading}
+                    >
+                      {metadataResetting ? "Resetting..." : "Reset data + refresh"}
+                    </button>
+                  ) : null}
                   <button
                     className="primary"
                     type="button"
                     onClick={handleRefresh}
                     disabled={refreshDisabled}
                   >
-                    {loading ? "Refreshing..." : "Refresh metadata"}
+                    {loading
+                      ? hasPreview
+                        ? "Refreshing..."
+                        : "Retrying..."
+                      : hasPreview
+                        ? "Refresh metadata"
+                        : "Retry metadata"}
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
Explicit provider IDs could coexist with unrelated IDs and metadata selected from title searches or retained guesses. Downstream episode, localized-title, anime, and scene enrichment could then use that conflicting identity.

Treat supplied and stored explicit IDs as authoritative anchors. Derive sibling IDs only through verified provider links, reconcile conflicting links before accepting metadata, and keep explicit clears effective throughout collection and scene detection. Preserve filename-search behavior when no positive anchor exists. Incompatible prepared and identity contracts receive new versions.

Anchored releases may retain fewer provider IDs when no verified relationship exists. Cached TMDB and TVmaze anchors require fresh link verification during preparation. Missing or conflicting provider evidence no longer silently selects a similarly named title. Existing tests that expected cleared IDs to be rediscovered now verify suppression.

Validation includes full Go race tests, repository lint and policy checks, modernization checks, backend build, frontend type and unit checks, and focused identity regressions, including SQLite reloads with no new overrides. One private TV case passes the embedded production BTN workflow with 13 checks passing, correct pinned IDs and episode naming, and complete cleanup. Tracker submission and client mutation remain disabled by the live harness.

CodeRabbit CLI reviewed the initial change set once. Its suggestion to allow title selection for a MAL-only anchor conflicts with the agreed identity contract and was rejected. Subsequent corrections receive independent correctness review, Ponytail review, and updated source documentation. The follow-up fixes also treat stored explicit provenance as a locked cross-reference and verify the replacement TMDB lookup in its regression test. These follow-up fixes receive separate CodeRabbit CLI review and the full Go race, lint, and policy checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added persistent options to clear TMDB, IMDb, TVDB, TVmaze, and MAL IDs from the CLI and Web UI.
  - Added safer external ID matching, conflict detection, and fallback searches.
  - Added an option to skip AniList enrichment while retaining anime classification.

- **Bug Fixes**
  - Preserved explicit provider selections and clears while preventing conflicting metadata from overriding verified identities.
  - Improved scene-based IMDb detection to respect provider locks and overrides.
  - Cleared stale provider metadata when locked IDs conflict.

- **Documentation**
  - Documented clearing metadata providers, retrying lookups, persistence behavior, and tracker eligibility impacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->