### PR TITLE
fix(hdb): sanitize torrent upload filenames

### DIFF
--- a/internal/trackers/impl/standalone/hdb/name.go
+++ b/internal/trackers/impl/standalone/hdb/name.go
@@ -9,10 +9,32 @@ import (
 	"strings"
 	"unicode"
 
+	"golang.org/x/text/unicode/norm"
+
 	pathutil "github.com/autobrr/upbrr/internal/pathing"
 	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
+
+// uploadTorrentFilename keeps endpoint filename restrictions separate from the reviewed display name.
+func uploadTorrentFilename(name string) string {
+	name = strings.NewReplacer("DD+", "DDP", "HDR10+", "HDR10P", "DTS:", "DTS-", "&", " and ", "'", "", "’", "").Replace(name)
+	name = strings.Map(func(char rune) rune {
+		switch {
+		case unicode.Is(unicode.Mn, char):
+			return -1
+		case char >= 'a' && char <= 'z', char >= 'A' && char <= 'Z', char >= '0' && char <= '9', char == '-', char == '_':
+			return char
+		default:
+			return '.'
+		}
+	}, norm.NFD.String(name))
+	name = strings.Trim(strings.Join(strings.FieldsFunc(name, func(char rune) bool { return char == '.' }), "."), ".-_")
+	if name == "" {
+		name = "release"
+	}
+	return name + ".torrent"
+}
 
 func releaseNamePolicy() trackers.ReleaseNamePolicyBinding {
 	return trackers.WithMovieYearProvider(trackers.WithEpisodeTitleMode(

--- a/internal/trackers/impl/standalone/hdb/payload_test.go
+++ b/internal/trackers/impl/standalone/hdb/payload_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package hdb
+
+import (
+	"bytes"
+	"io"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMultipartTorrentFilename(t *testing.T) {
+	torrentPath := filepath.Join(t.TempDir(), "prepared.torrent")
+	content := []byte("prepared torrent bytes")
+	if err := os.WriteFile(torrentPath, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{
+			name: "Example Film 2026 WEB-DL DD+5.1 HDR10+ DTS:X-GRP",
+			want: "Example.Film.2026.WEB-DL.DDP5.1.HDR10P.DTS-X-GRP.torrent",
+		},
+		{
+			name: "Café & Someone’s 'Story' 2026-GRP",
+			want: "Cafe.and.Someones.Story.2026-GRP.torrent",
+		},
+		{
+			name: "../Example\\Film: [2026]\"\r\n\t日本語😀 / 1080p_GRP...",
+			want: "Example.Film.2026.1080p_GRP.torrent",
+		},
+		{
+			name: "Example.Film.2026.1080p.WEB-DL-GRP",
+			want: "Example.Film.2026.1080p.WEB-DL-GRP.torrent",
+		},
+		{
+			name: "日本語😀..._-",
+			want: "release.torrent",
+		},
+	} {
+		t.Run(tc.want, func(t *testing.T) {
+			body, contentType, err := buildMultipartPayload(map[string]string{"name": tc.name}, torrentPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req := httptest.NewRequestWithContext(t.Context(), "POST", "/upload", bytes.NewReader(body))
+			req.Header.Set("Content-Type", contentType)
+			if err := req.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := req.MultipartForm.RemoveAll(); err != nil {
+					t.Error(err)
+				}
+			})
+			if got := req.FormValue("name"); got != tc.name {
+				t.Fatalf("display name = %q, want %q", got, tc.name)
+			}
+			file, header, err := req.FormFile("file")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+			if header.Filename != tc.want {
+				t.Fatalf("filename = %q, want %q", header.Filename, tc.want)
+			}
+			got, err := io.ReadAll(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, content) {
+				t.Fatal("torrent content changed")
+			}
+		})
+	}
+}

--- a/internal/trackers/impl/standalone/hdb/upload.go
+++ b/internal/trackers/impl/standalone/hdb/upload.go
@@ -323,7 +323,7 @@ func buildMultipartPayload(fields map[string]string, torrentPath string) ([]byte
 	}
 	defer file.Close()
 
-	part, err := writer.CreateFormFile("file", strings.ReplaceAll(fields["name"], " ", ".")+".torrent")
+	part, err := writer.CreateFormFile("file", uploadTorrentFilename(fields["name"]))
 	if err != nil {
 		_ = writer.Close()
 		return nil, "", fmt.Errorf("trackers: HDB create torrent form file: %w", err)


### PR DESCRIPTION
HDB can reject a torrent upload with "Invalid filename!" when the reviewed release name contains special characters. The multipart filename previously replaced only spaces with dots.

Normalize the HDB multipart filename with the existing tracker conventions DD+ → DDP, HDR10+ → HDR10P, DTS: → DTS-, ampersands → and, apostrophe removal, and accent decomposition. Replace remaining unsupported characters with dots, collapse repeated dots, and retain only ASCII letters, digits, dots, hyphens, and underscores. Use release.torrent if normalization leaves no usable name.

The reviewed display name, local torrent path, and torrent contents remain unchanged. Non-Latin characters without an ASCII decomposition become separators. Live HDB acceptance has not been verified.

Validation passes: HDB package race tests, make lint, make logpolicy, make gofix-check-changed, and git diff --check. Multipart regressions cover codec labels, punctuation, accents, control characters, non-Latin input, safe names, fallback naming, unchanged display names, and unchanged torrent bytes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved torrent upload filenames by safely handling accents, special characters, path separators, and empty or invalid names.
  * Preserved the original release title in upload metadata while using a sanitized `.torrent` filename.
* **Tests**
  * Added coverage for filename sanitization, fallback naming, multipart upload formatting, and preservation of torrent content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->