### PR TITLE
fix(bhd): correct duplicate evidence and pack precedence

### DIFF
--- a/internal/architecturepolicy/provider_metadata_reviews.json
+++ b/internal/architecturepolicy/provider_metadata_reviews.json
@@ -384,7 +384,7 @@
     "reason": "Calls reviewed provider consumers; audit this caller together with its provider-value helpers."
   },
   "internal/trackers/impl/standalone/bhd/profile.go:Profile": {
-    "sha256": "978ff3571c7b372c9b387e18dca79e8109ffacc1bdf7f0db5d16f93dad6778b1",
+    "sha256": "485dddf97ffd7fbb01e7fda47dc2315df394dbaf42120779b94f6152b4f2d0fb",
     "reason": "Calls reviewed provider consumers; audit this caller together with its provider-value helpers."
   },
   "internal/trackers/impl/standalone/bhdtv/upload.go:prepareUploadState": {

--- a/internal/trackers/definition.go
+++ b/internal/trackers/definition.go
@@ -16,7 +16,7 @@ import (
 )
 
 // GeneralDuplicatePolicyID identifies the always-on duplicate comparison contract.
-const GeneralDuplicatePolicyID = "general/duplicate/v5"
+const GeneralDuplicatePolicyID = "general/duplicate/v6"
 
 // DuplicateSearchContractID identifies effective work-scope completion semantics.
 const DuplicateSearchContractID = "duplicate-search/work-scope/v1"

--- a/internal/trackers/dupe/evaluator_test.go
+++ b/internal/trackers/dupe/evaluator_test.go
@@ -1539,7 +1539,11 @@ func TestEvaluateSeasonPackRequiresWorkAndSeasonNotResolution(t *testing.T) {
 					Episode:    2,
 					Resolution: "2160p",
 				}
-				candidate := TrackerCandidate{Season: 1, Pack: true}
+				candidate := TrackerCandidate{
+					Season:     1,
+					Pack:       true,
+					Resolution: "1080p",
+				}
 				if proposedPack {
 					target.Pack, target.Episode, candidate.Pack, candidate.Episode = true, 0, false, 2
 				}

--- a/internal/trackers/dupe/evaluator_test.go
+++ b/internal/trackers/dupe/evaluator_test.go
@@ -1524,8 +1524,68 @@ func TestEvaluateGeneralSeasonPackContainmentIsDirectional(t *testing.T) {
 		trackerspkg.DupePolicy{},
 		SearchEvidence{WorkScope: WorkScopeProviderID},
 	)
-	if got := differentResolution.Candidates[0]; got.Relation != api.DupeRelationCoexists || differentResolution.Blocks {
+	if got := differentResolution.Candidates[0]; got.Relation != api.DupeRelationExistingPreferred || !differentResolution.Blocks {
 		t.Fatalf("different-resolution pack relation = %#v", differentResolution)
+	}
+}
+
+func TestEvaluateSeasonPackRequiresWorkAndSeasonNotResolution(t *testing.T) {
+	t.Parallel()
+	for _, scope := range []WorkScope{WorkScopeProviderID, WorkScopeTrackerGroup, WorkScopeTitle} {
+		for _, proposedPack := range []bool{false, true} {
+			for _, sameSeason := range []bool{false, true} {
+				target := api.TrackerDuplicateTarget{
+					Season:     1,
+					Episode:    2,
+					Resolution: "2160p",
+				}
+				candidate := TrackerCandidate{Season: 1, Pack: true}
+				if proposedPack {
+					target.Pack, target.Episode, candidate.Pack, candidate.Episode = true, 0, false, 2
+				}
+				if !sameSeason {
+					candidate.Season = 2
+				}
+				result := Evaluate(target, []TrackerCandidate{candidate}, trackerspkg.DupePolicy{}, SearchEvidence{WorkScope: scope})
+				got := result.Candidates[0]
+				wantContainment := sameSeason && scope != WorkScopeTitle
+				if wantContainment {
+					want := api.DupeRelationExistingPreferred
+					if proposedPack {
+						want = api.DupeRelationCoexists
+					}
+					if got.Relation != want || got.WinningRule != GeneralPolicyID+"/season_pack_containment" {
+						t.Fatalf("scope=%s proposed_pack=%t same_season=%t: %#v", scope, proposedPack, sameSeason, got)
+					}
+				} else if got.WinningRule == GeneralPolicyID+"/season_pack_containment" {
+					t.Fatalf("unbound pack containment: %#v", got)
+				}
+			}
+		}
+	}
+}
+
+func TestEvaluateContradictoryPackTitlesRequireReview(t *testing.T) {
+	t.Parallel()
+	for _, proposedPack := range []bool{false, true} {
+		target := api.TrackerDuplicateTarget{
+			Names:      []string{"Example.Series.S01E02.2160p.WEB-DL-OTHER"},
+			Season:     1,
+			Episode:    2,
+			Resolution: "2160p",
+		}
+		candidate := NormalizeCandidate(api.DupeEntry{
+			Name: "Example.Series.S01E02.1080p.WEB-DL-GRP",
+			Pack: true,
+			Res:  "1080p",
+		}, "BHD")
+		if proposedPack {
+			target.Pack, target.Episode, candidate.Pack = true, 0, false
+		}
+		result := Evaluate(target, []TrackerCandidate{candidate}, trackerspkg.DupePolicy{}, SearchEvidence{Complete: true, WorkScope: WorkScopeProviderID})
+		if result.Blocks || !result.RequiresAction || result.Candidates[0].Relation != api.DupeRelationManualReview {
+			t.Fatalf("contradictory pack proposed=%t: %#v", proposedPack, result)
+		}
 	}
 }
 

--- a/internal/trackers/dupe/exact_only_test.go
+++ b/internal/trackers/dupe/exact_only_test.go
@@ -174,7 +174,7 @@ func TestEvaluateExactMatchOnlyEvidence(t *testing.T) {
 				candidate.Resolution = ""
 				candidate.Name = "Example.Series.VariantB-GRP"
 			},
-			want: api.DupeRelationInsufficientEvidence,
+			want: api.DupeRelationExistingPreferred,
 		},
 		{
 			name: "contradictory season overrides apparent disjoint scope",

--- a/internal/trackers/dupe/findings.go
+++ b/internal/trackers/dupe/findings.go
@@ -58,7 +58,7 @@ const (
 	findingPriorityExact           = 1000
 	findingPriorityContentConflict = 950
 	findingPriorityDisjointContent = 900
-	findingPriorityPackContainment = 850
+	findingPriorityPackContainment = 890
 	findingPriorityTrackerRule     = 810
 	findingPriorityTrackerMatched  = 800
 	findingPriorityTrackerMissing  = 700
@@ -80,6 +80,20 @@ func collectCandidateFindings(
 ) []RuleFinding {
 	findings := make([]RuleFinding, 0, 12)
 	findings = append(findings, collectExactFindings(target, candidate)...)
+	targetTitleScope := parseBestTitle(target.Names).Content
+	candidateTitleScope := parseReleaseTitle(candidate.Name, FactOriginTrackerTitle).Content
+	if contentScopesContradict(exactOnlyContentScope(targetFacts.Content, targetTitleScope), targetTitleScope) ||
+		contentScopesContradict(exactOnlyContentScope(candidateFacts.Content, candidateTitleScope), candidateTitleScope) {
+		findings = append(findings, RuleFinding{
+			RuleID:         GeneralPolicyID + "/content_scope",
+			Source:         "general",
+			Status:         RuleFindingIndeterminate,
+			Relation:       api.DupeRelationManualReview,
+			ReasonCode:     "content_scope_contradictory",
+			Contradictions: []string{"content_scope"},
+			Priority:       findingPriorityContentConflict,
+		})
+	}
 	findings = append(findings, collectGeneralFindings(targetFacts, candidateFacts, policy, workScope)...)
 	if policy.ExactMatchOnly {
 		findings = append(findings, collectExactOnlyFinding(target, targetFacts, candidate, candidateFacts, policy))
@@ -149,17 +163,6 @@ func collectExactOnlyFinding(
 		finding.Relation = api.DupeRelationExactDuplicate
 		finding.ReasonCode = "exact_identity"
 		finding.Priority = findingPriorityExact
-		return finding
-	}
-	// Structured and title coordinates must not disagree: otherwise even a
-	// general disjoint-content or pack finding could rely on the wrong scope.
-	if contentScopesContradict(targetFacts.Content, parseBestTitle(target.Names).Content) ||
-		contentScopesContradict(candidateFacts.Content, parseReleaseTitle(candidate.Name, FactOriginTrackerTitle).Content) {
-		finding.Status = RuleFindingIndeterminate
-		finding.Relation = api.DupeRelationManualReview
-		finding.ReasonCode = "content_scope_contradictory"
-		finding.Contradictions = []string{"content_scope"}
-		finding.Priority = findingPriorityContentConflict
 		return finding
 	}
 	namesKnown := strings.TrimSpace(candidate.Name) != "" && slices.ContainsFunc(target.Names, func(name string) bool {
@@ -250,8 +253,7 @@ func collectGeneralFindings(target normalizedFacts, candidate normalizedFacts, p
 	// applies when the search authoritatively bound candidates to the same
 	// work; season numbers alone cannot relate releases across works on a
 	// title-fallback search.
-	if (workScope == WorkScopeProviderID || workScope == WorkScopeTrackerGroup) &&
-		compareDimensionFacts(trackerspkg.DupeDimensionResolution, target.Resolution, candidate.Resolution) == DimensionEqual {
+	if workScope == WorkScopeProviderID || workScope == WorkScopeTrackerGroup {
 		if finding, ok := collectPackContainmentFinding(target.Content, candidate.Content); ok {
 			findings = append(findings, finding)
 		}

--- a/internal/trackers/dupe/service_test.go
+++ b/internal/trackers/dupe/service_test.go
@@ -129,7 +129,7 @@ func TestProjectAdapterResultDebugLogsEveryCandidateEvaluation(t *testing.T) {
 		t.Fatalf("candidate debug logs = %d, want 2", len(candidateLogs))
 	}
 	if !strings.Contains(candidateLogs[0], `tracker=BHD candidate_id="candidate-1" relation=same_slot`) ||
-		!strings.Contains(candidateLogs[0], `winning_rule=general/duplicate/v5/same_slot`) ||
+		!strings.Contains(candidateLogs[0], `winning_rule=general/duplicate/v6/same_slot`) ||
 		!strings.Contains(candidateLogs[0], `kind=web_dl class=web source_family=web`) ||
 		!strings.Contains(candidateLogs[0], `name="Example.Release.2026.1080p.WEB-DL-GRP"`) ||
 		!strings.Contains(candidateLogs[0], `facts="WEB-DL · EXAMPLE · 1080p"`) ||
@@ -340,7 +340,7 @@ func TestCandidateLogIncludesOnlyDecisiveDeduplicatedEvidence(t *testing.T) {
 	for _, value := range []string{
 		`compared="media_class | resolution"`,
 		`missing=""`,
-		`matched="general/duplicate/v5/media_class"`,
+		`matched="general/duplicate/v6/media_class"`,
 	} {
 		if !strings.Contains(logLine, value) {
 			t.Fatalf("candidate log missing %q: %q", value, logLine)

--- a/internal/trackers/impl/dupe_policy_test.go
+++ b/internal/trackers/impl/dupe_policy_test.go
@@ -13,6 +13,47 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+func TestBHDProjectedWEBMatchesAPIResolutionType(t *testing.T) {
+	t.Parallel()
+	registry, err := NewRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy, ok := registry.LookupDupePolicy("BHD")
+	if !ok {
+		t.Fatal("missing BHD policy")
+	}
+	projection, failure := registry.ProjectRelease(t.Context(), trackers.PreparationInput{
+		Tracker: "BHD",
+		Meta: api.UploadSubject{
+			ReleaseName: "Example.Series.S01E04.2160p.WEB-DL-GRP",
+			Type:        "WEBDL",
+			Source:      "WEB",
+			SeasonInt:   1,
+			EpisodeInt:  4,
+			Identity: api.ExternalIdentity{
+				Category: api.CanonicalCategoryTV,
+				TMDBID:   123,
+				IMDBID:   1234567,
+			},
+			Release: api.ReleaseInfo{Category: "TV", Resolution: "2160p"},
+		},
+	}, "", "", "")
+	if failure != nil {
+		t.Fatalf("project BHD: %v", failure)
+	}
+	candidate := dupe.NormalizeCandidate(api.DupeEntry{
+		Name: "Example.Series.S01E04.2160p.WEB-DL-OTHER",
+		Type: "2160p",
+		Res:  "2160p",
+	}, "BHD")
+	result := dupe.Evaluate(projection.DuplicateTarget, []dupe.TrackerCandidate{candidate}, policy,
+		dupe.SearchEvidence{Complete: true, WorkScope: dupe.WorkScopeProviderID})
+	if len(result.Candidates) != 1 || result.Candidates[0].Relation != api.DupeRelationSameSlot || !result.RequiresAction {
+		t.Fatalf("BHD WEB candidate hidden: %#v", result)
+	}
+}
+
 func TestDVLProjectedEpisodeRanges(t *testing.T) {
 	t.Parallel()
 	registry, err := NewRegistry()
@@ -51,48 +92,48 @@ func TestDVLProjectedEpisodeRanges(t *testing.T) {
 			want:           api.DupeRelationExistingPreferred,
 		},
 		{
-			name: "same range",
+			name:           "same range",
 			candidateRange: "S01E01-E03",
-			targetEpisode: 1,
-			want: api.DupeRelationCoexists,
+			targetEpisode:  1,
+			want:           api.DupeRelationCoexists,
 		},
 		{
-			name: "disjoint ranges",
+			name:           "disjoint ranges",
 			candidateRange: "S01E04-E05",
-			targetEpisode: 1,
-			want: api.DupeRelationCoexists,
+			targetEpisode:  1,
+			want:           api.DupeRelationCoexists,
 		},
 		{
-			name: "overlapping ranges",
+			name:           "overlapping ranges",
 			candidateRange: "S01E02-E04",
-			targetEpisode: 1,
-			want: api.DupeRelationInsufficientEvidence,
+			targetEpisode:  1,
+			want:           api.DupeRelationInsufficientEvidence,
 		},
 		{
-			name: "same start different end",
+			name:           "same start different end",
 			candidateRange: "S01E01-E02",
-			targetEpisode: 1,
-			want: api.DupeRelationInsufficientEvidence,
+			targetEpisode:  1,
+			want:           api.DupeRelationInsufficientEvidence,
 		},
 		{
-			name: "target coordinate conflict",
+			name:           "target coordinate conflict",
 			candidateRange: "S01E01-E03",
-			targetEpisode: 4,
-			want: api.DupeRelationManualReview,
+			targetEpisode:  4,
+			want:           api.DupeRelationManualReview,
 		},
 		{
-			name: "candidate coordinate conflict",
-			candidateRange: "S01E01-E03",
-			targetEpisode: 1,
+			name:             "candidate coordinate conflict",
+			candidateRange:   "S01E01-E03",
+			targetEpisode:    1,
 			candidateEpisode: 4,
-			want: api.DupeRelationManualReview,
+			want:             api.DupeRelationManualReview,
 		},
 		{
-			name: "candidate season conflict",
-			candidateRange: "S02E01-E03",
-			targetEpisode: 1,
+			name:             "candidate season conflict",
+			candidateRange:   "S02E01-E03",
+			targetEpisode:    1,
 			candidateEpisode: 1,
-			want: api.DupeRelationManualReview,
+			want:             api.DupeRelationManualReview,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/trackers/impl/registry_test.go
+++ b/internal/trackers/impl/registry_test.go
@@ -633,7 +633,10 @@ func TestNewRegistryIncludesBHDPolicies(t *testing.T) {
 	if groups, ok := registry.LookupBannedGroups("BHD"); !ok || !slices.Contains(groups, "TGS") {
 		t.Fatalf("BHD banned groups = %#v, %t", groups, ok)
 	}
-	if policy, ok := registry.LookupDupePolicy("BHD"); !ok || policy.ID != "bhd/duplicate/v2" || policy.SizeVariancePercent != 20 {
+	if policy, ok := registry.LookupDupePolicy("BHD"); !ok || policy.ID != "bhd/duplicate/v3" || policy.SizeVariancePercent != 0 ||
+		!slices.Equal(policy.SlotDimensions, []trackers.DupeDimension{
+			trackers.DupeDimensionMediaKind, trackers.DupeDimensionResolution,
+		}) {
 		t.Fatalf("BHD dupe policy = %#v, %t", policy, ok)
 	}
 	if definition, ok := registry.Lookup("BHD"); !ok {

--- a/internal/trackers/impl/standalone/bhd/dupe.go
+++ b/internal/trackers/impl/standalone/bhd/dupe.go
@@ -7,10 +7,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"net/http"
-	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -20,8 +20,6 @@ import (
 	"github.com/autobrr/upbrr/internal/trackers/dupe"
 	"github.com/autobrr/upbrr/pkg/api"
 )
-
-var seasonPattern = regexp.MustCompile(`(?i)S(\d{1,2})`)
 
 type dupeSearcher struct {
 	cfg      config.Config
@@ -58,14 +56,10 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 		category, tmdbPrefix = "TV", "tv"
 	}
 	payload := map[string]any{"action": "search", "categories": category}
-	payload["types"] = nil
 	if tmdbID != 0 {
 		payload["tmdb_id"] = tmdbPrefix + "/" + strconv.Itoa(tmdbID)
 	} else {
 		payload["imdb_id"] = imdbID
-	}
-	if season := bhdSeason(meta); season != "" && category == "TV" {
-		payload["search"] = season
 	}
 	if rss := strings.TrimSpace(cfg.BhdRSSKey); rss != "" {
 		payload["rsskey"] = rss
@@ -109,10 +103,16 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 		if decodeErr != nil || len(decoded) == 0 {
 			return dupe.Failed(dupe.FailureResponseParse, "BHD search failed", decodeErr)
 		}
-		if bhdInt(decoded["status_code"]) == 0 {
+		if bhdInt(decoded["status_code"]) != 1 {
 			return dupe.Failed(dupe.FailureResponseStatus, "BHD api rejected search", nil)
 		}
-		pageEntries := bhdEntries(decoded)
+		if success, present, valid := bhdBoolField(decoded, "success"); present && (!valid || !success) {
+			return dupe.Failed(dupe.FailureResponseStatus, "BHD api rejected search", nil)
+		}
+		pageEntries, err := bhdEntries(decoded)
+		if err != nil {
+			return dupe.Failed(dupe.FailureResponseParse, "BHD search results malformed", err)
+		}
 		entries = append(entries, pageEntries...)
 		pages++
 		rawPage, pageKnown := decoded["page"]
@@ -164,22 +164,44 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 	})
 }
 
-func bhdEntries(payload map[string]any) []api.DupeEntry {
-	results, _ := payload["results"].([]any)
+func bhdEntries(payload map[string]any) ([]api.DupeEntry, error) {
+	results, ok := payload["results"].([]any)
+	if !ok {
+		return nil, errors.New("BHD results must be an array")
+	}
 	entries := make([]api.DupeEntry, 0, len(results))
 	for _, raw := range results {
 		item, ok := raw.(map[string]any)
 		if !ok {
-			continue
+			return nil, errors.New("BHD result must be an object")
+		}
+		name, ok := item["name"].(string)
+		if !ok || strings.TrimSpace(name) == "" {
+			return nil, errors.New("BHD result name must be a non-empty string")
 		}
 		entry := api.DupeEntry{
-			Name:     bhdString(item["name"]),
+			Name:     strings.TrimSpace(name),
 			Link:     bhdString(item["url"]),
 			ID:       bhdString(item["id"]),
 			Category: bhdString(item["category"]),
 			Type:     bhdString(item["type"]),
 			Source:   bhdString(item["source"]),
 			Internal: bhdInt(item["internal"]) == 1,
+			Pack:     bhdInt(item["tv_pack"]) == 1,
+		}
+		switch resolution := normalizeResolution(entry.Type); resolution {
+		case "2160p", "1080p", "1080i", "720p", "576p", "540p", "480p":
+			entry.Res = resolution
+		case "bd remux", "uhd remux", "dvd remux":
+			entry.CanonicalType = "REMUX"
+		case "bd 25", "bd 50", "uhd 50", "uhd 66", "uhd 100", "dvd 5", "dvd 9":
+			entry.CanonicalType = "DISC"
+		}
+		if imdbID := bhdIMDBInt(item["imdb_id"]); imdbID > 0 {
+			entry.ProviderIDs = append(entry.ProviderIDs, api.TrackerProviderID{Provider: "imdb", Value: bhdIMDB(imdbID)})
+		}
+		if _, tmdbID := parseTMDB(item["tmdb_id"]); tmdbID > 0 {
+			entry.ProviderIDs = append(entry.ProviderIDs, api.TrackerProviderID{Provider: "tmdb", Value: strconv.Itoa(tmdbID)})
 		}
 		if size := bhdInt(item["size"]); size > 0 {
 			entry.SizeKnown, entry.SizeBytes = true, size
@@ -189,7 +211,7 @@ func bhdEntries(payload map[string]any) []api.DupeEntry {
 		entry.FlagsComplete = entry.HDR.Status == api.HDREvidenceComplete
 		entries = append(entries, entry)
 	}
-	return entries
+	return entries, nil
 }
 
 func bhdHDRFacts(item map[string]any) (api.HDRFacts, []string) {
@@ -306,31 +328,6 @@ func bhdConfig(cfg config.Config) (config.TrackerConfig, string) {
 		}
 	}
 	return config.TrackerConfig{}, ""
-}
-
-func bhdSeason(meta api.DuplicateSubject) string {
-	if meta.ReleaseNameOverrides.Season != nil {
-		return normalizeBHDSeason(*meta.ReleaseNameOverrides.Season)
-	}
-	match := seasonPattern.FindStringSubmatch(meta.ReleaseName)
-	if len(match) == 2 {
-		return normalizeBHDSeason(match[1])
-	}
-	return ""
-}
-
-func normalizeBHDSeason(value string) string {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return ""
-	}
-	if strings.HasPrefix(strings.ToUpper(trimmed), "S") {
-		return strings.ToUpper(trimmed)
-	}
-	if number, err := strconv.Atoi(trimmed); err == nil {
-		return "S" + strconv.Itoa(number)
-	}
-	return strings.ToUpper(trimmed)
 }
 
 func bhdIMDB(id int) string {

--- a/internal/trackers/impl/standalone/bhd/dupe_evaluation_test.go
+++ b/internal/trackers/impl/standalone/bhd/dupe_evaluation_test.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package bhd
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/trackers/dupe"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestBHDAPIResultsUseComparableMediaFacts(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		title      string
+		typeValue  string
+		dv         int
+		hdr        int
+		plus       int
+		pack       int
+		resolution string
+		want       api.DupeRelation
+	}{
+		{
+			name:      "matching WEB",
+			title:     "Example.Series.S01E04.2160p.WEB-DL-GRP",
+			typeValue: "2160p",
+			dv:        1,
+			hdr:       1,
+			want:      api.DupeRelationSameSlot,
+		},
+		{
+			name:      "SDR slot",
+			title:     "Example.Series.S01E04.2160p.WEB-DL-GRP",
+			typeValue: "2160p",
+			want:      api.DupeRelationCoexists,
+		},
+		{
+			name:      "DV only slot",
+			title:     "Example.Series.S01E04.2160p.WEB-DL-GRP",
+			typeValue: "2160p",
+			dv:        1,
+			want:      api.DupeRelationCoexists,
+		},
+		{
+			name:      "HDR10 plus does not hide overlap",
+			title:     "Example.Series.S01E04.2160p.WEB-DL-GRP",
+			typeValue: "2160p",
+			dv:        1,
+			hdr:       1,
+			plus:      1,
+			want:      api.DupeRelationSameSlot,
+		},
+		{
+			name:      "live shaped HDR disagreement stays actionable",
+			title:     "Example.Series.S01E04.2160p.WEB-DL.DV.HDR-GRP",
+			typeValue: "2160p",
+			dv:        1,
+			hdr:       1,
+			plus:      1,
+			want:      api.DupeRelationManualReview,
+		},
+		{
+			name:      "different resolution",
+			title:     "Example.Series.S01E04.1080p.WEB-DL-GRP",
+			typeValue: "1080p",
+			want:      api.DupeRelationCoexists,
+		},
+		{
+			name:      "different episode",
+			title:     "Example.Series.S01E03.2160p.WEB-DL-GRP",
+			typeValue: "2160p",
+			dv:        1,
+			hdr:       1,
+			want:      api.DupeRelationCoexists,
+		},
+		{
+			name:      "existing season pack",
+			title:     "Example.Series.S01.2160p.WEB-DL-GRP",
+			typeValue: "2160p",
+			dv:        1,
+			hdr:       1,
+			pack:      1,
+			want:      api.DupeRelationExistingPreferred,
+		},
+		{
+			name:      "pack API flag contradicts episode title",
+			title:     "Example.Series.S01E04.1080p.WEB-DL-GRP",
+			typeValue: "1080p",
+			pack:      1,
+			want:      api.DupeRelationManualReview,
+		},
+		{
+			name:      "remux is distinct",
+			title:     "Example.Series.S01E04.2160p.BluRay-GRP",
+			typeValue: "UHD Remux",
+			dv:        1,
+			hdr:       1,
+			want:      api.DupeRelationCoexists,
+		},
+		{
+			name:       "1080p size difference is not a free slot",
+			title:      "Example.Series.S01E04.1080p.WEB-DL-GRP",
+			typeValue:  "1080p",
+			resolution: "1080p",
+			want:       api.DupeRelationSameSlot,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			entries, err := bhdEntries(map[string]any{"results": []any{map[string]any{
+				"name":     tc.title,
+				"type":     tc.typeValue,
+				"category": "TV",
+				"size":     5000,
+				"dv":       tc.dv,
+				"hdr10":    tc.hdr,
+				"hdr10+":   tc.plus,
+				"hlg":      0,
+				"tv_pack":  tc.pack,
+			}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			resolution := "2160p"
+			if tc.resolution != "" {
+				resolution = tc.resolution
+			}
+			target := api.TrackerDuplicateTarget{
+				Names:      []string{"Example.Series.S01E04.WEB-DL-OTHER"},
+				Category:   "TV",
+				Type:       "WEBDL",
+				Source:     "WEB",
+				Resolution: resolution,
+				Season:     1,
+				Episode:    4,
+				SizeBytes:  1000,
+				HDR: api.HDRFacts{
+					Status:  api.HDREvidenceComplete,
+					Origin:  api.HDREvidenceMediaInfo,
+					Formats: []api.HDRFormat{api.HDRFormatDolbyVision, api.HDRFormatHDR10},
+				},
+			}
+			result := dupe.Evaluate(target, []dupe.TrackerCandidate{dupe.NormalizeCandidate(entries[0], "BHD")}, *Profile().DupePolicy,
+				dupe.SearchEvidence{Complete: true, WorkScope: dupe.WorkScopeProviderID})
+			if len(result.Candidates) != 1 || result.Candidates[0].Relation != tc.want {
+				t.Fatalf("want %s: %#v", tc.want, result.Candidates)
+			}
+		})
+	}
+}
+
+func TestBHDEntriesPreserveAPIIdentityAndType(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ raw, canonical, resolution string }{
+		{"2160p", "", "2160p"}, {"1080p", "", "1080p"}, {"1080i", "", "1080i"},
+		{"720p", "", "720p"}, {"576p", "", "576p"}, {"540p", "", "540p"}, {"480p", "", "480p"},
+		{"BD Remux", "REMUX", ""}, {"UHD Remux", "REMUX", ""}, {"DVD Remux", "REMUX", ""},
+		{"BD 25", "DISC", ""}, {"BD 50", "DISC", ""}, {"UHD 50", "DISC", ""}, {"UHD 66", "DISC", ""},
+		{"UHD 100", "DISC", ""}, {"DVD 5", "DISC", ""}, {"DVD 9", "DISC", ""}, {"Other", "", ""},
+	} {
+		t.Run(tc.raw, func(t *testing.T) {
+			entries, err := bhdEntries(map[string]any{"results": []any{map[string]any{
+				"name":    "Example.Series.S01-GRP",
+				"type":    tc.raw,
+				"source":  "WEB",
+				"tv_pack": 1,
+				"imdb_id": "tt1234567",
+				"tmdb_id": "tv/123",
+			}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			entry := entries[0]
+			if entry.Type != tc.raw || entry.CanonicalType != tc.canonical || entry.Res != tc.resolution || !entry.Pack || entry.Source != "WEB" {
+				t.Fatalf("API facts lost: %#v", entry)
+			}
+			if len(entry.ProviderIDs) != 2 || entry.ProviderIDs[0].Value != "tt1234567" || entry.ProviderIDs[1].Value != "123" {
+				t.Fatalf("provider IDs lost: %#v", entry.ProviderIDs)
+			}
+		})
+	}
+}
+
+func TestBHDConditionalWEBQualityAndEncodeSources(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, targetType, targetSource, candidateTitle, resolution string
+		want                                                       api.DupeRelation
+	}{
+		{"WEBRip needs quality review", "WEBDL", "WEB", "Example.Series.S01E04.1080p.WEBRip-GRP", "1080p", api.DupeRelationManualReview},
+		{"WEB-DL needs quality review", "WEBRIP", "WEB", "Example.Series.S01E04.1080p.WEB-DL-GRP", "1080p", api.DupeRelationManualReview},
+		{"different WEB resolution", "WEBDL", "WEB", "Example.Series.S01E04.720p.WEBRip-GRP", "720p", api.DupeRelationCoexists},
+		{"encode source does not create slot", "ENCODE", "HDDVD", "Example.Series.S01E04.1080p.BluRay.x264-GRP", "1080p", api.DupeRelationSameSlot},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			entries, err := bhdEntries(map[string]any{"results": []any{map[string]any{
+				"name": tc.candidateTitle, "type": tc.resolution,
+			}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			target := api.TrackerDuplicateTarget{
+				Names:      []string{"Example.Series.S01E04-OTHER"},
+				Type:       tc.targetType,
+				Source:     tc.targetSource,
+				Resolution: "1080p",
+				Season:     1,
+				Episode:    4,
+			}
+			result := dupe.Evaluate(target, []dupe.TrackerCandidate{dupe.NormalizeCandidate(entries[0], "BHD")}, *Profile().DupePolicy,
+				dupe.SearchEvidence{Complete: true, WorkScope: dupe.WorkScopeProviderID})
+			if result.Candidates[0].Relation != tc.want {
+				t.Fatalf("want %s: %#v", tc.want, result.Candidates[0])
+			}
+		})
+	}
+}

--- a/internal/trackers/impl/standalone/bhd/dupe_fixture_test.go
+++ b/internal/trackers/impl/standalone/bhd/dupe_fixture_test.go
@@ -27,7 +27,10 @@ func TestBHDHDRFixturePreservesIndependentFields(t *testing.T) {
 	if err := decoder.Decode(&payload); err != nil {
 		t.Fatalf("decode fixture: %v", err)
 	}
-	entries := bhdEntries(payload)
+	entries, err := bhdEntries(payload)
+	if err != nil {
+		t.Fatalf("parse entries: %v", err)
+	}
 	if len(entries) != 8 {
 		t.Fatalf("entries = %d", len(entries))
 	}

--- a/internal/trackers/impl/standalone/bhd/dupe_test.go
+++ b/internal/trackers/impl/standalone/bhd/dupe_test.go
@@ -50,11 +50,23 @@ func TestBHDSearchUsesExternalIDs(t *testing.T) {
 		{
 			name: "tv tmdb id",
 			meta: api.DuplicateSubject{
-				SourcePath: "source",
-				Identity:   api.ExternalIdentity{TMDBID: 123, Category: "TV"},
-				Release:    api.ReleaseInfo{Resolution: "1080p"},
+				SourcePath:  "source",
+				ReleaseName: "Example.Series.S01E04.1080p.WEB-DL-GRP",
+				Identity:    api.ExternalIdentity{TMDBID: 123, Category: "TV"},
+				Release:     api.ReleaseInfo{Resolution: "1080p"},
 			},
 			wantTMDBID:   "tv/123",
+			wantCategory: "TV",
+		},
+		{
+			name: "tv imdb with season override",
+			meta: api.DuplicateSubject{
+				ReleaseNameOverrides: api.ReleaseNameOverrides{Season: new("02")},
+				SourcePath:           "source",
+				ReleaseName:          "Example.Series.S01E04.1080p.WEB-DL-GRP",
+				Identity:             api.ExternalIdentity{IMDBID: 1234567, Category: "TV"},
+			},
+			wantIMDBID:   "tt1234567",
 			wantCategory: "TV",
 		},
 		{
@@ -159,69 +171,87 @@ func TestBHDSearchUsesExternalIDs(t *testing.T) {
 			if got := bhdStringFromAny(payload["categories"]); got != tc.wantCategory {
 				t.Fatalf("expected category %q, got %q", tc.wantCategory, got)
 			}
-			if value, ok := payload["types"]; !ok || value != nil {
-				t.Fatalf("expected policy-safe nil type filter, got %#v", value)
+			if value, ok := payload["types"]; ok {
+				t.Fatalf("expected no type filter, got %#v", value)
+			}
+			if value, ok := payload["search"]; ok {
+				t.Fatalf("expected no title or season filter, got %#v", value)
 			}
 		})
 	}
 }
 
-func TestBHDSearchContinuesFullPageWhenTotalPagesOmitted(t *testing.T) {
+func TestBHDSearchFollowsPages(t *testing.T) {
 	t.Parallel()
 
-	requestedPages := make([]int, 0, 2)
-	client := &http.Client{Transport: bhdRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		var request map[string]any
-		if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
-			t.Fatalf("decode request: %v", err)
-		}
-		page := int(bhdInt(request["page"]))
-		requestedPages = append(requestedPages, page)
-		count := 100
-		if page == 2 {
-			count = 1
-		}
-		results := make([]map[string]any, count)
-		for index := range count {
-			results[index] = map[string]any{
-				"name": fmt.Sprintf("Example.Release.2026.%03d.1080p-GRP", index+(page-1)*100),
+	for _, advertised := range []bool{false, true} {
+		t.Run(fmt.Sprintf("advertised=%t", advertised), func(t *testing.T) {
+			requestedPages := make([]int, 0, 2)
+			client := &http.Client{Transport: bhdRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				var request map[string]any
+				if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+					t.Fatalf("decode request: %v", err)
+				}
+				page := int(bhdInt(request["page"]))
+				requestedPages = append(requestedPages, page)
+				count := 100
+				if advertised {
+					count = 2
+				}
+				if page == 2 {
+					count = 1
+				}
+				results := make([]map[string]any, count)
+				for index := range count {
+					results[index] = map[string]any{
+						"name": fmt.Sprintf("Example.Release.2026.%03d.1080p-GRP", index+(page-1)*100),
+					}
+				}
+				response := map[string]any{
+					"status_code": 1,
+					"results":     results,
+				}
+				if advertised {
+					response["page"], response["total_pages"], response["total_results"] = page, 2, 3
+				}
+				body, err := json.Marshal(response)
+				if err != nil {
+					t.Fatalf("encode response: %v", err)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(body)),
+					Header:     make(http.Header),
+				}, nil
+			})}
+			searcher := &dupeSearcher{
+				cfg: config.Config{Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+					"BHD": {APIKey: "placeholder"},
+				}}},
+				http:     client,
+				baseURL:  "https://example.invalid/",
+				maxPages: 2,
 			}
-		}
-		body, err := json.Marshal(map[string]any{
-			"status_code": 1,
-			"results":     results,
-		})
-		if err != nil {
-			t.Fatalf("encode response: %v", err)
-		}
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewReader(body)),
-			Header:     make(http.Header),
-		}, nil
-	})}
-	searcher := &dupeSearcher{
-		cfg: config.Config{Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
-			"BHD": {APIKey: "placeholder"},
-		}}},
-		http:     client,
-		baseURL:  "https://example.invalid/",
-		maxPages: 2,
-	}
 
-	result := searcher.Search(context.Background(), api.DuplicateSubject{
-		Identity: api.ExternalIdentity{TMDBID: 1234567, Category: api.CanonicalCategoryMovie},
-	})
-	search := result.SearchEvidence()
-	if err := result.Cause(); err != nil {
-		t.Fatalf("search: %v", err)
-	}
-	if !slices.Equal(requestedPages, []int{1, 2}) ||
-		!search.Complete ||
-		search.Pages != 2 ||
-		len(search.Warnings) != 0 ||
-		len(result.Entries()) != 101 {
-		t.Fatalf("requested pages=%v search=%#v entries=%d", requestedPages, search, len(result.Entries()))
+			result := searcher.Search(context.Background(), api.DuplicateSubject{
+				Identity: api.ExternalIdentity{TMDBID: 1234567, Category: api.CanonicalCategoryMovie},
+			})
+			search := result.SearchEvidence()
+			if err := result.Cause(); err != nil {
+				t.Fatalf("search: %v", err)
+			}
+			wantEntries := 101
+			if advertised {
+				wantEntries = 3
+			}
+			if !slices.Equal(requestedPages, []int{1, 2}) ||
+				!search.Complete ||
+				search.Pages != 2 ||
+				len(search.Warnings) != 0 ||
+				len(result.Entries()) != wantEntries {
+				t.Fatalf("requested pages=%v search=%#v entries=%d", requestedPages, search, len(result.Entries()))
+			}
+		})
 	}
 }
 
@@ -306,5 +336,33 @@ func TestBHDSearchCountMismatchFailsClosed(t *testing.T) {
 	})
 	if search := result.SearchEvidence(); search.Complete || search.Pages != 1 || len(search.Warnings) != 1 || len(result.Entries()) != 1 {
 		t.Fatalf("count mismatch search=%#v entries=%d", search, len(result.Entries()))
+	}
+}
+
+func TestBHDSearchRejectsInvalidResults(t *testing.T) {
+	t.Parallel()
+	for _, body := range []string{
+		`{"status_code":1,"success":false,"results":[]}`,
+		`{"status_code":2,"results":[]}`,
+		`{"status_code":1}`,
+		`{"status_code":1,"results":null}`,
+		`{"status_code":1,"results":{}}`,
+		`{"status_code":1,"results":[null]}`,
+		`{"status_code":1,"results":[{"name":""}]}`,
+	} {
+		t.Run(body, func(t *testing.T) {
+			client := &http.Client{Transport: bhdRoundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body))}, nil
+			})}
+			cfg := config.Config{Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+				"BHD": {APIKey: "placeholder"},
+			}}}
+			result := dupe.NewAdapter(New(), "BHD", cfg, client, api.NopLogger{}).Search(t.Context(), api.DuplicateSubject{
+				Identity: api.ExternalIdentity{TMDBID: 123, Category: api.CanonicalCategoryTV},
+			})
+			if result.SearchEvidence().Complete || result.Disposition() != dupe.DispositionFailed {
+				t.Fatalf("invalid response must fail: %#v", result)
+			}
+		})
 	}
 }

--- a/internal/trackers/impl/standalone/bhd/profile.go
+++ b/internal/trackers/impl/standalone/bhd/profile.go
@@ -32,19 +32,38 @@ func Profile() standalone.Profile {
 		AudioPolicy:          &trackers.AudioPolicy{BlockEnglishOriginalWithForeign: true},
 		ImageHostPolicy:      &trackers.ImageHostPolicy{AllowedHosts: []string{"imgbox", "imgbb", "pixhost", "bhd", "passtheimage"}},
 		DupePolicy: &trackers.DupePolicy{
-			ID:         "bhd/duplicate/v2",
+			ID:         "bhd/duplicate/v3",
 			EvidenceID: "bhd-upload-rules",
 			SearchScope: trackers.DupeSearchScope{
 				MaxPages: 100,
 			},
 			SlotDimensions: []trackers.DupeDimension{
-				trackers.DupeDimensionType,
-				trackers.DupeDimensionSource,
+				trackers.DupeDimensionMediaKind,
 				trackers.DupeDimensionResolution,
-				trackers.DupeDimensionHDR,
 			},
-			SizeVariancePercent:     20,
-			SizeVarianceResolutions: []string{"1080p"},
+			ManualReviewRules: []trackers.DupeRule{
+				{
+					ID:                 "web_quality_comparison",
+					EvidenceID:         "bhd-upload-rules-2.3.1",
+					Relation:           "manual_review",
+					ReasonCode:         "web_quality_requires_review",
+					RequiresManualStep: true,
+					OverridesGeneral:   true,
+					Conditions: []trackers.DupeCondition{
+						{
+							Dimension:       trackers.DupeDimensionMediaKind,
+							TargetValues:    []string{"web_dl", "web_rip"},
+							CandidateValues: []string{"web_dl", "web_rip"},
+							ValuesDifferent: true,
+						},
+						{
+							Dimension:        trackers.DupeDimensionResolution,
+							ValuesEqual:      true,
+							RequiresComplete: true,
+						},
+					},
+				},
+			},
 		},
 		MetadataPolicy: &trackers.TrackerMetadataPolicy{
 			RequireKnownCategory: true,

--- a/internal/trackers/impl/standalone/btn/dupe_policy_test.go
+++ b/internal/trackers/impl/standalone/btn/dupe_policy_test.go
@@ -176,7 +176,7 @@ func TestBTNDuplicatePolicySeasonPackCapacity(t *testing.T) {
 	}
 }
 
-func TestBTNDuplicatePolicySeasonPackContainmentUsesResolutionSlot(t *testing.T) {
+func TestBTNDuplicatePolicySeasonPackContainmentCrossesResolutionSlots(t *testing.T) {
 	t.Parallel()
 
 	target := btnPolicyTarget("WEB-DL", "2160p", "H.265", "P2P")
@@ -189,10 +189,13 @@ func TestBTNDuplicatePolicySeasonPackContainmentUsesResolutionSlot(t *testing.T)
 	pack2160.ID, pack2160.Pack = "2160", true
 
 	result := dupe.Evaluate(target, []dupe.TrackerCandidate{pack720, pack1080, pack2160}, *duplicatePolicy(), btnCompleteSearch())
-	if !result.Blocks || result.RequiresAction || result.Candidates[0].Candidate.ID != "2160" ||
-		result.Candidates[0].Relation != api.DupeRelationExistingPreferred ||
-		result.Candidates[1].Relation != api.DupeRelationCoexists || result.Candidates[2].Relation != api.DupeRelationCoexists {
+	if !result.Blocks || result.RequiresAction || len(result.Candidates) != 3 {
 		t.Fatalf("season-pack resolution slots = %#v", result)
+	}
+	for _, candidate := range result.Candidates {
+		if candidate.Relation != api.DupeRelationExistingPreferred {
+			t.Fatalf("season pack must contain the episode across resolutions: %#v", candidate)
+		}
 	}
 }
 

--- a/internal/trackers/impl/unit3d/sites/lst/dupe_policy_test.go
+++ b/internal/trackers/impl/unit3d/sites/lst/dupe_policy_test.go
@@ -561,6 +561,34 @@ func TestLSTDuplicatePolicyMetadata(t *testing.T) {
 	}
 }
 
+func TestLSTSeasonPacksOutrankHighPriorityTrackerRules(t *testing.T) {
+	t.Parallel()
+	for _, pair := range []struct{ target, candidate string }{
+		{"WEBDL", "WEBRIP"}, {"WEBRIP", "WEBDL"}, {"WEBDL", "WEBDL"}, {"REMUX", "REMUX"},
+	} {
+		for _, proposedPack := range []bool{false, true} {
+			target := lstTarget("Example.Series-TARGET", pair.target, "2160p", "PROVIDER", "H.265", api.HDRFormatHDR10)
+			candidate := lstCandidateWithProvider("Example.Series-GRP", pair.candidate, "2160p", "PROVIDER", api.HDRFormatHDR10)
+			if pair.target == pair.candidate {
+				target.HDR = lstHDR(api.HDRFormatDolbyVision, api.HDRFormatHDR10)
+			}
+			target.Season, candidate.Season = 1, 1
+			target.Pack, candidate.Pack = proposedPack, !proposedPack
+			want := api.DupeRelationExistingPreferred
+			if proposedPack {
+				candidate.Episode, want = 1, api.DupeRelationCoexists
+			} else {
+				target.Episode = 1
+			}
+			result := dupe.Evaluate(target, []dupe.TrackerCandidate{candidate}, *Profile().DupePolicy,
+				dupe.SearchEvidence{Complete: true, WorkScope: dupe.WorkScopeProviderID})
+			if result.Candidates[0].Relation != want || result.RequiresAction || result.Blocks == proposedPack {
+				t.Fatalf("types=%v proposed_pack=%t: %#v", pair, proposedPack, result)
+			}
+		}
+	}
+}
+
 func lstTarget(
 	name string,
 	typeValue string,

--- a/internal/trackers/impl/unit3d/sites/ulcx/dupe_policy_test.go
+++ b/internal/trackers/impl/unit3d/sites/ulcx/dupe_policy_test.go
@@ -717,7 +717,7 @@ func TestULCXSeasonPackPrecedence(t *testing.T) {
 	}
 }
 
-func TestULCXSeasonPackWithMissingResolutionRemainsActionable(t *testing.T) {
+func TestULCXSeasonPackContainmentDoesNotRequireResolution(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {
 		name      string
@@ -744,7 +744,7 @@ func TestULCXSeasonPackWithMissingResolutionRemainsActionable(t *testing.T) {
 			t.Parallel()
 			test.target.Season, test.candidate.Season = 1, 1
 			test.target.Episode, test.candidate.Pack = 2, true
-			assertULCXRelation(t, test.target, test.candidate, api.DupeRelationInsufficientEvidence)
+			assertULCXRelation(t, test.target, test.candidate, api.DupeRelationExistingPreferred)
 		})
 	}
 }


### PR DESCRIPTION
BHD duplicate searches can miss every result because a season text filter changes `S01` to `S1`. Returned WEB releases can also disappear because the evaluator compares the target type `WEBDL` with BHD's API type `2160p` and incorrectly declares coexistence.

Search by TMDB or IMDb without title/type filters, follow API pagination, reject failed or malformed results, and retain provider IDs, resolution, pack, and disc/remux evidence. Compare normalized media kinds and resolutions. Remove unsupported source, size, and exact-HDR coexistence shortcuts; same-resolution WEB-DL/WEBRip quality comparisons require manual review. BHD's policy advances to v3.

The audit also corrects shared season-pack precedence: a pack for the same authoritative work and season contains an episode regardless of resolution. Contradictory structured/title content requires review before pack or disjoint-content decisions, while exact identity remains highest priority. The general policy advances to v6, invalidating approvals based on the previous policy. This shared correction affects all trackers; BTN and ULCX expectations now cover the required behavior.

Validation: full `make test-go` race suite, `make lint`, `make logpolicy`, `make gofix-check-changed`, and `git diff --check` pass. Regression coverage includes API pagination/errors, resolution/disc enums, projected BHD WEB comparisons, quality review, HDR uncertainty, and pack/title conflicts. Saved BHD API/rule snapshots provide the protocol evidence; no live API request was performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection for season packs across different resolutions and when resolution information is missing.
  * Added safeguards for contradictory episode and pack titles, routing ambiguous matches for manual review instead of applying a hard block.
  * Improved BHD duplicate matching across media types, resolutions, HDR, remux, and WEB releases.
  * Invalid or malformed BHD search results are now rejected with clearer parsing failures.
  * Improved handling of paginated BHD search results.

* **Policy Updates**
  * Updated duplicate policy handling to better prioritize season-pack containment and conditional WEB quality comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->