### PR TITLE
fix(trackers): correct group and 2160p HDR duplicate slots

### DIFF
--- a/internal/architecturepolicy/provider_metadata_reviews.json
+++ b/internal/architecturepolicy/provider_metadata_reviews.json
@@ -812,7 +812,7 @@
     "reason": "manual-aware preference or explicit-manual branch; provider evidence remains an input"
   },
   "internal/trackers/impl/standalone/hdb/dupe.go:*dupeSearcher.Search": {
-    "sha256": "150ea5d6461a864843e8fa2fb09193065ae032df0400bbb11452070ff8e71eb7",
+    "sha256": "f5ef24576439f55dd06a2092e9a0392444497033950aa60990d87d9d06637c97",
     "reason": "Calls reviewed provider consumers; audit this caller together with its provider-value helpers."
   },
   "internal/trackers/impl/standalone/hdb/dupe.go:hdbDupeCategoryID": {

--- a/internal/trackers/definition.go
+++ b/internal/trackers/definition.go
@@ -16,7 +16,7 @@ import (
 )
 
 // GeneralDuplicatePolicyID identifies the always-on duplicate comparison contract.
-const GeneralDuplicatePolicyID = "general/duplicate/v6"
+const GeneralDuplicatePolicyID = "general/duplicate/v7"
 
 // DuplicateSearchContractID identifies effective work-scope completion semantics.
 const DuplicateSearchContractID = "duplicate-search/work-scope/v1"
@@ -604,6 +604,8 @@ type DupeHDRCompatibilityMode string
 const (
 	DupeHDRCompatibilityNone        DupeHDRCompatibilityMode = ""
 	DupeHDRCompatibilityDirectional DupeHDRCompatibilityMode = "directional"
+	// DupeHDRCompatibilityHDR10Plus permits only an added HDR10+ capability to trump.
+	DupeHDRCompatibilityHDR10Plus DupeHDRCompatibilityMode = "hdr10_plus"
 )
 
 // DupeCondition is one fact predicate inside a directional rule. Conditions

--- a/internal/trackers/dupe/evaluator_test.go
+++ b/internal/trackers/dupe/evaluator_test.go
@@ -259,11 +259,11 @@ func TestEvaluateNBLUsesCoarseSDRHDRDVSlots(t *testing.T) {
 	}
 }
 
-func TestEvaluateANTHDRCompatibilityIsDirectional(t *testing.T) {
+func TestEvaluateExplicitHDRCompatibilityIsDirectional(t *testing.T) {
 	t.Parallel()
 
 	policy := trackerspkg.DupePolicy{
-		ID:                   "ant/duplicate/v3",
+		ID:                   "example/duplicate/v1",
 		SlotDimensions:       []trackerspkg.DupeDimension{trackerspkg.DupeDimensionHDR},
 		HDRCompatibilityMode: trackerspkg.DupeHDRCompatibilityDirectional,
 	}
@@ -1352,7 +1352,7 @@ func TestEvaluateGeneralHDRRequiresPositiveEvidence(t *testing.T) {
 			want: api.DupeRelationCoexists,
 		},
 		{
-			name: "2160p proposed DV HDR trumps HDR",
+			name: "2160p proposed DV HDR coexists with HDR",
 			target: api.TrackerDuplicateTarget{
 				Resolution: "2160p",
 				HDR:        testHDR(api.HDREvidenceComplete, api.HDRFormatDolbyVision, api.HDRFormatHDR10),
@@ -1361,10 +1361,10 @@ func TestEvaluateGeneralHDRRequiresPositiveEvidence(t *testing.T) {
 				Resolution: "2160p",
 				HDR:        testHDR(api.HDREvidenceComplete, api.HDRFormatHDR10Plus),
 			},
-			want: api.DupeRelationProposedTrumps,
+			want: api.DupeRelationCoexists,
 		},
 		{
-			name: "2160p existing DV HDR trumps HDR",
+			name: "2160p existing DV HDR coexists with HDR",
 			target: api.TrackerDuplicateTarget{
 				Resolution: "2160p",
 				HDR:        testHDR(api.HDREvidenceComplete, api.HDRFormatHDR10),
@@ -1373,10 +1373,10 @@ func TestEvaluateGeneralHDRRequiresPositiveEvidence(t *testing.T) {
 				Resolution: "2160p",
 				HDR:        testHDR(api.HDREvidenceComplete, api.HDRFormatDolbyVision, api.HDRFormatHDR10Plus),
 			},
-			want: api.DupeRelationExistingPreferred,
+			want: api.DupeRelationCoexists,
 		},
 		{
-			name: "distinct media class precedes DV HDR trumping",
+			name: "distinct media class preserves coexistence",
 			target: api.TrackerDuplicateTarget{
 				Type:       "WEB-DL",
 				Resolution: "2160p",
@@ -1426,7 +1426,7 @@ func TestEvaluateGeneralHDRRequiresPositiveEvidence(t *testing.T) {
 			want: api.DupeRelationSameSlot,
 		},
 		{
-			name: "partial 2160p resolution cannot prove coexistence",
+			name: "title resolution supports complete HDR evidence",
 			target: api.TrackerDuplicateTarget{
 				Resolution: "2160p",
 				HDR:        testHDR(api.HDREvidenceComplete, api.HDRFormatSDR),
@@ -1434,6 +1434,17 @@ func TestEvaluateGeneralHDRRequiresPositiveEvidence(t *testing.T) {
 			candidate: TrackerCandidate{
 				Name: "Example.Release.2026.2160p.HDR-GRP",
 				HDR:  testHDR(api.HDREvidenceComplete, api.HDRFormatHDR10),
+			},
+			want: api.DupeRelationCoexists,
+		},
+		{
+			name: "missing candidate resolution cannot establish 2160p HDR slots",
+			target: api.TrackerDuplicateTarget{
+				Resolution: "2160p",
+				HDR:        testHDR(api.HDREvidenceComplete, api.HDRFormatDolbyVision, api.HDRFormatHDR10),
+			},
+			candidate: TrackerCandidate{
+				HDR: testHDR(api.HDREvidenceComplete, api.HDRFormatHDR10),
 			},
 			want: api.DupeRelationSameSlot,
 		},

--- a/internal/trackers/dupe/findings.go
+++ b/internal/trackers/dupe/findings.go
@@ -348,7 +348,9 @@ func generalDimensionDiffers(dimension trackerspkg.DupeDimension, target Fact, c
 }
 
 func collectGeneralHDRFinding(target normalizedFacts, candidate normalizedFacts) (RuleFinding, bool) {
-	if target.Resolution.Status != FactComplete || candidate.Resolution.Status != FactComplete ||
+	// A candidate's explicit title resolution can bind the 2160p rule without
+	// treating title-only HDR markers as complete format evidence.
+	if target.Resolution.Status != FactComplete || candidate.Resolution.Status == FactContradictory ||
 		!strings.EqualFold(target.Resolution.Value, "2160p") || !strings.EqualFold(candidate.Resolution.Value, "2160p") {
 		return RuleFinding{}, false
 	}
@@ -363,18 +365,7 @@ func collectGeneralHDRFinding(target normalizedFacts, candidate normalizedFacts)
 	if !targetKnown || !candidateKnown || targetSlot == candidateSlot {
 		return RuleFinding{}, false
 	}
-	finding := generalFinding("hdr", "distinct_hdr_slot", findingPriorityGeneral)
-	switch {
-	case targetSlot == "dv_hdr" && candidateSlot == "hdr":
-		finding.Relation = api.DupeRelationProposedTrumps
-		finding.ReasonCode = "broader_hdr_compatibility"
-		finding.Priority = findingPriorityTrumpable
-	case targetSlot == "hdr" && candidateSlot == "dv_hdr":
-		finding.Relation = api.DupeRelationExistingPreferred
-		finding.ReasonCode = "existing_broader_hdr_compatibility"
-		finding.Priority = findingPriorityTrumpable
-	}
-	return finding, true
+	return generalFinding("hdr", "distinct_hdr_slot", findingPriorityGeneral), true
 }
 
 func generalDimensionSuppressed(policy trackerspkg.DupePolicy, dimension trackerspkg.DupeDimension) bool {
@@ -755,14 +746,23 @@ func compareTrackerHDR(target api.HDRFacts, candidate api.HDRFacts, policy track
 		}
 		return RuleFinding{}, false
 	}
-	if policy.HDRCompatibilityMode == trackerspkg.DupeHDRCompatibilityDirectional {
+	if policy.HDRCompatibilityMode == trackerspkg.DupeHDRCompatibilityDirectional ||
+		policy.HDRCompatibilityMode == trackerspkg.DupeHDRCompatibilityHDR10Plus {
 		targetCompatibility := hdrCompatibility(target)
 		candidateCompatibility := hdrCompatibility(candidate)
+		targetBroader := strictSuperset(targetCompatibility, candidateCompatibility)
+		candidateBroader := strictSuperset(candidateCompatibility, targetCompatibility)
+		if policy.HDRCompatibilityMode == trackerspkg.DupeHDRCompatibilityHDR10Plus {
+			targetBroader = targetBroader && len(targetCompatibility) == len(candidateCompatibility)+1 &&
+				slices.Contains(targetCompatibility, api.HDRFormatHDR10Plus) && !slices.Contains(candidateCompatibility, api.HDRFormatHDR10Plus)
+			candidateBroader = candidateBroader && len(candidateCompatibility) == len(targetCompatibility)+1 &&
+				slices.Contains(candidateCompatibility, api.HDRFormatHDR10Plus) && !slices.Contains(targetCompatibility, api.HDRFormatHDR10Plus)
+		}
 		switch {
-		case strictSuperset(targetCompatibility, candidateCompatibility):
+		case targetBroader:
 			finding.Relation = api.DupeRelationProposedTrumps
 			finding.ReasonCode = "broader_hdr_compatibility"
-		case strictSuperset(candidateCompatibility, targetCompatibility):
+		case candidateBroader:
 			finding.Relation = api.DupeRelationExistingPreferred
 			finding.ReasonCode = "existing_broader_hdr_compatibility"
 		}

--- a/internal/trackers/dupe/normalize.go
+++ b/internal/trackers/dupe/normalize.go
@@ -1294,7 +1294,7 @@ func mergeHDRWithTitle(structured api.HDRFacts, title api.HDRFacts) api.HDRFacts
 	if structured.Status == api.HDREvidenceMissing {
 		return title
 	}
-	if !sameCandidateHDR(structured.Formats, title.Formats) && len(title.Formats) > 0 {
+	if !sameCandidateHDR(hdrCompatibility(structured), hdrCompatibility(title)) && len(title.Formats) > 0 {
 		structured.Status = api.HDREvidenceContradictory
 		structured.Contradictions = append(structured.Contradictions, "explicit title HDR differs from structured HDR")
 		if !containsFold(structured.SourceFields, "title") {

--- a/internal/trackers/dupe/service_test.go
+++ b/internal/trackers/dupe/service_test.go
@@ -129,7 +129,7 @@ func TestProjectAdapterResultDebugLogsEveryCandidateEvaluation(t *testing.T) {
 		t.Fatalf("candidate debug logs = %d, want 2", len(candidateLogs))
 	}
 	if !strings.Contains(candidateLogs[0], `tracker=BHD candidate_id="candidate-1" relation=same_slot`) ||
-		!strings.Contains(candidateLogs[0], `winning_rule=general/duplicate/v6/same_slot`) ||
+		!strings.Contains(candidateLogs[0], `winning_rule=general/duplicate/v7/same_slot`) ||
 		!strings.Contains(candidateLogs[0], `kind=web_dl class=web source_family=web`) ||
 		!strings.Contains(candidateLogs[0], `name="Example.Release.2026.1080p.WEB-DL-GRP"`) ||
 		!strings.Contains(candidateLogs[0], `facts="WEB-DL · EXAMPLE · 1080p"`) ||
@@ -340,7 +340,7 @@ func TestCandidateLogIncludesOnlyDecisiveDeduplicatedEvidence(t *testing.T) {
 	for _, value := range []string{
 		`compared="media_class | resolution"`,
 		`missing=""`,
-		`matched="general/duplicate/v6/media_class"`,
+		`matched="general/duplicate/v7/media_class"`,
 	} {
 		if !strings.Contains(logLine, value) {
 			t.Fatalf("candidate log missing %q: %q", value, logLine)

--- a/internal/trackers/impl/dupe_policy_test.go
+++ b/internal/trackers/impl/dupe_policy_test.go
@@ -13,6 +13,52 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+func TestReleaseGroupsShareSlotsUnlessTrackerRulesAllowCoexistence(t *testing.T) {
+	t.Parallel()
+	registry, err := NewRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tracker := range []string{"", "HDB", "RF", "AR"} {
+		t.Run(tracker, func(t *testing.T) {
+			policy := trackers.DupePolicy{}
+			if tracker != "" {
+				var ok bool
+				policy, ok = registry.LookupDupePolicy(tracker)
+				if !ok {
+					t.Fatal("missing policy")
+				}
+			}
+			target := api.TrackerDuplicateTarget{
+				Type:       "WEBDL",
+				Source:     "WEB",
+				Resolution: "2160p",
+				VideoCodec: "H.265",
+				Group:      "GRP",
+				Season:     1,
+				Episode:    4,
+				HDR:        completeHDR(api.HDRFormatDolbyVision, api.HDRFormatHDR10),
+			}
+			candidate := dupe.NormalizeCandidate(api.DupeEntry{
+				Name:          "Example.Series.S01E04.2160p.WEB-DL.H.265-OTHER",
+				CanonicalType: "WEBDL",
+				Res:           "2160p",
+				HDR:           completeHDR(api.HDRFormatDolbyVision, api.HDRFormatHDR10),
+			}, tracker)
+			result := dupe.Evaluate(target, []dupe.TrackerCandidate{candidate}, policy,
+				dupe.SearchEvidence{Complete: true, WorkScope: dupe.WorkScopeProviderID})
+			want := api.DupeRelationSameSlot
+			if tracker == "AR" {
+				// AlphaRatio's uploading guidelines explicitly permit different release groups to coexist.
+				want = api.DupeRelationCoexists
+			}
+			if got := result.Candidates[0].Relation; got != want || result.RequiresAction != (want == api.DupeRelationSameSlot) {
+				t.Fatalf("cross-group evaluation = %#v, want %s", result, want)
+			}
+		})
+	}
+}
+
 func TestBHDProjectedWEBMatchesAPIResolutionType(t *testing.T) {
 	t.Parallel()
 	registry, err := NewRegistry()

--- a/internal/trackers/impl/dupe_policy_test.go
+++ b/internal/trackers/impl/dupe_policy_test.go
@@ -13,6 +13,48 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
+func TestBuiltIn2160pDVHDRSlots(t *testing.T) {
+	t.Parallel()
+	registry, err := NewRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tracker := range registry.Names() {
+		// These trackers have documented broader-HDR trump rules, covered by
+		// their tracker-local policy tests.
+		if tracker == "LST" || tracker == "ULCX" || tracker == "LUME" {
+			continue
+		}
+		t.Run(tracker, func(t *testing.T) {
+			policy, _ := registry.LookupDupePolicy(tracker)
+			for _, format := range []api.HDRFormat{api.HDRFormatSDR, api.HDRFormatDolbyVision, api.HDRFormatHDR10} {
+				target := api.TrackerDuplicateTarget{
+					Names:      []string{"Example.Release.2026.2160p.WEB-DL.H.265-GRP"},
+					Type:       "WEBDL",
+					Source:     "WEB",
+					Resolution: "2160p",
+					VideoCodec: "H.265",
+					Group:      "GRP",
+					HDR:        completeHDR(api.HDRFormatDolbyVision, api.HDRFormatHDR10),
+				}
+				candidate := dupe.NormalizeCandidate(api.DupeEntry{
+					Name:          "Example.Release.2026.2160p.WEB-DL.H.265-OTHER",
+					CanonicalType: "WEBDL",
+					Source:        "WEB",
+					Res:           "2160p",
+					Codec:         "H.265",
+					HDR:           completeHDR(format),
+				}, tracker)
+				result := dupe.Evaluate(target, []dupe.TrackerCandidate{candidate}, policy,
+					dupe.SearchEvidence{Complete: true, WorkScope: dupe.WorkScopeProviderID})
+				if result.Candidates[0].Relation != api.DupeRelationCoexists || result.RequiresAction {
+					t.Fatalf("DV+HDR versus %s: %#v", format, result)
+				}
+			}
+		})
+	}
+}
+
 func TestReleaseGroupsShareSlotsUnlessTrackerRulesAllowCoexistence(t *testing.T) {
 	t.Parallel()
 	registry, err := NewRegistry()

--- a/internal/trackers/impl/registry_test.go
+++ b/internal/trackers/impl/registry_test.go
@@ -426,7 +426,7 @@ func TestNewRegistryCapabilityInventory(t *testing.T) {
 	if _, ok := registry.LookupMetadataPolicy("ANT"); !ok {
 		t.Fatal("expected ANT tracker-owned metadata policy")
 	}
-	if policy, ok := registry.LookupDupePolicy("ANT"); !ok || policy.ID != "ant/duplicate/v3" ||
+	if policy, ok := registry.LookupDupePolicy("ANT"); !ok || policy.ID != "ant/duplicate/v4" ||
 		policy.EvidenceID != "ant-dupes-trumping" {
 		t.Fatalf("ANT dupe policy = %#v, %t", policy, ok)
 	}

--- a/internal/trackers/impl/standalone/ant/dupe_policy_test.go
+++ b/internal/trackers/impl/standalone/ant/dupe_policy_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package ant
+
+import (
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/trackers/dupe"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestHDR10PlusTrumpPreservesDolbyVisionSlot(t *testing.T) {
+	t.Parallel()
+	for _, withDV := range []bool{false, true} {
+		for _, proposedPlus := range []bool{false, true} {
+			base := api.HDRFacts{Status: api.HDREvidenceComplete, Formats: []api.HDRFormat{api.HDRFormatHDR10}}
+			plus := api.HDRFacts{Status: api.HDREvidenceComplete, Formats: []api.HDRFormat{api.HDRFormatHDR10Plus}}
+			if withDV {
+				base.Formats = append(base.Formats, api.HDRFormatDolbyVision)
+				plus.Formats = append(plus.Formats, api.HDRFormatDolbyVision)
+			}
+			targetHDR, candidateHDR := base, plus
+			want := api.DupeRelationExistingPreferred
+			if proposedPlus {
+				targetHDR, candidateHDR = plus, base
+				want = api.DupeRelationProposedTrumps
+			}
+			result := dupe.Evaluate(api.TrackerDuplicateTarget{
+				Type:       "WEBDL",
+				Source:     "WEB",
+				Resolution: "2160p",
+				VideoCodec: "H.265",
+				HDR:        targetHDR,
+			}, []dupe.TrackerCandidate{{
+				CanonicalType: "WEBDL",
+				Source:        "WEB",
+				Resolution:    "2160p",
+				Codec:         "H.265",
+				HDR:           candidateHDR,
+			}}, *Profile().DupePolicy, dupe.SearchEvidence{Complete: true, WorkScope: dupe.WorkScopeProviderID})
+			if got := result.Candidates[0].Relation; got != want {
+				t.Fatalf("DV=%t proposed_plus=%t: %#v, want %s", withDV, proposedPlus, result, want)
+			}
+		}
+	}
+}

--- a/internal/trackers/impl/standalone/ant/profile.go
+++ b/internal/trackers/impl/standalone/ant/profile.go
@@ -31,7 +31,7 @@ func Profile() standalone.Profile {
 		BannedGroups:         bannedGroups(),
 		UploadArtifactPolicy: &trackers.UploadArtifactPolicy{Source: "ANT", RequireAnnounce: true},
 		DupePolicy: &trackers.DupePolicy{
-			ID:         "ant/duplicate/v3",
+			ID:         "ant/duplicate/v4",
 			EvidenceID: "ant-dupes-trumping",
 			SearchScope: trackers.DupeSearchScope{
 				MaxPages: 100,
@@ -44,10 +44,10 @@ func Profile() standalone.Profile {
 				trackers.DupeDimensionHDR,
 			},
 			HDRPartialMode:       trackers.DupeHDRPartialGenericMarker,
-			HDRCompatibilityMode: trackers.DupeHDRCompatibilityDirectional,
+			HDRCompatibilityMode: trackers.DupeHDRCompatibilityHDR10Plus,
 			PrecedenceRules: []trackers.DupeRule{
 				{
-					ID:         "ant/duplicate/v3/exact_full_disc",
+					ID:         "ant/duplicate/v4/exact_full_disc",
 					Relation:   string(api.DupeRelationExactDuplicate),
 					ReasonCode: "exact_identity",
 					Conditions: []trackers.DupeCondition{
@@ -69,7 +69,7 @@ func Profile() standalone.Profile {
 					},
 				},
 				{
-					ID:         "ant/duplicate/v3/single_full_disc",
+					ID:         "ant/duplicate/v4/single_full_disc",
 					Relation:   string(api.DupeRelationExistingPreferred),
 					ReasonCode: "existing_full_disc",
 					Conditions: []trackers.DupeCondition{{

--- a/internal/trackers/impl/standalone/hdb/dupe.go
+++ b/internal/trackers/impl/standalone/hdb/dupe.go
@@ -164,7 +164,7 @@ func (s *dupeSearcher) Search(ctx context.Context, meta api.DuplicateSubject) du
 				Group:         firstHDBText(hdbString(item["releaseGroup"]), hdbString(item["group"])),
 				Flags:         flags,
 				FlagsPresent:  flagsPresent,
-				HDR:           dupe.NormalizeTrackerHDRFlags(flags, flagsPresent, false),
+				HDR:           dupe.NormalizeTrackerHDRFlags(flags, flagsPresent, flagsPresent),
 				Internal:      hdbInt(item["origin"]) == 1,
 				Description:   hdbString(item["descr"]),
 			}
@@ -313,7 +313,7 @@ func hdbCandidateType(value any) string {
 	}
 }
 
-// hdbTags normalizes array or comma-delimited tags and reports whether the response supplied tag evidence.
+// hdbTags normalizes a tag-name array and rejects missing or malformed evidence.
 func hdbTags(item map[string]any) ([]string, bool) {
 	value, present := item["tags"]
 	if !present {
@@ -323,22 +323,25 @@ func hdbTags(item map[string]any) ([]string, bool) {
 	switch typed := value.(type) {
 	case []any:
 		for _, raw := range typed {
-			if tag := hdbString(raw); tag != "" {
-				tags = append(tags, tag)
+			tag, ok := raw.(string)
+			if !ok {
+				return nil, false
 			}
+			if tag = strings.TrimSpace(tag); tag == "" {
+				return nil, false
+			}
+			tags = append(tags, tag)
 		}
 	case []string:
 		for _, raw := range typed {
-			if tag := strings.TrimSpace(raw); tag != "" {
-				tags = append(tags, tag)
+			tag := strings.TrimSpace(raw)
+			if tag == "" {
+				return nil, false
 			}
+			tags = append(tags, tag)
 		}
-	case string:
-		for raw := range strings.SplitSeq(typed, ",") {
-			if tag := strings.TrimSpace(raw); tag != "" {
-				tags = append(tags, tag)
-			}
-		}
+	default:
+		return nil, false
 	}
 	return tags, true
 }

--- a/internal/trackers/impl/standalone/hdb/dupe_hdr_test.go
+++ b/internal/trackers/impl/standalone/hdb/dupe_hdr_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2025-2026, Audionut and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package hdb
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/upbrr/internal/config"
+	"github.com/autobrr/upbrr/internal/trackers/dupe"
+	"github.com/autobrr/upbrr/pkg/api"
+)
+
+func TestHDBAPIHDRSlots(t *testing.T) {
+	t.Parallel()
+	client := &http.Client{Transport: hdbRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body: io.NopCloser(strings.NewReader(`{"status":0,"data":[
+				{"id":1,"name":"Example Series S01E04 2160p WEB-DL DoVi HEVC-NTb","tags":["Dolby Vision"]},
+				{"id":2,"name":"Example Series S01E04 2160p WEB-DL DoVi HDR10+ HEVC-NTb","tags":["Dolby Vision","HDR10","HDR10+"]},
+				{"id":3,"name":"Example Series S01E04 2160p WEB-DL HEVC-NTb","tags":[]},
+				{"id":4,"name":"Example Series S01E04 2160p WEB-DL HDR HEVC-NTb","tags":["HDR10"]},
+				{"id":5,"name":"Example Series S01E04 2160p WEB-DL HEVC-NTb"},
+				{"id":6,"name":"Example Series S01E04 2160p WEB-DL HEVC-NTb","tags":null},
+				{"id":7,"name":"Example Series S01E04 2160p WEB-DL HEVC-NTb","tags":""},
+				{"id":8,"name":"Example Series S01E04 2160p WEB-DL HEVC-NTb","tags":"HDR10"},
+				{"id":9,"name":"Example Series S01E04 2160p WEB-DL HEVC-NTb","tags":[""]},
+				{"id":10,"name":"Example Series S01E04 2160p WEB-DL HEVC-NTb","tags":[" "]}
+			]}`)),
+		}, nil
+	})}
+	adapter := dupe.NewAdapter(New(), "HDB", config.Config{
+		Trackers: config.TrackersConfig{Trackers: map[string]config.TrackerConfig{
+			"HDB": {Username: "user", Passkey: "pk"},
+		}},
+	}, client, &hdbCaptureLogger{})
+	search := adapter.Search(t.Context(), api.DuplicateSubject{
+		SourcePath: t.TempDir(),
+		Identity:   api.ExternalIdentity{IMDBID: 1234567, Category: api.CanonicalCategoryTV},
+	})
+	if search.Cause() != nil || len(search.Entries()) != 10 {
+		t.Fatalf("HDB search = %#v", search)
+	}
+	target := api.TrackerDuplicateTarget{
+		Names:      []string{"Example.Series.S01E04.DV.HDR.2160p.WEB.H265-CAKES"},
+		Type:       "WEBDL",
+		Source:     "WEB",
+		Resolution: "2160p",
+		VideoCodec: "H.265",
+		Season:     1,
+		Episode:    4,
+		HDR: api.HDRFacts{
+			Status:  api.HDREvidenceComplete,
+			Origin:  api.HDREvidenceMediaInfo,
+			Formats: []api.HDRFormat{api.HDRFormatDolbyVision, api.HDRFormatHDR10},
+		},
+	}
+	for index, entry := range search.Entries() {
+		candidate := dupe.NormalizeCandidate(entry, "HDB")
+		result := dupe.Evaluate(target, []dupe.TrackerCandidate{candidate}, *Profile().DupePolicy,
+			dupe.SearchEvidence{Complete: true, WorkScope: dupe.WorkScopeProviderID})
+		want := api.DupeRelationCoexists
+		if index == 1 || index >= 4 {
+			want = api.DupeRelationSameSlot
+		}
+		if got := result.Candidates[0].Relation; got != want || result.RequiresAction != (want == api.DupeRelationSameSlot) {
+			t.Fatalf("id=%s HDR slot evaluation = %#v, want %s", entry.ID, result, want)
+		}
+		if index == 1 && result.Candidates[0].Facts.HDR.Status != api.HDREvidenceComplete {
+			t.Fatalf("HDR10 fallback created a false contradiction: %#v", result.Candidates[0].Facts.HDR)
+		}
+		if index >= 4 && entry.HDR.Status != api.HDREvidenceMissing {
+			t.Fatalf("id=%s: absent tags manufactured HDR evidence: %#v", entry.ID, entry.HDR)
+		}
+	}
+}
+
+func TestHDBMalformedTagsDoNotEstablishSDR(t *testing.T) {
+	t.Parallel()
+	for _, value := range []any{
+		nil, "", "HDR10", 1, map[string]any{},
+		[]any{"Dolby Vision", 42}, []any{""}, []any{" "}, []any{"Dolby Vision", ""},
+		[]string{""}, []string{" "}, []string{"Dolby Vision", ""},
+	} {
+		if tags, present := hdbTags(map[string]any{"tags": value}); present {
+			t.Fatalf("malformed tags %#v accepted as complete evidence: %#v", value, tags)
+		}
+	}
+}

--- a/internal/trackers/impl/standalone/hdb/dupe_integration_test.go
+++ b/internal/trackers/impl/standalone/hdb/dupe_integration_test.go
@@ -217,7 +217,7 @@ func TestHDBHandlerSearchBuildsPayloadAndParsesResults(t *testing.T) {
 	}
 }
 
-func TestHDBFullDiscUsesMediumAndGroupSlot(t *testing.T) {
+func TestHDBFullDiscSharesSlotAcrossGroups(t *testing.T) {
 	t.Parallel()
 
 	target := api.TrackerDuplicateTarget{
@@ -240,8 +240,38 @@ func TestHDBFullDiscUsesMediumAndGroupSlot(t *testing.T) {
 
 	entry.Name = "Example Release 2026 1080p Blu-ray AVC TrueHD 7.1-OTHER"
 	result = dupe.Evaluate(target, []dupe.TrackerCandidate{dupe.NormalizeCandidate(entry, "HDB")}, policy, dupe.SearchEvidence{Complete: true})
-	if got := result.Candidates[0].Relation; got != api.DupeRelationCoexists {
+	if got := result.Candidates[0].Relation; got != api.DupeRelationSameSlot || !result.RequiresAction {
 		t.Fatalf("different-group HDB disc relation = %q", got)
+	}
+}
+
+func TestHDBEquivalentWEBReleasesShareSlotAcrossGroups(t *testing.T) {
+	t.Parallel()
+	target := api.TrackerDuplicateTarget{
+		Names:      []string{"Example.Series.S01E04.DV.HDR.2160p.WEB.H265-CAKES"},
+		Type:       "WEBDL",
+		Source:     "WEB",
+		Resolution: "2160p",
+		VideoCodec: "H.265",
+		Group:      "CAKES",
+		Season:     1,
+		Episode:    4,
+		HDR: api.HDRFacts{
+			Status:  api.HDREvidenceComplete,
+			Origin:  api.HDREvidenceMediaInfo,
+			Formats: []api.HDRFormat{api.HDRFormatDolbyVision, api.HDRFormatHDR10},
+		},
+	}
+	for _, group := range []string{"NTb", "CAKES"} {
+		candidate := dupe.NormalizeCandidate(api.DupeEntry{
+			Name: "Example Series S01E04 2160p WEB-DL DD+5.1 DoVi HDR HEVC-" + group,
+			HDR:  dupe.NormalizeTrackerHDRFlags([]string{"Dolby Vision", "HDR10"}, true, false),
+		}, "HDB")
+		result := dupe.Evaluate(target, []dupe.TrackerCandidate{candidate}, *Profile().DupePolicy,
+			dupe.SearchEvidence{Complete: true, WorkScope: dupe.WorkScopeProviderID})
+		if got := result.Candidates[0].Relation; got != api.DupeRelationSameSlot || !result.RequiresAction {
+			t.Fatalf("group=%s: HDB WEB evaluation = %#v", group, result)
+		}
 	}
 }
 

--- a/internal/trackers/impl/standalone/hdb/profile.go
+++ b/internal/trackers/impl/standalone/hdb/profile.go
@@ -31,7 +31,7 @@ func Profile() standalone.Profile {
 		},
 		NewDuplicateAdapter: func(deps dupe.Dependencies) dupe.Adapter { return newDuplicateAdapterAt(deps, hdbBaseURL) },
 		DupePolicy: &trackers.DupePolicy{
-			ID:         "hdb/duplicate/v3",
+			ID:         "hdb/duplicate/v4",
 			EvidenceID: "hdb-rules",
 			SearchScope: trackers.DupeSearchScope{
 				MaxPages: 100,
@@ -40,7 +40,6 @@ func Profile() standalone.Profile {
 				trackers.DupeDimensionSource,
 				trackers.DupeDimensionResolution,
 				trackers.DupeDimensionCodec,
-				trackers.DupeDimensionGroup,
 			},
 		},
 		MetadataPolicy: &trackers.TrackerMetadataPolicy{

--- a/internal/trackers/impl/standalone/hdb/profile.go
+++ b/internal/trackers/impl/standalone/hdb/profile.go
@@ -31,7 +31,7 @@ func Profile() standalone.Profile {
 		},
 		NewDuplicateAdapter: func(deps dupe.Dependencies) dupe.Adapter { return newDuplicateAdapterAt(deps, hdbBaseURL) },
 		DupePolicy: &trackers.DupePolicy{
-			ID:         "hdb/duplicate/v4",
+			ID:         "hdb/duplicate/v5",
 			EvidenceID: "hdb-rules",
 			SearchScope: trackers.DupeSearchScope{
 				MaxPages: 100,

--- a/internal/trackers/impl/unit3d/sites/rf/profile.go
+++ b/internal/trackers/impl/unit3d/sites/rf/profile.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Profile returns RF's no-group naming, site-specific type and resolution
-// mappings, required release-group dupe policy, and optional owned image host.
+// mappings, duplicate policy, and optional owned image host.
 func Profile() unit3d.Profile {
 	return unit3d.Profile{
 		Name:             "RF",
@@ -20,7 +20,7 @@ func Profile() unit3d.Profile {
 			ResolveResolutionID: resolutionID,
 		},
 		DupePolicy: &trackers.DupePolicy{
-			ID:         "rf/duplicate/v2",
+			ID:         "rf/duplicate/v3",
 			EvidenceID: "rf-rules",
 			SearchScope: trackers.DupeSearchScope{
 				MaxPages: 100,
@@ -29,7 +29,6 @@ func Profile() unit3d.Profile {
 				trackers.DupeDimensionType,
 				trackers.DupeDimensionResolution,
 				trackers.DupeDimensionHDR,
-				trackers.DupeDimensionGroup,
 			},
 		},
 		ImageHost: &trackers.ImageHostPolicy{


### PR DESCRIPTION
Equivalent releases could disappear from duplicate review on HDBits and ReelFliX solely because their release groups differed. HDBits also treated a 2160p DV+HDR release as sharing a slot with DV-only and SDR candidates because its API tag evidence remained incomplete.

Remove unsupported group slots on HDBits and ReelFliX. Across trackers, the default 2160p HDR slots are SDR, HDR-only, DV-only, and DV+HDR. Remove the default DV+HDR-over-HDR trump. Preserve existing behavior at 1080p and other resolutions, along with documented tracker-specific exceptions. Narrow Anthelion's override to its documented HDR10+ upgrade instead of allowing any broader HDR combination to trump.

Treat valid HDBits tag lists as complete API evidence, including an explicit empty list as SDR. Missing or malformed tags remain unknown. A candidate's explicit title resolution can establish that the 2160p rule applies without treating title-only HDR markers as complete evidence. Compare HDR10+ with its HDR10 fallback consistently so equivalent API and title evidence no longer produces a false contradiction. Bump the affected policy versions.

Regressions cover the HDBits API response shapes, every registered tracker without a documented HDR exception, the shared 2160p rule in both directions, unchanged 1080p behavior, and Anthelion's HDR10+ trump in both directions. AlphaRatio's documented group coexistence and DreadVault's confirmed distinct-release exception remain intact. Unknown evidence still requires review; no live tracker API test was performed.

Full Go race tests, lint, log policy, and changed-package Go modernization checks pass on the final changes. Independent correctness and simplification reviews pass. CodeRabbit CLI reports no findings across the full branch diff. Unrecognized HDB tags remain uncertain rather than being assumed SDR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated duplicate detection for HDB and RF so matching releases share a duplicate slot across release groups.
  * Improved recognition of equivalent WEB releases with matching Dolby Vision and HDR10 formats.
  * HDB disc duplicate handling now consistently requires action when releases occupy the same slot.
  * Improved HDR compatibility handling, including HDR10+ precedence and more accurate Dolby Vision/HDR coexistence.
  * Invalid HDB tag data is no longer treated as valid SDR evidence.

* **Tests**
  * Added coverage for cross-group duplicate handling, HDR compatibility, malformed metadata, and equivalent WEB releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->