### PR TITLE
Support fact overrides in live-test corpora

### DIFF
--- a/scripts/live-testing/README.md
+++ b/scripts/live-testing/README.md
@@ -132,6 +132,16 @@ Omitted providers retain normal resolution. Changing IDs requires a new run;
 saved-run continuation and comparisons retain the corpus fingerprint. Overrides
 do not waive tracker rules or existing-client duplicate blocks.
 
+An optional `fact_overrides` object supplies `Metadata` and `ReleaseName` groups
+using the production `ReleaseFactInstructions` field names and value types.
+Use explicit values; null fields are rejected because they supply no override.
+For example, `"fact_overrides": { "Metadata": { "Commentary": false },
+"ReleaseName": { "Tag": "GRP" } }` tests explicit values through preparation
+and later tracker stages. Omitted fields retain normal resolution. The run saves
+the requested values in each lane for comparison with facts and payloads.
+Keep test values in the private corpus. The CLI comparison helper rejects these
+cases because it does not yet translate arbitrary fact overrides into CLI flags.
+
 An Input case may also provide `source_lookup` and `tracker_ids`. `source_lookup`
 is an explicit source URL or identifier. `tracker_ids` maps tracker codes to
 operator-verified source IDs. The runner preserves only values present in the

--- a/scripts/live-testing/check-cli.ps1
+++ b/scripts/live-testing/check-cli.ps1
@@ -87,6 +87,7 @@ $lane = $lane[0]
 $entries = @(Read-PrivateJson (Join-Path $baselineDir 'corpus.private.json'))
 $entry = @($entries | Where-Object { $_.case.case_id -ceq $lane.caseId })
 if ($entry.Count -ne 1 -or $entry[0].status -ne 'ready' -or (Get-SourceFingerprint $entry[0].case).fingerprint -cne $lane.sourceFingerprint) { throw 'cli_source_evidence_changed' }
+if ((Get-CaseFactOverrides $entry[0].case).Count -gt 0) { throw 'cli_fact_overrides_not_representable' }
 if (@($lane.trackerIds).Count -eq 0 -or @($lane.trackerIds | Where-Object { $_ -cnotmatch '^[A-Z0-9]+$' }).Count -gt 0) { throw 'cli_tracker_scope_invalid' }
 $inputOnly = $baseline.suite -eq 'Input'
 $interactionArguments = @(Get-InteractionCLIArguments $InteractionMode)

--- a/scripts/live-testing/functions.ps1
+++ b/scripts/live-testing/functions.ps1
@@ -79,6 +79,55 @@ function Get-CaseIdentityOverrides($Case) {
   $identity
 }
 
+function Get-CaseFactOverrides($Case) {
+  if (-not $Case.Contains('fact_overrides')) { return @{} }
+  if ($Case.fact_overrides -isnot [System.Collections.IDictionary]) { throw 'corpus_fact_overrides_invalid' }
+  # Keep this test-input schema aligned with api.MetadataOverrides and
+  # api.ReleaseNameOverrides: the HTTP decoder ignores unknown JSON fields.
+  $fields = @{
+    Metadata = @{
+      String = @('Distributor', 'OriginalLanguage', 'Title', 'AlternateTitle', 'OriginalTitle')
+      Boolean = @('PersonalRelease', 'Commentary', 'WebDV', 'StreamOptimized', 'Anime', 'HardcodedSubs')
+      Strings = @('Genres', 'AudioLanguages', 'SubtitleLanguages', 'HardcodedSubtitleLanguages')
+      Tracks = @('TrackLanguages')
+    }
+    ReleaseName = @{
+      String = @('Category', 'Type', 'Source', 'Resolution', 'Tag', 'Service', 'Edition', 'Season', 'Episode', 'EpisodeTitle', 'ManualDate', 'Region')
+      Boolean = @('UseSeasonEpisode', 'NoSeason', 'NoYear', 'NoAKA', 'NoTag', 'NoEpisodeTitle', 'NoDistributor', 'NoEdition', 'NoDub', 'NoDual', 'DualAudio')
+      Integer = @('ManualYear')
+    }
+  }
+  foreach ($group in $Case.fact_overrides.Keys) {
+    if ($group -cnotin @('Metadata', 'ReleaseName') -or
+        $Case.fact_overrides[$group] -isnot [System.Collections.IDictionary]) { throw 'corpus_fact_overrides_invalid' }
+    foreach ($field in $Case.fact_overrides[$group].Keys) {
+      $kind = @($fields[$group].Keys | Where-Object { $field -cin $fields[$group][$_] })
+      if ($kind.Count -ne 1) { throw 'corpus_fact_overrides_invalid' }
+      $value = $Case.fact_overrides[$group][$field]
+      if ($null -eq $value) { throw 'corpus_fact_overrides_invalid' }
+      $valid = switch ($kind[0]) {
+        'String' { $value -is [string] }
+        'Boolean' { $value -is [bool] }
+        'Integer' { $value -is [int] -or $value -is [long] }
+        'Strings' { $value -is [System.Collections.IList] -and @($value | Where-Object { $_ -isnot [string] }).Count -eq 0 }
+        'Tracks' {
+          if ($value -isnot [System.Collections.IList]) { $false; break }
+          $invalidTracks = @($value | Where-Object {
+            $_ -isnot [System.Collections.IDictionary] -or
+            @($_.Keys | Where-Object { $_ -cnotin @('trackId', 'manifestFingerprint', 'languages') }).Count -gt 0 -or
+            $_.trackId -isnot [string] -or [string]::IsNullOrWhiteSpace($_.trackId) -or
+            $_.manifestFingerprint -isnot [string] -or [string]::IsNullOrWhiteSpace($_.manifestFingerprint) -or
+            $_.languages -isnot [System.Collections.IList] -or @($_.languages | Where-Object { $_ -isnot [string] }).Count -gt 0
+          })
+          $invalidTracks.Count -eq 0
+        }
+      }
+      if (-not $valid) { throw 'corpus_fact_overrides_invalid' }
+    }
+  }
+  $Case.fact_overrides
+}
+
 function Get-CaseIdentityCLIArguments($Case) {
   $null = Get-CaseIdentityOverrides $Case
   foreach ($provider in @('imdb', 'tmdb', 'tvdb', 'tvmaze', 'mal')) {
@@ -132,6 +181,7 @@ function Read-Corpus([string]$Path, [string[]]$Selected) {
     if ($entry.input_shape -notin @('file', 'disc-directory', 'episode-directory') -or -not $entry.fingerprint) { throw 'corpus_case_schema_invalid' }
     $null = Get-CaseIdentityOverrides $entry
     $null = Get-CaseSourceLookupInstructions $entry
+    $null = Get-CaseFactOverrides $entry
     $null = @(Get-CaseBDMVPlaylists $entry)
     $known[$entry.case_id] = $entry
   }

--- a/scripts/live-testing/run.ps1
+++ b/scripts/live-testing/run.ps1
@@ -267,6 +267,8 @@ try {
               $lane.expectedIdentity = $identity.Clone()
               $sourceInstructions = Get-CaseSourceLookupInstructions $entry.case
               $lane.explicitSourceLookup = $sourceInstructions.Count -gt 0
+              $lane.expectedFactOverrides = Get-CaseFactOverrides $entry.case
+              foreach ($group in $lane.expectedFactOverrides.Keys) { $sourceInstructions[$group] = $lane.expectedFactOverrides[$group] }
               if ($identity.Count -gt 0 -or $sourceInstructions.Count -gt 0) {
                 $intent.preparation.Instructions = $sourceInstructions
                 if ($identity.Count -gt 0) { $intent.preparation.Instructions.Identity = $identity }

--- a/scripts/live-testing/validate.ps1
+++ b/scripts/live-testing/validate.ps1
@@ -18,6 +18,26 @@ try {
   $loaded = @(Read-Corpus $corpusPath @('MOV-1080-WEB'))
   Assert-Check ($loaded.Count -eq 1 -and $loaded[0].status -eq 'ready') 'valid_corpus_rejected'
   Assert-Check ((Get-CaseIdentityOverrides $case).Count -eq 0 -and @(Get-CaseIdentityCLIArguments $case).Count -eq 0) 'omitted_identity_changed_defaults'
+  Assert-Check ((Get-CaseFactOverrides $case).Count -eq 0) 'omitted_fact_overrides_changed_defaults'
+  $factCase = $case.Clone()
+  $factCase.fact_overrides = @{ Metadata = @{ Title = 'Example Override'; Commentary = $false; SubtitleLanguages = @(); TrackLanguages = @(@{ trackId = 'track-1'; manifestFingerprint = 'manifest-1'; languages = @('French') }) }; ReleaseName = @{ Tag = 'GRP'; ManualYear = 2001 } }
+  Write-PrivateJson $corpusPath @{ schema_version = 1; cases = @($factCase) }
+  $factEntry = @(Read-Corpus $corpusPath @('MOV-1080-WEB'))[0]
+  $factOverrides = Get-CaseFactOverrides $factEntry.case
+  Assert-Check ($factOverrides.Metadata.Title -ceq 'Example Override' -and $factOverrides.Metadata.Commentary -ceq $false -and
+    $factOverrides.Metadata.SubtitleLanguages.Count -eq 0 -and $factOverrides.ReleaseName.Tag -ceq 'GRP') 'fact_override_values_changed'
+  foreach ($invalid in @($null, 'invalid', @{ Identity = @{} }, @{ Metadata = 'invalid' },
+    @{ Metadata = @{ Titlle = 'Example' } }, @{ Metadata = @{ Title = 1 } }, @{ Metadata = @{ Commentary = 'false' } },
+    @{ Metadata = @{ Title = $null } }, @{ ReleaseName = @{ ManualYear = $null } }, @{ Metadata = @{ Genres = @($null) } },
+    @{ Metadata = @{ Genres = @($true) } }, @{ ReleaseName = @{ ManualYear = 1.5 } },
+    @{ Metadata = @{ TrackLanguages = @(@{ trackId = 'track-1'; languages = @('French') }) } },
+    @{ Metadata = @{ TrackLanguages = @(@{ trackId = 'track-1'; manifestFingerprint = 'manifest-1'; languages = @('French'); extra = 'invalid' }) } },
+    @{ Metadata = @{ TrackLanguages = @(@{ trackId = 'track-1'; manifestFingerprint = 'manifest-1'; languages = @($false) }) } })) {
+    $factCase.fact_overrides = $invalid
+    $rejected = $false
+    try { Get-CaseFactOverrides $factCase | Out-Null } catch { $rejected = $_.Exception.Message -eq 'corpus_fact_overrides_invalid' }
+    Assert-Check $rejected 'invalid_fact_overrides_accepted'
+  }
   $identityCase = $case.Clone()
   $identityCase.metadata_ids = @{ imdb = 1234567; tmdb = 12345; tvdb = 23456; tvmaze = 34567; mal = 45678 }
   Write-PrivateJson $corpusPath @{ schema_version = 1; cases = @($identityCase) }


### PR DESCRIPTION
The Full live-testing corpus could override provider identities but could not supply reviewed metadata or release-name facts. That left tracker payload coverage dependent on each media sample's naturally resolved values.

This change adds a typed `fact_overrides` corpus field for the production `Metadata` and `ReleaseName` instruction groups. The runner validates every supported field before HTTP decoding, preserves explicit false, zero, and empty-list values, records requested facts for payload comparison, and rejects unsupported CLI parity checks. The README and harness validation cover valid, unknown, null, and incorrectly typed values.

The change affects only the opt-in live-testing harness. Existing corpora keep their current behavior when `fact_overrides` is omitted. Invalid private corpus data now fails before a run starts.

Validation:
- `pwsh -NoProfile -File scripts/live-testing/validate.ps1`
- PowerShell parser check for all four changed scripts
- Playwright browser discovery: 5 tests across 2 files
- `git diff --check`
- CodeRabbit CLI full review against `main`: 0 findings
- Live dry-run payload review across all 21 available trackers: 304 completed reports and 4,428 assertions with 0 payload issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Live-testing corpus entries can now specify explicit metadata and release-name facts for comparison during lane execution.
  - Supported values are validated and preserved for accurate result and payload comparisons.

- **Documentation**
  - Added guidance for configuring optional fact overrides, including required values and private-corpus usage.

- **Bug Fixes**
  - CLI parity checks now reject cases containing fact overrides that cannot be represented as CLI options.
  - Invalid override formats are detected during corpus validation with clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->