### PR TITLE
fix(dvl): add banned release groups

### DIFF
--- a/internal/trackers/impl/unit3d/sites/dvl/banned_groups.go
+++ b/internal/trackers/impl/unit3d/sites/dvl/banned_groups.go
@@ -6,8 +6,12 @@ package dvl
 // BannedGroups returns DreadVault's published release-group blacklist.
 func BannedGroups() []string {
 	return []string{
+		"AOC",
+		"AOS",
 		"BONE",
 		"EVO",
+		"FGT",
+		"LAMA",
 		"NeoNoir",
 		"PSA",
 		"RARBG",


### PR DESCRIPTION
DreadVault's rules page added AOC, AOS, FGT and LAMA to the banned list on 2026-09-06.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved content filtering by blocking additional banned groups, including AOC, AOS, FGT, and LAMA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->