### PR TITLE
fix: improve BTN auth validation diagnostics

### DIFF
--- a/internal/trackers/auth/ensure_test.go
+++ b/internal/trackers/auth/ensure_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/autobrr/upbrr/internal/config"
+	trackerscatalog "github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -350,6 +351,53 @@ func TestEnsureSessionKeepsCookiesOnInvalidLookingTransientAdapterText(t *testin
 	}
 	if adapter.deleteCalls != 0 {
 		t.Fatal("transient invalid-looking text must not delete stored session")
+	}
+}
+
+func TestEnsureSessionKeepsTrackerOwnedTransientDiagnosticsTransient(t *testing.T) {
+	t.Parallel()
+
+	diagnostic := &trackerscatalog.AuthResolutionError{
+		Reason:    "remote validation failed",
+		Transient: true,
+		Err:       errors.New("username password not configured; 2FA required"),
+	}
+	classified := classifyAdapterError("BTN", diagnostic)
+	var classifiedValidation *ValidationError
+	if !errors.As(classified, &classifiedValidation) || !classifiedValidation.Transient || classifiedValidation.ConfirmedInvalid {
+		t.Fatalf("expected tracker-owned transient diagnostic classification, got %v", classified)
+	}
+
+	adapter := &fakeAdapter{
+		capability: api.TrackerAuthCapability{
+			TrackerID:         "BTN",
+			SupportsLogin:     true,
+			SupportsAutoLogin: true,
+			SupportsManual2FA: true,
+		},
+		validate: func() (Session, error) {
+			return Session{}, classified
+		},
+	}
+	service := &Service{adapters: map[string]Adapter{"BTN": adapter}, challenges: NewChallengeManager(defaultChallengeTTL)}
+
+	session, err := service.EnsureSession(t.Context(), EnsureRequest{
+		TrackerID: "BTN",
+		Config:    config.TrackerConfig{Username: "user", Password: "pass"},
+		AutoLogin: true,
+	})
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) || !validationErr.Transient || validationErr.ConfirmedInvalid {
+		t.Fatalf("expected transient validation error, got session=%#v err=%v", session, err)
+	}
+	if session.ChallengeID != "" || adapter.validateCalls != 1 || adapter.loginCalls != 0 || adapter.deleteCalls != 0 {
+		t.Fatalf(
+			"transient diagnostic calls/session = validate=%d login=%d delete=%d session=%#v",
+			adapter.validateCalls,
+			adapter.loginCalls,
+			adapter.deleteCalls,
+			session,
+		)
 	}
 }
 

--- a/internal/trackers/impl/standalone/btn/auth.go
+++ b/internal/trackers/impl/standalone/btn/auth.go
@@ -22,12 +22,13 @@ import (
 )
 
 const (
-	btnDefaultBaseURL  = "https://backup.landof.tv"
-	btnUploadPath      = "/upload.php"
-	btnLoginPath       = "/login.php"
-	btnAPIRPCURL       = "https://api.broadcasthe.net/"
-	btnAPIJSONMaxBytes = 1024 * 1024
-	btnTorrentMaxBytes = 8 * 1024 * 1024
+	btnDefaultBaseURL       = "https://backup.landof.tv"
+	btnUploadPath           = "/upload.php"
+	btnLoginPath            = "/login.php"
+	btnAPIRPCURL            = "https://api.broadcasthe.net/"
+	btnAPIJSONMaxBytes      = 1024 * 1024
+	btnAuthResponseMaxBytes = 1024 * 1024
+	btnTorrentMaxBytes      = 8 * 1024 * 1024
 )
 
 // ErrSubmitted2FARejected marks a BTN failure after a submitted manual 2FA code
@@ -234,8 +235,8 @@ func loginBTNSession(ctx context.Context, cfg config.TrackerConfig, baseURL stri
 }
 
 // validateBTNClientSession confirms the client can reach BTN's upload page.
-// It treats explicit login redirects and logged-out markers as invalid session
-// evidence while keeping layout misses and upstream failures transient.
+// Only HTTP authorization failures and an exact login-page redirect prove a
+// stored session invalid. Other remote and layout failures stay transient.
 func validateBTNClientSession(ctx context.Context, client *http.Client, baseURL string) error {
 	if client == nil {
 		return errors.New("trackers: BTN session client missing")
@@ -247,32 +248,100 @@ func validateBTNClientSession(ctx context.Context, client *http.Client, baseURL 
 	req.Header.Set("User-Agent", "upbrr")
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("trackers: BTN upload auth request: %w", err)
+		return newBTNTransientAuthError("trackers: BTN upload auth request failed", err)
 	}
 	defer resp.Body.Close()
 	finalPath := ""
 	if resp.Request != nil && resp.Request.URL != nil {
-		finalPath = strings.ToLower(resp.Request.URL.EscapedPath())
+		finalPath = resp.Request.URL.Path
 	}
-	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, btnAuthResponseMaxBytes+1))
 	if readErr != nil {
-		return fmt.Errorf("trackers: BTN read upload auth response: %w", readErr)
+		return newBTNTransientAuthError("trackers: BTN upload auth response read failed", readErr)
 	}
 	bodyText := string(body)
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || strings.Contains(finalPath, "login") ||
-		btnLoggedOutPage(bodyText) {
-		return fmt.Errorf("%w: login required", errBTNSessionConfirmedInvalid)
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || finalPath == btnLoginPath {
+		if finalPath != "" {
+			return fmt.Errorf(
+				"%w: login required status=%d final_path=%s",
+				errBTNSessionConfirmedInvalid,
+				resp.StatusCode,
+				sanitizeBTNFinalPath(finalPath),
+			)
+		}
+		return fmt.Errorf("%w: login required status=%d", errBTNSessionConfirmedInvalid, resp.StatusCode)
+	}
+	if finalPath != btnUploadPath {
+		return newBTNTransientAuthError(btnAuthResponseDiagnostic("unexpected final path", resp.StatusCode, finalPath, body, btnAuthPageState(bodyText)), nil)
 	}
 	if resp.StatusCode >= 500 {
-		return fmt.Errorf("trackers: BTN upload auth unavailable status=%d", resp.StatusCode)
+		return newBTNTransientAuthError(btnAuthResponseDiagnostic("response unavailable", resp.StatusCode, finalPath, body, ""), nil)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("trackers: BTN upload auth failed status=%d", resp.StatusCode)
+		return newBTNTransientAuthError(btnAuthResponseDiagnostic("unexpected status", resp.StatusCode, finalPath, body, ""), nil)
 	}
 	if !btnLooksLikeUploadPage(bodyText) {
-		return errors.New("trackers: BTN upload auth page validation failed")
+		return newBTNTransientAuthError(btnAuthResponseDiagnostic("page validation failed", resp.StatusCode, finalPath, body, btnAuthPageState(bodyText)), nil)
 	}
 	return nil
+}
+
+type btnSafeError struct {
+	message string
+	cause   error
+}
+
+func (e btnSafeError) Error() string { return e.message }
+
+func (e btnSafeError) Unwrap() error { return e.cause }
+
+func newBTNTransientAuthError(message string, cause error) *trackers.AuthResolutionError {
+	var diagnostic error
+	if cause == nil {
+		diagnostic = errors.New(message)
+	} else {
+		diagnostic = btnSafeError{message: message, cause: cause}
+	}
+	return &trackers.AuthResolutionError{
+		Reason:    "remote validation failed",
+		Transient: true,
+		Err:       diagnostic,
+	}
+}
+
+func btnAuthResponseDiagnostic(reason string, status int, finalPath string, body []byte, pageState string) string {
+	message := fmt.Sprintf(
+		"trackers: BTN upload auth %s status=%d response_bytes=%d response_truncated=%t",
+		reason,
+		status,
+		len(body),
+		len(body) > btnAuthResponseMaxBytes,
+	)
+	if finalPath != btnUploadPath {
+		message += " final_path=" + sanitizeBTNFinalPath(finalPath)
+	}
+	if pageState != "" {
+		message += " page_state=" + pageState
+	}
+	return message
+}
+
+func btnAuthPageState(body string) string {
+	if btnLoggedOutPage(body) {
+		return "logged_out_marker"
+	}
+	return "upload_form_missing"
+}
+
+func sanitizeBTNFinalPath(finalPath string) string {
+	const redactedPath = "[REDACTED]"
+
+	switch finalPath {
+	case btnUploadPath, btnLoginPath, "/user.php", "/torrents.php":
+		return finalPath
+	default:
+		return redactedPath
+	}
 }
 
 // loadBTNCookiesIntoJar best-effort seeds an upload client with persisted BTN

--- a/internal/trackers/impl/standalone/btn/upload_integration_test.go
+++ b/internal/trackers/impl/standalone/btn/upload_integration_test.go
@@ -1620,10 +1620,10 @@ func TestBTNPrepareUploadDataBlocksMissingCanonicalTVMetadataBeforeAutofill(t *t
 	}
 }
 
-func TestBTNUploadCredentialLoginDoesNotPersistInvalidSession(t *testing.T) {
+func TestBTNUploadCredentialLoginDoesNotPersistUnvalidatedSession(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	dbPath := newBTNAuthDB(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -1646,11 +1646,42 @@ func TestBTNUploadCredentialLoginDoesNotPersistInvalidSession(t *testing.T) {
 		Username: "user",
 		Password: "pass",
 	}, dbPath, uploadContext{baseURL: server.URL})
-	if !errors.Is(err, errBTNSessionConfirmedInvalid) {
-		t.Fatalf("expected invalid session error, got %v", err)
+	resolution, ok := errors.AsType[*trackers.AuthResolutionError](err)
+	if !ok || !resolution.Transient || resolution.ConfirmedInvalid {
+		t.Fatalf("expected transient session validation error, got %v", err)
 	}
 	if values, err := loadBTNCookies(ctx, dbPath); err == nil {
 		t.Fatalf("expected invalid login cookies not to persist, got %#v", values)
+	}
+}
+
+func TestBTNUploadSessionKeepsStoredCookiesOnRedirectFailure(t *testing.T) {
+	t.Parallel()
+
+	dbPath := newBTNAuthDB(t)
+	if err := cookies.SaveTrackerCookieMap(t.Context(), dbPath, "BTN", map[string]string{"session": "stored"}); err != nil {
+		t.Fatalf("SaveTrackerCookieMap: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Cookie"), "session=stored") {
+			http.Error(w, "missing stored session", http.StatusInternalServerError)
+			return
+		}
+		http.Redirect(w, r, "/synthetic-secret.php?token=synthetic-secret", http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := ensureBTNUploadSession(t.Context(), config.TrackerConfig{}, dbPath, uploadContext{baseURL: server.URL})
+	resolution, ok := errors.AsType[*trackers.AuthResolutionError](err)
+	if !ok || !resolution.Transient || resolution.ConfirmedInvalid {
+		t.Fatalf("expected transient session validation error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "synthetic-secret") || strings.Contains(err.Error(), "token=") {
+		t.Fatalf("expected safe redirect diagnostic, got %q", err)
+	}
+	values, err := loadBTNCookies(t.Context(), dbPath)
+	if err != nil || values["session"] != "stored" {
+		t.Fatalf("expected stored cookies preserved, values=%#v err=%v", values, err)
 	}
 }
 
@@ -1658,10 +1689,9 @@ func TestValidateBTNClientSessionRequiresUploadFormStructure(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name                 string
-		body                 string
-		wantErr              bool
-		wantConfirmedInvalid bool
+		name    string
+		body    string
+		wantErr bool
 	}{
 		{
 			name:    "help page upload text rejected",
@@ -1669,10 +1699,9 @@ func TestValidateBTNClientSessionRequiresUploadFormStructure(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:                 "logged out upload help rejected",
-			body:                 `<html><h1>Upload</h1><p>Please log in before using the upload page.</p></html>`,
-			wantErr:              true,
-			wantConfirmedInvalid: true,
+			name:    "logged out upload help rejected",
+			body:    `<html><h1>Upload</h1><p>Please log in before using the upload page.</p></html>`,
+			wantErr: true,
 		},
 		{
 			name:    "transient success body rejected",
@@ -1702,21 +1731,290 @@ func TestValidateBTNClientSessionRequiresUploadFormStructure(t *testing.T) {
 			}))
 			t.Cleanup(server.Close)
 
-			err := validateBTNClientSession(context.Background(), server.Client(), server.URL)
+			err := validateBTNClientSession(t.Context(), server.Client(), server.URL)
 			if tt.wantErr && err == nil {
 				t.Fatal("expected upload auth page validation error")
 			}
-			if tt.wantConfirmedInvalid && !errors.Is(err, errBTNSessionConfirmedInvalid) {
-				t.Fatalf("expected confirmed-invalid session error, got %v", err)
-			}
-			if tt.wantErr && !tt.wantConfirmedInvalid && !strings.Contains(err.Error(), "upload auth page validation failed") {
-				t.Fatalf("expected upload marker validation error, got %v", err)
+			if tt.wantErr {
+				resolution, ok := errors.AsType[*trackers.AuthResolutionError](err)
+				if !ok || !resolution.Transient || resolution.ConfirmedInvalid || errors.Is(err, errBTNSessionConfirmedInvalid) {
+					t.Fatalf("expected transient upload marker validation error, got %v", err)
+				}
 			}
 			if !tt.wantErr && err != nil {
 				t.Fatalf("validateBTNClientSession: %v", err)
 			}
 		})
 	}
+}
+
+func TestValidateBTNClientSessionReportsRedirectAndLayoutDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		handler              http.HandlerFunc
+		wantConfirmedInvalid bool
+		want                 []string
+		absent               []string
+	}{
+		{
+			name: "non-login redirect reports path and detail",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/upload.php":
+					http.Redirect(w, r, "/torrents.php?token=synthetic-secret", http.StatusFound)
+				case "/torrents.php":
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_, _ = io.WriteString(w, `<div role="alert">Upload maintenance in progress</div>`)
+				default:
+					http.NotFound(w, r)
+				}
+			},
+			want:   []string{"status=503", "final_path=/torrents.php", "response_bytes=", "response_truncated=false"},
+			absent: []string{"synthetic-secret", "token=", "Upload maintenance in progress"},
+		},
+		{
+			name: "login redirect remains confirmed invalid and reports path",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/upload.php":
+					http.Redirect(w, r, "/login.php?passkey=synthetic-secret", http.StatusFound)
+				case "/login.php":
+					_, _ = io.WriteString(w, `<form action="/login.php"><input name="password"></form>`)
+				default:
+					http.NotFound(w, r)
+				}
+			},
+			wantConfirmedInvalid: true,
+			want:                 []string{"status=200", "final_path=/login.php"},
+			absent:               []string{"synthetic-secret", "passkey="},
+		},
+		{
+			name: "login-status redirect remains transient",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/upload.php":
+					http.Redirect(w, r, "/login-status.php", http.StatusFound)
+				case "/login-status.php":
+					_, _ = io.WriteString(w, `<form action="/login.php"><input name="password"></form>`)
+				default:
+					http.NotFound(w, r)
+				}
+			},
+			want:   []string{"status=200", "final_path=[REDACTED]", "page_state=logged_out_marker"},
+			absent: []string{"password", "login.php"},
+		},
+		{
+			name: "non-login redirect with logged-out page remains transient",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/upload.php":
+					http.Redirect(w, r, "/torrents.php", http.StatusFound)
+				case "/torrents.php":
+					_, _ = io.WriteString(w, `<div role="alert">Please log in before continuing</div>`)
+				default:
+					http.NotFound(w, r)
+				}
+			},
+			want:   []string{"status=200", "final_path=/torrents.php", "page_state=logged_out_marker"},
+			absent: []string{"Please log in before continuing"},
+		},
+		{
+			name: "secret redirect path is redacted",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/upload.php":
+					http.Redirect(w, r, "/synthetic-secret.php", http.StatusFound)
+				case "/synthetic-secret.php":
+					_, _ = io.WriteString(w, `<div role="alert">Upload maintenance in progress</div>`)
+				default:
+					http.NotFound(w, r)
+				}
+			},
+			want:   []string{"status=200", "final_path=[REDACTED]", "response_bytes="},
+			absent: []string{"synthetic-secret", "Upload maintenance in progress"},
+		},
+		{
+			name: "unknown short redirect path is redacted",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/upload.php":
+					http.Redirect(w, r, "/alice.php", http.StatusFound)
+				case "/alice.php":
+					_, _ = io.WriteString(w, `<div role="alert">Upload maintenance in progress</div>`)
+				default:
+					http.NotFound(w, r)
+				}
+			},
+			want:   []string{"status=200", "final_path=[REDACTED]", "response_bytes="},
+			absent: []string{"alice.php", "Upload maintenance in progress"},
+		},
+		{
+			name: "same upload path reports redacted layout detail",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/upload.php" {
+					http.NotFound(w, r)
+					return
+				}
+				_, _ = io.WriteString(w, `<div role="alert">Upload form disabled: passkey=synthetic-secret</div>`)
+				_, _ = io.WriteString(w, strings.Repeat(" ", 1024*1024))
+			},
+			want:   []string{"page validation failed", "status=200", "response_bytes=1048577", "response_truncated=true", "page_state=upload_form_missing"},
+			absent: []string{"synthetic-secret", "Upload form disabled", "passkey="},
+		},
+		{
+			name: "same upload path ignores prose and truncated JSON values",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/upload.php" {
+					http.NotFound(w, r)
+					return
+				}
+				_, _ = io.WriteString(w, `Account Jane Example token=synthetic-secret`)
+				_, _ = io.WriteString(w, `{"username":"synthetic-user","profile":"Jane\u0020Example","password":"synthetic-password","padding":"`)
+				_, _ = io.WriteString(w, strings.Repeat("x", 1024*1024))
+			},
+			want:   []string{"page validation failed", "status=200", "response_truncated=true", "page_state=upload_form_missing"},
+			absent: []string{"Jane Example", "synthetic-secret", "synthetic-user", "synthetic-password", "username", "password", "token="},
+		},
+		{
+			name: "same upload path missing-location redirect remains transient",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/upload.php" {
+					http.NotFound(w, r)
+					return
+				}
+				w.WriteHeader(http.StatusFound)
+			},
+			want: []string{"unexpected status", "status=302", "response_bytes=0", "response_truncated=false"},
+		},
+		{
+			name: "same upload path non-auth client error remains transient",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/upload.php" {
+					http.NotFound(w, r)
+					return
+				}
+				w.WriteHeader(http.StatusTooManyRequests)
+			},
+			want: []string{"unexpected status", "status=429", "response_bytes=0", "response_truncated=false"},
+		},
+		{
+			name: "same upload path server error remains transient",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/upload.php" {
+					http.NotFound(w, r)
+					return
+				}
+				w.WriteHeader(http.StatusServiceUnavailable)
+			},
+			want: []string{"response unavailable", "status=503", "response_bytes=0", "response_truncated=false"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			t.Cleanup(server.Close)
+
+			err := validateBTNClientSession(t.Context(), server.Client(), server.URL)
+			if err == nil {
+				t.Fatal("expected upload auth validation error")
+			}
+			if tt.wantConfirmedInvalid != errors.Is(err, errBTNSessionConfirmedInvalid) {
+				t.Fatalf("confirmed-invalid classification=%t, want %t: %v", errors.Is(err, errBTNSessionConfirmedInvalid), tt.wantConfirmedInvalid, err)
+			}
+			if !tt.wantConfirmedInvalid {
+				resolution, ok := errors.AsType[*trackers.AuthResolutionError](err)
+				if !ok || !resolution.Transient || resolution.ConfirmedInvalid {
+					t.Fatalf("expected transient tracker-owned resolution error, got %v", err)
+				}
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error=%q, want %q", err, want)
+				}
+			}
+			for _, absent := range tt.absent {
+				if strings.Contains(err.Error(), absent) {
+					t.Fatalf("error=%q, must not contain %q", err, absent)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateBTNClientSessionKeepsRedirectFailureSafeAndTransient(t *testing.T) {
+	t.Parallel()
+
+	redirectCause := errors.New("redirect to https://tracker.invalid/synthetic-secret.php?token=synthetic-secret username password not configured")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/upload.php" {
+			http.NotFound(w, r)
+			return
+		}
+		http.Redirect(w, r, "/synthetic-secret.php?token=synthetic-secret", http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+	client := server.Client()
+	client.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return redirectCause
+	}
+
+	err := validateBTNClientSession(t.Context(), client, server.URL)
+	if !errors.Is(err, redirectCause) {
+		t.Fatalf("expected redirect cause preserved, got %v", err)
+	}
+	resolution, ok := errors.AsType[*trackers.AuthResolutionError](err)
+	if !ok || !resolution.Transient || resolution.ConfirmedInvalid {
+		t.Fatalf("expected transient tracker-owned redirect error, got %v", err)
+	}
+	for _, secret := range []string{"synthetic-secret", "tracker.invalid", "username", "password", "not configured"} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("redirect failure leaked %q in %q", secret, err)
+		}
+	}
+}
+
+func TestValidateBTNClientSessionKeepsBodyReadFailureSafeAndTransient(t *testing.T) {
+	t.Parallel()
+
+	readCause := errors.New("read https://tracker.invalid/upload.php?token=synthetic-secret username=synthetic-user failed")
+	client := &http.Client{Transport: btnRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(btnErrorReader{err: readCause}),
+			Request:    req,
+		}, nil
+	})}
+
+	err := validateBTNClientSession(t.Context(), client, "https://tracker.invalid")
+	if !errors.Is(err, readCause) {
+		t.Fatalf("expected read cause preserved, got %v", err)
+	}
+	resolution, ok := errors.AsType[*trackers.AuthResolutionError](err)
+	if !ok || !resolution.Transient || resolution.ConfirmedInvalid {
+		t.Fatalf("expected transient tracker-owned read error, got %v", err)
+	}
+	for _, secret := range []string{"tracker.invalid", "synthetic-secret", "synthetic-user", "username", "token="} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("read failure leaked %q in %q", secret, err)
+		}
+	}
+}
+
+type btnRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn btnRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+type btnErrorReader struct {
+	err error
+}
+
+func (r btnErrorReader) Read([]byte) (int, error) {
+	return 0, r.err
 }
 
 func TestExtractAutofillFieldsSelectsOptionsOrderIndependently(t *testing.T) {


### PR DESCRIPTION
BTN upload-auth validation gave too little evidence when the upload check landed on another page. Some ambiguous responses could also be treated like confirmed invalid authentication.

This change reports safe diagnostic facts for the final redirect path, HTTP status, bounded response size, truncation, and fixed page-state markers. Unknown paths and response prose stay redacted. Only HTTP 401/403 or an exact /login.php redirect confirms invalid authentication; other request, redirect, response, and layout failures remain transient.

The impact is limited to BTN upload-auth validation and its auth coordinator classification. Existing cookies remain intact during ambiguous remote failures.

Validated with focused race tests for BTN and tracker auth, repository lint, log policy, changed-Go formatting checks, diff checks, pre-commit hooks, and two independent review passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session validation to distinguish confirmed invalid sessions from temporary or inconclusive validation failures.
  - Preserved stored cookies when session validation fails due to redirects, network issues, unexpected responses, or incomplete page data.
  - Prevented unnecessary login prompts, cookie deletion, and challenge creation when authentication status cannot be confirmed.
  - Added safer diagnostic reporting that limits response data and redacts sensitive paths or details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->