### PR TITLE
fix(workflow): restore preparation requirements on composite resume

### DIFF
--- a/internal/releaseworkflow/composite_upload.go
+++ b/internal/releaseworkflow/composite_upload.go
@@ -836,18 +836,18 @@ func (m *Module) runCompositeUpload(
 	command CompositeUploadCommand,
 ) (CommandResult, error) {
 	operationID, _ := ctx.Value(operationExecutionContextKey{}).(api.WorkflowOperationID)
-	initial, session, err := m.currentCompositeUpload(ctx, ownerID, command, operationID)
+	initial, session, requirements, err := m.currentCompositeUpload(ctx, ownerID, command, operationID)
 	if err != nil {
 		return CommandResult{}, err
 	}
-	if err := m.hydrateCompositePreparedRelease(ctx, initial, session); err != nil {
+	if err := m.hydrateCompositePreparedRelease(ctx, initial, session, requirements); err != nil {
 		return CommandResult{}, err
 	}
 	for range compositeUploadTransitionLimit {
 		if err := ctx.Err(); err != nil {
 			return CommandResult{}, fmt.Errorf("release workflow composite upload: %w", err)
 		}
-		current, session, err := m.currentCompositeUpload(ctx, ownerID, command, operationID)
+		current, session, _, err := m.currentCompositeUpload(ctx, ownerID, command, operationID)
 		if err != nil {
 			return CommandResult{}, err
 		}
@@ -1011,6 +1011,7 @@ func (m *Module) hydrateCompositePreparedRelease(
 	ctx context.Context,
 	current CommandResult,
 	session *compositeUploadSession,
+	requirements api.MetadataRequirementSet,
 ) error {
 	if current.Release == nil {
 		return nil
@@ -1020,6 +1021,7 @@ func (m *Module) hydrateCompositePreparedRelease(
 	}
 	input := *session.Intent.Preparation
 	input.SourcePath = current.Release.Release.Source.SourcePath
+	input.MetadataRequirements = requirements
 	input.Force = false
 	input.RequirePrepared = true
 	input.Controls.ConfirmBDMVRescan = false
@@ -1040,21 +1042,21 @@ func (m *Module) currentCompositeUpload(
 	ownerID string,
 	command CompositeUploadCommand,
 	operationID api.WorkflowOperationID,
-) (CommandResult, *compositeUploadSession, error) {
+) (CommandResult, *compositeUploadSession, api.MetadataRequirementSet, error) {
 	current, err := m.Current(ctx, ownerID, command.WorkflowID)
 	if err != nil {
-		return CommandResult{}, nil, err
+		return CommandResult{}, nil, api.MetadataRequirementSet{}, err
 	}
 	state, err := m.repository.Load(ctx, ownerID, command.WorkflowID)
 	if err != nil {
-		return CommandResult{}, nil, fmt.Errorf("release workflow load composite session: %w", err)
+		return CommandResult{}, nil, api.MetadataRequirementSet{}, fmt.Errorf("release workflow load composite session: %w", err)
 	}
 	if state.Composite == nil || state.Composite.Version != compositeUploadSessionVersion ||
 		state.Composite.RequestFingerprint != command.SessionFingerprint ||
 		state.Composite.ActiveOperationID != operationID {
-		return CommandResult{}, nil, fmt.Errorf("%w: composite upload session failed integrity validation", ErrInvalidTransition)
+		return CommandResult{}, nil, api.MetadataRequirementSet{}, fmt.Errorf("%w: composite upload session failed integrity validation", ErrInvalidTransition)
 	}
-	return current, state.Composite, nil
+	return current, state.Composite, state.PreparationDemand, nil
 }
 
 func compositeUploadGoalReached(current CommandResult, session *compositeUploadSession) bool {

--- a/internal/releaseworkflow/composite_upload_persistence_test.go
+++ b/internal/releaseworkflow/composite_upload_persistence_test.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package releaseworkflow
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/autobrr/upbrr/internal/externalidentity"
+	"github.com/autobrr/upbrr/internal/preparedrelease"
+	preparationstate "github.com/autobrr/upbrr/internal/preparedrelease/state"
+	"github.com/autobrr/upbrr/internal/services/db"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestCompositeUploadHydrationRestoresDurableDemandForPreparedRelease(t *testing.T) {
+	t.Parallel()
+
+	sourcePath := filepath.Join(t.TempDir(), "Example.Release.2026.1080p-GRP.mkv")
+	if err := os.WriteFile(sourcePath, []byte("synthetic media"), 0o600); err != nil {
+		t.Fatalf("write preparation source: %v", err)
+	}
+	databasePath := filepath.Join(t.TempDir(), "composite-hydration.sqlite")
+	repoA, err := db.Open(databasePath)
+	if err != nil {
+		t.Fatalf("open first repository: %v", err)
+	}
+	if err := repoA.Migrate(); err != nil {
+		_ = repoA.Close()
+		t.Fatalf("migrate first repository: %v", err)
+	}
+	persistentA, err := NewPersistentRepository(repoA)
+	if err != nil {
+		_ = repoA.Close()
+		t.Fatalf("new first persistent repository: %v", err)
+	}
+	preparerA := newCompositePersistencePreparer(t, repoA)
+	requirements := api.MetadataRequirementSet{
+		Version: "durable-composite-hydration-v1",
+		Requirements: []api.MetadataRequirement{{
+			Scope:       api.MetadataRequirementScopeAny,
+			AnyOf:       []api.MetadataRequirementField{"original_title"},
+			Disposition: api.RuleDispositionStrict,
+		}},
+	}
+	moduleA, err := New(
+		persistentA,
+		NewMemoryPrivateResourceStore(),
+		preparerA,
+		WithClock(fixedClock{now: time.Date(2026, time.September, 12, 12, 0, 0, 0, time.UTC)}),
+		WithIDGenerator(&sequenceIDGenerator{}),
+		WithInputReadinessEvaluator(compositeUploadDemandEvaluator{requirements: requirements}),
+	)
+	if err != nil {
+		_ = repoA.Close()
+		t.Fatalf("new first workflow module: %v", err)
+	}
+	request := compositeUploadTestRequest(false, api.ReleaseWorkflowUploadModeDebug, "durable-composite-hydration")
+	request.Source.Path = sourcePath
+	session, instructions, err := normalizeCompositeUploadRequest(request)
+	if err != nil {
+		_ = repoA.Close()
+		t.Fatalf("normalize composite request: %v", err)
+	}
+	created := executeCommand(t, moduleA, CreateWorkflowCommand{
+		WorkflowID:          "durable-composite-hydration",
+		Instructions:        instructions,
+		IdempotencyKey:      request.IdempotencyKey,
+		RequestFingerprint:  session.RequestFingerprint,
+		TrackerDecisionMode: TrackerDecisionModePostDupeGate,
+		Composite:           session,
+	})
+	prepared := executeCommand(t, moduleA, PrepareReleaseCommand{
+		WorkflowID:       created.Workflow.ID,
+		ExpectedRevision: created.Workflow.Revision,
+		Input:            *session.Intent.Preparation,
+		TrackerIDs:       session.Intent.TrackerIDs,
+		IdempotencyKey:   "prepare-durable-composite-hydration",
+	})
+	if prepared.Release == nil {
+		_ = repoA.Close()
+		t.Fatal("prepared release is unavailable")
+	}
+	if err := repoA.Close(); err != nil {
+		t.Fatalf("close first repository: %v", err)
+	}
+
+	repoB, err := db.Open(databasePath)
+	if err != nil {
+		t.Fatalf("reopen repository: %v", err)
+	}
+	t.Cleanup(func() { _ = repoB.Close() })
+	if err := repoB.Migrate(); err != nil {
+		t.Fatalf("migrate reopened repository: %v", err)
+	}
+	persistentB, err := NewPersistentRepository(repoB)
+	if err != nil {
+		t.Fatalf("new reopened persistent repository: %v", err)
+	}
+	preparerB := newCompositePersistencePreparer(t, repoB)
+	moduleB, err := New(persistentB, NewMemoryPrivateResourceStore(), preparerB)
+	if err != nil {
+		t.Fatalf("new restarted workflow module: %v", err)
+	}
+	state, err := persistentB.Load(t.Context(), testOwnerID, created.Workflow.ID)
+	if err != nil {
+		t.Fatalf("load restarted durable state: %v", err)
+	}
+	if state.Workflow.Release == nil {
+		t.Fatal("restarted workflow release is unavailable")
+	}
+	release, ok := state.Releases[state.Workflow.Release.ID]
+	if !ok {
+		t.Fatalf("restarted release snapshot %q is unavailable", state.Workflow.Release.ID)
+	}
+	current := CommandResult{Release: &release}
+	if state.Composite == nil || state.Composite.Intent.Preparation == nil ||
+		!reflect.DeepEqual(state.PreparationDemand, requirements) || !reflect.DeepEqual(state.Composite.Intent.Preparation.MetadataRequirements, api.MetadataRequirementSet{}) {
+		t.Fatalf("restarted composite preparation state = %#v", state)
+	}
+	if err := moduleB.hydrateCompositePreparedRelease(t.Context(), current, state.Composite, state.PreparationDemand); err != nil {
+		t.Fatalf("hydrate compatible prepared release: %v", err)
+	}
+
+	forced := *state.Composite.Intent.Preparation
+	forced.SourcePath = current.Release.Release.Source.SourcePath
+	forced.MetadataRequirements = state.PreparationDemand
+	forced.Force = true
+	if _, err := preparerB.Prepare(t.Context(), forced); err != nil {
+		t.Fatalf("replace prepared generation: %v", err)
+	}
+	if err := moduleB.hydrateCompositePreparedRelease(t.Context(), current, state.Composite, state.PreparationDemand); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("hydrate changed generation error = %v", err)
+	}
+}
+
+func newCompositePersistencePreparer(t *testing.T, store preparedrelease.Store) *preparedrelease.Module {
+	t.Helper()
+	preparer, err := preparedrelease.New(store, compositePersistenceIdentityResolver{}, compositePersistenceCollector{})
+	if err != nil {
+		t.Fatalf("new prepared release module: %v", err)
+	}
+	return preparer
+}
+
+type compositePersistenceIdentityResolver struct{}
+
+func (compositePersistenceIdentityResolver) Resolve(
+	_ context.Context,
+	request externalidentity.Request,
+) (externalidentity.Result, error) {
+	now := time.Now().UTC()
+	return externalidentity.Result{
+		Identity: api.ExternalIdentity{
+			SourcePath: request.SourcePath,
+			Generation: request.Generation,
+			TMDBID:     1234567,
+			Category:   api.CanonicalCategoryMovie,
+			Provenance: api.IdentityProvenanceSet{
+				TMDB:     api.IdentityProvenanceProvider,
+				Category: api.IdentityProvenanceProvider,
+			},
+			Conflict: api.IdentityConflictNone,
+			Resolution: api.IdentityResolutionKey{
+				SourceFingerprint: request.SourceFingerprint,
+				IntentFingerprint: "durable-composite-hydration",
+				ContractVersion:   externalidentity.ContractVersion,
+			},
+			ResolvedAt: now,
+		},
+		ProviderMetadata: api.SourceScopedMetadata{
+			SourcePath: request.SourcePath,
+			Generation: request.Generation,
+			UpdatedAt:  now,
+		},
+	}, nil
+}
+
+type compositePersistenceCollector struct{}
+
+func (compositePersistenceCollector) Collect(
+	_ context.Context,
+	request preparationstate.Request,
+) (preparedrelease.CollectedFacts, error) {
+	return preparedrelease.CollectedFacts{
+		Naming: api.NamingFacts{
+			Filename:         filepath.Base(request.Manifest.SourcePath),
+			ReleaseName:      "Example.Release.2026.1080p-GRP",
+			NamePresentation: api.ReleaseNamePresentation{Version: api.ReleaseNamePresentationVersionV1, OmitYear: true},
+		},
+		Assessments: api.ReleaseAssessments{
+			MediaInfoUniqueID:       api.UniqueIDStatusPresent,
+			MediaInfoEncodeSettings: api.EncodeSettingsStatusMissing,
+			Naming:                  api.NamingAssessment{Status: api.NamingStatusComplete},
+		},
+	}, nil
+}
+
+func (compositePersistenceCollector) HydratePrivateResources(
+	_ context.Context,
+	request preparationstate.Request,
+) (preparedrelease.CollectedResources, error) {
+	return preparedrelease.CollectedResources{SourcePath: request.Manifest.SourcePath}, nil
+}
+
+var _ preparedrelease.Collector = compositePersistenceCollector{}
+var _ preparedrelease.IdentityResolver = compositePersistenceIdentityResolver{}

--- a/internal/releaseworkflow/composite_upload_test.go
+++ b/internal/releaseworkflow/composite_upload_test.go
@@ -115,6 +115,62 @@ func TestCompositeUploadStrictDebugContinuesWithEligibleTrackers(t *testing.T) {
 	}
 }
 
+func TestCompositeUploadFeedbackHydratesPersistedMetadataDemand(t *testing.T) {
+	t.Parallel()
+
+	requirements := api.MetadataRequirementSet{
+		Version: "composite-hydration-v1",
+		Requirements: []api.MetadataRequirement{{
+			Scope:       api.MetadataRequirementScopeAny,
+			AnyOf:       []api.MetadataRequirementField{"original_title"},
+			Disposition: api.RuleDispositionStrict,
+		}},
+	}
+	basePreparer := testPreparer()
+	hydrationInputs := make(chan api.PrepareInput, 1)
+	preparer := basePreparer
+	preparer.PrepareFunc = func(ctx context.Context, input api.PrepareInput) (api.PrepareResult, error) {
+		if input.RequirePrepared {
+			hydrationInputs <- input
+			if !reflect.DeepEqual(input.MetadataRequirements, requirements) {
+				return api.PrepareResult{}, errors.New("compatible prepared generation is required")
+			}
+		}
+		return basePreparer.Prepare(ctx, input)
+	}
+	module, repository, _ := newCompositeUploadTestModule(t)
+	module.preparer = preparer
+	module.inputReadiness = compositeUploadDemandEvaluator{requirements: requirements}
+
+	started, err := module.StartUpload(t.Context(), testOwnerID, compositeUploadTestRequest(false, api.ReleaseWorkflowUploadModeDebug, "composite-hydration"))
+	if err != nil {
+		t.Fatalf("start composite debug upload: %v", err)
+	}
+	blocked := waitCompositeUploadTestOperation(t, module, started)
+	state, err := repository.Load(t.Context(), testOwnerID, blocked.Workflow.ID)
+	if err != nil {
+		t.Fatalf("load blocked composite state: %v", err)
+	}
+	if state.Composite == nil || state.Composite.Intent.Preparation == nil ||
+		!reflect.DeepEqual(state.PreparationDemand, requirements) || !reflect.DeepEqual(state.Composite.Intent.Preparation.MetadataRequirements, api.MetadataRequirementSet{}) {
+		t.Fatalf("persisted composite preparation state = %#v", state)
+	}
+
+	completed := approveCompositeUploadTrackers(t, module, blocked, []api.TrackerID{"ALPHA", "BETA"}, "approve-composite-hydration")
+	if completed.Operation == nil || completed.Operation.Status != api.StageStatusCompleted || completed.DryRun == nil {
+		t.Fatalf("resumed composite operation = %#v", completed)
+	}
+	select {
+	case input := <-hydrationInputs:
+		if input.SourcePath != blocked.Release.Release.Source.SourcePath || input.Force || !input.RequirePrepared ||
+			input.Controls.ConfirmBDMVRescan || input.Controls.ForceRecheck != nil || !reflect.DeepEqual(input.MetadataRequirements, requirements) {
+			t.Fatalf("composite hydration input = %#v", input)
+		}
+	default:
+		t.Fatal("composite resume did not hydrate the prepared release")
+	}
+}
+
 func TestCompositeUploadConfirmFeedbackResumesWithServerApproval(t *testing.T) {
 	t.Parallel()
 
@@ -975,6 +1031,15 @@ func compositeUploadTestRequest(
 		},
 		IdempotencyKey: idempotencyKey,
 	}
+}
+
+type compositeUploadDemandEvaluator struct {
+	readyInputReadinessEvaluator
+	requirements api.MetadataRequirementSet
+}
+
+func (e compositeUploadDemandEvaluator) Requirements(context.Context, []api.TrackerID) (api.MetadataRequirementSet, error) {
+	return e.requirements, nil
 }
 
 func newCompositeUploadTestModule(


### PR DESCRIPTION
Composite uploads can fail with "compatible prepared generation is required" after an upload prompt or restart, even when preparation just succeeded. Preparation fingerprints include tracker metadata requirements, but composite hydration reconstructs inputs without restoring the requirements saved separately in workflow state. Deleting stored release data recreates the same mismatch.

Restore the saved preparation requirements before the compatible-generation lookup. Keep exact generation and compatibility validation, along with the existing one-shot control resets. This needs no database migration or public API change.

Regression coverage exercises feedback resume and SQLite reopen with the real preparation module, including rejection of a replaced generation. Validation passes: full Go race suite, final releaseworkflow race tests, make lint, make logpolicy, make gofix-check-changed, git diff --check, and the CLI build. CodeRabbit CLI completed one pass with no findings; two subsequent test-only simplifications pass the final package checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Composite uploads now preserve required metadata when paused for approval and resumed.
  * Upload preparation remains consistent after restarting the application or reopening persistent workflow state.
  * Resuming a compatible prepared release now correctly applies the saved metadata requirements.
  * Invalid or outdated prepared releases continue to be rejected instead of being resumed incorrectly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->