### PR TITLE
ci: retry transient OSV scanner installation failures

### DIFF
--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -37,7 +37,19 @@ jobs:
 
       - name: Run OSV dependency scan
         if: ${{ !cancelled() }}
-        run: go run github.com/google/osv-scanner/v2/cmd/osv-scanner@${OSV_SCANNER_VERSION} scan source --lockfile go.mod --lockfile webui/pnpm-lock.yaml
+        run: |
+          for attempt in 1 2 3; do
+            if go install github.com/google/osv-scanner/v2/cmd/osv-scanner@${OSV_SCANNER_VERSION}; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::OSV scanner installation failed after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::OSV scanner installation failed; retrying in 10 seconds (attempt $attempt/3)"
+            sleep 10
+          done
+          "$(go env GOPATH)/bin/osv-scanner" scan source --lockfile go.mod --lockfile webui/pnpm-lock.yaml
 
   report_failure:
     name: Report vulnerability scan failure

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -39,7 +39,7 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           for attempt in 1 2 3; do
-            if go install github.com/google/osv-scanner/v2/cmd/osv-scanner@${OSV_SCANNER_VERSION}; then
+            if go install "github.com/google/osv-scanner/v2/cmd/osv-scanner@${OSV_SCANNER_VERSION}"; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then


### PR DESCRIPTION
The scheduled vulnerability scan in #449 stops before OSV runs because a transient Go checksum-server HTTP/2 error interrupts scanner installation.

Install the pinned OSV scanner separately, allowing three attempts with ten-second delays. Run the scanner once after installation succeeds. Exhausted installation attempts and actual scan failures still fail the job and retain the existing failure issue reporting. Scanner versions, lockfiles, and cancellation behavior remain unchanged.

Validation: actionlint passes; six mocked Bash cases cover immediate success, recovery on attempts two and three, exhausted installation retries, vulnerability findings, and scan errors after recovery. git diff --check passes; make gofix-check-changed reports no changed Go files. CodeRabbit CLI reviews the complete diff against main with zero findings. The live GitHub scan has not been rerun.

Closes #449.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved dependency vulnerability scanning reliability with automatic retries when setting up the scanner.
  - Added clearer warnings for temporary setup failures and explicit error reporting when all setup attempts fail.
  - Vulnerability scans continue to cover the project’s Go and web interface dependencies.
  - Scanner setup now handles package arguments more safely to ensure consistent scan execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->