### PR TITLE
docs: refresh metadata and tracker workflow guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Install the following on your machine:
 
 - [Git](https://git-scm.com/)
 - [Go](https://golang.org/dl/) — see [go.mod](./go.mod) for the required version
-- [Node.js](https://nodejs.org) (`^20.19.0`, `^22.13.0`, or `>=24`)
+- [Node.js](https://nodejs.org) (`^20.19.0`, `^22.13.0`, or `>=24` for the frontend; `>=24` for public documentation)
 - [pnpm](https://pnpm.io/installation) (10 or newer — version is pinned in `webui/package.json` via `packageManager`)
 - [GNU Make](https://www.gnu.org/software/make/) — top-level shortcuts for builds, checks, formatting, and hooks
 - [golangci-lint](https://golangci-lint.run/) — use the version pinned in the [CI workflow](./.github/workflows/golangci-lint.yml) for hooks and local checks
@@ -82,7 +82,7 @@ lefthook install
 
 What runs when Git invokes hooks:
 
-- `pre-commit` — on **staged files only**: `prettier --write` (webui), `eslint` (webui/src), `golangci-lint fmt` (Go), the composite-literal layout policy, `go run ./cmd/logpolicy` (when `internal/**` Go files change), and `go run ./cmd/pathpolicy` (when Go files change). Formatters auto-re-stage their fixes.
+- `pre-commit` — runs `prettier --write` (webui), `eslint` (webui/src), and `golangci-lint fmt` (Go) on staged files. Formatters auto-re-stage their fixes. Staged Go changes also trigger repository-wide composite-literal and path-policy checks; staged `internal/**` Go changes trigger the repository-wide log-policy check. These policy checks inspect the working tree, including unstaged changes.
 - `pre-push` — full-project TypeScript typecheck and `make lint`, which runs the architecture ownership, path-portability, composite-literal layout, and workflow-contract drift checkers before golangci-lint. CI mirrors these Go policy checks and frontend checks for pull requests.
 - `commit-msg` — `go run ./cmd/commitmsgcheck` enforces [Conventional Commits](https://www.conventionalcommits.org/) without requiring Node.js or `pnpm install`.
 

--- a/documentation/docs/introduction.md
+++ b/documentation/docs/introduction.md
@@ -25,6 +25,12 @@ upbrr is for uploaders who already understand:
 
 It guides those tasks. It does not replace tracker rules, staff direction, or operator judgment.
 
+## Documentation and versions
+
+The published site updates through the release workflow and is built from the exact release tag. Development builds can include changes documented only in the repository's [documentation source](https://github.com/autobrr/upbrr/tree/main/documentation/docs).
+
+Use your installed binary's `--help` and embedded [OpenAPI reference](./api/index.md) for its exact CLI and API contracts.
+
 ## What upbrr does
 
 A normal workflow can:

--- a/documentation/docs/trackers/index.md
+++ b/documentation/docs/trackers/index.md
@@ -42,6 +42,14 @@ Rule and validation outcomes can block a live upload while still allowing debug 
 
 `--skip-dupe-check` and similar bypasses remove safeguards. Use them only when you have manually completed the equivalent tracker checks.
 
+### Approve tracker warnings
+
+Some tracker warnings permit an explicit override. On **Dupe Check**, read the warnings on the affected tracker's card. Choose **Upload anyway** only after deciding that the release is appropriate for that tracker.
+
+Approval applies only to that tracker and its current warning set. Changed warnings require renewed approval. Strict failures remain blocked and cannot be overridden, including in debug mode.
+
+The interactive CLI and `--unattended_confirm` prompt for approval. Strict `--unattended` declines without prompting and skips that tracker; other eligible trackers can continue. Debug mode bypasses warnings that permit an override.
+
 ## Names and payloads
 
 upbrr resolves tracker-specific upload and search names before duplicate checking. Review the projected name for every tracker. The eventual payload uses that reviewed name rather than deriving a new name at submission time.

--- a/documentation/docs/web-ui/settings/metadata.md
+++ b/documentation/docs/web-ui/settings/metadata.md
@@ -11,15 +11,19 @@ Use **Settings → Metadata** to control how preparation gathers reusable torren
 | -------------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
 | **Skip auto torrent**            | Off     | Skips automated torrent-client searching during preparation.                                           |
 | **Skip tracker filename lookup** | Off     | Prevents filename-based tracker-data lookup when no tracker ID is already known.                       |
+| **Keep images**                  | On      | Preserves tracker-sourced image evidence for descriptions.                                             |
+| **Only ID**                      | Off     | Limits supported tracker-data lookups to identity fields.                                              |
 | **Use largest playlist**         | Off     | Lets unattended CLI preparation choose the largest Blu-ray playlist instead of requiring confirmation. |
 | **Get Bluray info**              | Off     | Enables blu-ray.com matching for BDMV or DVD sources with an IMDb ID.                                  |
 | **Bluray score**                 | `94.5`  | Sets the normal blu-ray.com candidate score threshold.                                                 |
 | **Bluray single score**          | `89.5`  | Sets the threshold used when only one candidate is available.                                          |
 
+**Keep images** and **Only ID** work independently. With both enabled, supported trackers can still supply images while omitting description text.
+
 ## Advanced compatibility fields
 
 - **BTN API** is a legacy location. Current configuration migrates it to the BTN entry under [Trackers](./trackers.md).
-- **Keep images**, **Only ID**, **User overrides**, **Ping Unit3D**, and **Check Predb** remain in the stored schema but have no current runtime reader. Similarly named per-release options can still affect an individual preparation.
+- **User overrides**, **Ping Unit3D**, and **Check Predb** remain in the stored schema but have no current runtime reader.
 
 ## Verify the change
 

--- a/documentation/docs/workflow/index.md
+++ b/documentation/docs/workflow/index.md
@@ -56,6 +56,8 @@ Each tracker can project its own upload and duplicate-search names from the revi
 
 Tracker rules and constructibility checks can mark a lane ready, blocked, skipped, or requiring manual review. A tracker-specific block need not stop other eligible trackers.
 
+For warnings that permit an override, use **Upload anyway** on the tracker's **Dupe Check** card or answer the CLI prompt. Approval covers the current warnings; changed warnings require renewed approval. Strict failures cannot be overridden. See [tracker warning approval](../trackers/index.md#approve-tracker-warnings) for unattended and debug behavior.
+
 ## 4. Review duplicate evidence
 
 Duplicate search results are evidence, not an automatic upload decision. Review candidate names, metadata, and tracker warnings. Where approval is required, select an explicit non-empty tracker subset after the duplicate stage.


### PR DESCRIPTION
The Metadata reference incorrectly marked Keep images and Only ID as unused, and the tracker guides omitted the warning approval procedure. This update documents both active settings, their interaction, and tracker-scoped approval through Upload anyway or CLI prompts, including unattended and debug behavior.

It also clarifies the documentation site's release-based publishing, the Node 24 requirement for documentation work, and the repository-wide scope of pre-commit policy checks. These are documentation-only changes; publication of the site remains tied to releases.

Validation: documentation dependency installation with the frozen lockfile and pnpm --dir documentation run check pass, covering formatting, TypeScript, strict links, and the production build. git diff --check passes. make gofix-check-changed reports no changed Go files. The Ponytail review finds no unnecessary complexity; the docstring gate finds no eligible source changes.

CodeRabbit CLI completed a review of the full change against origin/main with zero findings. Commit and push hooks pass.
