### PR TITLE
Review #450 (3/4): standalone tracker consumers

### DIFF
--- a/internal/trackers/impl/standalone/ant/taxonomy.go
+++ b/internal/trackers/impl/standalone/ant/taxonomy.go
@@ -6,6 +6,7 @@ package ant
 import (
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -140,9 +141,11 @@ func resolveTags(meta api.UploadSubject, answers map[string]string) (string, boo
 	if tagValue := normalizeTags(strings.TrimSpace(answers["tags"])); tagValue != "" {
 		return tagValue, true
 	}
-	values := make([]string, 0, 8)
-	if meta.ProviderMetadata.TMDB != nil {
-		values = append(values, splitTags(meta.ProviderMetadata.TMDB.Genres)...)
+	values := []string(nil)
+	if meta.EffectiveMetadata.GenresProvenance.IsManual() {
+		values = splitTags(trackers.PreferredGenreText(meta, ""))
+	} else if meta.ProviderMetadata.TMDB != nil {
+		values = splitTags(meta.ProviderMetadata.TMDB.Genres)
 	}
 	if len(values) == 0 {
 		if meta.ProviderMetadata.IMDB != nil && len(splitTags(meta.ProviderMetadata.IMDB.Genres)) > 0 {
@@ -180,9 +183,14 @@ func resolveTags(meta api.UploadSubject, answers map[string]string) (string, boo
 }
 
 func detectAdult(meta api.UploadSubject) bool {
-	candidates := []string{meta.Release.Genre, resolveKeywords(meta)}
-	if meta.ProviderMetadata.TMDB != nil {
-		candidates = append(candidates, meta.ProviderMetadata.TMDB.Genres)
+	candidates := []string{resolveKeywords(meta)}
+	if meta.EffectiveMetadata.GenresProvenance.IsManual() {
+		candidates = append(candidates, strings.Join(meta.EffectiveMetadata.Genres, ","))
+	} else {
+		candidates = append(candidates, meta.Release.Genre)
+		if meta.ProviderMetadata.TMDB != nil {
+			candidates = append(candidates, meta.ProviderMetadata.TMDB.Genres)
+		}
 	}
 	for _, candidate := range candidates {
 		lower := strings.ToLower(candidate)

--- a/internal/trackers/impl/standalone/ant/taxonomy_test.go
+++ b/internal/trackers/impl/standalone/ant/taxonomy_test.go
@@ -52,3 +52,26 @@ func TestResolveAudioFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveTagsAndAdultPreferManualGenres(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{
+		Release:          api.ReleaseInfo{Genre: "Porn"},
+		ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{Genres: "Action, Porn"}},
+		EffectiveMetadata: api.EffectiveMetadata{
+			Genres: []string{"Drama"}, GenresProvenance: api.FactProvenanceManual,
+		},
+	}
+	if got, manual := resolveTags(meta, nil); got != "drama" || manual {
+		t.Fatalf("manual tags = %q, manual = %t", got, manual)
+	}
+	meta.EffectiveMetadata.Genres = nil
+	meta.EffectiveMetadata.GenresProvenance = api.FactProvenanceManualEmpty
+	if got, _ := resolveTags(meta, nil); got != "" {
+		t.Fatalf("manual-empty tags = %q", got)
+	}
+	if detectAdult(meta) {
+		t.Fatal("manual-empty genres retained provider adult classification")
+	}
+}

--- a/internal/trackers/impl/standalone/ar/dupe.go
+++ b/internal/trackers/impl/standalone/ar/dupe.go
@@ -323,7 +323,17 @@ func mapCookiesToSlice(values map[string]*http.Cookie) []*http.Cookie {
 
 func arSearchQuery(meta api.DuplicateSubject) string {
 	query := resolveARSearchNameFields(meta.Release, meta.ReleaseName, meta.ProviderMetadata)
-	if query == "" && meta.Projection != nil {
+	if meta.EffectiveMetadata.TitleProvenance.IsManual() || meta.EffectiveMetadata.YearProvenance.IsManual() {
+		title, year := resolveARSearchNameParts(meta.Release, meta.ReleaseName, meta.ProviderMetadata)
+		title = meta.EffectiveMetadata.PreferredTitle(title)
+		year = meta.EffectiveMetadata.PreferredYear(year)
+		if title != "" && year > 0 {
+			query = strings.TrimSpace(title + " " + strconv.Itoa(year))
+		} else {
+			query = title
+		}
+	}
+	if query == "" && !meta.EffectiveMetadata.TitleProvenance.IsManual() && meta.Projection != nil {
 		query = dupe.ProjectedSearchName(meta)
 	}
 	return query

--- a/internal/trackers/impl/standalone/ar/name.go
+++ b/internal/trackers/impl/standalone/ar/name.go
@@ -21,10 +21,33 @@ func resolveARName(meta api.UploadSubject) string {
 }
 
 func resolveARSearchName(meta api.UploadSubject) string {
-	return resolveARSearchNameFields(meta.Release, meta.ReleaseName, meta.ProviderMetadata)
+	title, year := resolveARSearchNameParts(meta.Release, "", meta.ProviderMetadata)
+	title = trackers.PreferredTitle(meta, title)
+	year = trackers.PreferredYear(meta, year)
+	if title == "" && !meta.EffectiveMetadata.TitleProvenance.IsManual() {
+		title = strings.TrimSpace(meta.ReleaseName)
+	}
+	if title == "" {
+		return ""
+	}
+	if year > 0 {
+		return strings.TrimSpace(title + " " + strconv.Itoa(year))
+	}
+	return title
 }
 
 func resolveARSearchNameFields(release api.ReleaseInfo, releaseName string, metadata api.SourceScopedMetadata) string {
+	title, year := resolveARSearchNameParts(release, releaseName, metadata)
+	if title == "" {
+		return ""
+	}
+	if year > 0 {
+		return strings.TrimSpace(title + " " + strconv.Itoa(year))
+	}
+	return title
+}
+
+func resolveARSearchNameParts(release api.ReleaseInfo, releaseName string, metadata api.SourceScopedMetadata) (string, int) {
 	title := ""
 	if metadata.TMDB != nil {
 		title = strings.TrimSpace(metadata.TMDB.Title)
@@ -44,9 +67,6 @@ func resolveARSearchNameFields(release api.ReleaseInfo, releaseName string, meta
 	if title == "" {
 		title = strings.TrimSpace(releaseName)
 	}
-	if title == "" {
-		return ""
-	}
 	year := release.Year
 	if year == 0 && metadata.TMDB != nil {
 		year = metadata.TMDB.Year
@@ -57,8 +77,5 @@ func resolveARSearchNameFields(release api.ReleaseInfo, releaseName string, meta
 	if year == 0 && metadata.TVDB != nil {
 		year = metadata.TVDB.Year
 	}
-	if year > 0 {
-		return strings.TrimSpace(title + " " + strconv.Itoa(year))
-	}
-	return title
+	return title, year
 }

--- a/internal/trackers/impl/standalone/ar/name_test.go
+++ b/internal/trackers/impl/standalone/ar/name_test.go
@@ -91,3 +91,79 @@ func TestResolveARSearchNameUsesTVDBWhenOnlyTVDBMetadataExists(t *testing.T) {
 		t.Fatalf("duplicate search name = %q", got)
 	}
 }
+
+func TestResolveARSearchNamePrefersManualFacts(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{
+		ReleaseName: "Fallback Release",
+		Release:     api.ReleaseInfo{Title: "Parsed Title", Year: 2020},
+		ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{
+			Title: "Provider Title", Year: 2021,
+		}},
+		EffectiveMetadata: api.EffectiveMetadata{
+			Title:           "Manual Title",
+			TitleProvenance: api.FactProvenanceManual,
+			Year:            2030,
+			YearProvenance:  api.FactProvenanceManual,
+		},
+	}
+	if got := resolveARSearchName(meta); got != "Manual Title 2030" {
+		t.Fatalf("manual search name = %q", got)
+	}
+
+	meta.EffectiveMetadata.Title = ""
+	meta.EffectiveMetadata.TitleProvenance = api.FactProvenanceManualEmpty
+	if got := resolveARSearchName(meta); got != "" {
+		t.Fatalf("manual-empty search name = %q", got)
+	}
+}
+
+func TestResolveARGenresPrefersManualFacts(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{
+		Release:          api.ReleaseInfo{Genre: "Parsed"},
+		ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{Genres: "Provider"}},
+		EffectiveMetadata: api.EffectiveMetadata{
+			Genres: []string{"Manual"}, GenresProvenance: api.FactProvenanceManual,
+		},
+	}
+	if got := resolveGenres(meta); got != "Manual" {
+		t.Fatalf("manual genres = %q", got)
+	}
+	meta.EffectiveMetadata.Genres = nil
+	meta.EffectiveMetadata.GenresProvenance = api.FactProvenanceManualEmpty
+	if got := resolveGenres(meta); got != "" {
+		t.Fatalf("manual-empty genres = %q", got)
+	}
+}
+
+func TestARSearchQueryPrefersManualFacts(t *testing.T) {
+	t.Parallel()
+
+	meta := api.DuplicateSubject{
+		ReleaseName: "Fallback Release",
+		Release:     api.ReleaseInfo{Title: "Parsed Title", Year: 2020},
+		ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{
+			Title: "Provider Title", Year: 2021,
+		}},
+		EffectiveMetadata: api.EffectiveMetadata{
+			Title:           "Manual Title",
+			TitleProvenance: api.FactProvenanceManual,
+			Year:            2030,
+			YearProvenance:  api.FactProvenanceManual,
+		},
+	}
+	if got := arSearchQuery(meta); got != "Manual Title 2030" {
+		t.Fatalf("manual duplicate search = %q", got)
+	}
+	meta.EffectiveMetadata.Title = ""
+	meta.EffectiveMetadata.TitleProvenance = api.FactProvenanceManualEmpty
+	meta.Projection = &api.TrackerReleaseProjection{
+		DuplicateCriteria: api.TrackerDuplicateCriteria{Name: "Fallback Release 2030"},
+	}
+	if got := arSearchQuery(meta); got != "" {
+		t.Fatalf("manual-empty duplicate search = %q", got)
+	}
+}

--- a/internal/trackers/impl/standalone/ar/taxonomy.go
+++ b/internal/trackers/impl/standalone/ar/taxonomy.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/autobrr/upbrr/internal/providerid"
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -79,18 +80,20 @@ func resolveTags(meta api.UploadSubject) string {
 }
 
 func resolveGenres(meta api.UploadSubject) string {
+	var provider string
 	switch {
 	case meta.ProviderMetadata.TMDB != nil && strings.TrimSpace(meta.ProviderMetadata.TMDB.Genres) != "":
-		return strings.TrimSpace(meta.ProviderMetadata.TMDB.Genres)
+		provider = meta.ProviderMetadata.TMDB.Genres
 	case meta.ProviderMetadata.IMDB != nil && strings.TrimSpace(meta.ProviderMetadata.IMDB.Genres) != "":
-		return strings.TrimSpace(meta.ProviderMetadata.IMDB.Genres)
+		provider = meta.ProviderMetadata.IMDB.Genres
 	case meta.ProviderMetadata.TVDB != nil && strings.TrimSpace(meta.ProviderMetadata.TVDB.Genres) != "":
-		return strings.TrimSpace(meta.ProviderMetadata.TVDB.Genres)
+		provider = meta.ProviderMetadata.TVDB.Genres
 	case meta.ProviderMetadata.TVmaze != nil && strings.TrimSpace(meta.ProviderMetadata.TVmaze.Genres) != "":
-		return strings.TrimSpace(meta.ProviderMetadata.TVmaze.Genres)
+		provider = meta.ProviderMetadata.TVmaze.Genres
 	default:
-		return strings.TrimSpace(meta.Release.Genre)
+		provider = meta.Release.Genre
 	}
+	return trackers.PreferredGenreText(meta, provider)
 }
 
 func isSD(resolution string) bool {

--- a/internal/trackers/impl/standalone/asc/dupe.go
+++ b/internal/trackers/impl/standalone/asc/dupe.go
@@ -46,6 +46,9 @@ func (h dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) dup
 	if !meta.Anime && resolveASCIMDb(meta) == "" {
 		return dupe.NotRun(dupe.NotRunMissingMetadata, "missing IMDb ID for ASC dupe search", nil)
 	}
+	if meta.Anime && resolveASCTitle(meta) == "" {
+		return dupe.NotRun(dupe.NotRunMissingMetadata, "missing title for ASC anime dupe search", nil)
+	}
 
 	cookies, _, err := LoadCookies(ctx, h.cfg.MainSettings.DBPath)
 	if err != nil || len(cookies) == 0 {
@@ -415,14 +418,15 @@ func resolveASCCategory(meta api.DuplicateSubject) string {
 }
 
 func resolveASCTitle(meta api.DuplicateSubject) string {
-	if strings.TrimSpace(meta.Release.Title) != "" {
-		return strings.TrimSpace(meta.Release.Title)
+	title := strings.TrimSpace(meta.Release.Title)
+	if title == "" && meta.Projection != nil {
+		title = dupe.ProjectedSearchName(meta)
 	}
-	if meta.Projection != nil {
-		return dupe.ProjectedSearchName(meta)
+	if title == "" {
+		title = strings.TrimSpace(meta.ReleaseName)
 	}
-	if strings.TrimSpace(meta.ReleaseName) != "" {
-		return strings.TrimSpace(meta.ReleaseName)
+	if title == "" {
+		title = strings.TrimSpace(meta.SourcePath)
 	}
-	return strings.TrimSpace(meta.SourcePath)
+	return meta.EffectiveMetadata.PreferredTitle(title)
 }

--- a/internal/trackers/impl/standalone/asc/dupe_test.go
+++ b/internal/trackers/impl/standalone/asc/dupe_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package asc
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestResolveASCTitleHonorsManualTitle(t *testing.T) {
+	t.Parallel()
+
+	projection := &api.TrackerReleaseProjection{DuplicateCriteria: api.TrackerDuplicateCriteria{Name: "Projected Release"}}
+	manual := api.DuplicateSubject{
+		Release:    api.ReleaseInfo{Title: "Automatic Release"},
+		Projection: projection,
+		EffectiveMetadata: api.EffectiveMetadata{
+			Title:           "Manual Release",
+			TitleProvenance: api.FactProvenanceManual,
+		},
+	}
+	if got := resolveASCTitle(manual); got != "Manual Release" {
+		t.Fatalf("manual ASC search title = %q", got)
+	}
+	manual.EffectiveMetadata = api.EffectiveMetadata{TitleProvenance: api.FactProvenanceManualEmpty}
+	if got := resolveASCTitle(manual); got != "" {
+		t.Fatalf("manual-empty ASC search title = %q", got)
+	}
+	if got := resolveASCTitle(api.DuplicateSubject{Projection: projection}); got != "Projected Release" {
+		t.Fatalf("automatic ASC search title = %q", got)
+	}
+}

--- a/internal/trackers/impl/standalone/asc/metadata.go
+++ b/internal/trackers/impl/standalone/asc/metadata.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/languageutil"
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	"github.com/autobrr/upbrr/internal/providerid"
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -82,7 +84,7 @@ func resolveGenres(meta api.UploadSubject, answers map[string]string) string {
 	ptBR := api.ExtractTrackerLocalizedPTBR(meta)
 
 	// 1. Use localized if available
-	if ptBR.Genres != "" {
+	if !meta.EffectiveMetadata.GenresProvenance.IsManual() && ptBR.Genres != "" {
 		genres := strings.Split(strings.TrimSpace(ptBR.Genres), ",")
 		out := make([]string, 0, len(genres))
 		for _, genre := range genres {
@@ -110,6 +112,7 @@ func resolveGenres(meta api.UploadSubject, answers map[string]string) string {
 		genreText = strings.TrimSpace(meta.Release.Genre)
 	}
 
+	genreText = trackers.PreferredGenreText(meta, genreText)
 	if genreText == "" {
 		return ""
 	}
@@ -159,18 +162,24 @@ func resolveIMDbIDText(meta api.UploadSubject) string {
 }
 
 func resolveOriginalLanguage(meta api.UploadSubject) string {
+	provider := ""
 	switch {
 	case meta.ProviderMetadata.TMDB != nil && strings.TrimSpace(meta.ProviderMetadata.TMDB.OriginalLanguage) != "":
-		return strings.TrimSpace(meta.ProviderMetadata.TMDB.OriginalLanguage)
+		provider = meta.ProviderMetadata.TMDB.OriginalLanguage
 	case meta.ProviderMetadata.IMDB != nil && strings.TrimSpace(meta.ProviderMetadata.IMDB.OriginalLanguage) != "":
-		return strings.TrimSpace(meta.ProviderMetadata.IMDB.OriginalLanguage)
+		provider = meta.ProviderMetadata.IMDB.OriginalLanguage
 	case meta.ProviderMetadata.TVDB != nil && strings.TrimSpace(meta.ProviderMetadata.TVDB.OriginalLanguage) != "":
-		return strings.TrimSpace(meta.ProviderMetadata.TVDB.OriginalLanguage)
+		provider = meta.ProviderMetadata.TVDB.OriginalLanguage
 	case meta.ProviderMetadata.TVmaze != nil && strings.TrimSpace(meta.ProviderMetadata.TVmaze.Language) != "":
-		return strings.TrimSpace(meta.ProviderMetadata.TVmaze.Language)
-	default:
-		return ""
+		provider = meta.ProviderMetadata.TVmaze.Language
 	}
+	value := trackers.PreferredOriginalLanguage(meta, provider)
+	if meta.EffectiveMetadata.OriginalLanguageProvenance.IsManual() {
+		if normalized := languageutil.NormalizeLanguageCode(value); normalized != "" {
+			return normalized
+		}
+	}
+	return strings.TrimSpace(value)
 }
 
 func resolveRuntime(meta api.UploadSubject) string {
@@ -243,18 +252,18 @@ func resolveReleaseDate(meta api.UploadSubject) string {
 }
 
 func resolveYear(meta api.UploadSubject) int {
+	provider := 0
 	switch {
 	case meta.Release.Year > 0:
-		return meta.Release.Year
+		provider = meta.Release.Year
 	case meta.ProviderMetadata.TMDB != nil && meta.ProviderMetadata.TMDB.Year > 0:
-		return meta.ProviderMetadata.TMDB.Year
+		provider = meta.ProviderMetadata.TMDB.Year
 	case meta.ProviderMetadata.IMDB != nil && meta.ProviderMetadata.IMDB.Year > 0:
-		return meta.ProviderMetadata.IMDB.Year
+		provider = meta.ProviderMetadata.IMDB.Year
 	case meta.ProviderMetadata.TVDB != nil && meta.ProviderMetadata.TVDB.Year > 0:
-		return meta.ProviderMetadata.TVDB.Year
-	default:
-		return 0
+		provider = meta.ProviderMetadata.TVDB.Year
 	}
+	return trackers.PreferredYear(meta, provider)
 }
 
 func pluralSuffix(value int) string {

--- a/internal/trackers/impl/standalone/asc/metadata_test.go
+++ b/internal/trackers/impl/standalone/asc/metadata_test.go
@@ -26,6 +26,23 @@ func TestResolveGenresPreservesUnknownGenres(t *testing.T) {
 	}
 }
 
+func TestResolveGenresManualCorrectionBeatsLocalizedGenres(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{Localized: map[string]api.TMDBLocalizedData{"pt-BR": {Genres: "Ação"}}}}}
+	if got := resolveGenres(meta, nil); got != "Ação" {
+		t.Fatalf("automatic localized genres = %q", got)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{Genres: []string{"Drama"}, GenresProvenance: api.FactProvenanceManual}
+	if got := resolveGenres(meta, nil); got != "Drama" {
+		t.Fatalf("manual genres = %q", got)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{GenresProvenance: api.FactProvenanceManualEmpty}
+	if got := resolveGenres(meta, nil); got != "" {
+		t.Fatalf("manual empty genres = %q", got)
+	}
+}
+
 func TestResolveResolutionUsesResolvedFactOnly(t *testing.T) {
 	t.Parallel()
 
@@ -126,5 +143,18 @@ func TestResolveOverviewUsesScopedTVOverviewOnlyForEpisodeOrSeasonPack(t *testin
 				t.Fatalf("expected overview %q, got %q", tc.want, got)
 			}
 		})
+	}
+}
+
+func TestResolveLanguageAcceptsManualCanonicalDisplayName(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{EffectiveMetadata: api.EffectiveMetadata{OriginalLanguage: "French", OriginalLanguageProvenance: api.FactProvenanceManual}}
+	if got := resolveLanguage(meta); got != "2" {
+		t.Fatalf("manual French language ID = %q", got)
+	}
+	meta.EffectiveMetadata.OriginalLanguage = "fr"
+	if got := resolveLanguage(meta); got != "2" {
+		t.Fatalf("manual ISO French language ID = %q", got)
 	}
 }

--- a/internal/trackers/impl/standalone/asc/name.go
+++ b/internal/trackers/impl/standalone/asc/name.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	pathutil "github.com/autobrr/upbrr/internal/pathing"
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -29,25 +30,36 @@ func resolveUploadTitle(meta api.UploadSubject) string {
 
 func resolveDisplayTitle(meta api.UploadSubject) string {
 	ptBR := api.ExtractTrackerLocalizedPTBR(meta)
+	main := strings.TrimSpace(meta.Release.Title)
+	alt := ""
 	if tmdb := meta.ProviderMetadata.TMDB; tmdb != nil {
-		main := strings.TrimSpace(metautil.FirstNonEmptyTrimmed(ptBR.Title, tmdb.Title, meta.Release.Title))
-		alt := strings.TrimSpace(tmdb.OriginalTitle)
+		main = strings.TrimSpace(metautil.FirstNonEmptyTrimmed(ptBR.Title, tmdb.Title, meta.Release.Title))
 		if categoryOf(meta) == "TV" {
 			alt = strings.TrimSpace(metautil.FirstNonEmptyTrimmed(tmdb.Title, meta.Release.Title))
-		}
-		if meta.NamePresentation.Version == api.ReleaseNamePresentationVersionV1 && meta.NamePresentation.OmitAlternateTitle {
-			alt = ""
-		}
-		if main != "" && alt != "" && !strings.EqualFold(main, alt) {
-			return main + " (" + alt + ")"
-		}
-		if main != "" {
-			return main
+		} else {
+			alt = strings.TrimSpace(tmdb.OriginalTitle)
 		}
 	}
-	return strings.TrimSpace(metautil.FirstNonEmptyTrimmed(meta.Release.Title, meta.ReleaseName, pathutil.Base(meta.SourcePath)))
+	if meta.EffectiveMetadata.TitleProvenance.IsManual() {
+		main = trackers.PreferredTitle(meta, "")
+	}
+	if meta.EffectiveMetadata.OriginalTitleProvenance.IsManual() {
+		alt = trackers.PreferredOriginalTitle(meta, "")
+	}
+	if meta.NamePresentation.Version == api.ReleaseNamePresentationVersionV1 && meta.NamePresentation.OmitAlternateTitle {
+		alt = ""
+	}
+	if main != "" && alt != "" && !strings.EqualFold(main, alt) {
+		return main + " (" + alt + ")"
+	}
+	if main != "" {
+		return main
+	}
+	if meta.EffectiveMetadata.TitleProvenance.IsManual() {
+		return ""
+	}
+	return strings.TrimSpace(metautil.FirstNonEmptyTrimmed(meta.ReleaseName, pathutil.Base(meta.SourcePath)))
 }
-
 func resolveSearchTitle(meta api.UploadSubject) string {
 	if title := strings.TrimSpace(meta.Release.Title); title != "" {
 		return title

--- a/internal/trackers/impl/standalone/asc/name_test.go
+++ b/internal/trackers/impl/standalone/asc/name_test.go
@@ -52,6 +52,36 @@ func TestResolveUploadTitleOmitsEmptySeasonEpisodeDelimiter(t *testing.T) {
 	}
 }
 
+func TestResolveDisplayTitlePrefersManualFacts(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{
+		Release:     api.ReleaseInfo{Title: "Parsed Title"},
+		ReleaseName: "Fallback Name",
+		ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{
+			Title:         "Provider Title",
+			OriginalTitle: "Provider Original",
+			Localized:     map[string]api.TMDBLocalizedData{"pt-BR": {Title: "Localized Title"}},
+		}},
+		EffectiveMetadata: api.EffectiveMetadata{
+			Title:                   "Manual Title",
+			TitleProvenance:         api.FactProvenanceManual,
+			OriginalTitle:           "Manual Original",
+			OriginalTitleProvenance: api.FactProvenanceManual,
+		},
+	}
+	if got := resolveDisplayTitle(meta); got != "Manual Title (Manual Original)" {
+		t.Fatalf("display title = %q", got)
+	}
+
+	meta.EffectiveMetadata = api.EffectiveMetadata{
+		TitleProvenance: api.FactProvenanceManualEmpty, OriginalTitleProvenance: api.FactProvenanceManualEmpty,
+	}
+	if got := resolveDisplayTitle(meta); got != "" {
+		t.Fatalf("manual-empty display title = %q", got)
+	}
+}
+
 func TestReleaseNamePolicyPreservesDailyEpisodeIdentity(t *testing.T) {
 	t.Parallel()
 
@@ -84,5 +114,29 @@ func TestReleaseNamePolicyPreservesDailyEpisodeIdentity(t *testing.T) {
 	}
 	if got != "Example Show - 2026-02-03" {
 		t.Fatalf("daily upload title = %q", got)
+	}
+}
+
+func TestResolveDisplayTitlePreservesAutomaticAlternatesAndManualOriginalTitle(t *testing.T) {
+	t.Parallel()
+
+	movie := api.UploadSubject{Release: api.ReleaseInfo{Title: "Release"}, ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{Title: "TMDB", OriginalTitle: ""}}}
+	if got := resolveDisplayTitle(movie); got != "TMDB" {
+		t.Fatalf("blank movie alternate display = %q", got)
+	}
+	tv := movie
+	tv.Identity = api.ExternalIdentity{Category: api.CanonicalCategoryTV}
+	tv.ProviderMetadata.TMDB.Title = ""
+	if got := resolveDisplayTitle(tv); got != "Release" {
+		t.Fatalf("TV alternate release fallback display = %q", got)
+	}
+	manual := api.UploadSubject{Release: api.ReleaseInfo{Title: "Release"}, EffectiveMetadata: api.EffectiveMetadata{OriginalTitle: "Manual Original", OriginalTitleProvenance: api.FactProvenanceManual}}
+	if got := resolveDisplayTitle(manual); got != "Release (Manual Original)" {
+		t.Fatalf("manual original without TMDB display = %q", got)
+	}
+	manual.EffectiveMetadata.OriginalTitle = ""
+	manual.EffectiveMetadata.OriginalTitleProvenance = api.FactProvenanceManualEmpty
+	if got := resolveDisplayTitle(manual); got != "Release" {
+		t.Fatalf("manual-empty original display = %q", got)
 	}
 }

--- a/internal/trackers/impl/standalone/asc/profile.go
+++ b/internal/trackers/impl/standalone/asc/profile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/autobrr/upbrr/internal/trackers"
 	authcontract "github.com/autobrr/upbrr/internal/trackers/auth/contract"
 	"github.com/autobrr/upbrr/internal/trackers/impl/standalone"
+	"github.com/autobrr/upbrr/pkg/api"
 )
 
 // Profile returns ASC identity, preparation, dupe, auth, and policy behavior.
@@ -22,6 +23,11 @@ func Profile() standalone.Profile {
 		PrepareDescription:      prepareDescription,
 		PrepareUpload:           prepareUpload,
 		ValidationPolicy:        validationPolicy(),
+		MetadataPolicy: &trackers.TrackerMetadataPolicy{Requirements: []trackers.MetadataRequirement{{
+			Scope:       trackers.MetadataScopeAny,
+			AnyOf:       []trackers.MetadataField{trackers.MetadataFieldGenres},
+			Disposition: api.RuleDispositionStrict,
+		}}},
 		ReleaseNamePolicy: trackers.NewReleaseNamePolicy("standalone/asc/v2", func(input trackers.ReleaseNameInput) (trackers.ResolvedReleaseNames, error) {
 			uploadName := resolveUploadTitle(input.Subject)
 			if input.RequestedName != nil {

--- a/internal/trackers/impl/standalone/bhd/metadata_precedence_test.go
+++ b/internal/trackers/impl/standalone/bhd/metadata_precedence_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package bhd
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestBHDTVTitlePolicyPrefersManualTitle(t *testing.T) {
+	t.Parallel()
+	meta := api.UploadSubject{
+		SeasonStr: "S01",
+		ProviderMetadata: api.SourceScopedMetadata{TVDB: &api.TVDBMetadata{
+			NameEnglish: "Provider Series",
+		}},
+		EffectiveMetadata: api.EffectiveMetadata{
+			Title: "Manual Series", TitleProvenance: api.FactProvenanceManual,
+		},
+	}
+	if got := applyBHDTVTitlePolicy("Provider Series S01 1080p WEB-DL-GRP", meta); got != "Manual Series S01 1080p WEB-DL-GRP" {
+		t.Fatalf("manual title name = %q", got)
+	}
+	meta.EffectiveMetadata.Title = ""
+	meta.EffectiveMetadata.TitleProvenance = api.FactProvenanceManualEmpty
+	if got := applyBHDTVTitlePolicy("Provider Series S01 1080p WEB-DL-GRP", meta); got != "Provider Series S01 1080p WEB-DL-GRP" {
+		t.Fatalf("manual-empty title name = %q", got)
+	}
+}

--- a/internal/trackers/impl/standalone/bhd/name.go
+++ b/internal/trackers/impl/standalone/bhd/name.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
 	pathutil "github.com/autobrr/upbrr/internal/pathing"
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -92,24 +93,26 @@ func applyBHDMovieTitlePolicy(name string, meta api.UploadSubject) string {
 
 // bhdMovieTitles preserves the finalized alternate title while preferring TMDB titles and the IMDb year.
 func bhdMovieTitles(meta api.UploadSubject) (string, string, int) {
-	title := strings.TrimSpace(meta.Release.Title)
-	original := trimBHDAKAPrefix(meta.AlternateTitle)
+	original := trimBHDAKAPrefix(trackers.PreferredAlternateTitle(meta, meta.AlternateTitle))
 	omitAlternateTitle := meta.NamePresentation.Version == api.ReleaseNamePresentationVersionV1 && meta.NamePresentation.OmitAlternateTitle
 	if omitAlternateTitle {
 		original = ""
 	}
-	year := meta.Release.Year
+	providerTitle := ""
 	switch {
 	case meta.ProviderMetadata.TMDB != nil && strings.TrimSpace(meta.ProviderMetadata.TMDB.Title) != "":
-		title = strings.TrimSpace(meta.ProviderMetadata.TMDB.Title)
+		providerTitle = meta.ProviderMetadata.TMDB.Title
 	case meta.ProviderMetadata.IMDB != nil && strings.TrimSpace(meta.ProviderMetadata.IMDB.Title) != "":
-		title = strings.TrimSpace(meta.ProviderMetadata.IMDB.Title)
+		providerTitle = meta.ProviderMetadata.IMDB.Title
 	}
+	title := trackers.PreferredTitle(meta, providerTitle)
+	providerYear := 0
 	if meta.ProviderMetadata.IMDB != nil && meta.ProviderMetadata.IMDB.Year > 0 {
-		year = meta.ProviderMetadata.IMDB.Year
+		providerYear = meta.ProviderMetadata.IMDB.Year
 	} else if meta.ProviderMetadata.TMDB != nil && meta.ProviderMetadata.TMDB.Year > 0 {
-		year = meta.ProviderMetadata.TMDB.Year
+		providerYear = meta.ProviderMetadata.TMDB.Year
 	}
+	year := trackers.PreferredYear(meta, providerYear)
 	return title, original, year
 }
 
@@ -119,14 +122,15 @@ func applyBHDTVTitlePolicy(name string, meta api.UploadSubject) string {
 		return name
 	}
 	evidence := tvdb.NameDisambiguation
-	title := strings.TrimSpace(tvdb.NameEnglish)
-	if title == "" {
-		title = strings.TrimSpace(evidence.CanonicalName)
+	if meta.EffectiveMetadata.YearProvenance.IsManual() {
+		evidence.SeriesYear = meta.EffectiveMetadata.Year
 	}
-	if title == "" {
-		title = strings.TrimSpace(meta.Release.Title)
+	providerTitle := strings.TrimSpace(tvdb.NameEnglish)
+	if providerTitle == "" {
+		providerTitle = strings.TrimSpace(evidence.CanonicalName)
 	}
-	original := trimBHDAKAPrefix(meta.AlternateTitle)
+	title := trackers.PreferredTitle(meta, providerTitle)
+	original := trimBHDAKAPrefix(trackers.PreferredAlternateTitle(meta, meta.AlternateTitle))
 	if meta.NamePresentation.Version == api.ReleaseNamePresentationVersionV1 && meta.NamePresentation.OmitAlternateTitle {
 		original = ""
 	}

--- a/internal/trackers/impl/standalone/bhd/name_test.go
+++ b/internal/trackers/impl/standalone/bhd/name_test.go
@@ -260,3 +260,78 @@ func generatedBHDNameSubject(name string) api.UploadSubject {
 		},
 	}
 }
+
+func TestApplyBHDTVTitlePolicyHonorsManualAlternateTitle(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{
+		AlternateTitle:   "AKA Provider",
+		SeasonStr:        "S01",
+		EpisodeStr:       "E02",
+		ProviderMetadata: api.SourceScopedMetadata{TVDB: &api.TVDBMetadata{NameEnglish: "English"}},
+	}
+	const name = "Raw AKA Provider S01E02 1080p-GRP"
+	if got := applyBHDTVTitlePolicy(name, meta); got != "English AKA Provider S01E02 1080p-GRP" {
+		t.Fatalf("automatic alternate title = %q", got)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{AlternateTitle: "AKA Manual", AlternateTitleProvenance: api.FactProvenanceManual}
+	if got := applyBHDTVTitlePolicy(name, meta); got != "English AKA Manual S01E02 1080p-GRP" {
+		t.Fatalf("manual alternate title = %q", got)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{AlternateTitleProvenance: api.FactProvenanceManualEmpty}
+	if got := applyBHDTVTitlePolicy(name, meta); got != "English S01E02 1080p-GRP" {
+		t.Fatalf("manual empty alternate title = %q", got)
+	}
+}
+
+func TestResolveUploadNameAppliesBHDManualTVDBYear(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		releaseName string
+		year        int
+		want        string
+	}{
+		{
+			name:        "manual year",
+			releaseName: "Example Series 2030 AKA Example Original S01E02 Example Episode 1080p WEB-DL DD+ 5.1 Atmos H.265-GRP",
+			year:        2030,
+			want:        "Example Series AKA Example Original 2030 S01E02 Example Episode 1080p WEB-DL DDP Atmos 5.1 H.265-GRP",
+		},
+		{
+			name:        "manual empty year",
+			releaseName: "Example Series AKA Example Original S01E02 Example Episode 1080p WEB-DL DD+ 5.1 Atmos H.265-GRP",
+			want:        "Example Series AKA Example Original S01E02 Example Episode 1080p WEB-DL DDP Atmos 5.1 H.265-GRP",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			meta := generatedBHDNameSubject(test.releaseName)
+			meta.Identity.Category = api.CanonicalCategoryTV
+			meta.Release = api.ReleaseInfo{
+				Category:   "TV",
+				Resolution: "1080p",
+				Group:      "GRP",
+			}
+			meta.AlternateTitle = "AKA Example Original"
+			meta.ProviderMetadata.TVDB = &api.TVDBMetadata{
+				NameEnglish: "Example Series",
+				NameDisambiguation: api.TVDBNameDisambiguation{
+					CanonicalName: "Example Series",
+					SeriesYear:    2026,
+					IncludeYear:   true,
+				},
+			}
+			meta.EffectiveMetadata = api.EffectiveMetadata{Year: test.year, YearProvenance: api.FactProvenanceManual}
+			meta.SeasonStr, meta.EpisodeStr = "S01", "E02"
+			meta.Type, meta.Source, meta.Audio = "WEBDL", "WEB", "DD+ 5.1 Atmos"
+
+			if got := resolveUploadName(meta); got != test.want {
+				t.Fatalf("BHD manual TVDB year name = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/trackers/impl/standalone/bjs/metadata_precedence_test.go
+++ b/internal/trackers/impl/standalone/bjs/metadata_precedence_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package bjs
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestBJSMetadataSelectorsPreferManualFacts(t *testing.T) {
+	t.Parallel()
+	meta := api.UploadSubject{
+		ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{
+			Title:            "Provider Title",
+			OriginalLanguage: "en",
+			Genres:           "Porn",
+			Localized:        map[string]api.TMDBLocalizedData{"pt-BR": {Title: "Titulo Localizado", Genres: "Ação"}},
+		}},
+		EffectiveMetadata: api.EffectiveMetadata{
+			Title:                      "Manual Title",
+			TitleProvenance:            api.FactProvenanceManual,
+			OriginalLanguage:           "pt",
+			OriginalLanguageProvenance: api.FactProvenanceManual,
+			Genres:                     []string{"Drama"},
+			GenresProvenance:           api.FactProvenanceManual,
+		},
+	}
+	if got := resolveLanguage(meta); got != "Português" {
+		t.Fatalf("manual language = %q", got)
+	}
+	if got := resolveTags(meta, api.ExtractTrackerLocalizedPTBR(meta)); got != "drama" {
+		t.Fatalf("manual tags = %q", got)
+	}
+	if got := buildFields(meta, "", "", nil)["titulobrasileiro"]; got != "Manual Title" {
+		t.Fatalf("manual localized title = %q", got)
+	}
+	meta.EffectiveMetadata.Title = ""
+	meta.EffectiveMetadata.TitleProvenance = api.FactProvenanceManualEmpty
+	meta.EffectiveMetadata.OriginalTitleProvenance = api.FactProvenanceManualEmpty
+	fields := buildFields(meta, "", "", nil)
+	if got := fields["title"]; got != "" {
+		t.Fatalf("manual-empty original title = %q", got)
+	}
+	if got := fields["titulobrasileiro"]; got != "" {
+		t.Fatalf("manual-empty localized title = %q", got)
+	}
+	automatic := api.UploadSubject{
+		Release: api.ReleaseInfo{Title: "Legacy Release Title"},
+		EffectiveMetadata: api.EffectiveMetadata{
+			Title:         "Effective Title",
+			OriginalTitle: "Effective Original Title",
+		},
+	}
+	fields = buildFields(automatic, "", "", nil)
+	if got := fields["title"]; got != "Effective Original Title" {
+		t.Fatalf("automatic original title = %q", got)
+	}
+	if got := fields["titulobrasileiro"]; got != "Effective Title" {
+		t.Fatalf("automatic localized title = %q", got)
+	}
+	meta.EffectiveMetadata.Genres = nil
+	meta.EffectiveMetadata.GenresProvenance = api.FactProvenanceManualEmpty
+	if got := resolveAdult(meta); got != "2" {
+		t.Fatalf("manual-empty adult flag = %q", got)
+	}
+}
+
+func TestResolveLanguageAcceptsManualCanonicalPortuguese(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{EffectiveMetadata: api.EffectiveMetadata{OriginalLanguage: "Portuguese", OriginalLanguageProvenance: api.FactProvenanceManual}}
+	if got := resolveLanguage(meta); got != "Português" {
+		t.Fatalf("manual Portuguese language = %q", got)
+	}
+	meta.EffectiveMetadata.OriginalLanguage = "pt"
+	if got := resolveLanguage(meta); got != "Português" {
+		t.Fatalf("manual ISO Portuguese language = %q", got)
+	}
+}

--- a/internal/trackers/impl/standalone/bjs/profile.go
+++ b/internal/trackers/impl/standalone/bjs/profile.go
@@ -32,6 +32,10 @@ func Profile() standalone.Profile {
 				Scope:       trackers.MetadataScopeAny,
 				AnyOf:       []trackers.MetadataField{trackers.MetadataFieldTMDB},
 				Disposition: api.RuleDispositionStrict,
+			}, {
+				Scope:       trackers.MetadataScopeAny,
+				AnyOf:       []trackers.MetadataField{trackers.MetadataFieldTMDBLocalizedPTBR},
+				Disposition: api.RuleDispositionAdvisory,
 			}},
 		},
 		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: sourceFlag, RequireAnnounce: true},

--- a/internal/trackers/impl/standalone/bjs/taxonomy.go
+++ b/internal/trackers/impl/standalone/bjs/taxonomy.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/autobrr/upbrr/internal/languageutil"
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 
 	"golang.org/x/text/runes"
@@ -36,19 +38,27 @@ func resolveContainer(meta api.UploadSubject) string {
 }
 
 func resolveLanguage(meta api.UploadSubject) string {
-	if meta.ProviderMetadata.TMDB == nil {
-		return "Outro"
+	provider := ""
+	if meta.ProviderMetadata.TMDB != nil {
+		provider = meta.ProviderMetadata.TMDB.OriginalLanguage
 	}
-
-	langCode := strings.ToLower(strings.TrimSpace(meta.ProviderMetadata.TMDB.OriginalLanguage))
+	if meta.EffectiveMetadata.OriginalLanguageProvenance.IsManual() {
+		provider = trackers.PreferredOriginalLanguage(meta, provider)
+		if normalized := languageutil.NormalizeLanguageCode(provider); normalized != "" {
+			provider = normalized
+		}
+	}
+	langCode := strings.ToLower(strings.TrimSpace(provider))
 	if langCode == "" {
 		return "Outro"
 	}
 
 	if langCode == "pt" {
-		for _, country := range meta.ProviderMetadata.TMDB.OriginCountry {
-			if strings.ToUpper(strings.TrimSpace(country)) == "PT" {
-				return "Português (pt)"
+		if meta.ProviderMetadata.TMDB != nil {
+			for _, country := range meta.ProviderMetadata.TMDB.OriginCountry {
+				if strings.ToUpper(strings.TrimSpace(country)) == "PT" {
+					return "Português (pt)"
+				}
 			}
 		}
 		return "Português"
@@ -160,7 +170,7 @@ func resolveQuality(meta api.UploadSubject) string {
 // genres, preserving unknown fallback genre names after tag normalization.
 func resolveTags(meta api.UploadSubject, ptBR api.TMDBLocalizedData) string {
 	// 1. Use localized if available
-	if ptBR.Genres != "" {
+	if !meta.EffectiveMetadata.GenresProvenance.IsManual() && ptBR.Genres != "" {
 		genres := strings.Split(strings.TrimSpace(ptBR.Genres), ",")
 		out := make([]string, 0, len(genres))
 		for _, g := range genres {
@@ -177,15 +187,14 @@ func resolveTags(meta api.UploadSubject, ptBR api.TMDBLocalizedData) string {
 	}
 
 	// 2. Use metautil.TranslateGenreToPortugueseStrict to translate
-	var genreText string
+	provider := ""
 	switch {
 	case meta.ProviderMetadata.TMDB != nil && strings.TrimSpace(meta.ProviderMetadata.TMDB.Genres) != "":
-		genreText = strings.TrimSpace(meta.ProviderMetadata.TMDB.Genres)
+		provider = meta.ProviderMetadata.TMDB.Genres
 	case meta.ProviderMetadata.IMDB != nil && strings.TrimSpace(meta.ProviderMetadata.IMDB.Genres) != "":
-		genreText = strings.TrimSpace(meta.ProviderMetadata.IMDB.Genres)
-	default:
-		genreText = strings.TrimSpace(meta.Release.Genre)
+		provider = meta.ProviderMetadata.IMDB.Genres
 	}
+	genreText := trackers.PreferredGenreText(meta, provider)
 
 	if genreText == "" {
 		return ""
@@ -216,14 +225,22 @@ func resolveTags(meta api.UploadSubject, ptBR api.TMDBLocalizedData) string {
 // release genre text after accent-insensitive keyword matching.
 func resolveAdult(meta api.UploadSubject) string {
 	ptBR := api.ExtractTrackerLocalizedPTBR(meta)
-	parts := []string{resolveTags(meta, ptBR), ptBR.Genres}
-	if meta.ProviderMetadata.TMDB != nil {
-		parts = append(parts, meta.ProviderMetadata.TMDB.Keywords, meta.ProviderMetadata.TMDB.Genres)
+	parts := []string{resolveTags(meta, ptBR)}
+	if !meta.EffectiveMetadata.GenresProvenance.IsManual() {
+		parts = append(parts, ptBR.Genres)
 	}
-	if meta.ProviderMetadata.IMDB != nil {
+	if meta.ProviderMetadata.TMDB != nil {
+		parts = append(parts, meta.ProviderMetadata.TMDB.Keywords)
+		if !meta.EffectiveMetadata.GenresProvenance.IsManual() {
+			parts = append(parts, meta.ProviderMetadata.TMDB.Genres)
+		}
+	}
+	if !meta.EffectiveMetadata.GenresProvenance.IsManual() && meta.ProviderMetadata.IMDB != nil {
 		parts = append(parts, meta.ProviderMetadata.IMDB.Genres)
 	}
-	parts = append(parts, meta.Release.Genre)
+	if !meta.EffectiveMetadata.GenresProvenance.IsManual() {
+		parts = append(parts, meta.Release.Genre)
+	}
 	genres := normalizeAdultText(strings.Join(parts, " "))
 	if meta.Anime && strings.Contains(genres, "hentai") {
 		return "1"

--- a/internal/trackers/impl/standalone/bjs/upload.go
+++ b/internal/trackers/impl/standalone/bjs/upload.go
@@ -211,7 +211,6 @@ func buildFields(meta api.UploadSubject, description string, auth string, answer
 		tmdbOriginalTitle = meta.ProviderMetadata.TMDB.OriginalTitle
 		tmdbTitle = meta.ProviderMetadata.TMDB.Title
 	}
-
 	fields := map[string]string{
 		"audio":            resolveAudio(meta),
 		"auth":             auth,
@@ -233,8 +232,8 @@ func buildFields(meta api.UploadSubject, description string, auth string, answer
 		"submit":           "true",
 		"tags":             metautil.FirstNonEmptyTrimmed(strings.TrimSpace(answers["tags"]), resolveTags(meta, ptBR)),
 		"tipolegenda":      resolveSubtitle(meta),
-		"title":            metautil.FirstNonEmptyTrimmed(tmdbOriginalTitle, meta.Release.Title),
-		"titulobrasileiro": metautil.FirstNonEmptyTrimmed(ptBR.Title, tmdbTitle, meta.Release.Title),
+		"title":            trackers.PreferredOriginalTitle(meta, tmdbOriginalTitle),
+		"titulobrasileiro": trackers.PreferredTitle(meta, metautil.FirstNonEmptyTrimmed(ptBR.Title, tmdbTitle)),
 		"traileryoutube":   resolveYouTube(meta, ptBR),
 		"type":             resolveType(meta),
 		"year":             resolveYearLabel(meta),
@@ -464,13 +463,14 @@ func resolveRemasterTitle(meta api.UploadSubject) string {
 }
 
 func resolveYear(meta api.UploadSubject) int {
-	if meta.ProviderMetadata.TMDB != nil && meta.ProviderMetadata.TMDB.Year > 0 {
-		return meta.ProviderMetadata.TMDB.Year
+	provider := 0
+	if meta.ProviderMetadata.TMDB != nil {
+		provider = meta.ProviderMetadata.TMDB.Year
 	}
-	if meta.ProviderMetadata.IMDB != nil && meta.ProviderMetadata.IMDB.Year > 0 {
-		return meta.ProviderMetadata.IMDB.Year
+	if provider == 0 && meta.ProviderMetadata.IMDB != nil {
+		provider = meta.ProviderMetadata.IMDB.Year
 	}
-	return meta.Release.Year
+	return trackers.PreferredYear(meta, provider)
 }
 
 func resolveCreators(meta api.UploadSubject) string {

--- a/internal/trackers/impl/standalone/bt/dupe.go
+++ b/internal/trackers/impl/standalone/bt/dupe.go
@@ -59,41 +59,7 @@ func (h dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) dup
 	workScope := dupe.WorkScopeProviderID
 	if meta.Anime {
 		workScope = dupe.WorkScopeTitle
-		tvdbNameEnglish := ""
-		tvdbName := ""
-		if meta.ProviderMetadata.TVDB != nil {
-			tvdbNameEnglish = strings.TrimSpace(meta.ProviderMetadata.TVDB.NameEnglish)
-			tvdbName = strings.TrimSpace(meta.ProviderMetadata.TVDB.Name)
-		}
-
-		tmdbTitle := ""
-		tmdbOriginalTitle := ""
-		if meta.ProviderMetadata.TMDB != nil {
-			tmdbTitle = strings.TrimSpace(meta.ProviderMetadata.TMDB.Title)
-			tmdbOriginalTitle = strings.TrimSpace(meta.ProviderMetadata.TMDB.OriginalTitle)
-		}
-
-		imdbTitle := ""
-		if meta.ProviderMetadata.IMDB != nil {
-			imdbTitle = strings.TrimSpace(meta.ProviderMetadata.IMDB.Title)
-		}
-
-		switch {
-		case strings.TrimSpace(meta.Release.Title) != "":
-			searchStr = strings.TrimSpace(meta.Release.Title)
-		case tvdbNameEnglish != "":
-			searchStr = tvdbNameEnglish
-		case tmdbTitle != "":
-			searchStr = tmdbTitle
-		case imdbTitle != "":
-			searchStr = imdbTitle
-		case tvdbName != "":
-			searchStr = tvdbName
-		case tmdbOriginalTitle != "":
-			searchStr = tmdbOriginalTitle
-		case dupe.ProjectedSearchName(meta) != "":
-			searchStr = dupe.ProjectedSearchName(meta)
-		}
+		searchStr = animeSearchTitle(meta)
 	}
 
 	if searchStr == "" {
@@ -191,6 +157,44 @@ func (h dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) dup
 		return dupe.Failed(dupe.FailureRequest, "BT search canceled", err)
 	}
 	return btResolved(entries, workScope)
+}
+
+func animeSearchTitle(meta api.DuplicateSubject) string {
+	if meta.EffectiveMetadata.TitleProvenance.IsManual() {
+		return strings.TrimSpace(meta.EffectiveMetadata.PreferredTitle(""))
+	}
+	tvdbNameEnglish := ""
+	tvdbName := ""
+	if meta.ProviderMetadata.TVDB != nil {
+		tvdbNameEnglish = strings.TrimSpace(meta.ProviderMetadata.TVDB.NameEnglish)
+		tvdbName = strings.TrimSpace(meta.ProviderMetadata.TVDB.Name)
+	}
+	tmdbTitle := ""
+	tmdbOriginalTitle := ""
+	if meta.ProviderMetadata.TMDB != nil {
+		tmdbTitle = strings.TrimSpace(meta.ProviderMetadata.TMDB.Title)
+		tmdbOriginalTitle = strings.TrimSpace(meta.ProviderMetadata.TMDB.OriginalTitle)
+	}
+	imdbTitle := ""
+	if meta.ProviderMetadata.IMDB != nil {
+		imdbTitle = strings.TrimSpace(meta.ProviderMetadata.IMDB.Title)
+	}
+	switch {
+	case strings.TrimSpace(meta.Release.Title) != "":
+		return strings.TrimSpace(meta.Release.Title)
+	case tvdbNameEnglish != "":
+		return tvdbNameEnglish
+	case tmdbTitle != "":
+		return tmdbTitle
+	case imdbTitle != "":
+		return imdbTitle
+	case tvdbName != "":
+		return tvdbName
+	case tmdbOriginalTitle != "":
+		return tmdbOriginalTitle
+	default:
+		return dupe.ProjectedSearchName(meta)
+	}
 }
 
 func btResolved(entries []api.DupeEntry, workScope dupe.WorkScope) dupe.AdapterResult {

--- a/internal/trackers/impl/standalone/bt/metadata_precedence_test.go
+++ b/internal/trackers/impl/standalone/bt/metadata_precedence_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package bt
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestAnimeSearchAndAudioPreferManualFacts(t *testing.T) {
+	t.Parallel()
+	meta := api.UploadSubject{
+		Anime:          true,
+		ReleaseName:    "Fallback Release",
+		AudioLanguages: []string{"Portuguese"},
+		ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{
+			Title: "Provider Title", OriginalLanguage: "en",
+		}},
+		EffectiveMetadata: api.EffectiveMetadata{
+			Title:                      "Manual Title",
+			TitleProvenance:            api.FactProvenanceManual,
+			OriginalLanguage:           "pt",
+			OriginalLanguageProvenance: api.FactProvenanceManual,
+		},
+	}
+	if got := resolveSearchName(meta); got != "Manual Title" {
+		t.Fatalf("manual anime search name = %q", got)
+	}
+	if got := resolveAudio(meta); got != "Nacional" {
+		t.Fatalf("manual original language audio = %q", got)
+	}
+	meta.EffectiveMetadata.OriginalLanguage = ""
+	meta.EffectiveMetadata.OriginalLanguageProvenance = api.FactProvenanceManualEmpty
+	if got := resolveLanguage(meta); got != "" {
+		t.Fatalf("manual-empty original language = %q", got)
+	}
+	if got := resolveLanguage(api.UploadSubject{AudioLanguages: []string{"Portuguese"}}); got != "portuguese" {
+		t.Fatalf("automatic audio language fallback = %q", got)
+	}
+	meta.EffectiveMetadata.Title = ""
+	meta.EffectiveMetadata.TitleProvenance = api.FactProvenanceManualEmpty
+	if got := resolveSearchName(meta); got != "" {
+		t.Fatalf("manual-empty anime search name = %q", got)
+	}
+}
+
+func TestAnimeDupeSearchPrefersManualTitle(t *testing.T) {
+	t.Parallel()
+	meta := api.DuplicateSubject{
+		Anime:             true,
+		Release:           api.ReleaseInfo{Title: "Parsed Title"},
+		ProviderMetadata:  api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{Title: "Provider Title"}},
+		EffectiveMetadata: api.EffectiveMetadata{Title: "Manual Title", TitleProvenance: api.FactProvenanceManual},
+	}
+	if got := animeSearchTitle(meta); got != "Manual Title" {
+		t.Fatalf("manual anime duplicate search = %q", got)
+	}
+	meta.EffectiveMetadata.Title = ""
+	meta.EffectiveMetadata.TitleProvenance = api.FactProvenanceManualEmpty
+	if got := animeSearchTitle(meta); got != "" {
+		t.Fatalf("manual-empty anime duplicate search = %q", got)
+	}
+}
+
+func TestResolveLanguagePreservesAutomaticTMDBAndAudioPrecedence(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{
+		AudioLanguages:    []string{"Portuguese"},
+		ProviderMetadata:  api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{OriginalLanguage: ""}},
+		EffectiveMetadata: api.EffectiveMetadata{OriginalLanguage: "Japanese"},
+	}
+	if got := resolveLanguage(meta); got != "portuguese" {
+		t.Fatalf("automatic effective language changed audio fallback = %q", got)
+	}
+	meta.EffectiveMetadata.OriginalLanguage = "Japanese"
+	meta.EffectiveMetadata.OriginalLanguageProvenance = api.FactProvenanceManual
+	if got := resolveLanguage(meta); got != "Japonês" {
+		t.Fatalf("manual language = %q", got)
+	}
+}
+
+func TestResolveAudioAcceptsManualCanonicalPortuguese(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{AudioLanguages: []string{"Portuguese"}, EffectiveMetadata: api.EffectiveMetadata{OriginalLanguage: "Portuguese", OriginalLanguageProvenance: api.FactProvenanceManual}}
+	if got := resolveAudio(meta); got != "Nacional" {
+		t.Fatalf("manual Portuguese audio = %q", got)
+	}
+	meta.EffectiveMetadata.OriginalLanguage = "pt"
+	if got := resolveAudio(meta); got != "Nacional" {
+		t.Fatalf("manual ISO Portuguese audio = %q", got)
+	}
+}

--- a/internal/trackers/impl/standalone/bt/name.go
+++ b/internal/trackers/impl/standalone/bt/name.go
@@ -19,6 +19,9 @@ func resolveSearchName(meta api.UploadSubject) string {
 	if !meta.Anime {
 		return resolveUploadName(meta)
 	}
+	if meta.EffectiveMetadata.TitleProvenance.IsManual() {
+		return strings.TrimSpace(meta.EffectiveMetadata.Title)
+	}
 	candidates := make([]string, 0, 6)
 	if meta.ProviderMetadata.TVDB != nil {
 		candidates = append(candidates, strings.TrimSpace(meta.ProviderMetadata.TVDB.NameEnglish))

--- a/internal/trackers/impl/standalone/bt/profile.go
+++ b/internal/trackers/impl/standalone/bt/profile.go
@@ -7,6 +7,7 @@ import (
 	"github.com/autobrr/upbrr/internal/trackers"
 	authcontract "github.com/autobrr/upbrr/internal/trackers/auth/contract"
 	"github.com/autobrr/upbrr/internal/trackers/impl/standalone"
+	"github.com/autobrr/upbrr/pkg/api"
 )
 
 // Profile returns BT identity, preparation, dupe, auth, and policy behavior.
@@ -22,10 +23,15 @@ func Profile() standalone.Profile {
 		ValidationPolicy:        validationPolicy(),
 		ReleaseNamePolicy:       trackers.SimpleSubjectReleaseNameSearchPolicy("standalone/bt/v1", resolveUploadName, resolveSearchName),
 		NewDuplicateAdapter:     newDuplicateAdapter,
-		UploadArtifactPolicy:    &trackers.UploadArtifactPolicy{Source: sourceFlag, RequireAnnounce: true},
-		AudioPolicy:             &trackers.AudioPolicy{AllowBloat: true},
-		TorrentIdentityPolicy:   &trackers.TorrentIdentityPolicy{TrackerURLPatterns: []string{"t.brasiltracker.org"}},
-		AuthCapability:          authcontract.CookieCapability("BT"),
+		MetadataPolicy: &trackers.TrackerMetadataPolicy{Requirements: []trackers.MetadataRequirement{{
+			Scope:       trackers.MetadataScopeAny,
+			AnyOf:       []trackers.MetadataField{trackers.MetadataFieldTMDBLocalizedPTBR},
+			Disposition: api.RuleDispositionAdvisory,
+		}}},
+		UploadArtifactPolicy:  &trackers.UploadArtifactPolicy{Source: sourceFlag, RequireAnnounce: true},
+		AudioPolicy:           &trackers.AudioPolicy{AllowBloat: true},
+		TorrentIdentityPolicy: &trackers.TorrentIdentityPolicy{TrackerURLPatterns: []string{"t.brasiltracker.org"}},
+		AuthCapability:        authcontract.CookieCapability("BT"),
 	}
 }
 

--- a/internal/trackers/impl/standalone/bt/taxonomy.go
+++ b/internal/trackers/impl/standalone/bt/taxonomy.go
@@ -10,7 +10,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/languageutil"
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -288,7 +290,7 @@ func resolveEdition(meta api.UploadSubject) string {
 
 func resolveTags(meta api.UploadSubject, ptBR api.TMDBLocalizedData) string {
 	// 1. Use localized if available
-	if ptBR.Genres != "" {
+	if !meta.EffectiveMetadata.GenresProvenance.IsManual() && ptBR.Genres != "" {
 		genres := strings.Split(strings.TrimSpace(ptBR.Genres), ",")
 		out := make([]string, 0, len(genres))
 		for _, genre := range genres {
@@ -302,15 +304,14 @@ func resolveTags(meta api.UploadSubject, ptBR api.TMDBLocalizedData) string {
 	}
 
 	// 2. Use metautil.TranslateGenreToPortugueseStrict to translate
-	var genreText string
+	provider := ""
 	switch {
 	case meta.ProviderMetadata.TMDB != nil && strings.TrimSpace(meta.ProviderMetadata.TMDB.Genres) != "":
-		genreText = strings.TrimSpace(meta.ProviderMetadata.TMDB.Genres)
+		provider = meta.ProviderMetadata.TMDB.Genres
 	case meta.ProviderMetadata.IMDB != nil && strings.TrimSpace(meta.ProviderMetadata.IMDB.Genres) != "":
-		genreText = strings.TrimSpace(meta.ProviderMetadata.IMDB.Genres)
-	default:
-		genreText = strings.TrimSpace(meta.Release.Genre)
+		provider = meta.ProviderMetadata.IMDB.Genres
 	}
+	genreText := trackers.PreferredGenreText(meta, provider)
 
 	if genreText == "" {
 		return ""
@@ -333,12 +334,19 @@ func resolveTags(meta api.UploadSubject, ptBR api.TMDBLocalizedData) string {
 }
 
 func resolveLanguage(meta api.UploadSubject) string {
-	var lang string
-	if meta.ProviderMetadata.TMDB != nil {
-		lang = strings.TrimSpace(meta.ProviderMetadata.TMDB.OriginalLanguage)
-	}
-	if lang == "" && len(meta.AudioLanguages) > 0 {
-		lang = meta.AudioLanguages[0]
+	lang := ""
+	if meta.EffectiveMetadata.OriginalLanguageProvenance.IsManual() {
+		lang = trackers.PreferredOriginalLanguage(meta, "")
+		if normalized := languageutil.NormalizeLanguageCode(lang); normalized != "" {
+			lang = normalized
+		}
+	} else {
+		if meta.ProviderMetadata.TMDB != nil {
+			lang = strings.TrimSpace(meta.ProviderMetadata.TMDB.OriginalLanguage)
+		}
+		if lang == "" && len(meta.AudioLanguages) > 0 {
+			lang = meta.AudioLanguages[0]
+		}
 	}
 	lang = strings.ToLower(lang)
 	if lang == "" {
@@ -367,10 +375,16 @@ func resolveAudio(meta api.UploadSubject) string {
 	}
 	orig := ""
 	if meta.ProviderMetadata.TMDB != nil {
-		orig = strings.ToLower(strings.TrimSpace(meta.ProviderMetadata.TMDB.OriginalLanguage))
+		orig = meta.ProviderMetadata.TMDB.OriginalLanguage
+	}
+	if meta.EffectiveMetadata.OriginalLanguageProvenance.IsManual() {
+		orig = trackers.PreferredOriginalLanguage(meta, orig)
+		if normalized := languageutil.NormalizeLanguageCode(orig); normalized != "" {
+			orig = normalized
+		}
 	}
 	if pt {
-		if orig == "pt" {
+		if strings.EqualFold(strings.TrimSpace(orig), "pt") {
 			return "Nacional"
 		}
 		if len(meta.AudioLanguages) > 1 {

--- a/internal/trackers/impl/standalone/bt/upload.go
+++ b/internal/trackers/impl/standalone/bt/upload.go
@@ -560,23 +560,28 @@ func resolveLogo(meta api.UploadSubject) string {
 }
 
 func resolveYear(meta api.UploadSubject) int {
-	if meta.ProviderMetadata.TMDB != nil && meta.ProviderMetadata.TMDB.Year > 0 {
-		return meta.ProviderMetadata.TMDB.Year
+	provider := 0
+	if meta.ProviderMetadata.TMDB != nil {
+		provider = meta.ProviderMetadata.TMDB.Year
 	}
-	if meta.ProviderMetadata.IMDB != nil && meta.ProviderMetadata.IMDB.Year > 0 {
-		return meta.ProviderMetadata.IMDB.Year
+	if provider == 0 && meta.ProviderMetadata.IMDB != nil {
+		provider = meta.ProviderMetadata.IMDB.Year
 	}
-	return meta.Release.Year
+	return trackers.PreferredYear(meta, provider)
 }
 
 func resolveTitle(meta api.UploadSubject) string {
+	provider := ""
 	if meta.ProviderMetadata.TMDB != nil {
-		return metautil.FirstNonEmptyTrimmed(meta.ProviderMetadata.TMDB.Title, meta.Release.Title)
+		provider = meta.ProviderMetadata.TMDB.Title
 	}
-	return meta.Release.Title
+	return trackers.PreferredTitle(meta, provider)
 }
 
 func resolveLocalizedTitle(meta api.UploadSubject, ptBR api.TMDBLocalizedData) string {
+	if meta.EffectiveMetadata.TitleProvenance.IsManual() {
+		return meta.EffectiveMetadata.Title
+	}
 	if ptBR.Title != "" {
 		if meta.ProviderMetadata.TMDB != nil {
 			return metautil.FirstNonEmptyTrimmed(ptBR.Title, meta.ProviderMetadata.TMDB.OriginalTitle)

--- a/internal/trackers/impl/standalone/bt/upload_test.go
+++ b/internal/trackers/impl/standalone/bt/upload_test.go
@@ -98,6 +98,24 @@ func TestResolveTagsPreservesUnknownGenres(t *testing.T) {
 	}
 }
 
+func TestResolveTagsManualCorrectionBeatsLocalizedGenres(t *testing.T) {
+	t.Parallel()
+
+	localized := api.TMDBLocalizedData{Genres: "Ação"}
+	meta := api.UploadSubject{}
+	if got := resolveTags(meta, localized); got != "acao" {
+		t.Fatalf("automatic localized tags = %q", got)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{Genres: []string{"Drama"}, GenresProvenance: api.FactProvenanceManual}
+	if got := resolveTags(meta, localized); got != "drama" {
+		t.Fatalf("manual tags = %q", got)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{GenresProvenance: api.FactProvenanceManualEmpty}
+	if got := resolveTags(meta, localized); got != "" {
+		t.Fatalf("manual empty tags = %q", got)
+	}
+}
+
 func TestResolveLanguageUsesResolvedAudioFacts(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/impl/standalone/btn/dupe.go
+++ b/internal/trackers/impl/standalone/btn/dupe.go
@@ -367,6 +367,9 @@ func trackerID(meta api.DuplicateSubject) string {
 }
 
 func searchTitle(meta api.DuplicateSubject) string {
+	if meta.EffectiveMetadata.TitleProvenance.IsManual() {
+		return strings.TrimSpace(meta.EffectiveMetadata.PreferredTitle(""))
+	}
 	candidates := []string{strings.TrimSpace(meta.Release.Title)}
 	if meta.Projection != nil {
 		candidates = append(candidates, dupe.ProjectedSearchName(meta))

--- a/internal/trackers/impl/standalone/btn/metadata_precedence_test.go
+++ b/internal/trackers/impl/standalone/btn/metadata_precedence_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package btn
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestBTNMetadataSelectorsPreferManualFacts(t *testing.T) {
+	t.Parallel()
+	meta := api.UploadSubject{
+		ProviderMetadata: api.SourceScopedMetadata{
+			TVDB: &api.TVDBMetadata{OriginalLanguage: "ja", Genres: "Action"},
+		},
+		EffectiveMetadata: api.EffectiveMetadata{
+			OriginalLanguage:           "en",
+			OriginalLanguageProvenance: api.FactProvenanceManual,
+			Genres:                     []string{"Drama"},
+			GenresProvenance:           api.FactProvenanceManual,
+		},
+	}
+	if got := resolveBTNOriginalLanguage(meta); got != "en" {
+		t.Fatalf("manual original language = %q", got)
+	}
+	if got := resolveBTNTags(meta, nil); got != "Drama" {
+		t.Fatalf("manual tags = %q", got)
+	}
+	meta.EffectiveMetadata.Genres = nil
+	meta.EffectiveMetadata.GenresProvenance = api.FactProvenanceManualEmpty
+	if got := resolveBTNTags(meta, nil); got != "" {
+		t.Fatalf("manual-empty tags = %q", got)
+	}
+}
+
+func TestBTNTitleSearchPrefersManualFacts(t *testing.T) {
+	t.Parallel()
+	meta := api.UploadSubject{
+		Filename:          "Fallback File",
+		Release:           api.ReleaseInfo{Title: "Parsed Title"},
+		ProviderMetadata:  api.SourceScopedMetadata{TVDB: &api.TVDBMetadata{NameEnglish: "Provider Title"}},
+		EffectiveMetadata: api.EffectiveMetadata{Title: "Manual Title", TitleProvenance: api.FactProvenanceManual},
+	}
+	if got := resolveSearchName(meta); got != "Manual Title" {
+		t.Fatalf("manual upload search = %q", got)
+	}
+	meta.EffectiveMetadata.Title = ""
+	meta.EffectiveMetadata.TitleProvenance = api.FactProvenanceManualEmpty
+	if got := resolveSearchName(meta); got != "" {
+		t.Fatalf("manual-empty upload search = %q", got)
+	}
+
+	duplicate := api.DuplicateSubject{
+		Filename:          "Fallback File",
+		Release:           api.ReleaseInfo{Title: "Parsed Title"},
+		ProviderMetadata:  api.SourceScopedMetadata{TVDB: &api.TVDBMetadata{NameEnglish: "Provider Title"}},
+		EffectiveMetadata: api.EffectiveMetadata{TitleProvenance: api.FactProvenanceManualEmpty},
+	}
+	if got := searchTitle(duplicate); got != "" {
+		t.Fatalf("manual-empty duplicate search = %q", got)
+	}
+}

--- a/internal/trackers/impl/standalone/btn/name.go
+++ b/internal/trackers/impl/standalone/btn/name.go
@@ -145,6 +145,9 @@ func resolveSearchName(meta api.UploadSubject) string {
 	if meta.Identity.IMDBID != 0 || meta.Identity.TVDBID != 0 {
 		return resolveUploadName(meta)
 	}
+	if meta.EffectiveMetadata.TitleProvenance.IsManual() {
+		return strings.TrimSpace(meta.EffectiveMetadata.Title)
+	}
 	candidates := []string{strings.TrimSpace(meta.Release.Title)}
 	if meta.ProviderMetadata.TVDB != nil {
 		candidates = append(candidates, strings.TrimSpace(meta.ProviderMetadata.TVDB.Name), strings.TrimSpace(meta.ProviderMetadata.TVDB.NameEnglish))

--- a/internal/trackers/impl/standalone/btn/taxonomy.go
+++ b/internal/trackers/impl/standalone/btn/taxonomy.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -330,15 +331,19 @@ func resolveCountryID(meta api.UploadSubject) string {
 // resolveBTNOriginalLanguage returns provider original language in BTN
 // priority order: TVDB first, then IMDb when TVDB has no value.
 func resolveBTNOriginalLanguage(meta api.UploadSubject) string {
+	provider := ""
 	if meta.ProviderMetadata.TVDB != nil {
 		if language := strings.TrimSpace(meta.ProviderMetadata.TVDB.OriginalLanguage); language != "" {
-			return language
+			provider = language
 		}
 	}
-	if meta.ProviderMetadata.IMDB != nil {
-		return strings.TrimSpace(meta.ProviderMetadata.IMDB.OriginalLanguage)
+	if provider == "" && meta.ProviderMetadata.IMDB != nil {
+		provider = meta.ProviderMetadata.IMDB.OriginalLanguage
 	}
-	return ""
+	if meta.EffectiveMetadata.OriginalLanguageProvenance.IsManual() {
+		return trackers.PreferredOriginalLanguage(meta, provider)
+	}
+	return strings.TrimSpace(provider)
 }
 
 // isBTNEnglishLanguage reports whether a provider language value represents
@@ -384,15 +389,17 @@ func resolveBTNTags(meta api.UploadSubject, fields map[string]string) string {
 	if tags := strings.TrimSpace(fields["tags"]); tags != "" {
 		return tags
 	}
-	if meta.ProviderMetadata.TVDB != nil {
-		if tags := mapBTNGenres(meta.ProviderMetadata.TVDB.Genres); tags != "" {
-			return tags
-		}
+	provider := ""
+	if meta.ProviderMetadata.TVDB != nil && strings.TrimSpace(meta.ProviderMetadata.TVDB.Genres) != "" {
+		provider = meta.ProviderMetadata.TVDB.Genres
 	}
-	if meta.ProviderMetadata.IMDB != nil {
-		return mapBTNGenres(meta.ProviderMetadata.IMDB.Genres)
+	if provider == "" && meta.ProviderMetadata.IMDB != nil {
+		provider = meta.ProviderMetadata.IMDB.Genres
 	}
-	return ""
+	if meta.EffectiveMetadata.GenresProvenance.IsManual() {
+		return mapBTNGenres(trackers.PreferredGenreText(meta, provider))
+	}
+	return mapBTNGenres(provider)
 }
 
 func mapBTNGenres(genres string) string {

--- a/internal/trackers/impl/standalone/czt/dupe.go
+++ b/internal/trackers/impl/standalone/czt/dupe.go
@@ -145,17 +145,18 @@ func (h cztHandler) Search(ctx context.Context, meta api.DuplicateSubject) dupe.
 
 // cztSearchQuery prefers the release title to discover same-work candidates.
 func cztSearchQuery(meta api.DuplicateSubject) string {
-	if title := strings.TrimSpace(meta.Release.Title); title != "" {
-		return title
+	title := strings.TrimSpace(meta.Release.Title)
+	if title == "" && meta.Projection != nil {
+		title = dupe.ProjectedSearchName(meta)
 	}
-	if meta.Projection != nil {
-		return dupe.ProjectedSearchName(meta)
+	if title == "" {
+		title = metautil.FirstNonEmptyTrimmed(
+			meta.ReleaseName,
+			meta.SceneName,
+			meta.Filename,
+		)
 	}
-	return metautil.FirstNonEmptyTrimmed(
-		meta.ReleaseName,
-		meta.SceneName,
-		meta.Filename,
-	)
+	return meta.EffectiveMetadata.PreferredTitle(title)
 }
 
 // cztResultItems extracts torrent rows from the CZTeam search response. Auth or

--- a/internal/trackers/impl/standalone/czt/dupe_test.go
+++ b/internal/trackers/impl/standalone/czt/dupe_test.go
@@ -150,6 +150,32 @@ func TestCZTHandlerSearchPrefersBroadTitle(t *testing.T) {
 	}
 }
 
+func TestCZTSearchQueryHonorsManualTitle(t *testing.T) {
+	t.Parallel()
+
+	projection := &api.TrackerReleaseProjection{DuplicateCriteria: api.TrackerDuplicateCriteria{Name: "Projected Release"}}
+	manual := api.DuplicateSubject{
+		Release:    api.ReleaseInfo{Title: "Automatic Release"},
+		Projection: projection,
+		EffectiveMetadata: api.EffectiveMetadata{
+			Title:           "Manual Release",
+			TitleProvenance: api.FactProvenanceManual,
+		},
+	}
+	if got := cztSearchQuery(manual); got != "Manual Release" {
+		t.Fatalf("manual CZT search query = %q", got)
+	}
+
+	manual.EffectiveMetadata = api.EffectiveMetadata{TitleProvenance: api.FactProvenanceManualEmpty}
+	if got := cztSearchQuery(manual); got != "" {
+		t.Fatalf("manual-empty CZT search query = %q", got)
+	}
+
+	if got := cztSearchQuery(api.DuplicateSubject{Projection: projection}); got != "Projected Release" {
+		t.Fatalf("automatic CZT search query = %q", got)
+	}
+}
+
 func TestCZTHandlerSearchParsesWrappedAndAliasedResults(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/impl/standalone/ff/dupe.go
+++ b/internal/trackers/impl/standalone/ff/dupe.go
@@ -52,7 +52,10 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 	}
 	query := providerid.IMDb(meta.Identity.IMDBID).Prefixed()
 	if meta.Anime {
-		query = metautil.FirstNonEmptyTrimmed(meta.Release.Title, dupe.ProjectedSearchName(meta), meta.ReleaseName)
+		query = meta.EffectiveMetadata.PreferredTitle(metautil.FirstNonEmptyTrimmed(meta.Release.Title, dupe.ProjectedSearchName(meta), meta.ReleaseName))
+		if query == "" {
+			return dupe.NotRun(dupe.NotRunMissingMetadata, "missing title for FF anime dupe search", nil)
+		}
 	}
 	status, root, err := commonhttp.GetHTML(ctx, s.http, baseURL+"/torrents.php", url.Values{"searchstr": {query}}, trackerCookies)
 	if err != nil || status < http.StatusOK || status >= http.StatusMultipleChoices || root == nil {

--- a/internal/trackers/impl/standalone/fl/dupe.go
+++ b/internal/trackers/impl/standalone/fl/dupe.go
@@ -52,7 +52,7 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 		params.Set("searchin", "3")
 	} else {
 		workScope = dupe.WorkScopeTitle
-		query := metautil.FirstNonEmptyTrimmed(meta.Release.Title, dupe.ProjectedSearchName(meta), meta.ReleaseName)
+		query := meta.EffectiveMetadata.PreferredTitle(metautil.FirstNonEmptyTrimmed(meta.Release.Title, dupe.ProjectedSearchName(meta), meta.ReleaseName))
 		if query == "" {
 			return dupe.NotRun(dupe.NotRunMissingMetadata, "missing FL search query", nil)
 		}

--- a/internal/trackers/impl/standalone/fl/taxonomy.go
+++ b/internal/trackers/impl/standalone/fl/taxonomy.go
@@ -6,6 +6,7 @@ package fl
 import (
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -50,6 +51,9 @@ func resolveCategoryID(meta api.UploadSubject) int {
 }
 
 func resolveGenres(meta api.UploadSubject) string {
+	if meta.EffectiveMetadata.GenresProvenance.IsManual() {
+		return trackers.PreferredGenreText(meta, "")
+	}
 	if meta.ProviderMetadata.IMDB != nil {
 		return strings.TrimSpace(meta.ProviderMetadata.IMDB.Genres)
 	}

--- a/internal/trackers/impl/standalone/fl/upload_test.go
+++ b/internal/trackers/impl/standalone/fl/upload_test.go
@@ -301,3 +301,26 @@ func textResponse(req *http.Request, body string) *http.Response {
 		Request:    req,
 	}
 }
+
+func TestResolveGenresPreservesAutomaticProviderPresenceAndManualFacts(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{Release: api.ReleaseInfo{Genre: "Release"}, ProviderMetadata: api.SourceScopedMetadata{
+		IMDB: &api.IMDBMetadata{Genres: ""}, TMDB: &api.TMDBMetadata{Genres: "TMDB"},
+	}}
+	if got := resolveGenres(meta); got != "" {
+		t.Fatalf("blank IMDb genres = %q", got)
+	}
+	meta.ProviderMetadata.IMDB = nil
+	if got := resolveGenres(meta); got != "TMDB" {
+		t.Fatalf("TMDB genres = %q", got)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{Genres: []string{"Manual"}, GenresProvenance: api.FactProvenanceManual}
+	if got := resolveGenres(meta); got != "Manual" {
+		t.Fatalf("manual genres = %q", got)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{GenresProvenance: api.FactProvenanceManualEmpty}
+	if got := resolveGenres(meta); got != "" {
+		t.Fatalf("manual-empty genres = %q", got)
+	}
+}

--- a/internal/trackers/impl/standalone/gpw/taxonomy.go
+++ b/internal/trackers/impl/standalone/gpw/taxonomy.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/autobrr/upbrr/internal/metadata/metautil"
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -98,6 +99,9 @@ func resolveSubtitles(meta api.UploadSubject) []string {
 }
 
 func resolveTags(meta api.UploadSubject) string {
+	if meta.EffectiveMetadata.GenresProvenance.IsManual() {
+		return strings.TrimSpace(strings.ToLower(strings.ReplaceAll(trackers.PreferredGenreText(meta, ""), ", ", ",")))
+	}
 	if meta.ProviderMetadata.TMDB != nil {
 		return strings.TrimSpace(strings.ToLower(strings.ReplaceAll(meta.ProviderMetadata.TMDB.Genres, ", ", ",")))
 	}

--- a/internal/trackers/impl/standalone/gpw/upload.go
+++ b/internal/trackers/impl/standalone/gpw/upload.go
@@ -339,13 +339,14 @@ func resolveIdentifier(meta api.UploadSubject) string {
 }
 
 func resolveYear(meta api.UploadSubject) int {
-	if meta.ProviderMetadata.TMDB != nil && meta.ProviderMetadata.TMDB.Year > 0 {
-		return meta.ProviderMetadata.TMDB.Year
+	provider := 0
+	if meta.ProviderMetadata.TMDB != nil {
+		provider = meta.ProviderMetadata.TMDB.Year
 	}
-	if meta.ProviderMetadata.IMDB != nil && meta.ProviderMetadata.IMDB.Year > 0 {
-		return meta.ProviderMetadata.IMDB.Year
+	if provider == 0 && meta.ProviderMetadata.IMDB != nil {
+		provider = meta.ProviderMetadata.IMDB.Year
 	}
-	return meta.Release.Year
+	return trackers.PreferredYear(meta, provider)
 }
 
 func onOff(value bool) string {

--- a/internal/trackers/impl/standalone/gpw/upload_test.go
+++ b/internal/trackers/impl/standalone/gpw/upload_test.go
@@ -37,3 +37,20 @@ func TestBuildFieldsPersonalReleaseAndExclusiveFlags(t *testing.T) {
 		t.Fatalf("did not expect diy for disc personal release, got %#v", disc)
 	}
 }
+
+func TestResolveTagsPreservesAutomaticTMDBPresenceAndManualFacts(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{Release: api.ReleaseInfo{Genre: "Release"}, ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{Genres: ""}}}
+	if got := resolveTags(meta); got != "" {
+		t.Fatalf("blank TMDB tags = %q", got)
+	}
+	meta.ProviderMetadata.TMDB = nil
+	if got := resolveTags(meta); got != "release" {
+		t.Fatalf("release tags = %q", got)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{Genres: []string{"Manual Genre"}, GenresProvenance: api.FactProvenanceManual}
+	if got := resolveTags(meta); got != "manual genre" {
+		t.Fatalf("manual tags = %q", got)
+	}
+}

--- a/internal/trackers/impl/standalone/hdb/dupe.go
+++ b/internal/trackers/impl/standalone/hdb/dupe.go
@@ -85,7 +85,7 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 	}
 	if request.IMDB == nil && request.TVDB == nil {
 		workScope = dupe.WorkScopeTitle
-		query := firstHDBText(meta.Release.Title, dupe.ProjectedSearchName(meta), meta.ReleaseName, meta.Filename)
+		query := meta.EffectiveMetadata.PreferredTitle(firstHDBText(meta.Release.Title, dupe.ProjectedSearchName(meta), meta.ReleaseName, meta.Filename))
 		if query == "" {
 			s.logger.Warnf("dupechecking: HDB missing imdb/tvdb IDs and search text for %s", meta.SourcePath)
 			return dupe.NotRun(dupe.NotRunMissingMetadata, "missing imdb/tvdb id for HDB dupe search", nil)
@@ -349,5 +349,5 @@ func isHDBDupeTVCategory(meta api.DuplicateSubject) bool {
 }
 
 func hdbDupeCategoryID(meta api.DuplicateSubject) int {
-	return resolveHDBCategoryID(meta.SourcePath, meta.Identity, meta.ProviderMetadata)
+	return resolveHDBCategoryID(meta.SourcePath, meta.Identity, meta.ProviderMetadata, meta.EffectiveMetadata)
 }

--- a/internal/trackers/impl/standalone/hdb/dupe_integration_test.go
+++ b/internal/trackers/impl/standalone/hdb/dupe_integration_test.go
@@ -417,6 +417,47 @@ func TestHDBHandlerSearchFallsBackToTextSearchWhenIDsMissing(t *testing.T) {
 	}
 }
 
+func TestHDBHandlerTitleFallbackHonorsManualTitle(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	handler := &dupeSearcher{
+		cfg: config.Config{Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"HDB": {Username: "user", Passkey: "pk"},
+		}}},
+		http: &http.Client{Transport: hdbRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requests++
+			var payload map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			if got := hdbTestString(payload["search"]); got != "Projected Release" {
+				t.Fatalf("automatic HDB search title = %q", got)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"status":0,"data":[]}`)),
+				Header:     make(http.Header),
+			}, nil
+		})},
+		logger:   api.NopLogger{},
+		endpoint: "https://hdbits.org/api/torrents",
+		maxPages: 1,
+	}
+	projection := &api.TrackerReleaseProjection{DuplicateCriteria: api.TrackerDuplicateCriteria{Name: "Projected Release"}}
+	manualEmpty := api.DuplicateSubject{
+		Projection:        projection,
+		EffectiveMetadata: api.EffectiveMetadata{TitleProvenance: api.FactProvenanceManualEmpty},
+	}
+	result := handler.Search(t.Context(), manualEmpty)
+	if result.Disposition() != dupe.DispositionNotRun || result.Code() != dupe.NotRunMissingMetadata || requests != 0 {
+		t.Fatalf("manual-empty HDB result=%v code=%q requests=%d", result.Disposition(), result.Code(), requests)
+	}
+	if result := handler.Search(t.Context(), api.DuplicateSubject{Projection: projection}); result.Disposition() != dupe.DispositionResolved || requests != 1 {
+		t.Fatalf("automatic HDB result=%v requests=%d", result.Disposition(), requests)
+	}
+}
+
 func TestHDBHandlerSearchUsesTVDBWhenIMDbMissing(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()

--- a/internal/trackers/impl/standalone/hdb/name.go
+++ b/internal/trackers/impl/standalone/hdb/name.go
@@ -75,6 +75,9 @@ func isGeneratedHDBReleaseName(meta api.UploadSubject, name string) bool {
 }
 
 func authoritativeHDBOriginalTitle(meta api.UploadSubject) string {
+	if meta.EffectiveMetadata.OriginalTitleProvenance.IsManual() {
+		return strings.TrimSpace(meta.EffectiveMetadata.OriginalTitle)
+	}
 	metadata := meta.ProviderMetadata.IMDB
 	if metadata == nil || meta.Identity.IMDBID <= 0 || metadata.IMDBID != meta.Identity.IMDBID ||
 		!hdbProviderMetadataCurrent(meta) {
@@ -139,11 +142,12 @@ func hdbCategory(meta api.UploadSubject) string {
 }
 
 func hdbIMDbYear(meta api.UploadSubject) string {
-	if meta.ProviderMetadata.IMDB != nil && meta.ProviderMetadata.IMDB.Year > 0 {
-		return strconv.Itoa(meta.ProviderMetadata.IMDB.Year)
+	provider := 0
+	if meta.ProviderMetadata.IMDB != nil {
+		provider = meta.ProviderMetadata.IMDB.Year
 	}
-	if meta.Release.Year > 0 {
-		return strconv.Itoa(meta.Release.Year)
+	if year := trackers.PreferredYear(meta, provider); year > 0 {
+		return strconv.Itoa(year)
 	}
 	return ""
 }

--- a/internal/trackers/impl/standalone/hdb/name_test.go
+++ b/internal/trackers/impl/standalone/hdb/name_test.go
@@ -184,3 +184,36 @@ func TestHDBReleaseNamePolicyRejectsStaleIMDbOriginalTitle(t *testing.T) {
 		t.Fatalf("stale IMDb error = %v", err)
 	}
 }
+
+func TestHDBReleaseNamePolicyHonorsManualOriginalTitle(t *testing.T) {
+	t.Parallel()
+
+	const generated = "Example.Release.2026.1080p.WEB-DL.H.264-GRP"
+	meta := api.UploadSubject{
+		ReleaseName: generated,
+		GeneratedReleaseNames: api.GeneratedReleaseNameVariants{
+			IncludeEpisodeTitle: api.ReleaseNameVariant{Name: generated},
+		},
+		Identity:   api.ExternalIdentity{Category: api.CanonicalCategoryMovie},
+		Release:    api.ReleaseInfo{Year: 2026, Resolution: "1080p"},
+		Source:     "WEB-DL",
+		VideoCodec: "H.264",
+		EffectiveMetadata: api.EffectiveMetadata{
+			OriginalTitle:           "Manual Original",
+			OriginalTitleProvenance: api.FactProvenanceManual,
+		},
+	}
+	resolved, err := Profile().ReleaseNamePolicy.Resolver(trackers.ReleaseNameInput{Subject: meta})
+	if err != nil {
+		t.Fatalf("resolve manual HDB name: %v", err)
+	}
+	if !strings.HasPrefix(resolved.Upload, "Manual Original 2026") {
+		t.Fatalf("manual HDB name = %q", resolved.Upload)
+	}
+
+	meta.EffectiveMetadata = api.EffectiveMetadata{OriginalTitleProvenance: api.FactProvenanceManualEmpty}
+	_, err = Profile().ReleaseNamePolicy.Resolver(trackers.ReleaseNameInput{Subject: meta})
+	if err == nil || !strings.Contains(err.Error(), "current matching IMDb original title") {
+		t.Fatalf("manual empty original title error = %v", err)
+	}
+}

--- a/internal/trackers/impl/standalone/hdb/taxonomy.go
+++ b/internal/trackers/impl/standalone/hdb/taxonomy.go
@@ -17,38 +17,52 @@ func isHDBTVCategory(meta api.UploadSubject) bool {
 }
 
 func hdbCategoryID(meta api.UploadSubject) int {
-	return resolveHDBCategoryID(meta.SourcePath, meta.Identity, meta.ProviderMetadata)
+	return resolveHDBCategoryID(meta.SourcePath, meta.Identity, meta.ProviderMetadata, meta.EffectiveMetadata)
 }
 
-// resolveHDBCategoryID uses matching, current IMDb genres for documentaries in
-// either canonical category and TVDB genres as additional TV evidence. IMDb
-// metadata also identifies movie concert subtypes before the canonical fallback.
-func resolveHDBCategoryID(sourcePath string, identity api.ExternalIdentity, metadata api.SourceScopedMetadata) int {
+// resolveHDBCategoryID uses manual genres before matching, current provider
+// genres. IMDb type evidence independently identifies movie concert subtypes.
+func resolveHDBCategoryID(
+	sourcePath string,
+	identity api.ExternalIdentity,
+	metadata api.SourceScopedMetadata,
+	effective api.EffectiveMetadata,
+) int {
 	category, err := identity.RequireCategory()
 	if err != nil {
 		return 0
 	}
+	manualGenres := effective.GenresProvenance.IsManual()
+	if manualGenres && hdbHasGenre(strings.Join(effective.Genres, ","), "documentary") {
+		return 3
+	}
 
 	if metadata.IsCurrentFor(sourcePath, identity) {
+		genres := func(providerGenres string) string {
+			if manualGenres {
+				return strings.Join(effective.Genres, ",")
+			}
+			return providerGenres
+		}
 		imdb := metadata.IMDB
 		imdbMatches := imdb != nil && identity.IMDBID > 0 && imdb.IMDBID == identity.IMDBID
 		switch category {
 		case api.CanonicalCategoryMovie:
 			if imdbMatches {
-				if hdbHasGenre(imdb.Genres, "documentary") {
+				if hdbHasGenre(genres(imdb.Genres), "documentary") {
 					return 3
 				}
 				imdbType := strings.ToLower(strings.TrimSpace(imdb.Type))
-				if strings.Contains(imdbType, "concert") || (strings.Contains(imdbType, "video") && hdbHasGenre(imdb.Genres, "music")) {
+				if strings.Contains(imdbType, "concert") || (strings.Contains(imdbType, "video") && hdbHasGenre(genres(imdb.Genres), "music")) {
 					return 4
 				}
 			}
 		case api.CanonicalCategoryTV:
-			if imdbMatches && hdbHasGenre(imdb.Genres, "documentary") {
+			if imdbMatches && hdbHasGenre(genres(imdb.Genres), "documentary") {
 				return 3
 			}
 			tvdb := metadata.TVDB
-			if tvdb != nil && identity.TVDBID > 0 && tvdb.TVDBID == identity.TVDBID && hdbHasGenre(tvdb.Genres, "documentary") {
+			if tvdb != nil && identity.TVDBID > 0 && tvdb.TVDBID == identity.TVDBID && hdbHasGenre(genres(tvdb.Genres), "documentary") {
 				return 3
 			}
 		case api.CanonicalCategoryUnknown:

--- a/internal/trackers/impl/standalone/hdb/taxonomy_test.go
+++ b/internal/trackers/impl/standalone/hdb/taxonomy_test.go
@@ -33,10 +33,11 @@ func TestHDBCategoryIDs(t *testing.T) {
 	const sourcePath = "Example.Release.2026.mkv"
 
 	tests := []struct {
-		name     string
-		identity api.ExternalIdentity
-		metadata api.SourceScopedMetadata
-		want     int
+		name      string
+		identity  api.ExternalIdentity
+		metadata  api.SourceScopedMetadata
+		effective api.EffectiveMetadata
+		want      int
 	}{
 		{
 			name: "movie documentary from IMDb",
@@ -50,6 +51,76 @@ func TestHDBCategoryIDs(t *testing.T) {
 				IMDB:       &api.IMDBMetadata{IMDBID: 1234567, Genres: "Drama, Documentary"},
 			},
 			want: 3,
+		},
+		{
+			name: "manual drama suppresses IMDb documentary",
+			identity: api.ExternalIdentity{
+				SourcePath: sourcePath,
+				Category:   api.CanonicalCategoryMovie,
+				IMDBID:     1234567,
+			},
+			metadata: api.SourceScopedMetadata{
+				SourcePath: sourcePath,
+				IMDB:       &api.IMDBMetadata{IMDBID: 1234567, Genres: "Documentary"},
+			},
+			effective: api.EffectiveMetadata{Genres: []string{"Drama"}, GenresProvenance: api.FactProvenanceManual},
+			want:      1,
+		},
+		{
+			name: "manual empty suppresses IMDb documentary",
+			identity: api.ExternalIdentity{
+				SourcePath: sourcePath,
+				Category:   api.CanonicalCategoryMovie,
+				IMDBID:     1234567,
+			},
+			metadata: api.SourceScopedMetadata{
+				SourcePath: sourcePath,
+				IMDB:       &api.IMDBMetadata{IMDBID: 1234567, Genres: "Documentary"},
+			},
+			effective: api.EffectiveMetadata{GenresProvenance: api.FactProvenanceManualEmpty},
+			want:      1,
+		},
+		{
+			name: "manual documentary overrides raw drama",
+			identity: api.ExternalIdentity{
+				SourcePath: sourcePath,
+				Category:   api.CanonicalCategoryMovie,
+				IMDBID:     1234567,
+			},
+			metadata: api.SourceScopedMetadata{
+				SourcePath: sourcePath,
+				IMDB:       &api.IMDBMetadata{IMDBID: 1234567, Genres: "Drama"},
+			},
+			effective: api.EffectiveMetadata{Genres: []string{"Documentary"}, GenresProvenance: api.FactProvenanceManual},
+			want:      3,
+		},
+		{
+			name: "manual documentary applies without provider metadata",
+			identity: api.ExternalIdentity{
+				SourcePath: sourcePath,
+				Category:   api.CanonicalCategoryMovie,
+				IMDBID:     1234567,
+			},
+			effective: api.EffectiveMetadata{Genres: []string{"Documentary"}, GenresProvenance: api.FactProvenanceManual},
+			want:      3,
+		},
+		{
+			name: "manual empty preserves IMDb concert type",
+			identity: api.ExternalIdentity{
+				SourcePath: sourcePath,
+				Category:   api.CanonicalCategoryMovie,
+				IMDBID:     1234567,
+			},
+			metadata: api.SourceScopedMetadata{
+				SourcePath: sourcePath,
+				IMDB: &api.IMDBMetadata{
+					IMDBID: 1234567,
+					Type:   "Concert",
+					Genres: "Music",
+				},
+			},
+			effective: api.EffectiveMetadata{GenresProvenance: api.FactProvenanceManualEmpty},
+			want:      4,
 		},
 		{
 			name: "TV documentary from TVDB",
@@ -192,16 +263,18 @@ func TestHDBCategoryIDs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := hdbCategoryID(api.UploadSubject{
-				SourcePath:       sourcePath,
-				Identity:         tt.identity,
-				ProviderMetadata: tt.metadata,
+				SourcePath:        sourcePath,
+				Identity:          tt.identity,
+				ProviderMetadata:  tt.metadata,
+				EffectiveMetadata: tt.effective,
 			}); got != tt.want {
 				t.Fatalf("upload category ID = %d, want %d", got, tt.want)
 			}
 			if got := hdbDupeCategoryID(api.DuplicateSubject{
-				SourcePath:       sourcePath,
-				Identity:         tt.identity,
-				ProviderMetadata: tt.metadata,
+				SourcePath:        sourcePath,
+				Identity:          tt.identity,
+				ProviderMetadata:  tt.metadata,
+				EffectiveMetadata: tt.effective,
 			}); got != tt.want {
 				t.Fatalf("duplicate-search category ID = %d, want %d", got, tt.want)
 			}

--- a/internal/trackers/impl/standalone/hdb/validation_test.go
+++ b/internal/trackers/impl/standalone/hdb/validation_test.go
@@ -94,6 +94,31 @@ func TestHDBValidationPolicyVersion(t *testing.T) {
 	}
 }
 
+func TestHDBValidationHonorsManualOriginalTitle(t *testing.T) {
+	t.Parallel()
+
+	subject := hdbPassingSubject()
+	subject.SourcePath = "source.mkv"
+	subject.ReleaseName = "Generated Release 2026 1080p-GRP"
+	subject.EffectiveMetadata = api.EffectiveMetadata{OriginalTitle: "Manual Original", OriginalTitleProvenance: api.FactProvenanceManual}
+	failures, err := validationPolicy().Check(context.Background(), subject, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("validate manual original title: %v", err)
+	}
+	for _, failure := range failures {
+		if failure.Rule == "hdb_title_prohibition" {
+			t.Fatalf("manual original title must construct validation name: %#v", failures)
+		}
+	}
+
+	subject.EffectiveMetadata = api.EffectiveMetadata{OriginalTitleProvenance: api.FactProvenanceManualEmpty}
+	failures, err = validationPolicy().Check(context.Background(), subject, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("validate manual empty original title: %v", err)
+	}
+	requireHDBValidationFailure(t, failures, "hdb_title_prohibition", api.RuleDispositionAdvisory, api.MetadataEvidenceStatusUnavailable)
+}
+
 func TestHDBTitleProhibitedElements(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/trackers/impl/standalone/hds/taxonomy.go
+++ b/internal/trackers/impl/standalone/hds/taxonomy.go
@@ -6,6 +6,7 @@ package hds
 import (
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -57,6 +58,9 @@ func resolveCategoryID(meta api.UploadSubject) int {
 }
 
 func resolveGenres(meta api.UploadSubject) string {
+	if meta.EffectiveMetadata.GenresProvenance.IsManual() {
+		return trackers.PreferredGenreText(meta, "")
+	}
 	switch {
 	case meta.ProviderMetadata.TMDB != nil:
 		return strings.TrimSpace(meta.ProviderMetadata.TMDB.Genres)

--- a/internal/trackers/impl/standalone/hds/upload_test.go
+++ b/internal/trackers/impl/standalone/hds/upload_test.go
@@ -3,7 +3,11 @@
 
 package hds
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
 
 func TestSupportsHDSResolution(t *testing.T) {
 	t.Parallel()
@@ -44,5 +48,26 @@ func TestSupportsHDSResolution(t *testing.T) {
 		if got := supportsHDSResolution(tc.resolution); got != tc.expected {
 			t.Fatalf("%s: expected %t, got %t", tc.name, tc.expected, got)
 		}
+	}
+}
+
+func TestResolveGenresPreservesAutomaticProviderPresenceAndManualFacts(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{Genres: "Action"}, IMDB: &api.IMDBMetadata{Genres: "Drama"}}}
+	if got := resolveGenres(meta); got != "Action" {
+		t.Fatalf("TMDB genres = %q", got)
+	}
+	meta.ProviderMetadata.TMDB.Genres = " \t"
+	if got := resolveGenres(meta); got != "" {
+		t.Fatalf("blank TMDB genres = %q", got)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{Genres: []string{"Comedy"}, GenresProvenance: api.FactProvenanceManual}
+	if got := resolveGenres(meta); got != "Comedy" {
+		t.Fatalf("manual genres = %q", got)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{GenresProvenance: api.FactProvenanceManualEmpty}
+	if got := resolveGenres(meta); got != "" {
+		t.Fatalf("manual empty genres = %q", got)
 	}
 }

--- a/internal/trackers/impl/standalone/hdt/dupe.go
+++ b/internal/trackers/impl/standalone/hdt/dupe.go
@@ -51,7 +51,7 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 		params.Set("options", "2")
 	} else {
 		workScope = dupe.WorkScopeTitle
-		query := metautil.FirstNonEmptyTrimmed(meta.Release.Title, dupe.ProjectedSearchName(meta), meta.ReleaseName)
+		query := meta.EffectiveMetadata.PreferredTitle(metautil.FirstNonEmptyTrimmed(meta.Release.Title, dupe.ProjectedSearchName(meta), meta.ReleaseName))
 		if query == "" {
 			return dupe.NotRun(dupe.NotRunMissingMetadata, "missing title for HDT dupe search", nil)
 		}

--- a/internal/trackers/impl/standalone/is/dupe.go
+++ b/internal/trackers/impl/standalone/is/dupe.go
@@ -60,7 +60,7 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 		params.Set("keywords", providerid.IMDb(meta.Identity.IMDBID).Prefixed())
 	} else {
 		workScope = dupe.WorkScopeTitle
-		query := metautil.FirstNonEmptyTrimmed(meta.Release.Title, dupe.ProjectedSearchName(meta), meta.ReleaseName)
+		query := meta.EffectiveMetadata.PreferredTitle(metautil.FirstNonEmptyTrimmed(meta.Release.Title, dupe.ProjectedSearchName(meta), meta.ReleaseName))
 		if query == "" {
 			return dupe.NotRun(dupe.NotRunMissingMetadata, "missing title for IS dupe search", nil)
 		}

--- a/internal/trackers/impl/standalone/is/taxonomy.go
+++ b/internal/trackers/impl/standalone/is/taxonomy.go
@@ -6,6 +6,7 @@ package is
 import (
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -96,6 +97,9 @@ func hasEnglishAudio(meta api.UploadSubject) bool {
 }
 
 func resolveGenres(meta api.UploadSubject) string {
+	if meta.EffectiveMetadata.GenresProvenance.IsManual() {
+		return trackers.PreferredGenreText(meta, "")
+	}
 	if meta.ProviderMetadata.TMDB != nil {
 		return strings.TrimSpace(meta.ProviderMetadata.TMDB.Genres)
 	}

--- a/internal/trackers/impl/standalone/is/upload_test.go
+++ b/internal/trackers/impl/standalone/is/upload_test.go
@@ -3,7 +3,11 @@
 
 package is
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
 
 func TestSuccessfulUploadResponseExtractsTorrentID(t *testing.T) {
 	id, ok := successfulUploadResponse("https://immortalseed.me/details.php?hash=abc123", "")
@@ -29,5 +33,24 @@ func TestSuccessfulUploadResponseRejectsMissingSuccessSignals(t *testing.T) {
 	id, ok := successfulUploadResponse("https://immortalseed.me/upload.php", "<html>failed</html>")
 	if ok {
 		t.Fatalf("expected upload failure, got id %q", id)
+	}
+}
+
+func TestResolveGenresPreservesAutomaticTMDBPresenceAndManualFacts(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{Release: api.ReleaseInfo{Genre: "Release"}, ProviderMetadata: api.SourceScopedMetadata{
+		TMDB: &api.TMDBMetadata{Genres: ""}, IMDB: &api.IMDBMetadata{Genres: "IMDb"},
+	}}
+	if got := resolveGenres(meta); got != "" {
+		t.Fatalf("blank TMDB genres = %q", got)
+	}
+	meta.ProviderMetadata.TMDB = nil
+	if got := resolveGenres(meta); got != "IMDb" {
+		t.Fatalf("IMDb genres = %q", got)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{Genres: []string{"Manual"}, GenresProvenance: api.FactProvenanceManual}
+	if got := resolveGenres(meta); got != "Manual" {
+		t.Fatalf("manual genres = %q", got)
 	}
 }

--- a/internal/trackers/impl/standalone/nbl/dupe.go
+++ b/internal/trackers/impl/standalone/nbl/dupe.go
@@ -63,6 +63,7 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 		if searchName == "" {
 			searchName = dupe.ProjectedSearchName(meta)
 		}
+		searchName = meta.EffectiveMetadata.PreferredTitle(searchName)
 		if searchName == "" {
 			return dupe.NotRun(dupe.NotRunMissingMetadata, "missing tvmaze/imdb/title for NBL dupe search", nil)
 		}

--- a/internal/trackers/impl/standalone/nbl/dupe_test.go
+++ b/internal/trackers/impl/standalone/nbl/dupe_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackers/dupe"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -189,6 +190,36 @@ func TestNBLSearchUsesTagsAndTraversesAllPages(t *testing.T) {
 	}
 	if !entries[0].Pack || entries[0].Season != 1 || entries[1].Pack || entries[1].Episode != 1 {
 		t.Fatalf("NBL candidate coordinates = %#v", entries)
+	}
+}
+
+func TestNBLTitleFallbackHonorsManualTitle(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests++
+		if got := request.URL.Query().Get("release"); got != "Projected Release" {
+			t.Errorf("automatic NBL search title = %q", got)
+		}
+		_, _ = io.WriteString(response, `{"current_page":0,"total_pages":0,"count":0,"total_results":0,"items":[]}`)
+	}))
+	defer server.Close()
+
+	searcher := &dupeSearcher{
+		cfg:      config.Config{Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{"NBL": {APIKey: "synthetic-token"}}}},
+		http:     server.Client(),
+		endpoint: server.URL,
+		maxPages: 1,
+	}
+	projection := &api.TrackerReleaseProjection{DuplicateCriteria: api.TrackerDuplicateCriteria{Name: "Projected Release"}}
+	result := searcher.Search(t.Context(), api.DuplicateSubject{
+		Projection:        projection,
+		EffectiveMetadata: api.EffectiveMetadata{TitleProvenance: api.FactProvenanceManualEmpty},
+	})
+	if result.Disposition() != dupe.DispositionNotRun || result.Code() != dupe.NotRunMissingMetadata || requests != 0 {
+		t.Fatalf("manual-empty NBL result=%v code=%q requests=%d", result.Disposition(), result.Code(), requests)
+	}
+	if result := searcher.Search(t.Context(), api.DuplicateSubject{Projection: projection}); result.Disposition() != dupe.DispositionResolved || requests != 1 {
+		t.Fatalf("automatic NBL result=%v requests=%d", result.Disposition(), requests)
 	}
 }
 

--- a/internal/trackers/impl/standalone/ptp/definition.go
+++ b/internal/trackers/impl/standalone/ptp/definition.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/autobrr/upbrr/internal/config"
 	"github.com/autobrr/upbrr/internal/trackers"
+	"github.com/autobrr/upbrr/internal/trackers/impl/standalone"
+	"github.com/autobrr/upbrr/pkg/api"
 )
 
 // DataLookupConfigured reports whether PTP metadata lookup credentials are available.
@@ -21,6 +23,78 @@ func (d *Definition) DataLookupConfigured(cfg config.Config) bool {
 		}
 	}
 	return false
+}
+
+// InputSchema exposes PTP's fact-bound No English Subtitles intent before
+// projection. Auto leaves the final subtitle evidence authoritative.
+func (d *Definition) InputSchema(meta api.UploadSubject) *api.TrackerQuestionnaire {
+	value := strings.ToLower(strings.TrimSpace(standalone.QuestionnaireAnswers(meta, "PTP")["no_english_subtitles"]))
+	if value == "" {
+		value = "auto"
+	}
+	return &api.TrackerQuestionnaire{Tracker: "PTP", Fields: []api.TrackerQuestionnaireField{{
+		Key:     "no_english_subtitles",
+		Label:   "No English Subtitles",
+		Kind:    "select",
+		Options: []string{"auto", "yes", "no"},
+		Value:   value,
+		Help:    "Auto uses finalized subtitle and hardcoded-subtitle languages.",
+	}}}
+}
+
+// InputReadiness validates PTP's fact-bound hardcoded and subtitle intent.
+func (d *Definition) InputReadiness(meta api.UploadSubject) []api.InputReadinessFieldOutcome {
+	if !meta.HardcodedSubs {
+		return validateNoEnglishSubtitles(meta)
+	}
+	if len(meta.HardcodedSubtitleLanguages) == 0 {
+		field := api.CorrectionFieldMetadataHardcodedSubtitleLanguages
+		return append([]api.InputReadinessFieldOutcome{{
+			Key:             "metadata.hardcoded_subtitle_languages",
+			CorrectionField: &field,
+			Status:          api.InputReadinessFieldMissing,
+			Disposition:     api.RuleDispositionStrict,
+			Message:         "PTP requires hardcoded subtitle languages when hardcoded subtitles are enabled",
+		}}, validateNoEnglishSubtitles(meta)...)
+	}
+	for _, language := range meta.HardcodedSubtitleLanguages {
+		if _, ok := subtitleIDs[strings.ToLower(strings.TrimSpace(language))]; !ok {
+			field := api.CorrectionFieldMetadataHardcodedSubtitleLanguages
+			return append([]api.InputReadinessFieldOutcome{{
+				Key:             "metadata.hardcoded_subtitle_languages",
+				CorrectionField: &field,
+				Status:          api.InputReadinessFieldInvalid,
+				Disposition:     api.RuleDispositionStrict,
+				Message:         "PTP does not support one or more hardcoded subtitle languages",
+			}}, validateNoEnglishSubtitles(meta)...)
+		}
+	}
+	return validateNoEnglishSubtitles(meta)
+}
+
+func validateNoEnglishSubtitles(meta api.UploadSubject) []api.InputReadinessFieldOutcome {
+	value := strings.ToLower(strings.TrimSpace(standalone.QuestionnaireAnswers(meta, "PTP")["no_english_subtitles"]))
+	if value == "" || value == "auto" || value == "no" {
+		return nil
+	}
+	if value != "yes" {
+		return []api.InputReadinessFieldOutcome{{
+			Key:         "tracker_input.no_english_subtitles",
+			Status:      api.InputReadinessFieldInvalid,
+			Disposition: api.RuleDispositionStrict,
+			Message:     "PTP No English Subtitles must be auto, yes, or no",
+		}}
+	}
+	allSubtitles := append(append([]string(nil), meta.SubtitleLanguages...), meta.HardcodedSubtitleLanguages...)
+	if ptpHasEnglishLanguage(allSubtitles) {
+		return []api.InputReadinessFieldOutcome{{
+			Key:         "tracker_input.no_english_subtitles",
+			Status:      api.InputReadinessFieldInvalid,
+			Disposition: api.RuleDispositionStrict,
+			Message:     "PTP No English Subtitles conflicts with finalized English subtitle evidence",
+		}}
+	}
+	return nil
 }
 func prepareDescription(ctx context.Context, req trackers.PreparationInput) (trackers.DescriptionResult, error) {
 	select {

--- a/internal/trackers/impl/standalone/ptp/definition_test.go
+++ b/internal/trackers/impl/standalone/ptp/definition_test.go
@@ -148,6 +148,7 @@ func TestPTPFreshUploadTaxonomy(t *testing.T) {
 		Source:            "Web",
 		VideoCodec:        "HEVC",
 		HasEncodeSettings: true,
+		HardcodedSubs:     true,
 		ReleaseName:       "Example.Release.2026.1440p.WEB-DL.x265.HARDSUB-GRP",
 		FileList:          []string{"Example.Release.2026.1440p.WEB-DL.x265.HARDSUB-GRP.mkv"},
 		Release: api.ReleaseInfo{
@@ -184,11 +185,13 @@ func TestPTPFreshUploadTaxonomy(t *testing.T) {
 	if got := resolveTags(meta); got != "sci.fi, mystery" {
 		t.Fatalf("tags=%q", got)
 	}
+	meta.HardcodedSubs = true
 	meta.ReleaseName = "Example.Release.2026.1080p.WEB-DL.x265.HARDSUB.FORCED-GRP"
 	if got := resolveTrumpable(meta); len(got) != 1 || got[0] != 4 {
 		t.Fatalf("forced hardcoded trumpable=%#v", got)
 	}
 	meta.ReleaseName = "Example.Release.2026.1080p.WEB-DL.x265-GRP"
+	meta.HardcodedSubs = false
 	meta.FileList = nil
 	meta.AudioLanguages = []string{"Japanese"}
 	meta.SubtitleLanguages = []string{"French"}
@@ -196,6 +199,7 @@ func TestPTPFreshUploadTaxonomy(t *testing.T) {
 		t.Fatalf("no-English trumpable=%#v", got)
 	}
 	meta.ReleaseName = "Example.Release.2026.1080p.WEB-DL.x265.HARDSUB-GRP"
+	meta.HardcodedSubs = true
 	if got := resolveTrumpable(meta); len(got) != 2 || got[0] != 4 || got[1] != 14 {
 		t.Fatalf("hardcoded no-English trumpable=%#v", got)
 	}
@@ -215,9 +219,10 @@ func TestPTPHardcodedSubtitleQuestionnaire(t *testing.T) {
 	t.Parallel()
 
 	meta := api.UploadSubject{
-		ReleaseName: "Example.Release.2026.1080p.WEB-DL.x265.HARDSUB-GRP",
-		Release:     api.ReleaseInfo{Resolution: "1080p"},
-		Container:   "mkv",
+		ReleaseName:   "Example.Release.2026.1080p.WEB-DL.x265.HARDSUB-GRP",
+		HardcodedSubs: true,
+		Release:       api.ReleaseInfo{Resolution: "1080p"},
+		Container:     "mkv",
 	}
 	questionnaire := buildQuestionnaire(meta, "123")
 	if questionnaire == nil || len(questionnaire.Fields) != 1 || questionnaire.Fields[0].Key != "hardcoded_subtitle_languages" {
@@ -234,6 +239,103 @@ func TestPTPHardcodedSubtitleQuestionnaire(t *testing.T) {
 	}
 	if fields["subtitles[]"] != "50" || fields["trumpable[]"] != "4" {
 		t.Fatalf("hardcoded fields=%#v", fields)
+	}
+}
+
+func TestPTPInputReadinessUsesFinalizedHardcodedLanguages(t *testing.T) {
+	t.Parallel()
+
+	definition := New()
+	missing := definition.InputReadiness(api.UploadSubject{HardcodedSubs: true})
+	if len(missing) != 1 || missing[0].Status != api.InputReadinessFieldMissing || missing[0].Key != "metadata.hardcoded_subtitle_languages" {
+		t.Fatalf("missing=%#v", missing)
+	}
+	invalid := definition.InputReadiness(api.UploadSubject{
+		HardcodedSubs:               true,
+		HardcodedSubtitleLanguages:  []string{"English"},
+		TrackerQuestionnaireAnswers: map[string]map[string]string{"PTP": {"no_english_subtitles": "yes"}},
+	})
+	if len(invalid) != 1 || invalid[0].Status != api.InputReadinessFieldInvalid || invalid[0].Key != "tracker_input.no_english_subtitles" {
+		t.Fatalf("invalid=%#v", invalid)
+	}
+	if schema := definition.InputSchema(api.UploadSubject{}); schema == nil || len(schema.Fields) != 1 || schema.Fields[0].Value != "auto" ||
+		len(schema.Fields[0].Options) != 3 {
+		t.Fatalf("schema=%#v", schema)
+	}
+}
+
+func TestPTPUploadNoEnglishSubtitlesAnswerControlsTrumpable(t *testing.T) {
+	t.Parallel()
+
+	base := api.UploadSubject{
+		Release:   api.ReleaseInfo{Resolution: "1080p"},
+		Container: "mkv",
+	}
+	tests := []struct {
+		name   string
+		meta   api.UploadSubject
+		answer string
+		want   string
+	}{
+		{
+			name: "auto retains finalized foreign audio heuristic",
+			meta: api.UploadSubject{
+				Release:        api.ReleaseInfo{Resolution: "1080p"},
+				Container:      "mkv",
+				AudioLanguages: []string{"Japanese"},
+			},
+			answer: "auto",
+			want:   "14",
+		},
+		{
+			name:   "yes adds trumpable without audio evidence",
+			meta:   base,
+			answer: "yes",
+			want:   "14",
+		},
+		{
+			name: "no suppresses finalized foreign audio heuristic",
+			meta: api.UploadSubject{
+				Release:        api.ReleaseInfo{Resolution: "1080p"},
+				Container:      "mkv",
+				AudioLanguages: []string{"Japanese"},
+			},
+			answer: "no",
+			want:   "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.meta.TrackerQuestionnaireAnswers = map[string]map[string]string{"PTP": {"no_english_subtitles": test.answer}}
+			fields, err := buildUploadFields(test.meta, "description", "123", map[string]string{"no_english_subtitles": test.answer}, "")
+			if err != nil {
+				t.Fatalf("build upload fields: %v", err)
+			}
+			if got := fields["trumpable[]"]; got != test.want {
+				t.Fatalf("trumpable = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPTPUploadUsesPreparedHardcodedLanguages(t *testing.T) {
+	meta := api.UploadSubject{
+		HardcodedSubs:              true,
+		HardcodedSubtitleLanguages: []string{"English"},
+		Release:                    api.ReleaseInfo{Resolution: "1080p"},
+		Container:                  "mkv",
+	}
+	if questionnaire := buildQuestionnaire(meta, "123"); questionnaire != nil {
+		t.Fatalf("prepared languages still require input: %#v", questionnaire)
+	}
+	for _, answers := range []map[string]string{nil, {"hardcoded_subtitle_languages": "French"}} {
+		fields, err := buildUploadFields(meta, "description", "123", answers, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fields["subtitles[]"] != "3" || fields["trumpable[]"] != "4" {
+			t.Fatalf("prepared hardcoded language lost: %#v", fields)
+		}
 	}
 }
 

--- a/internal/trackers/impl/standalone/ptp/questionnaire.go
+++ b/internal/trackers/impl/standalone/ptp/questionnaire.go
@@ -56,7 +56,7 @@ func buildQuestionnaire(meta api.UploadSubject, groupID string) *api.TrackerQues
 			Required: false,
 		})
 	}
-	if hasHardcodedSubtitles(meta) {
+	if hasHardcodedSubtitles(meta) && len(meta.HardcodedSubtitleLanguages) == 0 {
 		fields = append(fields, api.TrackerQuestionnaireField{
 			Key:         "hardcoded_subtitle_languages",
 			Label:       "Hardcoded Subtitle Languages",

--- a/internal/trackers/impl/standalone/ptp/taxonomy.go
+++ b/internal/trackers/impl/standalone/ptp/taxonomy.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/trackers"
+	"github.com/autobrr/upbrr/internal/trackers/impl/standalone"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -174,12 +176,13 @@ func resolveSource(source string) string {
 }
 
 func resolveSubtitles(meta api.UploadSubject) []int {
-	if len(meta.SubtitleLanguages) == 0 {
+	languages := append(append([]string(nil), meta.SubtitleLanguages...), meta.HardcodedSubtitleLanguages...)
+	if len(languages) == 0 {
 		return []int{44}
 	}
-	ids := make([]int, 0, len(meta.SubtitleLanguages))
+	ids := make([]int, 0, len(languages))
 	seen := make(map[int]struct{})
-	for _, language := range meta.SubtitleLanguages {
+	for _, language := range languages {
 		if value, ok := subtitleIDs[strings.ToLower(strings.TrimSpace(language))]; ok {
 			if _, exists := seen[value]; exists {
 				continue
@@ -196,14 +199,21 @@ func resolveSubtitles(meta api.UploadSubject) []int {
 
 func resolveTags(meta api.UploadSubject) string {
 	values := make([]string, 0, 8)
-	if meta.ProviderMetadata.TMDB != nil {
-		for item := range strings.SplitSeq(meta.ProviderMetadata.TMDB.Genres, ",") {
-			if tag := ptpTag(item); tag != "" {
-				values = append(values, tag)
-			}
+	var genreText string
+	switch {
+	case meta.EffectiveMetadata.GenresProvenance.IsManual():
+		genreText = trackers.PreferredGenreText(meta, "")
+	case meta.ProviderMetadata.TMDB != nil:
+		genreText = meta.ProviderMetadata.TMDB.Genres
+	default:
+		genreText = meta.Release.Genre
+	}
+	for item := range strings.SplitSeq(genreText, ",") {
+		if tag := ptpTag(item); tag != "" {
+			values = append(values, tag)
 		}
 	}
-	if len(values) == 0 && strings.TrimSpace(meta.Release.Genre) != "" {
+	if len(values) == 0 && !meta.EffectiveMetadata.GenresProvenance.IsManual() {
 		for item := range strings.SplitSeq(meta.Release.Genre, ",") {
 			if tag := ptpTag(item); tag != "" {
 				values = append(values, tag)
@@ -253,29 +263,30 @@ func resolveTrumpable(meta api.UploadSubject) []int {
 	if hasHardcodedSubtitles(meta) {
 		values = append(values, 4)
 	}
-	if len(meta.AudioLanguages) > 0 && !ptpEnglishLanguage(meta.AudioLanguages[0]) && !ptpHasEnglishLanguage(meta.SubtitleLanguages) {
+	switch strings.ToLower(strings.TrimSpace(standalone.QuestionnaireAnswers(meta, "PTP")["no_english_subtitles"])) {
+	case "yes":
+		return append(values, 14)
+	case "no":
+		return values
+	}
+	subtitles := append(append([]string(nil), meta.SubtitleLanguages...), meta.HardcodedSubtitleLanguages...)
+	if len(meta.AudioLanguages) > 0 && !ptpEnglishLanguage(meta.AudioLanguages[0]) && !ptpHasEnglishLanguage(subtitles) {
 		values = append(values, 14)
 	}
 	return values
 }
 
 func hasHardcodedSubtitles(meta api.UploadSubject) bool {
-	name := strings.ToLower(strings.Join(append([]string{
-		meta.ReleaseName,
-		meta.ReleaseNameNoTag,
-		meta.Filename,
-	}, meta.FileList...), " "))
-	return strings.Contains(name, "hardsub") || strings.Contains(name, "hard-sub") || strings.Contains(name, "hardcoded")
+	return meta.HardcodedSubs
 }
 
 func withHardcodedSubtitleLanguages(meta api.UploadSubject, value string) (api.UploadSubject, error) {
-	if !hasHardcodedSubtitles(meta) {
+	if !hasHardcodedSubtitles(meta) || len(meta.HardcodedSubtitleLanguages) > 0 {
 		return meta, nil
 	}
 	if strings.TrimSpace(value) == "" {
 		return api.UploadSubject{}, errors.New("trackers: PTP hardcoded subtitle languages are required")
 	}
-	meta.SubtitleLanguages = append([]string(nil), meta.SubtitleLanguages...)
 	for language := range strings.SplitSeq(value, ",") {
 		language = strings.TrimSpace(language)
 		if language == "" {
@@ -284,7 +295,10 @@ func withHardcodedSubtitleLanguages(meta api.UploadSubject, value string) (api.U
 		if _, ok := subtitleIDs[strings.ToLower(language)]; !ok {
 			return api.UploadSubject{}, fmt.Errorf("trackers: PTP unsupported hardcoded subtitle language %q", language)
 		}
-		meta.SubtitleLanguages = append(meta.SubtitleLanguages, language)
+		meta.HardcodedSubtitleLanguages = append(meta.HardcodedSubtitleLanguages, language)
+	}
+	if len(meta.HardcodedSubtitleLanguages) == 0 {
+		return api.UploadSubject{}, errors.New("trackers: PTP hardcoded subtitle languages are required")
 	}
 	return meta, nil
 }

--- a/internal/trackers/impl/standalone/ptp/upload.go
+++ b/internal/trackers/impl/standalone/ptp/upload.go
@@ -552,6 +552,8 @@ func resolveGroupTitleYear(meta api.UploadSubject) (string, string) {
 	if year == 0 {
 		year = meta.Release.Year
 	}
+	title = trackers.PreferredTitle(meta, title)
+	year = trackers.PreferredYear(meta, year)
 	if year == 0 {
 		return title, ""
 	}

--- a/internal/trackers/impl/standalone/ptp/upload_test.go
+++ b/internal/trackers/impl/standalone/ptp/upload_test.go
@@ -709,10 +709,10 @@ func TestSubmitPreparedUploadPreservesLateHTMLFailure(t *testing.T) {
 		t.Context(),
 		trackers.PreparationInput{},
 		uploadState{
-baseURL: server.URL,
- uploadURL: server.URL,
- client: server.Client(),
-},
+			baseURL:   server.URL,
+			uploadURL: server.URL,
+			client:    server.Client(),
+		},
 		nil,
 		"application/octet-stream",
 		"",
@@ -741,4 +741,35 @@ func newPTPAuthDB(t *testing.T) string {
 	}
 	_ = repo.Close()
 	return dbPath
+}
+
+func TestResolveGroupTitleYearPreservesAutomaticProviderPairsAndManualCorrections(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{Year: 2024}, IMDB: &api.IMDBMetadata{Title: "IMDb title", Year: 2023}}}
+	if title, year := resolveGroupTitleYear(meta); title != "IMDb title" || year != "2023" {
+		t.Fatalf("IMDb provider pair = (%q, %q)", title, year)
+	}
+	meta.ProviderMetadata.TMDB.Title = "TMDB title"
+	if title, year := resolveGroupTitleYear(meta); title != "TMDB title" || year != "2024" {
+		t.Fatalf("TMDB title/year = (%q, %q)", title, year)
+	}
+	meta.ProviderMetadata.TMDB.Year = 0
+	meta.Release.Year = 2025
+	if title, year := resolveGroupTitleYear(meta); title != "TMDB title" || year != "2025" {
+		t.Fatalf("TMDB title with release year = (%q, %q)", title, year)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{
+		Title:           "Manual title",
+		Year:            2022,
+		TitleProvenance: api.FactProvenanceManual,
+		YearProvenance:  api.FactProvenanceManual,
+	}
+	if title, year := resolveGroupTitleYear(meta); title != "Manual title" || year != "2022" {
+		t.Fatalf("manual title/year = (%q, %q)", title, year)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{TitleProvenance: api.FactProvenanceManualEmpty, YearProvenance: api.FactProvenanceManualEmpty}
+	if title, year := resolveGroupTitleYear(meta); title != "" || year != "" {
+		t.Fatalf("manual empty title/year = (%q, %q)", title, year)
+	}
 }

--- a/internal/trackers/impl/standalone/rtf/dupe.go
+++ b/internal/trackers/impl/standalone/rtf/dupe.go
@@ -190,6 +190,7 @@ func cleanRTFSearchTitle(meta api.DuplicateSubject) string {
 	if query == "" {
 		query = strings.TrimSpace(meta.ReleaseName)
 	}
+	query = meta.EffectiveMetadata.PreferredTitle(query)
 	if query == "" {
 		return ""
 	}
@@ -300,7 +301,7 @@ func buildRTFDownloadLink(id string) string {
 }
 
 func isRTFContentOldEnough(meta api.DuplicateSubject, now time.Time) bool {
-	return rtfContentAgeEligibility(meta.Release, meta.ProviderMetadata, now) == rtfAgeEligible
+	return rtfContentAgeEligibility(meta.Release, meta.ProviderMetadata, meta.EffectiveMetadata, now) == rtfAgeEligible
 }
 
 func rtfJSONRequest(

--- a/internal/trackers/impl/standalone/rtf/dupe_test.go
+++ b/internal/trackers/impl/standalone/rtf/dupe_test.go
@@ -141,6 +141,32 @@ func TestRTFTitleFallbackRemainsExplicitlyIncomplete(t *testing.T) {
 	}
 }
 
+func TestCleanRTFSearchTitleHonorsManualTitle(t *testing.T) {
+	t.Parallel()
+
+	projection := &api.TrackerReleaseProjection{DuplicateCriteria: api.TrackerDuplicateCriteria{Name: "Projected Release"}}
+	manual := api.DuplicateSubject{
+		Release:    api.ReleaseInfo{Title: "Automatic Release"},
+		Projection: projection,
+		EffectiveMetadata: api.EffectiveMetadata{
+			Title:           "Manual Release",
+			TitleProvenance: api.FactProvenanceManual,
+		},
+	}
+	if got := cleanRTFSearchTitle(manual); got != "Manual Release" {
+		t.Fatalf("manual RTF search title = %q", got)
+	}
+
+	manual.EffectiveMetadata = api.EffectiveMetadata{TitleProvenance: api.FactProvenanceManualEmpty}
+	if got := cleanRTFSearchTitle(manual); got != "" {
+		t.Fatalf("manual-empty RTF search title = %q", got)
+	}
+
+	if got := cleanRTFSearchTitle(api.DuplicateSubject{Projection: projection}); got != "Projected Release" {
+		t.Fatalf("automatic RTF search title = %q", got)
+	}
+}
+
 func TestRTFMalformedTorrentPayloadFails(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/impl/standalone/rtf/rules.go
+++ b/internal/trackers/impl/standalone/rtf/rules.go
@@ -45,7 +45,7 @@ func checkRules(ctx context.Context, meta api.TrackerValidationSubject, _ api.Lo
 }
 
 func minimumContentAgeViolation(meta api.TrackerValidationSubject, now time.Time) bool {
-	return rtfContentAgeEligibility(meta.Release, meta.ProviderMetadata, now) != rtfAgeEligible
+	return rtfContentAgeEligibility(meta.Release, meta.ProviderMetadata, meta.EffectiveMetadata, now) != rtfAgeEligible
 }
 
 type rtfAgeEligibilityVerdict string
@@ -57,13 +57,15 @@ const (
 	rtfAgeIneligibleTooNew          rtfAgeEligibilityVerdict = "too_new"
 )
 
+// rtfContentAgeEligibility retains exact provider dates but not partial provider years when year is manual.
 func rtfContentAgeEligibility(
 	release api.ReleaseInfo,
 	metadata api.SourceScopedMetadata,
+	effective api.EffectiveMetadata,
 	now time.Time,
 ) rtfAgeEligibilityVerdict {
 	cutoff := now.UTC().AddDate(-10, -1, 0)
-	evidence := youngestRTFReleaseEvidence(release, metadata)
+	evidence := youngestRTFReleaseEvidence(release, metadata, effective)
 	if releaseDate, ok := evidence.exactDate(); ok {
 		if releaseDate.After(cutoff) {
 			return rtfAgeIneligibleTooNew
@@ -113,46 +115,65 @@ func (e *rtfReleaseAgeEvidence) exactDate() (time.Time, bool) {
 	return e.date, true
 }
 
-func youngestRTFReleaseEvidence(release api.ReleaseInfo, metadata api.SourceScopedMetadata) rtfReleaseAgeEvidence {
+func youngestRTFReleaseEvidence(
+	release api.ReleaseInfo,
+	metadata api.SourceScopedMetadata,
+	effective api.EffectiveMetadata,
+) rtfReleaseAgeEvidence {
 	var evidence rtfReleaseAgeEvidence
-	addRTFDateParts(&evidence, release.Year, release.Month, release.Day)
+	includePartialYears := !effective.YearProvenance.IsManual()
+	if !includePartialYears {
+		evidence.addYear(effective.Year)
+	}
+	addRTFDateParts(&evidence, release.Year, release.Month, release.Day, includePartialYears)
 
 	if value := metadata.TMDB; value != nil {
-		evidence.addYear(value.Year)
-		addRTFDateText(&evidence, value.ReleaseDate)
-		addRTFDateText(&evidence, value.FirstAirDate)
-		addRTFDateText(&evidence, value.LastAirDate)
+		if includePartialYears {
+			evidence.addYear(value.Year)
+		}
+		addRTFDateText(&evidence, value.ReleaseDate, includePartialYears)
+		addRTFDateText(&evidence, value.FirstAirDate, includePartialYears)
+		addRTFDateText(&evidence, value.LastAirDate, includePartialYears)
 	}
 	if value := metadata.IMDB; value != nil {
-		evidence.addYear(value.Year)
-		evidence.addYear(value.EndYear)
-		evidence.addYear(value.TVYear)
+		if includePartialYears {
+			evidence.addYear(value.Year)
+			evidence.addYear(value.EndYear)
+			evidence.addYear(value.TVYear)
+		}
 		for _, episode := range value.Episodes {
 			addRTFDateParts(
 				&evidence,
 				episode.ReleaseDate.Year,
 				episode.ReleaseDate.Month,
 				episode.ReleaseDate.Day,
+				includePartialYears,
 			)
-			evidence.addYear(episode.ReleaseYear)
+			if includePartialYears {
+				evidence.addYear(episode.ReleaseYear)
+			}
 		}
 	}
 	if value := metadata.TVDB; value != nil {
-		evidence.addYear(value.Year)
-		addRTFDateText(&evidence, value.FirstAired)
-		addRTFDateText(&evidence, value.EpisodeAired)
+		if includePartialYears {
+			evidence.addYear(value.Year)
+		}
+		addRTFDateText(&evidence, value.FirstAired, includePartialYears)
+		addRTFDateText(&evidence, value.EpisodeAired, includePartialYears)
 		for _, episode := range value.Episodes {
-			addRTFDateText(&evidence, episode.EpisodeAired)
+			addRTFDateText(&evidence, episode.EpisodeAired, includePartialYears)
 		}
 	}
 	if value := metadata.TVmaze; value != nil {
-		addRTFDateText(&evidence, value.Premiered)
-		addRTFDateText(&evidence, value.Ended)
+		addRTFDateText(&evidence, value.Premiered, includePartialYears)
+		addRTFDateText(&evidence, value.Ended, includePartialYears)
 	}
 	if value := metadata.AniList; value != nil {
-		evidence.addYear(value.SeasonYear)
-		addRTFDateText(&evidence, value.StartDate)
-		addRTFDateText(&evidence, value.EndDate)
+		if includePartialYears {
+			evidence.addYear(value.SeasonYear)
+		}
+		addRTFDateText(&evidence, value.StartDate, includePartialYears)
+		addRTFDateText(&evidence, value.EndDate, includePartialYears)
 		if value.NextAiringEpisode.AiringAt > 0 {
 			evidence.addDate(time.Unix(int64(value.NextAiringEpisode.AiringAt), 0))
 		}
@@ -161,9 +182,11 @@ func youngestRTFReleaseEvidence(release api.ReleaseInfo, metadata api.SourceScop
 	return evidence
 }
 
-func addRTFDateParts(evidence *rtfReleaseAgeEvidence, year, month, day int) {
-	evidence.addYear(year)
+func addRTFDateParts(evidence *rtfReleaseAgeEvidence, year, month, day int, includePartialYear bool) {
 	if year <= 0 || month <= 0 || day <= 0 {
+		if includePartialYear {
+			evidence.addYear(year)
+		}
 		return
 	}
 	value := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
@@ -173,12 +196,14 @@ func addRTFDateParts(evidence *rtfReleaseAgeEvidence, year, month, day int) {
 	evidence.addDate(value)
 }
 
-func addRTFDateText(evidence *rtfReleaseAgeEvidence, raw string) {
+func addRTFDateText(evidence *rtfReleaseAgeEvidence, raw string, includePartialYear bool) {
 	if value, ok := parseRTFDate(raw); ok {
 		evidence.addDate(value)
 		return
 	}
-	evidence.addYear(parseRTFYear(raw))
+	if includePartialYear {
+		evidence.addYear(parseRTFYear(raw))
+	}
 }
 
 func parseRTFDate(raw string) (time.Time, bool) {

--- a/internal/trackers/impl/standalone/rtf/rules_test.go
+++ b/internal/trackers/impl/standalone/rtf/rules_test.go
@@ -119,6 +119,93 @@ func TestMinimumContentAgeYearFallback(t *testing.T) {
 	}
 }
 
+func TestRTFManualYearSuppressesProviderYearFallback(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 18, 0, 0, 0, 0, time.UTC)
+	metadata := api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{Year: 2025}}
+	manualYear := api.EffectiveMetadata{Year: 2010, YearProvenance: api.FactProvenanceManual}
+	validation := api.TrackerValidationSubject{
+		EffectiveMetadata: manualYear,
+		Release:           api.ReleaseInfo{Year: 2025},
+		ProviderMetadata:  metadata,
+	}
+	if minimumContentAgeViolation(validation, now) {
+		t.Fatal("manual release year did not suppress newer provider year")
+	}
+	if !isRTFContentOldEnough(api.DuplicateSubject{
+		EffectiveMetadata: manualYear,
+		Release:           validation.Release,
+		ProviderMetadata:  metadata,
+	}, now) {
+		t.Fatal("duplicate search did not use manual release year")
+	}
+
+	manualEmpty := api.EffectiveMetadata{YearProvenance: api.FactProvenanceManualEmpty}
+	validation.EffectiveMetadata = manualEmpty
+	if !minimumContentAgeViolation(validation, now) {
+		t.Fatal("manual-empty release year fell back to provider year")
+	}
+	if isRTFContentOldEnough(api.DuplicateSubject{
+		EffectiveMetadata: manualEmpty,
+		Release:           validation.Release,
+		ProviderMetadata:  metadata,
+	}, now) {
+		t.Fatal("duplicate search fell back to provider year for manual-empty year")
+	}
+
+	validation.EffectiveMetadata = manualYear
+	validation.ProviderMetadata.TMDB.ReleaseDate = "2025-01-01"
+	if !minimumContentAgeViolation(validation, now) {
+		t.Fatal("manual year overrode provider exact-date evidence")
+	}
+}
+
+func TestRTFManualYearSuppressesPartialDateYears(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 18, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name     string
+		metadata api.SourceScopedMetadata
+	}{
+		{
+			name: "AniList year-only date",
+			metadata: api.SourceScopedMetadata{
+				AniList: &api.AniListMetadata{StartDate: "2025"},
+			},
+		},
+		{
+			name: "AniList partial month date",
+			metadata: api.SourceScopedMetadata{
+				AniList: &api.AniListMetadata{StartDate: "2025-01"},
+			},
+		},
+		{
+			name: "IMDb episode partial date",
+			metadata: api.SourceScopedMetadata{
+				IMDB: &api.IMDBMetadata{Episodes: []api.IMDBEpisode{{
+					ReleaseDate: api.IMDBReleaseDate{Year: 2025},
+				}}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			manualYear := api.EffectiveMetadata{Year: 2010, YearProvenance: api.FactProvenanceManual}
+			if got := rtfContentAgeEligibility(api.ReleaseInfo{}, test.metadata, manualYear, now); got != rtfAgeEligible {
+				t.Fatalf("manual year eligibility = %q, want %q", got, rtfAgeEligible)
+			}
+			manualEmpty := api.EffectiveMetadata{YearProvenance: api.FactProvenanceManualEmpty}
+			if got := rtfContentAgeEligibility(api.ReleaseInfo{}, test.metadata, manualEmpty, now); got != rtfAgeIneligibleMissingEvidence {
+				t.Fatalf("manual-empty year eligibility = %q, want %q", got, rtfAgeIneligibleMissingEvidence)
+			}
+		})
+	}
+}
+
 func TestRTFContentAgeEligibilityExactBoundaries(t *testing.T) {
 	t.Parallel()
 
@@ -198,7 +285,7 @@ func TestRTFContentAgeEligibilityExactBoundaries(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := rtfContentAgeEligibility(api.ReleaseInfo{}, tt.metadata, tt.now)
+			got := rtfContentAgeEligibility(api.ReleaseInfo{}, tt.metadata, api.EffectiveMetadata{}, tt.now)
 			if got != tt.want {
 				t.Fatalf("eligibility = %q, want %q", got, tt.want)
 			}
@@ -251,7 +338,7 @@ func TestRTFContentAgeEligibilityYearEvidence(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := rtfContentAgeEligibility(tt.release, api.SourceScopedMetadata{}, now)
+			got := rtfContentAgeEligibility(tt.release, api.SourceScopedMetadata{}, api.EffectiveMetadata{}, now)
 			if got != tt.want {
 				t.Fatalf("eligibility = %q, want %q", got, tt.want)
 			}
@@ -375,7 +462,7 @@ func TestYoungestRTFReleaseEvidenceUsesEveryExactDateSource(t *testing.T) {
 			}
 			tt.apply(&release, &metadata)
 
-			evidence := youngestRTFReleaseEvidence(release, metadata)
+			evidence := youngestRTFReleaseEvidence(release, metadata, api.EffectiveMetadata{})
 			got, ok := evidence.exactDate()
 			if !ok || !got.Equal(youngest) {
 				t.Fatalf("youngest exact date = (%s, %t), want (%s, true)", got.Format(time.DateOnly), ok, youngestText)
@@ -451,7 +538,7 @@ func TestYoungestRTFReleaseEvidenceUsesEveryYearSource(t *testing.T) {
 			metadata := api.SourceScopedMetadata{}
 			tt.apply(&release, &metadata)
 
-			evidence := youngestRTFReleaseEvidence(release, metadata)
+			evidence := youngestRTFReleaseEvidence(release, metadata, api.EffectiveMetadata{})
 			if evidence.year != youngestYear {
 				t.Fatalf("youngest year = %d, want %d", evidence.year, youngestYear)
 			}
@@ -476,7 +563,7 @@ func TestRTFAgeChecksUseYoungerYearOverOlderExactDate(t *testing.T) {
 		TMDB: &api.TMDBMetadata{ReleaseDate: "2010-01-01"},
 		IMDB: &api.IMDBMetadata{Year: 2025},
 	}
-	evidence := youngestRTFReleaseEvidence(api.ReleaseInfo{}, metadata)
+	evidence := youngestRTFReleaseEvidence(api.ReleaseInfo{}, metadata, api.EffectiveMetadata{})
 	if evidence.year != 2025 {
 		t.Fatalf("youngest year = %d, want 2025", evidence.year)
 	}
@@ -499,7 +586,7 @@ func TestRTFAgeChecksUseYoungerExactDateOverOlderYear(t *testing.T) {
 		TMDB: &api.TMDBMetadata{Year: 2010},
 		TVDB: &api.TVDBMetadata{EpisodeAired: "2016-07-19"},
 	}
-	evidence := youngestRTFReleaseEvidence(api.ReleaseInfo{}, metadata)
+	evidence := youngestRTFReleaseEvidence(api.ReleaseInfo{}, metadata, api.EffectiveMetadata{})
 	got, ok := evidence.exactDate()
 	if !ok || got.Format(time.DateOnly) != "2016-07-19" {
 		t.Fatalf("youngest exact date = (%s, %t), want (2016-07-19, true)", got.Format(time.DateOnly), ok)
@@ -523,7 +610,7 @@ func TestRTFReleaseEvidenceIgnoresBlurayMetadata(t *testing.T) {
 				MovieYear: "2025",
 			}},
 		},
-	})
+	}, api.EffectiveMetadata{})
 	if evidence.year != 2010 {
 		t.Fatalf("youngest year = %d, want canonical year 2010", evidence.year)
 	}

--- a/internal/trackers/impl/standalone/spd/description.go
+++ b/internal/trackers/impl/standalone/spd/description.go
@@ -106,10 +106,16 @@ func imdbURL(meta api.UploadSubject) string {
 }
 
 func genresText(meta api.UploadSubject) string {
+	var provider string
 	if meta.ProviderMetadata.TMDB != nil {
-		return metautil.FirstNonEmptyTrimmed(meta.ProviderMetadata.TMDB.Genres, meta.Release.Genre)
+		provider = metautil.FirstNonEmptyTrimmed(meta.ProviderMetadata.TMDB.Genres, meta.Release.Genre)
+	} else {
+		provider = meta.Release.Genre
 	}
-	return strings.TrimSpace(meta.Release.Genre)
+	if meta.EffectiveMetadata.GenresProvenance.IsManual() {
+		return trackers.PreferredGenreText(meta, provider)
+	}
+	return strings.TrimSpace(provider)
 }
 
 func keywordsText(meta api.UploadSubject) string {

--- a/internal/trackers/impl/standalone/spd/description_precedence_test.go
+++ b/internal/trackers/impl/standalone/spd/description_precedence_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package spd
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestGenresTextPrefersManualGenres(t *testing.T) {
+	t.Parallel()
+	meta := api.UploadSubject{
+		Release:          api.ReleaseInfo{Genre: "Parsed"},
+		ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{Genres: "Provider"}},
+		EffectiveMetadata: api.EffectiveMetadata{
+			Genres: []string{"Manual"}, GenresProvenance: api.FactProvenanceManual,
+		},
+	}
+	if got := genresText(meta); got != "Manual" {
+		t.Fatalf("manual genres = %q", got)
+	}
+	meta.EffectiveMetadata.Genres = nil
+	meta.EffectiveMetadata.GenresProvenance = api.FactProvenanceManualEmpty
+	if got := genresText(meta); got != "" {
+		t.Fatalf("manual-empty genres = %q", got)
+	}
+}

--- a/internal/trackers/impl/standalone/spd/dupe.go
+++ b/internal/trackers/impl/standalone/spd/dupe.go
@@ -45,14 +45,17 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 	switch {
 	case meta.Identity.IMDBID != 0:
 		params.Set("imdbId", providerid.IMDb(meta.Identity.IMDBID).Prefixed())
-	case strings.TrimSpace(meta.Release.Title) != "":
-		workScope = dupe.WorkScopeTitle
-		params.Set("search", strings.TrimSpace(meta.Release.Title))
-	case meta.Projection != nil:
-		workScope = dupe.WorkScopeTitle
-		params.Set("search", dupe.ProjectedSearchName(meta))
 	default:
-		return dupe.NotRun(dupe.NotRunMissingMetadata, "missing imdb/title for SPD dupe search", nil)
+		workScope = dupe.WorkScopeTitle
+		query := strings.TrimSpace(meta.Release.Title)
+		if query == "" && meta.Projection != nil {
+			query = dupe.ProjectedSearchName(meta)
+		}
+		query = meta.EffectiveMetadata.PreferredTitle(query)
+		if query == "" {
+			return dupe.NotRun(dupe.NotRunMissingMetadata, "missing imdb/title for SPD dupe search", nil)
+		}
+		params.Set("search", query)
 	}
 	return jsondupe.Search(ctx, s.http, jsondupe.ListSpec{
 		Endpoint:       s.endpoint,

--- a/internal/trackers/impl/standalone/spd/dupe_test.go
+++ b/internal/trackers/impl/standalone/spd/dupe_test.go
@@ -51,3 +51,32 @@ func TestDuplicateSearchUsesSPDQueryHeadersAndProjection(t *testing.T) {
 		t.Fatalf("unexpected search evidence: %#v", search)
 	}
 }
+
+func TestDuplicateSearchTitleFallbackHonorsManualTitle(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests++
+		if got := request.URL.Query().Get("search"); got != "Projected Release" {
+			t.Errorf("automatic SPD search title = %q", got)
+		}
+		_, _ = writer.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	searcher := &dupeSearcher{
+		cfg:      config.Config{Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{"SPD": {APIKey: "secret"}}}},
+		http:     server.Client(),
+		endpoint: server.URL,
+	}
+	projection := &api.TrackerReleaseProjection{DuplicateCriteria: api.TrackerDuplicateCriteria{Name: "Projected Release"}}
+	result := searcher.Search(t.Context(), api.DuplicateSubject{
+		Projection:        projection,
+		EffectiveMetadata: api.EffectiveMetadata{TitleProvenance: api.FactProvenanceManualEmpty},
+	})
+	if result.Disposition() != dupe.DispositionNotRun || result.Code() != dupe.NotRunMissingMetadata || requests != 0 {
+		t.Fatalf("manual-empty SPD result=%v code=%q requests=%d", result.Disposition(), result.Code(), requests)
+	}
+	if result := searcher.Search(t.Context(), api.DuplicateSubject{Projection: projection}); result.Disposition() != dupe.DispositionResolved || requests != 1 {
+		t.Fatalf("automatic SPD result=%v requests=%d", result.Disposition(), requests)
+	}
+}

--- a/internal/trackers/impl/standalone/thr/description.go
+++ b/internal/trackers/impl/standalone/thr/description.go
@@ -55,10 +55,16 @@ func imdbURL(meta api.UploadSubject) string {
 }
 
 func genresText(meta api.UploadSubject) string {
+	var provider string
 	if meta.ProviderMetadata.TMDB != nil {
-		return metautil.FirstNonEmptyTrimmed(meta.ProviderMetadata.TMDB.Genres, meta.Release.Genre)
+		provider = metautil.FirstNonEmptyTrimmed(meta.ProviderMetadata.TMDB.Genres, meta.Release.Genre)
+	} else {
+		provider = meta.Release.Genre
 	}
-	return strings.TrimSpace(meta.Release.Genre)
+	if meta.EffectiveMetadata.GenresProvenance.IsManual() {
+		return trackers.PreferredGenreText(meta, provider)
+	}
+	return strings.TrimSpace(provider)
 }
 
 func keywordsText(meta api.UploadSubject) string {

--- a/internal/trackers/impl/standalone/thr/description_precedence_test.go
+++ b/internal/trackers/impl/standalone/thr/description_precedence_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package thr
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestGenresTextPrefersManualGenres(t *testing.T) {
+	t.Parallel()
+	meta := api.UploadSubject{
+		Release:          api.ReleaseInfo{Genre: "Parsed"},
+		ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{Genres: "Provider"}},
+		EffectiveMetadata: api.EffectiveMetadata{
+			Genres: []string{"Manual"}, GenresProvenance: api.FactProvenanceManual,
+		},
+	}
+	if got := genresText(meta); got != "Manual" {
+		t.Fatalf("manual genres = %q", got)
+	}
+	meta.EffectiveMetadata.Genres = nil
+	meta.EffectiveMetadata.GenresProvenance = api.FactProvenanceManualEmpty
+	if got := genresText(meta); got != "" {
+		t.Fatalf("manual-empty genres = %q", got)
+	}
+}

--- a/internal/trackers/impl/standalone/tl/description.go
+++ b/internal/trackers/impl/standalone/tl/description.go
@@ -144,8 +144,9 @@ func screenshotBlock(images []api.ScreenshotImage) string {
 }
 
 func genresText(meta api.UploadSubject) string {
+	provider := ""
 	if meta.ProviderMetadata.TMDB != nil {
-		return metautil.FirstNonEmptyTrimmed(meta.ProviderMetadata.TMDB.Genres, meta.Release.Genre)
+		provider = meta.ProviderMetadata.TMDB.Genres
 	}
-	return strings.TrimSpace(meta.Release.Genre)
+	return trackers.PreferredGenreText(meta, provider)
 }

--- a/internal/trackers/impl/standalone/tl/dupe.go
+++ b/internal/trackers/impl/standalone/tl/dupe.go
@@ -41,6 +41,7 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 	if query == "" {
 		query = strings.TrimSpace(meta.ReleaseName)
 	}
+	query = meta.EffectiveMetadata.PreferredTitle(query)
 	if query == "" {
 		return dupe.NotRun(dupe.NotRunMissingMetadata, "missing title for TL dupe search", nil)
 	}

--- a/internal/trackers/impl/standalone/tl/dupe_test.go
+++ b/internal/trackers/impl/standalone/tl/dupe_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package tl
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackers/dupe"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+type tlRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f tlRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
+
+func TestDuplicateSearchTitleFallbackHonorsManualTitle(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	searcher := &dupeSearcher{
+		cfg: config.Config{Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{"TL": {Passkey: "passkey"}}}},
+		http: &http.Client{Transport: tlRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+			requests++
+			if !strings.HasSuffix(request.URL.Path, "/Projected Release") {
+				t.Errorf("automatic TL search path = %q", request.URL.Path)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"torrentList":[]}`)),
+				Header:     make(http.Header),
+			}, nil
+		})},
+	}
+	projection := &api.TrackerReleaseProjection{DuplicateCriteria: api.TrackerDuplicateCriteria{Name: "Projected Release"}}
+	result := searcher.Search(context.Background(), api.DuplicateSubject{
+		Projection:        projection,
+		EffectiveMetadata: api.EffectiveMetadata{TitleProvenance: api.FactProvenanceManualEmpty},
+	})
+	if result.Disposition() != dupe.DispositionNotRun || result.Code() != dupe.NotRunMissingMetadata || requests != 0 {
+		t.Fatalf("manual-empty TL result=%v code=%q requests=%d", result.Disposition(), result.Code(), requests)
+	}
+	if result := searcher.Search(context.Background(), api.DuplicateSubject{Projection: projection}); result.Disposition() != dupe.DispositionResolved || requests != 1 {
+		t.Fatalf("automatic TL result=%v requests=%d", result.Disposition(), requests)
+	}
+}

--- a/internal/trackers/impl/standalone/tl/metadata_precedence_test.go
+++ b/internal/trackers/impl/standalone/tl/metadata_precedence_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package tl
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestResolveCategoryPrefersManualOriginalLanguage(t *testing.T) {
+	t.Parallel()
+	meta := api.UploadSubject{
+		Identity:         api.ExternalIdentity{Category: api.CanonicalCategoryMovie},
+		ProviderMetadata: api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{OriginalLanguage: "en"}},
+		EffectiveMetadata: api.EffectiveMetadata{
+			OriginalLanguage: "fr", OriginalLanguageProvenance: api.FactProvenanceManual,
+		},
+	}
+	if got := resolveCategory(meta); got != "36" {
+		t.Fatalf("manual foreign category = %q", got)
+	}
+	meta.EffectiveMetadata.OriginalLanguage = ""
+	meta.EffectiveMetadata.OriginalLanguageProvenance = api.FactProvenanceManualEmpty
+	meta.ProviderMetadata.TMDB.OriginalLanguage = "fr"
+	if got := resolveCategory(meta); got != "32" {
+		t.Fatalf("manual-empty category = %q", got)
+	}
+}
+
+func TestResolveCategoryAcceptsManualCanonicalEnglish(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{Identity: api.ExternalIdentity{Category: api.CanonicalCategoryMovie}, EffectiveMetadata: api.EffectiveMetadata{OriginalLanguage: "English", OriginalLanguageProvenance: api.FactProvenanceManual}}
+	if got := resolveCategory(meta); got != "32" {
+		t.Fatalf("manual English category = %q", got)
+	}
+	meta.EffectiveMetadata.OriginalLanguage = "en"
+	if got := resolveCategory(meta); got != "32" {
+		t.Fatalf("manual ISO English category = %q", got)
+	}
+}

--- a/internal/trackers/impl/standalone/tl/taxonomy.go
+++ b/internal/trackers/impl/standalone/tl/taxonomy.go
@@ -6,6 +6,9 @@ package tl
 import (
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/languageutil"
+
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -13,15 +16,23 @@ func resolveCategory(meta api.UploadSubject) string {
 	if _, err := meta.Identity.RequireCategory(); err != nil {
 		return ""
 	}
-	originalLanguage := ""
+	provider := ""
 	if meta.ProviderMetadata.TMDB != nil {
-		originalLanguage = strings.TrimSpace(meta.ProviderMetadata.TMDB.OriginalLanguage)
+		provider = meta.ProviderMetadata.TMDB.OriginalLanguage
 	}
+	originalLanguage := provider
+	if meta.EffectiveMetadata.OriginalLanguageProvenance.IsManual() {
+		originalLanguage = trackers.PreferredOriginalLanguage(meta, provider)
+		if normalized := languageutil.NormalizeLanguageCode(originalLanguage); normalized != "" {
+			originalLanguage = normalized
+		}
+	}
+	isEnglish := strings.EqualFold(originalLanguage, "en")
 	if meta.Anime {
 		return "34"
 	}
 	if !isTV(meta) {
-		if originalLanguage != "" && !strings.EqualFold(originalLanguage, "en") {
+		if originalLanguage != "" && !isEnglish {
 			return "36"
 		}
 		if containsWord(genresText(meta), "Documentary") {
@@ -49,7 +60,7 @@ func resolveCategory(meta api.UploadSubject) string {
 			return "43"
 		}
 	}
-	if isTV(meta) && originalLanguage != "" && !strings.EqualFold(originalLanguage, "en") {
+	if isTV(meta) && originalLanguage != "" && !isEnglish {
 		return "44"
 	}
 	if meta.TVPack {

--- a/internal/trackers/impl/standalone/tvc/description.go
+++ b/internal/trackers/impl/standalone/tvc/description.go
@@ -71,7 +71,11 @@ func screenshotBlock(images []api.ScreenshotImage, count int) string {
 }
 
 func genresText(meta api.UploadSubject) string {
-	return metautil.FirstNonEmptyTrimmed(meta.ProviderMetadata.TMDB.Genres, meta.Release.Genre)
+	provider := ""
+	if meta.ProviderMetadata.TMDB != nil {
+		provider = meta.ProviderMetadata.TMDB.Genres
+	}
+	return trackers.PreferredGenreText(meta, provider)
 }
 
 func keywordsText(meta api.UploadSubject) string {

--- a/internal/trackers/impl/standalone/tvc/name.go
+++ b/internal/trackers/impl/standalone/tvc/name.go
@@ -7,18 +7,22 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/autobrr/upbrr/internal/metadata/metautil"
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
 func resolveName(meta api.UploadSubject) string {
 	typeName := strings.ReplaceAll(meta.Type, "WEBDL", "WEB-DL")
-	title := metautil.FirstNonEmptyTrimmed(meta.Release.Title, meta.ReleaseName)
-	name := title
-	year := meta.Release.Year
-	if meta.ProviderMetadata.TMDB != nil {
-		year = maxInt(year, meta.ProviderMetadata.TMDB.Year)
+	title := trackers.PreferredTitle(meta, "")
+	if title == "" && !meta.EffectiveMetadata.TitleProvenance.IsManual() {
+		title = meta.ReleaseName
 	}
+	name := title
+	providerYear := 0
+	if meta.ProviderMetadata.TMDB != nil {
+		providerYear = meta.ProviderMetadata.TMDB.Year
+	}
+	year := trackers.PreferredYear(meta, maxInt(meta.Release.Year, providerYear))
 	switch {
 	case !isTV(meta):
 		if year > 0 {

--- a/internal/trackers/impl/standalone/tvc/name_test.go
+++ b/internal/trackers/impl/standalone/tvc/name_test.go
@@ -36,4 +36,9 @@ func TestResolveNameUsesOnlyAvailableTVPresentationFacts(t *testing.T) {
 	if got := resolveName(base); strings.Contains(got, "S01E01") || strings.Contains(got, "(0)") {
 		t.Fatalf("cleared-facts name = %q", got)
 	}
+
+	base.EffectiveMetadata.TitleProvenance = api.FactProvenanceManualEmpty
+	if got := resolveName(base); strings.Contains(got, "Example Show") {
+		t.Fatalf("manual-empty name restored release title = %q", got)
+	}
 }

--- a/internal/trackers/impl/standalone/tvc/taxonomy.go
+++ b/internal/trackers/impl/standalone/tvc/taxonomy.go
@@ -6,6 +6,9 @@ package tvc
 import (
 	"strings"
 
+	"github.com/autobrr/upbrr/internal/languageutil"
+
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -28,10 +31,17 @@ var categoryMap = map[string]string{
 }
 
 func resolveCategory(meta api.UploadSubject) string {
-	if meta.ProviderMetadata.TMDB.OriginalLanguage != "" && !strings.EqualFold(meta.ProviderMetadata.TMDB.OriginalLanguage, "en") &&
-		!strings.EqualFold(meta.ProviderMetadata.TMDB.OriginalLanguage, "ga") &&
-		!strings.EqualFold(meta.ProviderMetadata.TMDB.OriginalLanguage, "gd") &&
-		!strings.EqualFold(meta.ProviderMetadata.TMDB.OriginalLanguage, "cy") {
+	originalLanguage := ""
+	if meta.EffectiveMetadata.OriginalLanguageProvenance.IsManual() {
+		originalLanguage = trackers.PreferredOriginalLanguage(meta, "")
+		if normalized := languageutil.NormalizeLanguageCode(originalLanguage); normalized != "" {
+			originalLanguage = normalized
+		}
+	} else if meta.ProviderMetadata.TMDB != nil {
+		originalLanguage = meta.ProviderMetadata.TMDB.OriginalLanguage
+	}
+	if originalLanguage != "" && !strings.EqualFold(originalLanguage, "en") &&
+		!strings.EqualFold(originalLanguage, "ga") && !strings.EqualFold(originalLanguage, "gd") && !strings.EqualFold(originalLanguage, "cy") {
 		return categoryMap["foreign"]
 	}
 	genres := strings.ToLower(genresText(meta))

--- a/internal/trackers/impl/standalone/tvc/upload_test.go
+++ b/internal/trackers/impl/standalone/tvc/upload_test.go
@@ -172,3 +172,35 @@ func TestPrepareUploadStateIncludesTVDBForCanonicalTVSeasonPack(t *testing.T) {
 		t.Fatalf("expected tvdb=456, got %q", got)
 	}
 }
+
+func TestResolveCategoryUsesManualOriginalLanguageOnlyWhenExplicit(t *testing.T) {
+	t.Parallel()
+
+	meta := api.UploadSubject{
+		Identity:          api.ExternalIdentity{Category: api.CanonicalCategoryTV},
+		ProviderMetadata:  api.SourceScopedMetadata{TMDB: &api.TMDBMetadata{OriginalLanguage: "en"}},
+		EffectiveMetadata: api.EffectiveMetadata{OriginalLanguage: "fr"},
+	}
+	if got := resolveCategory(meta); got == categoryMap["foreign"] {
+		t.Fatalf("automatic effective language changed category = %q", got)
+	}
+	meta.EffectiveMetadata.OriginalLanguageProvenance = api.FactProvenanceManual
+	if got := resolveCategory(meta); got != categoryMap["foreign"] {
+		t.Fatalf("manual language category = %q", got)
+	}
+	meta.EffectiveMetadata = api.EffectiveMetadata{OriginalLanguageProvenance: api.FactProvenanceManualEmpty}
+	if got := resolveCategory(meta); got == categoryMap["foreign"] {
+		t.Fatalf("manual-empty language category = %q", got)
+	}
+}
+
+func TestResolveCategoryAcceptsManualCanonicalBritishLanguages(t *testing.T) {
+	t.Parallel()
+
+	for _, language := range []string{"English", "Irish", "Welsh", "en", "ga", "cy"} {
+		meta := api.UploadSubject{Identity: api.ExternalIdentity{Category: api.CanonicalCategoryTV}, EffectiveMetadata: api.EffectiveMetadata{OriginalLanguage: language, OriginalLanguageProvenance: api.FactProvenanceManual}}
+		if got := resolveCategory(meta); got == categoryMap["foreign"] {
+			t.Fatalf("manual %s category = %q", language, got)
+		}
+	}
+}

--- a/internal/trackers/impl/standalone/validation.go
+++ b/internal/trackers/impl/standalone/validation.go
@@ -22,6 +22,29 @@ func UploadSubjectForValidation(subject api.TrackerValidationSubject) api.Upload
 		answers[tracker] = cloneAnswers(subject.QuestionnaireAnswers)
 	}
 	return api.UploadSubject{
+		EffectiveMetadata: api.EffectiveMetadata{
+			Title:                      subject.EffectiveMetadata.Title,
+			AlternateTitle:             subject.EffectiveMetadata.AlternateTitle,
+			OriginalTitle:              subject.EffectiveMetadata.OriginalTitle,
+			Year:                       subject.EffectiveMetadata.Year,
+			Genres:                     append([]string(nil), subject.EffectiveMetadata.Genres...),
+			OriginalLanguage:           subject.EffectiveMetadata.OriginalLanguage,
+			Distributor:                subject.EffectiveMetadata.Distributor,
+			TitleProvenance:            subject.EffectiveMetadata.TitleProvenance,
+			AlternateTitleProvenance:   subject.EffectiveMetadata.AlternateTitleProvenance,
+			OriginalTitleProvenance:    subject.EffectiveMetadata.OriginalTitleProvenance,
+			YearProvenance:             subject.EffectiveMetadata.YearProvenance,
+			GenresProvenance:           subject.EffectiveMetadata.GenresProvenance,
+			OriginalLanguageProvenance: subject.EffectiveMetadata.OriginalLanguageProvenance,
+			DistributorProvenance:      subject.EffectiveMetadata.DistributorProvenance,
+		},
+		ManualLanguages: api.ManualLanguageFacts{
+			Audio:              append([]string(nil), subject.ManualLanguages.Audio...),
+			Subtitles:          append([]string(nil), subject.ManualLanguages.Subtitles...),
+			HardcodedSubtitles: append([]string(nil), subject.ManualLanguages.HardcodedSubtitles...),
+		},
+		HardcodedSubs:               subject.HardcodedSubs,
+		HardcodedSubtitleLanguages:  append([]string(nil), subject.HardcodedSubtitleLanguages...),
 		SourcePath:                  subject.SourcePath,
 		VideoPath:                   subject.VideoPath,
 		FileList:                    append([]string(nil), subject.FileList...),


### PR DESCRIPTION
PR #450 exceeds CodeRabbit's 100-file review limit. This review-only stack part 3/4 covers standalone tracker consumers in 83 changed files.

The stack partitions the complete implementation from #450 at 3aab013c0b43d0857ab2f54fed9b3e85d3c84d9f. Each part targets the preceding part; the first targets main. The final stack tree exactly matches #450. Accepted review fixes are folded into #450 and propagated through the stack without rewriting published history.

Keep #450 as the integration and merge PR. Do not merge this review slice independently. Intermediate snapshots can have unresolved dependencies and are not claimed to build independently. Assess findings against the complete implementation.

All four initial GitHub CodeRabbit passes completed. Their 24 findings produced 14 accepted fixes and 10 source-backed withdrawals. The corrective diff passes a final local CodeRabbit review with zero findings, independent correctness review, Ponytail, and source documentation gates. The GitHub passes cover the pre-fix snapshots; no additional GitHub pass is claimed for this updated head.

The complete implementation passes full Go race tests, repository lint and path/log policies, changed-package modernization checks, backend and embedded builds, 261 frontend unit tests, frontend lint/dead-code/type/format checks, offline live-harness validation, and the embedded MAL-ID persistence regression. Packaging checks verify disjoint coverage, every slice below 100 files, whitespace, and exact final-tree equality.
