### PR TITLE
fix: preserve screenshot defaults and custom description images

### DIFF
--- a/cmd/upbrr/cli_options.go
+++ b/cmd/upbrr/cli_options.go
@@ -857,7 +857,11 @@ func (o cliOptions) interactionMode() api.InteractionMode {
 	return api.InteractionModeInteractive
 }
 
-func buildCLIRequest(opts cliOptions, visited map[string]bool, paths []string, screens int) (api.Request, error) {
+func buildCLIRequest(opts cliOptions, visited map[string]bool, paths []string, defaultScreens int) (api.Request, error) {
+	screens := defaultScreens
+	if visited["screens"] {
+		screens = opts.Screens
+	}
 	runLogLevel := ""
 	if visited["log-level"] {
 		normalized, err := api.ParseLogLevel(opts.LogLevel)

--- a/cmd/upbrr/composite_upload_test.go
+++ b/cmd/upbrr/composite_upload_test.go
@@ -17,22 +17,31 @@ import (
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
-func TestCLICompositeMediaUsesOnlyRequestedScreenshots(t *testing.T) {
+func TestCLICompositeMediaUsesConfiguredScreenshotsUnlessOverridden(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		args   []string
 		count  int
 		frames []int
 	}{
-		{name: "tracker defaults", args: []string{"Example.Show.S01E01.mkv"}},
+		{
+			name:  "configured default",
+			args:  []string{"Example.Show.S01E01.mkv"},
+			count: 7,
+		},
 		{
 			name:  "explicit count",
 			args:  []string{"--screens=5", "Example.Show.S01E01.mkv"},
 			count: 5,
 		},
 		{
+			name: "zero override",
+			args: []string{"-s", "0", "Example.Show.S01E01.mkv"},
+		},
+		{
 			name:   "manual frames",
 			args:   []string{"--manual_frames=100,200", "Example.Show.S01E01.mkv"},
+			count:  7,
 			frames: []int{100, 200},
 		},
 	} {
@@ -41,9 +50,13 @@ func TestCLICompositeMediaUsesOnlyRequestedScreenshots(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			request, err := buildCLIRequest(opts, visited, paths, opts.Screens)
+			cfg := config.Config{ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 7}}
+			request, err := buildCLIRequest(opts, visited, paths, cfg.ScreenshotHandling.Screens)
 			if err != nil {
 				t.Fatal(err)
+			}
+			if request.Options.Screens != tc.count {
+				t.Fatalf("description screenshot count = %d, want %d", request.Options.Screens, tc.count)
 			}
 			mapped, err := mapCLICompositeUploadRequest(request, false, "media-test")
 			if err != nil {

--- a/cmd/upbrr/main.go
+++ b/cmd/upbrr/main.go
@@ -255,7 +255,7 @@ func runUpload(
 			printCLIError(streams.errOut, err)
 		}
 	}()
-	screens := opts.Screens
+	screens := cfg.ScreenshotHandling.Screens
 	// Each input path runs under its own cliItemTimeout (applied per item in
 	// processCLIPaths) so a long queue is not killed by a single run-wide
 	// deadline. Pre-upload setup is split into purpose-scoped phase contexts,

--- a/cmd/workflowcontractgen/main.go
+++ b/cmd/workflowcontractgen/main.go
@@ -34,6 +34,7 @@ type schema struct {
 	Ref                  string             `json:"$ref,omitempty"`
 	Type                 string             `json:"type,omitempty"`
 	Format               string             `json:"format,omitempty"`
+	Minimum              *int               `json:"minimum,omitempty"`
 	Description          string             `json:"description,omitempty"`
 	Deprecated           bool               `json:"deprecated,omitempty"`
 	Enum                 []any              `json:"enum,omitempty"`
@@ -1211,6 +1212,7 @@ func (b *schemaBuilder) definition(value reflect.Type) *schema {
 			Type: "object",
 			Properties: map[string]*schema{
 				"uploadReleaseName": stringOrNull(),
+				"screenshotCount":   {AnyOf: []*schema{{Type: "integer", Minimum: new(0)}, {Type: "null"}}},
 				"additionalNames": {
 					Type:                 "object",
 					AdditionalProperties: stringOrNull(),

--- a/cmd/workflowcontractgen/main_test.go
+++ b/cmd/workflowcontractgen/main_test.go
@@ -27,6 +27,13 @@ func TestTrackerProjectionInstructionsSchemaPreservesTriStateFields(t *testing.T
 	if name == nil || renderTypeScript(name, 0) != "string | null" {
 		t.Fatalf("upload release name schema = %#v", name)
 	}
+	count := definition.Properties["screenshotCount"]
+	if count == nil || renderTypeScript(count, 0) != "number | null" || slices.Contains(definition.Required, "screenshotCount") {
+		t.Fatalf("optional screenshot count schema = %#v", count)
+	}
+	if count.AnyOf[0].Minimum == nil || *count.AnyOf[0].Minimum != 0 {
+		t.Fatalf("screenshot count minimum = %#v, want zero", count.AnyOf[0].Minimum)
+	}
 	for _, field := range []string{"additionalNames", "questionnaire"} {
 		property := definition.Properties[field]
 		if property == nil || property.AdditionalProperties == nil ||

--- a/documentation/docs/cli/index.md
+++ b/documentation/docs/cli/index.md
@@ -167,7 +167,7 @@ Reset examples:
 
 Apply fact corrections before tracker answers in separate commands. Combining them is rejected. Changes to source identity can require confirmation of saved content fields. Track corrections always require current scan evidence.
 
-Generated descriptions include manually supplied audio, subtitle, and hardcoded language lines. A complete custom description remains unchanged.
+Generated descriptions include manually supplied audio, subtitle, and hardcoded language lines. User-supplied descriptions pass through each tracker's normal formatting. Selected screenshots still appear in the tracker's usual location, including separate screenshot fields where applicable.
 
 Saved corrections use a newer database format. Older binaries do not support writing this correction state.
 
@@ -252,9 +252,11 @@ Trackers that require the cleared provider can remain blocked. Continue with tra
 
 ## Screenshots, images, and descriptions
 
+Without `--screens`, the CLI uses `screenshot_handling.screens` when selected trackers require screenshots. Tracker-specific image counts and limits still apply. An override below a tracker's screenshot requirements can block that upload.
+
 | Option                       | Aliases                             | Purpose                                               |
 | ---------------------------- | ----------------------------------- | ----------------------------------------------------- |
-| `--screens <count>`          | `-screens`, `-s`                    | Set screenshot count.                                 |
+| `--screens <count>`          | `-screens`, `-s`                    | Override the configured screenshot count.             |
 | `--manual_frames <list>`     | `-manual_frames`, `-mf`             | Use comma-separated frame numbers.                    |
 | `--comparison <paths>`       | `-comparison`, `-comps`             | Set one comparison folder or comma-separated folders. |
 | `--comparison_index <index>` | `-comparison_index`, `-comps_index` | Select the primary comparison index.                  |

--- a/documentation/docs/web-ui/index.md
+++ b/documentation/docs/web-ui/index.md
@@ -51,7 +51,7 @@ Audio, subtitle, and hardcoded-subtitle fields accept comma-separated languages.
 
 Changing Movie/TV with the same TMDB ID loads metadata from the correct category. If the source or provider identity changes, saved content corrections may require confirmation, replacement, or reset. A changed track manifest requires selecting a current track again.
 
-Input preparation stops after facts and local readiness. It does not run duplicate searches or later media operations. Generated descriptions later include manually supplied languages; complete custom descriptions remain unchanged.
+Input preparation stops after facts and local readiness. It does not run duplicate searches or later media operations. Generated descriptions later include manually supplied languages. User-supplied descriptions pass through each tracker's normal formatting. Selected screenshots still appear in the tracker's usual location, including separate screenshot fields where applicable.
 
 ### Clear a metadata provider
 

--- a/internal/core/workflow_description_test.go
+++ b/internal/core/workflow_description_test.go
@@ -248,6 +248,7 @@ func TestResolveWorkflowExactMediaKeepsChannelsAndHostedVariantsSeparate(t *test
 			Kind:     api.MediaArtifactScreenshot,
 			Purpose:  api.ScreenshotPurposeFinal,
 			Selected: true,
+			Source:   "comparison",
 			Order:    0,
 		},
 		{
@@ -329,6 +330,19 @@ func TestResolveWorkflowExactMediaKeepsChannelsAndHostedVariantsSeparate(t *test
 	if exact.ScreenshotUploads[0].RawURL != "https://img.example/screen-2.png" ||
 		exact.DVDMenuUploads[0].RawURL != "https://img.example/menu-2.png" {
 		t.Fatalf("hosted channels = %#v", exact)
+	}
+	for index := range media.Artifacts {
+		if media.Artifacts[index].Kind == api.MediaArtifactScreenshot && media.Artifacts[index].Source != "comparison" {
+			media.Artifacts[index].Selected = false
+		}
+	}
+	exact, err = resolveWorkflowExactMedia(private, media)
+	if err != nil {
+		t.Fatalf("resolve deselected media: %v", err)
+	}
+	if len(exact.Screenshots) != 1 || exact.Screenshots[0].Path != "screen-2.png" || len(exact.ScreenshotUploads) != 1 ||
+		len(exact.DVDMenus) != 2 || len(exact.DVDMenuUploads) != 1 {
+		t.Fatalf("automatic screenshot deselection leaked images or removed comparison/menu assets: %#v", exact)
 	}
 }
 

--- a/internal/core/workflow_media_test.go
+++ b/internal/core/workflow_media_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/autobrr/upbrr/internal/config"
 	internalerrors "github.com/autobrr/upbrr/internal/errors"
+	"github.com/autobrr/upbrr/internal/trackers"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -591,6 +592,95 @@ func TestWorkflowMediaBuilderCapturesOnlyProjectedNormalScreenshots(t *testing.T
 	}
 	if changed.CaptureFingerprint == snapshot.CaptureFingerprint {
 		t.Fatal("media capture fingerprint ignored release generation")
+	}
+}
+
+func TestWorkflowMediaCaptureUsesProjectedScreenshotOverride(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name          string
+		count         *int
+		minimum       int
+		want          int
+		withoutImages bool
+	}{
+		{name: "configured default", want: 7},
+		{
+			name:  "lower override",
+			count: new(2),
+			want:  2,
+		},
+		{name: "zero override", count: new(0)},
+		{name: "no-image tracker configured default", withoutImages: true},
+		{
+			name:          "no-image tracker explicit count",
+			count:         new(7),
+			withoutImages: true,
+		},
+		{
+			name:    "tracker minimum",
+			count:   new(0),
+			minimum: 3,
+			want:    3,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := config.Config{
+				ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 7},
+				Trackers:           config.TrackersConfig{Trackers: map[string]config.TrackerConfig{"ONE": {ImageCount: test.minimum}}},
+			}
+			registry := mediaImageHostRegistry(t)
+			trackerID := api.TrackerID("ONE")
+			if test.withoutImages {
+				trackerID = "NONE"
+				if err := registry.RegisterDescriptor(trackers.Descriptor{
+					Name:              "NONE",
+					Definition:        mediaImageHostDefinition("NONE"),
+					UploadContentMode: trackers.UploadContentModeNone,
+					Family:            trackers.FamilyStandalone,
+					BaseURL:           "https://none.example.invalid",
+				}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			projector, err := trackers.NewWorkflowProjector(registry, cfg, api.NopLogger{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _, _, projections, err := projector.Build(t.Context(), api.ReleaseSnapshot{}, api.UploadSubject{},
+				[]api.TrackerID{trackerID}, map[api.TrackerID]api.TrackerProjectionInstructions{trackerID: {ScreenshotCount: test.count}},
+				nil, api.WorkflowExecutionModeNormal)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan := api.ScreenshotPlan{}
+			for index := range test.want {
+				plan.SuggestedSelections = append(plan.SuggestedSelections, api.ScreenshotSelection{Index: index + 1, TimestampSeconds: float64(index+1) * 60})
+			}
+			screenshots := &workflowScreenshotFake{root: t.TempDir(), plan: &plan}
+			builder := workflowMediaBuilder{
+				config:      cfg,
+				resolver:    workflowMediaResolverFake{},
+				screenshots: screenshots,
+			}
+			instructions := api.MediaCaptureInstructions{Purpose: api.ScreenshotPurposeFinal}
+			snapshot, _, err := builder.Build(t.Context(), api.ReleaseRef{SourcePath: "Example.Release.2026.mkv", Generation: 1},
+				projections, instructions, time.Now())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(snapshot.Artifacts) != test.want {
+				t.Fatalf("captured %d screenshots, want %d", len(snapshot.Artifacts), test.want)
+			}
+			if test.want == 0 {
+				if screenshots.plans != 0 || screenshots.captures != 0 {
+					t.Fatal("zero override invoked screenshot capture")
+				}
+			} else if !slices.Equal(screenshots.planCounts, []int{test.want}) {
+				t.Fatalf("capture plan counts = %v, want %d", screenshots.planCounts, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/releaseworkflow/composite_upload.go
+++ b/internal/releaseworkflow/composite_upload.go
@@ -4,6 +4,7 @@
 package releaseworkflow
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -24,26 +25,27 @@ const (
 )
 
 type compositeUploadSession struct {
-	Version               int                                         `json:"version"`
-	RequestFingerprint    api.WorkflowFingerprint                     `json:"requestFingerprint"`
-	Intent                api.WorkflowIntent                          `json:"intent"`
-	Goal                  api.WorkflowGoal                            `json:"goal"`
-	Confirm               bool                                        `json:"confirm"`
-	PreparedRelease       api.ReleaseWorkflowPreparedReleaseMode      `json:"preparedRelease,omitempty"`
-	DuplicateDisposition  api.ReleaseWorkflowDuplicateDisposition     `json:"duplicateDisposition"`
-	RemoveTrackers        []api.TrackerID                             `json:"removeTrackers,omitempty"`
-	DefaultProjection     *api.ReleaseWorkflowUploadTrackerProjection `json:"defaultProjection,omitempty"`
-	ManualMedia           compositeUploadManualMedia                  `json:"manualMedia,omitempty"`
-	ActiveOperationID     api.WorkflowOperationID                     `json:"activeOperationId,omitempty"`
-	LastOperationID       api.WorkflowOperationID                     `json:"lastOperationId,omitempty"`
-	LastCommittedRevision api.WorkflowRevision                        `json:"lastCommittedRevision"`
-	Cursor                string                                      `json:"cursor,omitempty"`
-	ApprovedDryRun        *api.UploadDryRunResultRef                  `json:"approvedDryRun,omitempty"`
-	ApprovedFingerprint   api.WorkflowFingerprint                     `json:"approvedFingerprint,omitempty"`
-	ApprovedTrackerIDs    []api.TrackerID                             `json:"approvedTrackerIds,omitempty"`
-	FeedbackSequence      uint64                                      `json:"feedbackSequence,omitempty"`
-	FeedbackReceipts      map[string]compositeUploadFeedbackReceipt   `json:"feedbackReceipts,omitempty"`
-	TerminalReason        string                                      `json:"terminalReason,omitempty"`
+	Version                  int                                         `json:"version"`
+	RequestFingerprint       api.WorkflowFingerprint                     `json:"requestFingerprint"`
+	Intent                   api.WorkflowIntent                          `json:"intent"`
+	Goal                     api.WorkflowGoal                            `json:"goal"`
+	Confirm                  bool                                        `json:"confirm"`
+	PreparedRelease          api.ReleaseWorkflowPreparedReleaseMode      `json:"preparedRelease,omitempty"`
+	DuplicateDisposition     api.ReleaseWorkflowDuplicateDisposition     `json:"duplicateDisposition"`
+	RemoveTrackers           []api.TrackerID                             `json:"removeTrackers,omitempty"`
+	DefaultProjection        *api.ReleaseWorkflowUploadTrackerProjection `json:"defaultProjection,omitempty"`
+	RequestedScreenshotCount *int                                        `json:"requestedScreenshotCount,omitempty"`
+	ManualMedia              compositeUploadManualMedia                  `json:"manualMedia,omitempty"`
+	ActiveOperationID        api.WorkflowOperationID                     `json:"activeOperationId,omitempty"`
+	LastOperationID          api.WorkflowOperationID                     `json:"lastOperationId,omitempty"`
+	LastCommittedRevision    api.WorkflowRevision                        `json:"lastCommittedRevision"`
+	Cursor                   string                                      `json:"cursor,omitempty"`
+	ApprovedDryRun           *api.UploadDryRunResultRef                  `json:"approvedDryRun,omitempty"`
+	ApprovedFingerprint      api.WorkflowFingerprint                     `json:"approvedFingerprint,omitempty"`
+	ApprovedTrackerIDs       []api.TrackerID                             `json:"approvedTrackerIds,omitempty"`
+	FeedbackSequence         uint64                                      `json:"feedbackSequence,omitempty"`
+	FeedbackReceipts         map[string]compositeUploadFeedbackReceipt   `json:"feedbackReceipts,omitempty"`
+	TerminalReason           string                                      `json:"terminalReason,omitempty"`
 }
 
 type compositeUploadManualMedia struct {
@@ -305,6 +307,7 @@ func normalizeCompositeUploadRequest(
 			return slices.Contains(normalizeCompositeTrackerIDs(request.Trackers.Remove), id)
 		})
 	}
+	projections = compositeUploadScreenshotCountInstructions(projections, trackerIDs, request.Media.Screenshots.Count)
 	checkCount := uint8(1)
 	if request.Duplicates.CheckCount != nil && *request.Duplicates.CheckCount == 2 {
 		checkCount = 2
@@ -346,16 +349,17 @@ func normalizeCompositeUploadRequest(
 		}
 	}
 	session := &compositeUploadSession{
-		Version:              compositeUploadSessionVersion,
-		RequestFingerprint:   fingerprint,
-		Intent:               intent,
-		Goal:                 goal,
-		Confirm:              request.Unattended.Confirm,
-		PreparedRelease:      request.Execution.PreparedRelease,
-		DuplicateDisposition: onEvidence,
-		RemoveTrackers:       normalizeCompositeTrackerIDs(request.Trackers.Remove),
-		DefaultProjection:    cloneCompositeUploadProjection(request.Trackers.DefaultProjection),
-		FeedbackReceipts:     make(map[string]compositeUploadFeedbackReceipt),
+		Version:                  compositeUploadSessionVersion,
+		RequestFingerprint:       fingerprint,
+		Intent:                   intent,
+		Goal:                     goal,
+		Confirm:                  request.Unattended.Confirm,
+		PreparedRelease:          request.Execution.PreparedRelease,
+		DuplicateDisposition:     onEvidence,
+		RemoveTrackers:           normalizeCompositeTrackerIDs(request.Trackers.Remove),
+		DefaultProjection:        cloneCompositeUploadProjection(request.Trackers.DefaultProjection),
+		RequestedScreenshotCount: cloneIntPointer(request.Media.Screenshots.Count),
+		FeedbackReceipts:         make(map[string]compositeUploadFeedbackReceipt),
 	}
 	return session, instructions, nil
 }
@@ -574,15 +578,29 @@ func compositeUploadProjectionInstructions(
 	return result
 }
 
+func compositeUploadScreenshotCountInstructions(
+	instructions map[api.TrackerID]api.TrackerProjectionInstructions,
+	trackerIDs []api.TrackerID,
+	count *int,
+) map[api.TrackerID]api.TrackerProjectionInstructions {
+	if count == nil || len(trackerIDs) == 0 {
+		return instructions
+	}
+	if instructions == nil {
+		instructions = make(map[api.TrackerID]api.TrackerProjectionInstructions, len(trackerIDs))
+	}
+	for _, trackerID := range trackerIDs {
+		instruction := instructions[trackerID]
+		instruction.ScreenshotCount = cloneIntPointer(count)
+		instructions[trackerID] = instruction
+	}
+	return instructions
+}
+
 func compositeUploadMediaIntent(
 	input api.ReleaseWorkflowUploadMedia,
 ) (api.MediaCaptureInstructions, *api.WorkflowMediaSelection) {
-	count := 0
-	if input.Screenshots.Count != nil {
-		count = *input.Screenshots.Count
-	}
 	media := api.MediaCaptureInstructions{
-		ScreenshotCount: count,
 		Purpose:         api.ScreenshotPurposeFinal,
 		ManualFrames:    append([]int(nil), input.Screenshots.Frames...),
 		CaptureDVDMenus: optionalBool(input.DVDMenus.Capture),
@@ -1127,15 +1145,21 @@ func (m *Module) applyCompositeAutomaticPolicy(
 			intent.TrackerIDs = trackerIDs
 		})
 	}
-	if current.Selection != nil && session.DefaultProjection != nil {
+	if current.Selection != nil && (session.DefaultProjection != nil || session.RequestedScreenshotCount != nil) {
 		next := make(map[api.TrackerID]api.TrackerProjectionInstructions, len(session.Intent.ProjectionInstructions))
 		maps.Copy(next, session.Intent.ProjectionInstructions)
 		changed := false
 		for _, trackerID := range current.Selection.TrackerIDs {
-			merged := mergeCompositeProjectionDefaults(next[trackerID], *session.DefaultProjection)
+			merged := next[trackerID]
 			before, fingerprintErr := api.CanonicalWorkflowFingerprint(next[trackerID])
 			if fingerprintErr != nil {
 				return false, fmt.Errorf("release workflow fingerprint current tracker defaults: %w", fingerprintErr)
+			}
+			if session.DefaultProjection != nil {
+				merged = mergeCompositeProjectionDefaults(merged, *session.DefaultProjection)
+			}
+			if session.RequestedScreenshotCount != nil {
+				merged.ScreenshotCount = cloneIntPointer(session.RequestedScreenshotCount)
 			}
 			after, fingerprintErr := api.CanonicalWorkflowFingerprint(merged)
 			if fingerprintErr != nil {
@@ -1158,6 +1182,21 @@ func (m *Module) applyCompositeAutomaticPolicy(
 				},
 			)
 		}
+	}
+	if artifactIDs, err := m.compositeUploadExcessScreenshotIDs(ctx, ownerID, current, session, operationID); err != nil {
+		return false, err
+	} else if len(artifactIDs) > 0 {
+		if _, err := m.execute(ctx, ownerID, SetMediaSelectionCommand{
+			WorkflowID:       current.Workflow.ID,
+			ExpectedRevision: current.Workflow.Revision,
+			Media:            *current.Workflow.Media,
+			ArtifactIDs:      artifactIDs,
+			Selected:         false,
+			IdempotencyKey:   compositeUploadOperationKey(string(session.RequestFingerprint)+":trim-screenshots", uint64(current.Workflow.Revision)),
+		}); err != nil {
+			return false, fmt.Errorf("release workflow trim composite screenshots: %w", err)
+		}
+		return true, nil
 	}
 	if current.Dupes == nil {
 		return false, nil
@@ -1197,6 +1236,59 @@ func (m *Module) applyCompositeAutomaticPolicy(
 		}
 		maps.Copy(intent.DuplicateDecisions, decisions)
 	})
+}
+
+func (m *Module) compositeUploadExcessScreenshotIDs(
+	ctx context.Context,
+	ownerID string,
+	current CommandResult,
+	session *compositeUploadSession,
+	operationID api.WorkflowOperationID,
+) ([]api.PublicResourceID, error) {
+	if session.RequestedScreenshotCount == nil || current.Media == nil || current.Workflow.Media == nil ||
+		session.Intent.Media == nil || session.Intent.Media.Selections != nil || len(session.Intent.Media.ManualFrames) > 0 ||
+		session.Intent.MediaSelection != nil {
+		return nil, nil
+	}
+	state, err := m.repository.Load(ctx, ownerID, current.Workflow.ID)
+	if err != nil {
+		return nil, fmt.Errorf("release workflow load composite media selection: %w", err)
+	}
+	if state.Workflow.Revision != current.Workflow.Revision || state.Composite == nil || state.Composite.ActiveOperationID != operationID {
+		return nil, ErrRevisionConflict
+	}
+	targets, err := resolveDownstreamTrackerSet(&state, nil, downstreamStageMedia, m.clock.Now().UTC())
+	if err != nil {
+		if errors.Is(err, ErrInvalidTransition) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	required := 0
+	for _, projection := range targets.Projections().Projections {
+		required = max(required, projection.Artifacts.ScreenshotCount)
+	}
+	return compositeUploadSelectedScreenshotExcess(current.Media.Artifacts, required), nil
+}
+
+func compositeUploadSelectedScreenshotExcess(artifacts []api.MediaArtifact, required int) []api.PublicResourceID {
+	ordered := append([]api.MediaArtifact(nil), artifacts...)
+	slices.SortStableFunc(ordered, func(left, right api.MediaArtifact) int {
+		return cmp.Compare(left.Order, right.Order)
+	})
+	selected := 0
+	excess := make([]api.PublicResourceID, 0)
+	for _, artifact := range ordered {
+		if !artifact.Selected || artifact.Kind != api.MediaArtifactScreenshot ||
+			artifact.Purpose != api.ScreenshotPurposeFinal || artifact.Source == "comparison" {
+			continue
+		}
+		selected++
+		if selected > required {
+			excess = append(excess, artifact.ID)
+		}
+	}
+	return excess
 }
 
 func compositeUploadTrackerRemovalUpdate(
@@ -1857,6 +1949,9 @@ func (m *Module) applyCompositeUploadFeedback(
 				command.Response.TrackerID: *command.Response.Projection,
 			})
 			instruction := mapped[command.Response.TrackerID]
+			if state.Composite.RequestedScreenshotCount != nil {
+				instruction.ScreenshotCount = cloneIntPointer(state.Composite.RequestedScreenshotCount)
+			}
 			state.Composite.Intent.ProjectionInstructions[command.Response.TrackerID] = instruction
 			var projections *api.TrackerReleaseProjectionSet
 			if state.Workflow.TrackerProjections != nil {

--- a/internal/releaseworkflow/composite_upload_test.go
+++ b/internal/releaseworkflow/composite_upload_test.go
@@ -850,11 +850,432 @@ func TestNormalizeCompositeUploadRequestPreservesManualFramesIntent(t *testing.T
 			if err != nil {
 				t.Fatalf("normalize composite upload request: %v", err)
 			}
-			if session.Intent.Media == nil || session.Intent.Media.ScreenshotCount != count {
+			if session.Intent.Media == nil || session.Intent.Media.ScreenshotCount != 0 {
 				t.Fatalf("normalized media intent = %#v", session.Intent.Media)
 			}
 			if !reflect.DeepEqual(session.Intent.Media.ManualFrames, testCase.wantFrames) {
 				t.Fatalf("normalized manual frames = %#v, want %#v", session.Intent.Media.ManualFrames, testCase.wantFrames)
+			}
+		})
+	}
+}
+
+func TestNormalizeCompositeUploadRequestRetainsOptionalScreenshotCount(t *testing.T) {
+	t.Parallel()
+
+	zero, lower := 0, 1
+	for _, test := range []struct {
+		name    string
+		count   *int
+		present bool
+		want    int
+	}{
+		{name: "omitted"},
+		{
+			name:    "zero",
+			count:   &zero,
+			present: true,
+		},
+		{
+			name:    "lower",
+			count:   &lower,
+			present: true,
+			want:    lower,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			request := compositeUploadTestRequest(false, api.ReleaseWorkflowUploadModeUpload, "screenshot-count-"+test.name)
+			request.Media.Screenshots.Count = test.count
+			session, _, err := normalizeCompositeUploadRequest(request)
+			if err != nil {
+				t.Fatalf("normalize composite upload request: %v", err)
+			}
+			if (session.RequestedScreenshotCount != nil) != test.present {
+				t.Fatalf("retained screenshot count = %#v, want present=%t", session.RequestedScreenshotCount, test.present)
+			}
+			for _, trackerID := range request.Trackers.Include {
+				instruction, ok := session.Intent.ProjectionInstructions[trackerID]
+				if ok != test.present || (ok && (instruction.ScreenshotCount == nil || *instruction.ScreenshotCount != test.want)) {
+					t.Fatalf("projection instruction for %s = %#v, want screenshot count present=%t value=%d", trackerID, instruction, test.present, test.want)
+				}
+			}
+		})
+	}
+}
+
+func TestCompositeUploadDynamicSelectionSeedsRequestedScreenshotCount(t *testing.T) {
+	t.Parallel()
+
+	zero, lower := 0, 1
+	for _, test := range []struct {
+		name    string
+		count   *int
+		present bool
+		want    int
+	}{
+		{name: "omitted"},
+		{
+			name:    "zero",
+			count:   &zero,
+			present: true,
+		},
+		{
+			name:    "lower",
+			count:   &lower,
+			present: true,
+			want:    lower,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			module, _, _ := newCompositeUploadTestModule(t)
+			module.mediaBuilder = mediaArtifactBuilderFunc(func(
+				_ context.Context,
+				_ api.ReleaseRef,
+				projections api.TrackerReleaseProjectionSet,
+				instructions api.MediaCaptureInstructions,
+				_ time.Time,
+			) (api.MediaArtifactSet, any, error) {
+				requirements, err := mediaRequirementsFingerprint(projections.Projections)
+				if err != nil {
+					return api.MediaArtifactSet{}, nil, err
+				}
+				if instructions.ScreenshotCount != 0 {
+					t.Fatalf("composite capture screenshot count = %d, want tracker projection requirements only", instructions.ScreenshotCount)
+				}
+				count := 0
+				for _, projection := range projections.Projections {
+					count = max(count, projection.Artifacts.ScreenshotCount)
+				}
+				artifacts := make([]api.MediaArtifact, 0, count+1)
+				for index := range count {
+					artifacts = append(artifacts, api.MediaArtifact{
+						ID:       api.PublicResourceID(fmt.Sprintf("screenshot-%d", index)),
+						Kind:     api.MediaArtifactScreenshot,
+						Purpose:  api.ScreenshotPurposeFinal,
+						Selected: true,
+						Index:    index,
+						Order:    index,
+					})
+				}
+				var attempts []api.HostedImageAttempt
+				if count > 0 {
+					hosted := api.MediaArtifact{
+						ID:       "hosted-screenshot-0",
+						Kind:     api.MediaArtifactHostedImage,
+						Purpose:  api.ScreenshotPurposeFinal,
+						Selected: true,
+						Source:   "screenshot-0",
+					}
+					artifacts = append(artifacts, hosted)
+					trackerIDs := make([]api.TrackerID, 0, len(projections.Projections))
+					for _, projection := range projections.Projections {
+						trackerIDs = append(trackerIDs, projection.TrackerID)
+					}
+					attempts = []api.HostedImageAttempt{{
+						ID:         "host-screenshot-0",
+						UsageScope: "global",
+						TrackerIDs: trackerIDs,
+						Results:    []api.MediaArtifact{hosted},
+					}}
+				}
+				return api.MediaArtifactSet{
+					CaptureFingerprint:        testFingerprint(t, "dynamic-screenshot-count-"+test.name),
+					RequirementsFingerprint:   requirements,
+					Artifacts:                 artifacts,
+					HostAttempts:              attempts,
+					ImageRequirementsPrepared: true,
+				}, struct{}{}, nil
+			})
+			base := module.trackerProjector
+			var builds []map[api.TrackerID]*int
+			module.trackerProjector = trackerProjectionBuilderFunc(func(
+				ctx context.Context,
+				release api.ReleaseSnapshot,
+				subject api.UploadSubject,
+				trackerIDs []api.TrackerID,
+				instructions map[api.TrackerID]api.TrackerProjectionInstructions,
+				ruleAuthorizations map[api.TrackerID]api.WorkflowFingerprint,
+				executionMode api.WorkflowExecutionMode,
+			) (api.TrackerCatalogSnapshot, api.TrackerRuntimeSnapshot, api.TrackerSelection, api.TrackerReleaseProjectionSet, error) {
+				captured := make(map[api.TrackerID]*int, len(instructions))
+				for trackerID, instruction := range instructions {
+					captured[trackerID] = cloneIntPointer(instruction.ScreenshotCount)
+				}
+				builds = append(builds, captured)
+				catalog, runtime, selection, projections, err := base.Build(ctx, release, subject, trackerIDs, instructions, ruleAuthorizations, executionMode)
+				if err != nil {
+					return catalog, runtime, selection, projections, fmt.Errorf("build test tracker projections: %w", err)
+				}
+				for index := range projections.Projections {
+					if count := instructions[projections.Projections[index].TrackerID].ScreenshotCount; count != nil {
+						projections.Projections[index].Artifacts.ScreenshotCount = max(projections.Projections[index].Artifacts.ScreenshotCount, *count)
+					}
+				}
+				return catalog, runtime, selection, projections, nil
+			})
+
+			request := compositeUploadTestRequest(false, api.ReleaseWorkflowUploadModeDebug, "dynamic-screenshot-count-"+test.name)
+			request.Trackers.Include = nil
+			request.Media.Screenshots.Count = test.count
+			started, err := module.StartUpload(t.Context(), testOwnerID, request)
+			if err != nil {
+				t.Fatalf("start composite upload: %v", err)
+			}
+			blocked := waitCompositeUploadTestOperation(t, module, started)
+			completed := approveCompositeUploadTrackers(t, module, blocked, []api.TrackerID{"ALPHA", "BETA"}, "approve-dynamic-screenshot-count-"+test.name)
+			if completed.Operation == nil || completed.Operation.Status != api.StageStatusCompleted || completed.DryRun == nil || completed.Media == nil {
+				t.Fatalf("completed dynamic screenshot count upload = %#v", completed)
+			}
+			selectedScreenshots := 0
+			for _, artifact := range completed.Media.Artifacts {
+				if artifact.Selected && artifact.Kind == api.MediaArtifactScreenshot && artifact.Purpose == api.ScreenshotPurposeFinal {
+					selectedScreenshots++
+				}
+			}
+			if selectedScreenshots != test.want {
+				t.Fatalf("selected dynamic screenshots = %d, want %d", selectedScreenshots, test.want)
+			}
+			if len(builds) == 0 {
+				t.Fatal("composite upload did not project dynamically selected trackers")
+			}
+			latest := builds[len(builds)-1]
+			for _, trackerID := range []api.TrackerID{"ALPHA", "BETA"} {
+				count := latest[trackerID]
+				if (count != nil) != test.present || (count != nil && *count != test.want) {
+					t.Fatalf("latest projection screenshot count for %s = %#v, want present=%t value=%d builds=%#v", trackerID, count, test.present, test.want, builds)
+				}
+			}
+		})
+	}
+}
+
+func TestCompositeUploadRequestedScreenshotCountDoesNotCaptureWithoutProjectionRequirement(t *testing.T) {
+	t.Parallel()
+
+	module, _, _ := newCompositeUploadTestModule(t)
+	var captureInstructions []api.MediaCaptureInstructions
+	module.mediaBuilder = mediaArtifactBuilderFunc(func(
+		_ context.Context,
+		_ api.ReleaseRef,
+		projections api.TrackerReleaseProjectionSet,
+		instructions api.MediaCaptureInstructions,
+		_ time.Time,
+	) (api.MediaArtifactSet, any, error) {
+		captureInstructions = append(captureInstructions, instructions)
+		requirements, err := mediaRequirementsFingerprint(projections.Projections)
+		if err != nil {
+			return api.MediaArtifactSet{}, nil, err
+		}
+		return api.MediaArtifactSet{
+			CaptureFingerprint:        testFingerprint(t, "no-image-requested-screenshot-count"),
+			RequirementsFingerprint:   requirements,
+			ImageRequirementsPrepared: true,
+			Status:                    api.StageStatusCompleted,
+		}, struct{}{}, nil
+	})
+	count := 7
+	request := compositeUploadTestRequest(false, api.ReleaseWorkflowUploadModeDebug, "no-image-requested-screenshot-count")
+	request.Media.Screenshots.Count = &count
+	started, err := module.StartUpload(t.Context(), testOwnerID, request)
+	if err != nil {
+		t.Fatalf("start composite upload: %v", err)
+	}
+	blocked := waitCompositeUploadTestOperation(t, module, started)
+	completed := approveCompositeUploadTrackers(t, module, blocked, []api.TrackerID{"ALPHA", "BETA"}, "approve-no-image-requested-screenshot-count")
+	if completed.Operation == nil || completed.Operation.Status != api.StageStatusCompleted || completed.DryRun == nil || completed.Media == nil {
+		t.Fatalf("completed no-image screenshot count upload = %#v", completed)
+	}
+	if len(captureInstructions) == 0 {
+		t.Fatal("no-image composite upload did not prepare media")
+	}
+	for _, instructions := range captureInstructions {
+		if instructions.ScreenshotCount != 0 {
+			t.Fatalf("no-image composite capture screenshot count = %d, want 0", instructions.ScreenshotCount)
+		}
+	}
+	if len(completed.Media.Artifacts) != 0 {
+		t.Fatalf("no-image composite artifacts = %#v, want none", completed.Media.Artifacts)
+	}
+}
+
+func TestCompositeUploadSelectedScreenshotExcessRespectsTrackerMinimumAndOrder(t *testing.T) {
+	t.Parallel()
+
+	artifacts := []api.MediaArtifact{
+		{
+			ID:       "comparison",
+			Kind:     api.MediaArtifactScreenshot,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+			Source:   "comparison",
+		},
+		{
+			ID:       "third",
+			Kind:     api.MediaArtifactScreenshot,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+			Order:    3,
+		},
+		{
+			ID:       "first",
+			Kind:     api.MediaArtifactScreenshot,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+			Order:    1,
+		},
+		{
+			ID:       "second",
+			Kind:     api.MediaArtifactScreenshot,
+			Purpose:  api.ScreenshotPurposeFinal,
+			Selected: true,
+			Order:    2,
+		},
+		{
+			ID:       "menu",
+			Kind:     api.MediaArtifactDVDMenu,
+			Purpose:  api.ScreenshotPurposeMenu,
+			Selected: true,
+			Order:    0,
+		},
+	}
+	if actual, expected := compositeUploadSelectedScreenshotExcess(artifacts, 2), []api.PublicResourceID{"third"}; !slices.Equal(actual, expected) {
+		t.Fatalf("minimum-preserving screenshot excess = %#v, want %#v", actual, expected)
+	}
+	if actual, expected := compositeUploadSelectedScreenshotExcess(artifacts, 0), []api.PublicResourceID{"first", "second", "third"}; !slices.Equal(actual, expected) {
+		t.Fatalf("zero-count screenshot excess = %#v, want %#v", actual, expected)
+	}
+}
+
+func TestCompositeUploadAutomaticPolicyDeselectsExcessAutomaticScreenshots(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name  string
+		count int
+		want  []api.PublicResourceID
+	}{
+		{
+			name:  "lower",
+			count: 1,
+			want:  []api.PublicResourceID{"comparison", "first"},
+		},
+		{
+			name:  "zero",
+			count: 0,
+			want:  []api.PublicResourceID{"comparison"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			module, repository, _ := newCompositeUploadTestModule(t)
+			request := compositeUploadTestRequest(false, api.ReleaseWorkflowUploadModeDebug, "trim-automatic-screenshots-"+test.name)
+			started, err := module.StartUpload(t.Context(), testOwnerID, request)
+			if err != nil {
+				t.Fatalf("start composite upload: %v", err)
+			}
+			blocked := waitCompositeUploadTestOperation(t, module, started)
+			completed := approveCompositeUploadTrackers(t, module, blocked, []api.TrackerID{"ALPHA", "BETA"}, "approve-trim-automatic-screenshots-"+test.name)
+
+			const operationID api.WorkflowOperationID = "trim-automatic-screenshots"
+			if err := module.private.Put(
+				testOwnerID,
+				completed.Workflow.ID,
+				mediaPrivateResourceID(completed.Media.ID),
+				&retainedMediaResourceFake{stats: &retainedMediaResourceStats{}},
+				module.clock.Now().UTC().Add(time.Hour),
+			); err != nil {
+				t.Fatalf("replace retained test media: %v", err)
+			}
+			repository.mu.Lock()
+			state := repository.states[completed.Workflow.ID]
+			media := state.Media[state.Workflow.Media.ID]
+			media.Artifacts = []api.MediaArtifact{
+				{
+					ID:       "comparison",
+					Kind:     api.MediaArtifactScreenshot,
+					Purpose:  api.ScreenshotPurposeFinal,
+					Selected: true,
+					Source:   "comparison",
+				},
+				{
+					ID:       "third",
+					Kind:     api.MediaArtifactScreenshot,
+					Purpose:  api.ScreenshotPurposeFinal,
+					Selected: true,
+					Order:    3,
+				},
+				{
+					ID:       "first",
+					Kind:     api.MediaArtifactScreenshot,
+					Purpose:  api.ScreenshotPurposeFinal,
+					Selected: true,
+					Order:    1,
+				},
+				{
+					ID:       "second",
+					Kind:     api.MediaArtifactScreenshot,
+					Purpose:  api.ScreenshotPurposeFinal,
+					Selected: true,
+					Order:    2,
+				},
+				{
+					ID:       "menu",
+					Kind:     api.MediaArtifactDVDMenu,
+					Purpose:  api.ScreenshotPurposeMenu,
+					Selected: true,
+				},
+			}
+			state.Media[media.ID] = media
+			state.Composite.ActiveOperationID = operationID
+			state.Composite.RequestedScreenshotCount = &test.count
+			instructions := map[api.TrackerID]api.TrackerProjectionInstructions{}
+			for _, trackerID := range state.Selections[state.Workflow.Selection.ID].TrackerIDs {
+				instructions[trackerID] = api.TrackerProjectionInstructions{ScreenshotCount: cloneIntPointer(&test.count)}
+			}
+			state.Composite.Intent.ProjectionInstructions = instructions
+			instructionSnapshot := state.ProjectionInstructions[state.Workflow.ProjectionInstructions.ID]
+			instructionSnapshot.Instructions = instructions
+			state.ProjectionInstructions[instructionSnapshot.ID] = instructionSnapshot
+			projectionSnapshot := state.Projections[state.Workflow.TrackerProjections.ID]
+			for index := range projectionSnapshot.Projections {
+				projectionSnapshot.Projections[index].Artifacts.ScreenshotCount = test.count
+			}
+			state.Projections[projectionSnapshot.ID] = projectionSnapshot
+			repository.states[completed.Workflow.ID] = state
+			repository.mu.Unlock()
+
+			current, err := module.Current(t.Context(), testOwnerID, completed.Workflow.ID)
+			if err != nil {
+				t.Fatalf("load composite upload: %v", err)
+			}
+			updated, err := repository.Load(t.Context(), testOwnerID, completed.Workflow.ID)
+			if err != nil {
+				t.Fatalf("load composite state: %v", err)
+			}
+			changed, err := module.applyCompositeAutomaticPolicy(t.Context(), testOwnerID, current, updated.Composite, operationID)
+			if err != nil || !changed {
+				t.Fatalf("trim automatic screenshots changed=%t err=%v", changed, err)
+			}
+			after, err := module.Current(t.Context(), testOwnerID, completed.Workflow.ID)
+			if err != nil {
+				t.Fatalf("load trimmed media: %v", err)
+			}
+			if after.Media == nil {
+				t.Fatal("trimmed composite media is unavailable")
+			}
+			selectedScreenshots := make([]api.PublicResourceID, 0)
+			menuSelected := false
+			for _, artifact := range after.Media.Artifacts {
+				if artifact.Selected && artifact.Kind == api.MediaArtifactScreenshot && artifact.Purpose == api.ScreenshotPurposeFinal {
+					selectedScreenshots = append(selectedScreenshots, artifact.ID)
+				}
+				if artifact.Selected && artifact.Kind == api.MediaArtifactDVDMenu {
+					menuSelected = true
+				}
+			}
+			if !slices.Equal(selectedScreenshots, test.want) || !menuSelected {
+				t.Fatalf("trimmed media screenshots=%#v menuSelected=%t", selectedScreenshots, menuSelected)
 			}
 		})
 	}

--- a/internal/releaseworkflow/planner.go
+++ b/internal/releaseworkflow/planner.go
@@ -1044,6 +1044,7 @@ func effectiveProjectionInstructions(
 
 func projectionInstructionIsEmpty(instruction api.TrackerProjectionInstructions) bool {
 	return instruction.UploadReleaseName.IsZero() &&
+		instruction.ScreenshotCount == nil &&
 		len(instruction.AdditionalNames) == 0 &&
 		len(instruction.Questionnaire) == 0 &&
 		instruction.TrackerConfig.Anon == nil &&

--- a/internal/trackers/description_assets.go
+++ b/internal/trackers/description_assets.go
@@ -230,7 +230,7 @@ func resolveDescriptionAssets(
 		final := false
 		if canonical := descriptionGroupFromPreparedMeta(meta, tracker, preloaded, registry); strings.TrimSpace(canonical) != "" {
 			description = canonical
-			final = true
+			final = meta.DescriptionGroupsFinal
 		}
 		if final {
 			description = strings.TrimSpace(description)
@@ -293,11 +293,6 @@ func applyResolvedDescriptionScreenshots(
 		return
 	}
 	assets.Description = rewriteDescriptionSlotURLs(assets.Description, assets.Slots, screenshots, assets.Final)
-	if assets.Final {
-		assets.MenuImages = nil
-		assets.Screenshots = nil
-		return
-	}
 	if meta.ExactMedia != nil {
 		assets.MenuImages, assets.Screenshots = exactDescriptionMedia(tracker, meta, screenshots)
 	} else {
@@ -527,7 +522,7 @@ func resolveTrackerDescription(
 				len(strings.TrimSpace(canonical)),
 			)
 		}
-		return canonical, true, true
+		return canonical, true, meta.DescriptionGroupsFinal
 	}
 	if trimmed := strings.TrimSpace(meta.DescriptionOverride); trimmed != "" {
 		if logger != nil {

--- a/internal/trackers/description_assets_test.go
+++ b/internal/trackers/description_assets_test.go
@@ -843,8 +843,8 @@ func TestResolveDescriptionAssetsUsesCompositeGroupOverride(t *testing.T) {
 	if !assets.Override {
 		t.Fatalf("expected composite group description to be treated as override")
 	}
-	if !assets.Final {
-		t.Fatal("expected prepared composite group description to be final")
+	if assets.Final {
+		t.Fatal("expected custom composite group description to remain open for tracker composition")
 	}
 }
 
@@ -852,7 +852,8 @@ func TestResolveDescriptionAssetsPreservesFinalDescriptionThatSanitizerWouldEmpt
 	sourcePath := filepath.Join(t.TempDir(), "source.mkv")
 	finalDescription := "[center][url=https://github.com/z-ink/uploadrr][img=300]https://i.ibb.co/2NVWb0c/uploadrr.webp[/img][/url][/center]"
 	meta := api.UploadSubject{
-		SourcePath: sourcePath,
+		SourcePath:             sourcePath,
+		DescriptionGroupsFinal: true,
 		DescriptionGroups: []api.DescriptionBuilderGroup{{
 			GroupKey:       "unit3d",
 			Trackers:       []string{"AITHER"},
@@ -879,12 +880,12 @@ func TestResolveDescriptionAssetsPreservesFinalDescriptionThatSanitizerWouldEmpt
 		RawURL: "https://pixhost.example/raw-1.png",
 		Host:   "pixhost",
 	}})
-	if len(assets.Screenshots) != 0 {
-		t.Fatalf("expected screenshots not appended to final description, got %#v", assets.Screenshots)
+	if assets.Description != finalDescription || len(assets.Screenshots) != 1 {
+		t.Fatalf("expected unchanged final description with separate screenshot assets, got %#v", assets)
 	}
 }
 
-func TestApplyResolvedDescriptionScreenshotsDoesNotAppendFinalBuilderScreenshots(t *testing.T) {
+func TestApplyResolvedDescriptionScreenshotsRetainsFinalBuilderScreenshotAssets(t *testing.T) {
 	t.Parallel()
 
 	sourcePath := filepath.Join(t.TempDir(), "source.mkv")
@@ -908,8 +909,42 @@ func TestApplyResolvedDescriptionScreenshotsDoesNotAppendFinalBuilderScreenshots
 	if !strings.Contains(assets.Description, "https://pixhost.example/raw-1.png") {
 		t.Fatalf("expected final description URL rewritten, got %q", assets.Description)
 	}
-	if len(assets.Screenshots) != 0 {
-		t.Fatalf("expected final builder screenshots not to be appendable, got %#v", assets.Screenshots)
+	if len(assets.Screenshots) != 1 || assets.Screenshots[0].RawURL != "https://pixhost.example/raw-1.png" {
+		t.Fatalf("expected screenshot assets retained for separate upload fields, got %#v", assets.Screenshots)
+	}
+}
+
+func TestPrepareUploadContentKeepsFinalDescriptionAndSeparateMedia(t *testing.T) {
+	t.Parallel()
+
+	const body = "[b]Reviewed description[/b]"
+	shot := api.ScreenshotImage{RawURL: "https://images.example/screen.png"}
+	menu := api.ScreenshotImage{RawURL: "https://images.example/menu.png", Purpose: api.ScreenshotPurposeMenu}
+	meta := api.UploadSubject{
+		SourcePath:             filepath.Join(t.TempDir(), "Example.Release.2026"),
+		DescriptionGroupsFinal: true,
+		DescriptionGroups: []api.DescriptionBuilderGroup{{
+			GroupKey:       "unit3d",
+			Trackers:       []string{"AITHER"},
+			RawDescription: body,
+		}},
+		ExactMedia: &api.ExactMediaAssets{DVDMenus: []api.DVDMenuCaptureImage{{ScreenshotImage: menu}}},
+	}
+	registry := descriptionAssetsTestRegistry(t)
+	service := NewServiceWithRegistry(config.Config{}, api.NopLogger{}, &stubRepo{}, registry)
+	content := service.prepareUploadContent(t.Context(), "AITHER", meta, config.TrackerConfig{}, nil, imageHostPreflight{
+		"AITHER": {screenshots: []api.ScreenshotImage{shot}},
+	})
+	if content.Failure != nil || content.Assets == nil {
+		t.Fatalf("prepare final content: %+v", content)
+	}
+	assets := content.Assets
+	if !assets.Final || assets.Description != body {
+		t.Fatalf("final description changed: %+v", assets)
+	}
+	if len(assets.Screenshots) != 1 || assets.Screenshots[0].RawURL != shot.RawURL ||
+		len(assets.MenuImages) != 1 || assets.MenuImages[0].RawURL != menu.RawURL {
+		t.Fatalf("separate upload media lost: %+v", assets)
 	}
 }
 
@@ -954,8 +989,8 @@ func TestApplyResolvedDescriptionScreenshotsPreservesFinalNonRenderableImages(t 
 	if !strings.Contains(assets.Description, "https://pixhost.example/raw-1.png") {
 		t.Fatalf("expected renderable final screenshot URL rewritten, got %q", assets.Description)
 	}
-	if len(assets.Screenshots) != 0 {
-		t.Fatalf("expected final builder screenshots not to be appendable, got %#v", assets.Screenshots)
+	if len(assets.Screenshots) != 1 {
+		t.Fatalf("expected final screenshot assets preserved, got %#v", assets.Screenshots)
 	}
 }
 
@@ -1491,6 +1526,7 @@ func TestResolveDescriptionAssetsPreservesFinalDescriptionGroups(t *testing.T) {
 		"[right][url=https://github.com/autobrr/upbrr]Uploaded by upbrr[/url][/right]",
 	}, "\n\n")
 	meta := api.UploadSubject{
+		DescriptionGroupsFinal: true,
 		DescriptionGroups: []api.DescriptionBuilderGroup{{
 			GroupKey:       "unit3d",
 			Trackers:       []string{"AITHER"},

--- a/internal/trackers/impl/registry_test.go
+++ b/internal/trackers/impl/registry_test.go
@@ -5,6 +5,8 @@ package impl
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -157,6 +159,8 @@ func TestDescriptionDefinitionsPreserveFinalReviewedDescription(t *testing.T) {
 				Assets: &trackers.DescriptionAssets{
 					Description: finalDescription,
 					Final:       true,
+					Screenshots: []api.ScreenshotImage{{RawURL: "https://images.example/screen.png"}},
+					MenuImages:  []api.ScreenshotImage{{RawURL: "https://images.example/menu.png"}},
 				},
 			})
 			if failure != nil {
@@ -170,6 +174,104 @@ func TestDescriptionDefinitionsPreserveFinalReviewedDescription(t *testing.T) {
 
 			if got := plan.Description().Description; got != finalDescription {
 				t.Fatalf("final description changed:\nwant %q\ngot  %q", finalDescription, got)
+			}
+		})
+	}
+}
+
+type descriptionPreviewPersistence struct {
+	trackers.UploadPersistence
+}
+
+func (descriptionPreviewPersistence) ListTrackerMetadataByPath(context.Context, string) ([]api.TrackerMetadata, error) {
+	return nil, nil
+}
+
+func (descriptionPreviewPersistence) ListDescriptionOverridesByPath(context.Context, string) ([]api.DescriptionOverride, error) {
+	return nil, nil
+}
+
+func TestCustomDescriptionGroupsIncludeTrackerScreenshots(t *testing.T) {
+	t.Parallel()
+
+	registry := MustNewRegistry()
+	for _, tracker := range []string{"BHD", "AITHER", "PTP"} {
+		t.Run(tracker, func(t *testing.T) {
+			const body = "[b]User supplied release notes.[/b]"
+			source := filepath.Join(t.TempDir(), "Example.Release.2026.mkv")
+			media := &api.ExactMediaAssets{}
+			for index := range 6 {
+				imagePath := filepath.Join(t.TempDir(), fmt.Sprintf("screen-%d.png", index))
+				imageURL := fmt.Sprintf("https://images.example/screen-%d.png", index)
+				media.Screenshots = append(media.Screenshots, api.ScreenshotImage{
+					Path:    imagePath,
+					Purpose: api.ScreenshotPurposeFinal,
+				})
+				media.ScreenshotUploads = append(media.ScreenshotUploads, api.UploadedImageLink{
+					ImagePath:  imagePath,
+					Host:       "pixhost",
+					UsageScope: "global",
+					RawURL:     imageURL,
+					ImgURL:     imageURL,
+					WebURL:     imageURL,
+				})
+			}
+			meta := api.UploadSubject{
+				SourcePath:         source,
+				Options:            api.UploadOptions{Screens: 6},
+				ExactMedia:         media,
+				ImageHostOverrides: api.ImageHostOverrides{SkipUpload: new(true)},
+				DescriptionGroups: []api.DescriptionBuilderGroup{{
+					GroupKey:       trackers.DescriptionOverrideGroupForTrackerWithRegistry(tracker, registry),
+					Trackers:       []string{tracker},
+					RawDescription: body,
+					HasOverride:    true,
+				}},
+			}
+			cfg := config.Config{ImageHosting: config.ImageHostingConfig{Host1: "pixhost"}}
+			service := trackers.NewServiceWithRegistry(cfg, api.NopLogger{}, descriptionPreviewPersistence{}, registry)
+			preview, err := service.BuildPreparation(t.Context(), api.NewDescriptionSubject(meta), []string{tracker})
+			if err != nil || len(preview.ContentFailures) != 0 || len(preview.Descriptions) != 1 {
+				t.Fatalf("build custom description: preview=%+v err=%v", preview, err)
+			}
+			got := preview.Descriptions[0].RawDescription
+			bodyIndex := strings.Index(got, "User supplied release notes.")
+			if bodyIndex < 0 {
+				t.Fatalf("custom body missing: %q", got)
+			}
+			previous := bodyIndex
+			for index := range 6 {
+				image := fmt.Sprintf("screen-%d.png", index)
+				position := strings.Index(got, image)
+				if position <= previous {
+					t.Fatalf("screenshot %s missing or out of order after custom body: %q", image, got)
+				}
+				previous = position
+			}
+
+			meta.DescriptionGroups[0].RawDescription = got
+			meta.DescriptionGroupsFinal = true
+			assets, err := trackers.ResolveDescriptionAssets(t.Context(), tracker, meta, nil, api.NopLogger{}, registry)
+			if err != nil {
+				t.Fatalf("resolve retained description: %v", err)
+			}
+			definition, _ := registry.Lookup(tracker)
+			plan, failure := definition.Prepare(t.Context(), trackers.PreparationInput{
+				Intent:  trackers.PreparationIntentDescriptionPreview,
+				Tracker: tracker,
+				Meta:    meta,
+				Assets:  &assets,
+			})
+			if failure != nil {
+				t.Fatalf("prepare retained description: %v", failure)
+			}
+			defer func() {
+				if err := plan.Release(); err != nil {
+					t.Errorf("release retained description: %v", err)
+				}
+			}()
+			if plan.Description().Description != got {
+				t.Fatalf("retained description rebuilt: %q", plan.Description().Description)
 			}
 		})
 	}
@@ -352,6 +454,66 @@ func TestRegistryOmitsGeneratedEpisodeTitleForBLU(t *testing.T) {
 	}
 	if name != omitted {
 		t.Fatalf("BLU release name = %q, want %q", name, omitted)
+	}
+}
+
+func TestEveryTrackerProjectsScreenshotDefaultAndOverride(t *testing.T) {
+	t.Parallel()
+
+	registry := MustNewRegistry()
+	const configuredCount = 7
+	projector, err := trackers.NewWorkflowProjector(registry, config.Config{
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: configuredCount},
+	}, api.NopLogger{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := registry.Names()
+	ids := make([]api.TrackerID, len(names))
+	for index, name := range names {
+		ids[index] = api.TrackerID(name)
+	}
+	for _, test := range []struct {
+		name  string
+		count *int
+		want  int
+	}{
+		{name: "configured default", want: configuredCount},
+		{
+			name:  "lower override",
+			count: new(2),
+			want:  2,
+		},
+		{name: "zero override", count: new(0)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			instructions := make(map[api.TrackerID]api.TrackerProjectionInstructions, len(ids))
+			for _, id := range ids {
+				instructions[id] = api.TrackerProjectionInstructions{ScreenshotCount: test.count}
+			}
+			_, _, _, result, err := projector.Build(t.Context(), api.ReleaseSnapshot{}, api.UploadSubject{
+				ReleaseName: "Example.Release.2026.1080p-GRP",
+			}, ids, instructions, nil, api.WorkflowExecutionModeNormal)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(result.Projections) != len(names) {
+				t.Fatalf("projected %d trackers, want %d", len(result.Projections), len(names))
+			}
+			for _, projection := range result.Projections {
+				mode, ok := registry.LookupUploadContentMode(string(projection.TrackerID))
+				if !ok {
+					t.Fatalf("unknown projected tracker %s", projection.TrackerID)
+				}
+				want := 0
+				if mode.UsesImages() {
+					want = test.want
+				}
+				if projection.Artifacts.ScreenshotCount != want {
+					t.Errorf("tracker %s screenshot count = %d, want %d", projection.TrackerID, projection.Artifacts.ScreenshotCount, want)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/trackers/impl/standalone/bhd/definition_test.go
+++ b/internal/trackers/impl/standalone/bhd/definition_test.go
@@ -685,6 +685,66 @@ func TestBuildScreenshotSectionUsesTwoImagesPerRow(t *testing.T) {
 	}
 }
 
+func TestBuildDescriptionUsesAllSelectedScreenshotsByDefault(t *testing.T) {
+	images := []api.ScreenshotImage{
+		{RawURL: "https://img.example/1.png", WebURL: "https://img.example/1"},
+		{RawURL: "https://img.example/2.png", WebURL: "https://img.example/2"},
+		{RawURL: "https://img.example/3.png", WebURL: "https://img.example/3"},
+		{RawURL: "https://img.example/4.png", WebURL: "https://img.example/4"},
+		{RawURL: "https://img.example/5.png", WebURL: "https://img.example/5"},
+		{RawURL: "https://img.example/6.png", WebURL: "https://img.example/6"},
+	}
+
+	got := buildDescription(api.UploadSubject{}, config.Config{}, trackers.DescriptionAssets{
+		Description: "Custom user description",
+		Override:    true,
+		Screenshots: images,
+	})
+	want := strings.Join([]string{
+		"Custom user description",
+		strings.Join([]string{
+			`[align=center][url=https://img.example/1][img width=350]https://img.example/1.png[/img][/url] [url=https://img.example/2][img width=350]https://img.example/2.png[/img][/url]`,
+			`[url=https://img.example/3][img width=350]https://img.example/3.png[/img][/url] [url=https://img.example/4][img width=350]https://img.example/4.png[/img][/url]`,
+			`[url=https://img.example/5][img width=350]https://img.example/5.png[/img][/url] [url=https://img.example/6][img width=350]https://img.example/6.png[/img][/url][/align]`,
+		}, "\n\n"),
+		`[align=right][url=https://github.com/autobrr/upbrr]Uploaded by upbrr[/url][/align]`,
+	}, "\n\n")
+	if got != want {
+		t.Fatalf("unexpected BHD custom description: %q", got)
+	}
+}
+
+func TestBuildDescriptionHonorsExplicitScreenshotLimit(t *testing.T) {
+	images := []api.ScreenshotImage{
+		{RawURL: "https://img.example/1.png", WebURL: "https://img.example/1"},
+		{RawURL: "https://img.example/2.png", WebURL: "https://img.example/2"},
+		{RawURL: "https://img.example/3.png", WebURL: "https://img.example/3"},
+	}
+
+	got := buildDescription(api.UploadSubject{Options: api.UploadOptions{Screens: 2}}, config.Config{}, trackers.DescriptionAssets{
+		Description: "Custom user description",
+		Override:    true,
+		Screenshots: images,
+	})
+	if strings.Contains(got, "https://img.example/3.png") {
+		t.Fatalf("expected explicit screenshot limit to omit third image, got %q", got)
+	}
+	if strings.Count(got, "[img width=350]") != 2 {
+		t.Fatalf("expected explicit screenshot limit to retain two images, got %q", got)
+	}
+}
+
+func TestBuildDescriptionPreservesFinalDescription(t *testing.T) {
+	got := buildDescription(api.UploadSubject{}, config.Config{}, trackers.DescriptionAssets{
+		Description: " [b]Reviewed tracker description[/b] ",
+		Final:       true,
+		Screenshots: []api.ScreenshotImage{{RawURL: "https://img.example/1.png", WebURL: "https://img.example/1"}},
+	})
+	if got != "[b]Reviewed tracker description[/b]" {
+		t.Fatalf("expected final description to remain untouched, got %q", got)
+	}
+}
+
 func TestDefinitionBuildDescriptionStripsLegacyCreatedFooter(t *testing.T) {
 	result, err := prepareDescription(context.Background(), trackers.PreparationInput{
 		Tracker: "BHD",

--- a/internal/trackers/impl/standalone/bhd/description.go
+++ b/internal/trackers/impl/standalone/bhd/description.go
@@ -34,6 +34,10 @@ func buildDescription(meta api.UploadSubject, cfg config.Config, assets trackers
 	if len(images) == 0 {
 		images = screenshotsFromReport(cleaned.Images)
 	}
+	screenshotLimit := len(images)
+	if meta.Options.Screens > 0 {
+		screenshotLimit = meta.Options.Screens
+	}
 
 	parts := make([]string, 0, 5)
 	if discSection := buildDiscSection(meta, cfg.MainSettings.DBPath); discSection != "" {
@@ -45,7 +49,7 @@ func buildDescription(meta api.UploadSubject, cfg config.Config, assets trackers
 	if menus := buildDiscScreenshotSection(meta, assets.MenuImages, 0); menus != "" {
 		parts = append(parts, "[b]Disc Menus[/b]\n"+menus)
 	}
-	if screenshots := buildDiscScreenshotSection(meta, images, maxInt(1, meta.Options.Screens)); screenshots != "" {
+	if screenshots := buildDiscScreenshotSection(meta, images, screenshotLimit); screenshots != "" {
 		parts = append(parts, screenshots)
 	}
 	parts = append(parts, `[align=right][url=https://github.com/autobrr/upbrr]Uploaded by upbrr[/url][/align]`)
@@ -209,11 +213,4 @@ func readTextFileNoErr(path string) string {
 func hasGroup(tag string, name string) bool {
 	trimmed := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(tag, "-")))
 	return trimmed == strings.ToLower(strings.TrimSpace(name))
-}
-
-func maxInt(left int, right int) int {
-	if left > right {
-		return left
-	}
-	return right
 }

--- a/internal/trackers/workflow_projector.go
+++ b/internal/trackers/workflow_projector.go
@@ -283,7 +283,7 @@ func (p *WorkflowProjector) projectSelected(
 			Logger:                    logger,
 		}, inputFingerprint, catalogFingerprint, configFingerprints[trackerID])
 		if descriptor, ok := p.registry.LookupDescriptor(string(trackerID)); ok {
-			applyWorkflowProjectionRequirements(&projection, descriptor, subject, p.config)
+			applyWorkflowProjectionRequirements(&projection, descriptor, instruction.ScreenshotCount, p.config)
 		}
 		if failure != nil {
 			failures = append(failures, api.WorkflowFailure{
@@ -339,13 +339,18 @@ func projectionIneligibleProgressMessage(projection api.TrackerReleaseProjection
 func applyWorkflowProjectionRequirements(
 	projection *api.TrackerReleaseProjection,
 	descriptor Descriptor,
-	_ api.UploadSubject,
+	screenshotCount *int,
 	cfg config.Config,
 ) {
 	if descriptor.UploadContentMode.UsesImages() {
-		projection.Artifacts.ScreenshotCount = trackerConfigFor(cfg, descriptor.Name).ImageCount
-		if projection.Artifacts.ScreenshotCount <= 0 {
-			projection.Artifacts.ScreenshotCount = cfg.ScreenshotHandling.Screens
+		trackerScreenshotCount := trackerConfigFor(cfg, descriptor.Name).ImageCount
+		if screenshotCount != nil {
+			projection.Artifacts.ScreenshotCount = max(trackerScreenshotCount, *screenshotCount)
+		} else {
+			projection.Artifacts.ScreenshotCount = trackerScreenshotCount
+			if projection.Artifacts.ScreenshotCount <= 0 {
+				projection.Artifacts.ScreenshotCount = cfg.ScreenshotHandling.Screens
+			}
 		}
 	}
 	if descriptor.WorkflowMedia != nil {

--- a/internal/trackers/workflow_projector_test.go
+++ b/internal/trackers/workflow_projector_test.go
@@ -145,12 +145,94 @@ func TestApplyWorkflowProjectionRequirementsDoesNotInferDVDMenuMinimumFromCaptur
 	applyWorkflowProjectionRequirements(
 		&projection,
 		Descriptor{Name: "EXAMPLE", UploadContentMode: UploadContentModeDescription},
-		api.UploadSubject{DiscType: "DVD"},
+		nil,
 		cfg,
 	)
 
 	if projection.Artifacts.ScreenshotCount != 4 || projection.Artifacts.DVDMenuCount != 0 {
 		t.Fatalf("projected media requirements = %#v", projection.Artifacts)
+	}
+}
+
+func TestApplyWorkflowProjectionRequirementsUsesOptionalScreenshotOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		trackerImageCount int
+		override          *int
+		want              int
+	}{
+		{
+			name:     "zero bypasses global fallback",
+			override: new(0),
+			want:     0,
+		},
+		{
+			name:              "override increases tracker minimum",
+			trackerImageCount: 3,
+			override:          new(5),
+			want:              5,
+		},
+		{
+			name:              "tracker minimum wins",
+			trackerImageCount: 5,
+			override:          new(3),
+			want:              5,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := config.Config{
+				ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 4},
+				Trackers:           config.TrackersConfig{Trackers: map[string]config.TrackerConfig{"EXAMPLE": {ImageCount: test.trackerImageCount}}},
+			}
+			projection := api.TrackerReleaseProjection{}
+			applyWorkflowProjectionRequirements(
+				&projection,
+				Descriptor{Name: "EXAMPLE", UploadContentMode: UploadContentModeDescription},
+				test.override,
+				cfg,
+			)
+			if projection.Artifacts.ScreenshotCount != test.want {
+				t.Fatalf("projected screenshot count = %d, want %d", projection.Artifacts.ScreenshotCount, test.want)
+			}
+		})
+	}
+}
+
+func TestWorkflowProjectorPassesScreenshotOverride(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	if err := registry.RegisterDescriptor(Descriptor{
+		Name:              "EXAMPLE",
+		Definition:        stubDefinition{name: "EXAMPLE"},
+		UploadContentMode: UploadContentModeDescription,
+	}); err != nil {
+		t.Fatalf("register tracker: %v", err)
+	}
+	projector, err := NewWorkflowProjector(registry, config.Config{
+		ScreenshotHandling: config.ScreenshotHandlingConfig{Screens: 4},
+	}, api.NopLogger{})
+	if err != nil {
+		t.Fatalf("new workflow projector: %v", err)
+	}
+	override := 0
+	_, _, _, result, err := projector.Build(
+		t.Context(),
+		api.ReleaseSnapshot{},
+		api.UploadSubject{ReleaseName: "Example.Release.2026.1080p-GRP"},
+		[]api.TrackerID{"EXAMPLE"},
+		map[api.TrackerID]api.TrackerProjectionInstructions{"EXAMPLE": {ScreenshotCount: &override}},
+		nil,
+		api.WorkflowExecutionModeNormal,
+	)
+	if err != nil {
+		t.Fatalf("build projections: %v", err)
+	}
+	if len(result.Projections) != 1 || result.Projections[0].Artifacts.ScreenshotCount != 0 {
+		t.Fatalf("projected screenshot requirements = %#v", result.Projections)
 	}
 }
 
@@ -165,7 +247,7 @@ func TestApplyWorkflowProjectionRequirementsKeepsExplicitDVDMenuMinimum(t *testi
 			UploadContentMode: UploadContentModeDescription,
 			WorkflowMedia:     &WorkflowMediaRequirements{DVDMenuCount: 2},
 		},
-		api.UploadSubject{DiscType: "DVD"},
+		nil,
 		config.Config{},
 	)
 

--- a/internal/webserver/openapi/release-workflow-v1.json
+++ b/internal/webserver/openapi/release-workflow-v1.json
@@ -9400,6 +9400,17 @@
               ]
             }
           },
+          "screenshotCount": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "trackerConfig": {
             "$ref": "#/components/schemas/TrackerConfigOverrides"
           },

--- a/pkg/api/workflow_continuation.go
+++ b/pkg/api/workflow_continuation.go
@@ -181,6 +181,9 @@ func (r ContinueReleaseWorkflowRequest) Validate() error {
 	if r.Intent.DuplicateCheckCount > 2 {
 		return errors.New("duplicate check count cannot exceed two")
 	}
+	if err := validateTrackerProjectionInstructions(r.Intent.ProjectionInstructions); err != nil {
+		return err
+	}
 	if r.Intent.MediaSelection != nil {
 		if len(r.Intent.MediaSelection.ArtifactIDs) == 0 {
 			return errors.New("explicit media selection requires at least one artifact")

--- a/pkg/api/workflow_contracts.go
+++ b/pkg/api/workflow_contracts.go
@@ -107,13 +107,15 @@ type TrackerSelection struct {
 }
 
 // TrackerProjectionInstructions contains optional tracker-local caller intent.
-// Nil means automatic resolution; pointed-to empty values are explicit clears.
+// Nil values use automatic resolution; pointed-to empty strings explicitly clear their field.
 type TrackerProjectionInstructions struct {
-	UploadReleaseName WorkflowPatch[string]  `json:"-"`
-	AdditionalNames   map[string]*string     `json:"additionalNames,omitempty"`
-	Questionnaire     map[string]*string     `json:"questionnaire,omitempty"`
-	TrackerConfig     TrackerConfigOverrides `json:"trackerConfig,omitempty"`
-	TrackerSite       TrackerSiteOverrides   `json:"trackerSite,omitempty"`
+	UploadReleaseName WorkflowPatch[string] `json:"-"`
+	// ScreenshotCount overrides the global screenshot fallback. Zero disables that fallback, while a tracker ImageCount remains a minimum.
+	ScreenshotCount *int                   `json:"screenshotCount,omitempty"`
+	AdditionalNames map[string]*string     `json:"additionalNames,omitempty"`
+	Questionnaire   map[string]*string     `json:"questionnaire,omitempty"`
+	TrackerConfig   TrackerConfigOverrides `json:"trackerConfig,omitempty"`
+	TrackerSite     TrackerSiteOverrides   `json:"trackerSite,omitempty"`
 }
 
 // TrackerProjectionInstructionSnapshot retains tracker-local projection instructions.

--- a/pkg/api/workflow_contracts_test.go
+++ b/pkg/api/workflow_contracts_test.go
@@ -179,6 +179,96 @@ func TestTrackerProjectionInstructionsPreserveAbsentNullAndEmptyName(t *testing.
 	}
 }
 
+func TestTrackerProjectionInstructionsPreserveOptionalScreenshotCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		payload string
+		want    *int
+	}{
+		{name: "absent", payload: `{}`},
+		{
+			name:    "zero",
+			payload: `{"screenshotCount":0}`,
+			want:    new(0),
+		},
+		{
+			name:    "value",
+			payload: `{"screenshotCount":7}`,
+			want:    new(7),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var instructions TrackerProjectionInstructions
+			if err := json.Unmarshal([]byte(test.payload), &instructions); err != nil {
+				t.Fatalf("unmarshal projection instructions: %v", err)
+			}
+			if !reflect.DeepEqual(instructions.ScreenshotCount, test.want) {
+				t.Fatalf("screenshot count = %#v, want %#v", instructions.ScreenshotCount, test.want)
+			}
+			encoded, err := json.Marshal(instructions)
+			if err != nil {
+				t.Fatalf("marshal projection instructions: %v", err)
+			}
+			var roundTrip TrackerProjectionInstructions
+			if err := json.Unmarshal(encoded, &roundTrip); err != nil {
+				t.Fatalf("round-trip projection instructions: %v", err)
+			}
+			if !reflect.DeepEqual(roundTrip.ScreenshotCount, test.want) {
+				t.Fatalf("round-trip screenshot count = %#v, want %#v", roundTrip.ScreenshotCount, test.want)
+			}
+		})
+	}
+
+	zero := 0
+	snapshot := TrackerProjectionInstructionSnapshot{Instructions: map[TrackerID]TrackerProjectionInstructions{
+		"EXAMPLE": {ScreenshotCount: &zero},
+	}}
+	clone, err := snapshot.Clone()
+	if err != nil {
+		t.Fatalf("clone projection instructions: %v", err)
+	}
+	*clone.Instructions["EXAMPLE"].ScreenshotCount = 5
+	if *snapshot.Instructions["EXAMPLE"].ScreenshotCount != 0 {
+		t.Fatal("clone mutated screenshot count source value")
+	}
+}
+
+func TestTrackerProjectionInstructionSnapshotRejectsNegativeScreenshotCount(t *testing.T) {
+	t.Parallel()
+
+	negative := -1
+	snapshot := TrackerProjectionInstructionSnapshot{
+		ID:         "instructions-1",
+		WorkflowID: "workflow-1",
+		Revision:   1,
+		Instructions: map[TrackerID]TrackerProjectionInstructions{
+			"EXAMPLE": {ScreenshotCount: &negative},
+		},
+		CreatedAt: time.Date(2026, 9, 13, 0, 0, 0, 0, time.UTC),
+	}
+	var err error
+	snapshot, err = snapshot.WithFingerprint()
+	if err != nil {
+		t.Fatalf("fingerprint projection instructions: %v", err)
+	}
+	if err := snapshot.Validate(); err == nil || !strings.Contains(err.Error(), "screenshot count must not be negative") {
+		t.Fatalf("negative screenshot count error = %v", err)
+	}
+
+	zero := 0
+	snapshot.Instructions["EXAMPLE"] = TrackerProjectionInstructions{ScreenshotCount: &zero}
+	snapshot, err = snapshot.WithFingerprint()
+	if err != nil {
+		t.Fatalf("fingerprint zero screenshot count: %v", err)
+	}
+	if err := snapshot.Validate(); err != nil {
+		t.Fatalf("zero screenshot count validation: %v", err)
+	}
+}
+
 func TestTrackerProjectionInstructionsIgnoreRuleAuthorization(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/workflow_contracts_validation.go
+++ b/pkg/api/workflow_contracts_validation.go
@@ -15,6 +15,15 @@ func normalizeTrackerID(value TrackerID) TrackerID {
 	return TrackerID(strings.ToUpper(strings.TrimSpace(string(value))))
 }
 
+func validateTrackerProjectionInstructions(instructions map[TrackerID]TrackerProjectionInstructions) error {
+	for trackerID, instruction := range instructions {
+		if instruction.ScreenshotCount != nil && *instruction.ScreenshotCount < 0 {
+			return fmt.Errorf("tracker %s screenshot count must not be negative", trackerID)
+		}
+	}
+	return nil
+}
+
 func validateTypedRef[T ~string](id T, revision WorkflowRevision, label string) error {
 	if strings.TrimSpace(string(id)) == "" {
 		return fmt.Errorf("%s id is required", label)
@@ -489,6 +498,9 @@ func (s TrackerProjectionInstructionSnapshot) Validate() error {
 	}
 	if len(normalized.Instructions) != len(s.Instructions) {
 		return errors.New("tracker projection instructions contain blank or duplicate tracker ids")
+	}
+	if err := validateTrackerProjectionInstructions(normalized.Instructions); err != nil {
+		return fmt.Errorf("tracker projection instructions: %w", err)
 	}
 	want, err := normalized.ComputeFingerprint()
 	if err != nil {

--- a/pkg/api/workflow_presence.go
+++ b/pkg/api/workflow_presence.go
@@ -108,15 +108,18 @@ func (u *ReleaseFactInstructionUpdate) UnmarshalJSON(payload []byte) error {
 	return nil
 }
 
-// MarshalJSON preserves tracker projection instruction absence, null/reset, and explicit empty names.
+// MarshalJSON preserves tracker projection instruction absence, null/reset, explicit empty names, and screenshot counts.
 func (i TrackerProjectionInstructions) MarshalJSON() ([]byte, error) {
-	fields := make(map[string]any, 5)
+	fields := make(map[string]any, 6)
 	if i.UploadReleaseName.Present {
 		if i.UploadReleaseName.Reset {
 			fields["uploadReleaseName"] = nil
 		} else {
 			fields["uploadReleaseName"] = i.UploadReleaseName.Value
 		}
+	}
+	if i.ScreenshotCount != nil {
+		fields["screenshotCount"] = *i.ScreenshotCount
 	}
 	if i.AdditionalNames != nil {
 		fields["additionalNames"] = i.AdditionalNames
@@ -147,6 +150,11 @@ func (i *TrackerProjectionInstructions) UnmarshalJSON(payload []byte) error {
 	if raw, ok := fields["uploadReleaseName"]; ok {
 		if err := json.Unmarshal(raw, &i.UploadReleaseName); err != nil {
 			return fmt.Errorf("unmarshal tracker projection upload name: %w", err)
+		}
+	}
+	if raw, ok := fields["screenshotCount"]; ok {
+		if err := json.Unmarshal(raw, &i.ScreenshotCount); err != nil {
+			return fmt.Errorf("unmarshal tracker projection screenshot count: %w", err)
 		}
 	}
 	if raw, ok := fields["additionalNames"]; ok {

--- a/pkg/api/workflow_requests.go
+++ b/pkg/api/workflow_requests.go
@@ -181,7 +181,7 @@ func (r ProjectReleaseWorkflowTrackersRequest) Validate() error {
 	if !validWorkflowExecutionMode(r.ExecutionMode) {
 		return fmt.Errorf("unsupported workflow execution mode %q", r.ExecutionMode)
 	}
-	return nil
+	return validateTrackerProjectionInstructions(r.Instructions)
 }
 
 // PreflightReleaseWorkflowTrackersRequest runs live readiness checks.

--- a/pkg/api/workflow_requests_test.go
+++ b/pkg/api/workflow_requests_test.go
@@ -41,6 +41,50 @@ func TestWorkflowRequestFingerprintsAreDeterministic(t *testing.T) {
 	}
 }
 
+func TestProjectReleaseWorkflowTrackersRequestRejectsNegativeScreenshotCount(t *testing.T) {
+	t.Parallel()
+
+	negative := -1
+	request := ProjectReleaseWorkflowTrackersRequest{
+		ReleaseWorkflowCommandContext: testWorkflowCommandContext(),
+		Instructions: map[TrackerID]TrackerProjectionInstructions{
+			"EXAMPLE": {ScreenshotCount: &negative},
+		},
+	}
+	if err := request.Validate(); err == nil || !strings.Contains(err.Error(), "screenshot count must not be negative") {
+		t.Fatalf("negative screenshot count error = %v", err)
+	}
+
+	zero := 0
+	request.Instructions["EXAMPLE"] = TrackerProjectionInstructions{ScreenshotCount: &zero}
+	if err := request.Validate(); err != nil {
+		t.Fatalf("zero screenshot count validation: %v", err)
+	}
+}
+
+func TestContinueReleaseWorkflowRequestRejectsNegativeScreenshotCount(t *testing.T) {
+	t.Parallel()
+
+	negative := -1
+	request := ContinueReleaseWorkflowRequest{
+		Authority:      &WorkflowAuthority{WorkflowID: "workflow-1", ExpectedRevision: 1},
+		IdempotencyKey: "continue-1",
+		Goal:           WorkflowGoalTrackersAssessed,
+		Intent: WorkflowIntent{ProjectionInstructions: map[TrackerID]TrackerProjectionInstructions{
+			"EXAMPLE": {ScreenshotCount: &negative},
+		}},
+	}
+	if err := request.Validate(); err == nil || !strings.Contains(err.Error(), "screenshot count must not be negative") {
+		t.Fatalf("negative screenshot count error = %v", err)
+	}
+
+	zero := 0
+	request.Intent.ProjectionInstructions["EXAMPLE"] = TrackerProjectionInstructions{ScreenshotCount: &zero}
+	if err := request.Validate(); err != nil {
+		t.Fatalf("zero screenshot count validation: %v", err)
+	}
+}
+
 func TestContinueRejectsMixedCorrectionAndTrackerAnswerOwners(t *testing.T) {
 	for _, intent := range []WorkflowIntent{
 		{CorrectionPatch: &ReleaseCorrectionPatch{ExpectedRevision: new(uint64)}},

--- a/webui/src/api/generated/release-workflow.ts
+++ b/webui/src/api/generated/release-workflow.ts
@@ -2247,6 +2247,7 @@ export type TrackerProjectionInstructionSnapshotRef = Readonly<{
 export type TrackerProjectionInstructions = Readonly<{
   additionalNames?: Readonly<Record<string, string | null>>;
   questionnaire?: Readonly<Record<string, string | null>>;
+  screenshotCount?: number | null;
   trackerConfig?: TrackerConfigOverrides;
   trackerSite?: TrackerSiteOverrides;
   uploadReleaseName?: string | null;


### PR DESCRIPTION
Custom descriptions could bypass tracker screenshot placement, and BHD could render only one image when its description options lacked a screenshot count. The CLI also failed to carry the configured default into description generation.

Use `screenshot_handling.screens` when `--screens` is omitted. Preserve explicit overrides through projection and media selection, including zero and retained screenshots, while preserving tracker validation and manual frame choices. Trackers without image requirements skip automatic capture. User-supplied descriptions receive each tracker's normal formatting and screenshots; reviewed final descriptions retain their text and separate image payloads.

Validation: all registered trackers cover default, lower, and zero counts; regression tests cover capture, retained media, custom descriptions, and final descriptions. Full Go race tests, frontend checks, documentation checks, lint, log policy, changed-package Go fix checks, and CLI builds pass.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configure screenshot counts globally and override them per tracker, including setting zero to disable automatic capture.
  - Screenshot selections now flow through upload workflows and respect tracker minimum requirements.
  - Comparison images, DVD menus, and other selected media are preserved when screenshots are adjusted.
  - Custom descriptions retain tracker-formatted content and associated screenshot or menu media.

- **Bug Fixes**
  - Corrected screenshot fallback behavior when CLI values are omitted or explicitly overridden.

- **Documentation**
  - Updated CLI and Web UI guidance for description formatting and screenshot configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->