### PR TITLE
fix: expose BTN auth response diagnostics

### DIFF
--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -166,7 +166,7 @@ func RedactValue(value string, sensitiveKeys map[string]struct{}) string {
 // redactURL preserves ordinary URL context while structurally redacting known
 // sensitive userinfo, path, query, and fragment values.
 func redactURL(raw string, sensitiveKeys map[string]struct{}) string {
-	trimmed := strings.TrimRight(raw, ".,;:")
+	trimmed := strings.TrimRight(raw, ".,;:)")
 	suffix := strings.TrimPrefix(raw, trimmed)
 	parsed, err := url.Parse(trimmed)
 	if err != nil || parsed.Host == "" {

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -5,6 +5,7 @@ package redaction
 
 import (
 	"encoding/json"
+	"net/url"
 	"regexp"
 	"slices"
 	"strings"
@@ -26,6 +27,7 @@ var DefaultSensitiveKeys = map[string]struct{}{
 	"password":      {},
 	"auth":          {},
 	"cookie":        {},
+	"session":       {},
 	"csrf":          {},
 	"email":         {},
 	"username":      {},
@@ -42,15 +44,16 @@ var (
 	announcePathTokenRe = regexp.MustCompile(`(?i)(/announce(?:\.php)?/)([A-Za-z0-9]{10,})($|[/?#])`)
 	apiPathTokenRe      = regexp.MustCompile(`(?i)(/api/torrents/)([A-Za-z0-9]{10,})($|[/?#"])`)
 	proxyPathRe         = regexp.MustCompile(`(?i)(/proxy/)([^/\s?#"]+)`) // /proxy/<secret>
+	urlRe               = regexp.MustCompile(`(?i)(?:[a-z][a-z0-9+.-]*://|//)[^\s<>"']+`)
 	urlUserinfoRe       = regexp.MustCompile(`(?i)(\b[a-z][a-z0-9+.-]*://|//)([^/@\s]+)@`)
 	queryParamRe        = regexp.MustCompile(
-		`(?i)([?&](anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|auth|auth[_-]?key|csrf|info[_-]?hash|key|passkey|password|rss[_-]?key|secret|token|torrent[_-]?pass|uid|user|user[_-]?id|userid)=)(?:\[REDACTED\]|[^&\s,\[\])}"']+)`,
+		`(?i)([?&](anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|auth|auth[_-]?key|csrf|info[_-]?hash|key|passkey|password|rss[_-]?key|secret|session(?:[_-]?id)?|token|torrent[_-]?pass|uid|user|user[_-]?id|userid)=)(?:\[REDACTED\]|[^&\s,\[\])}"']+)`,
 	)
 	keyValueQuotedRe = regexp.MustCompile(
-		`(?i)\b(anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|authorization|auth|auth[_-]?key|cookie|csrf|passkey|password|rss[_-]?key|secret|token|torrent[_-]?pass)\b(\s*[:=]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')`,
+		`(?i)\b(anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|authorization|auth|auth[_-]?key|cookie|csrf|passkey|password|rss[_-]?key|secret|session(?:[_-]?id)?|token|torrent[_-]?pass)\b(\s*[:=]\s*)("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')`,
 	)
 	keyValuePlainRe = regexp.MustCompile(
-		`(?i)\b(anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|authorization|auth|auth[_-]?key|cookie|csrf|passkey|password|rss[_-]?key|secret|token|torrent[_-]?pass)\b(\s*[:=]\s*)(bearer\s+)?([^"'\s,;)\]}]+)`,
+		`(?i)\b(anti[_-]?csrf[_-]?token|api[_-]?key|api[_-]?token|authorization|auth|auth[_-]?key|cookie|csrf|passkey|password|rss[_-]?key|secret|session(?:[_-]?id)?|token|torrent[_-]?pass)\b(\s*[:=]\s*)(bearer\s+)?([^"'\s,;)\]}]+)`,
 	)
 	cookieTailRe   = regexp.MustCompile(`(?i)(\bcookie\b\s*[:=]\s*\[REDACTED\])(?:[;]\s*[^,\r\n]+)+`)
 	authTailRe     = regexp.MustCompile(`(?i)(\bauthorization\b\s*[:=]\s*bearer\s+\[REDACTED\])(?:,\s*[^,\s]+)+`)
@@ -115,9 +118,10 @@ func ExtractJSONBlocks(text string) []Block {
 }
 
 // RedactValue redacts valid embedded JSON plus known secret-bearing URL, path,
-// query, key/value, cookie, authorization, and long-hex patterns. Nil keys use
-// [DefaultSensitiveKeys] for embedded JSON; textual patterns use the package's
-// fixed secret vocabulary.
+// query, key/value, cookie, authorization, and long-hex patterns. URL components
+// are decoded before matching sensitive keys and paths. Nil keys use
+// [DefaultSensitiveKeys] for embedded JSON and URL values; other textual
+// patterns use the package's fixed secret vocabulary.
 func RedactValue(value string, sensitiveKeys map[string]struct{}) string {
 	keys := sensitiveKeys
 	if keys == nil {
@@ -144,10 +148,10 @@ func RedactValue(value string, sensitiveKeys map[string]struct{}) string {
 		}
 	}
 
-	value = passkeyPathRe.ReplaceAllString(value, `/[REDACTED]$2`)
-	value = announcePathTokenRe.ReplaceAllString(value, `${1}[REDACTED]${3}`)
-	value = apiPathTokenRe.ReplaceAllString(value, `${1}[REDACTED]${3}`)
-	value = proxyPathRe.ReplaceAllString(value, `${1}[REDACTED]`)
+	value = urlRe.ReplaceAllStringFunc(value, func(raw string) string {
+		return redactURL(raw, keys)
+	})
+	value = redactURLPath(value)
 	value = urlUserinfoRe.ReplaceAllString(value, `${1}[REDACTED]@`)
 	value = queryParamRe.ReplaceAllString(value, `${1}[REDACTED]`)
 	value = keyValueQuotedRe.ReplaceAllStringFunc(value, redactQuotedKeyValue)
@@ -156,8 +160,62 @@ func RedactValue(value string, sensitiveKeys map[string]struct{}) string {
 	value = authTailRe.ReplaceAllString(value, `${1}`)
 	value = longHexTokenRe.ReplaceAllString(value, `[REDACTED]`)
 
-	_ = keys
 	return value
+}
+
+// redactURL preserves ordinary URL context while structurally redacting known
+// sensitive userinfo, path, query, and fragment values.
+func redactURL(raw string, sensitiveKeys map[string]struct{}) string {
+	trimmed := strings.TrimRight(raw, ".,;:")
+	suffix := strings.TrimPrefix(raw, trimmed)
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Host == "" {
+		return "[REDACTED]" + suffix
+	}
+	if parsed.User != nil {
+		parsed.User = url.User("[REDACTED]")
+	}
+	parsed.Path = redactURLPath(parsed.Path)
+	parsed.RawPath = ""
+	query, ok := redactURLValues(parsed.RawQuery, sensitiveKeys)
+	if !ok {
+		parsed.RawQuery = "[REDACTED]"
+	} else {
+		parsed.RawQuery = query
+	}
+	if strings.ContainsAny(parsed.Fragment, "=&") {
+		fragment, ok := redactURLValues(parsed.Fragment, sensitiveKeys)
+		if !ok {
+			parsed.Fragment = "[REDACTED]"
+		} else {
+			parsed.Fragment = fragment
+		}
+	}
+	parsed.RawFragment = ""
+	return strings.ReplaceAll(parsed.String(), url.QueryEscape("[REDACTED]"), "[REDACTED]") + suffix
+}
+
+func redactURLPath(path string) string {
+	path = passkeyPathRe.ReplaceAllString(path, `/[REDACTED]$2`)
+	path = announcePathTokenRe.ReplaceAllString(path, `${1}[REDACTED]${3}`)
+	path = apiPathTokenRe.ReplaceAllString(path, `${1}[REDACTED]${3}`)
+	return proxyPathRe.ReplaceAllString(path, `${1}[REDACTED]`)
+}
+
+func redactURLValues(raw string, sensitiveKeys map[string]struct{}) (string, bool) {
+	if raw == "" {
+		return "", true
+	}
+	values, err := url.ParseQuery(raw)
+	if err != nil {
+		return "", false
+	}
+	for key := range values {
+		if isSensitiveKey(key, sensitiveKeys) {
+			values[key] = []string{"[REDACTED]"}
+		}
+	}
+	return values.Encode(), true
 }
 
 // redactQuotedKeyValue replaces the value part of a matched quoted secret

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -188,7 +188,12 @@ func redactURL(raw string, sensitiveKeys map[string]struct{}) string {
 		if !ok {
 			parsed.Fragment = "[REDACTED]"
 		} else {
-			parsed.Fragment = fragment
+			decodedFragment, err := url.PathUnescape(fragment)
+			if err != nil {
+				parsed.Fragment = "[REDACTED]"
+			} else {
+				parsed.Fragment = decodedFragment
+			}
 		}
 	}
 	parsed.RawFragment = ""

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -49,7 +49,7 @@ func TestRedactValueUsesCustomSensitiveKeysForURLValues(t *testing.T) {
 	t.Parallel()
 
 	keys := map[string]struct{}{"diagnosticcode": {}}
-	input := "https://tracker.example/diagnostics?diagnostic_code=query-secret&page=2#diagnostic-code=fragment-secret"
+	input := "https://tracker.example/diagnostics?diagnostic_code=query-secret&page=2#diagnostic-code=fragment-secret&state=a+b"
 	output := RedactValue(input, keys)
 
 	for _, secret := range []string{"query-secret", "fragment-secret"} {
@@ -59,6 +59,12 @@ func TestRedactValueUsesCustomSensitiveKeysForURLValues(t *testing.T) {
 	}
 	if !contains(output, "page=2") {
 		t.Fatal("expected ordinary URL query value preserved")
+	}
+	if !contains(output, "#diagnostic-code=[REDACTED]") || contains(output, "%255B") {
+		t.Fatal("expected readable custom fragment redaction marker")
+	}
+	if !contains(output, "state=a+b") || contains(output, "state=a%20b") {
+		t.Fatal("expected literal fragment plus preserved")
 	}
 }
 

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -62,6 +62,15 @@ func TestRedactValueUsesCustomSensitiveKeysForURLValues(t *testing.T) {
 	}
 }
 
+func TestRedactValuePreservesClosingURLParenthesis(t *testing.T) {
+	t.Parallel()
+
+	input := "web UI (browser URL http://127.0.0.1:7480/app)"
+	if output := RedactValue(input, nil); output != input {
+		t.Fatal("expected surrounding URL punctuation preserved")
+	}
+}
+
 func TestRedactValueSessionKeyVariants(t *testing.T) {
 	t.Parallel()
 

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -27,6 +27,82 @@ func TestRedactValueURLPatterns(t *testing.T) {
 	}
 }
 
+func TestRedactValueStructurallyRedactsEncodedURLSecrets(t *testing.T) {
+	t.Parallel()
+
+	input := "https://synthetic-user:synthetic-password@tracker.example/%61nnounce/%30%31%32%33%34%35%36%37%38%39abcdef?pass%6bey=synthetic-passkey&session=synthetic-session&page=2#token=synthetic-token"
+	output := RedactValue(input, nil)
+
+	for _, secret := range []string{"synthetic-user", "synthetic-password", "0123456789abcdef", "synthetic-passkey", "synthetic-session", "synthetic-token"} {
+		if contains(output, secret) {
+			t.Fatal("expected URL secret redacted")
+		}
+	}
+	for _, marker := range []string{"https://[REDACTED]@tracker.example/announce/[REDACTED]", "passkey=[REDACTED]", "session=[REDACTED]", "page=2", "#token=[REDACTED]"} {
+		if !contains(output, marker) {
+			t.Fatalf("expected structural URL context %q", marker)
+		}
+	}
+}
+
+func TestRedactValueUsesCustomSensitiveKeysForURLValues(t *testing.T) {
+	t.Parallel()
+
+	keys := map[string]struct{}{"diagnosticcode": {}}
+	input := "https://tracker.example/diagnostics?diagnostic_code=query-secret&page=2#diagnostic-code=fragment-secret"
+	output := RedactValue(input, keys)
+
+	for _, secret := range []string{"query-secret", "fragment-secret"} {
+		if contains(output, secret) {
+			t.Fatal("expected custom URL secret redacted")
+		}
+	}
+	if !contains(output, "page=2") {
+		t.Fatal("expected ordinary URL query value preserved")
+	}
+}
+
+func TestRedactValueSessionKeyVariants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "plain underscore", input: "session_id=plain-underscore-secret"},
+		{name: "plain hyphen", input: "session-id=plain-hyphen-secret"},
+		{name: "plain camel", input: "sessionId=plain-camel-secret"},
+		{name: "quoted underscore", input: `session_id="quoted-underscore-secret"`},
+		{name: "quoted hyphen", input: `session-id="quoted-hyphen-secret"`},
+		{name: "quoted camel", input: `sessionId="quoted-camel-secret"`},
+		{name: "query underscore", input: "error?session_id=query-underscore-secret"},
+		{name: "query hyphen", input: "error?session-id=query-hyphen-secret"},
+		{name: "query camel", input: "error?sessionId=query-camel-secret"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			output := RedactValue(tt.input, nil)
+			if contains(output, "secret") || !contains(output, "[REDACTED]") {
+				t.Fatal("expected session value redacted")
+			}
+		})
+	}
+}
+
+func TestRedactValueFailsClosedOnMalformedSensitiveURLQuery(t *testing.T) {
+	t.Parallel()
+
+	output := RedactValue("https://tracker.example/diagnostics?pass%6bey=%ZZ&page=2", nil)
+	if contains(output, "pass%6bey") || contains(output, "%ZZ") {
+		t.Fatal("expected malformed sensitive URL query redacted")
+	}
+	if !contains(output, "?[REDACTED]") {
+		t.Fatal("expected malformed sensitive URL query redaction marker")
+	}
+}
+
 func TestRedactValueAnnouncePathToken(t *testing.T) {
 	t.Parallel()
 
@@ -80,10 +156,10 @@ func TestRedactValueBareProxyPath(t *testing.T) {
 func TestRedactValuePlainKeyValuePairs(t *testing.T) {
 	t.Parallel()
 
-	input := `api_key: tracker-secret api-key=hyphen-secret apiToken: camel-secret auth_key=auth-secret rss-key=rss-secret torrentPass=torrent-secret AntiCsrfToken=csrf-secret token=plain-token Authorization=Bearer bearer-secret cookie: "session-secret" message=kept`
+	input := `api_key: tracker-secret api-key=hyphen-secret apiToken: camel-secret auth_key=auth-secret rss-key=rss-secret torrentPass=torrent-secret AntiCsrfToken=csrf-secret token=plain-token session=session-secret Authorization=Bearer bearer-secret cookie: "cookie-secret" message=kept`
 	output := RedactValue(input, nil)
 
-	for _, secret := range []string{"tracker-secret", "hyphen-secret", "camel-secret", "auth-secret", "rss-secret", "torrent-secret", "csrf-secret", "plain-token", "bearer-secret", "session-secret"} {
+	for _, secret := range []string{"tracker-secret", "hyphen-secret", "camel-secret", "auth-secret", "rss-secret", "torrent-secret", "csrf-secret", "plain-token", "session-secret", "bearer-secret", "cookie-secret"} {
 		if contains(output, secret) {
 			t.Fatal("expected sensitive key/value redacted")
 		}

--- a/internal/trackers/auth/service.go
+++ b/internal/trackers/auth/service.go
@@ -1248,7 +1248,7 @@ func mustTrackerConfig(cfg config.Config, trackerID string) config.TrackerConfig
 // invalid sessions clear the reported cookie count and include recovery action;
 // 2FA is actionable only when a reusable challenge id exists.
 func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
-	status.LastError = redact(err.Error())
+	status.LastError = redactEnsureError(err)
 	status.Message = "remote auth test failed"
 
 	if isCookieStorageFailure(err) {
@@ -1297,13 +1297,56 @@ func applyEnsureErrorToStatus(status *api.TrackerAuthStatus, err error) {
 	}
 }
 
+// redactEnsureError preserves complete joined storage failures with blanket URL
+// masking. Otherwise it exposes only an explicitly sanitized tracker public
+// detail, while all other error text retains blanket URL-path masking.
+func redactEnsureError(err error) string {
+	if !isCookieStorageFailure(err) {
+		if resolution, ok := errors.AsType[*trackerscatalog.AuthResolutionError](err); ok {
+			if publicDetail := strings.TrimSpace(resolution.PublicDetail); publicDetail != "" {
+				return strings.TrimSpace(redaction.RedactValue(publicDetail, nil))
+			}
+		}
+	}
+	return redact(err.Error())
+}
+
 // isCookieStorageFailure recognizes cookie persistence/load failures that should
 // be exposed as storage-unavailable rather than login-required auth states.
 func isCookieStorageFailure(err error) bool {
-	if err == nil || errors.Is(err, cookies.ErrTrackerCookiesNotFound) {
-		return false
+	matched, _ := cookieStorageFailureInChain(err)
+	return matched
+}
+
+func cookieStorageFailureInChain(err error) (matched bool, containsResolution bool) {
+	if err == nil {
+		return false, false
 	}
-	lower := strings.ToLower(err.Error())
+	if _, ok := err.(*trackerscatalog.AuthResolutionError); ok { //nolint:errorlint // Inspect this node so joined storage siblings remain visible.
+		return false, true
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, child := range joined.Unwrap() {
+			childMatched, childContainsResolution := cookieStorageFailureInChain(child)
+			matched = matched || childMatched
+			containsResolution = containsResolution || childContainsResolution
+		}
+		return matched, containsResolution
+	}
+	if errors.Is(err, cookies.ErrTrackerCookiesNotFound) {
+		return false, false
+	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		matched, containsResolution = cookieStorageFailureInChain(wrapped.Unwrap())
+		if containsResolution {
+			return matched, true
+		}
+	}
+	return matched || isCookieStorageMessage(err.Error()), false
+}
+
+func isCookieStorageMessage(message string) bool {
+	lower := strings.ToLower(message)
 	return strings.Contains(lower, "cookies:") ||
 		strings.Contains(lower, "cookie store") ||
 		strings.Contains(lower, "legacy cookie file")

--- a/internal/trackers/auth/service_test.go
+++ b/internal/trackers/auth/service_test.go
@@ -1629,6 +1629,131 @@ func TestApplyEnsureErrorToStatusRedactsURLPath(t *testing.T) {
 	}
 }
 
+func TestApplyEnsureErrorToStatusKeepsTypedTrackerDiagnosticURLPath(t *testing.T) {
+	t.Parallel()
+
+	status := api.TrackerAuthStatus{TrackerID: "BTN", State: StateConfigured}
+	applyEnsureErrorToStatus(&status, &trackers.AuthResolutionError{
+		Transient:    true,
+		PublicDetail: "trackers: BTN upload auth unexpected final path final_url=https://www.tracker.invalid/diagnostics.php?page=2&pass%6bey=synthetic-passkey&session_id=synthetic-session response_detail=\"sessionId=synthetic-body-session\"",
+		Err:          errors.New("raw diagnostic must not be displayed"),
+	})
+
+	if !strings.Contains(status.LastError, "/diagnostics.php?page=2&passkey=[REDACTED]&session_id=[REDACTED]") {
+		t.Fatalf("typed diagnostic lost safe URL path: %#v", status)
+	}
+	if !strings.Contains(status.LastError, "sessionId=[REDACTED]") {
+		t.Fatalf("typed diagnostic lost redacted response detail: %#v", status)
+	}
+	if strings.Contains(status.LastError, "synthetic-passkey") || strings.Contains(status.LastError, "synthetic-session") {
+		t.Fatalf("typed diagnostic leaked URL secret: %#v", status)
+	}
+}
+
+func TestApplyEnsureErrorToStatusPreservesJoinedStorageFailure(t *testing.T) {
+	t.Parallel()
+
+	diagnostic := "trackers: BTN upload auth login required final_url=https://www.tracker.invalid/login.php?session_id=synthetic-session"
+	err := errors.Join(
+		&trackers.AuthResolutionError{
+			ConfirmedInvalid: true,
+			PublicDetail:     diagnostic,
+			Err:              errors.New(diagnostic),
+		},
+		errors.New("cookies: delete tracker BTN from db: storage unavailable"),
+	)
+	status := api.TrackerAuthStatus{TrackerID: "BTN", State: StateConfigured}
+
+	applyEnsureErrorToStatus(&status, err)
+
+	if status.State != StateEncryptedStorageUnavailable {
+		t.Fatalf("expected storage failure state, got %#v", status)
+	}
+	for _, want := range []string{"BTN upload auth login required", "cookies: delete tracker BTN from db"} {
+		if !strings.Contains(status.LastError, want) {
+			t.Fatalf("joined storage failure lost %q: %#v", want, status)
+		}
+	}
+	if strings.Contains(status.LastError, "/login.php") || strings.Contains(status.LastError, "synthetic-session") {
+		t.Fatalf("joined storage failure leaked URL detail: %#v", status)
+	}
+}
+
+func TestIsCookieStorageFailureIgnoresTrackerPublicDetail(t *testing.T) {
+	t.Parallel()
+
+	phrases := []string{
+		"cookies: temporarily unavailable",
+		"cookie store temporarily unavailable",
+		"legacy cookie file temporarily unavailable",
+	}
+	for _, phrase := range phrases {
+		t.Run(phrase, func(t *testing.T) {
+			t.Parallel()
+			if !isCookieStorageFailure(errors.New(phrase)) {
+				t.Fatal("expected direct storage failure classification")
+			}
+			remote := &ValidationError{
+				TrackerID: "BTN",
+				Transient: true,
+				Err: &trackers.AuthResolutionError{
+					Transient:    true,
+					PublicDetail: phrase,
+					Err:          errors.New(phrase),
+				},
+			}
+			if isCookieStorageFailure(remote) {
+				t.Fatal("tracker public detail must not classify as a storage failure")
+			}
+		})
+	}
+}
+
+func TestApplyEnsureErrorToStatusMasksTypedErrorWithoutPublicDetail(t *testing.T) {
+	t.Parallel()
+
+	status := api.TrackerAuthStatus{TrackerID: "BTN", State: StateConfigured}
+	applyEnsureErrorToStatus(&status, &trackers.AuthResolutionError{
+		Transient: true,
+		Err:       errors.New("final_url=https://www.tracker.invalid/diagnostics.php?page=2"),
+	})
+
+	if strings.Contains(status.LastError, "/diagnostics.php") {
+		t.Fatalf("missing public detail must retain blanket URL masking: %#v", status)
+	}
+	if !strings.Contains(status.LastError, "https://www.tracker.invalid/[REDACTED]") {
+		t.Fatalf("missing public detail lost masked URL host context: %#v", status)
+	}
+}
+
+func TestApplyEnsureErrorToStatusKeepsConfirmedInvalidPublicDetail(t *testing.T) {
+	t.Parallel()
+
+	status := api.TrackerAuthStatus{
+		TrackerID:   "BTN",
+		State:       StateConfigured,
+		CookieCount: 2,
+	}
+	err := classifyAdapterError("BTN", &trackers.AuthResolutionError{
+		ConfirmedInvalid: true,
+		PublicDetail:     "trackers: BTN upload auth login required final_url=https://www.tracker.invalid/login.php?pass%6bey=synthetic-passkey",
+		Err:              errors.New("raw diagnostic must not be displayed"),
+	})
+	applyEnsureErrorToStatus(&status, err)
+
+	if status.State != StateLoginRequired || status.CookieCount != 0 {
+		t.Fatalf("confirmed-invalid status=%#v", status)
+	}
+	if !strings.Contains(status.LastError, "/login.php?passkey=[REDACTED]") {
+		t.Fatalf("confirmed-invalid detail lost safe final URL: %#v", status)
+	}
+	for _, secret := range []string{"synthetic-passkey", "raw diagnostic"} {
+		if strings.Contains(status.LastError, secret) {
+			t.Fatalf("confirmed-invalid detail leaked %q: %#v", secret, status)
+		}
+	}
+}
+
 func TestCookiesToMapPreservesCookieValueWhitespace(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trackers/definition.go
+++ b/internal/trackers/definition.go
@@ -26,8 +26,12 @@ var ErrSubmitted2FARejected = errors.New("trackers: submitted 2FA rejected")
 
 // AuthResolutionError reports tracker-owned remote auth classification to the generic coordinator.
 type AuthResolutionError struct {
-	// Reason is sanitized operator-facing failure detail.
+	// Reason identifies the tracker-owned auth resolution outcome.
 	Reason string
+	// PublicDetail is optional, already-sanitized operator-facing detail. The
+	// coordinator displays it only when the producer explicitly provides it.
+	// Err is never used as a public-detail source.
+	PublicDetail string
 	// AuthRequired reports that configured or interactive authentication is needed.
 	AuthRequired bool
 	// ConfirmedInvalid reports that existing authentication was rejected remotely.

--- a/internal/trackers/impl/standalone/btn/auth.go
+++ b/internal/trackers/impl/standalone/btn/auth.go
@@ -18,6 +18,7 @@ import (
 	"github.com/autobrr/upbrr/internal/cookies"
 	"github.com/autobrr/upbrr/internal/trackers"
 	authtotp "github.com/autobrr/upbrr/internal/trackers/auth/totp"
+	"github.com/autobrr/upbrr/internal/trackers/impl/commonhttp"
 	"github.com/autobrr/upbrr/pkg/api"
 )
 
@@ -252,36 +253,42 @@ func validateBTNClientSession(ctx context.Context, client *http.Client, baseURL 
 	}
 	defer resp.Body.Close()
 	finalPath := ""
+	finalURL := ""
 	if resp.Request != nil && resp.Request.URL != nil {
 		finalPath = resp.Request.URL.Path
+		finalURL = resp.Request.URL.String()
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || finalPath == btnLoginPath {
+		message := btnAuthLoginDiagnostic(resp.StatusCode, finalURL)
+		return &trackers.AuthResolutionError{
+			Reason:           "remote validation failed",
+			PublicDetail:     message,
+			ConfirmedInvalid: true,
+			Err:              btnSafeError{message: message, cause: errBTNSessionConfirmedInvalid},
+		}
 	}
 	body, readErr := io.ReadAll(io.LimitReader(resp.Body, btnAuthResponseMaxBytes+1))
 	if readErr != nil {
 		return newBTNTransientAuthError("trackers: BTN upload auth response read failed", readErr)
 	}
 	bodyText := string(body)
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || finalPath == btnLoginPath {
-		if finalPath != "" {
-			return fmt.Errorf(
-				"%w: login required status=%d final_path=%s",
-				errBTNSessionConfirmedInvalid,
-				resp.StatusCode,
-				sanitizeBTNFinalPath(finalPath),
-			)
-		}
-		return fmt.Errorf("%w: login required status=%d", errBTNSessionConfirmedInvalid, resp.StatusCode)
-	}
 	if finalPath != btnUploadPath {
-		return newBTNTransientAuthError(btnAuthResponseDiagnostic("unexpected final path", resp.StatusCode, finalPath, body, btnAuthPageState(bodyText)), nil)
+		return newBTNTransientAuthError(
+			btnAuthResponseDiagnostic("unexpected final path", resp.StatusCode, finalPath, finalURL, body, btnAuthPageState(bodyText)),
+			nil,
+		)
 	}
 	if resp.StatusCode >= 500 {
-		return newBTNTransientAuthError(btnAuthResponseDiagnostic("response unavailable", resp.StatusCode, finalPath, body, ""), nil)
+		return newBTNTransientAuthError(btnAuthResponseDiagnostic("response unavailable", resp.StatusCode, finalPath, finalURL, body, ""), nil)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return newBTNTransientAuthError(btnAuthResponseDiagnostic("unexpected status", resp.StatusCode, finalPath, body, ""), nil)
+		return newBTNTransientAuthError(btnAuthResponseDiagnostic("unexpected status", resp.StatusCode, finalPath, finalURL, body, ""), nil)
 	}
 	if !btnLooksLikeUploadPage(bodyText) {
-		return newBTNTransientAuthError(btnAuthResponseDiagnostic("page validation failed", resp.StatusCode, finalPath, body, btnAuthPageState(bodyText)), nil)
+		return newBTNTransientAuthError(
+			btnAuthResponseDiagnostic("page validation failed", resp.StatusCode, finalPath, finalURL, body, btnAuthPageState(bodyText)),
+			nil,
+		)
 	}
 	return nil
 }
@@ -303,13 +310,22 @@ func newBTNTransientAuthError(message string, cause error) *trackers.AuthResolut
 		diagnostic = btnSafeError{message: message, cause: cause}
 	}
 	return &trackers.AuthResolutionError{
-		Reason:    "remote validation failed",
-		Transient: true,
-		Err:       diagnostic,
+		Reason:       "remote validation failed",
+		PublicDetail: message,
+		Transient:    true,
+		Err:          diagnostic,
 	}
 }
 
-func btnAuthResponseDiagnostic(reason string, status int, finalPath string, body []byte, pageState string) string {
+func btnAuthLoginDiagnostic(status int, finalURL string) string {
+	message := fmt.Sprintf("trackers: BTN upload auth login required status=%d", status)
+	if finalURL != "" {
+		message += " final_url=" + commonhttp.RedactErrorDetail(finalURL)
+	}
+	return message
+}
+
+func btnAuthResponseDiagnostic(reason string, status int, finalPath string, finalURL string, body []byte, pageState string) string {
 	message := fmt.Sprintf(
 		"trackers: BTN upload auth %s status=%d response_bytes=%d response_truncated=%t",
 		reason,
@@ -318,10 +334,13 @@ func btnAuthResponseDiagnostic(reason string, status int, finalPath string, body
 		len(body) > btnAuthResponseMaxBytes,
 	)
 	if finalPath != btnUploadPath {
-		message += " final_path=" + sanitizeBTNFinalPath(finalPath)
+		message += " final_url=" + commonhttp.RedactErrorDetail(finalURL)
 	}
 	if pageState != "" {
 		message += " page_state=" + pageState
+	}
+	if detail := commonhttp.ExtractHTTPErrorDetail(body); detail != "" {
+		message += fmt.Sprintf(" response_detail=%q", detail)
 	}
 	return message
 }
@@ -331,17 +350,6 @@ func btnAuthPageState(body string) string {
 		return "logged_out_marker"
 	}
 	return "upload_form_missing"
-}
-
-func sanitizeBTNFinalPath(finalPath string) string {
-	const redactedPath = "[REDACTED]"
-
-	switch finalPath {
-	case btnUploadPath, btnLoginPath, "/user.php", "/torrents.php":
-		return finalPath
-	default:
-		return redactedPath
-	}
 }
 
 // loadBTNCookiesIntoJar best-effort seeds an upload client with persisted BTN

--- a/internal/trackers/impl/standalone/btn/upload_integration_test.go
+++ b/internal/trackers/impl/standalone/btn/upload_integration_test.go
@@ -1759,6 +1759,22 @@ func TestValidateBTNClientSessionReportsRedirectAndLayoutDiagnostics(t *testing.
 		absent               []string
 	}{
 		{
+			name: "unauthorized remains confirmed invalid",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			},
+			wantConfirmedInvalid: true,
+			want:                 []string{"status=401", "/upload.php"},
+		},
+		{
+			name: "forbidden remains confirmed invalid",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			},
+			wantConfirmedInvalid: true,
+			want:                 []string{"status=403", "/upload.php"},
+		},
+		{
 			name: "non-login redirect reports path and detail",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
@@ -1771,8 +1787,8 @@ func TestValidateBTNClientSessionReportsRedirectAndLayoutDiagnostics(t *testing.
 					http.NotFound(w, r)
 				}
 			},
-			want:   []string{"status=503", "final_path=/torrents.php", "response_bytes=", "response_truncated=false"},
-			absent: []string{"synthetic-secret", "token=", "Upload maintenance in progress"},
+			want:   []string{"status=503", "/torrents.php?token=[REDACTED]", "response_bytes=", "response_truncated=false", `response_detail="Upload maintenance in progress"`},
+			absent: []string{"synthetic-secret", "token=synthetic-secret"},
 		},
 		{
 			name: "login redirect remains confirmed invalid and reports path",
@@ -1787,8 +1803,8 @@ func TestValidateBTNClientSessionReportsRedirectAndLayoutDiagnostics(t *testing.
 				}
 			},
 			wantConfirmedInvalid: true,
-			want:                 []string{"status=200", "final_path=/login.php"},
-			absent:               []string{"synthetic-secret", "passkey="},
+			want:                 []string{"status=200", "/login.php?passkey=[REDACTED]"},
+			absent:               []string{"synthetic-secret"},
 		},
 		{
 			name: "login-status redirect remains transient",
@@ -1802,8 +1818,7 @@ func TestValidateBTNClientSessionReportsRedirectAndLayoutDiagnostics(t *testing.
 					http.NotFound(w, r)
 				}
 			},
-			want:   []string{"status=200", "final_path=[REDACTED]", "page_state=logged_out_marker"},
-			absent: []string{"password", "login.php"},
+			want: []string{"status=200", "/login-status.php", "page_state=logged_out_marker"},
 		},
 		{
 			name: "non-login redirect with logged-out page remains transient",
@@ -1817,26 +1832,24 @@ func TestValidateBTNClientSessionReportsRedirectAndLayoutDiagnostics(t *testing.
 					http.NotFound(w, r)
 				}
 			},
-			want:   []string{"status=200", "final_path=/torrents.php", "page_state=logged_out_marker"},
-			absent: []string{"Please log in before continuing"},
+			want: []string{"status=200", "/torrents.php", "page_state=logged_out_marker", `response_detail="Please log in before continuing"`},
 		},
 		{
-			name: "secret redirect path is redacted",
+			name: "ordinary unknown redirect path is visible",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/upload.php":
-					http.Redirect(w, r, "/synthetic-secret.php", http.StatusFound)
-				case "/synthetic-secret.php":
+					http.Redirect(w, r, "/diagnostics.php", http.StatusFound)
+				case "/diagnostics.php":
 					_, _ = io.WriteString(w, `<div role="alert">Upload maintenance in progress</div>`)
 				default:
 					http.NotFound(w, r)
 				}
 			},
-			want:   []string{"status=200", "final_path=[REDACTED]", "response_bytes="},
-			absent: []string{"synthetic-secret", "Upload maintenance in progress"},
+			want: []string{"status=200", "/diagnostics.php", "response_bytes=", `response_detail="Upload maintenance in progress"`},
 		},
 		{
-			name: "unknown short redirect path is redacted",
+			name: "unknown short redirect path is visible",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/upload.php":
@@ -1847,8 +1860,7 @@ func TestValidateBTNClientSessionReportsRedirectAndLayoutDiagnostics(t *testing.
 					http.NotFound(w, r)
 				}
 			},
-			want:   []string{"status=200", "final_path=[REDACTED]", "response_bytes="},
-			absent: []string{"alice.php", "Upload maintenance in progress"},
+			want: []string{"status=200", "/alice.php", "response_bytes=", `response_detail="Upload maintenance in progress"`},
 		},
 		{
 			name: "same upload path reports redacted layout detail",
@@ -1860,22 +1872,21 @@ func TestValidateBTNClientSessionReportsRedirectAndLayoutDiagnostics(t *testing.
 				_, _ = io.WriteString(w, `<div role="alert">Upload form disabled: passkey=synthetic-secret</div>`)
 				_, _ = io.WriteString(w, strings.Repeat(" ", 1024*1024))
 			},
-			want:   []string{"page validation failed", "status=200", "response_bytes=1048577", "response_truncated=true", "page_state=upload_form_missing"},
-			absent: []string{"synthetic-secret", "Upload form disabled", "passkey="},
+			want:   []string{"page validation failed", "status=200", "response_bytes=1048577", "response_truncated=true", "page_state=upload_form_missing", `response_detail="response exceeded 1 MiB; Upload form disabled: passkey=[REDACTED]"`},
+			absent: []string{"synthetic-secret", "passkey=synthetic-secret"},
 		},
 		{
-			name: "same upload path ignores prose and truncated JSON values",
+			name: "same upload path shows redacted prose and truncation",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != "/upload.php" {
 					http.NotFound(w, r)
 					return
 				}
 				_, _ = io.WriteString(w, `Account Jane Example token=synthetic-secret`)
-				_, _ = io.WriteString(w, `{"username":"synthetic-user","profile":"Jane\u0020Example","password":"synthetic-password","padding":"`)
 				_, _ = io.WriteString(w, strings.Repeat("x", 1024*1024))
 			},
-			want:   []string{"page validation failed", "status=200", "response_truncated=true", "page_state=upload_form_missing"},
-			absent: []string{"Jane Example", "synthetic-secret", "synthetic-user", "synthetic-password", "username", "password", "token="},
+			want:   []string{"page validation failed", "status=200", "response_truncated=true", "page_state=upload_form_missing", "Account Jane Example", "token=[REDACTED]"},
+			absent: []string{"synthetic-secret", "token=synthetic-secret"},
 		},
 		{
 			name: "same upload path missing-location redirect remains transient",
@@ -1924,23 +1935,68 @@ func TestValidateBTNClientSessionReportsRedirectAndLayoutDiagnostics(t *testing.
 			if tt.wantConfirmedInvalid != errors.Is(err, errBTNSessionConfirmedInvalid) {
 				t.Fatalf("confirmed-invalid classification=%t, want %t: %v", errors.Is(err, errBTNSessionConfirmedInvalid), tt.wantConfirmedInvalid, err)
 			}
-			if !tt.wantConfirmedInvalid {
-				resolution, ok := errors.AsType[*trackers.AuthResolutionError](err)
-				if !ok || !resolution.Transient || resolution.ConfirmedInvalid {
-					t.Fatalf("expected transient tracker-owned resolution error, got %v", err)
+			resolution, ok := errors.AsType[*trackers.AuthResolutionError](err)
+			if !ok {
+				t.Fatalf("expected tracker-owned resolution error, got %v", err)
+			}
+			if tt.wantConfirmedInvalid {
+				if !resolution.ConfirmedInvalid || resolution.Transient || resolution.PublicDetail == "" {
+					t.Fatalf("expected confirmed-invalid public tracker diagnostic, got %#v", resolution)
 				}
+			} else if !resolution.Transient || resolution.ConfirmedInvalid || resolution.PublicDetail == "" {
+				t.Fatalf("expected transient public tracker diagnostic, got %#v", resolution)
 			}
 			for _, want := range tt.want {
-				if !strings.Contains(err.Error(), want) {
-					t.Fatalf("error=%q, want %q", err, want)
+				if !strings.Contains(resolution.PublicDetail, want) {
+					t.Fatalf("public detail=%q, want %q", resolution.PublicDetail, want)
 				}
 			}
 			for _, absent := range tt.absent {
-				if strings.Contains(err.Error(), absent) {
-					t.Fatalf("error=%q, must not contain %q", err, absent)
+				if strings.Contains(resolution.PublicDetail, absent) {
+					t.Fatalf("public detail=%q, must not contain %q", resolution.PublicDetail, absent)
 				}
 			}
 		})
+	}
+}
+
+func TestValidateBTNClientSessionRedactsSensitiveURLAndResponseDetails(t *testing.T) {
+	t.Parallel()
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/upload.php":
+			redirectURL := strings.Replace(serverURL, "http://", "http://synthetic-user:synthetic-password@", 1) +
+				"/%61nnounce/%30%31%32%33%34%35%36%37%38%39abcdef?pass%6bey=synthetic-passkey&sessionId=synthetic-session&token=synthetic-token"
+			http.Redirect(w, r, redirectURL, http.StatusFound)
+		case "/announce/0123456789abcdef":
+			_, _ = io.WriteString(w, `<div role="alert">Maintenance for https://synthetic-user:synthetic-password@remote.invalid/%61nnounce/%30%31%32%33%34%35%36%37%38%39abcdef?pass%6bey=synthetic-passkey&amp;sessionId=synthetic-session&amp;token=synthetic-token session-id="synthetic-session-hyphen"</div>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	serverURL = server.URL
+	t.Cleanup(server.Close)
+
+	err := validateBTNClientSession(t.Context(), server.Client(), server.URL)
+	resolution, ok := errors.AsType[*trackers.AuthResolutionError](err)
+	if !ok || !resolution.Transient || resolution.ConfirmedInvalid {
+		t.Fatalf("expected transient tracker-owned diagnostic, got %v", err)
+	}
+	for _, want := range []string{
+		"final_url=http://[REDACTED]@",
+		"/announce/[REDACTED]?passkey=[REDACTED]&sessionId=[REDACTED]&token=[REDACTED]",
+		"response_detail=\"Maintenance for https://[REDACTED]@remote.invalid/announce/[REDACTED]?passkey=[REDACTED]&sessionId=[REDACTED]&token=[REDACTED] session-id=\\\"[REDACTED]\\\"\"",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error=%q, want %q", err, want)
+		}
+	}
+	for _, secret := range []string{"synthetic-user", "synthetic-password", "0123456789abcdef", "synthetic-passkey", "synthetic-session", "synthetic-session-hyphen", "synthetic-token"} {
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("error=%q, must not contain %q", err, secret)
+		}
 	}
 }
 
@@ -2000,6 +2056,61 @@ func TestValidateBTNClientSessionKeepsBodyReadFailureSafeAndTransient(t *testing
 		if strings.Contains(err.Error(), secret) {
 			t.Fatalf("read failure leaked %q in %q", secret, err)
 		}
+	}
+}
+
+func TestValidateBTNClientSessionClassifiesInvalidBeforeBodyRead(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		status    int
+		finalPath string
+	}{
+		{
+			name:      "unauthorized",
+			status:    http.StatusUnauthorized,
+			finalPath: btnUploadPath,
+		},
+		{
+			name:      "forbidden",
+			status:    http.StatusForbidden,
+			finalPath: btnUploadPath,
+		},
+		{
+			name:      "login redirect",
+			status:    http.StatusOK,
+			finalPath: btnLoginPath,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			readCause := errors.New("response body read failed")
+			client := &http.Client{Transport: btnRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				responseRequest := req.Clone(req.Context())
+				responseRequest.URL = &url.URL{
+					Scheme: "https",
+					Host:   "tracker.invalid",
+					Path:   tt.finalPath,
+				}
+				return &http.Response{
+					StatusCode: tt.status,
+					Body:       io.NopCloser(btnErrorReader{err: readCause}),
+					Request:    responseRequest,
+				}, nil
+			})}
+
+			err := validateBTNClientSession(t.Context(), client, "https://tracker.invalid")
+			resolution, ok := errors.AsType[*trackers.AuthResolutionError](err)
+			if !ok || !resolution.ConfirmedInvalid || resolution.Transient || !errors.Is(err, errBTNSessionConfirmedInvalid) {
+				t.Fatalf("expected confirmed-invalid tracker-owned error, got %v", err)
+			}
+			if errors.Is(err, readCause) {
+				t.Fatal("decisive invalid-auth signal must take precedence over body read failure")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

BTN upload authentication returned an opaque validation failure when BTN redirected away from `/upload.php` or served an unexpected page. The existing message exposed only response size and a coarse page state.

## Change

- Report the sanitized final URL and extracted response detail for BTN upload-auth failures.
- Preserve confirmed-invalid classification for HTTP 401, HTTP 403, and an exact `/login.php` redirect.
- Keep all other redirect, response, and layout failures transient.
- Gate path-preserving status text behind explicit tracker-owned public detail.
- Parse URL components before redacting encoded credentials, passkeys, tokens, sessions, and custom sensitive keys.
- Preserve complete blanket-redacted joined errors when cookie cleanup fails.

## Impact

Operators receive actionable BTN diagnostics without losing the redirect target or useful page message. Response detail remains size-limited and passes through shared redaction before reaching logs or the UI. Existing non-BTN and non-opted-in errors retain blanket URL-path masking.

## Validation

- `go test -count=1 -race -v -timeout 20m ./internal/redaction ./internal/trackers/impl/commonhttp ./internal/trackers/auth ./internal/trackers/impl/standalone/btn`
- `make lint`
- `make logpolicy`
- `make pathpolicy`
- `make gofix-check-changed`
- `git diff --check`
- Local CodeRabbit review and independent correctness review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection of sensitive information in URLs, query parameters, fragments, and authentication diagnostics.
  * Added broader handling for session-related secrets, encoded values, custom sensitive keys, and malformed URL data.
  * Authentication errors now provide clearer, appropriately redacted details, including final URLs and response information.
  * Improved detection of nested storage-related failures.
  * More accurately classifies invalid credentials and transient authentication failures.
* **Tests**
  * Expanded coverage for URL redaction, redirect details, response errors, malformed requests, and authentication status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->