### PR TITLE
chore(deps): pin go-mediainfo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.27.1
 
 require (
 	github.com/autobrr/go-bdinfo v0.4.2
-	github.com/autobrr/go-mediainfo v0.8.0
+	github.com/autobrr/go-mediainfo v0.8.1-0.20260911072119-0b32d930ae1f
 	github.com/autobrr/go-qbittorrent v1.18.0
 	github.com/autobrr/go-torrent v1.1.1
 	github.com/autobrr/mkbrr v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/autobrr/go-bdinfo v0.4.2 h1:Dj02JF/pNyNLjbwtiadXlrBRxn53r3yZgFSrefLKx
 github.com/autobrr/go-bdinfo v0.4.2/go.mod h1:OjpQR7TPcP7fBTo4GW1Yz1+biQG7YTo1OZH7KXX5gS0=
 github.com/autobrr/go-mediainfo v0.8.0 h1:XzsjHvBOlGx2BnwYCqwCOIJsmrFy4BJb0jgoB2qKuR0=
 github.com/autobrr/go-mediainfo v0.8.0/go.mod h1:P3LGxIPznO2TLKV/e58YgN0/ozP5pLCAncFzsdxMDcY=
+github.com/autobrr/go-mediainfo v0.8.1-0.20260911072119-0b32d930ae1f h1:I4MbK8P/U9toVGuygnD1U6deGwRLJz7SVoi4yHjXQHk=
+github.com/autobrr/go-mediainfo v0.8.1-0.20260911072119-0b32d930ae1f/go.mod h1:P3LGxIPznO2TLKV/e58YgN0/ozP5pLCAncFzsdxMDcY=
 github.com/autobrr/go-qbittorrent v1.18.0 h1:iuVM9PAUfUPbkLvS/VcojEEKqxbzkJ3JlgDlLz3khVM=
 github.com/autobrr/go-qbittorrent v1.18.0/go.mod h1:spB3GP7xDu0btv59uUdxkLPEzoT+9xpx86QpJr4DUOw=
 github.com/autobrr/go-torrent v1.1.1 h1:Vc5R3QGZlmAEoEyEYqT2B9j/CX7to82GzFlHhXbphCw=


### PR DESCRIPTION
Pin go-mediainfo to commit 0b32d930ae1f33250f010042367ba1548c62feeb.

This updates the module and checksum entries to the requested upstream revision. The change only alters dependency resolution; runtime behavior follows that revision.

Validated with go mod verify, go test -race -v -timeout 20m ./internal/metadata/..., make lint, make test-go, git diff --check, and a clean CodeRabbit CLI review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying media information component to a newer version for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->